### PR TITLE
docs(resolvers): clarify execution semantics and add implementation g…

### DIFF
--- a/docs/design/examples/comprehensive/solution.yaml
+++ b/docs/design/examples/comprehensive/solution.yaml
@@ -28,7 +28,7 @@ spec:
     environment:
       description: Target deployment environment
       resolve:
-        from:
+        with:
           # Try parameter first (from CLI: -r environment=prod)
           - provider: parameter
             inputs:
@@ -43,13 +43,13 @@ spec:
               value: dev
       # Transform: normalize to lowercase
       transform:
-        into:
+        with:
           - provider: cel
             inputs:
               expression: "__self.toLowerCase()"
       # Validate: must be one of approved environments
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"dev\", \"staging\", \"prod\"]"
@@ -62,7 +62,7 @@ spec:
     appName:
       description: Application name from file or parameter
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: app
@@ -74,7 +74,7 @@ spec:
             inputs:
               value: my-app
       transform:
-        into:
+        with:
           # Trim whitespace
           - provider: cel
             inputs:
@@ -88,7 +88,7 @@ spec:
             inputs:
               expression: "__self.replace(\"_\", \"-\")"
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               match: "^[a-z0-9-]+$"
@@ -102,7 +102,7 @@ spec:
     gitBranch:
       description: Current git branch
       resolve:
-        from:
+        with:
           - provider: git
             inputs:
               field: branch
@@ -110,12 +110,12 @@ spec:
     gitCommit:
       description: Current git commit SHA
       resolve:
-        from:
+        with:
           - provider: git
             inputs:
               field: commit
       transform:
-        into:
+        with:
           # Take first 7 characters for short SHA
           - provider: cel
             inputs:
@@ -128,7 +128,7 @@ spec:
     version:
       description: Computed version from git or parameter
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: version
@@ -144,7 +144,7 @@ spec:
     configFromAPI:
       description: Configuration fetched from remote API
       resolve:
-        from:
+        with:
           - provider: api
             inputs:
               endpoint: https://api.example.com/config
@@ -152,7 +152,7 @@ spec:
               headers:
                 Accept: application/json
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "has(__self.data) && __self.data.size() > 0"
@@ -165,7 +165,7 @@ spec:
     regions:
       description: Deployment regions as list
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: regions
@@ -173,7 +173,7 @@ spec:
             inputs:
               value: "us-east-1,us-west-2"
       transform:
-        into:
+        with:
           # Split CSV into array
           - provider: cel
             inputs:
@@ -183,7 +183,7 @@ spec:
             inputs:
               expression: "__self.filter(r, r.size() > 0)"
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self.size() > 0 && __self.size() <= 5"
@@ -196,7 +196,7 @@ spec:
     deploymentTemplate:
       description: Kubernetes deployment template
       resolve:
-        from:
+        with:
           - provider: filesystem
             inputs:
               operation: read
@@ -205,7 +205,7 @@ spec:
     serviceTemplate:
       description: Kubernetes service template
       resolve:
-        from:
+        with:
           - provider: filesystem
             inputs:
               operation: read
@@ -217,7 +217,7 @@ spec:
     dryRun:
       description: Whether to run in dry-run mode
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: dryRun
@@ -225,7 +225,7 @@ spec:
             inputs:
               value: false
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "type(__self) == bool"
@@ -237,7 +237,7 @@ spec:
     replicas:
       description: Number of replicas to deploy
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: replicas
@@ -245,7 +245,7 @@ spec:
             inputs:
               value: 3
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self >= 1 && __self <= 10"
@@ -258,7 +258,7 @@ spec:
     imageTag:
       description: Docker image tag combining app name and version
       resolve:
-        from:
+        with:
           - provider: cel
             inputs:
               expression: "_.appName + \":\" + _.version"

--- a/docs/design/examples/email-notifier/solution.yaml
+++ b/docs/design/examples/email-notifier/solution.yaml
@@ -11,7 +11,7 @@ spec:
     isDryRun:
       description: A dry run
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: dry-run
@@ -19,7 +19,7 @@ spec:
     environment:
       description: Deployment environment
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: environment
@@ -30,12 +30,12 @@ spec:
             inputs:
               value: dev
       transform:
-        into:
+        with:
           - provider: cel
             inputs:
               expression: "__self.toLowerCase()"
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"dev\", \"stage\", \"prod\"]"
@@ -44,7 +44,7 @@ spec:
     emailFrom:
       description: Sender email address
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: emailFrom
@@ -52,7 +52,7 @@ spec:
             inputs:
               key: EMAIL_FROM
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               match: "^[^@]+@[^@]+\\.[^@]+$"
@@ -61,7 +61,7 @@ spec:
     emailTo:
       description: Recipient email address
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: emailTo
@@ -69,7 +69,7 @@ spec:
             inputs:
               key: EMAIL_TO
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               match: "^[^@]+@[^@]+\\.[^@]+$"
@@ -78,7 +78,7 @@ spec:
     subject:
       description: Email subject line
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: subject
@@ -89,7 +89,7 @@ spec:
     body:
       description: Email body content
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: body

--- a/docs/design/examples/taskfile/solution.yaml
+++ b/docs/design/examples/taskfile/solution.yaml
@@ -11,7 +11,7 @@ spec:
     repo:
       description: Repository name
       resolve:
-        from:
+        with:
           - provider: static
             inputs:
               value: scafctl
@@ -19,7 +19,7 @@ spec:
     version:
       description: Version to build and release
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: version
@@ -27,7 +27,7 @@ spec:
             inputs:
               value: dev
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               match: '^(dev|\d+\.\d+\.\d+.*)$'
@@ -36,7 +36,7 @@ spec:
     goos:
       description: Target operating system
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: goos
@@ -44,7 +44,7 @@ spec:
             inputs:
               value: linux
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"linux\", \"darwin\", \"windows\"]"
@@ -53,7 +53,7 @@ spec:
     goarch:
       description: Target architecture
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: goarch
@@ -61,7 +61,7 @@ spec:
             inputs:
               value: amd64
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"amd64\", \"arm64\"]"
@@ -70,7 +70,7 @@ spec:
     buildDir:
       description: Build output directory
       resolve:
-        from:
+        with:
           - provider: static
             inputs:
               value: dist

--- a/docs/design/examples/terraform/solution.yaml
+++ b/docs/design/examples/terraform/solution.yaml
@@ -11,7 +11,7 @@ spec:
     app:
       description: Application name
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: app
@@ -19,7 +19,7 @@ spec:
             inputs:
               value: my-app
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               match: "^[a-z0-9-]+$"
@@ -28,7 +28,7 @@ spec:
     environments:
       description: Target deployment environments
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: environments
@@ -37,13 +37,13 @@ spec:
               value: "dev,qa,prod"
 
       transform:
-        into:
+        with:
           - provider: cel
             inputs:
               expression: "__self.split(\",\").map(e, e.trim())"
 
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self.size() > 0"
@@ -52,7 +52,7 @@ spec:
     mainTfTemplate:
       description: main.tf template content
       resolve:
-        from:
+        with:
           - provider: filesystem
             inputs:
               path: templates/main.tf.tmpl
@@ -60,7 +60,7 @@ spec:
     tfvarsTemplate:
       description: auto.tfvars template content
       resolve:
-        from:
+        with:
           - provider: filesystem
             inputs:
               path: templates/auto.tfvars.tmpl

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -40,21 +40,26 @@ A provider is not responsible for:
 
 Providers are invoked with a resolved execution context.
 
-For resolver execution:
+**Resolver Context in Go Context:**
 
-- `_` contains only resolver outputs
-- Nothing exists in `_` unless emitted by a resolver
+The resolver context (the `_` map containing all emitted resolver values) is stored in the Go `context.Context` as a `sync.Map`:
 
-For action execution:
+- Access via: `ResolverContextFromContext(ctx)` returns `map[string]any`
+- In resolver execution, contains all previously emitted resolver values
+- In action execution, may contain additional action-local variables
+- Providers access resolver values via the returned map: `data["resolverName"]`
 
-- Providers may receive additional action-local data, but this does not affect resolver semantics
+**Special symbols in resolver context:**
 
-Special symbols passed by the caller:
+- `__self` - The current value being transformed or validated (available in transform and validate phases)
+- `__item` - The current item in a foreach loop (available in action iterations)
 
-- `__self` will be the current value of the resolver
-- `__item` will be the current item in the foreach loop
+**Key principles:**
 
-Providers do not evaluate expressions or templates themselves. All inputs are fully resolved before invocation.
+- Resolver context contains only resolver outputs (nothing exists unless emitted by a resolver)
+- Providers do not evaluate expressions or templates themselves—all inputs are fully resolved before invocation
+- The resolver context map is read-only; providers should not mutate it
+- Access to the resolver context is optional—providers that don't need it don't have to retrieve it
 
 ---
 
@@ -92,7 +97,7 @@ Provider Invocation Request
 
 2. **Decode** - If the provider defines a `Decode` function in its descriptor, scafctl calls it to convert the validated `map[string]any` into a strongly-typed structure. This step is optional; providers can work directly with maps.
 
-3. **Execute** - The provider's `Execute(ctx, input)` method runs with the validated (and optionally decoded) inputs. The provider performs its operation based on the execution mode and dry-run flag from the context.
+3. **Execute** - The provider's `Execute(ctx, input)` method runs with the validated (and optionally decoded) inputs. The provider performs its operation based on the execution mode and dry-run flag from the context. Providers that need access to resolver values retrieve them via `ResolverContextFromContext(ctx)`.
 
 4. **Output Schema Validation** - If the provider defines an `OutputSchema`, scafctl validates the `ProviderOutput.Data` field against this schema after execution. This ensures both real and mock outputs conform to the declared structure.
 
@@ -135,6 +140,8 @@ scafctl uses typed context keys to prevent collisions and provide type safety:
   - Access via: `ExecutionModeFromContext(ctx)`
 - `dryRunKey` (unexported) - Boolean indicating whether this is a dry-run execution
   - Access via: `DryRunFromContext(ctx)`
+- `resolverContextKey` (unexported) - The resolver context map containing all emitted resolver values
+  - Access via: `ResolverContextFromContext(ctx)` returns `map[string]any`
 
 Typed keys ensure external packages cannot accidentally use the same context keys, preventing subtle bugs.
 
@@ -333,14 +340,16 @@ func (c ProviderCapability) IsValid() bool {
 type contextKey int
 
 const (
-  executionModeKey contextKey = iota // Key for ProviderCapability execution mode
-  dryRunKey                           // Key for boolean dry-run flag
+  executionModeKey   contextKey = iota // Key for ProviderCapability execution mode
+  dryRunKey                            // Key for boolean dry-run flag
+  resolverContextKey                   // Key for resolver context map
 )
 
 // NOTE: These keys are intentionally unexported. scafctl's orchestration layer
 // sets them using internal helpers such as:
 //   - WithExecutionMode(ctx context.Context, mode ProviderCapability) context.Context
 //   - WithDryRun(ctx context.Context, dryRun bool) context.Context
+//   - WithResolverContext(ctx context.Context, data map[string]any) context.Context
 // Provider implementations should treat these as read-only and access them only
 // via the accessor functions below, which provide context value accessors for
 // provider implementations.
@@ -352,6 +361,11 @@ func ExecutionModeFromContext(ctx context.Context) (ProviderCapability, bool) {
 func DryRunFromContext(ctx context.Context) bool {
   dryRun, _ := ctx.Value(dryRunKey).(bool)
   return dryRun
+}
+
+func ResolverContextFromContext(ctx context.Context) map[string]any {
+  data, _ := ctx.Value(resolverContextKey).(map[string]any)
+  return data // Returns nil map if not set, which is safe to read from
 }
 
 type ProviderDescriptor struct {
@@ -608,7 +622,7 @@ Resolvers invoke providers to obtain, transform, or validate values.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: env
       inputs:
         key: PROJECT_NAME
@@ -632,7 +646,7 @@ Transform steps are provider executions applied sequentially to a single value.
 
 ~~~yaml
 transform:
-  into:
+  with:
     - provider: cel
       inputs:
         expression: __self.toLowerCase()
@@ -677,7 +691,7 @@ Literal regex patterns:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match: "^[a-z0-9-]+$"
@@ -701,7 +715,7 @@ Using resolver for dynamic pattern:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match:
@@ -713,7 +727,7 @@ Using template for pattern:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match:
@@ -725,7 +739,7 @@ Using CEL expression for validation logic:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         expression: "__self in [\"dev\", \"staging\", \"prod\"]"
@@ -761,7 +775,7 @@ Reads a value supplied at invocation time.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: parameter
       inputs:
         key: env
@@ -775,7 +789,7 @@ Reads from the process environment.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: env
       inputs:
         key: PROJECT_NAME
@@ -789,7 +803,7 @@ Supplies a literal value.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: static
       inputs:
         value: my-app
@@ -803,7 +817,7 @@ Reads data from the local filesystem.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: filesystem
       inputs:
         operation: read
@@ -818,7 +832,7 @@ Reads data from a git repository or working tree.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: git
       inputs:
         field: branch
@@ -832,7 +846,7 @@ Fetches data from an HTTP endpoint.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: api
       inputs:
         endpoint: https://api.example.com/project
@@ -847,7 +861,7 @@ Derives a value using CEL.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: cel
       inputs:
         expression: _.org + "/" + _.repo
@@ -993,6 +1007,42 @@ func (p *APIProvider) Execute(ctx context.Context, input any) (ProviderOutput, e
   if !ok {
     return ProviderOutput{}, fmt.Errorf("execution mode not in context")
   }
+  
+  isDryRun := DryRunFromContext(ctx)
+  
+  // Extract timeout
+  deadline, hasDeadline := ctx.Deadline()
+  if hasDeadline {
+    timeout := time.Until(deadline)
+    // Adjust operation based on available time
+  }
+  
+  // Extract logger
+  lgr := logger.FromContext(ctx)
+  lgr.V(1).Info("executing provider", "mode", execMode, "dryRun", isDryRun)
+  
+  // Access resolver context if needed
+  // For example, in a CEL provider that needs to evaluate expressions:
+  data := ResolverContextFromContext(ctx)
+  
+  if execMode == CapabilityTransform || execMode == CapabilityValidation {
+    selfValue := data["__self"] // Current value in transform/validate
+    // Use selfValue in transformation or validation logic
+  }
+  
+  // Access other resolver values
+  if environment, ok := data["environment"].(string); ok {
+    lgr.V(1).Info("using environment", "env", environment)
+  }
+  
+  // Execute based on mode and dry-run flag
+  if isDryRun {
+    return p.mockExecute(execMode, input)
+  }
+  
+  return p.realExecute(ctx, execMode, input)
+}
+~~~
   
   isDryRun := DryRunFromContext(ctx)
   if isDryRun {

--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -30,18 +30,153 @@ A resolver is not responsible for:
 
 ## Resolver Context
 
-Resolvers evaluate expressions against a single context object named `_`.
+Resolvers evaluate expressions against a single resolver context object named `_`.
 
-Nothing appears in `_` unless it is emitted by a resolver.
+**Key principles:**
 
 - `_` contains only resolver outputs
-- If a solution needs metadata, it must define a resolver (for example `meta`) and populate it using a provider
+- Nothing appears in `_` unless explicitly emitted by a resolver
+- If a solution needs metadata (version, environment, etc.), it must define a resolver (e.g., `meta`) and populate it using a provider
 
-Special symbol:
+**Special symbols:**
 
 - `__self` refers to the current value being transformed or validated
+- In the resolve phase, `__self` represents the value from the previous source (available in `until:` conditions)
+- In the transform phase, `__self` is the value from the previous transform step
+- In the validate phase, `__self` is the final transformed value
+- Resolver names cannot be prefixed with `__` (reserved for internal use)
 
-> Note: resolvers cannot be prefixed with __ because this is reserved for internal use
+**Implementation:**
+
+Resolver results are stored in a thread-safe map (`sync.Map`) that is request-scoped (lives in the context). This map is exposed to CEL expressions as the `_` variable with type `map[string]any`.
+
+**Thread Safety:**
+
+- The resolver map uses `sync.Map` for concurrent read/write safety
+- All resolver writes are atomic and happen immediately after the emit phase
+- Reads from `_` within CEL expressions are safe during concurrent resolver execution
+- Provider implementations must be thread-safe as they may execute concurrently within the same phase
+- No additional locking is required when accessing resolver values via `_`
+
+**Execution Model:**
+
+Resolvers are executed in phases based on their dependency graph:
+
+- Resolvers are grouped into phases where all resolvers in phase N have no dependencies on each other
+- All resolvers in phase N must complete before any resolver in phase N+1 begins
+- Within a phase, resolvers execute concurrently (order is non-deterministic)
+- Each resolver writes to the `sync.Map` **immediately** after completing its emit phase
+- This ensures that failed resolvers can emit partial values that are visible to dependent resolvers before they fail
+
+---
+
+## Type System
+
+Resolvers support optional type declarations for validation and automatic type coercion.
+
+### Supported Types
+
+- `string` - Text values
+- `int` - Integer numbers
+- `float` - Floating-point numbers
+- `bool` - Boolean true/false
+- `array` - Ordered lists (coerces single values to single-element arrays)
+- `any` - No type constraint (default, use for maps/objects with dynamic structure)
+
+### Type Declaration
+
+Types are declared at the resolver level:
+
+~~~yaml
+spec:
+  resolvers:
+    port:
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: port
+
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
+
+    config:
+      type: any
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: config
+~~~
+
+### Type Coercion
+
+When a type is explicitly declared, scafctl will attempt to coerce the resolved value to the declared type:
+
+- `"8080"` → `8080` (string to int)
+- `"3.14"` → `3.14` (string to float)
+- `"true"` → `true` (string to bool)
+- `123` → `"123"` (int to string)
+- `"foo"` → `["foo"]` (single value to array)
+- `123` → `[123]` (single value to array)
+- `["a", "b"]` → `["a", "b"]` (array unchanged)
+- `[[1, 2]]` → `[[1, 2]]` (already an array, passes through)
+
+**Coercion rules:**
+
+- Type coercion only occurs when a type is explicitly declared
+- If coercion fails, the resolver fails with a type error
+- Coercion happens **twice**: after the resolve phase completes (before transform begins) and after the transform phase completes (before validate begins)
+- **No inter-step coercion**: Type coercion does NOT occur between individual transform steps. Transform steps work with the actual runtime types of values. Only the final output of the transform phase is coerced.
+- This ensures type consistency at resolver phase boundaries while allowing flexible type manipulation within the transform phase
+- **Array coercion**: Non-array values are wrapped in a single-element array. Already-arrays pass through unchanged. This is useful when a field can accept either a single value or multiple values.
+
+### Type Validation
+
+Type validation occurs automatically when a type is declared:
+
+~~~yaml
+spec:
+  resolvers:
+    replicas:
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: replicas  # Must be coercible to int
+~~~
+
+If the value cannot be coerced to the declared type, the resolver fails.
+
+### Type Constraints
+
+Additional constraints (min/max, length, pattern) should be enforced in the `validate` phase, not in the type declaration:
+
+~~~yaml
+spec:
+  resolvers:
+    port:
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: port
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1 && __self <= 65535"
+            message: "Port must be between 1 and 65535"
+~~~
+
 ---
 
 ## Resolver Model
@@ -65,6 +200,181 @@ Each resolver follows this sequence exactly and in order.
 
 Resolvers execute through four fixed phases.
 
+### Resolver Execution Order Visualization
+
+Resolvers are executed in phases based on their dependency graph. Here's a concrete example:
+
+~~~yaml
+spec:
+  resolvers:
+    # Phase 1: No dependencies - execute concurrently
+    static_value:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base"
+
+    param_value:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: input
+
+    # Phase 2: Depends only on Phase 1 resolvers - execute concurrently after Phase 1 completes
+    computed_from_static:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.static_value + "-derived"
+
+    computed_from_param:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.param_value.toUpperCase()
+
+    # Phase 3: Depends on Phase 2 resolvers - executes after Phase 2 completes
+    final_value:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.computed_from_static + "-" + _.computed_from_param
+~~~
+
+**Execution flow:**
+
+1. **Phase 1**: `static_value` and `param_value` execute concurrently (no dependencies)
+2. **Phase 1 completes**: Both values written to `_` before Phase 2 begins
+3. **Phase 2**: `computed_from_static` and `computed_from_param` execute concurrently
+4. **Phase 2 completes**: Both values written to `_` before Phase 3 begins
+5. **Phase 3**: `final_value` executes (depends on Phase 2 results)
+
+If any resolver in a phase fails, that phase completes its running resolvers, then execution terminates. Subsequent phases never execute.
+
+---
+
+## Resolver Naming Conventions
+
+Resolver names must follow these rules:
+
+**Restrictions:**
+
+- Cannot start with `__` (double underscore) - reserved for internal use
+- Cannot contain whitespace
+
+**Allowed formats:**
+
+- `camelCase` - **Recommended best practice**
+- `snake_case` - Acceptable
+- `kebab-case` - Acceptable
+- Any combination of alphanumeric characters, underscores, and hyphens
+
+**Examples:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Recommended (camelCase)
+    apiEndpoint:
+      resolve: ...
+
+    userName:
+      resolve: ...
+
+    # Acceptable (snake_case)
+    api_endpoint:
+      resolve: ...
+
+    # Acceptable (kebab-case)
+    api-endpoint:
+      resolve: ...
+
+    # INVALID - starts with __
+    __internal:
+      resolve: ...
+~~~
+
+**Reserved names:**
+
+- `__self` - Used for current value in transform/validate contexts
+- Any name starting with `__` is reserved for future internal use
+
+---
+
+## Empty and Null Value Handling
+
+Null values are valid and have specific handling semantics in scafctl resolvers.
+
+### Null as Valid Value
+
+- A resolver can successfully emit `null` as its value
+- `null` is treated as a valid emitted value and stored in `_`
+- Dependent resolvers can access and reference `null` values
+
+### Null Behavior in Resolve Phase
+
+When using `until:` with null values:
+
+~~~yaml
+spec:
+  resolvers:
+    name:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
+          - provider: env
+            inputs:
+              key: PROJECT_NAME
+          - provider: static
+            inputs:
+              value: null
+          - provider: static
+            inputs:
+              value: "fallback"
+        until:
+          expr: __self != null
+~~~
+
+**Evaluation with null:**
+
+- `__self != null` evaluates to `false` when `__self` is `null` (standard boolean logic)
+- When `until:` evaluates to `false`, processing continues to the next source
+- In the example above, all four sources would be evaluated because the first three could return `null`
+
+### Empty vs Null vs Missing
+
+- **`null`**: Resolver executed and emitted `null` - accessible via `_.resolverName`, value is `null`
+- **Empty string** (`""`): Valid string value, different from `null`
+- **Missing**: Resolver did not execute (e.g., `when: false`) - resolver does not exist in `_`, must check with `has(_.resolverName)`
+
+### Checking for Null Values
+
+~~~yaml
+spec:
+  resolvers:
+    optional_value:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: optional
+
+    dependent:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # Check if resolver exists AND is not null
+              expression: has(_.optional_value) && _.optional_value != null ? _.optional_value : "default"
+~~~
+
 ---
 
 ## 1. Resolve
@@ -73,7 +383,7 @@ The resolve phase selects an initial value from one or more sources.
 
 ~~~yaml
 resolve:
-  from:
+  with:
     - provider: parameter
       inputs:
         key: name
@@ -89,13 +399,40 @@ Key properties:
 
 - Uses providers explicitly
 - Sources are evaluated in order
-- First non-null value wins by default
+- **Default behavior** (when `until:` is not specified): All sources are evaluated until the first non-null value is found
 - Providers return data via `ProviderOutput` structure (containing data, optional warnings, and metadata)
 
 Optional controls:
 
 - `when:` to conditionally skip the resolve phase or a source (must be a boolean)
 - `until:` to stop evaluation early (must be a boolean)
+
+### `until:` in Resolve
+
+The `until:` control in the resolve phase stops source evaluation when a condition is met:
+
+- **Evaluation timing**: Checked **after** each source completes
+- **Early termination**: When the condition evaluates to `true`, processing stops and the current value is emitted
+- **Default behavior**: When `until:` is not specified, all sources are evaluated until the first non-null value is encountered
+- **Use case**: Stop at first non-null value or when a specific condition is satisfied
+
+**Example:**
+
+~~~yaml
+resolve:
+  with:
+    - provider: parameter
+      inputs:
+        key: name
+    - provider: env
+      inputs:
+        key: PROJECT_NAME
+    - provider: static
+      inputs:
+        value: my-app
+  until:
+    expr: __self != null  # Stop at first non-null value
+~~~
 
 ### `when:` Rule
 
@@ -104,25 +441,26 @@ Optional controls:
 Example:
 
 ~~~yaml
-resolvers:
-  foo:
-    resolve:
-      from:
-        - provider: static
-          inputs:
-            value: hello
+spec:
+  resolvers:
+    foo:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
 
-  name:
-    resolve:
-      from:
-        - provider: env
-          when:
-            expr: _.foo == "hello"
-          inputs:
-            key: PROJECT_NAME
-        - provider: static
-          inputs:
-            value: my-app
+    name:
+      resolve:
+        with:
+          - provider: env
+            when:
+              expr: _.foo == "hello"
+            inputs:
+              key: PROJECT_NAME
+          - provider: static
+            inputs:
+              value: my-app
 ~~~
 
 The resolve phase answers: where does the value come from?
@@ -149,13 +487,13 @@ The distinction is semantic:
 - Resolve selects an initial value from sources
 - Transform derives new values from an existing value
 
-Although transform uses providers, it does not choose between competing inputs. It applies a sequence of operations to a single value. This is why the keyword is `into` rather than `from`.
+All phases now use the `with:` keyword for consistency and simplicity.
 
 #### Example Using Multiple Providers
 
 ~~~yaml
 transform:
-  into:
+  with:
     - provider: filesystem
       inputs:
         operation: read
@@ -163,15 +501,15 @@ transform:
 
     - provider: cel
       inputs:
-        expr: __self.trim()
+        expression: __self.trim()
 
     - provider: cel
       inputs:
-        expr: __self.toLowerCase()
+        expression: __self.toLowerCase()
 
     - provider: cel
       inputs:
-        expr: __self.replace("_", "-")
+        expression: __self.replace("_", "-")
 ~~~
 
 In this example:
@@ -182,32 +520,107 @@ In this example:
 
 Transform providers must be deterministic and free of externally visible side effects.
 
-#### Controls
+#### Complex Provider Chaining Examples
 
-- `when:` at transform level to skip all steps
-- `when:` at item level to conditionally apply a step
-- `until:` to stop processing once a condition is met
+**Example 1: HTTP → JSON Parse → CEL → Base64**
 
-The transform phase answers: how should this value be shaped?
+~~~yaml
+spec:
+  resolvers:
+    encodedApiData:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://api.example.com/config"
+      transform:
+        with:
+          # Step 1: Fetch data from HTTP endpoint
+          - provider: http
+            inputs:
+              url: 
+                expr: __self
+              method: GET
+          # Step 2: Parse JSON response
+          - provider: jq
+            inputs:
+              expression: __self.apiKey
+          # Step 4: Encode result
+          - provider: base64
+            inputs:
+              expression: |
+                {
+                  "name": __self.metadata.name,
+                  "endpoint": __self.spec.host + ":" + string(__self.spec.port),
+                  "timeout": __self.spec.timeout.seconds + "s"
+                }
+# Result: Structured config object with computed endpoint
+~~~
 
----
+**Example 3: Multi-stage data transformation**
 
-## 3. Validate
+~~~yaml
+spec:
+  resolvers:
+    processedData:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: rawData
+      transform:
+        with:
+          # Step 1: Parse CSV input
+          - provider: csv
+            inputs:
+              expression: __self.filter(row, row.status == "active")
+          # Step 3: Transform each row
+          - provider: cel
+            inputs:
+              expression: |
+                __self.map(row, {
+                  "id": row.id,
+                  "name": row.name.toUpperCase(),
+                  "processedAt": now()
+                })
+          # Step 4: Convert to JSON
+          - provider: json
+            inputs:
+              match: "^[a-z0-9-]+$"
+            message: "Must be lowercase alphanumeric with hyphens"
+          - provider: validation
+            inputs:
+              notMatch: "^test$"
+            message: "Must not be 'test'"
+          - provider: validation
+            inputs:
+              expression: "__self.length() >= 3"
+            message: "Must be at least 3 characters"
+~~~
 
-The validate phase enforces constraints on the transformed value.
+**If user provides `name=A`:**
 
-Validation is provider-backed. Any provider that emits a boolean may be used for validation.
+- Validation 1: ❌ fails (contains uppercase)
+- Validation 2: ✅ passes (not "test")
+- Validation 3: ❌ fails (only 1 character)
 
-Validation providers must return `ProviderOutput` with `Data` containing a boolean value indicating success (true) or failure (false).
+**Error output:**
+```
+Error: Resolver 'name' validation failed:
+  - Must be lowercase alphanumeric with hyphens
+  - Must be at least 3 characters
+```
 
-scafctl provides a built-in provider named `validation` that supports `match`, `notMatch`.
+Only the failed validation messages are included in the error. The transformed value `"A"` is still emitted to `_` for use by error handlers or logging.
 
-Rules:
+### Validation Messages
 
-- All validations must pass
-- Validation failures stop execution
-- Validation does not mutate data
-- `match` and `notMatch` support all four input forms (literal, rslvr, expr, tmpl)
+Validation messages support all four input forms:
+
+- **Literal string**: Static error message
+- **Template (`tmpl`)**: Dynamic message with Go templating
+- **Expression (`expr`)**: Dynamic message computed via CEL
+- **Resolver (`rslvr`)**: Message from another resolver
 
 ### Examples
 
@@ -215,7 +628,7 @@ Literal regex match:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match: "^[a-z0-9-]+$"
@@ -226,7 +639,7 @@ Regex not match:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         notMatch: "^fff$"
@@ -237,7 +650,7 @@ Combining match and notMatch:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match: "^[a-z0-9-]+$"
@@ -249,7 +662,7 @@ Dynamic pattern using expression:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match:
@@ -261,7 +674,7 @@ Pattern from resolver:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         match:
@@ -273,11 +686,47 @@ CEL expression validation:
 
 ~~~yaml
 validate:
-  from:
+  with:
     - provider: validation
       inputs:
         expression: "__self in [\"dev\", \"staging\", \"prod\"]"
       message: "Invalid environment"
+~~~
+
+Dynamic message using template:
+
+~~~yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        match: "^[a-z0-9-]+$"
+      message:
+        tmpl: "Value '{{ .__self }}' must match pattern {{ _.namePattern }}"
+~~~
+
+Dynamic message using expression:
+
+~~~yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        expression: "__self.length() >= 3"
+      message:
+        expr: "'Value must be at least 3 characters, got ' + string(__self.length())"
+~~~
+
+Message from resolver:
+
+~~~yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        match: "^[a-z-]+$"
+      message:
+        rslvr: validationMessages.nameFormat
 ~~~
 
 ---
@@ -289,6 +738,113 @@ If resolve, transform, and validate succeed, the resolver emits its value.
 - The value becomes available as `_.<resolverName>`
 - Values are immutable after emission
 - Emission is implicit and cannot be customized
+
+### Value Immutability
+
+**Important:** Resolver value immutability is enforced by **convention**, not by runtime checks.
+
+**Behavior:**
+
+- scafctl does **not** perform deep copying of resolver values
+- Maps, arrays, and objects emitted by resolvers are stored by reference in the resolver context
+- Mutating a resolver value from CEL or provider code may cause unexpected behavior
+- Resolvers and actions should treat all values from `_` as read-only
+
+**Safe practices:**
+
+~~~yaml
+spec:
+  resolvers:
+    baseConfig:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                timeout: 30
+                retries: 3
+
+    # Good: Create new object, don't mutate baseConfig
+    extendedConfig:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                {
+                  "timeout": _.baseConfig.timeout,
+                  "retries": _.baseConfig.retries,
+                  "newField": "value"
+                }
+
+    # Unsafe: Attempting to mutate (behavior undefined)
+    # This pattern should be avoided
+    mutatedConfig:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                _.baseConfig.timeout = 60  # DO NOT DO THIS
+~~~
+
+**Why no enforcement?**
+
+- Performance: Deep copying every resolver value would add significant overhead
+- CEL immutability: CEL expressions naturally create new values rather than mutating existing ones
+- Provider responsibility: Providers should return new values, not mutate inputs
+
+If you need to modify a resolver value, create a new value derived from the original.
+
+---
+
+## Provider Output Structure
+
+Providers return data via a standardized structure that carries the value along with optional metadata.
+
+### Structure Definition
+
+~~~go
+type ProviderOutput struct {
+    Data     any                    // The actual value returned by the provider
+    Warnings []string               // Optional warnings (logged but don't stop execution)
+    Metadata map[string]any         // Provider-specific metadata (cache status, timing, etc.)
+}
+~~~
+
+### Field Usage
+
+**`Data` field:**
+- Contains the actual value returned by the provider
+- Type varies based on provider and context
+- Validation providers must return a boolean in `Data`
+- Resolve and transform providers can return any type
+
+**`Warnings` field:**
+- Contains non-fatal issues encountered during provider execution
+- Warnings are logged but do not stop resolver execution
+- Examples: cache misses, deprecated API usage, rate limit warnings
+
+**`Metadata` field:**
+- Provider-specific information about the operation
+- Common keys: `cache_hit`, `request_duration_ms`, `source`, `retry_count`
+- Used for observability and debugging
+- Not accessible in CEL expressions (internal use only)
+
+### Example
+
+~~~go
+// HTTP provider returning cached data
+return &ProviderOutput{
+    Data: responseBody,
+    Warnings: []string{"Response time exceeded 1s"},
+    Metadata: map[string]any{
+        "cache_hit":           true,
+        "request_duration_ms": 1250,
+        "status_code":         200,
+    },
+}
+~~~
 
 ---
 
@@ -344,7 +900,7 @@ inputs:
 For a single input field, it is an error to specify more than one of:
 
 - literal
-- `resolver`
+- `rslvr`
 - `expr`
 - `tmpl`
 
@@ -353,10 +909,16 @@ For a single input field, it is an error to specify more than one of:
 ### Go Representation (Custom Unmarshalling)
 
 ~~~go
+import (
+  "github.com/oakwood-commons/scafctl/pkg/celexp"
+  "github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
 type ValueRef struct {
   Literal  any
   Resolver *string
-  Expr     *string
+  Expr     *celexp.Expression
+  Tmpl     *gotmpl.GoTemplatingContent
 }
 
 func (v *ValueRef) UnmarshalYAML(node *yaml.Node) error {
@@ -364,8 +926,9 @@ func (v *ValueRef) UnmarshalYAML(node *yaml.Node) error {
 
   case yaml.MappingNode:
     var raw struct {
-      Resolver *string `yaml:"resolver"`
-      Expr     *string `yaml:"expr"`
+      Resolver *string                      `yaml:"rslvr"`
+      Expr     *celexp.Expression           `yaml:"expr"`
+      Tmpl     *gotmpl.GoTemplatingContent  `yaml:"tmpl"`
     }
     if err := node.Decode(&raw); err != nil {
       return err
@@ -378,13 +941,17 @@ func (v *ValueRef) UnmarshalYAML(node *yaml.Node) error {
     if raw.Expr != nil {
       count++
     }
+    if raw.Tmpl != nil {
+      count++
+    }
 
     if count != 1 {
-      return fmt.Errorf("invalid value ref: expected exactly one of resolver or expr")
+      return fmt.Errorf("invalid value ref: expected exactly one of rslvr, expr, or tmpl")
     }
 
     v.Resolver = raw.Resolver
     v.Expr = raw.Expr
+    v.Tmpl = raw.Tmpl
     return nil
 
   default:
@@ -485,6 +1052,28 @@ cat config.json | scafctl run solution example -r config=-
 -r data=https://example.com/data.json
 ~~~
 
+### Parsing Precedence
+
+When multiple formats are ambiguous, scafctl applies the following parsing order:
+
+1. **Stdin check**: If value is exactly `-`, read from stdin
+2. **File protocol**: If value starts with `file://`, treat as file reference
+3. **HTTP protocol**: If value starts with `http://` or `https://`, treat as URL reference
+4. **JSON parse**: If value starts with `{` or `[`, attempt JSON parse
+5. **Boolean parse**: If value is exactly `true` or `false` (case-insensitive), parse as boolean
+6. **Number parse**: Attempt to parse as integer or float
+7. **CSV detection**: If value contains `,` and not enclosed in quotes, split as CSV list
+8. **Literal string**: Fallback to treating value as literal string
+
+**Examples:**
+
+- `-r url=https://example.com` → URL reference (rule 3)
+- `-r url="https://example.com"` → Literal string (quotes override protocol detection)
+- `-r count=42` → Integer (rule 6)
+- `-r items=a,b,c` → Array `["a", "b", "c"]` (rule 7)
+- `-r flag=true` → Boolean `true` (rule 5)
+- `-r config={"key":"value"}` → JSON object (rule 4)
+
 ---
 
 ## Interaction with Cobra
@@ -508,33 +1097,531 @@ All parsing, decoding, validation, and error reporting occurs in scafctl core, n
 
 ---
 
+## Conditional Execution
+
+Resolvers support conditional execution using the `when:` clause.
+
+### Resolver-Level `when:`
+
+A resolver can be conditionally skipped based on previously emitted resolver values:
+
+~~~yaml
+spec:
+  resolvers:
+    feature_flag:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: enableFeatureX
+          - provider: static
+            inputs:
+              value: false
+
+    feature_x_config:
+      when:
+        expr: _.feature_flag == true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: featureXConfig
+~~~
+
+### Behavior When `when:` is False
+
+If the `when:` condition evaluates to `false`:
+
+- The resolver is **completely absent** from `_`
+- The resolver does not execute any phase (resolve, transform, validate)
+- No value is emitted
+- Dependent resolvers must handle the missing resolver
+
+### Handling Missing Resolvers
+
+Dependent resolvers must check for the existence of conditional resolvers using the `has()` CEL function:
+
+~~~yaml
+spec:
+  resolvers:
+    optional_feature:
+      when:
+        expr: _.flags.enableX == true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "feature-enabled"
+
+    dependent:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: has(_.optional_feature) ? _.optional_feature : "feature-disabled"
+~~~
+
+### Phase-Level `when:`
+
+There is **no** phase-level `when:` control. The `when:` clause only appears at:
+
+- Resolver level (skip entire resolver)
+- Source level in resolve phase (skip individual source)
+- Step level in transform phase (skip individual transform step)
+
+### Rules
+
+- `when:` expressions can only reference previously emitted resolvers
+- `when:` must evaluate to a boolean
+- **Dependency graph vs execution**: All resolvers (including conditional ones) appear in the dependency graph to determine execution order. However, only resolvers whose `when:` condition evaluates to `true` will execute and emit values to the `sync.Map` (accessible via `_`)
+- Resolvers with `when: false` are absent from `_` and must be checked with `has()`
+- Circular dependencies involving `when:` are rejected during graph construction
+
+---
+
 ## Resolver Dependencies
 
 Resolvers form a directed acyclic graph inferred from references.
 
 ~~~yaml
-resolvers:
-  name:
-    resolve:
-      from:
-        - provider: parameter
-          inputs:
-            key: name
+spec:
+  resolvers:
+    name:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
 
-  image:
-    resolve:
-      from:
-        - provider: cel
-          inputs:
-            expr: _.name + ":latest"
+    image:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.name + ":latest"
 ~~~
 
 Rules:
 
-- Dependencies are inferred from `_` references
-- Execution order is computed automatically
-- Independent resolvers execute concurrently
-- Cycles are rejected
+- Dependencies are inferred from `_` references in the dependency graph
+- Execution order is computed automatically from the dependency graph
+- Independent resolvers (no dependencies on each other) execute concurrently
+- Cycles in the dependency graph are rejected
+
+### Circular Dependency Detection
+
+Circular dependencies are detected during graph construction and cause immediate failure.
+
+**Example 1: Direct circular dependency (invalid)**
+
+~~~yaml
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.b + "-suffix"
+    b:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.a + "-suffix"
+~~~
+
+**Error message:**
+```
+Error: Circular dependency detected in resolvers: a → b → a
+```
+
+**Example 2: Indirect circular dependency (invalid)**
+
+~~~yaml
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.c + "-a"
+    b:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.a + "-b"
+    c:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.b + "-c"
+~~~
+
+**Error message:**
+```
+Error: Circular dependency detected in resolvers: a → c → b → a
+```
+
+**Example 3: Circular dependency with `when:` clause (invalid)**
+
+~~~yaml
+spec:
+  resolvers:
+    a:
+      when:
+        expr: _.b == "trigger"  # Creates dependency on b
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "a-value"
+    b:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: has(_.a) ? _.a + "-b" : "default-b"  # Creates dependency on a
+~~~
+
+**Error message:**
+```
+Error: Circular dependency detected in resolvers: a → b → a
+```
+
+**Important:** Even though `a` is conditionally executed, it still creates a dependency on `b` in the `when:` clause. The dependency graph includes all resolvers and all references, regardless of conditional execution.
+
+**Example 4: Valid conditional reference (no cycle)**
+
+~~~yaml
+spec:
+  resolvers:
+    feature_flag:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: enableFeature
+          - provider: static
+            inputs:
+              value: false
+
+    feature_config:
+      when:
+        expr: _.feature_flag == true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: featureConfig
+
+    app_config:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # No cycle: app_config depends on feature_config, but feature_config doesn't depend on app_config
+              expression: has(_.feature_config) ? _.feature_config : {"default": true}
+~~~
+
+This is valid because the dependency flow is: `feature_flag` → `feature_config` → `app_config` (no cycles).
+
+---
+
+## Resolver Timeouts
+
+Resolvers support configurable timeouts to prevent hung providers from blocking execution indefinitely.
+
+### Timeout Configuration
+
+Timeouts can be specified at three levels:
+
+1. **Global default**: Applied to all resolvers unless overridden (default: 30 seconds)
+2. **Resolver-level**: Specified in resolver definition
+3. **Provider-level**: Some providers may have their own internal timeouts
+
+**Timeout precedence:**
+
+- The **resolver timeout is the hard limit** for all resolver execution (all phases combined)
+- Provider-level timeouts should be **shorter than or equal to** the resolver timeout
+- If a provider has a longer timeout than the resolver, the resolver timeout will cancel the provider's operation when reached
+- Provider implementations receive a context with the resolver timeout and should respect context cancellation
+- When both are configured, the resolver timeout takes precedence—the operation will be cancelled when the resolver timeout expires, regardless of provider timeout settings
+
+### Resolver-Level Timeout
+
+~~~yaml
+spec:
+  resolvers:
+    external_data:
+      timeout: 10s  # This resolver must complete within 10 seconds
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://slow-api.example.com/data
+~~~
+
+### Timeout Behavior
+
+- Timeout applies to the entire resolver execution (all phases combined)
+- On timeout, the resolver fails with a timeout error
+- Partial results are emitted according to standard error handling rules
+- The timeout context is propagated to the provider implementation
+- Providers should respect context cancellation for proper timeout handling
+
+### Best Practices
+
+- Set shorter timeouts for external dependencies (HTTP, database queries)
+- Use longer timeouts for complex transformations or validations
+- Provider implementations should implement their own internal timeouts for granular control
+- Consider retry logic in providers rather than relying solely on resolver timeouts
+
+---
+
+## Error Handling
+
+When a resolver encounters an error during any phase, execution stops and an error is returned.
+
+### Error Propagation
+
+- **Current phase completion**: Resolvers in the current phase (same dependency level) are allowed to complete
+- **Subsequent phase halt**: All resolvers in subsequent phases (higher dependency levels) are never executed
+- **Execution termination**: Once the current phase completes, the entire resolver execution process terminates with an error
+
+### Partial Emission
+
+Resolvers emit the value from the last successful phase before failure:
+
+- If **resolve** succeeds but **transform** fails → emit the resolved value (pre-transform)
+- If **resolve** and **transform** succeed but **validate** fails → emit the transformed value
+- The failed resolver's partial value is accessible in `_`
+
+**Important notes about partial values:**
+
+- Partial values are stored in `_` **identically to successful values**
+- There is **no flag or marker** indicating a resolver failed
+- Dependent resolvers cannot distinguish between successful and partial emission by inspecting `_` alone
+- The resolver execution process terminates with an error after the current phase completes
+- Partial emission exists primarily for error reporting and debugging
+
+**Checking for resolver failures:**
+
+You cannot programmatically detect resolver failures within the solution configuration because execution stops when a resolver fails. However, partial values are useful for:
+
+- Error messages that reference the failed resolver's value
+- Logging and debugging output
+- Understanding what data was available before the failure
+
+**Example:**
+
+~~~yaml
+spec:
+  resolvers:
+    userName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: user  # Returns "ADMIN"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: __self.unknownFunc()  # Fails with error
+      # Result: _.userName = "ADMIN" (resolved value, before transform)
+      # Error is raised, but "ADMIN" is accessible in error context
+~~~
+
+In this example, the resolver fails during transform, but `_.userName` contains `"ADMIN"`. This allows error messages to reference the value that caused the problem.
+
+### Example
+
+~~~yaml
+spec:
+  resolvers:
+    # Phase 1
+    base:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-value"
+
+    # Phase 1 (independent of base)
+    name:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name  # Returns "MyApp"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: __self.toLowerCase()  # Fails due to error
+      # Result: _.name = "MyApp" (resolved value, not transformed)
+      # Error occurs, but phase 1 completes (base resolver finishes)
+
+    # Phase 2 (depends on name)
+    image:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.name + "-image"  
+      # This resolver is NEVER EXECUTED because name failed in phase 1
+
+    # Phase 2 (depends on base)
+    derived:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.base + "-suffix"
+      # This resolver is NEVER EXECUTED because execution stopped after phase 1
+~~~
+
+In this example:
+
+1. Phase 1 executes: `base` succeeds, `name` fails during transform but emits "MyApp"
+2. Phase 1 completes (all resolvers in phase 1 finish)
+3. Execution terminates with error
+4. Phase 2 resolvers (`image`, `derived`) are never executed
+
+### Retry Behavior
+
+Retry logic is a provider concern, not a resolver concern. Providers may implement their own retry mechanisms.
+
+### Context Cancellation
+
+Resolver execution respects context cancellation for graceful shutdown.
+
+**Cancellation behavior:**
+
+- User interruption (Ctrl+C) or timeout triggers context cancellation
+- Cancellation propagates immediately to all running resolvers in the current phase
+- Provider implementations must respect context cancellation and return promptly
+- Resolvers that have not yet started are never executed
+- Partial results from cancelled resolvers are **not** emitted to `_`
+- Dependent resolvers in subsequent phases are never executed
+
+**Provider requirements:**
+
+- Providers should check context cancellation at appropriate intervals
+- Long-running operations (HTTP requests, file I/O) should pass the context through
+- On cancellation, providers should clean up resources and return a cancellation error
+
+**Example of cancellation-aware provider:**
+
+~~~go
+func (p *HTTPProvider) Execute(ctx context.Context, inputs map[string]any) (*ProviderOutput, error) {
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil {
+        return nil, err
+    }
+    
+    resp, err := p.client.Do(req)
+    if err != nil {
+        if ctx.Err() != nil {
+            return nil, fmt.Errorf("request cancelled: %w", ctx.Err())
+        }
+        return nil, err
+    }
+    // ... rest of implementation
+}
+~~~
+
+---
+
+## Caching & Performance
+
+### Intra-Execution Caching
+
+Resolver results are automatically cached within a single solution execution:
+
+- Once a resolver emits a value to `_`, it is not re-executed during that execution
+- All references to `_.resolverName` return the same cached value
+- The cache lifetime is scoped to a single solution run
+
+### Provider-Level Caching
+
+Caching of expensive operations (HTTP calls, file reads, etc.) is a provider concern:
+
+- Providers may implement their own caching strategies
+- Cache invalidation occurs when cache keys change
+- Resolvers do not declare themselves as "expensive" - the execution model handles all resolvers uniformly
+
+### Example
+
+~~~yaml
+spec:
+  resolvers:
+    api_config:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/config
+              # Provider handles caching based on URL and headers
+
+    derived_value:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.api_config.setting  # Uses cached result from api_config
+~~~
+
+### Memory Considerations
+
+Resolver values are stored in memory for the duration of solution execution. Consider the following when designing resolvers:
+
+**Size limitations:**
+
+- Avoid emitting very large values (multi-MB) from resolvers
+- Large datasets should be processed incrementally rather than loaded entirely into resolver context
+- The `sync.Map` storing resolver values is held in memory until solution execution completes
+
+**Best practices for large data:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Bad: Loading large file into resolver
+    largeDataset:
+      resolve:
+        with:
+          - provider: filesystem
+            inputs:
+              operation: read
+              path: ./data/large-file.json  # 50MB file
+
+    # Good: Store file reference, not content
+    datasetPath:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: ./data/large-file.json
+
+    # Actions can then stream/process the file incrementally
+~~~
+
+**Memory optimization tips:**
+
+- Use file paths or URLs as resolver values instead of loading full content
+- Filter or transform large datasets to extract only needed fields in resolvers
+- Consider whether data truly needs to be shared (via resolvers)
+
+**Concurrent access:**
+
+- The `sync.Map` used for resolver context is optimized for concurrent reads
+- Multiple resolvers reading from `_` simultaneously do not create contention
+- Memory is not duplicated when multiple resolvers reference the same value
 
 ---
 
@@ -554,6 +1641,445 @@ scafctl run solution myapp --resolve-all
 
 ---
 
+## Best Practices
+
+### Resolver Granularity
+
+**Keep resolvers focused and single-purpose:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: Separate concerns
+    apiHost:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: host
+
+    apiPort:
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: port
+
+    apiEndpoint:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "https://" + _.apiHost + ":" + string(_.apiPort)
+~~~
+
+~~~yaml
+spec:
+  resolvers:
+    # Avoid: One massive resolver doing too much
+    apiConfig:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: config  # Contains host, port, protocol, auth, etc.
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                {
+                  "endpoint": __self.protocol + "://" + __self.host + ":" + string(__self.port),
+                  "auth": __self.auth_type + ":" + __self.auth_token,
+                  "timeout": __self.timeout_ms,
+                  # Too much logic in one place
+                }
+~~~
+
+**When to split resolvers:**
+
+- When different parts have different fallback strategies
+- When different parts have different validation rules
+- When intermediate values are useful to other resolvers
+- When type coercion is needed for specific fields
+
+**When to combine resolvers:**
+
+- When the combined value is always used together
+- When splitting creates unnecessary complexity
+- When the data source naturally provides the complete structure
+
+### Dependency Management
+
+**Minimize dependency chains:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: Flat dependency structure
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+
+    clusterName:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.environment + "-" + _.region + "-cluster"
+~~~
+
+~~~yaml
+spec:
+  resolvers:
+    # Avoid: Unnecessary chaining
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+
+    regionPrefix:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.region + "-"
+
+    clusterName:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.regionPrefix + "cluster"  # Unnecessary intermediate step
+~~~
+
+**Leverage concurrent execution:**
+
+- Design resolvers to execute in parallel when possible
+- Avoid creating artificial dependencies between independent resolvers
+- Group related resolvers that depend on the same inputs
+
+### Transform vs Validate
+
+**Use transform for data shaping:**
+
+~~~yaml
+spec:
+  resolvers:
+    userName:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: user
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: __self.trim().toLowerCase()
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z0-9-]+$"
+            message: "Username must be lowercase alphanumeric with hyphens"
+~~~
+
+**Use validate for constraints:**
+
+~~~yaml
+spec:
+  resolvers:
+    port:
+      type: int
+      resolve:
+        from:
+          - provider: parameter
+            inputs:
+              key: port
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1 && __self <= 65535"
+            message: "Port must be between 1 and 65535"
+~~~
+
+**Guidelines:**
+
+- **Transform**: Normalizing, formatting, deriving, cleaning data
+- **Validate**: Enforcing business rules, checking constraints, ensuring correctness
+- Avoid using transform for validation (e.g., don't throw errors in CEL expressions)
+- Avoid using validate for data transformation
+
+### Conditional Resolvers
+
+**Use `when:` for feature flags and optional configuration:**
+
+~~~yaml
+spec:
+  resolvers:
+    enableCaching:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: cache
+          - provider: static
+            inputs:
+              value: false
+
+    cacheConfig:
+      when:
+        expr: _.enableCaching == true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: cacheConfig
+
+    dependent:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # Always check with has()
+              expression: has(_.cacheConfig) ? _.cacheConfig.ttl : 0
+~~~
+
+**Guidelines:**
+
+- Always use `has()` when referencing conditional resolvers
+- Document which resolvers are conditionally executed
+- Consider providing safe defaults when conditional resolvers are absent
+
+### Type Declarations
+
+**Declare types for CLI parameters and external inputs:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: Declare types for user input
+    replicas:
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: replicas
+
+    enableDebug:
+      type: bool
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: debug
+~~~
+
+**Use `any` for complex or dynamic structures:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: Use any for complex JSON
+    config:
+      type: any
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: config
+~~~
+
+**Guidelines:**
+
+- Always declare types for scalar CLI parameters
+- Use `any` for maps/objects with dynamic keys
+- Let type coercion handle string-to-type conversion
+- Validate type constraints in the `validate` phase, not through type declarations
+
+### Error Handling
+
+**Design for graceful failure with fallbacks:**
+
+~~~yaml
+spec:
+  resolvers:
+    apiUrl:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: url
+          - provider: env
+            inputs:
+              key: API_URL
+          - provider: static
+            inputs:
+              value: "https://api.example.com"
+~~~
+
+**Document failure modes:**
+
+~~~yaml
+spec:
+  resolvers:
+    externalData:
+      description: "Fetches configuration from external API. Falls back to local cache if API is unavailable."
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://config-api.example.com/settings"
+          - provider: filesystem
+            inputs:
+              operation: read
+              path: "./cache/settings.json"
+~~~
+
+**Guidelines:**
+
+- Provide sensible defaults using static providers
+- Order sources from most specific to most general
+- Use `until:` to short-circuit on successful retrieval
+- Document expected failure scenarios in resolver descriptions
+
+### Naming
+
+**Use descriptive, consistent names:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: Clear and descriptive
+    databaseConnectionString:
+      resolve:
+        with: []
+
+    kubernetesNamespace:
+      resolve:
+        with: []
+
+    # Avoid: Ambiguous or too short
+    db:
+      resolve:
+        with: []
+
+    ns:
+      resolve:
+        with: []
+~~~
+
+**Establish naming conventions:**
+
+- Use camelCase consistently (recommended)
+- Group related resolvers with common prefixes (e.g., `api*`, `database*`)
+- Use full words instead of abbreviations
+- Make boolean resolver names clearly boolean (e.g., `enableFeatureX`, `isProduction`)
+
+### Performance
+
+**Avoid unnecessary dependencies:**
+
+~~~yaml
+spec:
+  resolvers:
+    # Good: No dependency on unrelated resolvers
+    serviceA:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: serviceA
+
+    serviceB:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: serviceB
+    # serviceA and serviceB execute concurrently
+~~~
+
+~~~yaml
+spec:
+  resolvers:
+    # Avoid: Artificial dependency
+    serviceA:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: serviceA
+
+    serviceB:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # Unnecessary reference to serviceA
+              expression: _.serviceA != null ? "serviceB-value" : "serviceB-value"
+    # serviceB must wait for serviceA even though it doesn't need it
+~~~
+
+**Leverage provider-level caching:**
+
+- Expensive operations (HTTP calls, file reads) are cached by providers
+- Avoid duplicating expensive provider calls in multiple resolvers
+- Extract shared expensive operations to a single resolver and reference it
+
+---
+
+## Resolver Metadata
+
+Resolvers support metadata fields for documentation and operational purposes:
+
+### Supported Metadata Fields
+
+- **`description`**: Human-readable explanation of the resolver's purpose
+- **`displayName`**: Friendly name for UI and logging (defaults to resolver key)
+- **`sensitive`**: Boolean flag indicating the value should be redacted in logs and output
+- **`example`**: Example value for documentation and testing
+
+### Example
+
+~~~yaml
+spec:
+  resolvers:
+    api_token:
+      description: API authentication token for external service
+      displayName: API Token
+      sensitive: true
+      example: "sk_test_1234567890abcdef"
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: token
+          - provider: env
+            inputs:
+              key: API_TOKEN
+~~~
+
+---
+
 ## Resolver Example
 
 ~~~yaml
@@ -561,9 +2087,12 @@ spec:
   resolvers:
     environment:
       description: Deployment environment
+      displayName: Environment
+      example: dev
+      type: string
 
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: env
@@ -572,13 +2101,13 @@ spec:
               value: dev
 
       transform:
-        into:
+        with:
           - provider: cel
             inputs:
-              expr: __self.toLowerCase()
+              expression: __self.toLowerCase()
 
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"dev\", \"staging\", \"prod\"]"

--- a/docs/design/solutions.md
+++ b/docs/design/solutions.md
@@ -86,7 +86,7 @@ resolvers:
   image:
     description: Container image to deploy
     resolve:
-      from:
+      with:
         - provider: parameter
           inputs:
             key: image
@@ -94,7 +94,7 @@ resolvers:
           inputs:
             value: nginx:1.27
     validate:
-      from:
+      with:
         - provider: validation
           inputs:
             match: "^[a-z0-9.-]+:[a-z0-9.-]+$"
@@ -302,7 +302,7 @@ spec:
     environment:
       description: Target deployment environment
       resolve:
-        from:
+        with:
           - provider: parameter
             inputs:
               key: env
@@ -310,12 +310,12 @@ spec:
             inputs:
               value: dev
       transform:
-        into:
+        with:
           - provider: cel
             inputs:
               expression: "__self.toLowerCase()"
       validate:
-        from:
+        with:
           - provider: validation
             inputs:
               expression: "__self in [\"dev\", \"staging\", \"prod\"]"
@@ -366,16 +366,16 @@ spec:
     resolverName:
       description: string             # Optional: resolver purpose
       resolve:
-        from:                         # Required: provider list
+        with:                         # Required: provider list
           - provider: provider-name
             inputs: {}
       transform:                      # Optional: transformation pipeline
-        into:
+        with:
           - provider: cel
             inputs:
               expression: string
       validate:                       # Optional: validation rules
-        from:
+        with:
           - provider: validation
             inputs:
               expression: string

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -65,7 +65,7 @@ Given this resolver:
 resolvers:
   environment:
     resolve:
-      from:
+      with:
         - provider: parameter
           inputs:
             key: env
@@ -74,13 +74,13 @@ resolvers:
             value: dev
 
     transform:
-      into:
+      with:
         - provider: cel
           inputs:
             expression: "__self.toLowerCase()"
 
     validate:
-      from:
+      with:
         - provider: validation
           inputs:
             expression: "__self in [\"dev\", \"staging\", \"prod\"]"


### PR DESCRIPTION
clarify execution semantics and add implementation guidance

- Clarify type coercion occurs only after complete phases, not between transform steps
- Add dedicated section explaining default behavior when `until:` is omitted
- Document timeout precedence (resolver timeout is hard limit over provider timeouts)
- Add Memory Considerations section with best practices for large data handling
- Expand Value Immutability section explaining convention-based enforcement
- Clarify partial emission behavior in error handling (no distinguishing markers in context)
- Add comprehensive provider chaining examples for multi-step transformations
- Standardize terminology: use "resolver context" and "dependency graph" consistently

These improvements address operational details and edge cases encountered in practice while maintaining the core design principles.