### PR TITLE
fix(release): migrate from deprecated brews to homebrew_casks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,5 +45,6 @@ jobs:
         run: task release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GIT_EVENT: push
           GIT_REF: ${{ github.ref }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,18 +45,17 @@ signs:
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "--yes"
-brews:
+homebrew_casks:
   - name: scafctl
     repository:
       owner: oakwood-commons
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/oakwood-commons/scafctl"
     description: "A configuration discovery and scaffolding tool using CEL for dynamic evaluation"
     license: "Apache-2.0"
-    install: |
-      bin.install "scafctl"
-    test: |
-      system "#{bin}/scafctl", "version"
+    binaries:
+      - "scafctl"
 release:
   draft: false
   prerelease: auto


### PR DESCRIPTION
## Description

Replace deprecated `brews` configuration with `homebrew_casks` as recommended by GoReleaser v2.10+. Switch from formula-style `install`/`test` blocks to the cask-style `binaries` array.

This resolves the deprecation warning:
"brews is being phased out in favor of homebrew_casks"