### PR TITLE
feat(provider): add directory builtin provider with documentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,35 @@ linters:
       - path: pkg/celexp/ext/sort/sort\.go
         linters:
           - dupl
+      # Exclude var-naming for packages that intentionally shadow standard library names
+      - path: pkg/filepath/filepath\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/fs/fs\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/metrics/metrics\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/celexp/ext/debug/debug\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/cmd/scafctl/build/solution\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/plugin/server\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/plugin/.*\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
 formatters:
   enable:
     - gofumpt

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ scafctl is a CLI tool that lets you declaratively gather data from any source (A
 - **Solution** — A YAML file that declares what data to gather and what work to do. Solutions are versionable, composable, and shareable via OCI registries.
 - **Resolver** — A named unit that gathers or computes a value using one or more providers. Resolvers can depend on each other and execute in parallel when possible.
 - **Action** — A side-effect operation (run a command, call an API, write a file) organized into a dependency graph with support for parallelism, retries, conditions, and forEach loops.
-- **Provider** — A pluggable backend that does the actual work (e.g. `http`, `exec`, `file`, `cel`). scafctl ships with 15 built-in providers and supports external plugins.
+- **Provider** — A pluggable backend that does the actual work (e.g. `http`, `exec`, `file`, `cel`). scafctl ships with 16 built-in providers and supports external plugins.
 
 ## Installation
 
@@ -87,7 +87,7 @@ Zsh users must have `compinit` loaded before the completion file is sourced.
 - **Resolvers**: Gather and transform configuration data from multiple sources
 - **Actions**: Execute side-effect operations as a declarative action graph
 - **CEL Integration**: Use Common Expression Language for dynamic evaluation
-- **Providers**: 15 built-in providers (HTTP, exec, file, git, CEL, and more)
+- **Providers**: 16 built-in providers (HTTP, exec, file, directory, git, CEL, and more)
 - **Catalog**: Publish, version, and share reusable solutions via OCI registries
 - **Secrets**: Encrypted secrets management with OS keyring integration
 - **Plugins**: Extend scafctl with custom providers via a plugin system
@@ -159,12 +159,13 @@ Run: `scafctl run solution -f deploy.yaml`
 
 ## Built-in Providers
 
-scafctl ships with 15 providers. Use `scafctl explain provider <name>` to see full schema and examples.
+scafctl ships with 16 providers. Use `scafctl explain provider <name>` to see full schema and examples.
 
 | Provider | Description |
 | ---------- | ------------- |
 | `cel` | Evaluate CEL expressions |
 | `debug` | Log debug information during execution |
+| `directory` | List, create, remove, and copy directories |
 | `env` | Read environment variables |
 | `exec` | Execute shell commands |
 | `file` | Read and write files |
@@ -194,6 +195,7 @@ See the [Provider Reference](docs/tutorials/provider-reference.md) and [Provider
 - [Go Templates](docs/tutorials/go-templates-tutorial.md) — Templating with Go templates
 - [Configuration](docs/tutorials/config-tutorial.md) — Managing application settings
 - [Caching](docs/tutorials/cache-tutorial.md) — Provider result caching
+- [Directory Provider](docs/tutorials/directory-provider-tutorial.md) — Listing, scanning, and managing directories
 - [Snapshots](docs/tutorials/snapshots-tutorial.md) — Capturing and diffing output
 - [Plugin Development](docs/tutorials/plugin-development.md) — Building custom providers
 - [Provider Development](docs/tutorials/provider-development.md) — Contributing providers

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -1026,6 +1026,23 @@ resolve:
 
 ---
 
+### directory
+
+Lists, creates, removes, and copies directories with support for recursive traversal, glob/regex filtering, content reading, and checksums.
+
+~~~yaml
+resolve:
+  with:
+    - provider: directory
+      inputs:
+        operation: list
+        path: ./src
+        recursive: true
+        filterGlob: "*.go"
+~~~
+
+---
+
 ### git
 
 Reads data from a git repository or working tree.

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -27,5 +27,6 @@ Step-by-step guides for learning scafctl features.
 ## Reference
 
 - [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
+- [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
 - [Provider Development Guide](provider-development.md) — Build custom providers
 - [Plugin Development Guide](plugin-development.md) — Extend scafctl with plugins

--- a/docs/tutorials/directory-provider-tutorial.md
+++ b/docs/tutorials/directory-provider-tutorial.md
@@ -1,0 +1,401 @@
+---
+title: "Directory Provider Tutorial"
+weight: 95
+---
+
+# Directory Provider Tutorial
+
+This tutorial walks you through using the `directory` provider to list, scan, create, remove, and copy directories. You'll learn how to use filtering, recursive traversal, content reading, and checksums for filesystem-oriented workflows.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with YAML syntax and solution files
+- A local directory with some files to experiment with
+
+## Table of Contents
+
+1. [Listing Directory Contents](#listing-directory-contents)
+2. [Recursive Traversal](#recursive-traversal)
+3. [Filtering with Globs and Regex](#filtering-with-globs-and-regex)
+4. [Reading File Contents](#reading-file-contents)
+5. [Computing Checksums](#computing-checksums)
+6. [Creating Directories](#creating-directories)
+7. [Removing Directories](#removing-directories)
+8. [Copying Directories](#copying-directories)
+9. [Dry Run Mode](#dry-run-mode)
+10. [Common Patterns](#common-patterns)
+
+---
+
+## Listing Directory Contents
+
+The simplest use of the directory provider is listing files and directories in a given path.
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: list-directory
+  version: 1.0.0
+
+spec:
+  resolvers:
+    project-files:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+```
+
+Run it:
+
+```bash
+scafctl run solution -f list-dir.yaml
+```
+
+The output includes an `entries` array where each entry has:
+
+| Field | Description |
+|-------|-------------|
+| `name` | File or directory name |
+| `path` | Relative path from the listed directory |
+| `absolutePath` | Full filesystem path |
+| `size` | Size in bytes |
+| `isDir` | Whether the entry is a directory |
+| `type` | `file` or `dir` |
+| `mode` | Permission mode (e.g., `0644`) |
+| `modTime` | Last modification time (RFC3339) |
+| `extension` | File extension (e.g., `.go`) |
+| `mimeType` | MIME type based on extension |
+
+The output also provides summary fields: `totalCount`, `fileCount`, `dirCount`, `totalSize`, and `basePath`.
+
+---
+
+## Recursive Traversal
+
+Enable `recursive: true` to traverse subdirectories. Control the depth with `maxDepth` (default: 10, maximum: 50).
+
+```yaml
+spec:
+  resolvers:
+    all-files:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./src
+              recursive: true
+              maxDepth: 5
+```
+
+> **Tip:** Use `excludeHidden: true` to skip files and directories starting with `.` (e.g., `.git`, `.env`).
+
+---
+
+## Filtering with Globs and Regex
+
+### Glob Filtering
+
+Use `filterGlob` to match entry names using standard glob patterns:
+
+```yaml
+spec:
+  resolvers:
+    go-files:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./pkg
+              recursive: true
+              filterGlob: "*.go"
+```
+
+Common glob patterns:
+- `*.go` — all Go files
+- `*.yaml` — all YAML files
+- `test_*` — files starting with `test_`
+- `*.{json,yaml}` — JSON and YAML files (if your shell expands it)
+
+### Regex Filtering
+
+For more complex matching, use `filterRegex`:
+
+```yaml
+spec:
+  resolvers:
+    test-files:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./pkg
+              recursive: true
+              filterRegex: "_test\\.go$"
+```
+
+> **Note:** `filterGlob` and `filterRegex` are mutually exclusive. The provider returns an error if both are specified.
+
+---
+
+## Reading File Contents
+
+Set `includeContent: true` to read file contents into each entry. Text files are returned as plain strings; binary files are base64-encoded.
+
+```yaml
+spec:
+  resolvers:
+    config-contents:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./config
+              includeContent: true
+              filterGlob: "*.yaml"
+              maxFileSize: 524288  # Skip files larger than 512 KB
+```
+
+Each entry with content will include:
+
+| Field | Description |
+|-------|-------------|
+| `content` | The file content (text or base64) |
+| `contentEncoding` | `text` for text files, `base64` for binary files |
+
+Files exceeding `maxFileSize` (default: 1 MB) are skipped with a warning.
+
+---
+
+## Computing Checksums
+
+When `includeContent` is true, you can also compute checksums using `md5`, `sha256`, or `sha512`:
+
+```yaml
+spec:
+  resolvers:
+    verified-configs:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./config
+              includeContent: true
+              checksum: sha256
+              filterGlob: "*.yaml"
+```
+
+Each entry will include `checksum` and `checksumAlgorithm` fields.
+
+> **Note:** Checksums require `includeContent: true` since the file must be read to compute the hash.
+
+---
+
+## Creating Directories
+
+Use the `mkdir` operation to create directories. Set `createDirs: true` to create the full path (like `mkdir -p`).
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: create-dirs
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      setup-output:
+        provider: directory
+        inputs:
+          operation: mkdir
+          path: ./output/reports/2026
+          createDirs: true
+```
+
+The action returns `{ "success": true, "operation": "mkdir", "path": "<absolute-path>" }`.
+
+Without `createDirs: true`, the parent directory must already exist or the operation fails.
+
+---
+
+## Removing Directories
+
+The `rmdir` operation removes directories. By default it only removes empty directories. Use `force: true` to remove non-empty directories recursively.
+
+```yaml
+workflow:
+  actions:
+    cleanup:
+      provider: directory
+      inputs:
+        operation: rmdir
+        path: ./tmp/build-cache
+        force: true
+```
+
+> **Warning:** `force: true` permanently deletes the directory and all its contents. Use `--dry-run` first to verify what would be removed.
+
+---
+
+## Copying Directories
+
+The `copy` operation recursively copies a directory tree to a new location:
+
+```yaml
+workflow:
+  actions:
+    backup:
+      provider: directory
+      inputs:
+        operation: copy
+        path: ./config
+        destination: ./config-backup
+```
+
+Both `path` (source) and `destination` are required. The source must be an existing directory.
+
+---
+
+## Dry Run Mode
+
+All mutating operations (`mkdir`, `rmdir`, `copy`) support dry-run mode. Use `--dry-run` to see what would happen without making changes:
+
+```bash
+scafctl run solution -f solution.yaml --dry-run
+```
+
+In dry-run mode, the provider returns the intended operation details without modifying the filesystem. The `list` operation runs normally since it is read-only.
+
+---
+
+## Common Patterns
+
+### Find and Process Config Files
+
+Use the directory provider to discover config files, then process them with other providers:
+
+```yaml
+spec:
+  resolvers:
+    configs:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./config
+              recursive: true
+              filterGlob: "*.yaml"
+              includeContent: true
+
+    config-count:
+      type: any
+      dependsOn: [configs]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                {
+                  "count": _.configs.fileCount,
+                  "names": _.configs.entries.map(e, e.name)
+                }
+```
+
+### Verify File Integrity
+
+Compute checksums for all files in a directory and compare against known values:
+
+```yaml
+spec:
+  resolvers:
+    checksums:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./dist
+              recursive: true
+              includeContent: true
+              checksum: sha256
+              excludeHidden: true
+
+    integrity-check:
+      type: any
+      dependsOn: [checksums]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                _.checksums.entries.map(e, {
+                  "file": e.name,
+                  "sha256": e.checksum
+                })
+```
+
+### Setup and Teardown with Actions
+
+Combine directory operations in an action workflow:
+
+```yaml
+workflow:
+  actions:
+    create-workspace:
+      provider: directory
+      inputs:
+        operation: mkdir
+        path: ./workspace/output
+        createDirs: true
+
+    run-build:
+      provider: exec
+      dependsOn: [create-workspace]
+      inputs:
+        command: "make build"
+        shell: true
+
+    archive-output:
+      provider: directory
+      dependsOn: [run-build]
+      inputs:
+        operation: copy
+        path: ./workspace/output
+        destination: ./archive/latest
+
+  finally:
+    cleanup-workspace:
+      provider: directory
+      inputs:
+        operation: rmdir
+        path: ./workspace
+        force: true
+```
+
+---
+
+## Next Steps
+
+- See the [Provider Reference](../provider-reference/) for the complete directory provider input/output schema
+- Explore [Resolver Tutorial](../resolver-tutorial/) for combining providers with dependencies and transforms
+- Check the [Actions Tutorial](../actions-tutorial/) for building workflows with directory operations

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -25,6 +25,7 @@ Providers are execution primitives used by resolvers and actions. Each provider 
 |----------|:----:|:---------:|:----------:|:------:|
 | [cel](#cel) | ❌ | ✅ | ❌ | ✅ |
 | [debug](#debug) | ✅ | ✅ | ✅ | ✅ |
+| [directory](#directory) | ✅ | ❌ | ❌ | ✅ |
 | [env](#env) | ✅ | ❌ | ❌ | ❌ |
 | [exec](#exec) | ✅ | ✅ | ❌ | ✅ |
 | [file](#file) | ✅ | ✅ | ❌ | ✅ |
@@ -113,6 +114,124 @@ transform:
       inputs:
         expression: "_.config"
         format: json
+```
+
+---
+
+## directory
+
+Directory operations: listing contents with filtering, creating, removing, and copying directories.
+
+### Capabilities
+
+`from`, `action`
+
+### Inputs
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `operation` | string | ✅ | Operation: `list`, `mkdir`, `rmdir`, `copy` |
+| `path` | string | ✅ | Target directory path (absolute or relative) |
+| `recursive` | bool | ❌ | Enable recursive directory traversal (default: `false`) |
+| `maxDepth` | int | ❌ | Maximum recursion depth, 1–50 (default: `10`) |
+| `includeContent` | bool | ❌ | Read and include file contents in output (default: `false`) |
+| `maxFileSize` | int | ❌ | Maximum file size in bytes for content reading (default: `1048576`) |
+| `filterGlob` | string | ❌ | Glob pattern to filter entries (e.g., `*.go`). Mutually exclusive with `filterRegex` |
+| `filterRegex` | string | ❌ | Regex to filter entry names. Mutually exclusive with `filterGlob` |
+| `excludeHidden` | bool | ❌ | Exclude hidden files/directories (names starting with `.`) |
+| `checksum` | string | ❌ | Compute checksum for files: `md5`, `sha256`, `sha512` (requires `includeContent`) |
+| `createDirs` | bool | ❌ | Create parent directories for `mkdir` (like `mkdir -p`) |
+| `destination` | string | ❌ | Destination path for `copy` operation |
+| `force` | bool | ❌ | Force removal of non-empty directories for `rmdir` |
+
+### Output (list)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entries` | array | List of directory entries |
+| `entries[].path` | string | Relative path from the listed directory |
+| `entries[].absolutePath` | string | Absolute filesystem path |
+| `entries[].name` | string | File or directory name |
+| `entries[].extension` | string | File extension including dot (e.g., `.go`) |
+| `entries[].size` | int | Size in bytes |
+| `entries[].isDir` | bool | Whether entry is a directory |
+| `entries[].type` | string | Entry type: `file` or `dir` |
+| `entries[].mode` | string | File permission mode (e.g., `0644`) |
+| `entries[].modTime` | string | Last modification time (RFC3339) |
+| `entries[].mimeType` | string | MIME type based on extension |
+| `entries[].content` | string | File content (when `includeContent` is true) |
+| `entries[].contentEncoding` | string | `text` or `base64` |
+| `entries[].checksum` | string | File checksum (when `checksum` is specified) |
+| `entries[].checksumAlgorithm` | string | Algorithm used |
+| `totalCount` | int | Total number of entries |
+| `dirCount` | int | Number of directories |
+| `fileCount` | int | Number of files |
+| `totalSize` | int | Total size of all files in bytes |
+| `basePath` | string | Absolute path of the listed directory |
+
+### Output (mkdir, rmdir, copy)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | Whether the operation succeeded |
+| `operation` | string | Operation that was performed |
+| `path` | string | Absolute path of the target directory |
+
+### Examples
+
+```yaml
+# List directory contents
+resolve:
+  with:
+    - provider: directory
+      inputs:
+        operation: list
+        path: ./src
+
+# Recursively find all Go files
+resolve:
+  with:
+    - provider: directory
+      inputs:
+        operation: list
+        path: ./pkg
+        recursive: true
+        filterGlob: "*.go"
+        excludeHidden: true
+
+# List with file contents and checksums
+resolve:
+  with:
+    - provider: directory
+      inputs:
+        operation: list
+        path: ./config
+        recursive: true
+        includeContent: true
+        filterGlob: "*.yaml"
+        checksum: sha256
+        maxFileSize: 524288
+
+# Create nested directory structure
+provider: directory
+inputs:
+  operation: mkdir
+  path: ./output/reports/2026
+  createDirs: true
+
+# Force-remove a directory
+provider: directory
+inputs:
+  operation: rmdir
+  path: ./tmp/build-output
+  force: true
+
+# Copy a directory tree
+provider: directory
+inputs:
+  operation: copy
+  path: ./config
+  destination: ./config-backup
 ```
 
 ---

--- a/examples/solutions/directory/solution.yaml
+++ b/examples/solutions/directory/solution.yaml
@@ -1,0 +1,138 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: directory-provider-example
+  description: |
+    Demonstrates the directory provider capabilities:
+    - Listing directory contents with filtering
+    - Recursive traversal with glob patterns
+    - Reading file contents with checksums
+    - Creating, removing, and copying directories
+  version: 1.0.0
+
+spec:
+  # ============================================================================
+  # RESOLVERS: Directory listing and scanning
+  # ============================================================================
+  resolvers:
+    # -------------------------------------------------------------------------
+    # Example 1: Simple flat directory listing
+    # -------------------------------------------------------------------------
+    project-files:
+      description: List files in the current directory
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+
+    # -------------------------------------------------------------------------
+    # Example 2: Recursive listing with glob filter
+    # -------------------------------------------------------------------------
+    go-source-files:
+      description: Find all Go source files recursively
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+              recursive: true
+              filterGlob: "*.go"
+              excludeHidden: true
+
+    # -------------------------------------------------------------------------
+    # Example 3: Find config files with content and checksums
+    # -------------------------------------------------------------------------
+    config-files:
+      description: Read all YAML config files with integrity checksums
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+              recursive: true
+              filterGlob: "*.yaml"
+              includeContent: true
+              checksum: sha256
+              maxFileSize: 524288
+
+    # -------------------------------------------------------------------------
+    # Example 4: Filter with regex
+    # -------------------------------------------------------------------------
+    test-files:
+      description: Find all test files using regex
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+              recursive: true
+              filterRegex: "_test\\.go$"
+              excludeHidden: true
+
+    # -------------------------------------------------------------------------
+    # Example 5: Count files using CEL transform
+    # -------------------------------------------------------------------------
+    file-summary:
+      description: Summarize directory contents
+      type: any
+      dependsOn:
+        - go-source-files
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                {
+                  "totalFiles": _["go-source-files"].fileCount,
+                  "totalSize": _["go-source-files"].totalSize,
+                  "files": _["go-source-files"].entries.map(e, e.name)
+                }
+
+  # ============================================================================
+  # ACTIONS: Directory mutations
+  # ============================================================================
+  workflow:
+    actions:
+      # -----------------------------------------------------------------------
+      # Create output directory structure
+      # -----------------------------------------------------------------------
+      create-output-dirs:
+        provider: directory
+        inputs:
+          operation: mkdir
+          path: ./output/reports
+          createDirs: true
+
+      # -----------------------------------------------------------------------
+      # Copy config to backup location
+      # -----------------------------------------------------------------------
+      backup-configs:
+        provider: directory
+        dependsOn: [create-output-dirs]
+        inputs:
+          operation: copy
+          path: ./config
+          destination: ./output/config-backup
+
+      # -----------------------------------------------------------------------
+      # Clean up temporary build artifacts
+      # -----------------------------------------------------------------------
+      cleanup-temp:
+        provider: directory
+        dependsOn: [backup-configs]
+        condition:
+          expr: "false"  # Disabled by default — set to true to enable cleanup
+        inputs:
+          operation: rmdir
+          path: ./tmp
+          force: true

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/celprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/debugprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/directoryprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/envprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/execprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/fileprovider"
@@ -58,6 +59,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		envprovider.NewEnvProvider(),
 		celprovider.NewCelProvider(),
 		fileprovider.NewFileProvider(),
+		directoryprovider.NewDirectoryProvider(),
 		validationprovider.NewValidationProvider(),
 		execprovider.NewExecProvider(),
 		gitprovider.NewGitProvider(),
@@ -116,6 +118,7 @@ func ProviderNames() []string {
 		"env",
 		"cel",
 		"file",
+		"directory",
 		"validation",
 		"exec",
 		"git",

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -70,6 +70,37 @@ func TestDefaultRegistry(t *testing.T) {
 	})
 }
 
+func TestProviderNames(t *testing.T) {
+	names := ProviderNames()
+
+	// Should have all built-in providers
+	expectedCount := 15 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity
+	assert.Len(t, names, expectedCount, "should have %d built-in providers", expectedCount)
+
+	// Verify expected names are present
+	expectedNames := []string{
+		"http",
+		"env",
+		"cel",
+		"file",
+		"directory",
+		"validation",
+		"exec",
+		"git",
+		"debug",
+		"sleep",
+		"parameter",
+		"static",
+		"go-template",
+		"secret",
+		"identity",
+	}
+
+	for _, expected := range expectedNames {
+		assert.Contains(t, names, expected, "should contain provider %q", expected)
+	}
+}
+
 func TestDefaultRegistry_ProviderFunctionality(t *testing.T) {
 	ctx := context.Background()
 	reg, err := DefaultRegistry(ctx)
@@ -127,6 +158,7 @@ func TestAllProvidersRegistered(t *testing.T) {
 		{"env", "environment"},
 		{"cel", "CEL"},
 		{"file", "file"},
+		{"directory", "director"},
 		{"validation", "validat"},
 		{"exec", "execut"},
 		{"git", "git"},

--- a/pkg/provider/builtin/directoryprovider/directory.go
+++ b/pkg/provider/builtin/directoryprovider/directory.go
@@ -1,0 +1,895 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package directoryprovider
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // MD5 is user-requested, not for security
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"mime"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+)
+
+// ProviderName is the name of this provider.
+const ProviderName = "directory"
+
+const (
+	// DefaultMaxDepth is the default recursion depth for directory listing.
+	DefaultMaxDepth = 10
+	// MaxAllowedDepth is the absolute maximum recursion depth.
+	MaxAllowedDepth = 50
+	// DefaultMaxFileSize is the default max file size for content reading (1 MB).
+	DefaultMaxFileSize = 1 << 20
+	// binaryDetectSize is the number of bytes to sample for binary detection.
+	binaryDetectSize = 8192
+)
+
+// DirectoryProvider provides directory operations.
+type DirectoryProvider struct {
+	descriptor *provider.Descriptor
+}
+
+// NewDirectoryProvider creates a new directory provider instance.
+func NewDirectoryProvider() *DirectoryProvider {
+	version := semver.MustParse("1.0.0")
+
+	return &DirectoryProvider{
+		descriptor: &provider.Descriptor{
+			Name:        ProviderName,
+			DisplayName: "Directory Provider",
+			Description: "Provider for directory operations: listing contents with filtering, creating, removing, and copying directories",
+			APIVersion:  "v1",
+			Version:     version,
+			Category:    "filesystem",
+			Tags:        []string{"directory", "filesystem", "listing", "glob", "scan"},
+			MockBehavior: "Returns mock directory listing without reading actual filesystem for list operations; " +
+				"reports intended action without modifying filesystem for mkdir/rmdir/copy",
+			Capabilities: []provider.Capability{
+				provider.CapabilityFrom,   // list operation
+				provider.CapabilityAction, // mkdir, rmdir, copy operations
+			},
+			Schema: schemahelper.ObjectSchema([]string{"operation", "path"}, map[string]*jsonschema.Schema{
+				"operation": schemahelper.StringProp("Operation to perform",
+					schemahelper.WithExample("list"),
+					schemahelper.WithEnum("list", "mkdir", "rmdir", "copy")),
+				"path": schemahelper.StringProp("Target directory path (absolute or relative)",
+					schemahelper.WithExample("./src"),
+					schemahelper.WithMaxLength(4096)),
+				"recursive": schemahelper.BoolProp("Enable recursive directory traversal",
+					schemahelper.WithDefault(false)),
+				"maxDepth": schemahelper.IntProp("Maximum recursion depth (1-50)",
+					schemahelper.WithDefault(DefaultMaxDepth),
+					schemahelper.WithMinimum(1),
+					schemahelper.WithMaximum(MaxAllowedDepth)),
+				"includeContent": schemahelper.BoolProp("Read and include file contents in output",
+					schemahelper.WithDefault(false)),
+				"maxFileSize": schemahelper.IntProp("Maximum file size in bytes for content reading; files exceeding this are skipped",
+					schemahelper.WithDefault(DefaultMaxFileSize),
+					schemahelper.WithMinimum(0)),
+				"filterGlob": schemahelper.StringProp("Glob pattern to filter entries (e.g., '*.go', '**/*.yaml'). Mutually exclusive with filterRegex",
+					schemahelper.WithExample("*.go"),
+					schemahelper.WithMaxLength(500)),
+				"filterRegex": schemahelper.StringProp("Regular expression to filter entry names. Mutually exclusive with filterGlob",
+					schemahelper.WithExample("^test_.*\\.py$"),
+					schemahelper.WithMaxLength(500)),
+				"excludeHidden": schemahelper.BoolProp("Exclude hidden files and directories (names starting with '.')",
+					schemahelper.WithDefault(false)),
+				"checksum": schemahelper.StringProp("Compute checksum for files (requires includeContent). Supported: md5, sha256, sha512",
+					schemahelper.WithEnum("md5", "sha256", "sha512")),
+				"createDirs": schemahelper.BoolProp("Create parent directories for mkdir (like mkdir -p)",
+					schemahelper.WithDefault(false)),
+				"destination": schemahelper.StringProp("Destination path for copy operation",
+					schemahelper.WithMaxLength(4096)),
+				"force": schemahelper.BoolProp("Force removal of non-empty directories for rmdir",
+					schemahelper.WithDefault(false)),
+			}),
+			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"entries": schemahelper.ArrayProp("List of directory entries",
+						schemahelper.WithItems(schemahelper.ObjectProp("A directory entry",
+							nil,
+							map[string]*jsonschema.Schema{
+								"path":              schemahelper.StringProp("Relative path from the listed directory"),
+								"absolutePath":      schemahelper.StringProp("Absolute filesystem path"),
+								"name":              schemahelper.StringProp("File or directory name"),
+								"extension":         schemahelper.StringProp("File extension including dot (e.g., '.go')"),
+								"size":              schemahelper.IntProp("Size in bytes"),
+								"isDir":             schemahelper.BoolProp("Whether this entry is a directory"),
+								"type":              schemahelper.StringProp("Entry type: file or dir"),
+								"mode":              schemahelper.StringProp("File permission mode (e.g., '0644')"),
+								"modTime":           schemahelper.StringProp("Last modification time in RFC3339 format"),
+								"mimeType":          schemahelper.StringProp("MIME type based on file extension"),
+								"content":           schemahelper.StringProp("File content (only when includeContent is true)"),
+								"contentEncoding":   schemahelper.StringProp("Content encoding: text or base64"),
+								"checksum":          schemahelper.StringProp("File checksum (only when checksum algorithm is specified)"),
+								"checksumAlgorithm": schemahelper.StringProp("Checksum algorithm used"),
+							},
+						))),
+					"totalCount": schemahelper.IntProp("Total number of entries"),
+					"dirCount":   schemahelper.IntProp("Number of directories"),
+					"fileCount":  schemahelper.IntProp("Number of files"),
+					"totalSize":  schemahelper.IntProp("Total size of all files in bytes"),
+					"basePath":   schemahelper.StringProp("Absolute path of the listed directory"),
+				}),
+				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"success":   schemahelper.BoolProp("Whether the operation succeeded"),
+					"operation": schemahelper.StringProp("Operation that was performed"),
+					"path":      schemahelper.StringProp("Absolute path of the target directory"),
+				}),
+			},
+			Examples: []provider.Example{
+				{
+					Name:        "List directory contents",
+					Description: "List files and directories in the current directory",
+					YAML: `name: list-src
+provider: directory
+inputs:
+  operation: list
+  path: ./src`,
+				},
+				{
+					Name:        "Recursive listing with glob filter",
+					Description: "Recursively list all Go files in a directory",
+					YAML: `name: find-go-files
+provider: directory
+inputs:
+  operation: list
+  path: ./pkg
+  recursive: true
+  filterGlob: "*.go"`,
+				},
+				{
+					Name:        "List with file contents",
+					Description: "List YAML files and include their contents",
+					YAML: `name: read-configs
+provider: directory
+inputs:
+  operation: list
+  path: ./config
+  recursive: true
+  includeContent: true
+  filterGlob: "*.yaml"
+  maxFileSize: 524288`,
+				},
+				{
+					Name:        "Create directory",
+					Description: "Create a nested directory structure",
+					YAML: `name: create-output-dir
+provider: directory
+inputs:
+  operation: mkdir
+  path: ./output/reports/2026
+  createDirs: true`,
+				},
+				{
+					Name:        "Remove directory",
+					Description: "Force-remove a directory and all its contents",
+					YAML: `name: cleanup-temp
+provider: directory
+inputs:
+  operation: rmdir
+  path: ./tmp/build-output
+  force: true`,
+				},
+				{
+					Name:        "Copy directory",
+					Description: "Copy a directory tree to a new location",
+					YAML: `name: backup-config
+provider: directory
+inputs:
+  operation: copy
+  path: ./config
+  destination: ./config-backup`,
+				},
+			},
+		},
+	}
+}
+
+// Descriptor returns the provider's descriptor.
+func (p *DirectoryProvider) Descriptor() *provider.Descriptor {
+	return p.descriptor
+}
+
+// Execute performs the directory operation.
+func (p *DirectoryProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected map[string]any, got %T", ProviderName, input)
+	}
+
+	operation, ok := inputs["operation"].(string)
+	if !ok {
+		return nil, fmt.Errorf("%s: operation is required and must be a string", ProviderName)
+	}
+
+	path, ok := inputs["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("%s: path is required and must be a string", ProviderName)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid path: %w", ProviderName, err)
+	}
+
+	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation, "path", path)
+
+	if dryRun := provider.DryRunFromContext(ctx); dryRun {
+		result, dryErr := p.executeDryRun(operation, absPath, inputs)
+		if dryErr != nil {
+			return nil, fmt.Errorf("%s: %w", ProviderName, dryErr)
+		}
+		lgr.V(1).Info("provider completed (dry-run)", "provider", ProviderName, "operation", operation)
+		return result, nil
+	}
+
+	var result *provider.Output
+	switch operation {
+	case "list":
+		result, err = p.executeList(absPath, inputs)
+	case "mkdir":
+		result, err = p.executeMkdir(absPath, inputs)
+	case "rmdir":
+		result, err = p.executeRmdir(absPath, inputs)
+	case "copy":
+		result, err = p.executeCopy(absPath, inputs)
+	default:
+		return nil, fmt.Errorf("%s: unsupported operation: %s", ProviderName, operation)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", operation)
+	return result, nil
+}
+
+// listOptions holds parsed options for the list operation.
+type listOptions struct {
+	recursive      bool
+	maxDepth       int
+	includeContent bool
+	maxFileSize    int64
+	filterGlob     string
+	filterRegex    *regexp.Regexp
+	excludeHidden  bool
+	checksum       string
+}
+
+// entryInfo holds information about a single directory entry.
+type entryInfo struct {
+	Path              string `json:"path"`
+	AbsolutePath      string `json:"absolutePath"`
+	Name              string `json:"name"`
+	Extension         string `json:"extension"`
+	Size              int64  `json:"size"`
+	IsDir             bool   `json:"isDir"`
+	Type              string `json:"type"`
+	Mode              string `json:"mode"`
+	ModTime           string `json:"modTime"`
+	MimeType          string `json:"mimeType,omitempty"`
+	Content           string `json:"content,omitempty"`
+	ContentEncoding   string `json:"contentEncoding,omitempty"`
+	Checksum          string `json:"checksum,omitempty"`
+	ChecksumAlgorithm string `json:"checksumAlgorithm,omitempty"`
+}
+
+// parseListOptions parses and validates list operation inputs.
+func parseListOptions(inputs map[string]any) (*listOptions, error) {
+	opts := &listOptions{
+		maxDepth:    DefaultMaxDepth,
+		maxFileSize: DefaultMaxFileSize,
+	}
+
+	if v, ok := inputs["recursive"].(bool); ok {
+		opts.recursive = v
+	}
+
+	if v, ok := inputs["maxDepth"]; ok {
+		depth, err := toInt(v)
+		if err != nil {
+			return nil, fmt.Errorf("maxDepth must be an integer: %w", err)
+		}
+		if depth < 1 || depth > MaxAllowedDepth {
+			return nil, fmt.Errorf("maxDepth must be between 1 and %d, got %d", MaxAllowedDepth, depth)
+		}
+		opts.maxDepth = depth
+	}
+
+	if v, ok := inputs["includeContent"].(bool); ok {
+		opts.includeContent = v
+	}
+
+	if v, ok := inputs["maxFileSize"]; ok {
+		size, err := toInt64(v)
+		if err != nil {
+			return nil, fmt.Errorf("maxFileSize must be an integer: %w", err)
+		}
+		if size < 0 {
+			return nil, fmt.Errorf("maxFileSize must be non-negative, got %d", size)
+		}
+		opts.maxFileSize = size
+	}
+
+	if v, ok := inputs["filterGlob"].(string); ok && v != "" {
+		opts.filterGlob = v
+	}
+
+	if v, ok := inputs["filterRegex"].(string); ok && v != "" {
+		if opts.filterGlob != "" {
+			return nil, fmt.Errorf("filterGlob and filterRegex are mutually exclusive")
+		}
+		re, err := regexp.Compile(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filterRegex: %w", err)
+		}
+		opts.filterRegex = re
+	}
+
+	if v, ok := inputs["excludeHidden"].(bool); ok {
+		opts.excludeHidden = v
+	}
+
+	if v, ok := inputs["checksum"].(string); ok && v != "" {
+		switch v {
+		case "md5", "sha256", "sha512":
+			opts.checksum = v
+		default:
+			return nil, fmt.Errorf("unsupported checksum algorithm: %s (supported: md5, sha256, sha512)", v)
+		}
+	}
+
+	return opts, nil
+}
+
+// executeList performs the list operation.
+func (p *DirectoryProvider) executeList(absPath string, inputs map[string]any) (*provider.Output, error) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("directory does not exist: %s", absPath)
+		}
+		return nil, fmt.Errorf("failed to stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", absPath)
+	}
+
+	opts, err := parseListOptions(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []map[string]any
+	var warnings []string
+	var dirCount, fileCount int
+	var totalSize int64
+
+	walkErr := p.walkDirectory(absPath, absPath, 0, opts, func(entry entryInfo) {
+		m := entryToMap(entry)
+		entries = append(entries, m)
+		if entry.IsDir {
+			dirCount++
+		} else {
+			fileCount++
+			totalSize += entry.Size
+		}
+	}, &warnings)
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	if entries == nil {
+		entries = []map[string]any{}
+	}
+
+	output := &provider.Output{
+		Data: map[string]any{
+			"entries":    entries,
+			"totalCount": dirCount + fileCount,
+			"dirCount":   dirCount,
+			"fileCount":  fileCount,
+			"totalSize":  totalSize,
+			"basePath":   absPath,
+		},
+	}
+
+	if len(warnings) > 0 {
+		output.Warnings = warnings
+	}
+
+	return output, nil
+}
+
+// walkDirectory recursively traverses a directory tree.
+func (p *DirectoryProvider) walkDirectory(
+	basePath, currentPath string,
+	depth int,
+	opts *listOptions,
+	emit func(entryInfo),
+	warnings *[]string,
+) error {
+	dirEntries, err := os.ReadDir(currentPath)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s: %w", currentPath, err)
+	}
+
+	for _, de := range dirEntries {
+		name := de.Name()
+
+		// Skip hidden files/dirs if requested
+		if opts.excludeHidden && strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		// Skip symlinks
+		if de.Type()&fs.ModeSymlink != 0 {
+			continue
+		}
+
+		entryPath := filepath.Join(currentPath, name)
+		relPath, _ := filepath.Rel(basePath, entryPath)
+
+		fi, err := de.Info()
+		if err != nil {
+			*warnings = append(*warnings, fmt.Sprintf("failed to stat %s: %v", relPath, err))
+			continue
+		}
+
+		// Skip symlinks detected via Lstat (ReadDir uses Lstat)
+		if fi.Mode()&fs.ModeSymlink != 0 {
+			continue
+		}
+
+		isDir := fi.IsDir()
+
+		// Apply filters (to file/dir name)
+		if !matchesFilter(name, opts) {
+			// For directories in recursive mode, still recurse into them even if the dir name
+			// doesn't match the filter — the filter applies to leaf names
+			if isDir && opts.recursive && depth < opts.maxDepth {
+				if walkErr := p.walkDirectory(basePath, entryPath, depth+1, opts, emit, warnings); walkErr != nil {
+					*warnings = append(*warnings, fmt.Sprintf("error traversing %s: %v", relPath, walkErr))
+				}
+			}
+			continue
+		}
+
+		entry := entryInfo{
+			Path:         filepath.ToSlash(relPath),
+			AbsolutePath: entryPath,
+			Name:         name,
+			Size:         fi.Size(),
+			IsDir:        isDir,
+			Mode:         fmt.Sprintf("%04o", fi.Mode().Perm()),
+			ModTime:      fi.ModTime().UTC().Format(time.RFC3339),
+		}
+
+		if isDir {
+			entry.Type = "dir"
+		} else {
+			entry.Extension = filepath.Ext(name)
+			if entry.Extension != "" {
+				entry.MimeType = mime.TypeByExtension(entry.Extension)
+			}
+			entry.Type = "file"
+
+			// Read content if requested
+			if opts.includeContent && fi.Size() <= opts.maxFileSize {
+				content, encoding, readErr := readFileContent(entryPath)
+				if readErr != nil {
+					*warnings = append(*warnings, fmt.Sprintf("failed to read %s: %v", relPath, readErr))
+				} else {
+					entry.Content = content
+					entry.ContentEncoding = encoding
+				}
+			} else if opts.includeContent && fi.Size() > opts.maxFileSize {
+				*warnings = append(*warnings, fmt.Sprintf("skipped content for %s: size %d exceeds maxFileSize %d", relPath, fi.Size(), opts.maxFileSize))
+			}
+
+			// Compute checksum if requested and content was read
+			if opts.checksum != "" && opts.includeContent && entry.Content != "" {
+				cs, csErr := computeChecksum(entryPath, opts.checksum)
+				if csErr != nil {
+					*warnings = append(*warnings, fmt.Sprintf("failed to compute checksum for %s: %v", relPath, csErr))
+				} else {
+					entry.Checksum = cs
+					entry.ChecksumAlgorithm = opts.checksum
+				}
+			}
+		}
+
+		emit(entry)
+
+		// Recurse into subdirectories
+		if isDir && opts.recursive && depth < opts.maxDepth {
+			if walkErr := p.walkDirectory(basePath, entryPath, depth+1, opts, emit, warnings); walkErr != nil {
+				*warnings = append(*warnings, fmt.Sprintf("error traversing %s: %v", relPath, walkErr))
+			}
+		}
+	}
+
+	return nil
+}
+
+// matchesFilter checks if a filename matches the configured filter.
+func matchesFilter(name string, opts *listOptions) bool {
+	if opts.filterGlob != "" {
+		matched, err := filepath.Match(opts.filterGlob, name)
+		if err != nil {
+			return false
+		}
+		return matched
+	}
+
+	if opts.filterRegex != nil {
+		return opts.filterRegex.MatchString(name)
+	}
+
+	return true
+}
+
+// entryToMap converts an entryInfo struct to a map[string]any.
+func entryToMap(e entryInfo) map[string]any {
+	m := map[string]any{
+		"path":         e.Path,
+		"absolutePath": e.AbsolutePath,
+		"name":         e.Name,
+		"extension":    e.Extension,
+		"size":         e.Size,
+		"isDir":        e.IsDir,
+		"type":         e.Type,
+		"mode":         e.Mode,
+		"modTime":      e.ModTime,
+	}
+
+	if e.MimeType != "" {
+		m["mimeType"] = e.MimeType
+	}
+	if e.Content != "" {
+		m["content"] = e.Content
+		m["contentEncoding"] = e.ContentEncoding
+	}
+	if e.Checksum != "" {
+		m["checksum"] = e.Checksum
+		m["checksumAlgorithm"] = e.ChecksumAlgorithm
+	}
+
+	return m
+}
+
+// readFileContent reads a file and returns its content as a string plus encoding type.
+// Binary files are base64-encoded; text files are returned as-is.
+func readFileContent(path string) (content, encoding string, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", err
+	}
+
+	if isBinary(data) {
+		return base64.StdEncoding.EncodeToString(data), "base64", nil
+	}
+
+	return string(data), "text", nil
+}
+
+// isBinary detects whether data is binary by checking for null bytes in the
+// first binaryDetectSize bytes.
+func isBinary(data []byte) bool {
+	sample := data
+	if len(sample) > binaryDetectSize {
+		sample = sample[:binaryDetectSize]
+	}
+
+	for _, b := range sample {
+		if b == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// computeChecksum computes a hash of the file at path using the given algorithm.
+func computeChecksum(path, algorithm string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var h hash.Hash
+	switch algorithm {
+	case "md5":
+		h = md5.New() //nolint:gosec // MD5 is used for content identification, not security
+	case "sha256":
+		h = sha256.New()
+	case "sha512":
+		h = sha512.New()
+	default:
+		return "", fmt.Errorf("unsupported algorithm: %s", algorithm)
+	}
+
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// executeMkdir creates a directory.
+func (p *DirectoryProvider) executeMkdir(absPath string, inputs map[string]any) (*provider.Output, error) {
+	createDirs, _ := inputs["createDirs"].(bool)
+
+	if createDirs {
+		if err := os.MkdirAll(absPath, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create directories: %w", err)
+		}
+	} else {
+		if err := os.Mkdir(absPath, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":   true,
+			"operation": "mkdir",
+			"path":      absPath,
+		},
+	}, nil
+}
+
+// executeRmdir removes a directory.
+func (p *DirectoryProvider) executeRmdir(absPath string, inputs map[string]any) (*provider.Output, error) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("directory does not exist: %s", absPath)
+		}
+		return nil, fmt.Errorf("failed to stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", absPath)
+	}
+
+	force, _ := inputs["force"].(bool)
+
+	if force {
+		if err := os.RemoveAll(absPath); err != nil {
+			return nil, fmt.Errorf("failed to remove directory: %w", err)
+		}
+	} else {
+		if err := os.Remove(absPath); err != nil {
+			return nil, fmt.Errorf("failed to remove directory (is it empty?): %w", err)
+		}
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":   true,
+			"operation": "rmdir",
+			"path":      absPath,
+		},
+	}, nil
+}
+
+// executeCopy copies a directory tree to a destination.
+func (p *DirectoryProvider) executeCopy(absPath string, inputs map[string]any) (*provider.Output, error) {
+	destination, ok := inputs["destination"].(string)
+	if !ok || destination == "" {
+		return nil, fmt.Errorf("destination is required for copy operation")
+	}
+
+	absDest, err := filepath.Abs(destination)
+	if err != nil {
+		return nil, fmt.Errorf("invalid destination path: %w", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("source directory does not exist: %s", absPath)
+		}
+		return nil, fmt.Errorf("failed to stat source: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("source is not a directory: %s", absPath)
+	}
+
+	if err := copyDir(absPath, absDest); err != nil {
+		return nil, fmt.Errorf("failed to copy directory: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":     true,
+			"operation":   "copy",
+			"path":        absPath,
+			"destination": absDest,
+		},
+	}, nil
+}
+
+// copyDir recursively copies a directory tree from src to dst.
+func copyDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dst, srcInfo.Mode().Perm()); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		// Skip symlinks
+		if entry.Type()&fs.ModeSymlink != 0 {
+			continue
+		}
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a single file from src to dst, preserving permissions.
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// executeDryRun handles dry-run mode for mutating operations.
+// List is read-only and executes normally even in dry-run mode.
+func (p *DirectoryProvider) executeDryRun(operation, absPath string, inputs map[string]any) (*provider.Output, error) {
+	switch operation {
+	case "list":
+		// List is read-only, execute normally even in dry-run
+		return p.executeList(absPath, inputs)
+
+	case "mkdir":
+		createDirs, _ := inputs["createDirs"].(bool)
+		msg := fmt.Sprintf("Would create directory: %s", absPath)
+		if createDirs {
+			msg = fmt.Sprintf("Would create directory tree: %s", absPath)
+		}
+		return &provider.Output{
+			Data: map[string]any{
+				"success":   true,
+				"operation": "mkdir",
+				"path":      absPath,
+				"_dryRun":   true,
+				"_message":  msg,
+			},
+		}, nil
+
+	case "rmdir":
+		force, _ := inputs["force"].(bool)
+		msg := fmt.Sprintf("Would remove directory: %s", absPath)
+		if force {
+			msg = fmt.Sprintf("Would force-remove directory and contents: %s", absPath)
+		}
+		return &provider.Output{
+			Data: map[string]any{
+				"success":   true,
+				"operation": "rmdir",
+				"path":      absPath,
+				"_dryRun":   true,
+				"_message":  msg,
+			},
+		}, nil
+
+	case "copy":
+		destination, _ := inputs["destination"].(string)
+		absDest, _ := filepath.Abs(destination)
+		return &provider.Output{
+			Data: map[string]any{
+				"success":     true,
+				"operation":   "copy",
+				"path":        absPath,
+				"destination": absDest,
+				"_dryRun":     true,
+				"_message":    fmt.Sprintf("Would copy %s to %s", absPath, absDest),
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported operation: %s", operation)
+	}
+}
+
+// toInt converts a numeric value to int, handling both int and float64 (from JSON).
+func toInt(v any) (int, error) {
+	switch val := v.(type) {
+	case int:
+		return val, nil
+	case int64:
+		return int(val), nil
+	case float64:
+		return int(val), nil
+	case json.Number:
+		n, err := val.Int64()
+		if err != nil {
+			return 0, err
+		}
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int", v)
+	}
+}
+
+// toInt64 converts a numeric value to int64, handling both int and float64 (from JSON).
+func toInt64(v any) (int64, error) {
+	switch val := v.(type) {
+	case int:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case float64:
+		return int64(val), nil
+	case json.Number:
+		return val.Int64()
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int64", v)
+	}
+}

--- a/pkg/provider/builtin/directoryprovider/directory_test.go
+++ b/pkg/provider/builtin/directoryprovider/directory_test.go
@@ -1,0 +1,1047 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package directoryprovider
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDirectoryProvider(t *testing.T) {
+	p := NewDirectoryProvider()
+
+	assert.NotNil(t, p)
+	assert.NotNil(t, p.descriptor)
+	assert.Equal(t, "directory", p.descriptor.Name)
+	assert.Equal(t, "Directory Provider", p.descriptor.DisplayName)
+	assert.Equal(t, "v1", p.descriptor.APIVersion)
+	assert.Equal(t, "filesystem", p.descriptor.Category)
+	assert.Contains(t, p.descriptor.Capabilities, provider.CapabilityFrom)
+	assert.Contains(t, p.descriptor.Capabilities, provider.CapabilityAction)
+}
+
+func TestDirectoryProvider_Descriptor(t *testing.T) {
+	p := NewDirectoryProvider()
+	desc := p.Descriptor()
+
+	assert.NotNil(t, desc)
+	assert.Equal(t, "directory", desc.Name)
+	assert.NotNil(t, desc.Schema.Properties)
+	assert.Contains(t, desc.Schema.Properties, "operation")
+	assert.Contains(t, desc.Schema.Properties, "path")
+	assert.Contains(t, desc.Schema.Properties, "recursive")
+	assert.Contains(t, desc.Schema.Properties, "maxDepth")
+	assert.Contains(t, desc.Schema.Properties, "includeContent")
+	assert.Contains(t, desc.Schema.Properties, "filterGlob")
+	assert.Contains(t, desc.Schema.Properties, "filterRegex")
+	assert.Contains(t, desc.Schema.Properties, "excludeHidden")
+	assert.Contains(t, desc.Schema.Properties, "checksum")
+	assert.NotNil(t, desc.OutputSchemas[provider.CapabilityFrom])
+	assert.NotNil(t, desc.OutputSchemas[provider.CapabilityAction])
+	assert.NotEmpty(t, desc.Examples)
+	assert.NotEmpty(t, desc.Tags)
+}
+
+func TestDirectoryProvider_Execute_InvalidInput(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+
+	t.Run("wrong input type", func(t *testing.T) {
+		_, err := p.Execute(ctx, "not a map")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected map[string]any")
+	})
+
+	t.Run("missing operation", func(t *testing.T) {
+		_, err := p.Execute(ctx, map[string]any{"path": "."})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "operation is required")
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		_, err := p.Execute(ctx, map[string]any{"operation": "list"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path is required")
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+		_, err := p.Execute(ctx, map[string]any{"operation": "invalid", "path": "."})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported operation")
+	})
+}
+
+// =============================================================================
+// List operation tests
+// =============================================================================
+
+func TestDirectoryProvider_List_FlatDirectory(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 3, data["totalCount"])
+	assert.Equal(t, 1, data["dirCount"])
+	assert.Equal(t, 2, data["fileCount"])
+	assert.Equal(t, dir, data["basePath"])
+
+	entries := data["entries"].([]map[string]any)
+	assert.Len(t, entries, 3)
+
+	for _, e := range entries {
+		assert.NotEmpty(t, e["path"])
+		assert.NotEmpty(t, e["absolutePath"])
+		assert.NotEmpty(t, e["name"])
+		assert.NotEmpty(t, e["mode"])
+		assert.NotEmpty(t, e["modTime"])
+		assert.NotEmpty(t, e["type"])
+	}
+}
+
+func TestDirectoryProvider_List_Recursive(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "mid.txt"), []byte("mid"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "deep.txt"), []byte("deep"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+		"recursive": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	// Should include: root.txt, a/, a/mid.txt, a/b/, a/b/deep.txt
+	assert.Equal(t, 5, data["totalCount"])
+	assert.Equal(t, 2, data["dirCount"])
+	assert.Equal(t, 3, data["fileCount"])
+}
+
+func TestDirectoryProvider_List_MaxDepth(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "c", "deep.txt"), []byte("deep"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "shallow.txt"), []byte("shallow"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+		"recursive": true,
+		"maxDepth":  1,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e["path"].(string))
+	}
+	assert.Contains(t, names, "a")
+	assert.Contains(t, names, "a/shallow.txt")
+	assert.Contains(t, names, "a/b")
+	assert.NotContains(t, names, "a/b/c")
+	assert.NotContains(t, names, "a/b/c/deep.txt")
+}
+
+func TestDirectoryProvider_List_FilterGlob(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# Readme"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("key: val"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "list",
+		"path":       dir,
+		"filterGlob": "*.go",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 2, data["fileCount"])
+	entries := data["entries"].([]map[string]any)
+	for _, e := range entries {
+		assert.Equal(t, ".go", e["extension"])
+	}
+}
+
+func TestDirectoryProvider_List_FilterGlob_Recursive(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.txt"), []byte("text"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "nested.go"), []byte("package sub"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("text"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "list",
+		"path":       dir,
+		"recursive":  true,
+		"filterGlob": "*.go",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 2, data["fileCount"])
+	entries := data["entries"].([]map[string]any)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e["path"].(string))
+	}
+	assert.Contains(t, names, "root.go")
+	assert.Contains(t, names, "sub/nested.go")
+}
+
+func TestDirectoryProvider_List_FilterRegex(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test_main.py"), []byte("pass"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test_utils.py"), []byte("pass"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.py"), []byte("pass"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":   "list",
+		"path":        dir,
+		"filterRegex": "^test_.*\\.py$",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 2, data["fileCount"])
+}
+
+func TestDirectoryProvider_List_MutuallyExclusiveFilters(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "list",
+		"path":        dir,
+		"filterGlob":  "*.go",
+		"filterRegex": "test_.*",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestDirectoryProvider_List_InvalidRegex(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "list",
+		"path":        dir,
+		"filterRegex": "[invalid",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filterRegex")
+}
+
+func TestDirectoryProvider_List_ExcludeHidden(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden"), []byte("secret"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "visible.txt"), []byte("public"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hiddendir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":     "list",
+		"path":          dir,
+		"excludeHidden": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 1, data["totalCount"])
+	entries := data["entries"].([]map[string]any)
+	assert.Equal(t, "visible.txt", entries[0]["name"])
+}
+
+func TestDirectoryProvider_List_IncludesHiddenByDefault(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden"), []byte("secret"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "visible.txt"), []byte("public"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 2, data["totalCount"])
+}
+
+func TestDirectoryProvider_List_IncludeContent(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	content := "Hello, World!"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte(content), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, content, entries[0]["content"])
+	assert.Equal(t, "text", entries[0]["contentEncoding"])
+}
+
+func TestDirectoryProvider_List_IncludeContent_BinaryFile(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	binaryData := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x01, 0x02, 0x03}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "image.png"), binaryData, 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, "base64", entries[0]["contentEncoding"])
+	decoded, err := base64.StdEncoding.DecodeString(entries[0]["content"].(string))
+	require.NoError(t, err)
+	assert.Equal(t, binaryData, decoded)
+}
+
+func TestDirectoryProvider_List_IncludeContent_ExceedsMaxFileSize(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	largeContent := make([]byte, 100)
+	for i := range largeContent {
+		largeContent[i] = 'A'
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "large.txt"), largeContent, 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+		"maxFileSize":    50,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	_, hasContent := entries[0]["content"]
+	assert.False(t, hasContent)
+	assert.NotEmpty(t, result.Warnings)
+	assert.Contains(t, result.Warnings[0], "exceeds maxFileSize")
+}
+
+func TestDirectoryProvider_List_Checksum(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+		"checksum":       "sha256",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	assert.NotEmpty(t, entries[0]["checksum"])
+	assert.Equal(t, "sha256", entries[0]["checksumAlgorithm"])
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", entries[0]["checksum"])
+}
+
+func TestDirectoryProvider_List_Checksum_MD5(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+		"checksum":       "md5",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	assert.NotEmpty(t, entries[0]["checksum"])
+	assert.Equal(t, "md5", entries[0]["checksumAlgorithm"])
+}
+
+func TestDirectoryProvider_List_InvalidChecksum(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"includeContent": true,
+		"checksum":       "invalid",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported checksum algorithm")
+}
+
+func TestDirectoryProvider_List_SkipsSymlinks(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	targetFile := filepath.Join(dir, "target.txt")
+	require.NoError(t, os.WriteFile(targetFile, []byte("target"), 0o644))
+	require.NoError(t, os.Symlink(targetFile, filepath.Join(dir, "link.txt")))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 1, data["fileCount"])
+	entries := data["entries"].([]map[string]any)
+	assert.Equal(t, "target.txt", entries[0]["name"])
+}
+
+func TestDirectoryProvider_List_NonexistentDir(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      "/nonexistent/directory",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestDirectoryProvider_List_PathIsFile(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      filePath,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestDirectoryProvider_List_EmptyDirectory(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 0, data["totalCount"])
+	assert.Equal(t, 0, data["dirCount"])
+	assert.Equal(t, 0, data["fileCount"])
+	entries := data["entries"].([]map[string]any)
+	assert.Empty(t, entries)
+}
+
+func TestDirectoryProvider_List_FileMetadata(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.go"), []byte("package main"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	e := entries[0]
+	assert.Equal(t, "test.go", e["name"])
+	assert.Equal(t, ".go", e["extension"])
+	assert.Equal(t, "file", e["type"])
+	assert.False(t, e["isDir"].(bool))
+	assert.NotEmpty(t, e["mode"])
+	assert.NotEmpty(t, e["modTime"])
+	assert.Equal(t, int64(12), e["size"])
+}
+
+func TestDirectoryProvider_List_DirMetadata(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	entries := data["entries"].([]map[string]any)
+	require.Len(t, entries, 1)
+
+	e := entries[0]
+	assert.Equal(t, "subdir", e["name"])
+	assert.Equal(t, "dir", e["type"])
+	assert.True(t, e["isDir"].(bool))
+}
+
+func TestDirectoryProvider_List_InvalidMaxDepth(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	t.Run("too low", func(t *testing.T) {
+		_, err := p.Execute(ctx, map[string]any{
+			"operation": "list",
+			"path":      dir,
+			"maxDepth":  0,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maxDepth must be between")
+	})
+
+	t.Run("too high", func(t *testing.T) {
+		_, err := p.Execute(ctx, map[string]any{
+			"operation": "list",
+			"path":      dir,
+			"maxDepth":  100,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maxDepth must be between")
+	})
+}
+
+func TestDirectoryProvider_List_TotalSize(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaaa"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbbbbb"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, int64(10), data["totalSize"])
+}
+
+// =============================================================================
+// Mkdir operation tests
+// =============================================================================
+
+func TestDirectoryProvider_Mkdir_Simple(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	newDir := filepath.Join(dir, "newdir")
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "mkdir",
+		"path":      newDir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "mkdir", data["operation"])
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestDirectoryProvider_Mkdir_WithCreateDirs(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	newDir := filepath.Join(dir, "a", "b", "c")
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "mkdir",
+		"path":       newDir,
+		"createDirs": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestDirectoryProvider_Mkdir_WithoutCreateDirs_NestedFails(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	newDir := filepath.Join(dir, "a", "b", "c")
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "mkdir",
+		"path":      newDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create directory")
+}
+
+func TestDirectoryProvider_Mkdir_AlreadyExists(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	existingDir := filepath.Join(dir, "existing")
+	require.NoError(t, os.Mkdir(existingDir, 0o755))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "mkdir",
+		"path":      existingDir,
+	})
+	require.Error(t, err)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "mkdir",
+		"path":       existingDir,
+		"createDirs": true,
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+}
+
+// =============================================================================
+// Rmdir operation tests
+// =============================================================================
+
+func TestDirectoryProvider_Rmdir_EmptyDir(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "removeme")
+	require.NoError(t, os.Mkdir(targetDir, 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      targetDir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "rmdir", data["operation"])
+
+	_, err = os.Stat(targetDir)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDirectoryProvider_Rmdir_NonEmptyWithoutForce(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "notempty")
+	require.NoError(t, os.Mkdir(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "file.txt"), []byte("content"), 0o644))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      targetDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove directory")
+}
+
+func TestDirectoryProvider_Rmdir_NonEmptyWithForce(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "forcedelete")
+	require.NoError(t, os.MkdirAll(filepath.Join(targetDir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "file.txt"), []byte("content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "sub", "nested.txt"), []byte("nested"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      targetDir,
+		"force":     true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	_, err = os.Stat(targetDir)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDirectoryProvider_Rmdir_NonexistentDir(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      "/nonexistent/directory/path",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestDirectoryProvider_Rmdir_PathIsFile(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      filePath,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+// =============================================================================
+// Copy operation tests
+// =============================================================================
+
+func TestDirectoryProvider_Copy_Success(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "source")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("root content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "sub", "nested.txt"), []byte("nested"), 0o644))
+
+	dstDir := filepath.Join(dir, "destination")
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":   "copy",
+		"path":        srcDir,
+		"destination": dstDir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "copy", data["operation"])
+
+	content, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "root content", string(content))
+
+	content, err = os.ReadFile(filepath.Join(dstDir, "sub", "nested.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(content))
+}
+
+func TestDirectoryProvider_Copy_MissingDestination(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "copy",
+		"path":      dir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination is required")
+}
+
+func TestDirectoryProvider_Copy_SourceNotExists(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "copy",
+		"path":        "/nonexistent/source",
+		"destination": filepath.Join(dir, "dest"),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestDirectoryProvider_Copy_SourceNotDirectory(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "copy",
+		"path":        filePath,
+		"destination": filepath.Join(dir, "dest"),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+// =============================================================================
+// Dry-run tests
+// =============================================================================
+
+func TestDirectoryProvider_DryRun_List(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0o644))
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 1, data["fileCount"])
+}
+
+func TestDirectoryProvider_DryRun_Mkdir(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+	newDir := filepath.Join(dir, "newdir")
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "mkdir",
+		"path":      newDir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.True(t, data["_dryRun"].(bool))
+	assert.Contains(t, data["_message"].(string), "Would create directory")
+
+	_, err = os.Stat(newDir)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDirectoryProvider_DryRun_Rmdir(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "removeme")
+	require.NoError(t, os.Mkdir(targetDir, 0o755))
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "rmdir",
+		"path":      targetDir,
+		"force":     true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["_dryRun"].(bool))
+	assert.Contains(t, data["_message"].(string), "force-remove")
+
+	_, err = os.Stat(targetDir)
+	assert.NoError(t, err)
+}
+
+func TestDirectoryProvider_DryRun_Copy(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":   "copy",
+		"path":        dir,
+		"destination": filepath.Join(dir, "dest"),
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["_dryRun"].(bool))
+	assert.Contains(t, data["_message"].(string), "Would copy")
+}
+
+// =============================================================================
+// Helper function tests
+// =============================================================================
+
+func TestIsBinary(t *testing.T) {
+	t.Run("text content", func(t *testing.T) {
+		assert.False(t, isBinary([]byte("Hello, World!\nThis is text.")))
+	})
+
+	t.Run("binary content with null bytes", func(t *testing.T) {
+		assert.True(t, isBinary([]byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x01}))
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		assert.False(t, isBinary([]byte{}))
+	})
+}
+
+func TestMatchesFilter(t *testing.T) {
+	t.Run("no filter matches all", func(t *testing.T) {
+		assert.True(t, matchesFilter("anything.txt", &listOptions{}))
+	})
+
+	t.Run("glob matches", func(t *testing.T) {
+		opts := &listOptions{filterGlob: "*.go"}
+		assert.True(t, matchesFilter("main.go", opts))
+		assert.False(t, matchesFilter("readme.md", opts))
+	})
+
+	t.Run("regex matches", func(t *testing.T) {
+		opts := &listOptions{filterRegex: regexp.MustCompile(`^test_.*\.py$`)}
+		assert.True(t, matchesFilter("test_main.py", opts))
+		assert.False(t, matchesFilter("main.py", opts))
+	})
+}
+
+func TestToInt(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		v, err := toInt(42)
+		require.NoError(t, err)
+		assert.Equal(t, 42, v)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		v, err := toInt(int64(42))
+		require.NoError(t, err)
+		assert.Equal(t, 42, v)
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		v, err := toInt(42.0)
+		require.NoError(t, err)
+		assert.Equal(t, 42, v)
+	})
+
+	t.Run("string fails", func(t *testing.T) {
+		_, err := toInt("42")
+		require.Error(t, err)
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -147,6 +147,7 @@ func TestIntegration_GetProvider(t *testing.T) {
 	assert.Contains(t, stdout, "http")
 	assert.Contains(t, stdout, "exec")
 	assert.Contains(t, stdout, "cel")
+	assert.Contains(t, stdout, "directory")
 }
 
 func TestIntegration_GetProviderJSON(t *testing.T) {
@@ -2278,4 +2279,55 @@ func TestIntegration_BuildSolution_DryRunShowsDetails(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	// Dry run should show structured output: files, analysis, summary
 	assert.Contains(t, stdout, "Dry run")
+}
+
+// ============================================================================
+// Directory Provider Integration Tests
+// ============================================================================
+
+func TestIntegration_RunSolution_DirectoryProvider(t *testing.T) {
+	// Create a temp directory with test files
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "hello.txt"), []byte("world"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "sub", "nested.go"), []byte("package sub"), 0o644))
+
+	// Create a solution YAML that uses the directory provider
+	solutionFile := filepath.Join(tmpDir, "dir-solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dir-test
+  version: 1.0.0
+  description: Directory provider integration test
+
+spec:
+  resolvers:
+    listing:
+      description: List temp directory
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: "` + tmpDir + `"
+              recursive: true
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", solutionFile,
+		"--skip-actions",
+		"-o", "json",
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d", exitCode)
+	assert.Contains(t, stdout, "hello.txt")
+	assert.Contains(t, stdout, "nested.go")
+	assert.Contains(t, stdout, "totalCount")
 }


### PR DESCRIPTION
Add new directory provider for filesystem operations including list, mkdir, rmdir, and copy with support for recursive traversal, glob/regex filtering, content reading, and checksums.

New files:
- pkg/provider/builtin/directoryprovider/directory.go
- pkg/provider/builtin/directoryprovider/directory_test.go
- docs/tutorials/directory-provider-tutorial.md
- examples/solutions/directory/solution.yaml

Documentation updates:
- README.md: Update provider count (15→16), add to provider table
- docs/tutorials/provider-reference.md: Add capabilities matrix entry and full section with inputs/outputs/examples
- docs/tutorials/_index.md: Add tutorial link
- docs/design/providers.md: Add to Built-in Providers section

Provider registration:
- pkg/provider/builtin/builtin.go: Register directory provider
- pkg/provider/builtin/builtin_test.go: Add test coverage
- tests/integration/cli_test.go: Add integration test

Fix linting issues:
- .golangci.yml: Add revive var-naming exclusions for packages that intentionally shadow standard library names (filepath, fs, metrics, debug, solution)