### PR TITLE
feat(logging): overhaul CLI logging with quiet-by-default and user-co…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,6 +99,18 @@ linters:
         linters:
           - revive
         text: "var-naming: avoid package names"
+      - path: pkg/celexp/ext/filepath/filepath\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/celexp/ext/strings/strings\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
+      - path: pkg/cmd/scafctl/build/build\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
 formatters:
   enable:
     - gofumpt

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Zsh users must have `compinit` loaded before the completion file is sourced.
 - **Plugins**: Extend scafctl with custom providers via a plugin system
 - **Snapshots**: Capture and diff resolver output over time
 - **Linting**: Validate solution files for correctness before execution
+- **Logging**: Quiet by default with user-controlled verbosity, format, and file output
 
 ## Quick Start
 
@@ -194,6 +195,7 @@ See the [Provider Reference](docs/tutorials/provider-reference.md) and [Provider
 - [CEL Expressions](docs/tutorials/cel-tutorial.md) — Dynamic evaluation with CEL
 - [Go Templates](docs/tutorials/go-templates-tutorial.md) — Templating with Go templates
 - [Configuration](docs/tutorials/config-tutorial.md) — Managing application settings
+- [Logging](docs/tutorials/logging-tutorial.md) — Controlling log output, formats, and destinations
 - [Caching](docs/tutorials/cache-tutorial.md) — Provider result caching
 - [Directory Provider](docs/tutorials/directory-provider-tutorial.md) — Listing, scanning, and managing directories
 - [Snapshots](docs/tutorials/snapshots-tutorial.md) — Capturing and diffing output
@@ -300,6 +302,51 @@ scafctl config remove-catalog my-registry
 ```
 
 See the [Configuration Tutorial](docs/tutorials/config-tutorial.md).
+
+## Logging
+
+By default, scafctl produces **no structured log output** — only styled user messages (errors, warnings, success). This keeps the CLI clean for human users and pipe-friendly for scripts.
+
+### Quick Reference
+
+```bash
+# Default: no logs, just styled errors/warnings
+scafctl run solution -f solution.yaml
+
+# Enable debug logging (human-readable console format)
+scafctl run solution -f solution.yaml --debug
+scafctl run solution -f solution.yaml --log-level debug
+
+# JSON structured logs (for log aggregation / piping)
+scafctl run solution -f solution.yaml --log-level info --log-format json
+
+# Write logs to a file instead of stderr
+scafctl run solution -f solution.yaml --debug --log-file /tmp/scafctl.log
+
+# Environment variables (useful for CI/CD)
+export SCAFCTL_DEBUG=1             # Enable debug logging
+export SCAFCTL_LOG_LEVEL=info      # Set specific level
+export SCAFCTL_LOG_FORMAT=json     # Set format
+export SCAFCTL_LOG_PATH=/tmp/scafctl.log  # Log to file
+```
+
+### Log Levels
+
+| Level | Description |
+|-------|-------------|
+| `none` | No log output (default) |
+| `error` | Errors only |
+| `warn` | Warnings and errors |
+| `info` | Informational messages |
+| `debug` | Verbose debugging (V-level 1) |
+| `trace` | Very verbose (V-level 2) |
+| `1`-`3` | Numeric V-levels for fine-grained control |
+
+### Precedence
+
+Flag (`--log-level`) > `--debug` > environment variable > config file > default (`none`)
+
+See the [Logging Tutorial](docs/tutorials/logging-tutorial.md) for detailed examples.
 
 ## Secrets
 

--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -1529,7 +1529,10 @@ These flags should be available on the root command and inherited by all subcomm
 | `--quiet` | `-q` | bool | `false` | Suppress non-essential output |
 | `--no-color` | | bool | `false` | Disable colored output |
 | `--config` | | string | `~/.scafctl/config.yaml` | Path to config file |
-| `--log-level` | | int | `0` | Log level (-1=Debug, 0=Info, 1=Warn, 2=Error) |
+| `--log-level` | | string | `none` | Log level: none, error, warn, info, debug, trace, or numeric V-level |
+| `--debug` | `-d` | bool | `false` | Enable debug logging (shorthand for --log-level debug) |
+| `--log-format` | | string | `console` | Log format: console (colored) or json (structured) |
+| `--log-file` | | string | `""` | Write logs to a file path |
 
 ### Adding Global Flags
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -576,7 +576,10 @@ These flags are available on most commands:
 | `--quiet` | `-q` | Suppress non-essential output | ✅ Implemented |
 | `--no-color` | | Disable colored output | ✅ Implemented |
 | `--config` | | Path to config file (default: `~/.scafctl/config.yaml`) | ✅ Implemented |
-| `--log-level` | | Set log level (-1=Debug, 0=Info, 1=Warn, 2=Error) | ✅ Implemented |
+| `--log-level` | | Set log level (none, error, warn, info, debug, trace, or numeric V-level) | ✅ Implemented |
+| `--debug` | `-d` | Enable debug logging (shorthand for --log-level debug) | ✅ Implemented |
+| `--log-format` | | Log format: console (default) or json | ✅ Implemented |
+| `--log-file` | | Write logs to a file path | ✅ Implemented |
 | `--catalog` | | Target a specific configured catalog | 📋 Planned |
 
 **Note**: The `-o/--output` flag is available per-command (not global) on commands that support structured output.

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -216,6 +216,10 @@ All providers implement structured logging via logr:
 
 **Usage:**
 ```bash
+# Logs are suppressed by default. Enable debug to see provider execution:
+scafctl run solution -f solution.yaml --debug
+
+# Or use a specific V-level:
 scafctl run solution -f solution.yaml --log-level 1
 ```
 

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -22,6 +22,7 @@ Step-by-step guides for learning scafctl features.
 - [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
 - [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
 - [Configuration Tutorial](config-tutorial.md) — Manage application configuration
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
 
 ## Reference

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -192,7 +192,8 @@ State:    ~/Library/Application Support/scafctl/state/
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `logging.level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `logging.level` | string | `none` | Log level: `none`, `error`, `warn`, `info`, `debug`, `trace`, or numeric V-level |
+| `logging.format` | string | `console` | Log format: `console` (colored), `json` (structured) |
 | `settings.defaultCatalog` | string | `local` | Default catalog name |
 | `httpClient.timeout` | duration | `30s` | HTTP request timeout |
 | `httpClient.retry.maxRetries` | int | `3` | Max HTTP retries |
@@ -229,7 +230,7 @@ version: 1
 settings:
   defaultCatalog: "local"
 logging:
-  level: "info"
+  level: "none"
 catalogs:
   - name: local
     type: filesystem
@@ -267,11 +268,11 @@ scafctl config set logging.level debug
 
 # After debugging, reset
 scafctl config unset logging.level
-scafctl config use-catalog production
 ```
 
 ## Next Steps
 
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output destination
 - [Catalog Tutorial](catalog-tutorial.md) — Build and manage solutions in the catalog
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data
 - [Getting Started](getting-started.md) — Run your first solution

--- a/docs/tutorials/logging-tutorial.md
+++ b/docs/tutorials/logging-tutorial.md
@@ -1,0 +1,319 @@
+---
+title: "Logging & Debugging"
+weight: 95
+---
+
+# Logging & Debugging Tutorial
+
+This tutorial covers controlling scafctl's log output — verbosity, format, destination, and environment variable overrides.
+
+## Overview
+
+By default, scafctl produces **no structured log output**. Only styled user messages (errors, warnings, success indicators) are shown. This keeps the CLI clean for human users and pipe-friendly for scripts.
+
+When you need to see what's happening under the hood — debugging a solution, reporting a bug, or feeding structured logs to a log aggregation system — scafctl gives you full control over log verbosity, format, and destination.
+
+```
+┌──────────────────────────────────────────────────┐
+│  Default:     No logs, just styled output        │
+│  --debug:     Console-format debug logs          │
+│  --log-level: Named or numeric verbosity         │
+│  --log-format: console (default) or json         │
+│  --log-file:  Write logs to a file               │
+│  Env vars:    Override from CI/CD or scripts     │
+└──────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### Default Behavior
+
+Run any command — you'll see only styled user-facing messages:
+
+```bash
+scafctl run solution -f solution.yaml
+# Output: styled results, errors show as ❌ messages
+
+scafctl run solution -f invalid.yaml
+# Output: ❌ failed to load solution from 'invalid.yaml': ...
+# No JSON log noise on stderr
+```
+
+### Enable Debug Logging
+
+The quickest way to see what scafctl is doing:
+
+```bash
+scafctl run solution -f solution.yaml --debug
+
+# or equivalently:
+scafctl run solution -f solution.yaml --log-level debug
+```
+
+This shows colored, human-readable logs on stderr alongside normal output:
+
+```
+2026-01-15T10:30:00.000-0500    DEBUG   run/solution.go:326     running solution {"file": "solution.yaml", ...}
+2026-01-15T10:30:00.001-0500    DEBUG   get/get.go:347  Reading solution from local filesystem  {"path": "solution.yaml"}
+```
+
+## Log Levels
+
+scafctl supports both **named levels** (recommended) and **numeric V-levels** for fine-grained control.
+
+### Named Levels
+
+| Level | Description | Use Case |
+|-------|-------------|----------|
+| `none` | Suppress all structured log output | Default; normal CLI usage |
+| `error` | Errors only | Production monitoring |
+| `warn` | Warnings and errors | Catch potential issues |
+| `info` | Informational messages | See what's happening |
+| `debug` | Verbose debugging | Troubleshooting solutions |
+| `trace` | Very verbose | Deep debugging |
+
+```bash
+# Show only errors
+scafctl run solution -f solution.yaml --log-level error
+
+# Show info and above
+scafctl run solution -f solution.yaml --log-level info
+
+# Maximum verbosity
+scafctl run solution -f solution.yaml --log-level trace
+```
+
+### Numeric V-Levels
+
+For fine-grained control matching the internal `V()` levels used in the code:
+
+| V-Level | Equivalent Named Level | What It Shows |
+|---------|----------------------|---------------|
+| `1` | `debug` | Provider execution, resolver lifecycle |
+| `2` | `trace` | Internal data flow, template rendering |
+| `3` | _(no alias)_ | Ultra-verbose internals |
+
+```bash
+# Same as --log-level debug
+scafctl run solution -f solution.yaml --log-level 1
+
+# Same as --log-level trace
+scafctl run solution -f solution.yaml --log-level 2
+
+# Ultra-verbose (no named alias)
+scafctl run solution -f solution.yaml --log-level 3
+```
+
+## Log Formats
+
+### Console Format (Default)
+
+Human-readable, colored output. Best for terminal use:
+
+```bash
+scafctl run solution -f solution.yaml --debug
+# or explicitly:
+scafctl run solution -f solution.yaml --log-level debug --log-format console
+```
+
+Output:
+
+```
+2026-01-15T10:30:00.000-0500    DEBUG   run/solution.go:326     running solution {"file": "solution.yaml", ...}
+2026-01-15T10:30:00.001-0500    ERROR   get/get.go:360  Failed to unmarshal     {"error": "..."}
+```
+
+### JSON Format
+
+Structured JSON, ideal for log aggregation (Splunk, Datadog, ELK), piping to `jq`, or machine parsing:
+
+```bash
+scafctl run solution -f solution.yaml --log-level info --log-format json
+```
+
+Output:
+
+```json
+{"level":"info","timestamp":"2026-01-15T10:30:00.000-0500","caller":"run/solution.go:326","message":"running solution","file":"solution.yaml"}
+{"level":"error","timestamp":"2026-01-15T10:30:00.001-0500","caller":"get/get.go:360","message":"Failed to unmarshal","error":"..."}
+```
+
+Filter with `jq`:
+
+```bash
+scafctl run solution -f solution.yaml --log-level debug --log-format json 2>&1 | jq 'select(.level == "error")'
+```
+
+## Log File Output
+
+Write logs to a file instead of (or in addition to) stderr:
+
+```bash
+# Logs go to file only; stderr shows just styled output
+scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/scafctl.log
+
+# Logs go to BOTH file and stderr (combine with --debug)
+scafctl run solution -f solution.yaml --debug --log-file /tmp/scafctl.log
+```
+
+When `--debug` and `--log-file` are used together, logs are written to both destinations. Without `--debug`, the file receives the logs and stderr stays clean.
+
+View the log file:
+
+```bash
+tail -f /tmp/scafctl.log
+```
+
+## Environment Variables
+
+Environment variables are useful for CI/CD pipelines, container environments, and scripts where you can't pass flags.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SCAFCTL_DEBUG` | Enable debug logging (set to `1`, `true`, or any non-empty non-`0` value) | `SCAFCTL_DEBUG=1` |
+| `SCAFCTL_LOG_LEVEL` | Set log level | `SCAFCTL_LOG_LEVEL=info` |
+| `SCAFCTL_LOG_FORMAT` | Set log format | `SCAFCTL_LOG_FORMAT=json` |
+| `SCAFCTL_LOG_PATH` | Write logs to a file | `SCAFCTL_LOG_PATH=/var/log/scafctl.log` |
+
+### Examples
+
+```bash
+# CI/CD: structured JSON logs for log aggregation
+export SCAFCTL_LOG_LEVEL=info
+export SCAFCTL_LOG_FORMAT=json
+scafctl run solution -f solution.yaml
+
+# Container: debug to a file
+export SCAFCTL_DEBUG=1
+export SCAFCTL_LOG_PATH=/var/log/scafctl.log
+scafctl run solution -f solution.yaml
+
+# Quick debug in shell
+SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
+```
+
+## Precedence
+
+When multiple sources set the log level, scafctl applies them in this order (highest priority first):
+
+```
+1. --log-level flag          (explicit flag always wins)
+2. --debug / -d flag         (shorthand for --log-level debug)
+3. SCAFCTL_LOG_LEVEL env     (environment variable)
+4. SCAFCTL_DEBUG env         (debug shortcut)
+5. config file logging.level (persistent preference)
+6. default: "none"           (no logs)
+```
+
+The same pattern applies to format and file path:
+- `--log-format` flag > `SCAFCTL_LOG_FORMAT` env > config `logging.format` > default `"console"`
+- `--log-file` flag > `SCAFCTL_LOG_PATH` env > default (no file)
+
+## Configuration File
+
+You can set logging defaults in your config file so you don't need flags every time:
+
+```yaml
+# ~/.config/scafctl/config.yaml (Linux)
+# ~/Library/Application Support/scafctl/config.yaml (macOS)
+logging:
+  level: "info"       # Always show info-level logs
+  format: "console"   # Human-readable (default)
+  timestamps: true    # Include timestamps (default)
+```
+
+Manage via CLI:
+
+```bash
+# Set persistent log level
+scafctl config set logging.level info
+
+# Set persistent format
+scafctl config set logging.format json
+
+# Reset to defaults
+scafctl config unset logging.level
+scafctl config unset logging.format
+```
+
+## Common Workflows
+
+### Debugging a Failing Solution
+
+```bash
+# Step 1: Run with debug to see what's happening
+scafctl run solution -f solution.yaml --debug
+
+# Step 2: If you need even more detail
+scafctl run solution -f solution.yaml --log-level trace
+
+# Step 3: Capture logs for a bug report
+scafctl run solution -f solution.yaml --log-level trace --log-format json --log-file debug.log 2>&1
+```
+
+### CI/CD Pipeline
+
+```bash
+# Fail-fast with only error logs in JSON for log aggregation
+scafctl run solution -f solution.yaml --log-level error --log-format json
+```
+
+Or set via environment:
+
+```yaml
+# GitHub Actions example
+env:
+  SCAFCTL_LOG_LEVEL: error
+  SCAFCTL_LOG_FORMAT: json
+steps:
+  - run: scafctl run solution -f solution.yaml
+```
+
+### Separating Logs from Output
+
+Use `--log-file` to keep stderr clean while still capturing logs:
+
+```bash
+# Logs to file, styled output to stderr, data to stdout
+scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/run.log -o json > results.json
+
+# Review logs separately
+cat /tmp/run.log
+```
+
+### Temporary Debug Session
+
+Set and unset config for a debugging session:
+
+```bash
+# Enable debug temporarily via config
+scafctl config set logging.level debug
+
+# Run your commands...
+scafctl run solution -f solution.yaml
+
+# Reset when done
+scafctl config unset logging.level
+```
+
+Or use the environment variable (no config changes needed):
+
+```bash
+SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
+```
+
+## Summary
+
+| What You Want | Command |
+|---|---|
+| Clean output (default) | `scafctl run solution -f s.yaml` |
+| Quick debug | `scafctl ... --debug` |
+| Specific level | `scafctl ... --log-level warn` |
+| JSON for tooling | `scafctl ... --log-level info --log-format json` |
+| Logs to file | `scafctl ... --debug --log-file debug.log` |
+| CI/CD env vars | `SCAFCTL_LOG_LEVEL=error SCAFCTL_LOG_FORMAT=json` |
+
+## Next Steps
+
+- [Configuration Tutorial](config-tutorial.md) — Manage all application settings
+- [Getting Started](getting-started.md) — Run your first solution

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,8 +11,11 @@ scafctl run solution -f examples/<path-to-example>.yaml
 # Run with parameters
 scafctl run solution -f examples/resolvers/parameters.yaml -r name=Alice
 
-# Run with verbose output
-scafctl run solution -f examples/actions/hello-world.yaml -v
+# Run with debug logging (see what scafctl is doing)
+scafctl run solution -f examples/actions/hello-world.yaml --debug
+
+# Run with JSON logs for troubleshooting
+scafctl run solution -f examples/actions/hello-world.yaml --log-level info --log-format json
 ```
 
 ---
@@ -91,6 +94,7 @@ Complete solutions demonstrating real-world use cases.
 | [taskfile/](solutions/taskfile/) | Taskfile.yaml generation |
 | [email-notifier/](solutions/email-notifier/) | Email notification workflow |
 | [k8s-clusters/](solutions/k8s-clusters/) | Read a Go template file, iterate 10 K8s clusters, render and write unique manifests |
+| [bad-solution-yaml/](solutions/bad-solution-yaml/) | Invalid solution demonstrating error handling for conflicting ValueRef keys |
 
 ---
 

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -49,7 +49,7 @@ Copy an example configuration:
 General application behavior: default catalog, colored output, quiet mode.
 
 ### `logging`
-Log level (-1=debug, 0=info, 1=warn, 2=error), format (json/text), timestamps.
+Log level (none/error/warn/info/debug/trace or numeric V-level), format (console/json), timestamps.
 
 ### `httpClient`
 Global HTTP settings: timeouts, retries, caching, circuit breaker.
@@ -73,8 +73,13 @@ All config values can be overridden via environment variables:
 ```bash
 # Use SCAFCTL_ prefix with underscores for nested keys
 export SCAFCTL_SETTINGS_NOCOLOR=true
-export SCAFCTL_LOGGING_LEVEL=-1
 export SCAFCTL_HTTPCLIENT_TIMEOUT=60s
+
+# Logging-specific env vars (override config and flags)
+export SCAFCTL_LOG_LEVEL=debug      # Set log level
+export SCAFCTL_LOG_FORMAT=json       # Set log format
+export SCAFCTL_LOG_PATH=/tmp/scafctl.log  # Write logs to file
+export SCAFCTL_DEBUG=1               # Shortcut: enable debug logging
 ```
 
 ## See Also

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -42,19 +42,26 @@ settings:
 # Logging - Control log output format and verbosity
 # =============================================================================
 logging:
-  # Log level determines verbosity:
-  #   -1 = Debug (most verbose, includes trace information)
-  #    0 = Info (default, normal operation messages)
-  #    1 = Warn (warnings and errors only)
-  #    2 = Error (errors only)
-  # Default: 0
-  level: 0
+  # Log level determines verbosity. Named levels (recommended):
+  #   "none"  - Suppress all log output (default, CLI-first UX)
+  #   "error" - Errors only
+  #   "warn"  - Warnings and errors
+  #   "info"  - Normal operation messages
+  #   "debug" - Verbose, includes trace information (alias for V-level 1)
+  #   "trace" - Very verbose (alias for V-level 2)
+  #
+  # Numeric V-levels are also supported for fine-grained control:
+  #   "1" = debug, "2" = trace, "3" = ultra-verbose
+  #
+  # Default: "none"
+  level: "none"
 
   # Output format for log messages:
-  #   "json" - Structured JSON, ideal for log aggregation (default)
-  #   "text" - Human-readable colored output for development
-  # Default: "json"
-  format: "json"
+  #   "console" - Human-readable colored output (default)
+  #   "json"    - Structured JSON, ideal for log aggregation and piping
+  #   "text"    - Alias for "console"
+  # Default: "console"
+  format: "console"
 
   # Include timestamps in log output
   # Default: true

--- a/examples/config/minimal-config.yaml
+++ b/examples/config/minimal-config.yaml
@@ -25,11 +25,12 @@ settings:
 
 # Logging configuration
 logging:
-  # Use "text" format for human-readable output during development
-  # format: "text"
+  # Logs are suppressed by default (level: "none").
+  # Set to "debug" for troubleshooting or "info" for normal operation.
+  # level: "debug"
 
-  # Increase verbosity for debugging (-1 = debug, 0 = info, 1 = warn, 2 = error)
-  # level: -1
+  # Format: "console" (default, colored), "json" (structured)
+  # format: "json"
 
 # Add your catalogs below
 # Use: scafctl config add-catalog to add interactively

--- a/examples/solutions/bad-solution-yaml/solution.yaml
+++ b/examples/solutions/bad-solution-yaml/solution.yaml
@@ -1,0 +1,156 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: bad-solution-yaml
+  version: 1.0.0
+  description: A solution with invalid YAML syntax to demonstrate error handling
+
+spec:
+  resolvers:
+    bad:
+      description: A resolver with invalid YAML syntax
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: repo
+                tmpl: "This is a bad resolver with invalid YAML syntax"
+                
+    repo:
+      description: Repository name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: scafctl
+
+    version:
+      description: Version to build and release
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version
+          - provider: static
+            inputs:
+              value: dev
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: '^(dev|\d+\.\d+\.\d+.*)$'
+            message: "Invalid version format"
+
+    goos:
+      description: Target operating system
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: goos
+          - provider: static
+            inputs:
+              value: linux
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self in [\"linux\", \"darwin\", \"windows\"]"
+            message: "Invalid OS: must be linux, darwin, or windows"
+
+    goarch:
+      description: Target architecture
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: goarch
+          - provider: static
+            inputs:
+              value: amd64
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self in [\"amd64\", \"arm64\"]"
+            message: "Invalid architecture: must be amd64 or arm64"
+
+    buildDir:
+      description: Build output directory
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: dist
+
+  actions:
+    clean:
+      description: Clean build directory
+      provider: exec
+      inputs:
+        cmd:
+          - rm
+          - -rf
+        args:
+          directory:
+            rslvr: buildDir
+
+    test:
+      description: Run tests
+      provider: exec
+      dependsOn: [clean]
+      inputs:
+        cmd:
+          - go
+          - test
+          - ./...
+
+    build:
+      description: Build binary
+      provider: exec
+      dependsOn: [test]
+      inputs:
+        env:
+          GOOS:
+            rslvr: goos
+          GOARCH:
+            rslvr: goarch
+        cmd:
+          - go
+          - build
+          - -o
+        args:
+          output:
+            tmpl: "{{ .buildDir }}/{{ .repo }}"
+          source: ./cmd/scafctl
+        context:
+          buildDir:
+            rslvr: buildDir
+          repo:
+            rslvr: repo
+
+    release:
+      description: Create GitHub release
+      provider: api
+      dependsOn: [build]
+      when:
+        expr: "_.version != \"dev\""
+      inputs:
+        endpoint: https://api.github.com/repos/oakwood-commons/scafctl/releases
+        method: POST
+        headers:
+          Authorization:
+            tmpl: "Bearer {{ .github_token }}"
+        body:
+          tag_name:
+            rslvr: version
+          name:
+            tmpl: "Release {{ .version }}"
+          draft: false
+          prerelease:
+            expr: "_.version.contains(\"alpha\") || _.version.contains(\"beta\")"
+        context:
+          version:
+            rslvr: version

--- a/pkg/celexp/ext/debug/debug_test.go
+++ b/pkg/celexp/ext/debug/debug_test.go
@@ -25,7 +25,7 @@ func newTestWriter() (*writer.Writer, *bytes.Buffer) {
 	cliParams := &settings.Run{
 		NoColor:     true,
 		IsQuiet:     false,
-		MinLogLevel: -1, // Enable debug output
+		MinLogLevel: "debug", // Enable debug output
 	}
 	w := writer.New(ioStreams, cliParams)
 	return w, errBuf

--- a/pkg/cmd/scafctl/config/config_test.go
+++ b/pkg/cmd/scafctl/config/config_test.go
@@ -185,7 +185,7 @@ func TestSetOptions_Run(t *testing.T) {
 	mgr := appconfig.NewManager(configPath)
 	cfg, err := mgr.Load()
 	require.NoError(t, err)
-	assert.Equal(t, 2, cfg.Logging.Level)
+	assert.Equal(t, "2", cfg.Logging.Level)
 }
 
 func TestSetOptions_parseValue(t *testing.T) {
@@ -221,7 +221,7 @@ func TestUnsetOptions_Run(t *testing.T) {
 
 	configContent := `
 logging:
-  level: 2
+  level: "2"
 settings:
   noColor: true
 `
@@ -249,7 +249,7 @@ settings:
 	mgr := appconfig.NewManager(configPath)
 	cfg, err := mgr.Load()
 	require.NoError(t, err)
-	assert.Equal(t, 0, cfg.Logging.Level)
+	assert.Equal(t, "none", cfg.Logging.Level)
 }
 
 func TestAddCatalogOptions_Run(t *testing.T) {

--- a/pkg/cmd/scafctl/config/unset.go
+++ b/pkg/cmd/scafctl/config/unset.go
@@ -116,8 +116,8 @@ func (o *UnsetOptions) getDefaultValue(key string) any {
 		"settings.defaultCatalog": "local",
 		"settings.noColor":        false,
 		"settings.quiet":          false,
-		"logging.level":           0,
-		"logging.format":          "json",
+		"logging.level":           "none",
+		"logging.format":          "console",
 		"logging.timestamps":      true,
 		"logging.enableProfiling": false,
 	}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -42,6 +42,9 @@ var (
 	cliParams  = settings.NewCliParams()
 	configPath string
 	appConfig  *config.Config
+	debugFlag  bool
+	logFormat  string
+	logFile    string
 )
 
 // AppConfig returns the loaded application configuration.
@@ -82,25 +85,68 @@ func Root() *cobra.Command {
 			if !cCmd.Flags().Changed("quiet") {
 				cliParams.IsQuiet = cfg.Settings.Quiet
 			}
+
+			// Resolve log level with precedence: flag > --debug > env > config > default ("none")
+			resolvedLogLevel := cliParams.MinLogLevel // flag value or default
 			if !cCmd.Flags().Changed("log-level") {
-				// Safe conversion with bounds check
-				logLevel := cfg.Logging.Level
-				if logLevel > 127 {
-					logLevel = 127
-				} else if logLevel < -128 {
-					logLevel = -128
+				// Flag not explicitly set — check env vars, then config
+				if envLevel := os.Getenv("SCAFCTL_LOG_LEVEL"); envLevel != "" {
+					resolvedLogLevel = envLevel
+				} else if envDebug := os.Getenv("SCAFCTL_DEBUG"); envDebug != "" && envDebug != "0" && envDebug != "false" {
+					resolvedLogLevel = logger.LevelDebug
+				} else if cfg.Logging.Level != "" {
+					resolvedLogLevel = cfg.Logging.Level
 				}
-				cliParams.MinLogLevel = int8(logLevel) //nolint:gosec // bounds checked above
+			}
+			// --debug flag always wins (it's an explicit override)
+			if debugFlag {
+				resolvedLogLevel = logger.LevelDebug
+			}
+			cliParams.MinLogLevel = resolvedLogLevel
+
+			// Resolve log format with precedence: flag > env > config > default ("console")
+			resolvedFormat := logFormat // flag value or default
+			if !cCmd.Flags().Changed("log-format") {
+				if envFormat := os.Getenv("SCAFCTL_LOG_FORMAT"); envFormat != "" {
+					resolvedFormat = envFormat
+				} else if cfg.Logging.Format != "" {
+					resolvedFormat = cfg.Logging.Format
+				}
 			}
 
-			// Build logger options from config
-			logOpts := logger.Options{
-				Level:      cliParams.MinLogLevel * -1,
-				Timestamps: cfg.Logging.Timestamps,
-				Format:     logger.FormatJSON,
+			// Resolve log file with precedence: flag > env > default (empty = stderr)
+			resolvedLogFile := logFile
+			if !cCmd.Flags().Changed("log-file") {
+				if envPath := os.Getenv("SCAFCTL_LOG_PATH"); envPath != "" {
+					resolvedLogFile = envPath
+				}
 			}
-			if cfg.Logging.Format == config.LoggingFormatText {
-				logOpts.Format = logger.FormatText
+
+			// Parse the resolved log level string to a zap level
+			zapLevel, parseErr := logger.ParseLogLevel(resolvedLogLevel)
+			if parseErr != nil {
+				_, _ = os.Stderr.WriteString("Warning: " + parseErr.Error() + ", defaulting to 'none'\n")
+				zapLevel = logger.LogLevelNone
+			}
+
+			// Map format string to logger.LogFormat
+			var logFmt logger.LogFormat
+			switch resolvedFormat {
+			case config.LoggingFormatJSON:
+				logFmt = logger.FormatJSON
+			case config.LoggingFormatText, config.LoggingFormatConsole:
+				logFmt = logger.FormatConsole
+			default:
+				logFmt = logger.FormatConsole
+			}
+
+			// Build logger options
+			logOpts := logger.Options{
+				Level:      zapLevel,
+				Timestamps: cfg.Logging.Timestamps,
+				Format:     logFmt,
+				FilePath:   resolvedLogFile,
+				AlsoStderr: resolvedLogFile != "" && debugFlag,
 			}
 
 			lgr := logger.GetWithOptions(logOpts)
@@ -179,7 +225,10 @@ func Root() *cobra.Command {
 
 	ioStreams := terminal.NewIOStreams(os.Stdin, os.Stdout, os.Stderr, true)
 
-	cCmd.PersistentFlags().Int8Var(&cliParams.MinLogLevel, "log-level", 0, "Set the minimum log level (-1=Debug, 0=Info, 1=Warn, 2=Error)")
+	cCmd.PersistentFlags().StringVar(&cliParams.MinLogLevel, "log-level", "none", "Set the log level (none, error, warn, info, debug, trace, or a numeric V-level)")
+	cCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debug logging (shorthand for --log-level debug)")
+	cCmd.PersistentFlags().StringVar(&logFormat, "log-format", "console", "Set the log output format (console, json)")
+	cCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write logs to a file instead of stderr")
 	cCmd.PersistentFlags().BoolVarP(&cliParams.IsQuiet, "quiet", "q", false, "Do not print additional information")
 	cCmd.PersistentFlags().BoolVar(&cliParams.NoColor, "no-color", false, "Disable color output")
 	cCmd.PersistentFlags().StringVar(&configPath, "config", "", "Path to config file (default: ~/.scafctl/config.yaml)")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -113,8 +114,8 @@ func (m *Manager) setDefaults() {
 	})
 
 	// Logging defaults
-	m.v.SetDefault("logging.level", 0)
-	m.v.SetDefault("logging.format", LoggingFormatJSON)
+	m.v.SetDefault("logging.level", "none")
+	m.v.SetDefault("logging.format", LoggingFormatConsole)
 	m.v.SetDefault("logging.timestamps", true)
 	m.v.SetDefault("logging.enableProfiling", false)
 
@@ -237,8 +238,11 @@ func (m *Manager) Set(key string, value any) {
 	if m.config != nil {
 		switch key {
 		case "logging.level":
-			if v, ok := value.(int); ok {
+			switch v := value.(type) {
+			case string:
 				m.config.Logging.Level = v
+			case int:
+				m.config.Logging.Level = strconv.Itoa(v)
 			}
 		case "logging.format":
 			if v, ok := value.(string); ok {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,7 +29,7 @@ func TestManager_Load_NoFile(t *testing.T) {
 	assert.Equal(t, "local", cfg.Catalogs[0].Name)
 	assert.Equal(t, CatalogTypeFilesystem, cfg.Catalogs[0].Type)
 	assert.Equal(t, paths.CatalogDir(), cfg.Catalogs[0].Path)
-	assert.Equal(t, 0, cfg.Logging.Level)
+	assert.Equal(t, "none", cfg.Logging.Level)
 	assert.Equal(t, "local", cfg.Settings.DefaultCatalog)
 	assert.False(t, cfg.Settings.NoColor)
 	assert.False(t, cfg.Settings.Quiet)
@@ -49,7 +49,7 @@ catalogs:
 settings:
   defaultCatalog: test
 logging:
-  level: 1
+  level: warn
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ logging:
 	assert.Equal(t, "filesystem", cfg.Catalogs[0].Type)
 	assert.Equal(t, "./test", cfg.Catalogs[0].Path)
 	assert.Equal(t, "test", cfg.Settings.DefaultCatalog)
-	assert.Equal(t, 1, cfg.Logging.Level)
+	assert.Equal(t, "warn", cfg.Logging.Level)
 }
 
 func TestManager_Load_WithFullConfig(t *testing.T) {
@@ -90,7 +90,7 @@ settings:
   noColor: true
   quiet: false
 logging:
-  level: -1
+  level: debug
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ logging:
 	assert.Equal(t, "local", cfg.Settings.DefaultCatalog)
 	assert.True(t, cfg.Settings.NoColor)
 	assert.False(t, cfg.Settings.Quiet)
-	assert.Equal(t, -1, cfg.Logging.Level)
+	assert.Equal(t, "debug", cfg.Logging.Level)
 }
 
 func TestManager_Load_InvalidYAML(t *testing.T) {
@@ -160,7 +160,7 @@ func TestManager_Save(t *testing.T) {
 		Type: CatalogTypeFilesystem,
 		Path: "./new",
 	})
-	cfg.Logging.Level = 2
+	cfg.Logging.Level = "error"
 
 	// Save
 	err = mgr.Save()
@@ -175,7 +175,7 @@ func TestManager_Save(t *testing.T) {
 	assert.Len(t, cfg2.Catalogs, 2)
 	assert.Equal(t, "local", cfg2.Catalogs[0].Name)
 	assert.Equal(t, "new-catalog", cfg2.Catalogs[1].Name)
-	assert.Equal(t, 2, cfg2.Logging.Level)
+	assert.Equal(t, "error", cfg2.Logging.Level)
 }
 
 func TestManager_SaveAs(t *testing.T) {
@@ -223,8 +223,8 @@ func TestManager_GetSet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set and get
-	mgr.Set("logging.level", 3)
-	assert.Equal(t, 3, mgr.Get("logging.level"))
+	mgr.Set("logging.level", "3")
+	assert.Equal(t, "3", mgr.Get("logging.level"))
 
 	mgr.Set("settings.noColor", true)
 	assert.Equal(t, true, mgr.Get("settings.noColor"))

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -49,8 +49,8 @@ type Settings struct {
 
 // LoggingConfig holds logging configuration.
 type LoggingConfig struct {
-	Level           int    `json:"level,omitempty" yaml:"level,omitempty" mapstructure:"level" doc:"Log level (-1=Debug, 0=Info, 1=Warn, 2=Error)" example:"0" maximum:"3"`
-	Format          string `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format" doc:"Output format (json, text)" example:"json" maxLength:"10"`
+	Level           string `json:"level,omitempty" yaml:"level,omitempty" mapstructure:"level" doc:"Log level (none, error, warn, info, debug, trace, or a numeric V-level)" example:"none" maxLength:"10"`
+	Format          string `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format" doc:"Output format (console, json, text)" example:"console" maxLength:"10"`
 	Timestamps      bool   `json:"timestamps,omitempty" yaml:"timestamps,omitempty" mapstructure:"timestamps" doc:"Include timestamps in logs"`
 	EnableProfiling bool   `json:"enableProfiling,omitempty" yaml:"enableProfiling,omitempty" mapstructure:"enableProfiling" doc:"Enable profiling (unhides --pprof flag)"`
 }
@@ -58,8 +58,11 @@ type LoggingConfig struct {
 // LoggingFormatJSON is the JSON log format.
 const LoggingFormatJSON = "json"
 
-// LoggingFormatText is the text log format.
+// LoggingFormatText is the text log format (alias for console).
 const LoggingFormatText = "text"
+
+// LoggingFormatConsole is the human-readable console log format.
+const LoggingFormatConsole = "console"
 
 // CatalogType constants define the supported catalog types.
 const (

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -6,6 +6,8 @@ package config
 import (
 	"fmt"
 	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
 // Validate validates the entire configuration.
@@ -181,14 +183,16 @@ func (a *ActionConfig) Validate() error {
 // Validate validates the logging configuration.
 // Returns an error if any value is invalid.
 func (l *LoggingConfig) Validate() error {
-	// Validate log level range
-	if l.Level < -1 || l.Level > 2 {
-		return fmt.Errorf("level: must be between -1 (Debug) and 2 (Error), got %d", l.Level)
+	// Validate log level (must be a recognized named level or numeric V-level)
+	if l.Level != "" {
+		if _, err := logger.ParseLogLevel(l.Level); err != nil {
+			return fmt.Errorf("level: %w", err)
+		}
 	}
 
 	// Validate format
-	if l.Format != "" && l.Format != LoggingFormatJSON && l.Format != LoggingFormatText {
-		return fmt.Errorf("format: must be %q or %q, got %q", LoggingFormatJSON, LoggingFormatText, l.Format)
+	if l.Format != "" && l.Format != LoggingFormatJSON && l.Format != LoggingFormatText && l.Format != LoggingFormatConsole {
+		return fmt.Errorf("format: must be %q, %q, or %q, got %q", LoggingFormatConsole, LoggingFormatJSON, LoggingFormatText, l.Format)
 	}
 
 	return nil

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -157,7 +157,7 @@ func TestConfig_Validate_ValidConfig(t *testing.T) {
 		Version:  1,
 		Settings: Settings{},
 		Logging: LoggingConfig{
-			Level: 0,
+			Level: "info",
 		},
 		HTTPClient: HTTPClientConfig{
 			Timeout:   "30s",
@@ -309,7 +309,7 @@ func TestLoggingConfig_Validate(t *testing.T) {
 		{
 			name: "valid default config",
 			cfg: LoggingConfig{
-				Level:      0,
+				Level:      "info",
 				Format:     LoggingFormatJSON,
 				Timestamps: true,
 			},
@@ -318,7 +318,7 @@ func TestLoggingConfig_Validate(t *testing.T) {
 		{
 			name: "valid debug level",
 			cfg: LoggingConfig{
-				Level:  -1,
+				Level:  "debug",
 				Format: LoggingFormatText,
 			},
 			wantErr: false,
@@ -326,38 +326,59 @@ func TestLoggingConfig_Validate(t *testing.T) {
 		{
 			name: "valid error level",
 			cfg: LoggingConfig{
-				Level: 2,
+				Level: "error",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid trace level",
+			cfg: LoggingConfig{
+				Level: "trace",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid numeric V-level",
+			cfg: LoggingConfig{
+				Level: "3",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid none level",
+			cfg: LoggingConfig{
+				Level: "none",
 			},
 			wantErr: false,
 		},
 		{
 			name: "empty format is valid",
 			cfg: LoggingConfig{
-				Level:  0,
+				Level:  "info",
 				Format: "",
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid level too low",
+			name: "invalid level string",
 			cfg: LoggingConfig{
-				Level: -2,
+				Level: "verbose",
 			},
 			wantErr: true,
-			errMsg:  "level: must be between -1 (Debug) and 2 (Error)",
+			errMsg:  "level: invalid log level",
 		},
 		{
-			name: "invalid level too high",
+			name: "valid console format",
 			cfg: LoggingConfig{
-				Level: 3,
+				Level:  "info",
+				Format: LoggingFormatConsole,
 			},
-			wantErr: true,
-			errMsg:  "level: must be between -1 (Debug) and 2 (Error)",
+			wantErr: false,
 		},
 		{
 			name: "invalid format",
 			cfg: LoggingConfig{
-				Level:  0,
+				Level:  "info",
 				Format: "xml",
 			},
 			wantErr: true,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -56,36 +58,108 @@ type LogFormat string
 const (
 	// FormatJSON outputs logs in JSON format.
 	FormatJSON LogFormat = "json"
-	// FormatText outputs logs in human-readable text format.
+	// FormatConsole outputs logs in human-readable text format.
+	FormatConsole LogFormat = "console"
+	// FormatText is an alias for FormatConsole for backward compatibility with config files.
 	FormatText LogFormat = "text"
 )
 
+// Named log level constants used in config and CLI flags.
+const (
+	// LevelNone disables all structured log output.
+	LevelNone = "none"
+	// LevelError shows only error-level logs.
+	LevelError = "error"
+	// LevelWarn shows warning and error logs.
+	LevelWarn = "warn"
+	// LevelInfo shows info, warning, and error logs.
+	LevelInfo = "info"
+	// LevelDebug shows debug (V(1)) and above logs.
+	LevelDebug = "debug"
+	// LevelTrace shows trace (V(2)) and above logs.
+	LevelTrace = "trace"
+)
+
+// LogLevelNone is the sentinel zap level value that silences all log output.
+// It is set above FatalLevel so no log entry can reach it.
+const LogLevelNone = zapcore.FatalLevel + 1
+
+// ParseLogLevel converts a named or numeric log level string to a zapcore.Level.
+// Named levels: none, error, warn, info, debug, trace.
+// Numeric levels: any integer string (e.g., "3", "5") is treated as a logr V-level
+// and negated to produce the corresponding zap level (user's 3 → zap -3 → V(3) visible).
+func ParseLogLevel(s string) (zapcore.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case LevelNone, "":
+		return LogLevelNone, nil
+	case LevelError:
+		return zapcore.ErrorLevel, nil
+	case LevelWarn:
+		return zapcore.WarnLevel, nil
+	case LevelInfo:
+		return zapcore.InfoLevel, nil
+	case LevelDebug:
+		return zapcore.Level(-1), nil // V(1)
+	case LevelTrace:
+		return zapcore.Level(-2), nil // V(2)
+	default:
+		// Try numeric V-level
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return zapcore.InfoLevel, fmt.Errorf("invalid log level %q: must be one of none, error, warn, info, debug, trace, or a numeric V-level", s)
+		}
+		// Numeric values are treated as V-levels: user provides positive number,
+		// we negate to get the zap level (e.g., 3 → -3 → V(3) visible).
+		if n < 0 {
+			// Already negative means the user is specifying a raw zap level directly
+			return zapcore.Level(n), nil //nolint:gosec // intentional int→int8 for raw zap level
+		}
+		return zapcore.Level(-n), nil //nolint:gosec // intentional negation
+	}
+}
+
+// IsDebugLevel returns true if the given log level string resolves to debug or deeper.
+// This is used by the writer package to gate debug output.
+func IsDebugLevel(level string) bool {
+	l, err := ParseLogLevel(level)
+	if err != nil {
+		return false
+	}
+	return l <= zapcore.Level(-1)
+}
+
 // Options configures the logger behavior.
 type Options struct {
-	// Level is the minimum log level (-1=Debug, 0=Info, 1=Warn, 2=Error).
-	Level int8
-	// Format is the output format (json or text).
+	// Level is the minimum zap log level.
+	Level zapcore.Level
+	// Format is the output format (json, console, or text).
 	Format LogFormat
 	// Timestamps controls whether timestamps are included in log output.
 	Timestamps bool
+	// FilePath is an optional file path to write logs to. When set, logs are
+	// written to this file. If empty, logs go to stderr.
+	FilePath string
+	// AlsoStderr controls whether logs are also written to stderr when FilePath
+	// is set. When FilePath is empty, this has no effect (stderr is always used).
+	AlsoStderr bool
 }
 
 // DefaultOptions returns the default logger options.
 func DefaultOptions() Options {
 	return Options{
-		Level:      0,
-		Format:     FormatJSON,
+		Level:      LogLevelNone,
+		Format:     FormatConsole,
 		Timestamps: true,
 	}
 }
 
 // Get initializes the global Zap and Logr loggers with default options.
 // It can only be called once. Subsequent calls will have no effect.
-// logLevel: The minimum logging level (-1=Debug, 0=Info, 1=Warn, 2=Error).
+// logLevel: The minimum zap logging level (e.g., -1=Debug/V(1), 0=Info, 1=Warn, 2=Error).
 // This function must be called before using FromContext or any logging operations.
 func Get(logLevel int8) *logr.Logger {
 	return GetWithOptions(Options{
-		Level:      logLevel,
+		Level:      zapcore.Level(logLevel),
 		Format:     FormatJSON,
 		Timestamps: true,
 	})
@@ -96,6 +170,13 @@ func Get(logLevel int8) *logr.Logger {
 // This function must be called before using FromContext or any logging operations.
 func GetWithOptions(opts Options) *logr.Logger {
 	once.Do(func() {
+		// If level is set to LogLevelNone, return a noop logger
+		if opts.Level >= LogLevelNone {
+			gl := logr.Discard()
+			globalLogrLogger = &gl
+			return
+		}
+
 		// Encoder Configuration: How log entries are formatted
 		encoderCfg := zap.NewProductionEncoderConfig()
 		encoderCfg.MessageKey = MessageKey
@@ -109,23 +190,44 @@ func GetWithOptions(opts Options) *logr.Logger {
 		}
 
 		// Determine the minimum log level
-		minimumLogLevel := zapcore.Level(opts.Level)
+		minimumLogLevel := opts.Level
 
 		buildInfo, _ := debug.ReadBuildInfo()
 
 		// Create encoder based on format
 		var encoder zapcore.Encoder
-		if opts.Format == FormatText {
+		if opts.Format == FormatText || opts.Format == FormatConsole {
 			encoderCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
 			encoder = zapcore.NewConsoleEncoder(encoderCfg)
 		} else {
 			encoder = zapcore.NewJSONEncoder(encoderCfg)
 		}
 
+		// Determine output destination(s)
+		var writeSyncer zapcore.WriteSyncer
+		switch {
+		case opts.FilePath != "":
+			f, err := os.OpenFile(opts.FilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+			switch {
+			case err != nil:
+				fmt.Fprintf(os.Stderr, "WARNING: failed to open log file %q: %v, falling back to stderr\n", opts.FilePath, err)
+				writeSyncer = zapcore.Lock(os.Stderr)
+			case opts.AlsoStderr:
+				writeSyncer = zapcore.NewMultiWriteSyncer(
+					zapcore.Lock(os.Stderr),
+					zapcore.AddSync(f),
+				)
+			default:
+				writeSyncer = zapcore.AddSync(f)
+			}
+		default:
+			writeSyncer = zapcore.Lock(os.Stderr)
+		}
+
 		// Create a Zap Core: Combines encoder, sink (output destination), and level
 		core := zapcore.NewCore(
 			encoder,
-			zapcore.Lock(os.Stderr),               // Output to standard error, safely (thread-safe)
+			writeSyncer,
 			zap.NewAtomicLevelAt(minimumLogLevel), // Set the logging level
 		).With(
 			[]zapcore.Field{

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -139,7 +139,7 @@ type VersionInfo struct {
 // It includes options for logging, entry point configuration, output formatting,
 // and error handling behavior.
 type Run struct {
-	MinLogLevel        int8
+	MinLogLevel        string
 	EntryPointSettings EntryPointSettings
 	IsQuiet            bool
 	NoColor            bool
@@ -147,11 +147,11 @@ type Run struct {
 }
 
 // NewCliParams initializes and returns a pointer to a Run struct with default CLI parameters.
-// It sets logging level to 0, configures entry point settings for CLI usage, and sets
-// default flags for quiet mode, color output, and error handling.
+// It sets logging level to "none" (no structured logs by default), configures entry point
+// settings for CLI usage, and sets default flags for quiet mode, color output, and error handling.
 func NewCliParams() *Run {
 	return &Run{
-		MinLogLevel: 0,
+		MinLogLevel: "none",
 		EntryPointSettings: EntryPointSettings{
 			FromAPI: false,
 			FromCli: true,

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -15,7 +15,7 @@ func TestNewCliParams(t *testing.T) {
 		{
 			name: "default CLI params",
 			want: &Run{
-				MinLogLevel: 0,
+				MinLogLevel: "none",
 				EntryPointSettings: EntryPointSettings{
 					FromAPI: false,
 					FromCli: true,

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -358,7 +358,7 @@ func (o *Getter) FromLocalFileSystem(_ context.Context, path string) (*solution.
 	err = sol.LoadFromBytes(data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "path", path)
-		return &solution.Solution{}, fmt.Errorf("unable to get the solution. Failed unmarshalling data from file '%s': %w", path, err)
+		return &solution.Solution{}, fmt.Errorf("failed to load solution from '%s': %w", path, err)
 	}
 
 	o.logger.V(1).Info("Successfully loaded solution from local filesystem", "path", path)
@@ -425,7 +425,7 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 	err = sol.LoadFromBytes(data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "url", url)
-		return nil, fmt.Errorf("unable to get the solution. Failed unmarshalling data from URL '%s': %w", url, err)
+		return nil, fmt.Errorf("failed to load solution from '%s': %w", url, err)
 	}
 
 	o.logger.Info("Successfully loaded solution from URL", "url", url)

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -224,7 +224,7 @@ func TestFromUrl(t *testing.T) {
 		sol, err := getter.FromURL(ctx, server.URL)
 		require.Error(t, err)
 		assert.Nil(t, sol)
-		assert.Contains(t, err.Error(), "Failed unmarshalling data")
+		assert.Contains(t, err.Error(), "failed to load solution from")
 	})
 
 	t.Run("with custom HTTP client", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestFromLocalFileSystem(t *testing.T) {
 		sol, err := getter.FromLocalFileSystem(ctx, "invalid.json")
 		require.Error(t, err)
 		require.NotNil(t, sol) // Returns empty solution on error
-		assert.Contains(t, err.Error(), "Failed unmarshalling data")
+		assert.Contains(t, err.Error(), "failed to load solution from")
 	})
 
 	t.Run("with custom logger", func(t *testing.T) {

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -224,20 +224,24 @@ func (s *Solution) FromYAML(data []byte) error {
 }
 
 // UnmarshalFromBytes attempts to unmarshal the provided byte slice into the Solution struct.
-// It first tries to unmarshal using YAML format. If that fails, it attempts to unmarshal using JSON format.
-// Returns an error if unmarshalling fails for both formats.
+// It first tries to unmarshal using YAML format. If that fails and the content looks like JSON,
+// it attempts to unmarshal using JSON format. Returns only the relevant error for clarity.
 func (s *Solution) UnmarshalFromBytes(bytes []byte) error {
 	if len(bytes) == 0 {
 		return errors.New("no data provided to unmarshal solution")
 	}
 	yamlErr := s.FromYAML(bytes)
-	if yamlErr != nil {
-		err := s.FromJSON(bytes)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal solution using yaml and json bytes: YAML error: %w, JSON error: %w", yamlErr, err)
+	if yamlErr == nil {
+		return nil
+	}
+	// Only try JSON if the content looks like JSON (starts with { or [)
+	trimmed := strings.TrimSpace(string(bytes))
+	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+		if jsonErr := s.FromJSON(bytes); jsonErr == nil {
+			return nil
 		}
 	}
-	return nil
+	return yamlErr
 }
 
 // LoadFromBytes unmarshals the provided bytes, applies defaults, and validates the solution.

--- a/pkg/spec/valueref.go
+++ b/pkg/spec/valueref.go
@@ -58,7 +58,17 @@ func (v *ValueRef) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if count != 1 {
-			return fmt.Errorf("invalid value ref: expected exactly one of rslvr, expr, or tmpl")
+			var found []string
+			if raw.Resolver != nil {
+				found = append(found, "rslvr")
+			}
+			if raw.Expr != nil {
+				found = append(found, "expr")
+			}
+			if raw.Tmpl != nil {
+				found = append(found, "tmpl")
+			}
+			return fmt.Errorf("invalid value ref at line %d, column %d: expected exactly one of rslvr, expr, or tmpl, but found [%s]", node.Line, node.Column, strings.Join(found, ", "))
 		}
 
 		v.Resolver = raw.Resolver

--- a/pkg/spec/valueref_test.go
+++ b/pkg/spec/valueref_test.go
@@ -138,7 +138,7 @@ tmpl: "{{ .name }}"`,
 			var vr ValueRef
 			err := yaml.Unmarshal([]byte(tt.yaml), &vr)
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "expected exactly one of rslvr, expr, or tmpl")
+			assert.Contains(t, err.Error(), "expected exactly one of rslvr, expr, or tmpl, but found")
 		})
 	}
 }

--- a/pkg/terminal/writer/writer.go
+++ b/pkg/terminal/writer/writer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
@@ -126,9 +127,9 @@ func (w *Writer) Infof(format string, args ...any) {
 
 // Debug writes a debug message to stdout.
 // Respects --quiet and --no-color flags.
-// Only writes if log level indicates debug output is enabled (MinLogLevel <= -1).
+// Only writes if log level indicates debug output is enabled (debug, trace, or numeric V-level).
 func (w *Writer) Debug(msg string) {
-	if w.cliParams.IsQuiet || w.cliParams.MinLogLevel > -1 {
+	if w.cliParams.IsQuiet || !logger.IsDebugLevel(w.cliParams.MinLogLevel) {
 		return
 	}
 	fmt.Fprintln(w.ioStreams.Out, output.DebugMessage(msg, w.cliParams.NoColor))
@@ -136,7 +137,7 @@ func (w *Writer) Debug(msg string) {
 
 // Debugf writes a formatted debug message to stdout.
 // Respects --quiet and --no-color flags.
-// Only writes if log level indicates debug output is enabled (MinLogLevel <= -1).
+// Only writes if log level indicates debug output is enabled (debug, trace, or numeric V-level).
 func (w *Writer) Debugf(format string, args ...any) {
 	w.Debug(fmt.Sprintf(format, args...))
 }

--- a/pkg/terminal/writer/writer_test.go
+++ b/pkg/terminal/writer/writer_test.go
@@ -196,7 +196,7 @@ func TestInfo_Quiet(t *testing.T) {
 
 func TestDebug(t *testing.T) {
 	w, outBuf, _ := newTestWriter()
-	w.cliParams.MinLogLevel = -1 // Enable debug
+	w.cliParams.MinLogLevel = "debug" // Enable debug
 
 	w.Debug("Debug information")
 	assert.Contains(t, outBuf.String(), "Debug information")
@@ -205,7 +205,7 @@ func TestDebug(t *testing.T) {
 
 func TestDebugf(t *testing.T) {
 	w, outBuf, _ := newTestWriter()
-	w.cliParams.MinLogLevel = -1 // Enable debug
+	w.cliParams.MinLogLevel = "debug" // Enable debug
 	w.cliParams.NoColor = true
 
 	w.Debugf("Variable x = %d", 42)
@@ -214,7 +214,7 @@ func TestDebugf(t *testing.T) {
 
 func TestDebug_NotEnabled(t *testing.T) {
 	w, outBuf, _ := newTestWriter()
-	w.cliParams.MinLogLevel = 0 // Info level, debug disabled
+	w.cliParams.MinLogLevel = "none" // Logs disabled, debug not enabled
 
 	w.Debug("Debug information")
 	assert.Empty(t, outBuf.String())
@@ -222,7 +222,7 @@ func TestDebug_NotEnabled(t *testing.T) {
 
 func TestDebug_Quiet(t *testing.T) {
 	w, outBuf, _ := newTestWriter()
-	w.cliParams.MinLogLevel = -1 // Enable debug
+	w.cliParams.MinLogLevel = "debug" // Enable debug
 	w.cliParams.IsQuiet = true
 
 	w.Debug("Debug information")

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -219,6 +219,18 @@ func TestIntegration_RunSolution_InvalidYAML(t *testing.T) {
 	t.Logf("stderr: %s", stderr)
 }
 
+func TestIntegration_RunSolution_BadSolutionYAML(t *testing.T) {
+	_, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/solutions/bad-solution-yaml/solution.yaml",
+		"--skip-actions",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "expected exactly one of rslvr, expr, or tmpl, but found")
+	assert.Contains(t, stderr, "line")
+}
+
 func TestIntegration_RunSolution_DryRun(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t,
 		"run", "solution",


### PR DESCRIPTION
…ntrolled output

BREAKING CHANGE: `--log-level` flag changed from int8 to string. Config `logging.level` changed from int to string. Numeric values still work but named levels (none, error, warn, info, debug, trace) are now recommended.

Logging is now suppressed by default (`level: "none"`) to keep CLI output clean for human users and pipe-friendly for scripts. No structured JSON logs appear on stderr unless explicitly requested.

New flags:
- `--debug / -d`: Shorthand for `--log-level debug`
- `--log-format`: Choose between `console` (default, colored) and `json`
- `--log-file`: Write logs to a file instead of (or in addition to) stderr

New environment variables:
- `SCAFCTL_DEBUG`: Enable debug logging (set to `1` or `true`)
- `SCAFCTL_LOG_LEVEL`: Set log level
- `SCAFCTL_LOG_FORMAT`: Set log format
- `SCAFCTL_LOG_PATH`: Write logs to a file

Precedence: flag > --debug > env var > config file > default ("none")

Also includes:
- Improved error messages with line/column info for ValueRef validation
- Simplified solution load error messages
- New `bad-solution-yaml` example demonstrating error handling
- Comprehensive logging tutorial in docs
- Updated config examples, tutorials, and design docs
- Lint exclusions for packages intentionally shadowing stdlib names