### PR TITLE
feat(paths)!: use CLI conventions for XDG paths on macOS

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -696,8 +696,8 @@ scafctl secrets rotate
 ~~~
 
 Secrets are encrypted with AES-256-GCM and stored in platform-specific locations:
-- **macOS**: `~/Library/Application Support/scafctl/secrets/`
-- **Linux**: `~/.config/scafctl/secrets/`
+- **macOS**: `~/.local/share/scafctl/secrets/`
+- **Linux**: `~/.local/share/scafctl/secrets/`
 - **Windows**: `%APPDATA%\scafctl\secrets\`
 
 ---

--- a/docs/design/misc.md
+++ b/docs/design/misc.md
@@ -115,7 +115,7 @@ Render mode supports secret redaction via `--redact` flag on snapshots.
 - **CLI**: `scafctl secrets list/get/set/delete/exists/export/import/rotate`
 - **Platform paths** (XDG Base Directory Specification):
   - Linux: `~/.local/share/scafctl/secrets/`
-  - macOS: `~/Library/Application Support/scafctl/secrets/`
+  - macOS: `~/.local/share/scafctl/secrets/`
   - Windows: `%LOCALAPPDATA%\scafctl\secrets\`
 
 ---

--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -23,7 +23,7 @@ The cache uses XDG Base Directory paths:
 
 | Platform | Default Location |
 |----------|------------------|
-| macOS | `~/Library/Caches/scafctl/` |
+| macOS | `~/.cache/scafctl/` |
 | Linux | `~/.cache/scafctl/` |
 | Windows | `%LOCALAPPDATA%\cache\scafctl\` |
 
@@ -50,7 +50,7 @@ Cache Information
 Platform: darwin/arm64
 
 HTTP Cache:  2.4 MB (156 files)
-             ~/Library/Caches/scafctl/http-cache
+             ~/.cache/scafctl/http-cache
 
 Total: 2.4 MB (156 files)
 ```
@@ -69,7 +69,7 @@ Output:
   "caches": [
     {
       "name": "HTTP Cache",
-      "path": "/Users/me/Library/Caches/scafctl/http-cache",
+      "path": "/Users/me/.cache/scafctl/http-cache",
       "size": 2516582,
       "sizeHuman": "2.4 MB",
       "fileCount": 156,

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -25,7 +25,7 @@ The catalog uses XDG Base Directory paths:
 
 | Platform | Default Location |
 |----------|------------------|
-| macOS | `~/Library/Application Support/scafctl/catalog` |
+| macOS | `~/.local/share/scafctl/catalog` |
 | Linux | `~/.local/share/scafctl/catalog` |
 | Windows | `%LOCALAPPDATA%\scafctl\catalog` |
 

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -180,10 +180,10 @@ Typical output:
 ```
 XDG Paths (darwin/arm64)
 
-Config:   ~/Library/Application Support/scafctl/config.yaml
-Data:     ~/Library/Application Support/scafctl/
-Cache:    ~/Library/Caches/scafctl/
-State:    ~/Library/Application Support/scafctl/state/
+Config:   ~/.config/scafctl/config.yaml
+Data:     ~/.local/share/scafctl/
+Cache:    ~/.cache/scafctl/
+State:    ~/.local/state/scafctl/
 ```
 
 ## Configuration Reference
@@ -209,7 +209,7 @@ The config file is located at the XDG config path:
 
 | Platform | Default Location |
 |----------|------------------|
-| macOS | `~/Library/Application Support/scafctl/config.yaml` |
+| macOS | `~/.config/scafctl/config.yaml` |
 | Linux | `~/.config/scafctl/config.yaml` |
 | Windows | `%APPDATA%\scafctl\config.yaml` |
 

--- a/docs/tutorials/logging-tutorial.md
+++ b/docs/tutorials/logging-tutorial.md
@@ -215,7 +215,7 @@ You can set logging defaults in your config file so you don't need flags every t
 
 ```yaml
 # ~/.config/scafctl/config.yaml (Linux)
-# ~/Library/Application Support/scafctl/config.yaml (macOS)
+# ~/.config/scafctl/config.yaml (macOS)
 logging:
   level: "info"       # Always show info-level logs
   format: "console"   # Human-readable (default)

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -16,7 +16,7 @@ scafctl follows the [XDG Base Directory Specification](https://specifications.fr
 | Platform | Config Path |
 |----------|-------------|
 | Linux    | `~/.config/scafctl/config.yaml` |
-| macOS    | `~/Library/Application Support/scafctl/config.yaml` |
+| macOS    | `~/.config/scafctl/config.yaml` |
 | Windows  | `%LOCALAPPDATA%\scafctl\config.yaml` |
 
 ## Usage

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -5,7 +5,7 @@
 #
 # Config locations (XDG Base Directory Specification):
 #   Linux:   ~/.config/scafctl/config.yaml
-#   macOS:   ~/Library/Application Support/scafctl/config.yaml
+#   macOS:   ~/.config/scafctl/config.yaml
 #   Windows: %LOCALAPPDATA%\scafctl\config.yaml
 #
 # Most options have sensible defaults - you only need to specify
@@ -111,7 +111,7 @@ httpClient:
   # Directory for filesystem cache storage
   # XDG cache directory defaults:
   #   Linux:   ~/.cache/scafctl/http-cache/
-  #   macOS:   ~/Library/Caches/scafctl/http-cache/
+  #   macOS:   ~/.cache/scafctl/http-cache/
   #   Windows: %LOCALAPPDATA%\cache\scafctl\http-cache\
   # Leave commented to use the XDG default
   # cacheDir: "~/.cache/scafctl/http-cache"
@@ -247,7 +247,7 @@ action:
 #
 # Default catalog location (XDG data directory):
 #   Linux:   ~/.local/share/scafctl/catalog/
-#   macOS:   ~/Library/Application Support/scafctl/catalog/
+#   macOS:   ~/.local/share/scafctl/catalog/
 #   Windows: %LOCALAPPDATA%\scafctl\catalog\
 
 catalogs:

--- a/examples/config/minimal-config.yaml
+++ b/examples/config/minimal-config.yaml
@@ -5,7 +5,7 @@
 #
 # Config locations (XDG Base Directory Specification):
 #   Linux:   ~/.config/scafctl/config.yaml
-#   macOS:   ~/Library/Application Support/scafctl/config.yaml
+#   macOS:   ~/.config/scafctl/config.yaml
 #   Windows: %LOCALAPPDATA%\scafctl\config.yaml
 #
 # For all available options, see: examples/config/full-config.yaml
@@ -37,7 +37,7 @@ logging:
 #
 # Default catalog location (XDG data directory):
 #   Linux:   ~/.local/share/scafctl/catalog/
-#   macOS:   ~/Library/Application Support/scafctl/catalog/
+#   macOS:   ~/.local/share/scafctl/catalog/
 #   Windows: %LOCALAPPDATA%\scafctl\catalog\
 catalogs:
   - name: local

--- a/pkg/catalog/doc.go
+++ b/pkg/catalog/doc.go
@@ -19,7 +19,7 @@
 // It uses the XDG-compliant path from paths.CatalogDir():
 //
 //   - Linux: ~/.local/share/scafctl/catalog/
-//   - macOS: ~/Library/Application Support/scafctl/catalog/
+//   - macOS: ~/.local/share/scafctl/catalog/
 //   - Windows: %LOCALAPPDATA%\scafctl\catalog\
 //
 // The local catalog stores artifacts as OCI artifacts in OCI Image Layout format,

--- a/pkg/cmd/scafctl/build/build.go
+++ b/pkg/cmd/scafctl/build/build.go
@@ -26,7 +26,7 @@ func CommandBuild(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 
 			The local catalog is stored at:
 			  - Linux: ~/.local/share/scafctl/catalog/
-			  - macOS: ~/Library/Application Support/scafctl/catalog/
+			  - macOS: ~/.local/share/scafctl/catalog/
 			  - Windows: %LOCALAPPDATA%\scafctl\catalog\
 		`),
 	}

--- a/pkg/cmd/scafctl/cache/cache.go
+++ b/pkg/cmd/scafctl/cache/cache.go
@@ -24,7 +24,7 @@ func CommandCache(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 
 			The cache is stored at:
 			  - Linux: ~/.cache/scafctl/
-			  - macOS: ~/Library/Caches/scafctl/
+			  - macOS: ~/.cache/scafctl/
 			  - Windows: %LOCALAPPDATA%\cache\scafctl\
 		`),
 	}

--- a/pkg/cmd/scafctl/catalog/catalog.go
+++ b/pkg/cmd/scafctl/catalog/catalog.go
@@ -26,7 +26,7 @@ func CommandCatalog(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 
 			The local catalog is stored at:
 			  - Linux: ~/.local/share/scafctl/catalog/
-			  - macOS: ~/Library/Application Support/scafctl/catalog/
+			  - macOS: ~/.local/share/scafctl/catalog/
 			  - Windows: %LOCALAPPDATA%\scafctl\catalog\
 		`),
 	}

--- a/pkg/cmd/scafctl/config/config.go
+++ b/pkg/cmd/scafctl/config/config.go
@@ -24,7 +24,7 @@ func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 
 			Configuration follows the XDG Base Directory Specification:
 			  - Linux:   ~/.config/scafctl/config.yaml
-			  - macOS:   ~/Library/Application Support/scafctl/config.yaml
+			  - macOS:   ~/.config/scafctl/config.yaml
 			  - Windows: %LOCALAPPDATA%\scafctl\config.yaml
 
 			Use --config flag to specify an alternate location.

--- a/pkg/cmd/scafctl/config/paths.go
+++ b/pkg/cmd/scafctl/config/paths.go
@@ -261,10 +261,10 @@ func getIllustrativePaths(platform string) []PathInfo {
 		cacheHome = "~/.cache"
 		stateHome = "~/.local/state"
 	case "darwin":
-		configHome = "~/Library/Application Support"
-		dataHome = "~/Library/Application Support"
-		cacheHome = "~/Library/Caches"
-		stateHome = "~/Library/Application Support"
+		configHome = "~/.config"
+		dataHome = "~/.local/share"
+		cacheHome = "~/.cache"
+		stateHome = "~/.local/state"
 	case "windows":
 		configHome = "%LOCALAPPDATA%"
 		dataHome = "%LOCALAPPDATA%"

--- a/pkg/cmd/scafctl/secrets/secrets.go
+++ b/pkg/cmd/scafctl/secrets/secrets.go
@@ -24,7 +24,7 @@ func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 
 			Secrets are encrypted with AES-256-GCM and stored in XDG-compliant locations:
 			  - Linux:   ~/.local/share/scafctl/secrets/
-			  - macOS:   ~/Library/Application Support/scafctl/secrets/
+			  - macOS:   ~/.local/share/scafctl/secrets/
 			  - Windows: %LOCALAPPDATA%\scafctl\secrets\
 
 			The master encryption key is stored in your OS keychain for security.

--- a/pkg/paths/doc.go
+++ b/pkg/paths/doc.go
@@ -27,10 +27,10 @@
 //   - State: ~/.local/state/scafctl/
 //
 // macOS:
-//   - Config: ~/Library/Application Support/scafctl/
-//   - Data: ~/Library/Application Support/scafctl/
-//   - Cache: ~/Library/Caches/scafctl/
-//   - State: ~/Library/Application Support/scafctl/
+//   - Config: ~/.config/scafctl/
+//   - Data: ~/.local/share/scafctl/
+//   - Cache: ~/.cache/scafctl/
+//   - State: ~/.local/state/scafctl/
 //
 // Windows:
 //   - Config: %LOCALAPPDATA%\scafctl\

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -33,7 +33,7 @@ const (
 //
 // Platform defaults:
 //   - Linux: ~/.config/scafctl/config.yaml
-//   - macOS: ~/Library/Application Support/scafctl/config.yaml
+//   - macOS: ~/.config/scafctl/config.yaml
 //   - Windows: %LOCALAPPDATA%\scafctl\config.yaml
 func ConfigFile() (string, error) {
 	return xdg.ConfigFile(filepath.Join(AppName, ConfigFileName))
@@ -63,7 +63,7 @@ func ConfigDir() string {
 //
 // Platform defaults:
 //   - Linux: ~/.local/share/scafctl/secrets/
-//   - macOS: ~/Library/Application Support/scafctl/secrets/
+//   - macOS: ~/.local/share/scafctl/secrets/
 //   - Windows: %LOCALAPPDATA%\scafctl\secrets\
 //
 // Note: Secrets are stored in DATA_HOME (not CONFIG_HOME) because they are
@@ -106,7 +106,7 @@ func CacheDir() string {
 //
 // Platform defaults:
 //   - Linux: ~/.cache/scafctl/http-cache/
-//   - macOS: ~/Library/Caches/scafctl/http-cache/
+//   - macOS: ~/.cache/scafctl/http-cache/
 //   - Windows: %LOCALAPPDATA%\cache\scafctl\http-cache\
 func HTTPCacheDir() string {
 	return filepath.Join(xdg.CacheHome, AppName, HTTPCacheDirName)
@@ -118,7 +118,7 @@ func HTTPCacheDir() string {
 //
 // Platform defaults:
 //   - Linux: ~/.local/share/scafctl/catalog/
-//   - macOS: ~/Library/Application Support/scafctl/catalog/
+//   - macOS: ~/.local/share/scafctl/catalog/
 //   - Windows: %LOCALAPPDATA%\scafctl\catalog\
 func CatalogDir() string {
 	return filepath.Join(xdg.DataHome, AppName, CatalogDirName)
@@ -131,7 +131,7 @@ func CatalogDir() string {
 //
 // Platform defaults:
 //   - Linux: ~/.local/state/scafctl/
-//   - macOS: ~/Library/Application Support/scafctl/
+//   - macOS: ~/.local/state/scafctl/
 //   - Windows: %LOCALAPPDATA%\scafctl\
 func StateDir() string {
 	return filepath.Join(xdg.StateHome, AppName)

--- a/pkg/paths/paths_darwin.go
+++ b/pkg/paths/paths_darwin.go
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package paths
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+)
+
+// init overrides the adrg/xdg library's macOS defaults to follow CLI tool
+// conventions instead of GUI application conventions.
+//
+// The adrg/xdg library defaults macOS to ~/Library/Application Support and
+// ~/Library/Caches, which is appropriate for GUI applications but not for
+// CLI tools. Most CLI tools (gh, git, packer, stripe, kubectl, docker,
+// terraform) use ~/.config, ~/.local/share, ~/.cache, and ~/.local/state
+// on macOS.
+//
+// This override only applies when the corresponding XDG environment variable
+// is not set, so user overrides are always respected.
+//
+// We set the environment variables rather than just the exported xdg package
+// variables because xdg.DataFile()/xdg.ConfigFile() use internal state that
+// is only updated via xdg.Reload().
+//
+// See: https://atmos.tools/changelog/macos-xdg-cli-conventions
+//
+//nolint:gochecknoinits // init is required to override xdg defaults before any path function is called.
+func init() {
+	applyDefaults()
+}
+
+// applyDefaults sets XDG environment variables to CLI tool conventions on
+// macOS when they are not already set, then reloads the xdg library so both
+// exported variables (xdg.DataHome) and internal state (used by xdg.DataFile)
+// reflect the overrides.
+//
+// This is called from init() and can be called again after xdg.Reload()
+// to reapply the overrides.
+func applyDefaults() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+
+	changed := false
+
+	if os.Getenv("XDG_CONFIG_HOME") == "" {
+		os.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config"))
+		changed = true
+	}
+
+	if os.Getenv("XDG_DATA_HOME") == "" {
+		os.Setenv("XDG_DATA_HOME", filepath.Join(homeDir, ".local", "share"))
+		changed = true
+	}
+
+	if os.Getenv("XDG_CACHE_HOME") == "" {
+		os.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
+		changed = true
+	}
+
+	if os.Getenv("XDG_STATE_HOME") == "" {
+		os.Setenv("XDG_STATE_HOME", filepath.Join(homeDir, ".local", "state"))
+		changed = true
+	}
+
+	if changed {
+		xdg.Reload()
+	}
+}

--- a/pkg/paths/paths_other.go
+++ b/pkg/paths/paths_other.go
@@ -1,0 +1,11 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !darwin
+
+package paths
+
+// applyDefaults is a no-op on non-darwin platforms.
+// On darwin, this overrides the adrg/xdg library defaults to use
+// CLI tool conventions instead of GUI conventions.
+func applyDefaults() {}

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -259,13 +259,14 @@ func TestPlatformDefaults(t *testing.T) {
 		t.Setenv(env, "")
 	}
 	xdg.Reload()
+	applyDefaults() // Reapply CLI conventions after xdg.Reload() resets to library defaults
 	defer xdg.Reload()
 
 	t.Run("config uses platform-appropriate path", func(t *testing.T) {
 		path := ConfigDir()
 		switch runtime.GOOS {
 		case "darwin":
-			assert.Contains(t, path, "Library/Application Support")
+			assert.Contains(t, path, ".config")
 		case "linux":
 			assert.Contains(t, path, ".config")
 		case "windows":
@@ -278,7 +279,7 @@ func TestPlatformDefaults(t *testing.T) {
 		path := CacheDir()
 		switch runtime.GOOS {
 		case "darwin":
-			assert.Contains(t, path, "Library/Caches")
+			assert.Contains(t, path, ".cache")
 		case "linux":
 			assert.Contains(t, path, ".cache")
 		case "windows":

--- a/pkg/secrets/README.md
+++ b/pkg/secrets/README.md
@@ -107,7 +107,7 @@ store, err := secrets.New(
 | Platform | Default Secrets Directory |
 |----------|---------------------------|
 | Linux    | `~/.local/share/scafctl/secrets/` (or `$XDG_DATA_HOME/scafctl/secrets/`) |
-| macOS    | `~/Library/Application Support/scafctl/secrets/` |
+| macOS    | `~/.local/share/scafctl/secrets/` |
 | Windows  | `%LOCALAPPDATA%\scafctl\secrets\` |
 
 Override with the `SCAFCTL_SECRETS_DIR` environment variable.

--- a/pkg/secrets/options.go
+++ b/pkg/secrets/options.go
@@ -29,7 +29,7 @@ type Option func(*config)
 // WithSecretsDir overrides the default secrets directory.
 // If empty, the XDG-compliant default will be used:
 //   - Linux: ~/.local/share/scafctl/secrets/ (XDG_DATA_HOME)
-//   - macOS: ~/Library/Application Support/scafctl/secrets/
+//   - macOS: ~/.local/share/scafctl/secrets/
 //   - Windows: %LOCALAPPDATA%\scafctl\secrets\
 //
 // This can also be overridden by the SCAFCTL_SECRETS_DIR environment variable.

--- a/pkg/secrets/storage.go
+++ b/pkg/secrets/storage.go
@@ -35,7 +35,7 @@ const (
 //  1. SCAFCTL_SECRETS_DIR environment variable (if set)
 //  2. XDG-compliant path via paths.SecretsDir():
 //     - Linux: ~/.local/share/scafctl/secrets/
-//     - macOS: ~/Library/Application Support/scafctl/secrets/
+//     - macOS: ~/.local/share/scafctl/secrets/
 //     - Windows: %LOCALAPPDATA%\scafctl\secrets\
 func getSecretsDir() (string, error) {
 	// Check environment variable override first

--- a/pkg/secrets/storage_test.go
+++ b/pkg/secrets/storage_test.go
@@ -41,7 +41,7 @@ func TestGetSecretsDir(t *testing.T) {
 		// Platform-specific checks
 		switch runtime.GOOS {
 		case "darwin":
-			assert.Contains(t, dir, "Library/Application Support")
+			assert.Contains(t, dir, ".local/share")
 		case "linux":
 			home, _ := os.UserHomeDir()
 			xdgData := os.Getenv("XDG_DATA_HOME")

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -54,7 +54,7 @@ const (
 // DefaultHTTPCacheDir returns the default directory for HTTP cache.
 // Uses XDG Base Directory Specification:
 //   - Linux: ~/.cache/scafctl/http-cache/
-//   - macOS: ~/Library/Caches/scafctl/http-cache/
+//   - macOS: ~/.cache/scafctl/http-cache/
 //   - Windows: %LOCALAPPDATA%\cache\scafctl\http-cache\
 func DefaultHTTPCacheDir() string {
 	return filepath.Join(xdg.CacheHome, "scafctl", "http-cache")


### PR DESCRIPTION
Override adrg/xdg library defaults on macOS to use ~/.config, ~/.local/share, ~/.cache, and ~/.local/state instead of ~/Library/Application Support and ~/Library/Caches. This aligns with CLI tool ecosystem conventions used by gh, kubectl, docker, terraform, and other DevOps tools.

BREAKING CHANGE: macOS users will need to migrate existing config, secrets, and catalog data from ~/Library/Application Support/scafctl/ to the new locations (~/.config/scafctl/, ~/.local/share/scafctl/, etc.).