### PR TITLE
feat(run resolver): add graph, snapshot, dry-run, and skip-transform …

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -751,11 +751,22 @@ scafctl run resolver -f solution.yaml
 # Run specific resolvers (with their transitive dependencies)
 scafctl run resolver db config -f solution.yaml
 
-# Verbose mode includes __execution metadata (phases, timing, providers) in output
-scafctl run resolver --verbose -f solution.yaml
-
-# JSON output for scripting
+# JSON output (always includes __execution metadata)
 scafctl run resolver -f solution.yaml -o json
+
+# Skip transform and validation phases
+scafctl run resolver --skip-transform -f solution.yaml
+
+# Show execution plan without running
+scafctl run resolver --dry-run -f solution.yaml
+
+# Dependency graph (ASCII, DOT, Mermaid, or JSON)
+scafctl run resolver --graph -f solution.yaml
+scafctl run resolver --graph --graph-format=dot -f solution.yaml
+
+# Snapshot execution state
+scafctl run resolver --snapshot --snapshot-file=out.json -f solution.yaml
+scafctl run resolver --snapshot --snapshot-file=out.json --redact -f solution.yaml
 
 # Interactive TUI for exploring results
 scafctl run resolver -f solution.yaml -i

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -456,7 +456,7 @@ scafctl run solution -f my-solution.yaml --dry-run
 scafctl run resolver -f my-solution.yaml
 
 # Run specific resolvers for inspection
-scafctl run resolver db config -f my-solution.yaml --verbose
+scafctl run resolver db config -f my-solution.yaml
 ```
 
 ### Render Mode

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -5,7 +5,7 @@ weight: 25
 
 # Run Resolver Tutorial
 
-This tutorial covers the `scafctl run resolver` command — a debugging and inspection tool for executing resolvers without running actions. You'll learn how to run all resolvers, target specific resolvers, inspect execution phases, and use verbose mode for troubleshooting.
+This tutorial covers the `scafctl run resolver` command — a debugging and inspection tool for executing resolvers without running actions. You'll learn how to run all resolvers, target specific resolvers, inspect execution metadata, skip phases, and use dry-run for planning.
 
 ## Prerequisites
 
@@ -17,11 +17,15 @@ This tutorial covers the `scafctl run resolver` command — a debugging and insp
 
 1. [Run All Resolvers](#run-all-resolvers)
 2. [Run Specific Resolvers](#run-specific-resolvers)
-3. [Verbose Mode](#verbose-mode)
-4. [Output Formats](#output-formats)
-5. [Debugging Dependencies](#debugging-dependencies)
-6. [Working with Parameters](#working-with-parameters)
-7. [Common Workflows](#common-workflows)
+3. [Execution Metadata](#execution-metadata)
+4. [Skipping Phases](#skipping-phases)
+5. [Dry Run](#dry-run)
+6. [Dependency Graph](#dependency-graph)
+7. [Snapshots](#snapshots)
+8. [Output Formats](#output-formats)
+9. [Debugging Dependencies](#debugging-dependencies)
+10. [Working with Parameters](#working-with-parameters)
+11. [Common Workflows](#common-workflows)
 
 ---
 
@@ -181,22 +185,22 @@ Error: unknown resolver(s): nonexistent (available: environment, region, app_nam
 
 ---
 
-## Verbose Mode
+## Execution Metadata
 
-Use `--verbose` to include per-resolver execution metadata in the output. This is the primary debugging tool.
+The `run resolver` command is a debugging tool, so it always includes a `__execution` key in the output alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. timeline).
 
 ```bash
-scafctl run resolver --verbose -f dep-demo.yaml -o json
+scafctl run resolver -f dep-demo.yaml -o json
 ```
-
-When `--verbose` is used, the output includes a `__execution` key alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. diagrams, timeline).
 
 Current sections:
 
 - **`resolvers`**: Per-resolver metadata including phase, duration, status, provider, dependencies, and phase metrics (resolve/transform/validate breakdown)
 - **`summary`**: Aggregate stats — total duration, resolver count, phase count
+- **`dependencyGraph`**: Full dependency graph with nodes, edges, phases, stats, and pre-rendered **diagrams** (ASCII, DOT, Mermaid)
+- **`providerSummary`**: Per-provider usage statistics (resolver count, total duration, call count, success/failure counts, average duration)
 
-Example JSON output with `--verbose`:
+Example JSON output:
 
 ```json
 {
@@ -242,10 +246,221 @@ Example JSON output with `--verbose`:
 ### Combine with Named Resolvers
 
 ```bash
-scafctl run resolver endpoint --verbose -f dep-demo.yaml -o json
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 
 The `__execution` section only includes metadata for the requested resolvers and their dependencies.
+
+> **Tip**: For `run solution`, execution metadata is opt-in via `--show-execution`.
+
+---
+
+## Skipping Phases
+
+Resolvers execute through three ordered phases: **resolve → transform → validate**. You can skip phases to inspect intermediate values.
+
+### Skip Validation
+
+Skip only the validation phase:
+
+```bash
+scafctl run resolver --skip-validation -f solution.yaml -o json
+```
+
+This runs resolve and transform, but skips validation rules. Useful when you want to see the final transformed value without validation errors blocking output.
+
+### Skip Transform (and Validation)
+
+Skip both transform and validation phases, returning raw resolved values:
+
+```bash
+scafctl run resolver --skip-transform -f solution.yaml -o json
+```
+
+This runs only the resolve phase. Useful for inspecting what providers return before any transformations are applied.
+
+> **Note**: `--skip-transform` implies `--skip-validation` because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
+
+---
+
+## Dry Run
+
+Use `--dry-run` to show the execution plan without running any providers:
+
+```bash
+scafctl run resolver --dry-run -f dep-demo.yaml -o json
+```
+
+This displays:
+- DAG-based execution phases (which resolvers run in which order)
+- Per-resolver dependencies, provider types, and configured phases
+- Active and skipped phases based on flags
+
+Example output:
+
+```json
+{
+  "dryRun": true,
+  "executionPlan": {
+    "totalResolvers": 3,
+    "totalPhases": 2,
+    "activePhases": ["resolve", "transform", "validate"],
+    "skippedPhases": [],
+    "phases": [
+      { "phase": 1, "resolvers": ["base_url", "unrelated"] },
+      { "phase": 2, "resolvers": ["endpoint"] }
+    ]
+  },
+  "resolvers": {
+    "base_url": {
+      "provider": "static",
+      "dependencies": [],
+      "configuredPhases": ["resolve"]
+    },
+    "endpoint": {
+      "provider": "static",
+      "dependencies": ["base_url"],
+      "configuredPhases": ["resolve", "transform"]
+    }
+  }
+}
+```
+
+Combine with skip flags to see what would be active:
+
+```bash
+scafctl run resolver --dry-run --skip-transform -f dep-demo.yaml -o json
+```
+
+---
+
+## Dependency Graph
+
+The `--graph` flag renders the resolver dependency graph **without executing any providers**. This is useful for understanding the structure and execution order of your resolvers.
+
+### ASCII Graph (default)
+
+```bash
+scafctl run resolver --graph -f dep-demo.yaml
+```
+
+The ASCII output shows resolvers grouped by phase with dependency arrows.
+
+### Graphviz DOT Format
+
+Generate DOT output and pipe it to Graphviz for a visual diagram:
+
+```bash
+scafctl run resolver --graph --graph-format=dot -f dep-demo.yaml | dot -Tpng > graph.png
+```
+
+### Mermaid Format
+
+Generate a Mermaid diagram for embedding in Markdown or documentation:
+
+```bash
+scafctl run resolver --graph --graph-format=mermaid -f dep-demo.yaml
+```
+
+### JSON Format
+
+Get the graph as structured JSON for programmatic analysis:
+
+```bash
+scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq .
+```
+
+The JSON output includes:
+- **nodes**: List of resolvers with name, type, phase, provider, and conditional flag
+- **edges**: Dependency relationships (`from` → `to` with dependency type)
+- **phases**: Phase groups showing which resolvers execute together
+- **stats**: Graph metrics including total resolvers, phases, edges, max depth, and **critical path**
+
+### Critical Path
+
+The graph stats include a **critical path** — the longest chain of dependencies that determines the minimum sequential execution depth. This helps identify bottlenecks:
+
+```bash
+scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq '.stats.criticalPath'
+```
+
+### Graph in Execution Metadata
+
+When running resolvers normally, the dependency graph and a provider usage summary are automatically embedded in `__execution`:
+
+```bash
+scafctl run resolver -f dep-demo.yaml -o json | jq '.__execution.dependencyGraph'
+scafctl run resolver -f dep-demo.yaml -o json | jq '.__execution.providerSummary'
+```
+
+The **providerSummary** shows per-provider statistics: resolver count, total duration, call count, success/failure counts, and average duration.
+
+### Extracting Diagrams from Execution Metadata
+
+The `dependencyGraph` in `__execution` includes a `diagrams` field with pre-rendered ASCII, DOT, and Mermaid representations. Use the `-e` flag (CEL expression) to extract a specific diagram:
+
+```bash
+# Extract the Mermaid diagram
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.mermaid'
+
+# Extract the DOT diagram and render with Graphviz
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.dot' | dot -Tpng > graph.png
+
+# Extract the ASCII diagram
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.ascii'
+```
+
+You can also extract diagrams when running only specific resolvers:
+
+```bash
+# Get the Mermaid diagram for just log_level and health_check_endpoints (and their deps)
+scafctl run resolver log_level health_check_endpoints -f solution.yaml -o json \
+  -e '_.__execution.dependencyGraph.diagrams.mermaid'
+```
+
+This is useful for generating focused dependency visualizations of a resolver subset without rendering the full solution graph.
+
+{{% hint info %}}
+`--graph` is mutually exclusive with `--dry-run` and `--snapshot`.
+{{% /hint %}}
+
+---
+
+## Snapshots
+
+The `--snapshot` flag executes resolvers and saves the complete execution state to a JSON file. This mirrors the snapshot functionality in `scafctl render solution --snapshot`.
+
+### Basic Snapshot
+
+```bash
+scafctl run resolver --snapshot --snapshot-file=snapshot.json -f demo.yaml
+```
+
+This creates a snapshot file containing:
+- **metadata**: Solution name, version, build version, timestamp, total duration, and execution status
+- **resolvers**: Complete execution state of each resolver including resolved values, durations, and provider information
+- **parameters**: Input parameters used during execution
+
+### Redacting Sensitive Values
+
+Use `--redact` to replace sensitive resolver values with `<redacted>`:
+
+```bash
+scafctl run resolver --snapshot --snapshot-file=snapshot.json --redact -f demo.yaml
+```
+
+Resolvers marked with `sensitive: true` will have their values replaced in the snapshot.
+
+### Snapshot Use Cases
+
+- **Debugging**: Capture a full execution trace for offline analysis
+- **Auditing**: Record resolver outputs for compliance
+- **Testing**: Compare snapshots between runs to detect regressions
+- **Support**: Redacted snapshots can be shared without exposing secrets
+
+{{% hint info %}}
+`--snapshot` requires `--snapshot-file` to be specified. It is mutually exclusive with `--dry-run` and `--graph`.
+{{% /hint %}}
 
 ---
 
@@ -285,10 +500,10 @@ A common debugging workflow is to inspect how resolver dependencies cascade.
 scafctl resolver graph -f dep-demo.yaml
 ```
 
-### Step 2: Run Target Resolver with Verbose
+### Step 2: Run Target Resolver
 
 ```bash
-scafctl run resolver endpoint --verbose -f dep-demo.yaml -o json
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 
 ### Step 3: Inspect a Single Resolver's Value
@@ -370,7 +585,23 @@ echo "Exit code: $?"
 Isolate a failing resolver and its dependencies:
 
 ```bash
-scafctl run resolver failing-resolver --verbose -f solution.yaml -o json
+scafctl run resolver failing-resolver -f solution.yaml -o json
+```
+
+### Inspect Raw Resolved Values
+
+Skip transforms to see what providers actually return:
+
+```bash
+scafctl run resolver --skip-transform -f solution.yaml -o json
+```
+
+### Preview Execution Plan
+
+See what would happen without running anything:
+
+```bash
+scafctl run resolver --dry-run -f solution.yaml -o json
 ```
 
 ### Comparing Resolver Outputs
@@ -399,6 +630,7 @@ Metrics are displayed on stderr after execution completes.
 - [Resolver Tutorial](resolver-tutorial.md) — Learn resolver fundamentals
 - [Actions Tutorial](actions-tutorial.md) — Execute actions after resolvers
 - [CEL Tutorial](cel-tutorial.md) — Filter and transform resolver output
+- [Snapshots Tutorial](snapshots-tutorial.md) — Deeper dive into snapshot analysis
 
 ---
 
@@ -411,11 +643,28 @@ scafctl run resolver -f solution.yaml
 # Named resolvers (with dependencies)
 scafctl run resolver db config -f solution.yaml
 
-# Verbose debugging (includes __execution metadata in output)
-scafctl run resolver --verbose -f solution.yaml
-
-# JSON output
+# JSON output (always includes __execution metadata)
 scafctl run resolver -f solution.yaml -o json
+
+# Skip transform and validation phases
+scafctl run resolver --skip-transform -f solution.yaml
+
+# Show execution plan without running
+scafctl run resolver --dry-run -f solution.yaml
+
+# Dependency graph (ASCII)
+scafctl run resolver --graph -f solution.yaml
+
+# Dependency graph (DOT/Mermaid/JSON)
+scafctl run resolver --graph --graph-format=dot -f solution.yaml
+scafctl run resolver --graph --graph-format=mermaid -f solution.yaml
+scafctl run resolver --graph --graph-format=json -f solution.yaml
+
+# Snapshot execution state
+scafctl run resolver --snapshot --snapshot-file=out.json -f solution.yaml
+
+# Snapshot with sensitive value redaction
+scafctl run resolver --snapshot --snapshot-file=out.json --redact -f solution.yaml
 
 # With parameters
 scafctl run resolver -f solution.yaml -r key=value

--- a/docs/tutorials/snapshots-tutorial.md
+++ b/docs/tutorials/snapshots-tutorial.md
@@ -35,6 +35,17 @@ scafctl render solution -f my-solution.yaml \
   --snapshot --snapshot-file=snapshot.json
 ```
 
+### From `run resolver`
+
+You can also capture snapshots when running resolvers only (without actions):
+
+```bash
+scafctl run resolver -f my-solution.yaml \
+  --snapshot --snapshot-file=snapshot.json
+```
+
+This is useful when you want to inspect resolver execution without triggering actions.
+
 ### From `snapshot save`
 
 Or use the dedicated save command:

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -113,6 +113,7 @@ type sharedResolverOptions struct {
 	Progress        bool
 	ValidateAll     bool
 	SkipValidation  bool
+	SkipTransform   bool
 	ShowMetrics     bool
 	WarnValueSize   int64
 	MaxValueSize    int64
@@ -408,6 +409,9 @@ func (o *sharedResolverOptions) executeResolvers(
 	if o.SkipValidation {
 		executorOpts = append(executorOpts, resolver.WithSkipValidation(true))
 	}
+	if o.SkipTransform {
+		executorOpts = append(executorOpts, resolver.WithSkipTransform(true))
+	}
 	executor := resolver.NewExecutor(resolverAdapter, executorOpts...)
 
 	// Execute resolvers
@@ -447,7 +451,9 @@ func (o *sharedResolverOptions) executeResolvers(
 
 // filterResolversWithDependencies returns the specified resolvers and all their dependencies.
 // When targetNames is empty, all resolvers are returned.
-func filterResolversWithDependencies(resolvers []*resolver.Resolver, targetNames []string) []*resolver.Resolver {
+// Uses resolver.ExtractDependencies to detect dependencies from CEL expressions,
+// Go templates, explicit rslvr: references, and provider-specific extraction.
+func filterResolversWithDependencies(resolvers []*resolver.Resolver, targetNames []string, lookup resolver.DescriptorLookup) []*resolver.Resolver {
 	if len(targetNames) == 0 {
 		return resolvers
 	}
@@ -472,7 +478,7 @@ func filterResolversWithDependencies(resolvers []*resolver.Resolver, targetNames
 			return
 		}
 
-		deps := extractResolverDependencies(r)
+		deps := resolver.ExtractDependencies(r, lookup)
 		for _, dep := range deps {
 			collectDeps(dep)
 		}
@@ -634,54 +640,6 @@ func calculateValueSize(value any) int64 {
 	return int64(len(data))
 }
 
-// extractResolverDependencies extracts dependency names from a resolver
-func extractResolverDependencies(r *resolver.Resolver) []string {
-	var deps []string
-	seen := make(map[string]bool)
-
-	addDep := func(name string) {
-		if !seen[name] {
-			seen[name] = true
-			deps = append(deps, name)
-		}
-	}
-
-	// Check resolve phase
-	if r.Resolve != nil {
-		for _, src := range r.Resolve.With {
-			for _, vr := range src.Inputs {
-				if vr != nil && vr.Resolver != nil {
-					addDep(*vr.Resolver)
-				}
-			}
-		}
-	}
-
-	// Check transform phase
-	if r.Transform != nil {
-		for _, tr := range r.Transform.With {
-			for _, vr := range tr.Inputs {
-				if vr != nil && vr.Resolver != nil {
-					addDep(*vr.Resolver)
-				}
-			}
-		}
-	}
-
-	// Check validate phase
-	if r.Validate != nil {
-		for _, vl := range r.Validate.With {
-			for _, vr := range vl.Inputs {
-				if vr != nil && vr.Resolver != nil {
-					addDep(*vr.Resolver)
-				}
-			}
-		}
-	}
-
-	return deps
-}
-
 // registryAdapter adapts provider.Registry to resolver.RegistryInterface
 type registryAdapter struct {
 	registry *provider.Registry
@@ -701,6 +659,182 @@ func (r *registryAdapter) Get(name string) (provider.Provider, error) {
 
 func (r *registryAdapter) List() []provider.Provider {
 	return r.registry.ListProviders()
+}
+
+// buildExecutionData constructs structured execution metadata from resolver results.
+// The returned map is extensible — new top-level sections can be added without
+// breaking consumers (e.g. "diagrams", "timeline", "warnings").
+func buildExecutionData(
+	resolverCtx *resolver.Context,
+	resolvers []*resolver.Resolver,
+	totalElapsed time.Duration,
+) map[string]any {
+	allResults := resolverCtx.GetAllResults()
+
+	// Build per-resolver execution metadata
+	resolverMeta := make(map[string]any, len(resolvers))
+	for _, r := range resolvers {
+		deps := resolver.ExtractDependencies(r, nil)
+		entry := map[string]any{
+			"provider":     resolverProviderName(r),
+			"dependencies": deps,
+		}
+
+		if result, ok := allResults[r.Name]; ok {
+			entry["phase"] = result.Phase
+			entry["duration"] = result.TotalDuration.Round(time.Millisecond).String()
+			entry["status"] = string(result.Status)
+			entry["providerCallCount"] = result.ProviderCallCount
+			entry["valueSizeBytes"] = result.ValueSizeBytes
+			entry["dependencyCount"] = result.DependencyCount
+
+			// Per-phase breakdown (resolve, transform, validate)
+			if len(result.PhaseMetrics) > 0 {
+				metrics := make([]map[string]any, 0, len(result.PhaseMetrics))
+				for _, pm := range result.PhaseMetrics {
+					metrics = append(metrics, map[string]any{
+						"phase":    pm.Phase,
+						"duration": pm.Duration.Round(time.Millisecond).String(),
+					})
+				}
+				entry["phaseMetrics"] = metrics
+			}
+
+			// Include failed attempts for debugging
+			if len(result.FailedAttempts) > 0 {
+				attempts := make([]map[string]any, 0, len(result.FailedAttempts))
+				for _, fa := range result.FailedAttempts {
+					attempt := map[string]any{
+						"provider":   fa.Provider,
+						"phase":      fa.Phase,
+						"duration":   fa.Duration.Round(time.Millisecond).String(),
+						"sourceStep": fa.SourceStep,
+					}
+					if fa.Error != "" {
+						attempt["error"] = fa.Error
+					}
+					if fa.OnError != "" {
+						attempt["onError"] = fa.OnError
+					}
+					attempts = append(attempts, attempt)
+				}
+				entry["failedAttempts"] = attempts
+			}
+		} else {
+			entry["phase"] = 0
+			entry["duration"] = "0s"
+			entry["status"] = "unknown"
+		}
+
+		resolverMeta[r.Name] = entry
+	}
+
+	// Build summary
+	phaseCount := 0
+	for _, result := range allResults {
+		if result.Phase > phaseCount {
+			phaseCount = result.Phase
+		}
+	}
+
+	summary := map[string]any{
+		"totalDuration": totalElapsed.Round(time.Millisecond).String(),
+		"resolverCount": len(resolvers),
+		"phaseCount":    phaseCount,
+	}
+
+	return map[string]any{
+		"resolvers": resolverMeta,
+		"summary":   summary,
+	}
+}
+
+// buildProviderSummary aggregates per-provider usage statistics from resolver execution.
+func buildProviderSummary(
+	resolverCtx *resolver.Context,
+	resolvers []*resolver.Resolver,
+) map[string]any {
+	allResults := resolverCtx.GetAllResults()
+
+	type providerStats struct {
+		count         int
+		totalDuration time.Duration
+		callCount     int
+		successCount  int
+		failedCount   int
+	}
+
+	stats := make(map[string]*providerStats)
+
+	for _, r := range resolvers {
+		provName := resolverProviderName(r)
+		ps, ok := stats[provName]
+		if !ok {
+			ps = &providerStats{}
+			stats[provName] = ps
+		}
+		ps.count++
+
+		if result, ok := allResults[r.Name]; ok {
+			ps.totalDuration += result.TotalDuration
+			ps.callCount += result.ProviderCallCount
+			if result.Status == resolver.ExecutionStatusSuccess {
+				ps.successCount++
+			} else {
+				ps.failedCount++
+			}
+		}
+	}
+
+	summary := make(map[string]any, len(stats))
+	for name, ps := range stats {
+		entry := map[string]any{
+			"resolverCount": ps.count,
+			"totalDuration": ps.totalDuration.Round(time.Millisecond).String(),
+			"callCount":     ps.callCount,
+			"successCount":  ps.successCount,
+			"failedCount":   ps.failedCount,
+		}
+		if ps.count > 0 {
+			entry["avgDuration"] = (ps.totalDuration / time.Duration(ps.count)).Round(time.Millisecond).String()
+		}
+		summary[name] = entry
+	}
+
+	return summary
+}
+
+// renderGraph renders a graph in the specified format using the graphRenderer interface.
+func renderGraph(w io.Writer, graph graphRenderer, data any, format string) error {
+	switch format {
+	case "ascii":
+		return graph.RenderASCII(w)
+	case "dot":
+		return graph.RenderDOT(w)
+	case "mermaid":
+		return graph.RenderMermaid(w)
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(data)
+	default:
+		return fmt.Errorf("unsupported graph format: %s (supported: ascii, dot, mermaid, json)", format)
+	}
+}
+
+// graphRenderer defines the interface for types that can render as ASCII, DOT, and Mermaid.
+type graphRenderer interface {
+	RenderASCII(w io.Writer) error
+	RenderDOT(w io.Writer) error
+	RenderMermaid(w io.Writer) error
+}
+
+// resolverProviderName extracts the primary provider name from a resolver
+func resolverProviderName(r *resolver.Resolver) string {
+	if r.Resolve != nil && len(r.Resolve.With) > 0 {
+		return r.Resolve.With[0].Provider
+	}
+	return "unknown"
 }
 
 func (r *registryAdapter) DescriptorLookup() resolver.DescriptorLookup {

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -5,14 +5,17 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -26,9 +29,27 @@ type ResolverOptions struct {
 	// If empty, all resolvers are executed.
 	Names []string
 
-	// Verbose enables additional output: execution phases, timing,
-	// dependency edges, and provider information.
-	Verbose bool
+	// SkipTransform skips the transform and validation phases,
+	// returning raw resolved values.
+	SkipTransform bool
+
+	// DryRun shows the execution plan without running providers.
+	DryRun bool
+
+	// Graph renders the resolver dependency graph instead of executing.
+	Graph bool
+
+	// GraphFormat controls the graph rendering format (ascii, dot, mermaid, json).
+	GraphFormat string
+
+	// Snapshot saves an execution snapshot to a file instead of normal output.
+	Snapshot bool
+
+	// SnapshotFile is the path to write the snapshot file.
+	SnapshotFile string
+
+	// Redact redacts sensitive values in the snapshot.
+	Redact bool
 }
 
 // CommandResolver creates the 'run resolver' subcommand
@@ -59,6 +80,10 @@ This command is designed for debugging and inspecting resolver execution.
 It loads a solution file and executes only the resolvers, skipping the
 action/workflow phase entirely.
 
+The output always includes a __execution key containing per-resolver execution
+metadata: phase numbers, timing, provider info, dependencies, the resolver
+dependency graph, provider usage summary, and an aggregate summary.
+
 RESOLVER SELECTION:
   Pass resolver names as positional arguments to execute only specific
   resolvers and their transitive dependencies. When no names are provided,
@@ -69,14 +94,32 @@ RESOLVER SELECTION:
     scafctl run resolver db config          Execute 'db', 'config', and their deps
     scafctl run resolver auth -f sol.yaml   Execute 'auth' and its deps
 
-VERBOSE MODE:
-  Use --verbose to include a __execution key in the output containing
-  per-resolver execution metadata:
-  - Execution phase number and status
-  - Per-resolver duration and phase metrics breakdown
-  - Provider type and dependency information
-  - Aggregate summary (total duration, resolver count, phase count)
-  The __execution key is extensible for future additions (e.g. diagrams).
+SKIPPING PHASES:
+  Use --skip-validation to skip the validation phase of all resolvers.
+  Use --skip-transform to skip both the transform and validation phases,
+  returning only the raw resolved values. This is useful for inspecting
+  what providers return before any transformation.
+
+DRY RUN:
+  Use --dry-run to show the execution plan without running any providers.
+  This displays the DAG-based execution phases, resolver dependencies,
+  provider types, and configured phases for each resolver.
+
+GRAPH MODE:
+  Use --graph to visualize the resolver dependency graph without executing
+  any providers. Shows execution phases, parallelization opportunities,
+  dependencies, and the critical path.
+
+  Supported formats (--graph-format):
+    ascii   - Human-readable ASCII art (default)
+    dot     - Graphviz DOT format (pipe to 'dot' command for PNG/SVG)
+    mermaid - Mermaid diagram syntax
+    json    - Machine-readable JSON format
+
+SNAPSHOT MODE:
+  Use --snapshot to save a full execution snapshot to a file. Snapshots
+  capture resolver values, timing, phases, parameters, and metadata for
+  debugging, testing, comparison, and audit trails.
 
 RESOLVER PARAMETERS:
   Parameters can be passed using -r/--resolver flag in several formats:
@@ -108,11 +151,29 @@ Examples:
   # Run with parameters
   scafctl run resolver -r env=prod -r region=us-east1
 
-  # Run with verbose output for debugging
-  scafctl run resolver --verbose -f ./my-solution.yaml
-
   # JSON output for scripting
   scafctl run resolver -f ./my-solution.yaml -o json | jq .
+
+  # Skip transform and validation phases (raw resolved values)
+  scafctl run resolver --skip-transform -f ./my-solution.yaml
+
+  # Show execution plan without running providers
+  scafctl run resolver --dry-run -f ./my-solution.yaml
+
+  # Show resolver dependency graph (ASCII)
+  scafctl run resolver --graph -f ./my-solution.yaml
+
+  # Generate PNG graph using Graphviz
+  scafctl run resolver --graph --graph-format=dot -f ./my-solution.yaml | dot -Tpng > graph.png
+
+  # Generate Mermaid diagram
+  scafctl run resolver --graph --graph-format=mermaid -f ./my-solution.yaml
+
+  # Save execution snapshot
+  scafctl run resolver --snapshot --snapshot-file=snapshot.json -f ./my-solution.yaml
+
+  # Save snapshot with sensitive data redacted
+  scafctl run resolver --snapshot --snapshot-file=snapshot.json --redact -f ./my-solution.yaml
 
   # Explore results interactively
   scafctl run resolver -f ./my-solution.yaml -i
@@ -140,7 +201,13 @@ Examples:
 	addSharedResolverFlags(cCmd, &options.sharedResolverOptions)
 
 	// Resolver-specific flags
-	cCmd.Flags().BoolVar(&options.Verbose, "verbose", false, "Include __execution metadata in output (phases, timing, dependencies, providers)")
+	cCmd.Flags().BoolVar(&options.SkipTransform, "skip-transform", false, "Skip transform and validation phases, returning raw resolved values")
+	cCmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Show execution plan without running providers")
+	cCmd.Flags().BoolVar(&options.Graph, "graph", false, "Show resolver dependency graph instead of executing")
+	cCmd.Flags().StringVar(&options.GraphFormat, "graph-format", "ascii", "Graph output format: ascii, dot, mermaid, json")
+	cCmd.Flags().BoolVar(&options.Snapshot, "snapshot", false, "Save execution snapshot instead of normal output")
+	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
+	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
 
 	return cCmd
 }
@@ -152,10 +219,37 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		"file", o.File,
 		"output", o.Output,
 		"names", o.Names,
-		"verbose", o.Verbose,
+		"skipTransform", o.SkipTransform,
+		"dryRun", o.DryRun,
+		"graph", o.Graph,
+		"snapshot", o.Snapshot,
 		"resolveAll", o.ResolveAll,
 		"progress", o.Progress,
 		"showMetrics", o.ShowMetrics)
+
+	// Validate mutually exclusive modes
+	modeCount := 0
+	if o.DryRun {
+		modeCount++
+	}
+	if o.Graph {
+		modeCount++
+	}
+	if o.Snapshot {
+		modeCount++
+	}
+	if modeCount > 1 {
+		return o.exitWithCode(ctx,
+			fmt.Errorf("--dry-run, --graph, and --snapshot are mutually exclusive"),
+			exitcode.InvalidInput)
+	}
+
+	// Validate snapshot requirements
+	if o.Snapshot && o.SnapshotFile == "" {
+		return o.exitWithCode(ctx,
+			fmt.Errorf("--snapshot-file is required when using --snapshot"),
+			exitcode.InvalidInput)
+	}
 
 	// Prepare solution: load, set up registry, handle bundles
 	sol, reg, cleanup, err := o.prepareSolutionForExecution(ctx)
@@ -174,7 +268,11 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 
 	// Get all resolvers, then filter by names if specified
 	allResolvers := sol.Spec.ResolversToSlice()
-	resolvers := filterResolversWithDependencies(allResolvers, o.Names)
+	var lookup resolver.DescriptorLookup
+	if reg != nil {
+		lookup = reg.DescriptorLookup()
+	}
+	resolvers := filterResolversWithDependencies(allResolvers, o.Names, lookup)
 
 	// Validate requested names exist
 	if len(o.Names) > 0 {
@@ -197,6 +295,26 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		}
 	}
 
+	// Graph mode: show dependency graph without executing providers
+	if o.Graph {
+		return o.showResolverGraph(ctx, resolvers, reg)
+	}
+
+	// Dry run: show execution plan without running providers
+	if o.DryRun {
+		return o.showResolverDryRun(ctx, resolvers, reg)
+	}
+
+	// Snapshot mode: execute resolvers and save snapshot
+	if o.Snapshot {
+		return o.showResolverSnapshot(ctx, sol, resolvers, params, reg)
+	}
+
+	// Wire skip-transform flag into shared options for executeResolvers
+	if o.SkipTransform {
+		o.sharedResolverOptions.SkipTransform = true
+	}
+
 	// Track timing
 	start := time.Now()
 
@@ -214,108 +332,213 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
 	}
 
-	// Verbose: include __execution metadata in output
-	if o.Verbose {
-		results["__execution"] = o.buildExecutionData(resolverCtx, resolvers, elapsed)
+	// Always include __execution metadata — this is a debugging command
+	executionData := buildExecutionData(resolverCtx, resolvers, elapsed)
+
+	// Build and embed the resolver dependency graph
+	graph, graphErr := resolver.BuildGraph(resolvers, lookup)
+	if graphErr == nil {
+		if err := graph.RenderDiagrams(); err != nil {
+			lgr.V(1).Info("failed to render dependency graph diagrams", "error", err)
+		}
+		// Convert to map[string]any so CEL expressions can traverse the graph
+		graphJSON, err := json.Marshal(graph)
+		if err == nil {
+			var graphMap map[string]any
+			if err := json.Unmarshal(graphJSON, &graphMap); err == nil {
+				executionData["dependencyGraph"] = graphMap
+			} else {
+				lgr.V(1).Info("failed to unmarshal dependency graph", "error", err)
+			}
+		} else {
+			lgr.V(1).Info("failed to marshal dependency graph", "error", err)
+		}
+	} else {
+		lgr.V(1).Info("failed to build dependency graph for __execution", "error", graphErr)
 	}
+
+	// Embed provider usage summary
+	executionData["providerSummary"] = buildProviderSummary(resolverCtx, resolvers)
+
+	results["__execution"] = executionData
 
 	return o.writeResolverOutput(ctx, results, "scafctl run resolver")
 }
 
-// buildExecutionData constructs structured execution metadata from resolver results.
-// The returned map is extensible — new top-level sections can be added without
-// breaking consumers (e.g. "diagrams", "timeline", "warnings").
-func (o *ResolverOptions) buildExecutionData(
-	resolverCtx *resolver.Context,
-	resolvers []*resolver.Resolver,
-	totalElapsed time.Duration,
-) map[string]any {
-	allResults := resolverCtx.GetAllResults()
+// showResolverDryRun displays the execution plan without running providers
+func (o *ResolverOptions) showResolverDryRun(ctx context.Context, resolvers []*resolver.Resolver, reg *provider.Registry) error {
+	// Build execution phases from the resolver DAG
+	var lookup resolver.DescriptorLookup
+	if reg != nil {
+		lookup = reg.DescriptorLookup()
+	}
+	phases, err := resolver.BuildPhases(resolvers, lookup)
+	if err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to build execution plan: %w", err), exitcode.InvalidInput)
+	}
 
-	// Build per-resolver execution metadata
-	resolverMeta := make(map[string]any, len(resolvers))
+	// Build structured dry-run output
+	plan := buildDryRunPlan(phases, resolvers, o.SkipTransform, o.SkipValidation)
+
+	return o.writeResolverOutput(ctx, plan, "scafctl run resolver --dry-run")
+}
+
+// buildDryRunPlan constructs the structured execution plan for dry-run output
+func buildDryRunPlan(phases []*resolver.PhaseGroup, resolvers []*resolver.Resolver, skipTransform, skipValidation bool) map[string]any {
+	// Build phase list
+	phaseList := make([]map[string]any, 0, len(phases))
+	for _, pg := range phases {
+		resolverNames := make([]string, len(pg.Resolvers))
+		for i, r := range pg.Resolvers {
+			resolverNames[i] = r.Name
+		}
+		phaseList = append(phaseList, map[string]any{
+			"phase":     pg.Phase,
+			"resolvers": resolverNames,
+		})
+	}
+
+	// Determine active phases
+	activePhases := []string{"resolve"}
+	skippedPhases := []string{}
+	if !skipTransform {
+		activePhases = append(activePhases, "transform")
+	} else {
+		skippedPhases = append(skippedPhases, "transform", "validate")
+	}
+	if !skipValidation && !skipTransform {
+		activePhases = append(activePhases, "validate")
+	} else if skipValidation && !skipTransform {
+		skippedPhases = append(skippedPhases, "validate")
+	}
+
+	// Build per-resolver info
+	resolverInfo := make(map[string]any, len(resolvers))
 	for _, r := range resolvers {
 		deps := resolver.ExtractDependencies(r, nil)
-		entry := map[string]any{
-			"provider":     resolverProviderName(r),
-			"dependencies": deps,
+		configuredPhases := []string{"resolve"}
+		if r.Transform != nil {
+			configuredPhases = append(configuredPhases, "transform")
+		}
+		if r.Validate != nil {
+			configuredPhases = append(configuredPhases, "validate")
 		}
 
-		if result, ok := allResults[r.Name]; ok {
-			entry["phase"] = result.Phase
-			entry["duration"] = result.TotalDuration.Round(time.Millisecond).String()
-			entry["status"] = string(result.Status)
-			entry["providerCallCount"] = result.ProviderCallCount
-			entry["valueSizeBytes"] = result.ValueSizeBytes
-			entry["dependencyCount"] = result.DependencyCount
-
-			// Per-phase breakdown (resolve, transform, validate)
-			if len(result.PhaseMetrics) > 0 {
-				metrics := make([]map[string]any, 0, len(result.PhaseMetrics))
-				for _, pm := range result.PhaseMetrics {
-					metrics = append(metrics, map[string]any{
-						"phase":    pm.Phase,
-						"duration": pm.Duration.Round(time.Millisecond).String(),
-					})
-				}
-				entry["phaseMetrics"] = metrics
-			}
-
-			// Include failed attempts for debugging
-			if len(result.FailedAttempts) > 0 {
-				attempts := make([]map[string]any, 0, len(result.FailedAttempts))
-				for _, fa := range result.FailedAttempts {
-					attempt := map[string]any{
-						"provider":   fa.Provider,
-						"phase":      fa.Phase,
-						"duration":   fa.Duration.Round(time.Millisecond).String(),
-						"sourceStep": fa.SourceStep,
-					}
-					if fa.Error != "" {
-						attempt["error"] = fa.Error
-					}
-					if fa.OnError != "" {
-						attempt["onError"] = fa.OnError
-					}
-					attempts = append(attempts, attempt)
-				}
-				entry["failedAttempts"] = attempts
-			}
-		} else {
-			entry["phase"] = 0
-			entry["duration"] = "0s"
-			entry["status"] = "unknown"
+		resolverInfo[r.Name] = map[string]any{
+			"provider":         resolverProviderName(r),
+			"dependencies":     deps,
+			"configuredPhases": configuredPhases,
 		}
-
-		resolverMeta[r.Name] = entry
-	}
-
-	// Build summary
-	phaseCount := 0
-	for _, result := range allResults {
-		if result.Phase > phaseCount {
-			phaseCount = result.Phase
-		}
-	}
-
-	summary := map[string]any{
-		"totalDuration": totalElapsed.Round(time.Millisecond).String(),
-		"resolverCount": len(resolvers),
-		"phaseCount":    phaseCount,
 	}
 
 	return map[string]any{
-		"resolvers": resolverMeta,
-		"summary":   summary,
+		"dryRun": true,
+		"executionPlan": map[string]any{
+			"totalResolvers": len(resolvers),
+			"totalPhases":    len(phases),
+			"activePhases":   activePhases,
+			"skippedPhases":  skippedPhases,
+			"phases":         phaseList,
+		},
+		"resolvers": resolverInfo,
 	}
 }
 
-// resolverProviderName extracts the primary provider name from a resolver
-func resolverProviderName(r *resolver.Resolver) string {
-	if r.Resolve != nil && len(r.Resolve.With) > 0 {
-		return r.Resolve.With[0].Provider
+// showResolverGraph renders the resolver dependency graph without executing providers
+func (o *ResolverOptions) showResolverGraph(ctx context.Context, resolvers []*resolver.Resolver, reg *provider.Registry) error {
+	var lookup resolver.DescriptorLookup
+	if reg != nil {
+		lookup = reg.DescriptorLookup()
 	}
-	return "unknown"
+
+	graph, err := resolver.BuildGraph(resolvers, lookup)
+	if err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to build dependency graph: %w", err), exitcode.InvalidInput)
+	}
+
+	if err := renderGraph(o.IOStreams.Out, graph, graph, o.GraphFormat); err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to render graph: %w", err), exitcode.GeneralError)
+	}
+
+	return nil
+}
+
+// showResolverSnapshot executes resolvers and saves the execution state as a snapshot file
+func (o *ResolverOptions) showResolverSnapshot(
+	ctx context.Context,
+	sol *solution.Solution,
+	resolvers []*resolver.Resolver,
+	params map[string]any,
+	reg *provider.Registry,
+) error {
+	lgr := logger.FromContext(ctx)
+
+	// Wire skip-transform flag into shared options for executeResolvers
+	if o.SkipTransform {
+		o.sharedResolverOptions.SkipTransform = true
+	}
+
+	start := time.Now()
+
+	// Execute resolvers
+	_, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg)
+	elapsed := time.Since(start)
+
+	status := resolver.ExecutionStatusSuccess
+	if err != nil {
+		lgr.V(1).Info("resolver execution completed with errors", "error", err)
+		status = resolver.ExecutionStatusFailed
+		// Continue to capture snapshot even with errors
+	}
+
+	// Re-inject resolver context into context.Context for CaptureSnapshot
+	snapshotCtx := resolver.WithContext(ctx, resolverCtx)
+
+	versionStr := ""
+	if sol.Metadata.Version != nil {
+		versionStr = sol.Metadata.Version.String()
+	}
+
+	snapshot, err := resolver.CaptureSnapshot(
+		snapshotCtx,
+		sol.Metadata.Name,
+		versionStr,
+		settings.VersionInformation.BuildVersion,
+		params,
+		elapsed,
+		status,
+	)
+	if err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to capture snapshot: %w", err), exitcode.GeneralError)
+	}
+
+	// Redact sensitive values if requested
+	if o.Redact {
+		lgr.V(1).Info("redacting sensitive values")
+		resolverLikes := make([]resolver.ResolverLike, 0, len(resolvers))
+		for _, r := range resolvers {
+			resolverLikes = append(resolverLikes, &resolverAdapter{name: r.Name, sensitive: r.Sensitive})
+		}
+		resolver.RedactSensitiveValues(snapshot, resolverLikes)
+	}
+
+	// Save snapshot
+	lgr.V(1).Info("saving snapshot", "output", o.SnapshotFile)
+	if err := resolver.SaveSnapshot(snapshot, o.SnapshotFile); err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to save snapshot: %w", err), exitcode.GeneralError)
+	}
+
+	fmt.Fprintf(o.IOStreams.Out, "Snapshot saved to %s\n", o.SnapshotFile)
+	fmt.Fprintf(o.IOStreams.Out, "  Solution: %s", snapshot.Metadata.Solution)
+	if snapshot.Metadata.Version != "" {
+		fmt.Fprintf(o.IOStreams.Out, " (v%s)", snapshot.Metadata.Version)
+	}
+	fmt.Fprintln(o.IOStreams.Out)
+	fmt.Fprintf(o.IOStreams.Out, "  Resolvers: %d\n", len(snapshot.Resolvers))
+	fmt.Fprintf(o.IOStreams.Out, "  Duration: %s\n", snapshot.Metadata.TotalDuration)
+	fmt.Fprintf(o.IOStreams.Out, "  Status: %s\n", snapshot.Metadata.Status)
+
+	return nil
 }
 
 // resolverNamesString returns a comma-separated string of resolver names
@@ -326,3 +549,12 @@ func resolverNamesString(resolvers []*resolver.Resolver) string {
 	}
 	return strings.Join(names, ", ")
 }
+
+// resolverAdapter adapts a Resolver's fields to the ResolverLike interface
+type resolverAdapter struct {
+	name      string
+	sensitive bool
+}
+
+func (a *resolverAdapter) GetName() string    { return a.name }
+func (a *resolverAdapter) GetSensitive() bool { return a.sensitive }

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -48,11 +48,12 @@ func TestCommandResolver(t *testing.T) {
 	assert.NotNil(t, ff.Lookup("phase-timeout"))
 
 	// Verify resolver-specific flags
-	assert.NotNil(t, ff.Lookup("verbose"))
+	assert.NotNil(t, ff.Lookup("skip-transform"))
+	assert.NotNil(t, ff.Lookup("dry-run"))
 
 	// Should NOT have solution-specific flags
 	assert.Nil(t, ff.Lookup("action-timeout"))
-	assert.Nil(t, ff.Lookup("dry-run"))
+	assert.Nil(t, ff.Lookup("show-execution"))
 }
 
 func TestCommandResolver_FlagDefaults(t *testing.T) {
@@ -72,9 +73,13 @@ func TestCommandResolver_FlagDefaults(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "table", output)
 
-	verbose, err := ff.GetBool("verbose")
+	skipTransform, err := ff.GetBool("skip-transform")
 	require.NoError(t, err)
-	assert.False(t, verbose)
+	assert.False(t, skipTransform)
+
+	dryRun, err := ff.GetBool("dry-run")
+	require.NoError(t, err)
+	assert.False(t, dryRun)
 
 	progress, err := ff.GetBool("progress")
 	require.NoError(t, err)
@@ -277,6 +282,109 @@ spec:
 	assert.NotContains(t, output, "independent-value")
 }
 
+func TestResolverOptions_Run_MultipleNamedResolvers(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-named-resolver-test
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: production
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-west-2
+    host:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: env
+    port:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 8080
+    url:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: host
+    unrelated:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: should-not-appear
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Names: []string{"host", "port"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include host, port, and transitive dep env (host -> env via rslvr:)
+	assert.Contains(t, result, "host")
+	assert.Contains(t, result, "port")
+	assert.Contains(t, result, "env")
+
+	// Should NOT include url, unrelated, or region (not requested, not a dependency)
+	assert.NotContains(t, result, "url")
+	assert.NotContains(t, result, "unrelated")
+	assert.NotContains(t, result, "region")
+}
+
 func TestResolverOptions_Run_UnknownName(t *testing.T) {
 	t.Parallel()
 
@@ -330,7 +438,7 @@ spec:
 	assert.Contains(t, err.Error(), "existing")
 }
 
-func TestResolverOptions_Run_Verbose(t *testing.T) {
+func TestResolverOptions_Run_ExecutionMetadataAlwaysIncluded(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -371,7 +479,6 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		Verbose: true,
 	}
 
 	lgr := logger.Get(0)
@@ -415,10 +522,6 @@ spec:
 	assert.Contains(t, summary, "resolverCount")
 	assert.Contains(t, summary, "phaseCount")
 	assert.Equal(t, float64(1), summary["resolverCount"])
-
-	// stderr should NOT have verbose text anymore
-	assert.NotContains(t, stderr.String(), "Resolver Execution Plan")
-	assert.NotContains(t, stderr.String(), "Execution completed in")
 }
 
 func TestResolverOptions_Run_EmptySolution(t *testing.T) {
@@ -683,7 +786,8 @@ func TestBuildExecutionData(t *testing.T) {
 	}
 
 	opts := &ResolverOptions{}
-	data := opts.buildExecutionData(resolverCtx, resolvers, 300*time.Millisecond)
+	_ = opts // verify type exists
+	data := buildExecutionData(resolverCtx, resolvers, 300*time.Millisecond)
 
 	// Check top-level sections
 	assert.Contains(t, data, "resolvers")
@@ -740,8 +844,7 @@ func TestBuildExecutionData_MissingResult(t *testing.T) {
 		},
 	}
 
-	opts := &ResolverOptions{}
-	data := opts.buildExecutionData(resolverCtx, resolvers, 100*time.Millisecond)
+	data := buildExecutionData(resolverCtx, resolvers, 100*time.Millisecond)
 
 	resolversMeta := data["resolvers"].(map[string]any)
 	missingMeta, ok := resolversMeta["missing"].(map[string]any)
@@ -783,7 +886,8 @@ func TestBuildExecutionData_WithFailedAttempts(t *testing.T) {
 	}
 
 	opts := &ResolverOptions{}
-	data := opts.buildExecutionData(resolverCtx, resolvers, 100*time.Millisecond)
+	_ = opts // verify type exists
+	data := buildExecutionData(resolverCtx, resolvers, 100*time.Millisecond)
 
 	resolversMeta := data["resolvers"].(map[string]any)
 	fbMeta := resolversMeta["fallback"].(map[string]any)
@@ -848,7 +952,8 @@ func TestBuildExecutionData_CELDependencies(t *testing.T) {
 	}
 
 	opts := &ResolverOptions{}
-	data := opts.buildExecutionData(resolverCtx, resolvers, 20*time.Millisecond)
+	_ = opts // verify type exists
+	data := buildExecutionData(resolverCtx, resolvers, 20*time.Millisecond)
 
 	resolversMeta := data["resolvers"].(map[string]any)
 	hostnameMeta := resolversMeta["hostname"].(map[string]any)
@@ -860,4 +965,680 @@ func TestBuildExecutionData_CELDependencies(t *testing.T) {
 	assert.Contains(t, deps, "env")
 	assert.Contains(t, deps, "region")
 	assert.Equal(t, 2, hostnameMeta["dependencyCount"])
+}
+
+func TestResolverOptions_Run_SkipTransform(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: skip-transform-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'TRANSFORMED: ' + __self"
+      validate:
+        with:
+          - provider: cel
+            inputs:
+              expression: "size(__self) > 0"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &bytes.Buffer{},
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		SkipTransform: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+
+	// Should have the raw resolved value, not the transformed one
+	assert.Contains(t, output, "hello")
+	assert.NotContains(t, output, "TRANSFORMED")
+
+	// Should still have __execution metadata
+	assert.Contains(t, output, "__execution")
+
+	// Parse and verify __execution has only resolve phase in metrics
+	var result map[string]any
+	err = json.Unmarshal([]byte(output), &result)
+	require.NoError(t, err)
+
+	execution := result["__execution"].(map[string]any)
+	resolversMeta := execution["resolvers"].(map[string]any)
+	greetingMeta := resolversMeta["greeting"].(map[string]any)
+
+	// Should have only the resolve phase metric (transform and validate skipped)
+	if phaseMetrics, ok := greetingMeta["phaseMetrics"].([]any); ok {
+		for _, pm := range phaseMetrics {
+			pmMap := pm.(map[string]any)
+			assert.NotEqual(t, "transform", pmMap["phase"], "transform phase should be skipped")
+			assert.NotEqual(t, "validate", pmMap["phase"], "validate phase should be skipped")
+		}
+	}
+}
+
+func TestResolverOptions_Run_DryRun(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dry-run-test
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: production
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'Hello from ' + _.env"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &bytes.Buffer{},
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		DryRun: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+
+	// Should show execution plan, not actual values
+	assert.Contains(t, output, "dryRun")
+	assert.Contains(t, output, "executionPlan")
+	assert.Contains(t, output, "resolvers")
+
+	// Should NOT contain resolved values (providers not called)
+	assert.NotContains(t, output, "production")
+	assert.NotContains(t, output, "Hello from")
+
+	// Parse and verify structure
+	var result map[string]any
+	err = json.Unmarshal([]byte(output), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, result["dryRun"])
+
+	plan := result["executionPlan"].(map[string]any)
+	assert.Equal(t, float64(2), plan["totalResolvers"])
+
+	activePhases := plan["activePhases"].([]any)
+	assert.Contains(t, activePhases, "resolve")
+	assert.Contains(t, activePhases, "transform")
+	assert.Contains(t, activePhases, "validate")
+
+	resolversInfo := result["resolvers"].(map[string]any)
+	assert.Contains(t, resolversInfo, "env")
+	assert.Contains(t, resolversInfo, "greeting")
+
+	greetingInfo := resolversInfo["greeting"].(map[string]any)
+	assert.Equal(t, "static", greetingInfo["provider"])
+	configuredPhases := greetingInfo["configuredPhases"].([]any)
+	assert.Contains(t, configuredPhases, "resolve")
+	assert.Contains(t, configuredPhases, "transform")
+}
+
+func TestBuildDryRunPlan(t *testing.T) {
+	t.Parallel()
+
+	resolvers := []*resolver.Resolver{
+		{
+			Name: "env",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+		{
+			Name: "db",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "cel"}},
+			},
+			Transform: &resolver.TransformPhase{},
+			Validate:  &resolver.ValidatePhase{},
+		},
+	}
+
+	phases := []*resolver.PhaseGroup{
+		{Phase: 1, Resolvers: []*resolver.Resolver{resolvers[0]}},
+		{Phase: 2, Resolvers: []*resolver.Resolver{resolvers[1]}},
+	}
+
+	t.Run("no skips", func(t *testing.T) {
+		t.Parallel()
+		plan := buildDryRunPlan(phases, resolvers, false, false)
+		assert.Equal(t, true, plan["dryRun"])
+
+		execPlan := plan["executionPlan"].(map[string]any)
+		activePhases := execPlan["activePhases"].([]string)
+		assert.Equal(t, []string{"resolve", "transform", "validate"}, activePhases)
+		skippedPhases := execPlan["skippedPhases"].([]string)
+		assert.Empty(t, skippedPhases)
+	})
+
+	t.Run("skip validation", func(t *testing.T) {
+		t.Parallel()
+		plan := buildDryRunPlan(phases, resolvers, false, true)
+		execPlan := plan["executionPlan"].(map[string]any)
+		activePhases := execPlan["activePhases"].([]string)
+		assert.Equal(t, []string{"resolve", "transform"}, activePhases)
+		skippedPhases := execPlan["skippedPhases"].([]string)
+		assert.Equal(t, []string{"validate"}, skippedPhases)
+	})
+
+	t.Run("skip transform", func(t *testing.T) {
+		t.Parallel()
+		plan := buildDryRunPlan(phases, resolvers, true, false)
+		execPlan := plan["executionPlan"].(map[string]any)
+		activePhases := execPlan["activePhases"].([]string)
+		assert.Equal(t, []string{"resolve"}, activePhases)
+		skippedPhases := execPlan["skippedPhases"].([]string)
+		assert.Equal(t, []string{"transform", "validate"}, skippedPhases)
+	})
+}
+
+func TestCommandResolver_GraphSnapshotFlagDefaults(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandResolver(cliParams, streams, "")
+	ff := cmd.Flags()
+
+	graph, err := ff.GetBool("graph")
+	require.NoError(t, err)
+	assert.False(t, graph)
+
+	graphFormat, err := ff.GetString("graph-format")
+	require.NoError(t, err)
+	assert.Equal(t, "ascii", graphFormat)
+
+	snapshot, err := ff.GetBool("snapshot")
+	require.NoError(t, err)
+	assert.False(t, snapshot)
+
+	snapshotFile, err := ff.GetString("snapshot-file")
+	require.NoError(t, err)
+	assert.Empty(t, snapshotFile)
+
+	redact, err := ff.GetBool("redact")
+	require.NoError(t, err)
+	assert.False(t, redact)
+}
+
+func TestResolverOptions_Run_MutualExclusivity(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: mutex-test
+  version: 1.0.0
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: x
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	makeOpts := func(dryRun, graph, snapshot bool) *ResolverOptions {
+		return &ResolverOptions{
+			sharedResolverOptions: sharedResolverOptions{
+				IOStreams:       &terminal.IOStreams{In: nil, Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+				CliParams:       func() *settings.Run { p := settings.NewCliParams(); p.ExitOnError = false; return p }(),
+				File:            solutionPath,
+				KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+				ResolverTimeout: 30 * time.Second,
+				PhaseTimeout:    5 * time.Minute,
+				registry:        testRegistry(),
+			},
+			DryRun:   dryRun,
+			Graph:    graph,
+			Snapshot: snapshot,
+		}
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	t.Run("dry-run and graph", func(t *testing.T) {
+		t.Parallel()
+		err := makeOpts(true, true, false).Run(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("dry-run and snapshot", func(t *testing.T) {
+		t.Parallel()
+		err := makeOpts(true, false, true).Run(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("graph and snapshot", func(t *testing.T) {
+		t.Parallel()
+		err := makeOpts(false, true, true).Run(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("snapshot without file", func(t *testing.T) {
+		t.Parallel()
+		err := makeOpts(false, false, true).Run(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "--snapshot-file")
+	})
+}
+
+func TestResolverOptions_Run_ExecutionIncludesGraph(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: graph-embed-test
+  version: 1.0.0
+spec:
+  resolvers:
+    base:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: base-val
+    dependent:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: dep-val
+      dependsOn:
+        - base
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &bytes.Buffer{}}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	execution, ok := result["__execution"].(map[string]any)
+	require.True(t, ok)
+
+	// Verify dependencyGraph embedded
+	graphData, ok := execution["dependencyGraph"].(map[string]any)
+	require.True(t, ok, "__execution.dependencyGraph should be present")
+	assert.Contains(t, graphData, "nodes")
+	assert.Contains(t, graphData, "edges")
+	assert.Contains(t, graphData, "stats")
+
+	stats := graphData["stats"].(map[string]any)
+	assert.Equal(t, float64(2), stats["totalResolvers"])
+	assert.Contains(t, stats, "criticalPath")
+	assert.Contains(t, stats, "criticalDepth")
+
+	// Verify diagrams embedded
+	diagrams, ok := graphData["diagrams"].(map[string]any)
+	require.True(t, ok, "__execution.dependencyGraph.diagrams should be present")
+	assert.NotEmpty(t, diagrams["ascii"])
+	assert.Contains(t, diagrams["dot"].(string), "digraph")
+	assert.Contains(t, diagrams["mermaid"].(string), "graph")
+
+	// Verify providerSummary embedded
+	providerSummary, ok := execution["providerSummary"].(map[string]any)
+	require.True(t, ok, "__execution.providerSummary should be present")
+	assert.Contains(t, providerSummary, "static")
+}
+
+func TestResolverOptions_Run_GraphMode(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: graph-mode-test
+  version: 1.0.0
+spec:
+  resolvers:
+    a:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: val-a
+    b:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: val-b
+      dependsOn:
+        - a
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	formats := []struct {
+		format   string
+		contains string
+	}{
+		{"ascii", "a"},
+		{"dot", "digraph"},
+		{"mermaid", "graph"},
+	}
+
+	for _, f := range formats {
+		t.Run(f.format, func(t *testing.T) {
+			t.Parallel()
+			var stdout bytes.Buffer
+			streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &bytes.Buffer{}}
+			cliParams := settings.NewCliParams()
+			cliParams.ExitOnError = false
+
+			opts := &ResolverOptions{
+				sharedResolverOptions: sharedResolverOptions{
+					IOStreams:       streams,
+					CliParams:       cliParams,
+					File:            solutionPath,
+					KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+					ResolverTimeout: 30 * time.Second,
+					PhaseTimeout:    5 * time.Minute,
+					registry:        testRegistry(),
+				},
+				Graph:       true,
+				GraphFormat: f.format,
+			}
+
+			lgr := logger.Get(0)
+			ctx := logger.WithLogger(context.Background(), lgr)
+
+			err := opts.Run(ctx)
+			require.NoError(t, err)
+			assert.Contains(t, stdout.String(), f.contains)
+		})
+	}
+
+	t.Run("json format", func(t *testing.T) {
+		t.Parallel()
+		var stdout bytes.Buffer
+		streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &bytes.Buffer{}}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &ResolverOptions{
+			sharedResolverOptions: sharedResolverOptions{
+				IOStreams:       streams,
+				CliParams:       cliParams,
+				File:            solutionPath,
+				KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+				ResolverTimeout: 30 * time.Second,
+				PhaseTimeout:    5 * time.Minute,
+				registry:        testRegistry(),
+			},
+			Graph:       true,
+			GraphFormat: "json",
+		}
+
+		lgr := logger.Get(0)
+		ctx := logger.WithLogger(context.Background(), lgr)
+
+		err := opts.Run(ctx)
+		require.NoError(t, err)
+
+		var graphData map[string]any
+		err = json.Unmarshal(stdout.Bytes(), &graphData)
+		require.NoError(t, err)
+		assert.Contains(t, graphData, "nodes")
+		assert.Contains(t, graphData, "edges")
+		assert.Contains(t, graphData, "stats")
+	})
+}
+
+func TestResolverOptions_Run_SnapshotMode(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: snapshot-test
+  version: 2.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+    secret:
+      type: string
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: s3cr3t
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	t.Run("basic snapshot", func(t *testing.T) {
+		t.Parallel()
+		snapshotFile := filepath.Join(t.TempDir(), "snap.json")
+		var stdout bytes.Buffer
+		streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &bytes.Buffer{}}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &ResolverOptions{
+			sharedResolverOptions: sharedResolverOptions{
+				IOStreams:       streams,
+				CliParams:       cliParams,
+				File:            solutionPath,
+				KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+				ResolverTimeout: 30 * time.Second,
+				PhaseTimeout:    5 * time.Minute,
+				registry:        testRegistry(),
+			},
+			Snapshot:     true,
+			SnapshotFile: snapshotFile,
+		}
+
+		err := opts.Run(ctx)
+		require.NoError(t, err)
+
+		// Verify file was created
+		_, statErr := os.Stat(snapshotFile)
+		assert.NoError(t, statErr)
+
+		// Verify output mentions snapshot
+		assert.Contains(t, stdout.String(), "Snapshot saved to")
+		assert.Contains(t, stdout.String(), "snapshot-test")
+
+		// Read and parse snapshot
+		data, err := os.ReadFile(snapshotFile)
+		require.NoError(t, err)
+		var snapshot map[string]any
+		err = json.Unmarshal(data, &snapshot)
+		require.NoError(t, err)
+
+		meta := snapshot["metadata"].(map[string]any)
+		assert.Equal(t, "snapshot-test", meta["solution"])
+		assert.Equal(t, "2.0.0", meta["version"])
+		assert.Equal(t, "success", meta["status"])
+	})
+
+	t.Run("snapshot with redact", func(t *testing.T) {
+		t.Parallel()
+		snapshotFile := filepath.Join(t.TempDir(), "snap-redacted.json")
+		var stdout bytes.Buffer
+		streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &bytes.Buffer{}}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &ResolverOptions{
+			sharedResolverOptions: sharedResolverOptions{
+				IOStreams:       streams,
+				CliParams:       cliParams,
+				File:            solutionPath,
+				KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+				ResolverTimeout: 30 * time.Second,
+				PhaseTimeout:    5 * time.Minute,
+				registry:        testRegistry(),
+			},
+			Snapshot:     true,
+			SnapshotFile: snapshotFile,
+			Redact:       true,
+		}
+
+		err := opts.Run(ctx)
+		require.NoError(t, err)
+
+		// Read and parse snapshot
+		data, err := os.ReadFile(snapshotFile)
+		require.NoError(t, err)
+		var snapshot map[string]any
+		err = json.Unmarshal(data, &snapshot)
+		require.NoError(t, err)
+
+		// The sensitive resolver's value should be redacted
+		resolversMap := snapshot["resolvers"].(map[string]any)
+		secretResolver := resolversMap["secret"].(map[string]any)
+		// Redacted values use "<redacted>"
+		assert.Equal(t, "<redacted>", secretResolver["value"])
+	})
+}
+
+func TestResolverAdapter(t *testing.T) {
+	t.Parallel()
+
+	a := &resolverAdapter{name: "test", sensitive: true}
+	assert.Equal(t, "test", a.GetName())
+	assert.True(t, a.GetSensitive())
+
+	b := &resolverAdapter{name: "other", sensitive: false}
+	assert.Equal(t, "other", b.GetName())
+	assert.False(t, b.GetSensitive())
 }

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -35,6 +35,9 @@ type SolutionOptions struct {
 	ActionTimeout        time.Duration
 	MaxActionConcurrency int
 	DryRun               bool
+
+	// ShowExecution enables __execution metadata in output
+	ShowExecution bool
 }
 
 // CommandSolution creates the 'run solution' subcommand
@@ -140,7 +143,10 @@ Examples:
   scafctl run solution --max-action-concurrency=2
 
   # Show progress during execution
-  scafctl run solution --progress`,
+  scafctl run solution --progress
+
+  # Include resolver execution metadata in output
+  scafctl run solution --show-execution -f ./my-solution.yaml -o json`,
 		Args: cobra.MaximumNArgs(1),
 		PreRun: func(cCmd *cobra.Command, args []string) {
 			// Track which flags were explicitly set by the user
@@ -165,6 +171,7 @@ Examples:
 	cCmd.Flags().DurationVar(&options.ActionTimeout, "action-timeout", settings.DefaultActionTimeout, "Default timeout per action")
 	cCmd.Flags().IntVar(&options.MaxActionConcurrency, "max-action-concurrency", 0, "Maximum concurrent actions (0=unlimited)")
 	cCmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Validate and show what would be executed without running")
+	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata in output (phases, timing, dependencies, providers)")
 
 	return cCmd
 }
@@ -246,16 +253,25 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	// Execute resolvers if present
 	resolvers := sol.Spec.ResolversToSlice()
-	resolverData, _, err := o.executeResolvers(ctx, sol, resolvers, params, reg)
+
+	// Track timing for execution metadata
+	start := time.Now()
+
+	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg)
 	if err != nil {
 		return o.exitWithCode(ctx, err, exitcode.GeneralError)
 	}
+
+	resolverElapsed := time.Since(start)
 
 	// If no workflow, output resolver results
 	if !sol.Spec.HasWorkflow() {
 		results := o.buildResolverOutputMap(resolverData, sol)
 		if err := o.checkValueSizes(results, *lgr); err != nil {
 			return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
+		}
+		if o.ShowExecution {
+			results["__execution"] = buildExecutionData(resolverCtx, resolvers, resolverElapsed)
 		}
 		return o.writeResolverOutput(ctx, results, "scafctl run solution")
 	}
@@ -302,7 +318,11 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	}
 
 	// Build and write output
-	return o.writeActionOutput(ctx, result)
+	var executionData map[string]any
+	if o.ShowExecution {
+		executionData = buildExecutionData(resolverCtx, resolvers, resolverElapsed)
+	}
+	return o.writeActionOutput(ctx, result, executionData)
 }
 
 // showDryRun displays what would be executed without actually running
@@ -342,7 +362,7 @@ func (o *SolutionOptions) showDryRun(graph *action.Graph) {
 }
 
 // writeActionOutput writes the action execution results
-func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.ExecutionResult) error {
+func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.ExecutionResult, executionData map[string]any) error {
 	if o.Output == "quiet" {
 		return nil
 	}
@@ -379,6 +399,11 @@ func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.Ex
 	}
 	if len(result.SkippedActions) > 0 {
 		output["skippedActions"] = result.SkippedActions
+	}
+
+	// Include execution metadata if requested
+	if executionData != nil {
+		output["__execution"] = executionData
 	}
 
 	var data []byte

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -6,6 +6,7 @@ package run
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -53,6 +54,7 @@ func TestCommandSolution(t *testing.T) {
 	assert.NotNil(t, flags.Lookup("max-value-size"))
 	assert.NotNil(t, flags.Lookup("resolver-timeout"))
 	assert.NotNil(t, flags.Lookup("phase-timeout"))
+	assert.NotNil(t, flags.Lookup("show-execution"))
 }
 
 func TestCommandSolution_FlagDefaults(t *testing.T) {
@@ -96,6 +98,10 @@ func TestCommandSolution_FlagDefaults(t *testing.T) {
 	phaseTimeout, err := flags.GetDuration("phase-timeout")
 	require.NoError(t, err)
 	assert.Equal(t, 5*time.Minute, phaseTimeout)
+
+	showExecution, err := flags.GetBool("show-execution")
+	require.NoError(t, err)
+	assert.False(t, showExecution)
 }
 
 func TestSolutionOptions_Run_NoFile(t *testing.T) {
@@ -701,4 +707,127 @@ spec:
 	err = cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid")
+}
+
+func TestSolutionOptions_Run_ShowExecution(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: show-execution-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &bytes.Buffer{},
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &SolutionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		ShowExecution: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "hello")
+	assert.Contains(t, output, "__execution")
+	assert.Contains(t, output, "resolvers")
+	assert.Contains(t, output, "summary")
+
+	// Parse and verify structure
+	var result map[string]any
+	err = json.Unmarshal([]byte(output), &result)
+	require.NoError(t, err)
+
+	execution, ok := result["__execution"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, execution, "resolvers")
+	assert.Contains(t, execution, "summary")
+}
+
+func TestSolutionOptions_Run_NoShowExecution(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-show-execution-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &bytes.Buffer{},
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &SolutionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		ShowExecution: false,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "hello")
+	// Without --show-execution, __execution should NOT be present
+	assert.NotContains(t, output, "__execution")
 }

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -51,6 +51,7 @@ type Executor struct {
 	progressCallback ProgressCallback // Optional callback for progress events
 	validateAll      bool             // Continue execution and collect all errors instead of stopping at first
 	skipValidation   bool             // Skip the validation phase of all resolvers
+	skipTransform    bool             // Skip the transform and validation phases of all resolvers
 }
 
 // ExecutorOption is a functional option for configuring the Executor
@@ -117,6 +118,15 @@ func WithValidateAll(enabled bool) ExecutorOption {
 func WithSkipValidation(enabled bool) ExecutorOption {
 	return func(e *Executor) {
 		e.skipValidation = enabled
+	}
+}
+
+// WithSkipTransform disables the transform and validation phases for all resolvers.
+// When enabled, resolvers will execute only the resolve phase, returning the raw
+// resolved value without any transformations or validations applied.
+func WithSkipTransform(enabled bool) ExecutorOption {
+	return func(e *Executor) {
+		e.skipTransform = enabled
 	}
 }
 
@@ -567,7 +577,8 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 	}
 
 	// Execute transform phase
-	if r.Transform != nil {
+	// Skip if transform is disabled via executor option (also skips validate)
+	if r.Transform != nil && !e.skipTransform {
 		phaseStart := time.Now()
 		transformed, providerCalls, err := e.executeTransformPhase(resolverContext, r.Transform, value)
 		providerCallCount += providerCalls
@@ -613,8 +624,8 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 	}
 
 	// Execute validate phase (runs all validations and aggregates failures)
-	// Skip if validation is disabled via executor option
-	if r.Validate != nil && !e.skipValidation {
+	// Skip if validation is disabled via executor option, or if transform is skipped (implies skip validation)
+	if r.Validate != nil && !e.skipValidation && !e.skipTransform {
 		phaseStart := time.Now()
 		providerCalls, validationErr := e.executeValidatePhase(resolverContext, r.Name, r.Sensitive, r.Validate, value)
 		providerCallCount += providerCalls

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -4,6 +4,7 @@
 package resolver
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -360,12 +361,20 @@ type GraphEdge struct {
 	Label string `json:"label" yaml:"label" doc:"Edge label"`
 }
 
+// GraphDiagrams contains pre-rendered diagram representations of the dependency graph.
+type GraphDiagrams struct {
+	ASCII   string `json:"ascii" yaml:"ascii" doc:"ASCII art representation of the graph"`
+	DOT     string `json:"dot" yaml:"dot" doc:"Graphviz DOT format representation"`
+	Mermaid string `json:"mermaid" yaml:"mermaid" doc:"Mermaid.js diagram representation"`
+}
+
 // Graph represents the complete resolver dependency graph
 type Graph struct {
-	Nodes  []*GraphNode `json:"nodes" yaml:"nodes" doc:"Graph nodes"`
-	Edges  []*GraphEdge `json:"edges" yaml:"edges" doc:"Graph edges"`
-	Phases []*PhaseInfo `json:"phases" yaml:"phases" doc:"Phase information"`
-	Stats  *GraphStats  `json:"stats" yaml:"stats" doc:"Graph statistics"`
+	Nodes    []*GraphNode   `json:"nodes" yaml:"nodes" doc:"Graph nodes"`
+	Edges    []*GraphEdge   `json:"edges" yaml:"edges" doc:"Graph edges"`
+	Phases   []*PhaseInfo   `json:"phases" yaml:"phases" doc:"Phase information"`
+	Stats    *GraphStats    `json:"stats" yaml:"stats" doc:"Graph statistics"`
+	Diagrams *GraphDiagrams `json:"diagrams" yaml:"diagrams" doc:"Pre-rendered diagram representations"`
 }
 
 // PhaseInfo contains information about a phase
@@ -377,10 +386,12 @@ type PhaseInfo struct {
 
 // GraphStats contains graph statistics
 type GraphStats struct {
-	TotalResolvers  int     `json:"totalResolvers" yaml:"totalResolvers" doc:"Total number of resolvers"`
-	TotalPhases     int     `json:"totalPhases" yaml:"totalPhases" doc:"Total number of execution phases"`
-	MaxParallelism  int     `json:"maxParallelism" yaml:"maxParallelism" doc:"Maximum parallelism across all phases"`
-	AvgDependencies float64 `json:"avgDependencies" yaml:"avgDependencies" doc:"Average number of dependencies per resolver"`
+	TotalResolvers  int      `json:"totalResolvers" yaml:"totalResolvers" doc:"Total number of resolvers"`
+	TotalPhases     int      `json:"totalPhases" yaml:"totalPhases" doc:"Total number of execution phases"`
+	MaxParallelism  int      `json:"maxParallelism" yaml:"maxParallelism" doc:"Maximum parallelism across all phases"`
+	AvgDependencies float64  `json:"avgDependencies" yaml:"avgDependencies" doc:"Average number of dependencies per resolver"`
+	CriticalPath    []string `json:"criticalPath" yaml:"criticalPath" doc:"Longest dependency chain in the graph"`
+	CriticalDepth   int      `json:"criticalDepth" yaml:"criticalDepth" doc:"Length of the critical path"`
 }
 
 // BuildGraph creates a Graph from resolvers.
@@ -447,7 +458,7 @@ func BuildGraph(resolvers []*Resolver, lookup DescriptorLookup) (*Graph, error) 
 	return graph, nil
 }
 
-// calculateGraphStats computes graph statistics
+// calculateGraphStats computes graph statistics including the critical path
 func calculateGraphStats(graph *Graph) *GraphStats {
 	totalDeps := 0
 	maxParallelism := 0
@@ -467,12 +478,92 @@ func calculateGraphStats(graph *Graph) *GraphStats {
 		avgDeps = float64(totalDeps) / float64(len(graph.Nodes))
 	}
 
+	criticalPath := computeCriticalPath(graph)
+
 	return &GraphStats{
 		TotalResolvers:  len(graph.Nodes),
 		TotalPhases:     len(graph.Phases),
 		MaxParallelism:  maxParallelism,
 		AvgDependencies: avgDeps,
+		CriticalPath:    criticalPath,
+		CriticalDepth:   len(criticalPath),
 	}
+}
+
+// computeCriticalPath finds the longest dependency chain in the graph.
+// It uses dynamic programming on the DAG to find the path with the most nodes.
+func computeCriticalPath(graph *Graph) []string {
+	if len(graph.Nodes) == 0 {
+		return nil
+	}
+
+	// Build adjacency list (node -> dependents that depend on it)
+	dependents := make(map[string][]string)
+	for _, edge := range graph.Edges {
+		// edge.From depends on edge.To, so edge.To feeds into edge.From
+		dependents[edge.To] = append(dependents[edge.To], edge.From)
+	}
+
+	// Build dependency set per node for quick lookup
+	depCount := make(map[string]int)
+	for _, node := range graph.Nodes {
+		depCount[node.Name] = len(node.Dependencies)
+	}
+
+	// DP: longest path ending at each node
+	longest := make(map[string]int)
+	parent := make(map[string]string)
+	var bestNode string
+	bestLen := 0
+
+	// Process nodes in phase order (phase 1 first = roots)
+	for _, phase := range graph.Phases {
+		for _, name := range phase.Resolvers {
+			node := graph.findNode(name)
+			if node == nil {
+				continue
+			}
+
+			myLen := 1
+			myParent := ""
+
+			// Check all dependencies (predecessors in the chain)
+			// Tie-break alphabetically for deterministic output when paths are equal length
+			for _, dep := range node.Dependencies {
+				if l, ok := longest[dep.Resolver]; ok && (l+1 > myLen || (l+1 == myLen && dep.Resolver < myParent)) {
+					myLen = l + 1
+					myParent = dep.Resolver
+				}
+			}
+
+			longest[name] = myLen
+			if myParent != "" {
+				parent[name] = myParent
+			}
+
+			if myLen > bestLen {
+				bestLen = myLen
+				bestNode = name
+			}
+		}
+	}
+
+	if bestLen == 0 {
+		return nil
+	}
+
+	// Reconstruct path from best node back to root
+	path := make([]string, 0, bestLen)
+	for node := bestNode; node != ""; node = parent[node] {
+		path = append(path, node)
+	}
+
+	// Reverse to get root -> leaf order
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	return path
 }
 
 // findNode finds a node by name
@@ -617,6 +708,34 @@ func (g *Graph) RenderASCII(w io.Writer) error {
 	fmt.Fprintf(w, "  Total Phases: %d\n", g.Stats.TotalPhases)
 	fmt.Fprintf(w, "  Max Parallelism: %d\n", g.Stats.MaxParallelism)
 	fmt.Fprintf(w, "  Avg Dependencies: %.2f\n", g.Stats.AvgDependencies)
+
+	return nil
+}
+
+// RenderDiagrams pre-renders all diagram representations and stores them in
+// the Diagrams field. This allows diagram strings to appear in JSON/YAML
+// output without requiring an io.Writer at consumption time.
+func (g *Graph) RenderDiagrams() error {
+	g.Diagrams = &GraphDiagrams{}
+
+	var buf bytes.Buffer
+
+	if err := g.RenderASCII(&buf); err != nil {
+		return fmt.Errorf("rendering ASCII diagram: %w", err)
+	}
+	g.Diagrams.ASCII = buf.String()
+
+	buf.Reset()
+	if err := g.RenderDOT(&buf); err != nil {
+		return fmt.Errorf("rendering DOT diagram: %w", err)
+	}
+	g.Diagrams.DOT = buf.String()
+
+	buf.Reset()
+	if err := g.RenderMermaid(&buf); err != nil {
+		return fmt.Errorf("rendering Mermaid diagram: %w", err)
+	}
+	g.Diagrams.Mermaid = buf.String()
 
 	return nil
 }

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -766,6 +766,122 @@ func TestBuildGraph(t *testing.T) {
 	}
 }
 
+func TestCriticalPath(t *testing.T) {
+	tests := []struct {
+		name              string
+		resolvers         []*Resolver
+		wantCriticalPath  []string
+		wantCriticalDepth int
+	}{
+		{
+			name:              "empty graph",
+			resolvers:         []*Resolver{},
+			wantCriticalPath:  nil,
+			wantCriticalDepth: 0,
+		},
+		{
+			name: "single resolver",
+			resolvers: []*Resolver{
+				{
+					Name: "only",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "x"}}}},
+					},
+				},
+			},
+			wantCriticalPath:  []string{"only"},
+			wantCriticalDepth: 1,
+		},
+		{
+			name: "linear chain a->b->c",
+			resolvers: []*Resolver{
+				{
+					Name: "a",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "a"}}}},
+					},
+				},
+				{
+					Name: "b",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("a")}}}},
+					},
+				},
+				{
+					Name: "c",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("b")}}}},
+					},
+				},
+			},
+			wantCriticalPath:  []string{"a", "b", "c"},
+			wantCriticalDepth: 3,
+		},
+		{
+			name: "diamond: a->b, a->c, b->d, c->d - path length is 3",
+			resolvers: []*Resolver{
+				{
+					Name: "a",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "a"}}}},
+					},
+				},
+				{
+					Name: "b",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("a")}}}},
+					},
+				},
+				{
+					Name: "c",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("a")}}}},
+					},
+				},
+				{
+					Name:      "d",
+					DependsOn: []string{"b", "c"},
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "d"}}}},
+					},
+				},
+			},
+			wantCriticalPath:  []string{"a", "b", "d"},
+			wantCriticalDepth: 3,
+		},
+		{
+			name: "parallel independent resolvers - critical path is 1",
+			resolvers: []*Resolver{
+				{
+					Name: "x",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "x"}}}},
+					},
+				},
+				{
+					Name: "y",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "y"}}}},
+					},
+				},
+			},
+			wantCriticalDepth: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph, err := BuildGraph(tt.resolvers, nil)
+			require.NoError(t, err)
+
+			if tt.wantCriticalPath != nil {
+				assert.Equal(t, tt.wantCriticalPath, graph.Stats.CriticalPath)
+			}
+			assert.Equal(t, tt.wantCriticalDepth, graph.Stats.CriticalDepth)
+		})
+	}
+}
+
 // Helper functions
 func stringPtr(s string) *string {
 	return &s

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -99,6 +99,7 @@ func runScafctl(t *testing.T, args ...string) (stdout, stderr string, exitCode i
 // ============================================================================
 
 func TestIntegration_Version(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "version")
 
 	assert.Equal(t, 0, exitCode)
@@ -106,6 +107,7 @@ func TestIntegration_Version(t *testing.T) {
 }
 
 func TestIntegration_VersionJSON(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "version", "-o", "json")
 
 	assert.Equal(t, 0, exitCode)
@@ -117,6 +119,7 @@ func TestIntegration_VersionJSON(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_Help(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -127,6 +130,7 @@ func TestIntegration_Help(t *testing.T) {
 }
 
 func TestIntegration_RunHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "run", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -138,6 +142,7 @@ func TestIntegration_RunHelp(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_GetProvider(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "get", "provider")
 
 	assert.Equal(t, 0, exitCode)
@@ -151,6 +156,7 @@ func TestIntegration_GetProvider(t *testing.T) {
 }
 
 func TestIntegration_GetProviderJSON(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "get", "provider", "-o", "json")
 
 	assert.Equal(t, 0, exitCode)
@@ -163,6 +169,7 @@ func TestIntegration_GetProviderJSON(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_ExplainProvider(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "explain", "provider")
 
 	assert.Equal(t, 0, exitCode)
@@ -171,6 +178,7 @@ func TestIntegration_ExplainProvider(t *testing.T) {
 }
 
 func TestIntegration_ExplainProviderNotFound(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "explain", "nonexistentkind")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -182,6 +190,7 @@ func TestIntegration_ExplainProviderNotFound(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_RunSolution_HelloWorld(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/hello-world.yaml",
@@ -195,6 +204,7 @@ func TestIntegration_RunSolution_HelloWorld(t *testing.T) {
 }
 
 func TestIntegration_RunSolution_FileNotFound(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "/nonexistent/solution.yaml",
@@ -205,6 +215,7 @@ func TestIntegration_RunSolution_FileNotFound(t *testing.T) {
 }
 
 func TestIntegration_RunSolution_InvalidYAML(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	solutionPath := filepath.Join(tmpDir, "invalid.yaml")
 
@@ -220,6 +231,7 @@ func TestIntegration_RunSolution_InvalidYAML(t *testing.T) {
 }
 
 func TestIntegration_RunSolution_BadSolutionYAML(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/solutions/bad-solution-yaml/solution.yaml",
@@ -231,6 +243,7 @@ func TestIntegration_RunSolution_BadSolutionYAML(t *testing.T) {
 }
 
 func TestIntegration_RunSolution_DryRun(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/hello-world.yaml",
@@ -243,6 +256,7 @@ func TestIntegration_RunSolution_DryRun(t *testing.T) {
 }
 
 func TestIntegration_RunResolver_Basic(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/actions/hello-world.yaml",
@@ -255,15 +269,20 @@ func TestIntegration_RunResolver_Basic(t *testing.T) {
 }
 
 func TestIntegration_RunResolver_Help(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "run", "resolver", "--help")
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "Execute resolvers from a solution without running actions")
-	assert.Contains(t, stdout, "--verbose")
+	assert.Contains(t, stdout, "--skip-transform")
+	assert.Contains(t, stdout, "--dry-run")
+	assert.Contains(t, stdout, "--graph")
+	assert.Contains(t, stdout, "--snapshot")
 	assert.Contains(t, stdout, "--file")
 }
 
 func TestIntegration_RunResolver_Alias(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "res",
 		"-f", "examples/resolver-demo.yaml",
@@ -275,6 +294,7 @@ func TestIntegration_RunResolver_Alias(t *testing.T) {
 }
 
 func TestIntegration_RunResolver_NamedResolver(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
@@ -287,7 +307,31 @@ func TestIntegration_RunResolver_NamedResolver(t *testing.T) {
 	assert.Contains(t, stdout, "production")
 }
 
+func TestIntegration_RunResolver_MultipleNamedResolvers(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"hostname", "port",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+
+	// hostname depends on environment and region (via CEL: _.environment + '-server-' + _.region)
+	// Both requested resolvers and their transitive deps should be present
+	assert.Contains(t, stdout, "\"hostname\"")
+	assert.Contains(t, stdout, "\"port\"")
+	assert.Contains(t, stdout, "\"environment\"")
+	assert.Contains(t, stdout, "\"region\"")
+
+	// exposedPort and config were not requested and are not dependencies
+	assert.NotContains(t, stdout, "\"exposedPort\"")
+	assert.NotContains(t, stdout, "\"config\"")
+}
+
 func TestIntegration_RunResolver_UnknownName(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
@@ -298,16 +342,16 @@ func TestIntegration_RunResolver_UnknownName(t *testing.T) {
 	assert.Contains(t, stderr, "unknown resolver(s): nonexistent")
 }
 
-func TestIntegration_RunResolver_Verbose(t *testing.T) {
+func TestIntegration_RunResolver_ExecutionMetadataAlwaysIncluded(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
-		"--verbose",
 		"-o", "json",
 	)
 
 	assert.Equal(t, 0, exitCode)
-	// Verbose metadata is now in the structured output, not stderr
+	// __execution metadata is always included in run resolver output
 	assert.Contains(t, stdout, "__execution")
 	assert.Contains(t, stdout, "resolvers")
 	assert.Contains(t, stdout, "summary")
@@ -315,7 +359,184 @@ func TestIntegration_RunResolver_Verbose(t *testing.T) {
 	assert.Contains(t, stdout, "phaseCount")
 }
 
+func TestIntegration_RunResolver_SkipTransform(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--skip-transform",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "__execution")
+}
+
+func TestIntegration_RunResolver_DryRun(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--dry-run",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "dryRun")
+	assert.Contains(t, stdout, "executionPlan")
+	assert.Contains(t, stdout, "resolvers")
+}
+
+func TestIntegration_RunResolver_GraphASCII(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--graph",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "environment")
+}
+
+func TestIntegration_RunResolver_GraphDot(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--graph",
+		"--graph-format=dot",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "digraph")
+}
+
+func TestIntegration_RunResolver_GraphMermaid(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--graph",
+		"--graph-format=mermaid",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "graph")
+}
+
+func TestIntegration_RunResolver_GraphJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--graph",
+		"--graph-format=json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "nodes")
+	assert.Contains(t, stdout, "edges")
+	assert.Contains(t, stdout, "stats")
+	assert.Contains(t, stdout, "criticalPath")
+}
+
+func TestIntegration_RunResolver_ExecutionIncludesGraphAndProviderSummary(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"dependencyGraph\"")
+	assert.Contains(t, stdout, "\"providerSummary\"")
+	assert.Contains(t, stdout, "criticalPath")
+	assert.Contains(t, stdout, "criticalDepth")
+	assert.Contains(t, stdout, "\"diagrams\"")
+	assert.Contains(t, stdout, "\"ascii\"")
+	assert.Contains(t, stdout, "\"dot\"")
+	assert.Contains(t, stdout, "\"mermaid\"")
+}
+
+func TestIntegration_RunResolver_Snapshot(t *testing.T) {
+	t.Parallel()
+	snapshotFile := filepath.Join(t.TempDir(), "snapshot.json")
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--snapshot",
+		"--snapshot-file="+snapshotFile,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Snapshot saved to")
+
+	// Verify snapshot file was created and is valid JSON
+	data, err := os.ReadFile(snapshotFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "metadata")
+	assert.Contains(t, string(data), "resolvers")
+}
+
+func TestIntegration_RunResolver_SnapshotRedact(t *testing.T) {
+	t.Parallel()
+	snapshotFile := filepath.Join(t.TempDir(), "snapshot-redact.json")
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--snapshot",
+		"--snapshot-file="+snapshotFile,
+		"--redact",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Snapshot saved to")
+}
+
+func TestIntegration_RunResolver_MutualExclusive_DryRunGraph(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--dry-run",
+		"--graph",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "mutually exclusive")
+}
+
+func TestIntegration_RunResolver_SnapshotRequiresFile(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--snapshot",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "--snapshot-file")
+}
+
+func TestIntegration_RunSolution_ShowExecution(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/resolver-demo.yaml",
+		"--show-execution",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "__execution")
+	assert.Contains(t, stdout, "resolvers")
+	assert.Contains(t, stdout, "summary")
+}
+
 func TestIntegration_RunSolution_ConditionalRetry(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/conditional-retry.yaml",
@@ -365,6 +586,7 @@ func TestIntegration_RunSolution_K8sClusters(t *testing.T) {
 }
 
 func TestIntegration_RunSolution_RetryIfWithCommandNotFound(t *testing.T) {
+	t.Parallel()
 	// Test that retryIf: "false" prevents retries on actual errors
 	// Using a non-existent command which returns a real error
 	tmpDir := t.TempDir()
@@ -405,6 +627,7 @@ spec:
 }
 
 func TestIntegration_RunSolution_RetryIfWithRetryEnabled(t *testing.T) {
+	t.Parallel()
 	// Test that retryIf: "true" allows retries on actual errors
 	// This creates a temp script that succeeds on second run
 	tmpDir := t.TempDir()
@@ -466,6 +689,7 @@ spec:
 // ============================================================================
 
 func TestIntegration_RenderSolution(t *testing.T) {
+	t.Parallel()
 	// Use run resolver to get resolver outputs
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
@@ -479,6 +703,7 @@ func TestIntegration_RenderSolution(t *testing.T) {
 }
 
 func TestIntegration_RenderSolutionJSON(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
@@ -491,6 +716,7 @@ func TestIntegration_RenderSolutionJSON(t *testing.T) {
 }
 
 func TestIntegration_RenderSolutionYAML(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
@@ -510,6 +736,7 @@ func TestIntegration_RenderSolutionYAML(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_ResolverGraph(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/hello-world.yaml",
@@ -523,6 +750,7 @@ func TestIntegration_ResolverGraph(t *testing.T) {
 }
 
 func TestIntegration_ResolverGraphMermaid(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/hello-world.yaml",
@@ -535,6 +763,7 @@ func TestIntegration_ResolverGraphMermaid(t *testing.T) {
 }
 
 func TestIntegration_ResolverGraphJSON(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/hello-world.yaml",
@@ -551,6 +780,7 @@ func TestIntegration_ResolverGraphJSON(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_ActionGraph(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/sequential-chain.yaml",
@@ -565,6 +795,7 @@ func TestIntegration_ActionGraph(t *testing.T) {
 }
 
 func TestIntegration_ActionGraphMermaid(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/sequential-chain.yaml",
@@ -578,6 +809,7 @@ func TestIntegration_ActionGraphMermaid(t *testing.T) {
 }
 
 func TestIntegration_ActionGraphDOT(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/sequential-chain.yaml",
@@ -591,6 +823,7 @@ func TestIntegration_ActionGraphDOT(t *testing.T) {
 }
 
 func TestIntegration_ActionGraphJSON(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
 		"render", "solution",
 		"-f", "examples/actions/sequential-chain.yaml",
@@ -608,6 +841,7 @@ func TestIntegration_ActionGraphJSON(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_ConfigView(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "config", "view")
 
 	// May return non-zero if no config exists, but shouldn't crash
@@ -615,6 +849,7 @@ func TestIntegration_ConfigView(t *testing.T) {
 }
 
 func TestIntegration_ConfigSchema(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "config", "schema")
 
 	assert.Equal(t, 0, exitCode)
@@ -627,6 +862,7 @@ func TestIntegration_ConfigSchema(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_SecretsList(t *testing.T) {
+	t.Parallel()
 	// This test just verifies the command doesn't crash
 	_, _, exitCode := runScafctl(t, "secrets", "list")
 
@@ -635,6 +871,7 @@ func TestIntegration_SecretsList(t *testing.T) {
 }
 
 func TestIntegration_SecretsHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "secrets", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -649,6 +886,7 @@ func TestIntegration_SecretsHelp(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_AuthStatus(t *testing.T) {
+	t.Parallel()
 	// This test just verifies the command doesn't crash
 	stdout, _, exitCode := runScafctl(t, "auth", "status")
 
@@ -656,6 +894,7 @@ func TestIntegration_AuthStatus(t *testing.T) {
 }
 
 func TestIntegration_AuthHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "auth", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -669,6 +908,7 @@ func TestIntegration_AuthHelp(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_InvalidCommand(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "invalidcommand")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -676,6 +916,7 @@ func TestIntegration_InvalidCommand(t *testing.T) {
 }
 
 func TestIntegration_MissingRequiredFlag(t *testing.T) {
+	t.Parallel()
 	_, _, exitCode := runScafctl(t, "run", "solution")
 
 	// Should fail due to missing -f flag
@@ -687,6 +928,7 @@ func TestIntegration_MissingRequiredFlag(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_SequentialChain(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/sequential-chain.yaml",
@@ -699,6 +941,7 @@ func TestIntegration_SequentialChain(t *testing.T) {
 }
 
 func TestIntegration_ConditionalExecution(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/conditional-execution.yaml",
@@ -711,6 +954,7 @@ func TestIntegration_ConditionalExecution(t *testing.T) {
 }
 
 func TestIntegration_ParallelWithDeps(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "examples/actions/parallel-with-deps.yaml",
@@ -727,6 +971,7 @@ func TestIntegration_ParallelWithDeps(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_QuietMode(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"--quiet",
 		"run", "solution",
@@ -744,10 +989,12 @@ func TestIntegration_QuietMode(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_OutputFormats(t *testing.T) {
+	t.Parallel()
 	formats := []string{"json", "yaml", "table"}
 
 	for _, format := range formats {
 		t.Run(format, func(t *testing.T) {
+			t.Parallel()
 			stdout, _, exitCode := runScafctl(t,
 				"run", "resolver",
 				"-f", "examples/resolver-demo.yaml",
@@ -765,6 +1012,7 @@ func TestIntegration_OutputFormats(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_Lint_Help(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "lint", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -775,6 +1023,7 @@ func TestIntegration_Lint_Help(t *testing.T) {
 }
 
 func TestIntegration_Lint_RequiresFile(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "lint")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -782,6 +1031,7 @@ func TestIntegration_Lint_RequiresFile(t *testing.T) {
 }
 
 func TestIntegration_Lint_ValidSolution(t *testing.T) {
+	t.Parallel()
 	// Test with a simple solution file that should have minimal issues
 	stdout, _, exitCode := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "json")
 
@@ -792,6 +1042,7 @@ func TestIntegration_Lint_ValidSolution(t *testing.T) {
 }
 
 func TestIntegration_Lint_SeverityFilter(t *testing.T) {
+	t.Parallel()
 	// Test error-only filter
 	stdout, _, _ := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "--severity", "error", "-o", "json")
 
@@ -802,6 +1053,7 @@ func TestIntegration_Lint_SeverityFilter(t *testing.T) {
 }
 
 func TestIntegration_Lint_QuietMode(t *testing.T) {
+	t.Parallel()
 	// Quiet mode should produce no output on success
 	stdout, _, exitCode := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "quiet")
 
@@ -812,6 +1064,7 @@ func TestIntegration_Lint_QuietMode(t *testing.T) {
 }
 
 func TestIntegration_Lint_JSONOutput(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "json")
 
 	// Verify JSON structure
@@ -823,6 +1076,7 @@ func TestIntegration_Lint_JSONOutput(t *testing.T) {
 }
 
 func TestIntegration_Lint_InvalidFile(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "lint", "-f", "nonexistent.yaml")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -830,6 +1084,7 @@ func TestIntegration_Lint_InvalidFile(t *testing.T) {
 }
 
 func TestIntegration_Lint_YAMLOutput(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "yaml")
 
 	// Verify YAML structure
@@ -839,6 +1094,7 @@ func TestIntegration_Lint_YAMLOutput(t *testing.T) {
 }
 
 func TestIntegration_Lint_Alias(t *testing.T) {
+	t.Parallel()
 	// Test the 'l' alias works
 	stdout, _, exitCode := runScafctl(t, "l", "-f", "examples/resolver-demo.yaml", "-o", "json")
 
@@ -848,6 +1104,7 @@ func TestIntegration_Lint_Alias(t *testing.T) {
 }
 
 func TestIntegration_Lint_CheckAlias(t *testing.T) {
+	t.Parallel()
 	// Test the 'check' alias works
 	stdout, _, exitCode := runScafctl(t, "check", "-f", "examples/resolver-demo.yaml", "-o", "json")
 
@@ -857,6 +1114,7 @@ func TestIntegration_Lint_CheckAlias(t *testing.T) {
 }
 
 func TestIntegration_Lint_WarningSeverityFilter(t *testing.T) {
+	t.Parallel()
 	// Test warning filter includes warnings and errors but not info
 	stdout, _, _ := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "--severity", "warning", "-o", "json")
 
@@ -866,6 +1124,7 @@ func TestIntegration_Lint_WarningSeverityFilter(t *testing.T) {
 }
 
 func TestIntegration_Lint_ActionSolution(t *testing.T) {
+	t.Parallel()
 	// Test linting a solution with actions
 	stdout, _, exitCode := runScafctl(t, "lint", "-f", "examples/actions/hello-world.yaml", "-o", "json")
 
@@ -875,6 +1134,7 @@ func TestIntegration_Lint_ActionSolution(t *testing.T) {
 }
 
 func TestIntegration_Lint_ComplexSolution(t *testing.T) {
+	t.Parallel()
 	// Test linting a more complex solution
 	stdout, _, exitCode := runScafctl(t, "lint", "-f", "examples/solutions/comprehensive/solution.yaml", "-o", "json")
 
@@ -886,6 +1146,7 @@ func TestIntegration_Lint_ComplexSolution(t *testing.T) {
 }
 
 func TestIntegration_Lint_TableOutput(t *testing.T) {
+	t.Parallel()
 	// Test default table output (explicit)
 	stdout, _, exitCode := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "table")
 
@@ -900,6 +1161,7 @@ func TestIntegration_Lint_TableOutput(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_BuildHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "build", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -908,6 +1170,7 @@ func TestIntegration_BuildHelp(t *testing.T) {
 }
 
 func TestIntegration_BuildSolutionHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "build", "solution", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -949,6 +1212,7 @@ func TestIntegration_BuildSolution_VersionOverrideWarning(t *testing.T) {
 }
 
 func TestIntegration_BuildSolution_FileNotFound(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "build", "solution", "nonexistent.yaml", "--version", "1.0.0")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -1039,6 +1303,7 @@ func TestIntegration_BuildSolution_NoBundle(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_CatalogHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1049,6 +1314,7 @@ func TestIntegration_CatalogHelp(t *testing.T) {
 }
 
 func TestIntegration_CatalogListHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "list", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1102,6 +1368,7 @@ func TestIntegration_CatalogList_FilterByKind(t *testing.T) {
 }
 
 func TestIntegration_CatalogInspectHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "inspect", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1155,6 +1422,7 @@ func TestIntegration_CatalogInspect_SpecificVersion(t *testing.T) {
 }
 
 func TestIntegration_CatalogDeleteHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "delete", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1212,6 +1480,7 @@ func TestIntegration_CatalogDelete_Success(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_CatalogPruneHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "prune", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1426,6 +1695,7 @@ func TestIntegration_GetSolution_FromCatalog_ByName(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogSaveHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "catalog", "save", "--help")
 	assert.Contains(t, stdout, "save")
 	assert.Contains(t, stdout, "output")
@@ -1498,6 +1768,7 @@ func TestIntegration_CatalogSave_SpecificVersion(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogLoadHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "catalog", "load", "--help")
 	assert.Contains(t, stdout, "load")
 	assert.Contains(t, stdout, "input")
@@ -1505,6 +1776,7 @@ func TestIntegration_CatalogLoadHelp(t *testing.T) {
 }
 
 func TestIntegration_CatalogLoad_RequiresInput(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "catalog", "load")
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "required")
@@ -1624,6 +1896,7 @@ func TestIntegration_CatalogSaveLoad_RoundTrip(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogPushHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "catalog", "push", "--help")
 	assert.Contains(t, stdout, "Push a catalog artifact to a remote OCI registry")
 	assert.Contains(t, stdout, "--catalog")
@@ -1659,6 +1932,7 @@ func TestIntegration_CatalogPush_ArtifactNotFound(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogPullHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "catalog", "pull", "--help")
 	assert.Contains(t, stdout, "Pull a catalog artifact from a remote OCI registry")
 	assert.Contains(t, stdout, "--as")
@@ -1680,6 +1954,7 @@ func TestIntegration_CatalogPull_InvalidReference(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogDeleteRemoteHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, _ := runScafctl(t, "catalog", "delete", "--help")
 	assert.Contains(t, stdout, "Delete an artifact from the local or remote catalog")
 	assert.Contains(t, stdout, "ghcr.io/myorg/scafctl/solutions/my-solution")
@@ -1704,6 +1979,7 @@ func TestIntegration_CatalogDelete_RemoteDetection(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CatalogTagHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "catalog", "tag", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1781,6 +2057,7 @@ func TestIntegration_CatalogTag_MoveAlias(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_CacheHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "cache", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1790,6 +2067,7 @@ func TestIntegration_CacheHelp(t *testing.T) {
 }
 
 func TestIntegration_CacheClearHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "cache", "clear", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1800,6 +2078,7 @@ func TestIntegration_CacheClearHelp(t *testing.T) {
 }
 
 func TestIntegration_CacheInfoHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "cache", "info", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -1831,6 +2110,7 @@ func TestIntegration_CacheClear_Empty(t *testing.T) {
 }
 
 func TestIntegration_CacheClear_InvalidKind(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "cache", "clear", "--kind", "invalid", "--force")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -1865,6 +2145,7 @@ func TestIntegration_CacheClear_HTTPKind(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_SolutionProvider_ResolverComposition(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "tests/integration/testdata/solution-provider/parent-resolver.yaml",
@@ -1878,6 +2159,7 @@ func TestIntegration_SolutionProvider_ResolverComposition(t *testing.T) {
 }
 
 func TestIntegration_SolutionProvider_WorkflowComposition(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "tests/integration/testdata/solution-provider/parent-action.yaml",
@@ -1889,6 +2171,7 @@ func TestIntegration_SolutionProvider_WorkflowComposition(t *testing.T) {
 }
 
 func TestIntegration_SolutionProvider_CircularReference(t *testing.T) {
+	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "tests/integration/testdata/solution-provider/circular-a.yaml",
@@ -1899,6 +2182,7 @@ func TestIntegration_SolutionProvider_CircularReference(t *testing.T) {
 }
 
 func TestIntegration_SolutionProvider_DryRun(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "tests/integration/testdata/solution-provider/parent-action.yaml",
@@ -1913,6 +2197,7 @@ func TestIntegration_SolutionProvider_DryRun(t *testing.T) {
 }
 
 func TestIntegration_SolutionProvider_PropagateErrorsFalse(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Create a child solution that will fail (references a nonexistent provider)
@@ -1968,6 +2253,7 @@ spec:
 }
 
 func TestIntegration_SolutionProvider_MaxDepthExceeded(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Create a self-referencing solution with maxDepth: 1
@@ -2003,6 +2289,7 @@ spec:
 }
 
 func TestIntegration_SolutionProvider_ChildNotFound(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	parentSolution := `apiVersion: scafctl.io/v1
@@ -2035,6 +2322,7 @@ spec:
 }
 
 func TestIntegration_SolutionProvider_ResolverFilter(t *testing.T) {
+	t.Parallel()
 	// Parent requests only the "greeting" resolver from the child.
 	// The child has two resolvers: greeting (static) and echo-param (parameter).
 	// Since we only request "greeting", echo-param should not run and its absence
@@ -2074,6 +2362,7 @@ spec:
 }
 
 func TestIntegration_SolutionProvider_ResolverFilterNotFound(t *testing.T) {
+	t.Parallel()
 	// Request a resolver that does not exist in the child solution.
 	tmpDir := t.TempDir()
 
@@ -2107,6 +2396,7 @@ spec:
 }
 
 func TestIntegration_SolutionProvider_Timeout(t *testing.T) {
+	t.Parallel()
 	// Use a very short timeout with a normal child solution.
 	// The child should still succeed because the timeout is generous enough.
 	tmpDir := t.TempDir()
@@ -2148,6 +2438,7 @@ spec:
 // ============================================================================
 
 func TestIntegration_BundleHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "bundle", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2158,6 +2449,7 @@ func TestIntegration_BundleHelp(t *testing.T) {
 }
 
 func TestIntegration_BundleVerifyHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "bundle", "verify", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2166,6 +2458,7 @@ func TestIntegration_BundleVerifyHelp(t *testing.T) {
 }
 
 func TestIntegration_BundleDiffHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "bundle", "diff", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2176,6 +2469,7 @@ func TestIntegration_BundleDiffHelp(t *testing.T) {
 }
 
 func TestIntegration_BundleExtractHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "bundle", "extract", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2189,18 +2483,21 @@ func TestIntegration_BundleExtractHelp(t *testing.T) {
 }
 
 func TestIntegration_BundleVerify_MissingRef(t *testing.T) {
+	t.Parallel()
 	_, _, exitCode := runScafctl(t, "bundle", "verify")
 
 	assert.NotEqual(t, 0, exitCode)
 }
 
 func TestIntegration_BundleDiff_MissingArgs(t *testing.T) {
+	t.Parallel()
 	_, _, exitCode := runScafctl(t, "bundle", "diff")
 
 	assert.NotEqual(t, 0, exitCode)
 }
 
 func TestIntegration_BundleExtract_MissingRef(t *testing.T) {
+	t.Parallel()
 	_, _, exitCode := runScafctl(t, "bundle", "extract")
 
 	assert.NotEqual(t, 0, exitCode)
@@ -2280,6 +2577,7 @@ func TestIntegration_BundleDiff_SameVersion(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_VendorHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "vendor", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2288,6 +2586,7 @@ func TestIntegration_VendorHelp(t *testing.T) {
 }
 
 func TestIntegration_VendorUpdateHelp(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "vendor", "update", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2331,6 +2630,7 @@ spec:
 // ============================================================================
 
 func TestIntegration_BuildSolutionHelp_DedupeFlags(t *testing.T) {
+	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "build", "solution", "--help")
 
 	assert.Equal(t, 0, exitCode)
@@ -2389,6 +2689,7 @@ func TestIntegration_BuildSolution_DryRunShowsDetails(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_RunSolution_DirectoryProvider(t *testing.T) {
+	t.Parallel()
 	// Create a temp directory with test files
 	tmpDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "hello.txt"), []byte("world"), 0o644))


### PR DESCRIPTION
…modes

Add comprehensive debugging features to the run resolver command:

- Add --graph flag with ASCII/DOT/Mermaid/JSON formats for dependency visualization
- Add --snapshot/--snapshot-file/--redact flags for capturing execution state
- Add --dry-run flag to preview execution plan without running providers
- Add --skip-transform flag to return raw resolved values
- Add --show-execution flag to run solution for opt-in execution metadata
- Always include __execution metadata in run resolver output (debugging command)
- Embed dependencyGraph with pre-rendered diagrams and providerSummary in __execution
- Add critical path calculation to graph stats
- Fix dependency detection using resolver.ExtractDependencies for CEL expressions
- Rename __execution.graph to __execution.dependencyGraph for clarity
- Update tutorials and documentation

BREAKING CHANGE: run resolver now always outputs __execution metadata (removed --verbose flag)
