### PR TITLE
feat(cli): add 'scafctl run provider' command for direct provider exe…

### DIFF
--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -1,0 +1,331 @@
+---
+title: "Run Provider Tutorial"
+weight: 26
+---
+
+# Run Provider Tutorial
+
+This tutorial covers the `scafctl run provider` command — a tool for executing individual providers directly without a solution or resolver file. This is useful for testing, debugging, and exploring providers in isolation.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Familiarity with [providers](provider-reference.md)
+
+## Table of Contents
+
+1. [Basic Usage](#basic-usage)
+2. [Passing Inputs](#passing-inputs)
+3. [File-Based Inputs](#file-based-inputs)
+4. [Capabilities](#capabilities)
+5. [Dry Run](#dry-run)
+6. [Output Formats](#output-formats)
+7. [Plugin Providers](#plugin-providers)
+8. [Discovering Providers](#discovering-providers)
+9. [Common Examples](#common-examples)
+
+---
+
+## Basic Usage
+
+The `scafctl run provider` command takes a provider name as its only positional argument and provider inputs via `--input` flags.
+
+```bash
+scafctl run provider <provider-name> --input <key>=<value>
+```
+
+### Your First Provider Execution
+
+Run the `static` provider to return a simple value:
+
+```bash
+scafctl run provider static --input value=hello
+```
+
+Output:
+
+```json
+{
+  "data": "hello"
+}
+```
+
+The output always contains a `data` field with the provider's return value. Additional fields like `warnings` and `metadata` appear when relevant.
+
+---
+
+## Passing Inputs
+
+Inputs are passed using `--input` flags. Multiple inputs can be specified by repeating the flag.
+
+### Simple Key-Value Pairs
+
+```bash
+scafctl run provider http --input url=https://httpbin.org/get --input method=GET
+```
+
+### Array Values
+
+Comma-separated values are automatically converted to arrays:
+
+```bash
+scafctl run provider exec --input command=echo --input args=hello,world
+```
+
+### Values Containing Commas
+
+If a value itself contains commas (not intended as array separators), wrap it in
+quotes inside the flag value. Use single quotes around the entire flag to prevent
+shell interpretation:
+
+```bash
+scafctl run provider cel --input 'expression="[1,2,3].map(x, x * 2)"'
+```
+
+### Multiple Values for the Same Key
+
+Repeating the same key creates an array:
+
+```bash
+scafctl run provider exec --input command=echo --input args=hello --input args=world
+```
+
+---
+
+## File-Based Inputs
+
+For complex inputs, load them from a YAML or JSON file using the `@` prefix:
+
+### Create an Input File
+
+Create `inputs.yaml`:
+
+```yaml
+url: https://httpbin.org/post
+method: POST
+body: '{"message": "hello"}'
+headers:
+  Content-Type: application/json
+```
+
+### Run with File Input
+
+```bash
+scafctl run provider http --input @inputs.yaml
+```
+
+### Mix File and Inline Inputs
+
+File and inline inputs are merged. When the same key appears in both,
+the values are combined into an array. To override a file value, omit
+that key from the file:
+
+```bash
+scafctl run provider http --input @inputs.yaml --input timeout=30
+```
+
+This loads all values from `inputs.yaml` and adds `timeout=30`.
+
+---
+
+## Capabilities
+
+Providers declare capabilities that define what kind of operation they perform:
+
+| Capability | Description |
+|------------|-------------|
+| `from` | Data sourcing (default for most providers) |
+| `transform` | Data transformation |
+| `validation` | Input validation |
+| `authentication` | Authentication flows |
+| `action` | Side-effecting operations |
+
+By default, `scafctl run provider` uses the provider's first declared capability. Use `--capability` to select a specific one:
+
+```bash
+# Run a provider with a specific capability
+scafctl run provider cel --input expression="1 + 2" --capability transform
+```
+
+### Viewing Available Capabilities
+
+Use `scafctl get provider <name>` to see which capabilities a provider supports:
+
+```bash
+scafctl get provider cel
+```
+
+---
+
+## Dry Run
+
+Use `--dry-run` to see what would be executed without actually running the provider:
+
+```bash
+scafctl run provider http --input url=https://example.com --dry-run
+```
+
+The provider will return simulated output without performing any side effects (no HTTP request, no command execution, etc.).
+
+---
+
+## Output Formats
+
+The default output format is JSON. Use `-o` to change it:
+
+```bash
+# JSON output (default)
+scafctl run provider static --input value=hello -o json
+
+# YAML output
+scafctl run provider static --input value=hello -o yaml
+
+# Table output
+scafctl run provider static --input value=hello -o table
+
+# Quiet mode (exit code only)
+scafctl run provider static --input value=hello -o quiet
+```
+
+### Interactive Mode
+
+Explore complex output in an interactive TUI:
+
+```bash
+scafctl run provider http --input url=https://api.example.com -i
+```
+
+### CEL Expressions
+
+Filter or transform output using CEL expressions:
+
+```bash
+scafctl run provider http --input url=https://api.example.com -e "_.data"
+```
+
+### Execution Metrics
+
+Use `--show-metrics` to display timing information:
+
+```bash
+scafctl run provider http --input url=https://httpbin.org/get --show-metrics
+```
+
+---
+
+## Plugin Providers
+
+Load providers from plugin executables using `--plugin-dir`:
+
+```bash
+# Load plugins from a directory
+scafctl run provider echo --input message=hello --plugin-dir ./plugins
+
+# Multiple plugin directories
+scafctl run provider my-plugin --input key=value --plugin-dir ./plugins --plugin-dir /opt/plugins
+```
+
+See the [Plugin Development](plugin-development.md) tutorial for creating custom providers.
+
+---
+
+## Discovering Providers
+
+### List All Providers
+
+```bash
+scafctl get providers
+```
+
+### View Provider Details
+
+```bash
+scafctl get provider http
+```
+
+This shows the provider's schema, capabilities, examples, and auto-generated CLI usage examples.
+
+### Filter by Capability
+
+```bash
+scafctl get providers --capability=validation
+```
+
+### Browse Interactively
+
+```bash
+scafctl get providers -i
+```
+
+---
+
+## Common Examples
+
+### Read an Environment Variable
+
+```bash
+scafctl run provider env --input operation=get --input name=HOME
+```
+
+### Execute a Shell Command
+
+```bash
+scafctl run provider exec --input command=date
+```
+
+### Read a File
+
+```bash
+scafctl run provider file --input operation=read --input path=README.md
+```
+
+### List a Directory
+
+```bash
+scafctl run provider directory --input operation=list --input path=./pkg
+```
+
+### Evaluate a CEL Expression
+
+```bash
+# Simple expression (no commas)
+scafctl run provider cel --input expression="1 + 2"
+
+# Expressions with commas must be quoted to avoid CSV splitting
+scafctl run provider cel --input 'expression="[1,2,3].map(x, x * 2)"'
+```
+
+### Make an HTTP Request
+
+```bash
+scafctl run provider http --input url=https://httpbin.org/get --input method=GET
+```
+
+### Get Git Repository Status
+
+```bash
+scafctl run provider git --input operation=status --input path=.
+```
+
+### Render a Go Template
+
+```bash
+scafctl run provider go-template --input name=greeting --input 'template=Hello World'
+```
+
+### Redact Sensitive Output
+
+Use `--redact` to mask sensitive values in the output. This example retrieves
+a secret (which must already exist in the scafctl secrets store):
+
+```bash
+scafctl run provider secret --input operation=get --input name=my-secret --redact
+```
+
+---
+
+## Next Steps
+
+- [Provider Reference](provider-reference.md) — full provider documentation
+- [Resolver Tutorial](resolver-tutorial.md) — using providers within resolvers
+- [Plugin Development](plugin-development.md) — creating custom providers

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -1,0 +1,24 @@
+# Provider Examples
+
+Example input files for use with `scafctl run provider --input @<file>`.
+
+## Files
+
+| File | Provider | Description |
+|------|----------|-------------|
+| [static-hello.yaml](static-hello.yaml) | `static` | Simple static string value |
+| [http-get.yaml](http-get.yaml) | `http` | HTTP GET request |
+| [exec-ls.yaml](exec-ls.yaml) | `exec` | Execute `ls -la` command |
+
+## Usage
+
+```bash
+# Run with a file-based input
+scafctl run provider static --input @examples/providers/static-hello.yaml
+
+# Run with inline inputs
+scafctl run provider static --input value=hello
+
+# Combine file and inline inputs (inline takes precedence)
+scafctl run provider http --input @examples/providers/http-get.yaml --input method=POST
+```

--- a/examples/providers/exec-ls.yaml
+++ b/examples/providers/exec-ls.yaml
@@ -1,0 +1,4 @@
+# Exec provider input - list current directory
+command: ls
+args:
+  - "-la"

--- a/examples/providers/http-get.yaml
+++ b/examples/providers/http-get.yaml
@@ -1,0 +1,3 @@
+# HTTP provider input - simple GET request
+url: https://httpbin.org/get
+method: GET

--- a/examples/providers/static-hello.yaml
+++ b/examples/providers/static-hello.yaml
@@ -1,0 +1,2 @@
+# Static provider input - simple string value
+value: hello from file

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/oakwood-commons/kvx v0.0.0-20260210155541-485326533661
+	github.com/oakwood-commons/kvx v0.2.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.23.2
@@ -51,7 +51,6 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/alex-shpak/hugo-book v0.0.0-20260108111751-81a841c92d62 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
-github.com/alex-shpak/hugo-book v0.0.0-20260108111751-81a841c92d62 h1:LQYO67RaSBiWnW3ZPyVPZCVTOFaNK/dc/ZRbh8Wu8Wo=
-github.com/alex-shpak/hugo-book v0.0.0-20260108111751-81a841c92d62/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -226,8 +224,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oakwood-commons/kvx v0.0.0-20260210155541-485326533661 h1:u5GSJP+Ln09nKTH4+dldzSv6ENzobzpmNryIy/QK8t0=
-github.com/oakwood-commons/kvx v0.0.0-20260210155541-485326533661/go.mod h1:ayCeqWN7ev+58azBRwWUU2kXcwnXP1OzwTYixEoBjmI=
+github.com/oakwood-commons/kvx v0.2.1 h1:mJQbRXAqOwYzbFyO8eJsP//ddsbuFKpgeCFsORuF9SM=
+github.com/oakwood-commons/kvx v0.2.1/go.mod h1:JiNeIGJ8Wv6GeQUBmIg/XE2zceHCEGVv4EsgSQS+jos=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/cmd/scafctl/get/provider/provider.go
+++ b/pkg/cmd/scafctl/get/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -353,6 +354,16 @@ func (o *Options) printProviderDetail(desc *provider.Descriptor) error {
 		}
 	}
 
+	// CLI Usage examples (auto-generated from schema)
+	cliExamples := generateCLIExamples(desc)
+	if len(cliExamples) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("CLI Usage:"))
+		for _, example := range cliExamples {
+			fmt.Fprintf(out, "  %s\n", dimStyle(example))
+		}
+	}
+
 	// Links
 	if len(desc.Links) > 0 {
 		fmt.Fprintln(out)
@@ -490,7 +501,106 @@ func buildProviderDetail(desc provider.Descriptor) map[string]any {
 		output["maintainers"] = maintainers
 	}
 
+	// Add CLI usage examples
+	cliExamples := generateCLIExamples(&desc)
+	if len(cliExamples) > 0 {
+		output["cliUsage"] = cliExamples
+	}
+
 	return output
+}
+
+// generateCLIExamples auto-generates CLI usage examples from the provider's schema.
+// It builds "scafctl run provider <name>" commands using required fields and
+// type-appropriate placeholder values.
+func generateCLIExamples(desc *provider.Descriptor) []string {
+	if desc.Schema == nil || len(desc.Schema.Properties) == 0 {
+		return nil
+	}
+
+	// Build required set
+	requiredSet := make(map[string]bool, len(desc.Schema.Required))
+	for _, name := range desc.Schema.Required {
+		requiredSet[name] = true
+	}
+
+	// Collect required fields with placeholder values, sorted for deterministic output
+	requiredNames := make([]string, 0)
+	for name := range desc.Schema.Properties {
+		if requiredSet[name] {
+			requiredNames = append(requiredNames, name)
+		}
+	}
+	slices.Sort(requiredNames)
+
+	// Build input flags for required fields
+	inputFlags := make([]string, 0, len(requiredNames))
+	for _, name := range requiredNames {
+		prop := desc.Schema.Properties[name]
+		placeholder := schemaPlaceholder(name, prop)
+		inputFlags = append(inputFlags, fmt.Sprintf("--input %s=%s", name, placeholder))
+	}
+
+	var examples []string
+
+	// Example with required fields only
+	if len(inputFlags) > 0 {
+		cmd := fmt.Sprintf("scafctl run provider %s %s", desc.Name, strings.Join(inputFlags, " "))
+		examples = append(examples, cmd)
+	} else {
+		// No required fields - show a minimal example
+		examples = append(examples, fmt.Sprintf("scafctl run provider %s", desc.Name))
+	}
+
+	// If multiple capabilities, show an example with --capability for non-first capabilities
+	if len(desc.Capabilities) > 1 {
+		for _, cap := range desc.Capabilities[1:] {
+			baseCmdParts := []string{fmt.Sprintf("scafctl run provider %s", desc.Name)}
+			if len(inputFlags) > 0 {
+				baseCmdParts = append(baseCmdParts, inputFlags...)
+			}
+			baseCmdParts = append(baseCmdParts, fmt.Sprintf("--capability %s", cap))
+			examples = append(examples, strings.Join(baseCmdParts, " "))
+		}
+	}
+
+	// Add file-based input example
+	examples = append(examples, fmt.Sprintf("scafctl run provider %s --input @inputs.yaml", desc.Name))
+
+	return examples
+}
+
+// schemaPlaceholder returns a reasonable placeholder value for a schema property.
+func schemaPlaceholder(name string, prop *jsonschema.Schema) string {
+	if prop == nil {
+		return "<value>"
+	}
+
+	// Use the first example if available
+	if len(prop.Examples) > 0 {
+		return fmt.Sprintf("%v", prop.Examples[0])
+	}
+
+	// Use the first enum value if available
+	if len(prop.Enum) > 0 {
+		return fmt.Sprintf("%v", prop.Enum[0])
+	}
+
+	// Type-based placeholder
+	switch prop.Type {
+	case "string":
+		return fmt.Sprintf("<%s>", name)
+	case "integer", "number":
+		return "0"
+	case "boolean":
+		return "true"
+	case "array":
+		return fmt.Sprintf("<%s1>,<%s2>", name, name)
+	case "object":
+		return fmt.Sprintf("@%s.yaml", name)
+	default:
+		return fmt.Sprintf("<%s>", name)
+	}
 }
 
 // buildSchemaOutput converts a JSON Schema to a map for output

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -1,0 +1,369 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// ProviderOptions holds configuration for the run provider command
+type ProviderOptions struct {
+	IOStreams *terminal.IOStreams
+	CliParams *settings.Run
+
+	// kvx output integration
+	flags.KvxOutputFlags
+
+	// ProviderName is the name of the provider to execute (positional arg).
+	ProviderName string
+
+	// InputParams are the provider input parameters (--input key=value or --input @file.yaml).
+	InputParams []string
+
+	// Capability specifies which capability to execute.
+	// Defaults to the first capability declared by the provider.
+	Capability string
+
+	// DryRun shows what would be executed without running the provider.
+	DryRun bool
+
+	// PluginDirs are directories to scan for plugin providers.
+	PluginDirs []string
+
+	// ShowMetrics shows provider execution metrics after completion.
+	ShowMetrics bool
+
+	// Redact redacts sensitive fields in the output.
+	Redact bool
+}
+
+// CommandProvider creates the 'run provider' subcommand
+func CommandProvider(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	options := &ProviderOptions{}
+
+	cfg := runCommandConfig{
+		cliParams: cliParams,
+		ioStreams: ioStreams,
+		path:      path,
+		runner:    options,
+		getOutputFn: func() string {
+			return options.Output
+		},
+		setIOStreamFn: func(ios *terminal.IOStreams, cli *settings.Run) {
+			options.IOStreams = ios
+			options.CliParams = cli
+		},
+	}
+
+	cCmd := &cobra.Command{
+		Use:     "provider <name>",
+		Aliases: []string{"prov", "p"},
+		Short:   "Execute a single provider directly",
+		Long: `Execute a provider directly without a solution or resolver file.
+
+This command is useful for testing, debugging, and exploring individual
+providers in isolation. It accepts the provider name as a positional
+argument and provider inputs via --input flags.
+
+PROVIDER INPUTS:
+  Inputs are passed using --input flags in several formats:
+    --input key=value         Simple key-value pair
+    --input key=val1,val2     Multiple values become an array
+    --input @file.yaml        Load inputs from a YAML file
+    --input @file.json        Load inputs from a JSON file
+
+  Multiple --input flags can be combined. When the same key appears
+  in both a file and a flag, the flag value takes precedence.
+
+CAPABILITIES:
+  Providers declare capabilities (from, transform, validation, action,
+  authentication). By default, the first declared capability is used.
+  Use --capability to select a specific one.
+
+PLUGIN PROVIDERS:
+  Use --plugin-dir to load plugin providers from a directory.
+  Multiple --plugin-dir flags can be specified.
+
+OUTPUT FORMATS:
+  json     JSON output (default)
+  yaml     YAML output
+  table    Table view
+  quiet    Suppress output (exit code only)
+
+EXIT CODES:
+  0  Success
+  1  Provider execution failed
+  2  Validation failed (invalid inputs)
+
+Examples:
+  # Run the static provider with a simple value
+  scafctl run provider static --input value=hello
+
+  # Run the env provider to read an environment variable
+  scafctl run provider env --input name=HOME -o json
+
+  # Run the http provider with multiple inputs
+  scafctl run provider http --input url=https://api.example.com --input method=GET
+
+  # Run the exec provider to execute a command
+  scafctl run provider exec --input command=echo --input args=hello
+
+  # Load inputs from a YAML file
+  scafctl run provider http --input @inputs.yaml
+
+  # Run with a specific capability
+  scafctl run provider validation --input value=test --capability validation
+
+  # Dry-run to see what would be executed
+  scafctl run provider http --input url=https://example.com --dry-run
+
+  # Load plugin providers from a directory
+  scafctl run provider echo --input message=hello --plugin-dir ./plugins
+
+  # Show execution metrics
+  scafctl run provider http --input url=https://example.com --show-metrics
+
+  # Explore results interactively
+  scafctl run provider http --input url=https://api.example.com -i`,
+		Args: cobra.ExactArgs(1),
+		PreRun: func(_ *cobra.Command, args []string) {
+			options.ProviderName = args[0]
+		},
+		RunE:         makeRunEFunc(cfg, "provider"),
+		SilenceUsage: true,
+	}
+
+	// Provider input flags
+	cCmd.Flags().StringArrayVar(&options.InputParams, "input", nil, "Provider input parameters (key=value or @file.yaml)")
+	cCmd.Flags().StringVar(&options.Capability, "capability", "", "Capability to execute (default: first declared capability)")
+	cCmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Show what would be executed without running the provider")
+	cCmd.Flags().StringArrayVar(&options.PluginDirs, "plugin-dir", nil, "Directory to scan for plugin providers")
+	cCmd.Flags().BoolVar(&options.ShowMetrics, "show-metrics", false, "Show provider execution metrics after completion (output to stderr)")
+	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive fields in output")
+
+	// kvx output flags — default to JSON (not table) since provider output is unstructured
+	validFormats := kvx.BaseOutputFormats()
+	cCmd.Flags().StringVarP(&options.Output, "output", "o", "json",
+		fmt.Sprintf("Output format: %s (default: json)", strings.Join(validFormats, ", ")))
+	cCmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", false,
+		"Launch interactive viewer to explore results (requires terminal)")
+	cCmd.Flags().StringVarP(&options.Expression, "expression", "e", "",
+		"CEL expression to filter/transform output data (e.g., '_.data')")
+
+	return cCmd
+}
+
+// Run executes a single provider directly
+func (o *ProviderOptions) Run(ctx context.Context) error {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("running provider",
+		"name", o.ProviderName,
+		"capability", o.Capability,
+		"dryRun", o.DryRun,
+		"output", o.Output,
+		"pluginDirs", o.PluginDirs,
+		"showMetrics", o.ShowMetrics)
+
+	w := writer.FromContext(ctx)
+
+	// Enable metrics collection if requested
+	if o.ShowMetrics {
+		provider.GlobalMetrics.Enable()
+	}
+	defer func() {
+		if o.ShowMetrics {
+			writeMetrics(o.IOStreams.ErrOut)
+		}
+	}()
+
+	// Build provider registry
+	reg, err := builtin.DefaultRegistry(ctx)
+	if err != nil {
+		lgr.V(0).Info("warning: failed to register some providers", "error", err)
+		reg = provider.GetGlobalRegistry()
+	}
+
+	// Load plugin providers if requested
+	if len(o.PluginDirs) > 0 {
+		lgr.V(1).Info("loading plugin providers", "dirs", o.PluginDirs)
+		if err := plugin.RegisterPluginProviders(reg, o.PluginDirs); err != nil {
+			w.Warningf("failed to load some plugins: %v", err)
+		}
+	}
+
+	// Look up the provider
+	prov, ok := reg.Get(o.ProviderName)
+	if !ok {
+		err := fmt.Errorf("provider %q not found (use 'scafctl get providers' to list available providers)", o.ProviderName)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	desc := prov.Descriptor()
+
+	// Parse input parameters
+	inputs, err := ParseResolverFlags(o.InputParams)
+	if err != nil {
+		err := fmt.Errorf("failed to parse input parameters: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	lgr.V(1).Info("parsed inputs", "count", len(inputs))
+
+	// Resolve capability
+	capability, err := o.resolveCapability(desc)
+	if err != nil {
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	lgr.V(1).Info("using capability", "capability", capability)
+
+	// Set up execution context
+	ctx = provider.WithExecutionMode(ctx, capability)
+	ctx = provider.WithDryRun(ctx, o.DryRun)
+
+	// Execute the provider
+	start := time.Now()
+	result, err := provider.Execute(ctx, prov, inputs)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		w.Errorf("provider execution failed: %v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	lgr.V(1).Info("provider executed",
+		"duration", elapsed.Round(time.Millisecond),
+		"dryRun", result.DryRun,
+		"hasWarnings", len(result.Output.Warnings) > 0)
+
+	// Build output
+	output := o.buildOutput(result, elapsed)
+
+	// Redact sensitive fields if requested
+	if o.Redact && len(desc.SensitiveFields) > 0 {
+		o.redactSensitiveFields(output, desc.SensitiveFields)
+	}
+
+	return o.writeOutput(ctx, output)
+}
+
+// resolveCapability determines which capability to use for execution.
+// If --capability is specified, validates and uses it.
+// Otherwise, defaults to the first declared capability.
+func (o *ProviderOptions) resolveCapability(desc *provider.Descriptor) (provider.Capability, error) {
+	if o.Capability != "" {
+		requested := provider.Capability(o.Capability)
+		if !requested.IsValid() {
+			return "", fmt.Errorf("invalid capability %q (valid: from, transform, validation, authentication, action)", o.Capability)
+		}
+
+		// Check if the provider supports this capability
+		for _, c := range desc.Capabilities {
+			if c == requested {
+				return requested, nil
+			}
+		}
+
+		capStrs := make([]string, len(desc.Capabilities))
+		for i, c := range desc.Capabilities {
+			capStrs[i] = string(c)
+		}
+		return "", fmt.Errorf("provider %q does not support capability %q (supported: %v)", desc.Name, o.Capability, capStrs)
+	}
+
+	// Default to first capability
+	if len(desc.Capabilities) == 0 {
+		return "", fmt.Errorf("provider %q declares no capabilities", desc.Name)
+	}
+
+	return desc.Capabilities[0], nil
+}
+
+// buildOutput constructs the output map from an execution result
+func (o *ProviderOptions) buildOutput(result *provider.ExecutionResult, elapsed time.Duration) map[string]any {
+	output := map[string]any{
+		"data": result.Output.Data,
+	}
+
+	if len(result.Output.Warnings) > 0 {
+		output["warnings"] = result.Output.Warnings
+	}
+
+	if len(result.Output.Metadata) > 0 {
+		output["metadata"] = result.Output.Metadata
+	}
+
+	if result.DryRun {
+		output["dryRun"] = true
+	}
+
+	if o.ShowMetrics {
+		output["__execution"] = map[string]any{
+			"provider": result.Provider.Descriptor().Name,
+			"duration": elapsed.Round(time.Millisecond).String(),
+			"dryRun":   result.DryRun,
+		}
+	}
+
+	return output
+}
+
+// redactSensitiveFields replaces sensitive field values with "[REDACTED]" in the output
+func (o *ProviderOptions) redactSensitiveFields(output map[string]any, sensitiveFields []string) {
+	data, ok := output["data"]
+	if !ok {
+		return
+	}
+
+	dataMap, ok := data.(map[string]any)
+	if !ok {
+		return
+	}
+
+	for _, field := range sensitiveFields {
+		if _, exists := dataMap[field]; exists {
+			dataMap[field] = "[REDACTED]"
+		}
+	}
+}
+
+// writeOutput writes provider output using kvx
+func (o *ProviderOptions) writeOutput(ctx context.Context, output map[string]any) error {
+	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
+		o.Output,
+		o.Interactive,
+		o.Expression,
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName("scafctl run provider"),
+		kvx.WithOutputHelp("scafctl run provider", []string{
+			"Provider Output Viewer",
+			"",
+			"Navigate: ↑↓ arrows | Back: ← | Enter: →",
+			"Search: / or F3 | Expression: F6",
+			"Copy path: F5 | Quit: q or F10",
+		}),
+	)
+	kvxOpts.IOStreams = o.IOStreams
+
+	return kvxOpts.Write(output)
+}

--- a/pkg/cmd/scafctl/run/run.go
+++ b/pkg/cmd/scafctl/run/run.go
@@ -16,21 +16,23 @@ func CommandRun(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 	cCmd := &cobra.Command{
 		Use:     "run",
 		Aliases: []string{"r"},
-		Short:   fmt.Sprintf("Runs %s solutions and resolvers", settings.CliBinaryName),
-		Long: `Run executes solutions or resolvers from solution files.
+		Short:   fmt.Sprintf("Runs %s solutions, resolvers, and providers", settings.CliBinaryName),
+		Long: `Run executes solutions, resolvers, or individual providers.
 
 Resolvers within the same dependency phase execute concurrently for optimal performance.
 Actions are executed in dependency phases after resolvers complete.
 
 SUBCOMMANDS:
   solution  Run a solution (resolvers + actions)
-  resolver  Run resolvers only (for debugging/inspection)`,
+  resolver  Run resolvers only (for debugging/inspection)
+  provider  Run a single provider directly (for testing/debugging)`,
 		SilenceUsage: true,
 	}
 
 	runPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 	cCmd.AddCommand(CommandSolution(cliParams, ioStreams, runPath))
 	cCmd.AddCommand(CommandResolver(cliParams, ioStreams, runPath))
+	cCmd.AddCommand(CommandProvider(cliParams, ioStreams, runPath))
 
 	return cCmd
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -186,6 +186,136 @@ func TestIntegration_ExplainProviderNotFound(t *testing.T) {
 }
 
 // ============================================================================
+// Run Provider Tests
+// ============================================================================
+
+func TestIntegration_RunProvider_Help(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--input")
+	assert.Contains(t, stdout, "--capability")
+	assert.Contains(t, stdout, "--dry-run")
+	assert.Contains(t, stdout, "--plugin-dir")
+}
+
+func TestIntegration_RunProvider_Static(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=hello")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hello")
+}
+
+func TestIntegration_RunProvider_StaticJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=hello", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"data\"")
+	assert.Contains(t, stdout, "hello")
+}
+
+func TestIntegration_RunProvider_Env(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "env", "--input", "operation=get", "--input", "name=PATH")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "data")
+	assert.NotEmpty(t, stdout)
+}
+
+func TestIntegration_RunProvider_InvalidProvider(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "nonexistent-provider-xyz")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "not found")
+}
+
+func TestIntegration_RunProvider_MissingInput(t *testing.T) {
+	t.Parallel()
+	// env provider requires 'name' input
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "env")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.NotEmpty(t, stderr)
+}
+
+func TestIntegration_RunProvider_Capability(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=test", "--capability", "from")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "test")
+}
+
+func TestIntegration_RunProvider_InvalidCapability(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=test", "--capability", "bogus")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "invalid capability")
+}
+
+func TestIntegration_RunProvider_DryRun(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=hello", "--dry-run")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "dryRun")
+}
+
+func TestIntegration_RunProvider_InputFile(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "@examples/providers/static-hello.yaml")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "data")
+}
+
+func TestIntegration_RunProvider_Alias(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "prov", "static", "--input", "value=alias-test")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "alias-test")
+}
+
+func TestIntegration_RunProvider_ShowMetrics(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=metrics-test", "--show-metrics")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "metrics-test")
+	assert.Contains(t, stderr, "Provider Execution Metrics")
+}
+
+// ============================================================================
+// Get Provider CLI Usage Tests
+// ============================================================================
+
+func TestIntegration_GetProvider_CLIUsage(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "provider", "http")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "CLI Usage:")
+	assert.Contains(t, stdout, "scafctl run provider http")
+	assert.Contains(t, stdout, "--input")
+}
+
+func TestIntegration_GetProvider_CLIUsageJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "provider", "static", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "cliUsage")
+	assert.Contains(t, stdout, "scafctl run provider static")
+}
+
+// ============================================================================
 // Run Solution Tests
 // ============================================================================
 


### PR DESCRIPTION
…cution

Add a new command to execute individual providers without a solution or resolver file. Useful for testing, debugging, and exploring providers.

Features:
- Execute any built-in or plugin provider directly
- Pass inputs via --input key=value or --input @file.yaml
- Select specific capability with --capability flag
- Dry-run mode with --dry-run
- Plugin provider support with --plugin-dir
- Execution metrics with --show-metrics
- Sensitive field redaction with --redact
- All kvx output formats (json, yaml, table, quiet, interactive)

Also adds:
- Auto-generated CLI usage examples in 'scafctl get provider' output
- Tutorial documentation for the new command
- Example input files in examples/providers/
- Integration tests for the new command
