### PR TITLE
feat(testing): add subprocess executor and functional integration test suite

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,3 +44,8 @@ jobs:
         run: task test
         env:
           SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+
+      - name: Run functional integration tests
+        run: task integration
+        env:
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
         env:
           SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
       
+      - name: Run functional integration tests
+        run: task integration
+        env:
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+
       - name: Run tests with coverage
         run: task test-cover
         if: matrix.os == 'ubuntu-latest'

--- a/docs/design/future-enhancements.md
+++ b/docs/design/future-enhancements.md
@@ -154,6 +154,28 @@ The capability model is designed for extension. Future capabilities may include:
 
 ---
 
+## Functional Testing
+
+Source: [functional-testing.md](functional-testing.md)
+
+### Auto-Generated Tests (`-o test`)
+
+A future output type for commands that support `-o`. When used, scafctl captures the command and its arguments, executes it, and generates a complete test definition with assertions derived from the actual output plus a snapshot golden file.
+
+### Catalog Regression Testing (`scafctl pipeline`)
+
+A future command that executes functional tests across solutions in a remote catalog, enabling validation that scafctl changes don't break existing solutions. Fetches matching solutions, extracts bundled test files, runs `test functional`, and reports aggregate results.
+
+### Test Scaffolding (`scafctl test init`)
+
+A future command that generates a starter test suite for an existing solution by analyzing its structure — parsing resolvers with defaults and outputting skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before running anything.
+
+### Watch Mode (`--watch`)
+
+A future flag for `scafctl test functional` that re-runs tests when solution files change. Monitors the solution file and its bundle/compose files for changes, then re-runs affected tests.
+
+---
+
 ## Resolvers
 
 Source: [resolvers.md](resolvers.md)

--- a/docs/design/misc.md
+++ b/docs/design/misc.md
@@ -24,9 +24,9 @@ These concerns apply across resolvers, actions, providers, plugins, and solution
 | Error Model | ✅ Implemented | Rich error types with location, cause, context |
 | Determinism Rules | ✅ Implemented | Resolver purity enforced, `MockBehavior` declared |
 | Resolver DAG Visualization | ✅ Implemented | ASCII, DOT, Mermaid, JSON formats |
-| Action DAG Visualization | ⚠️ Partial | JSON/YAML render, no ASCII/DOT/Mermaid yet |
+| Action DAG Visualization | ✅ Implemented | ASCII, DOT, Mermaid, JSON formats via `--action-graph` |
 | Validation | ✅ Implemented | Schema, dependency, type validation |
-| Linting | 📋 Planned | Unused resolvers, unreachable actions, anti-patterns |
+| Linting | ✅ Implemented | `scafctl lint` with error/warning/info severities |
 | Extensibility (Providers/Plugins) | ✅ Implemented | Plugin system for external providers |
 | Render vs Run Separation | ✅ Implemented | `scafctl render` vs `scafctl run` |
 | Dry-run Mode | ✅ Implemented | `--dry-run` flag, `DryRunFromContext()` |
@@ -202,22 +202,23 @@ scafctl supports:
 
 ### Linting
 
-> **Status**: 📋 Planned
+> **Status**: ✅ Implemented in `pkg/cmd/scafctl/lint/lint.go`
 
-Linting may include:
+Linting rules include:
 
-- Unused resolvers
-- Unreachable actions
-- Missing dependencies
-- Anti-pattern detection
+**Errors**: empty solutions, reserved names, missing providers, invalid expressions/templates, invalid dependencies, finally-with-forEach, workflow validation, unbundled test files, invalid test names, undefined required properties, invalid result schemas
 
-Linting is advisory, not blocking.
+**Warnings**: unused resolvers, empty workflows, unused templates
+
+**Info**: missing descriptions, long timeouts, unused finally actions, permissive result schemas
+
+Linting is advisory, not blocking. Output supports table, JSON, YAML, and quiet formats via `-o` flag.
 
 ---
 
 ## Visualization and Introspection
 
-> **Status**: ✅ Mostly Implemented
+> **Status**: ✅ Implemented
 
 ### Goals
 
@@ -228,7 +229,7 @@ Linting is advisory, not blocking.
 ### Outputs
 
 - Resolver DAG visualization ✅ (`--graph` with ASCII, DOT, Mermaid, JSON)
-- Action DAG visualization ⚠️ (JSON/YAML render only, ASCII/DOT/Mermaid planned)
+- Action DAG visualization ✅ (`--action-graph` with ASCII, DOT, Mermaid, JSON)
 - Rendered action graph inspection ✅ (`scafctl render solution`)
 - Dependency summaries ✅ (`scafctl explain solution`)
 

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -986,3 +986,90 @@ scafctl test l -f solution.yaml
 | `--tag` | | — | Filter by tag (repeatable) |
 | `--solution` | | — | Filter by solution name glob (repeatable) |
 | `--filter` | | — | Filter by test name glob (repeatable) |
+
+
+## Future Enhancements
+
+### Auto-Generated Tests (`-o test`)
+
+A future output type for commands that support `-o`. When used, scafctl captures the command and its arguments, executes it, and generates a complete test definition with assertions derived from the actual output.
+
+~~~bash
+scafctl render solution -f solution.yaml -r env=prod -o test
+~~~
+
+Would output:
+
+~~~yaml
+renders-prod:
+  description: "Auto-generated test for: render solution -r env=prod"
+  command: [render, solution]
+  args: ["-r", "env=prod"]
+  assertions:
+    - expression: 'size(output.actions) == 3'
+    - expression: 'output.actions["render-main"].inputs.output == "prod/main.tf"'
+    - expression: 'output.actions["render-main"].provider == "template"'
+  snapshot: "testdata/renders-prod.json"
+~~~
+
+The generator would execute the command, derive CEL assertions from the output shape, write a snapshot golden file, and emit the test YAML to stdout.
+
+---
+
+### Catalog Regression Testing (`scafctl pipeline`)
+
+A future command that executes functional tests across solutions in a remote catalog. This enables the scafctl team to validate that changes to scafctl don't break existing solutions.
+
+~~~bash
+scafctl pipeline test --catalog https://catalog.example.com --solutions "terraform-*"
+~~~
+
+Would fetch matching solutions, extract bundled test files, run `test functional` against each, and report aggregate results.
+
+This is the primary use case for requiring test files to be bundled and why `scafctl lint` errors on unbundled test files.
+
+---
+
+### Test Scaffolding (`scafctl test init`)
+
+A future command that generates a starter test suite for an existing solution by analyzing its structure:
+
+~~~bash
+scafctl test init -f solution.yaml
+~~~
+
+Would parse the solution, identify resolvers with defaults, and output skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before you run anything.
+
+---
+
+### Watch Mode (`--watch`)
+
+A future flag that re-runs tests when solution files change:
+
+~~~bash
+scafctl test functional -f solution.yaml --watch
+~~~
+
+Monitors the solution file and its bundle/compose files for changes, then re-runs affected tests.
+
+---
+
+### Tutorial Outline
+
+The planned tutorial at `docs/tutorials/functional-testing.md` should cover:
+
+1. **Writing your first test** — minimal solution with one test case, `scafctl test functional` invocation, reading output
+2. **Assertions deep dive** — CEL expressions vs regex/contains, `target` field, `output` variable structure per command, negation assertions
+3. **Test inheritance** — `_`-prefixed templates, `extends` chains, merge behavior for args/assertions/tags
+4. **Snapshots** — golden file workflow, `--update-snapshots`, normalization pipeline
+5. **CI integration** — JUnit XML reporting with `--report-file`, exit codes, `--fail-fast` patterns
+6. **Advanced features** — init/cleanup steps, test files, `skipExpression`, retries, suite-level setup
+
+The example solution at `examples/solutions/tested-solution/` should include:
+
+- A solution with 2-3 resolvers and a template action
+- 3-4 inline tests covering: CEL expression assertion, contains/regex assertion, `expectFailure` for validation, and a snapshot test
+- A `testdata/` directory with a golden file
+- A `bundle.include` covering the test files
+
+---

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -295,11 +295,6 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.AddCommand(cachecmd.CommandCache(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(bundlecmd.CommandBundle(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(vendorcmd.CommandVendor(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(testcmd.CommandTest(cliParams, ioStreams, settings.CliBinaryName, func(testIO *terminal.IOStreams, exitFunc func(code int)) *cobra.Command {
-		return Root(&RootOptions{
-			IOStreams: testIO,
-			ExitFunc:  exitFunc,
-		})
-	}))
+	cCmd.AddCommand(testcmd.CommandTest(cliParams, ioStreams, settings.CliBinaryName))
 	return cCmd
 }

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -6,6 +6,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -39,12 +40,11 @@ type FunctionalOptions struct {
 	FailFast        bool
 	Verbose         bool
 	KeepSandbox     bool
-	// commandBuilder creates a root cobra.Command for in-process execution.
-	commandBuilder soltesting.CommandBuilder
+	NoProgress      bool
 }
 
 // CommandFunctional creates the 'test functional' subcommand.
-func CommandFunctional(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string, cmdBuilder soltesting.CommandBuilder) *cobra.Command {
+func CommandFunctional(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	opts := &FunctionalOptions{}
 
 	cCmd := &cobra.Command{
@@ -85,7 +85,6 @@ Examples:
 
 			opts.IOStreams = ioStreams
 			opts.CliParams = cliParams
-			opts.commandBuilder = cmdBuilder
 
 			return runFunctional(ctx, opts)
 		},
@@ -109,6 +108,7 @@ Examples:
 	cCmd.Flags().BoolVar(&opts.FailFast, "fail-fast", false, "Stop remaining tests on first failure")
 	cCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output (assertion counts, details)")
 	cCmd.Flags().BoolVar(&opts.KeepSandbox, "keep-sandbox", false, "Keep sandbox directories after test execution")
+	cCmd.Flags().BoolVar(&opts.NoProgress, "no-progress", false, "Disable live progress output during test execution")
 
 	return cCmd
 }
@@ -172,7 +172,18 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 		}
 	}
 
+	// Resolve the binary path for subprocess execution.
+	// Each test runs as a child process for true parallelism and env isolation.
+	binaryPath, err := os.Executable()
+	if err != nil {
+		if w != nil {
+			w.Errorf("failed to resolve executable path: %s", err)
+		}
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
 	runner := &soltesting.Runner{
+		BinaryPath:      binaryPath,
 		Concurrency:     concurrency,
 		FailFast:        opts.FailFast,
 		UpdateSnapshots: opts.UpdateSnapshots,
@@ -187,11 +198,31 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 			Tags:             opts.Tag,
 			SolutionPatterns: opts.Solution,
 		},
-		NewCommand: opts.commandBuilder,
+	}
+
+	// Set up progress reporting unless explicitly disabled or output format
+	// is non-table (json/yaml/quiet — progress would corrupt structured output).
+	if !opts.NoProgress && !opts.DryRun {
+		format, _ := kvx.ParseOutputFormat(opts.Output)
+		if kvx.IsTableFormat(format) || opts.Output == "" {
+			if kvx.IsTerminal(opts.IOStreams.ErrOut) {
+				runner.Progress = NewMPBTestProgress(opts.IOStreams.ErrOut)
+			} else {
+				runner.Progress = NewLineTestProgress(opts.IOStreams.ErrOut)
+			}
+		}
 	}
 
 	// Execute tests
+	start := time.Now()
 	results, err := runner.Run(ctx, solutions)
+	elapsed := time.Since(start)
+
+	// Wait for progress output to flush before writing the report
+	if runner.Progress != nil {
+		runner.Progress.Wait()
+	}
+
 	if err != nil {
 		if w != nil {
 			w.Errorf("test execution failed: %s", err)
@@ -205,7 +236,7 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 	outputOpts.Format = format
 	outputOpts.Ctx = ctx
 
-	if err := soltesting.ReportResults(results, outputOpts, opts.Verbose); err != nil {
+	if err := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed); err != nil {
 		if w != nil {
 			w.Errorf("reporting failed: %s", err)
 		}

--- a/pkg/cmd/scafctl/test/progress.go
+++ b/pkg/cmd/scafctl/test/progress.go
@@ -1,0 +1,237 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// MPBTestProgress displays animated spinner bars per test using mpb.
+// Intended for interactive (TTY) terminals.
+//
+// Lock ordering: mpb's render goroutine calls decorator closures on a timer.
+// Decorator closures must NEVER acquire mu because OnTestStart/OnTestComplete
+// hold mu while calling mpb methods (AddBar, Increment, Abort), which would
+// deadlock with the render goroutine. Instead, decorator-visible data is stored
+// in sync.Map fields that are safe for concurrent lock-free reads.
+type MPBTestProgress struct {
+	progress *mpb.Progress
+	// mu protects bars and barStarts only. It must NOT be held when mpb's
+	// render goroutine might call decorator closures.
+	mu        sync.Mutex
+	bars      map[string]*mpb.Bar
+	barStarts map[string]time.Time
+	// results and barElapsed are read by decorator closures from mpb's render
+	// goroutine, so they use sync.Map to avoid lock ordering issues.
+	results    sync.Map // key → *soltesting.TestResult
+	barElapsed sync.Map // key → time.Duration
+}
+
+// NewMPBTestProgress creates an mpb-based progress reporter that writes to w.
+func NewMPBTestProgress(w io.Writer) *MPBTestProgress {
+	p := mpb.New(
+		mpb.WithOutput(w),
+		mpb.WithWidth(0),
+		mpb.WithRefreshRate(100*time.Millisecond),
+	)
+	return &MPBTestProgress{
+		progress:  p,
+		bars:      make(map[string]*mpb.Bar),
+		barStarts: make(map[string]time.Time),
+	}
+}
+
+func (p *MPBTestProgress) barKey(solution, test string) string {
+	return solution + " :: " + test
+}
+
+// OnTestStart creates a new spinner bar for the test.
+func (p *MPBTestProgress) OnTestStart(solution, test string) {
+	key := p.barKey(solution, test)
+
+	p.mu.Lock()
+	p.barStarts[key] = time.Now()
+	p.mu.Unlock()
+
+	// Elapsed time — shown only after completion.
+	// Reads from sync.Map; no mutex needed.
+	elapsedDecor := decor.Any(func(s decor.Statistics) string {
+		if s.Completed || s.Aborted {
+			if v, ok := p.barElapsed.Load(key); ok {
+				if d, ok := v.(time.Duration); ok {
+					return fmtDuration(d)
+				}
+			}
+		}
+		return ""
+	})
+
+	// Status text — shown only after completion.
+	// Reads from sync.Map; no mutex needed.
+	statusDecor := decor.Any(func(s decor.Statistics) string {
+		if s.Completed || s.Aborted {
+			if v, ok := p.results.Load(key); ok {
+				if r, ok := v.(*soltesting.TestResult); ok {
+					return fmt.Sprintf("%-5s", r.Status)
+				}
+			}
+		}
+		return ""
+	})
+
+	bar := p.progress.AddBar(1,
+		mpb.PrependDecorators(
+			decor.OnAbort(
+				decor.OnComplete(
+					decor.Spinner(spinnerFrames, decor.WCSyncSpace),
+					"✓ ",
+				),
+				"✗ ",
+			),
+			decor.Name(key, decor.WCSyncSpaceR),
+		),
+		mpb.AppendDecorators(statusDecor, decor.Name("  "), elapsedDecor),
+		mpb.BarFillerClearOnComplete(),
+	)
+
+	p.mu.Lock()
+	p.bars[key] = bar
+	p.mu.Unlock()
+}
+
+// OnTestComplete records the result and marks the bar finished.
+func (p *MPBTestProgress) OnTestComplete(result soltesting.TestResult) {
+	key := p.barKey(result.Solution, result.Test)
+	resultCopy := result
+
+	// Store result and elapsed in sync.Map so decorators can read lock-free.
+	p.results.Store(key, &resultCopy)
+
+	p.mu.Lock()
+	start, hasStart := p.barStarts[key]
+	p.mu.Unlock()
+
+	if hasStart {
+		p.barElapsed.Store(key, time.Since(start))
+	} else {
+		p.barElapsed.Store(key, result.Duration)
+	}
+
+	p.mu.Lock()
+	bar, ok := p.bars[key]
+	p.mu.Unlock()
+
+	if !ok {
+		// Test completed without OnTestStart (validation error, dry run, etc.)
+		// Create a bar and immediately finish it.
+		icon := "✓ "
+		switch result.Status {
+		case soltesting.StatusPass:
+			// icon already set to "✓ "
+		case soltesting.StatusFail, soltesting.StatusError:
+			icon = "✗ "
+		case soltesting.StatusSkip:
+			icon = "⊘ "
+		}
+
+		bar = p.progress.AddBar(1,
+			mpb.PrependDecorators(
+				decor.Name(icon),
+				decor.Name(key, decor.WCSyncSpaceR),
+			),
+			mpb.AppendDecorators(
+				decor.Name(fmt.Sprintf("%-5s  %s", result.Status, fmtDuration(result.Duration))),
+			),
+			mpb.BarFillerClearOnComplete(),
+		)
+		bar.Increment()
+
+		p.mu.Lock()
+		p.bars[key] = bar
+		p.mu.Unlock()
+		return
+	}
+
+	switch result.Status {
+	case soltesting.StatusFail, soltesting.StatusError:
+		bar.Abort(false)
+	case soltesting.StatusPass, soltesting.StatusSkip:
+		bar.Increment()
+	}
+}
+
+// Wait blocks until all bars finish rendering.
+func (p *MPBTestProgress) Wait() {
+	p.progress.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// LineTestProgress — non-TTY fallback
+// ---------------------------------------------------------------------------
+
+// LineTestProgress prints one line per completed test.
+// Suitable for non-interactive output (CI logs, piped streams).
+type LineTestProgress struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+// NewLineTestProgress creates a line-based progress reporter.
+func NewLineTestProgress(w io.Writer) *LineTestProgress {
+	return &LineTestProgress{w: w}
+}
+
+// OnTestStart is a no-op for line-based output.
+func (r *LineTestProgress) OnTestStart(_, _ string) {}
+
+// OnTestComplete prints a single status line.
+func (r *LineTestProgress) OnTestComplete(result soltesting.TestResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	icon := "✓"
+	switch result.Status {
+	case soltesting.StatusPass:
+		// icon already set to "✓"
+	case soltesting.StatusFail:
+		icon = "✗"
+	case soltesting.StatusError:
+		icon = "!"
+	case soltesting.StatusSkip:
+		icon = "⊘"
+	}
+
+	dur := ""
+	if result.Duration > 0 {
+		dur = fmt.Sprintf("  (%s)", fmtDuration(result.Duration))
+	}
+
+	fmt.Fprintf(r.w, "%s %-5s  %s :: %s%s\n", icon, result.Status, result.Solution, result.Test, dur)
+}
+
+// Wait is a no-op for line-based output.
+func (r *LineTestProgress) Wait() {}
+
+// ---------------------------------------------------------------------------
+
+// fmtDuration formats a duration in compact human-readable form.
+func fmtDuration(d time.Duration) string {
+	switch {
+	case d < time.Millisecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}

--- a/pkg/cmd/scafctl/test/test.go
+++ b/pkg/cmd/scafctl/test/test.go
@@ -7,16 +7,12 @@ import (
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
-	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
 )
 
 // CommandTest creates the 'test' command that runs and manages functional tests.
-// cmdBuilder is used for in-process CLI execution — it creates a root cobra.Command
-// with isolated IOStreams and ExitFunc. This avoids an import cycle between
-// pkg/cmd/scafctl/test and pkg/cmd/scafctl.
-func CommandTest(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string, cmdBuilder soltesting.CommandBuilder) *cobra.Command {
+func CommandTest(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cCmd := &cobra.Command{
 		Use:     "test",
 		Aliases: []string{"t"},
@@ -35,7 +31,7 @@ under a tests/ directory.`, settings.CliBinaryName),
 	}
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
-	cCmd.AddCommand(CommandFunctional(cliParams, ioStreams, cmdPath, cmdBuilder))
+	cCmd.AddCommand(CommandFunctional(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 
 	return cCmd

--- a/pkg/solution/soltesting/progress.go
+++ b/pkg/solution/soltesting/progress.go
@@ -1,0 +1,22 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+// TestProgressCallback receives notifications as test execution progresses.
+// Implementations must be safe for concurrent use when runner concurrency > 1.
+type TestProgressCallback interface {
+	// OnTestStart is called when an individual test begins execution.
+	// It is not called for tests that fail before execution (validation errors,
+	// dry runs, setup failures, etc.) — those only receive OnTestComplete.
+	OnTestStart(solution, test string)
+
+	// OnTestComplete is called when a test finishes with its result.
+	// This is called for every test, including those that were skipped or
+	// errored before execution began.
+	OnTestComplete(result TestResult)
+
+	// Wait blocks until all progress output has been flushed.
+	// Must be called after the last OnTestComplete before reading stdout output.
+	Wait()
+}

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -14,12 +14,23 @@ import (
 
 // ResultSummary holds aggregated counts for reporting.
 type ResultSummary struct {
-	Passed   int           `json:"passed"`
-	Failed   int           `json:"failed"`
-	Errors   int           `json:"errors"`
-	Skipped  int           `json:"skipped"`
-	Total    int           `json:"total"`
-	Duration time.Duration `json:"duration"`
+	Passed       int           `json:"passed"`
+	Failed       int           `json:"failed"`
+	Errors       int           `json:"errors"`
+	Skipped      int           `json:"skipped"`
+	Total        int           `json:"total"`
+	Duration     time.Duration `json:"duration"`
+	WallDuration time.Duration `json:"wallDuration,omitempty"`
+}
+
+// ElapsedDuration returns WallDuration if set, otherwise falls back to
+// the summed individual Duration. Use this for summary display so that
+// parallel runs show wall-clock time instead of cumulative CPU time.
+func (s ResultSummary) ElapsedDuration() time.Duration {
+	if s.WallDuration > 0 {
+		return s.WallDuration
+	}
+	return s.Duration
 }
 
 // Summarize computes a ResultSummary from a slice of TestResults.
@@ -46,15 +57,17 @@ func Summarize(results []TestResult) ResultSummary {
 // For table format it writes a human-readable table with summary.
 // For JSON/YAML it delegates to kvx.OutputOptions.Write.
 // For quiet format it writes nothing.
-func ReportResults(results []TestResult, opts *kvx.OutputOptions, verbose bool) error {
+// The elapsed parameter, when > 0, overrides the summed individual durations
+// in the summary line with the actual wall-clock time.
+func ReportResults(results []TestResult, opts *kvx.OutputOptions, verbose bool, elapsed time.Duration) error {
 	switch {
 	case kvx.IsQuietFormat(opts.Format):
 		return nil
 	case kvx.IsTableFormat(opts.Format):
-		return reportTable(results, opts.IOStreams.Out, verbose)
+		return reportTable(results, opts.IOStreams.Out, verbose, elapsed)
 	default:
 		// JSON / YAML
-		return opts.Write(buildReportData(results))
+		return opts.Write(buildReportData(results, elapsed))
 	}
 }
 
@@ -84,8 +97,9 @@ type assertionOutput struct {
 	Message string `json:"message,omitempty"`
 }
 
-func buildReportData(results []TestResult) reportData {
+func buildReportData(results []TestResult, elapsed time.Duration) reportData {
 	summary := Summarize(results)
+	summary.WallDuration = elapsed
 	outputs := make([]testResultOutput, 0, len(results))
 	for _, r := range results {
 		out := testResultOutput{
@@ -114,7 +128,7 @@ func buildReportData(results []TestResult) reportData {
 }
 
 // reportTable writes a human-readable table to w.
-func reportTable(results []TestResult, w io.Writer, verbose bool) error {
+func reportTable(results []TestResult, w io.Writer, verbose bool, elapsed time.Duration) error {
 	if len(results) == 0 {
 		fmt.Fprintln(w, "No tests found.")
 		return nil
@@ -174,10 +188,11 @@ func reportTable(results []TestResult, w io.Writer, verbose bool) error {
 
 	// Summary
 	summary := Summarize(results)
+	summary.WallDuration = elapsed
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%d passed, %d failed, %d errors, %d skipped (%s)\n",
 		summary.Passed, summary.Failed, summary.Errors, summary.Skipped,
-		formatDuration(summary.Duration))
+		formatDuration(summary.ElapsedDuration()))
 
 	return nil
 }

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -27,6 +29,11 @@ type CommandBuilder func(ioStreams *terminal.IOStreams, exitFunc func(code int))
 
 // Runner is the main test execution engine for functional tests.
 type Runner struct {
+	// BinaryPath is the absolute path to the scafctl binary for subprocess
+	// execution. Each test's CLI command runs as an isolated child process,
+	// giving true parallelism and process-level env/state isolation.
+	// When empty, falls back to NewCommand (in-process, for unit tests only).
+	BinaryPath string
 	// Concurrency is the number of tests to run in parallel. 0 or 1 = sequential.
 	Concurrency int
 	// FailFast stops remaining tests for a solution on first failure.
@@ -48,8 +55,26 @@ type Runner struct {
 	// Filter contains filter options to apply.
 	Filter FilterOptions
 	// NewCommand builds a root cobra.Command for in-process execution.
-	// Must be set before calling Run(). Typically wraps scafctl.Root().
+	// Used only as a fallback when BinaryPath is empty (unit tests).
+	// Production code should always set BinaryPath instead.
 	NewCommand CommandBuilder
+	// Progress receives notifications as tests execute.
+	// When nil, no progress output is emitted.
+	Progress TestProgressCallback
+}
+
+// emitTestStart notifies the progress callback that a test is starting.
+func (r *Runner) emitTestStart(solution, test string) {
+	if r.Progress != nil {
+		r.Progress.OnTestStart(solution, test)
+	}
+}
+
+// emitTestComplete notifies the progress callback that a test has finished.
+func (r *Runner) emitTestComplete(result TestResult) {
+	if r.Progress != nil {
+		r.Progress.OnTestComplete(result)
+	}
 }
 
 // Run orchestrates functional test execution across all solutions.
@@ -77,12 +102,14 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 		if err := ResolveExtends(st.Tests); err != nil {
 			// All tests in this solution get error status
 			for name := range st.Tests {
-				allResults = append(allResults, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusError,
 					Message:  fmt.Sprintf("extends resolution failed: %s", err),
-				})
+				}
+				r.emitTestComplete(result)
+				allResults = append(allResults, result)
 			}
 			continue
 		}
@@ -93,12 +120,14 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 				continue
 			}
 			if err := tc.Validate(); err != nil {
-				allResults = append(allResults, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusError,
 					Message:  fmt.Sprintf("validation failed: %s", err),
-				})
+				}
+				r.emitTestComplete(result)
+				allResults = append(allResults, result)
 				delete(st.Tests, name)
 			}
 		}
@@ -119,12 +148,14 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 				if tc.IsTemplate() {
 					continue
 				}
-				allResults = append(allResults, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusSkip,
 					Message:  "dry run",
-				})
+				}
+				r.emitTestComplete(result)
+				allResults = append(allResults, result)
 			}
 			continue
 		}
@@ -149,12 +180,14 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 			// All tests become error status
 			results := make([]TestResult, 0, len(testNames))
 			for _, name := range testNames {
-				results = append(results, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusError,
 					Message:  fmt.Sprintf("suite setup failed: %s", err),
-				})
+				}
+				r.emitTestComplete(result)
+				results = append(results, result)
 			}
 			return results, nil
 		}
@@ -180,26 +213,32 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 		// Sequential execution
 		for _, name := range testNames {
 			if err := ctx.Err(); err != nil {
-				results = append(results, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusError,
 					Message:  "context cancelled",
-				})
+				}
+				r.emitTestComplete(result)
+				results = append(results, result)
 				continue
 			}
 
 			if failFastTriggered {
-				results = append(results, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusSkip,
 					Message:  "skipped due to --fail-fast",
-				})
+				}
+				r.emitTestComplete(result)
+				results = append(results, result)
 				continue
 			}
 
+			r.emitTestStart(st.SolutionName, name)
 			result := r.runTestWithRetries(ctx, st, name, solutionDir)
+			r.emitTestComplete(result)
 			results = append(results, result)
 
 			if r.FailFast && (result.Status == StatusFail || result.Status == StatusError) {
@@ -213,13 +252,15 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 
 		for _, name := range testNames {
 			if err := ctx.Err(); err != nil {
-				mu.Lock()
-				results = append(results, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusError,
 					Message:  "context cancelled",
-				})
+				}
+				r.emitTestComplete(result)
+				mu.Lock()
+				results = append(results, result)
 				mu.Unlock()
 				continue
 			}
@@ -228,13 +269,15 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 			skip := failFastTriggered
 			mu.Unlock()
 			if skip {
-				mu.Lock()
-				results = append(results, TestResult{
+				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
 					Status:   StatusSkip,
 					Message:  "skipped due to --fail-fast",
-				})
+				}
+				r.emitTestComplete(result)
+				mu.Lock()
+				results = append(results, result)
 				mu.Unlock()
 				continue
 			}
@@ -245,7 +288,9 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 				defer wg.Done()
 				defer func() { <-sem }()
 
+				r.emitTestStart(st.SolutionName, testName)
 				result := r.runTestWithRetries(ctx, st, testName, solutionDir)
+				r.emitTestComplete(result)
 
 				mu.Lock()
 				results = append(results, result)
@@ -471,6 +516,91 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 
 // executeCommand builds and runs a scafctl CLI command in-process.
 func (r *Runner) executeCommand(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
+	if r.BinaryPath != "" {
+		return r.executeCommandSubprocess(ctx, tc, st, sandbox)
+	}
+	return r.executeCommandInProcess(ctx, tc, st, sandbox)
+}
+
+// executeCommandSubprocess runs a scafctl CLI command as an isolated child process.
+// Each invocation gets its own process environment, so concurrent tests cannot
+// interfere with each other's env vars or global state.
+func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
+	timeout := r.TestTimeout
+	if tc.Timeout != nil {
+		timeout = tc.Timeout.Duration
+	}
+
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	// Build command args
+	args := make([]string, 0, len(tc.Command)+len(tc.Args)+4)
+	args = append(args, tc.Command...)
+	args = append(args, tc.Args...)
+
+	// Auto-inject -f <sandbox-solution-path> unless injectFile is false
+	if tc.GetInjectFile() {
+		args = append(args, "-f", sandbox.SolutionPath())
+	}
+
+	// Disable color in subprocess output
+	args = append(args, "--no-color")
+
+	// Build the subprocess
+	cmd := exec.CommandContext(ctx, r.BinaryPath, args...) //nolint:gosec // binary path is set by the test runner
+	cmd.Dir = sandbox.Path()
+
+	// Capture stdout/stderr
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	// Build isolated environment: inherit parent env + overlay test env vars.
+	// Each subprocess gets its own copy, so no races.
+	envMap := r.buildEnvMap(tc, st.TestConfig, sandbox.Path())
+	cmd.Env = os.Environ()
+	for k, v := range envMap {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	// Execute
+	cmdErr := cmd.Run()
+
+	// Determine exit code
+	exitCode := 0
+	if cmdErr != nil {
+		var exitErr *exec.ExitError
+		if ok := errors.As(cmdErr, &exitErr); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			// Non-exit error (e.g., binary not found, signal)
+			return nil, fmt.Errorf("subprocess execution failed: %w", cmdErr)
+		}
+	}
+
+	cmdOutput := &CommandOutput{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}
+
+	// Try to parse JSON from stdout
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(cmdOutput.Stdout), &parsed); err == nil {
+		cmdOutput.Output = parsed
+	}
+
+	return cmdOutput, nil
+}
+
+// executeCommandInProcess runs a scafctl CLI command in the current process.
+// This path is used only when BinaryPath is empty (unit tests with mock commands).
+// It is NOT safe for concurrent execution because os.Setenv is process-global.
+func (r *Runner) executeCommandInProcess(ctx context.Context, tc *TestCase, _ *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
 	timeout := r.TestTimeout
 	if tc.Timeout != nil {
 		timeout = tc.Timeout.Duration
@@ -505,16 +635,6 @@ func (r *Runner) executeCommand(ctx context.Context, tc *TestCase, st *SolutionT
 	var capturedExitCode int
 	exitFunc := func(code int) {
 		capturedExitCode = code
-	}
-
-	// Build environment
-	envMap := r.buildEnvMap(tc, st.TestConfig, sandbox.Path())
-
-	// Set env vars for the command
-	for k, v := range envMap {
-		strVal := fmt.Sprintf("%v", v)
-		os.Setenv(k, strVal) //nolint:errcheck // env vars for test isolation
-		defer os.Unsetenv(k) //nolint:errcheck // cleanup env vars after test
 	}
 
 	// Create root command with isolated IOStreams

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -666,7 +666,7 @@ func TestSummarize(t *testing.T) {
 
 func TestReportTableEmpty(t *testing.T) {
 	var buf strings.Builder
-	err := reportTable(nil, &buf, false)
+	err := reportTable(nil, &buf, false, 0)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No tests found")
 }
@@ -678,7 +678,7 @@ func TestReportTableBasic(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	err := reportTable(results, &buf, false)
+	err := reportTable(results, &buf, false, 0)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -707,7 +707,7 @@ func TestReportTableVerbose(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	err := reportTable(results, &buf, true)
+	err := reportTable(results, &buf, true, 0)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -859,7 +859,7 @@ func TestBuildReportData(t *testing.T) {
 		{Solution: "sol", Test: "t2", Status: StatusFail, Duration: 200 * time.Millisecond, Message: "failed"},
 	}
 
-	data := buildReportData(results)
+	data := buildReportData(results, 0)
 	assert.Len(t, data.Results, 2)
 	assert.Equal(t, 2, data.Summary.Total)
 	assert.Equal(t, 1, data.Summary.Passed)

--- a/tests/integration/solutions/README.md
+++ b/tests/integration/solutions/README.md
@@ -1,0 +1,99 @@
+# Functional Test Solutions
+
+Self-testing solution suite that exercises scafctl features from the solution execution level using `scafctl test functional`.
+
+## Running
+
+```bash
+# Run all functional test solutions
+scafctl test functional --tests-path tests/integration/solutions
+
+# Run with tag filter
+scafctl test functional --tests-path tests/integration/solutions --tag smoke
+scafctl test functional --tests-path tests/integration/solutions --tag provider
+scafctl test functional --tests-path tests/integration/solutions --tag edge-case
+
+# Run a specific solution
+scafctl test functional --tests-path tests/integration/solutions --solution "test-static-*"
+
+# List all discovered tests
+scafctl test list --tests-path tests/integration/solutions
+
+# Via task runner (builds binary first)
+task integration
+```
+
+## Structure
+
+```
+tests/integration/solutions/
+├── hello-world/              # Minimal smoke test (pre-existing)
+├── composed/                 # Minimal compose test (pre-existing)
+├── providers/                # Provider-specific tests
+│   ├── static/               # Literal values, all types
+│   ├── env/                  # Environment variable operations
+│   ├── cel/                  # CEL expression evaluation
+│   ├── exec/                 # Shell command execution
+│   ├── file/                 # File read/write/exists
+│   ├── directory/            # Directory list/mkdir
+│   ├── go-template/          # Go template rendering
+│   ├── validation/           # Match/notMatch/expression validation
+│   └── sleep/                # Sleep/timing
+├── resolvers/                # Resolver feature tests
+│   ├── dag/                  # Dependency graph ordering
+│   ├── until/                # Fallback chains, until conditions
+│   ├── type-coercion/        # Type field coercion
+│   ├── transform-chain/      # Multi-step transform pipelines
+│   ├── conditional/          # When conditions
+│   ├── timeout/              # Per-resolver timeout
+│   └── sensitive/            # Sensitive value masking
+├── rendering/                # Template rendering tests
+├── composition/              # Multi-file compose tests
+│   └── parts/                # Composed YAML fragments
+└── edge-cases/               # Negative/error tests
+    ├── validation-failures/  # Intentional validation errors
+    ├── invalid-provider/     # Unknown provider handling
+    └── timeout-enforcement/  # Timeout violation behavior
+```
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `smoke` | Quick verification tests, good for CI gates |
+| `provider` | Provider-specific tests |
+| `static`, `env`, `cel`, `exec`, `file`, `directory`, `go-template`, `validation`, `sleep` | Individual provider tests |
+| `resolver` | Resolver feature tests |
+| `dag`, `until`, `type-coercion`, `transform`, `conditional`, `timeout`, `sensitive` | Individual resolver feature tests |
+| `rendering` | Template rendering tests |
+| `composition` | Multi-file compose tests |
+| `edge-case` | Error handling and boundary tests |
+| `negative` | Tests expecting failures |
+
+## Conventions
+
+- **One solution per feature area** for isolation — a failure in file provider tests doesn't mask CEL provider results
+- **`_base` templates** with `extends` for DRY test definitions within each solution
+- **`testConfig.skipBuiltins`** when builtins would fail by design (edge-case solutions)
+- **Self-contained tests** — use `init`/`cleanup` steps and sandbox isolation; no external dependencies
+- **JSON output** (`-o json`) with CEL `__output` assertions for structured verification
+- **`expectFailure: true`** for negative tests that should produce errors
+
+## Adding a New Test Solution
+
+1. Create `tests/integration/solutions/<category>/<feature>/solution.yaml`
+2. Define resolvers that exercise the feature
+3. Add inline `tests:` with a `_base` template and tagged test cases
+4. Set `testConfig.skipBuiltins` if builtins don't apply
+5. Run `scafctl test functional -f <your-solution.yaml>` to verify
+6. The `task integration` step will automatically discover it
+
+## Excluded Providers
+
+These providers are excluded from functional tests due to external dependencies:
+- **`http`** — requires a network endpoint
+- **`git`** — requires a git repository with specific state
+- **`secret`** — requires keyring/credential store
+- **`identity`** — requires authentication handlers
+
+They can be added later with mocked endpoints or conditional `skipExpression` guards.

--- a/tests/integration/solutions/composed/solution.yaml
+++ b/tests/integration/solutions/composed/solution.yaml
@@ -19,6 +19,9 @@ spec:
             inputs:
               value: composed-test-output
 
+  testConfig:
+    skipBuiltins: true
+
   tests:
     _base:
       description: Base template for rendering tests
@@ -26,3 +29,9 @@ spec:
       args: ["-o", "json"]
       assertions:
         - expression: __exitCode == 0
+
+    render-check:
+      description: Verify rendering works via compose
+      extends: [_base]
+      assertions:
+        - contains: message

--- a/tests/integration/solutions/composed/tests/rendering.yaml
+++ b/tests/integration/solutions/composed/tests/rendering.yaml
@@ -1,7 +1,2 @@
-spec:
-  tests:
-    render-check:
-      description: Verify rendering works via compose
-      extends: [_base]
-      assertions:
-        - contains: message
+# Tests moved to main solution.yaml to avoid standalone discovery errors.
+# This file is kept as a placeholder for the compose path reference.

--- a/tests/integration/solutions/composition/parts/base-resolvers.yaml
+++ b/tests/integration/solutions/composition/parts/base-resolvers.yaml
@@ -1,0 +1,9 @@
+spec:
+  resolvers:
+    baseMessage:
+      description: Base resolver originally from main solution
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: from-main

--- a/tests/integration/solutions/composition/parts/resolvers.yaml
+++ b/tests/integration/solutions/composition/parts/resolvers.yaml
@@ -1,0 +1,17 @@
+spec:
+  resolvers:
+    composedResolver:
+      description: Resolver defined in a composed file
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: from-composed-file
+
+    derivedFromBase:
+      description: Resolver depending on a main-file resolver
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.baseMessage + "-and-composed"'

--- a/tests/integration/solutions/composition/parts/tests.yaml
+++ b/tests/integration/solutions/composition/parts/tests.yaml
@@ -1,0 +1,3 @@
+# This file is intentionally left without tests.
+# All tests are defined in the main solution.yaml file.
+# Only resolvers are composed from external files.

--- a/tests/integration/solutions/composition/solution.yaml
+++ b/tests/integration/solutions/composition/solution.yaml
@@ -1,0 +1,55 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-composition
+  version: 1.0.0
+  description: Tests for solution composition
+
+compose:
+  - parts/base-resolvers.yaml
+  - parts/resolvers.yaml
+
+spec:
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for composition tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [composition]
+      assertions:
+        - expression: __exitCode == 0
+
+    base-resolver:
+      description: Verify base resolver from main file
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: '__output.baseMessage == "from-main"'
+          message: "Main file resolver should be available"
+
+    composed-resolver:
+      description: Verify resolver from composed file
+      extends: [_base]
+      assertions:
+        - expression: '__output.composedResolver == "from-composed-file"'
+          message: "Composed file resolver should be available"
+
+    cross-file-dependency:
+      description: Verify composed resolver can reference main resolver
+      extends: [_base]
+      assertions:
+        - expression: '__output.derivedFromBase == "from-main-and-composed"'
+          message: "Composed resolver should access main file resolver"
+
+    all-resolvers-merged:
+      description: Verify all resolvers from all files are present
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: '"baseMessage" in __output'
+        - expression: '"composedResolver" in __output'
+        - expression: '"derivedFromBase" in __output'

--- a/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
@@ -1,0 +1,33 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-invalid-provider
+  version: 1.0.0
+  description: |
+    Functional tests for invalid provider error handling.
+    Verifies that unknown provider names produce clear errors.
+
+spec:
+  resolvers:
+    badProvider:
+      description: Resolver using a non-existent provider
+      resolve:
+        with:
+          - provider: does-not-exist
+            inputs:
+              value: "anything"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    unknown-provider:
+      description: Verify unknown provider produces meaningful error
+      command: [run, resolver]
+      tags: [edge-case, negative]
+      expectFailure: true
+      assertions:
+        - notContains: "panic"
+          target: combined
+          message: "Should not panic on unknown provider"

--- a/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
+++ b/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
@@ -1,0 +1,37 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-timeout-enforcement
+  version: 1.0.0
+  description: |
+    Functional tests for timeout enforcement.
+    Verifies that resolver-level timeouts are enforced
+    when a provider exceeds the allowed duration.
+
+spec:
+  resolvers:
+    # This resolver should timeout because sleep > timeout
+    slowResolver:
+      description: Resolver that exceeds its timeout
+      timeout: "500ms"
+      resolve:
+        with:
+          - provider: sleep
+            inputs:
+              duration: "5s"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    timeout-exceeded:
+      description: Verify resolver timeout is enforced
+      command: [run, resolver]
+      args: ["--resolver", "slowResolver"]
+      tags: [edge-case, timeout, negative]
+      timeout: "15s"
+      expectFailure: true
+      assertions:
+        - notContains: "panic"
+          target: combined

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -1,0 +1,109 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-validation-failures
+  version: 1.0.0
+  description: Tests for validation failure behavior
+
+spec:
+  resolvers:
+    validValue:
+      description: A value that passes validation
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "good"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z]+$"
+            message: "Must be lowercase letters"
+
+    invalidRegex:
+      description: A value that fails regex validation
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "BAD_VALUE!"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z]+$"
+            message: "Must be lowercase letters only"
+
+    invalidExpression:
+      description: A value that fails CEL expression validation
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 999
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1 && __self <= 100"
+            message: "Value must be between 1 and 100"
+
+    invalidNotMatch:
+      description: A value that fails notMatch validation
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "has spaces in it"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              notMatch: "\\s"
+            message: "Value must not contain spaces"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    valid-passes:
+      description: Verify valid value passes validation
+      command: [run, resolver]
+      args: ["validValue", "-o", "json"]
+      tags: [edge-case, validation, smoke]
+      assertions:
+        - expression: __exitCode == 0
+        - expression: '__output.validValue == "good"'
+
+    regex-failure:
+      description: Verify regex validation failure
+      command: [run, resolver]
+      args: ["invalidRegex"]
+      tags: [edge-case, validation, negative]
+      expectFailure: true
+      assertions:
+        - expression: __exitCode != 0
+          message: "Should fail validation"
+
+    expression-failure:
+      description: Verify CEL expression validation failure
+      command: [run, resolver]
+      args: ["invalidExpression"]
+      tags: [edge-case, validation, negative]
+      expectFailure: true
+      assertions:
+        - expression: __exitCode != 0
+          message: "Should fail validation"
+
+    not-match-failure:
+      description: Verify notMatch validation failure
+      command: [run, resolver]
+      args: ["invalidNotMatch"]
+      tags: [edge-case, validation, negative]
+      expectFailure: true
+      assertions:
+        - expression: __exitCode != 0
+          message: "Should fail validation"

--- a/tests/integration/solutions/hello-world/solution.yaml
+++ b/tests/integration/solutions/hello-world/solution.yaml
@@ -16,6 +16,9 @@ spec:
             inputs:
               value: Hello, World!
 
+  testConfig:
+    skipBuiltins: true
+
   tests:
     render-basic:
       description: Verify solution renders successfully

--- a/tests/integration/solutions/providers/cel/solution.yaml
+++ b/tests/integration/solutions/providers/cel/solution.yaml
@@ -1,0 +1,228 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-cel-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the cel provider.
+    Verifies CEL expression evaluation including string operations,
+    math, list/map manipulation, resolver namespace access, and type handling.
+
+spec:
+  resolvers:
+    # Base values for CEL expressions to reference
+    name:
+      description: A name value for CEL tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello World"
+
+    items:
+      description: A list value for CEL tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - apple
+                - banana
+                - cherry
+
+    count:
+      description: A numeric value for CEL tests
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 10
+
+    # CEL-computed resolvers
+    upperName:
+      description: Uppercase via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.name.upperAscii()"
+
+    lowerName:
+      description: Lowercase via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.name.lowerAscii()"
+
+    concatenated:
+      description: String concatenation via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"prefix-" + _.name + "-suffix"'
+
+    listSize:
+      description: List size via CEL
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "size(_.items)"
+
+    filteredList:
+      description: Filtered list via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.items.filter(i, i.startsWith("b") || i.startsWith("c"))'
+
+    mappedList:
+      description: Mapped list via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.items.map(i, i.upperAscii())'
+
+    mathResult:
+      description: Math operations via CEL
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "(_.count * 3) + 5"
+
+    conditional:
+      description: Ternary conditional via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.count > 5 ? "large" : "small"'
+
+    containsCheck:
+      description: List contains check via CEL
+      type: bool
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"banana" in _.items'
+
+    stringReplace:
+      description: String replace via CEL
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.name.replace(" ", "_")'
+
+    # Transform chain using CEL
+    transformed:
+      description: Multi-step CEL transform
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "  Mixed Case Input  "
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.trim()"
+          - provider: cel
+            inputs:
+              expression: "__self.lowerAscii()"
+          - provider: cel
+            inputs:
+              expression: '__self.replace(" ", "-")'
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for CEL provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, cel]
+      assertions:
+        - expression: __exitCode == 0
+
+    upper-ascii:
+      description: Verify upperAscii string function
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.upperName == "HELLO WORLD"
+
+    lower-ascii:
+      description: Verify lowerAscii string function
+      extends: [_base]
+      assertions:
+        - expression: __output.lowerName == "hello world"
+
+    concatenation:
+      description: Verify string concatenation
+      extends: [_base]
+      assertions:
+        - expression: __output.concatenated == "prefix-Hello World-suffix"
+
+    list-size:
+      description: Verify size() function on lists
+      extends: [_base]
+      assertions:
+        - expression: __output.listSize == 3
+
+    list-filter:
+      description: Verify filter() on lists
+      extends: [_base]
+      assertions:
+        - expression: size(__output.filteredList) == 2
+        - expression: '"banana" in __output.filteredList'
+        - expression: '"cherry" in __output.filteredList'
+
+    list-map:
+      description: Verify map() on lists
+      extends: [_base]
+      assertions:
+        - expression: __output.mappedList[0] == "APPLE"
+        - expression: __output.mappedList[1] == "BANANA"
+
+    math-operations:
+      description: Verify arithmetic in CEL
+      extends: [_base]
+      assertions:
+        - expression: __output.mathResult == 35
+
+    ternary-conditional:
+      description: Verify ternary operator
+      extends: [_base]
+      assertions:
+        - expression: __output.conditional == "large"
+
+    contains-check:
+      description: Verify 'in' operator on lists
+      extends: [_base]
+      assertions:
+        - expression: __output.containsCheck == true
+
+    string-replace:
+      description: Verify replace() string function
+      extends: [_base]
+      assertions:
+        - expression: __output.stringReplace == "Hello_World"
+
+    transform-chain:
+      description: Verify multi-step CEL transform pipeline
+      extends: [_base]
+      assertions:
+        - expression: __output.transformed == "mixed-case-input"
+          message: "Chained transforms should trim, lowercase, and replace spaces"

--- a/tests/integration/solutions/providers/directory/solution.yaml
+++ b/tests/integration/solutions/providers/directory/solution.yaml
@@ -1,0 +1,63 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-directory-provider
+  version: 1.0.0
+  description: Tests for the directory provider
+
+spec:
+  resolvers:
+    listCurrentDir:
+      description: List files in current directory
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+
+    listRecursive:
+      description: List files recursively
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: .
+              recursive: true
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for directory provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, directory]
+      assertions:
+        - expression: __exitCode == 0
+
+    list-current-dir:
+      description: Verify listing current directory
+      extends: [_base]
+      tags: [smoke]
+      init:
+        - command: "touch file-a.txt file-b.txt file-c.log"
+      cleanup:
+        - command: "rm -f file-a.txt file-b.txt file-c.log"
+      assertions:
+        - contains: "file-a.txt"
+        - contains: "file-b.txt"
+
+    list-recursive:
+      description: Verify recursive listing
+      extends: [_base]
+      init:
+        - command: "mkdir -p subdir && touch subdir/nested.txt top.txt"
+      cleanup:
+        - command: "rm -rf subdir top.txt"
+      assertions:
+        - contains: "nested.txt"
+        - contains: "top.txt"

--- a/tests/integration/solutions/providers/env/solution.yaml
+++ b/tests/integration/solutions/providers/env/solution.yaml
@@ -1,0 +1,84 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-env-provider
+  version: 1.0.0
+  description: Tests for the env provider
+
+spec:
+  resolvers:
+    homeDir:
+      description: Read HOME environment variable
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: HOME
+
+    withDefault:
+      description: Read unset variable with default
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: SCAFCTL_TEST_UNSET_VAR_12345
+              default: fallback-value
+
+    testInjected:
+      description: Read a variable injected via test env block
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: SCAFCTL_FUNC_TEST_VAR
+
+  testConfig:
+    skipBuiltins: true
+    env:
+      SCAFCTL_FUNC_TEST_VAR: "global-test-value"
+
+  tests:
+    _base:
+      description: Base template for env provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, env]
+      assertions:
+        - expression: __exitCode == 0
+
+    home-dir:
+      description: Verify HOME variable is readable
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.homeDir.exists == true
+          message: "HOME should exist"
+        - expression: '__output.homeDir.value != ""'
+          message: "HOME should be non-empty"
+
+    default-value:
+      description: Verify default is returned for unset variable
+      extends: [_base]
+      assertions:
+        - expression: '__output.withDefault.value == "fallback-value"'
+          message: "Unset variable should return the default value"
+
+    global-env-injection:
+      description: Verify testConfig env vars are available
+      extends: [_base]
+      assertions:
+        - expression: '__output.testInjected.value == "global-test-value"'
+          message: "testConfig env var should be accessible"
+
+    per-test-env-override:
+      description: Verify per-test env overrides global testConfig env
+      extends: [_base]
+      env:
+        SCAFCTL_FUNC_TEST_VAR: "overridden-value"
+      assertions:
+        - expression: '__output.testInjected.value == "overridden-value"'
+          message: "Per-test env should override testConfig env"

--- a/tests/integration/solutions/providers/exec/solution.yaml
+++ b/tests/integration/solutions/providers/exec/solution.yaml
@@ -1,0 +1,164 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-exec-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the exec provider.
+    Verifies command execution, stdout/stderr capture, exit codes,
+    environment variable passthrough, and piped commands.
+
+spec:
+  resolvers:
+    echoSimple:
+      description: Simple echo command
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "echo hello-from-exec"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout.trim() : string(__self)"
+
+    echoWithArgs:
+      description: Echo with arguments
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: echo
+              args: ["-n", "no-newline"]
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout : string(__self)"
+
+    pipedCommand:
+      description: Piped command execution
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "echo 'alpha bravo charlie' | tr ' ' '\\n' | sort | head -1"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout.trim() : string(__self)"
+
+    envPassthrough:
+      description: Environment variable passthrough
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "echo $SCAFCTL_EXEC_TEST_VAR"
+              env:
+                SCAFCTL_EXEC_TEST_VAR: "exec-env-value"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout.trim() : string(__self)"
+
+    multilineOutput:
+      description: Multi-line output capture
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "printf 'line1\\nline2\\nline3'"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout : string(__self)"
+
+    stdinInput:
+      description: Command with stdin
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "cat"
+              stdin: "stdin-content"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout.trim() : string(__self)"
+
+    exitCodeCapture:
+      description: Capture exit code from exec
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "true"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.exitCode) ? __self.exitCode : 0"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for exec provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, exec]
+      assertions:
+        - expression: __exitCode == 0
+
+    simple-echo:
+      description: Verify simple echo command
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.echoSimple == "hello-from-exec"
+
+    echo-with-args:
+      description: Verify echo with args
+      extends: [_base]
+      assertions:
+        - expression: __output.echoWithArgs == "no-newline"
+
+    piped-command:
+      description: Verify piped command execution
+      extends: [_base]
+      assertions:
+        - expression: __output.pipedCommand == "alpha"
+          message: "Sorted first word should be alpha"
+
+    env-passthrough:
+      description: Verify environment variable passthrough to exec
+      extends: [_base]
+      assertions:
+        - expression: __output.envPassthrough == "exec-env-value"
+
+    multiline-output:
+      description: Verify multi-line output capture
+      extends: [_base]
+      assertions:
+        - expression: __output.multilineOutput.contains("line1")
+        - expression: __output.multilineOutput.contains("line3")
+
+    stdin-input:
+      description: Verify stdin is passed to command
+      extends: [_base]
+      assertions:
+        - expression: __output.stdinInput == "stdin-content"
+
+    exit-code-capture:
+      description: Verify exit code is captured
+      extends: [_base]
+      assertions:
+        - expression: __output.exitCodeCapture == 0

--- a/tests/integration/solutions/providers/file/solution.yaml
+++ b/tests/integration/solutions/providers/file/solution.yaml
@@ -1,0 +1,106 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-file-provider
+  version: 1.0.0
+  description: Tests for the file provider
+
+spec:
+  resolvers:
+    readFixture:
+      description: Read a fixture file
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./test-fixture.txt
+
+    fileExists:
+      description: Check if a file exists
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: exists
+              path: ./test-fixture.txt
+
+    fileNotExists:
+      description: Check if a non-existent file exists
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: exists
+              path: ./this-file-does-not-exist.txt
+
+    readJson:
+      description: Read a JSON fixture file
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./test-data.json
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for file provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, file]
+      assertions:
+        - expression: __exitCode == 0
+
+    read-fixture:
+      description: Verify reading a file
+      extends: [_base]
+      tags: [smoke]
+      init:
+        - command: "echo -n 'fixture-content' > test-fixture.txt"
+        - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+      cleanup:
+        - command: "rm -f test-fixture.txt test-data.json"
+      assertions:
+        - expression: '__output.readFixture.content == "fixture-content"'
+          message: "Should read the fixture file content"
+
+    file-exists:
+      description: Verify file exists check returns true
+      extends: [_base]
+      init:
+        - command: "echo -n 'exists' > test-fixture.txt"
+        - command: "echo -n '{}' > test-data.json"
+      cleanup:
+        - command: "rm -f test-fixture.txt test-data.json"
+      assertions:
+        - expression: __output.fileExists.exists == true
+          message: "Existing file should return true"
+
+    file-not-exists:
+      description: Verify file exists check returns false
+      extends: [_base]
+      init:
+        - command: "echo -n 'needed' > test-fixture.txt"
+        - command: "echo -n '{}' > test-data.json"
+      cleanup:
+        - command: "rm -f test-fixture.txt test-data.json"
+      assertions:
+        - expression: __output.fileNotExists.exists == false
+          message: "Non-existent file should return false"
+
+    read-json-content:
+      description: Verify reading JSON file content
+      extends: [_base]
+      init:
+        - command: "echo -n 'dummy' > test-fixture.txt"
+        - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+      cleanup:
+        - command: "rm -f test-fixture.txt test-data.json"
+      assertions:
+        - expression: '__output.readJson.content.contains("key")'
+        - expression: '__output.readJson.content.contains("value")'

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -1,0 +1,139 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-go-template-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the go-template provider.
+    Verifies template rendering with variable substitution,
+    conditionals, loops, and resolver data access.
+
+spec:
+  resolvers:
+    appName:
+      description: Application name for template tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-service
+
+    version:
+      description: Version for template tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "2.1.0"
+
+    features:
+      description: Feature list for template tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - logging
+                - metrics
+                - tracing
+
+    simpleTemplate:
+      description: Simple variable substitution
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: simple
+              template: "App: {{.appName}}, Version: {{.version}}"
+
+    conditionalTemplate:
+      description: Conditional template rendering
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: conditional
+              template: '{{if eq .appName "my-service"}}production-ready{{else}}development{{end}}'
+
+    loopTemplate:
+      description: Template with range loop
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: loop
+              template: "Features:{{range .features}} [{{.}}]{{end}}"
+
+    multilineTemplate:
+      description: Multiline template rendering
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: multiline
+              template: |
+                name: {{.appName}}
+                version: {{.version}}
+                featureCount: {{len .features}}
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for go-template provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, go-template]
+      assertions:
+        - expression: __exitCode == 0
+
+    simple-substitution:
+      description: Verify simple variable substitution
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.simpleTemplate == "App: my-service, Version: 2.1.0"
+
+    conditional-true:
+      description: Verify conditional template (true branch)
+      extends: [_base]
+      assertions:
+        - expression: __output.conditionalTemplate == "production-ready"
+
+    loop-rendering:
+      description: Verify range loop template
+      extends: [_base]
+      assertions:
+        - expression: __output.loopTemplate.contains("[logging]")
+        - expression: __output.loopTemplate.contains("[metrics]")
+        - expression: __output.loopTemplate.contains("[tracing]")
+
+    multiline-rendering:
+      description: Verify multiline template
+      extends: [_base]
+      assertions:
+        - expression: __output.multilineTemplate.contains("name: my-service")
+        - expression: __output.multilineTemplate.contains("version: 2.1.0")
+        - expression: __output.multilineTemplate.contains("featureCount: 3")

--- a/tests/integration/solutions/providers/sleep/solution.yaml
+++ b/tests/integration/solutions/providers/sleep/solution.yaml
@@ -1,0 +1,40 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-sleep-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the sleep provider.
+    Verifies basic sleep execution and duration output.
+
+spec:
+  resolvers:
+    shortSleep:
+      description: A very short sleep
+      resolve:
+        with:
+          - provider: sleep
+            inputs:
+              duration: "100ms"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for sleep provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, sleep]
+      assertions:
+        - expression: __exitCode == 0
+
+    short-sleep:
+      description: Verify sleep provider completes successfully
+      extends: [_base]
+      tags: [smoke]
+      timeout: "10s"
+      assertions:
+        - contains: shortSleep
+          message: "Sleep resolver should appear in output"

--- a/tests/integration/solutions/providers/static/solution.yaml
+++ b/tests/integration/solutions/providers/static/solution.yaml
@@ -1,0 +1,219 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-static-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the static provider.
+    Verifies literal value resolution across all supported types:
+    strings, integers, booleans, floats, lists, maps, and null.
+
+spec:
+  resolvers:
+    stringValue:
+      description: Static string value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello world
+
+    intValue:
+      description: Static integer value
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+
+    boolTrue:
+      description: Static boolean true
+      type: bool
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: true
+
+    boolFalse:
+      description: Static boolean false
+      type: bool
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: false
+
+    floatValue:
+      description: Static float value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 3.14
+
+    listValue:
+      description: Static list value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - alpha
+                - bravo
+                - charlie
+
+    mapValue:
+      description: Static map value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                host: localhost
+                port: 8080
+                enabled: true
+
+    nestedValue:
+      description: Static deeply nested value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                database:
+                  primary:
+                    host: db.example.com
+                    port: 5432
+                  replicas:
+                    - host: replica1.example.com
+                    - host: replica2.example.com
+
+    emptyString:
+      description: Static empty string value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: ""
+
+    emptyList:
+      description: Static empty list value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: []
+
+    emptyMap:
+      description: Static empty map value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: {}
+
+    multilineString:
+      description: Static multiline string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: |
+                line one
+                line two
+                line three
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for static provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, static]
+      assertions:
+        - expression: __exitCode == 0
+
+    string-value:
+      description: Verify static string resolution
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.stringValue == "hello world"
+
+    int-value:
+      description: Verify static integer resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.intValue == 42
+
+    bool-true:
+      description: Verify static boolean true resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.boolTrue == true
+
+    bool-false:
+      description: Verify static boolean false resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.boolFalse == false
+
+    float-value:
+      description: Verify static float resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.floatValue == 3.14
+
+    list-value:
+      description: Verify static list resolution
+      extends: [_base]
+      assertions:
+        - expression: size(__output.listValue) == 3
+        - expression: __output.listValue[0] == "alpha"
+        - expression: __output.listValue[2] == "charlie"
+
+    map-value:
+      description: Verify static map resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.mapValue.host == "localhost"
+        - expression: __output.mapValue.port == 8080
+        - expression: __output.mapValue.enabled == true
+
+    nested-value:
+      description: Verify static nested structure resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.nestedValue.database.primary.host == "db.example.com"
+        - expression: __output.nestedValue.database.primary.port == 5432
+        - expression: size(__output.nestedValue.database.replicas) == 2
+
+    empty-string:
+      description: Verify static empty string resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.emptyString == ""
+
+    empty-list:
+      description: Verify static empty list resolution
+      extends: [_base]
+      assertions:
+        - expression: size(__output.emptyList) == 0
+
+    empty-map:
+      description: Verify static empty map resolution
+      extends: [_base]
+      assertions:
+        - expression: size(__output.emptyMap) == 0
+
+    multiline-string:
+      description: Verify static multiline string resolution
+      extends: [_base]
+      assertions:
+        - expression: __output.multilineString.contains("line one")
+        - expression: __output.multilineString.contains("line three")

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -1,0 +1,127 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-validation-provider
+  version: 1.0.0
+  description: Tests for the validation provider (passing cases only)
+
+spec:
+  resolvers:
+    validName:
+      description: A valid lowercase name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-valid-app
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z0-9-]+$"
+            message: "Name must be lowercase alphanumeric with hyphens"
+
+    validEmail:
+      description: A valid email format
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: user@example.com
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[^@]+@[^@]+\\.[^@]+$"
+            message: "Must be a valid email format"
+
+    noSpaces:
+      description: A value validated with notMatch
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: no-spaces-here
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              notMatch: "\\s"
+            message: "Value must not contain spaces"
+
+    celValidation:
+      description: A value validated with CEL expression
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1 && __self <= 100"
+            message: "Value must be between 1 and 100"
+
+    multiValidation:
+      description: Value with multiple validation rules
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z]+$"
+            message: "Must be all lowercase letters"
+          - provider: validation
+            inputs:
+              expression: "size(__self) >= 3 && size(__self) <= 20"
+            message: "Must be between 3 and 20 characters"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for validation provider tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [provider, validation]
+      assertions:
+        - expression: __exitCode == 0
+
+    valid-name:
+      description: Verify match validation passes
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: '__output.validName == "my-valid-app"'
+
+    valid-email:
+      description: Verify email pattern validation passes
+      extends: [_base]
+      assertions:
+        - expression: '__output.validEmail == "user@example.com"'
+
+    not-match-passes:
+      description: Verify notMatch validation passes
+      extends: [_base]
+      assertions:
+        - expression: '__output.noSpaces == "no-spaces-here"'
+
+    cel-expression-passes:
+      description: Verify CEL expression validation passes
+      extends: [_base]
+      assertions:
+        - expression: __output.celValidation == 42
+
+    multiple-validations:
+      description: Verify multiple validation rules all pass
+      extends: [_base]
+      assertions:
+        - expression: '__output.multiValidation == "hello"'

--- a/tests/integration/solutions/rendering/solution.yaml
+++ b/tests/integration/solutions/rendering/solution.yaml
@@ -1,0 +1,95 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-rendering
+  version: 1.0.0
+  description: Tests for resolver data availability and output
+
+spec:
+  resolvers:
+    projectName:
+      description: Project name
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: projectName
+          - provider: static
+            inputs:
+              value: test-project
+
+    language:
+      description: Language
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: language
+          - provider: static
+            inputs:
+              value: go
+
+    version:
+      description: Version
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "1.0.0"
+
+    features:
+      description: Feature list
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - api
+                - cli
+                - docs
+
+    computed:
+      description: Computed value from other resolvers
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.projectName + "-" + _.language + "-" + _.version'
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base for resolver tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [rendering]
+      assertions:
+        - expression: __exitCode == 0
+
+    resolver-data-available:
+      description: Verify all resolver data is available
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: '__output.projectName == "test-project"'
+        - expression: '__output.language == "go"'
+        - expression: '__output.version == "1.0.0"'
+        - expression: size(__output.features) == 3
+        - expression: '__output.computed == "test-project-go-1.0.0"'
+
+    render-json-output:
+      description: Verify JSON output contains all resolvers
+      extends: [_base]
+      assertions:
+        - expression: '"projectName" in __output'
+        - expression: '"features" in __output'
+
+    render-with-params:
+      description: Verify custom parameter overrides default
+      extends: [_base]
+      args: ["-o", "json", "-r", "projectName=custom-app"]
+      assertions:
+        - expression: '__output.projectName == "custom-app"'

--- a/tests/integration/solutions/resolvers/conditional/solution.yaml
+++ b/tests/integration/solutions/resolvers/conditional/solution.yaml
@@ -1,0 +1,139 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-conditional
+  version: 1.0.0
+  description: |
+    Functional tests for resolver 'when' conditions.
+    Verifies conditional resolver execution based on
+    CEL expressions evaluating other resolver values.
+
+spec:
+  resolvers:
+    environment:
+      description: Target environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+          - provider: static
+            inputs:
+              value: dev
+
+    enableDebug:
+      description: Debug flag
+      type: bool
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: debug
+          - provider: static
+            inputs:
+              value: false
+
+    # Conditional resolver: only runs when environment is "prod"
+    prodConfig:
+      description: Production-only configuration
+      when:
+        expr: '_.environment == "prod"'
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "production-settings"
+
+    # Conditional resolver: only runs when environment is "dev"
+    devConfig:
+      description: Development-only configuration
+      when:
+        expr: '_.environment == "dev"'
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "development-settings"
+
+    # Conditional based on boolean
+    debugInfo:
+      description: Debug info only when debug is enabled
+      when:
+        expr: "_.enableDebug == true"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "debug-enabled"
+
+    # Always runs (no condition)
+    alwaysPresent:
+      description: Always resolves regardless of conditions
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "always-here"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for conditional resolver tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, conditional]
+      assertions:
+        - expression: __exitCode == 0
+
+    dev-default:
+      description: Verify dev config resolves by default
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.devConfig == "development-settings"
+          message: "devConfig should resolve when env=dev"
+        - expression: __output.alwaysPresent == "always-here"
+
+    dev-no-prod:
+      description: Verify prod config is skipped in dev
+      extends: [_base]
+      assertions:
+        - expression: '!("prodConfig" in __output) || __output.prodConfig == null'
+          message: "prodConfig should not resolve when env=dev"
+
+    prod-config:
+      description: Verify prod config resolves when env=prod
+      extends: [_base]
+      args: ["-r", "env=prod"]
+      assertions:
+        - expression: __output.prodConfig == "production-settings"
+
+    prod-no-dev:
+      description: Verify dev config is skipped in prod
+      extends: [_base]
+      args: ["-r", "env=prod"]
+      assertions:
+        - expression: '!("devConfig" in __output) || __output.devConfig == null'
+          message: "devConfig should not resolve when env=prod"
+
+    debug-disabled:
+      description: Verify debug info skipped when debug=false
+      extends: [_base]
+      assertions:
+        - expression: '!("debugInfo" in __output) || __output.debugInfo == null'
+
+    debug-enabled:
+      description: Verify debug info resolves when debug=true
+      extends: [_base]
+      args: ["-r", "debug=true"]
+      assertions:
+        - expression: __output.debugInfo == "debug-enabled"
+
+    always-present:
+      description: Verify unconditional resolver always resolves
+      extends: [_base]
+      assertions:
+        - expression: __output.alwaysPresent == "always-here"

--- a/tests/integration/solutions/resolvers/dag/solution.yaml
+++ b/tests/integration/solutions/resolvers/dag/solution.yaml
@@ -1,0 +1,156 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-dag
+  version: 1.0.0
+  description: |
+    Functional tests for resolver DAG (dependency graph) execution.
+    Verifies implicit dependencies via _.ref, explicit dependsOn,
+    multi-level chains, and diamond dependency patterns.
+
+spec:
+  resolvers:
+    # Level 0: No dependencies
+    firstName:
+      description: First name (no deps)
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: John
+
+    lastName:
+      description: Last name (no deps)
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Doe
+
+    # Level 1: Depends on level 0
+    fullName:
+      description: Full name (implicit dep on firstName + lastName)
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.firstName + " " + _.lastName'
+
+    # Level 1: Explicit dependsOn
+    greeting:
+      description: Greeting with explicit dependency
+      dependsOn: [firstName]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"Hello, " + _.firstName + "!"'
+
+    # Level 2: Depends on level 1 (multi-level chain)
+    formalGreeting:
+      description: Formal greeting (depends on fullName)
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"Dear " + _.fullName + ","'
+
+    # Diamond: depends on both fullName and greeting (both depend on firstName)
+    summary:
+      description: Summary combining diamond dependencies
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.greeting + " Your full name is " + _.fullName + "."'
+
+    # Deep chain: 4 levels deep
+    chainA:
+      description: Chain level A
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "A"
+
+    chainB:
+      description: Chain level B
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.chainA + "B"'
+
+    chainC:
+      description: Chain level C
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.chainB + "C"'
+
+    chainD:
+      description: Chain level D
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.chainC + "D"'
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for DAG tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, dag]
+      assertions:
+        - expression: __exitCode == 0
+
+    implicit-deps:
+      description: Verify implicit dependencies via _.ref are resolved
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.fullName == "John Doe"
+          message: "fullName should combine firstName and lastName"
+
+    explicit-depends-on:
+      description: Verify explicit dependsOn is honored
+      extends: [_base]
+      assertions:
+        - expression: __output.greeting == "Hello, John!"
+
+    multi-level-chain:
+      description: Verify multi-level dependency chain
+      extends: [_base]
+      assertions:
+        - expression: __output.formalGreeting == "Dear John Doe,"
+
+    diamond-dependency:
+      description: Verify diamond dependency pattern
+      extends: [_base]
+      assertions:
+        - expression: __output.summary == 'Hello, John! Your full name is John Doe.'
+
+    deep-chain:
+      description: Verify 4-level deep dependency chain
+      extends: [_base]
+      assertions:
+        - expression: __output.chainD == "ABCD"
+          message: "Each level should append its letter"
+
+    all-resolvers-present:
+      description: Verify all resolvers are in output
+      extends: [_base]
+      assertions:
+        - expression: '"firstName" in __output'
+        - expression: '"lastName" in __output'
+        - expression: '"fullName" in __output'
+        - expression: '"greeting" in __output'
+        - expression: '"formalGreeting" in __output'
+        - expression: '"summary" in __output'
+        - expression: '"chainD" in __output'

--- a/tests/integration/solutions/resolvers/sensitive/solution.yaml
+++ b/tests/integration/solutions/resolvers/sensitive/solution.yaml
@@ -1,0 +1,53 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-sensitive
+  version: 1.0.0
+  description: |
+    Functional tests for resolver sensitive field.
+    Verifies that sensitive resolvers have their values
+    masked in non-JSON output.
+
+spec:
+  resolvers:
+    secret:
+      description: A sensitive value
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "super-secret-password"
+
+    normalValue:
+      description: A normal non-sensitive value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "visible-value"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    sensitive-in-json:
+      description: Verify sensitive value is accessible in JSON output
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, sensitive, smoke]
+      assertions:
+        - expression: __exitCode == 0
+        - expression: __output.normalValue == "visible-value"
+
+    sensitive-masked-table:
+      description: Verify sensitive value is masked in table output
+      command: [run, resolver]
+      tags: [resolver, sensitive]
+      assertions:
+        - expression: __exitCode == 0
+        - notContains: "super-secret-password"
+          message: "Sensitive value should be masked in table output"
+        - contains: "visible-value"
+          message: "Non-sensitive value should be visible"

--- a/tests/integration/solutions/resolvers/timeout/solution.yaml
+++ b/tests/integration/solutions/resolvers/timeout/solution.yaml
@@ -1,0 +1,61 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-timeout
+  version: 1.0.0
+  description: |
+    Functional tests for resolver timeout enforcement.
+    Verifies that per-resolver timeouts are enforced and
+    that resolvers within timeout complete normally.
+
+spec:
+  resolvers:
+    fastResolver:
+      description: Fast resolver well within timeout
+      timeout: "10s"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "fast-result"
+
+    timedSleep:
+      description: Short sleep within timeout
+      timeout: "10s"
+      resolve:
+        with:
+          - provider: sleep
+            inputs:
+              duration: "100ms"
+      transform:
+        with:
+          - provider: static
+            inputs:
+              value: "sleep-completed"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for timeout tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, timeout]
+      assertions:
+        - expression: __exitCode == 0
+
+    fast-within-timeout:
+      description: Verify fast resolver completes within timeout
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.fastResolver == "fast-result"
+
+    sleep-within-timeout:
+      description: Verify sleep completes within timeout
+      extends: [_base]
+      timeout: "15s"
+      assertions:
+        - expression: __output.timedSleep == "sleep-completed"

--- a/tests/integration/solutions/resolvers/transform-chain/solution.yaml
+++ b/tests/integration/solutions/resolvers/transform-chain/solution.yaml
@@ -1,0 +1,145 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-transform-chain
+  version: 1.0.0
+  description: |
+    Functional tests for resolver transform chains.
+    Verifies multi-step transformation pipelines using
+    different providers and __self access.
+
+spec:
+  resolvers:
+    # Multi-step string transform
+    cleanedInput:
+      description: Multi-step string cleaning
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "  Hello, WORLD!  "
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.trim()"
+          - provider: cel
+            inputs:
+              expression: "__self.lowerAscii()"
+          - provider: cel
+            inputs:
+              expression: '__self.replace(",", "")'
+          - provider: cel
+            inputs:
+              expression: '__self.replace("!", "")'
+          - provider: cel
+            inputs:
+              expression: '__self.replace(" ", "-")'
+
+    # Transform with type change: string → list → filtered list → string
+    csvToList:
+      description: CSV string to filtered list
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "apple,banana,,cherry,,date"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.split(",")'
+          - provider: cel
+            inputs:
+              expression: "__self.filter(item, item != '')"
+          - provider: cel
+            inputs:
+              expression: "__self.map(item, item.upperAscii())"
+
+    # Transform from exec output
+    execTransform:
+      description: Transform exec output through chain
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "echo '  test-value  '"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "has(__self.stdout) ? __self.stdout : string(__self)"
+          - provider: cel
+            inputs:
+              expression: "__self.trim()"
+
+    # Identity transform (no-op passthrough)
+    passthrough:
+      description: Value passes through without transforms
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "unchanged"
+
+    # Go-template transform step
+    templateTransform:
+      description: Transform using go-template provider
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "placeholder"
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: config
+              template: "app={{ .cleanedInput }}"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for transform chain tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, transform]
+      assertions:
+        - expression: __exitCode == 0
+
+    multi-step-clean:
+      description: Verify multi-step string cleaning
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.cleanedInput == "hello-world"
+          message: "Should trim, lowercase, remove punctuation, and hyphenate"
+
+    csv-to-filtered-list:
+      description: Verify CSV to filtered uppercase list
+      extends: [_base]
+      assertions:
+        - expression: size(__output.csvToList) == 4
+        - expression: __output.csvToList[0] == "APPLE"
+        - expression: __output.csvToList[3] == "DATE"
+
+    exec-output-transform:
+      description: Verify exec output is transformed through chain
+      extends: [_base]
+      assertions:
+        - expression: __output.execTransform == "test-value"
+
+    passthrough-no-transform:
+      description: Verify value passes through without transforms
+      extends: [_base]
+      assertions:
+        - expression: __output.passthrough == "unchanged"
+
+    template-transform:
+      description: Verify go-template transform step
+      extends: [_base]
+      assertions:
+        - expression: __output.templateTransform == "app=hello-world"

--- a/tests/integration/solutions/resolvers/type-coercion/solution.yaml
+++ b/tests/integration/solutions/resolvers/type-coercion/solution.yaml
@@ -1,0 +1,127 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-type-coercion
+  version: 1.0.0
+  description: Tests for resolver type coercion
+
+spec:
+  resolvers:
+    stringToInt:
+      description: Coerce string to int
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "42"
+
+    stringToBool:
+      description: Coerce string to bool
+      type: bool
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "true"
+
+    intToString:
+      description: Coerce int to string
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 123
+
+    boolToString:
+      description: Coerce bool to string
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: true
+
+    wholeFloatToInt:
+      description: Coerce whole float to int
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 3.0
+
+    nativeInt:
+      description: Native int (no coercion needed)
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 99
+
+    nativeString:
+      description: Native string (no coercion needed)
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "native"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for type coercion tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, type-coercion]
+      assertions:
+        - expression: __exitCode == 0
+
+    string-to-int:
+      description: Verify string to int coercion
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: __output.stringToInt == 42
+
+    string-to-bool:
+      description: Verify string to bool coercion
+      extends: [_base]
+      assertions:
+        - expression: __output.stringToBool == true
+
+    int-to-string:
+      description: Verify int to string coercion
+      extends: [_base]
+      assertions:
+        - expression: '__output.intToString == "123"'
+
+    bool-to-string:
+      description: Verify bool to string coercion
+      extends: [_base]
+      assertions:
+        - expression: '__output.boolToString == "true"'
+
+    float-to-int:
+      description: Verify whole float to int coercion
+      extends: [_base]
+      assertions:
+        - expression: __output.wholeFloatToInt == 3
+
+    native-int:
+      description: Verify native int needs no coercion
+      extends: [_base]
+      assertions:
+        - expression: __output.nativeInt == 99
+
+    native-string:
+      description: Verify native string needs no coercion
+      extends: [_base]
+      assertions:
+        - expression: '__output.nativeString == "native"'

--- a/tests/integration/solutions/resolvers/until/solution.yaml
+++ b/tests/integration/solutions/resolvers/until/solution.yaml
@@ -1,0 +1,86 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-until
+  version: 1.0.0
+  description: Tests for resolver fallback chains
+
+spec:
+  resolvers:
+    defaultFallback:
+      description: Default until behavior (first non-null)
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: nonExistentParam1
+          - provider: parameter
+            inputs:
+              key: nonExistentParam2
+          - provider: static
+            inputs:
+              value: "third-source-wins"
+
+    paramOverride:
+      description: Parameter takes priority when provided
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: overrideKey
+          - provider: static
+            inputs:
+              value: "static-fallback"
+
+    errorContinue:
+      description: Continue on error in resolve sources
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./this-file-does-not-exist-at-all.txt
+            onError: continue
+          - provider: static
+            inputs:
+              value: "fallback-after-error"
+
+  testConfig:
+    skipBuiltins: true
+
+  tests:
+    _base:
+      description: Base template for until/fallback tests
+      command: [run, resolver]
+      args: ["-o", "json"]
+      tags: [resolver, until]
+      assertions:
+        - expression: __exitCode == 0
+
+    default-fallback:
+      description: Verify default fallback to last non-null source
+      extends: [_base]
+      tags: [smoke]
+      assertions:
+        - expression: '__output.defaultFallback == "third-source-wins"'
+
+    param-override:
+      description: Verify parameter overrides static when provided
+      extends: [_base]
+      args: ["-o", "json", "-r", "overrideKey=param-value"]
+      assertions:
+        - expression: '__output.paramOverride == "param-value"'
+
+    param-fallback:
+      description: Verify static fallback when parameter not provided
+      extends: [_base]
+      assertions:
+        - expression: '__output.paramOverride == "static-fallback"'
+
+    error-continue:
+      description: Verify onError continue skips failed source
+      extends: [_base]
+      assertions:
+        - expression: '__output.errorContinue == "fallback-after-error"'
+          message: "Should fall through to static after file read fails"


### PR DESCRIPTION
- Refactor test runner to execute commands as subprocesses instead of in-process, enabling true parallelism and process-level isolation
- Add live progress reporting with animated spinners (TTY) or line-based output (CI) via MPBTestProgress and LineTestProgress
- Add --no-progress flag to disable progress output
- Track wall-clock duration in test reports for accurate parallel timing
- Update CI workflows to run integration tests via 'task integration'
- Add comprehensive functional test solutions covering providers (static, env, cel, exec, file, directory, go-template, validation, sleep), resolvers (dag, until, type-coercion, transform-chain, conditional, timeout, sensitive), rendering, composition, and edge cases
- Update misc.md to reflect completed action DAG visualization and linting
- Add future-enhancements.md consolidating planned features across design docs
- Add docs/tutorials/functional-testing.md with future enhancement section
