### PR TITLE
feat(test): add test init command and watch mode for functional testing

### DIFF
--- a/docs/design/functional-testing.md
+++ b/docs/design/functional-testing.md
@@ -64,6 +64,7 @@ This is the primary mechanism for validating solutions in CI and during developm
 | `TestCase.Validate()` | ✅ Done | Comprehensive test case validation method |
 | Extends non-existent error | ✅ Done | `extends` referencing non-existent test names is a parse-time error |
 | Tests per solution limit | ✅ Done | Max 500 tests per solution |
+| Watch mode (`--watch`) | ✅ Done | `fsnotify`-based file watcher in `soltesting/watch.go` |
 
 ---
 
@@ -1431,25 +1432,41 @@ This is the primary use case for requiring test files to be bundled and why `sca
 
 ### Test Scaffolding (`scafctl test init`)
 
-A future command that generates a starter test suite for an existing solution by analyzing its structure:
+✅ **Implemented.** Generates a starter test suite for an existing solution by analyzing its structure:
 
 ~~~bash
 scafctl test init -f solution.yaml
 ~~~
 
-Would parse the solution, identify resolvers with defaults, and output skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before you run anything.
+Parses the solution, identifies resolvers with defaults, validation rules, and workflow actions,
+then outputs skeleton test YAML to stdout. Unlike `-o test` (which captures actual output),
+`test init` generates a starting point before you run anything.
+
+**Generated test categories:**
+- Smoke tests: `resolve-defaults`, `render-defaults`, `lint`
+- Per-resolver tests: `resolver-<name>` with non-null assertions
+- Validation failure tests: `resolver-<name>-invalid` with `expectFailure: true`
+- Per-action tests: `action-<name>` with provider tags
+
+**Implementation:**
+- `pkg/solution/soltesting/scaffold.go` — scaffolding logic (`Scaffold()`, `ScaffoldInput`, `ScaffoldToYAML()`)
+- `pkg/cmd/scafctl/test/init.go` — CLI subcommand
 
 ---
 
 ### Watch Mode (`--watch`)
 
-A future flag that re-runs tests when solution files change:
+Re-runs tests when solution files change:
 
 ~~~bash
 scafctl test functional -f solution.yaml --watch
 ~~~
 
-Monitors the solution file and its bundle/compose files for changes, then re-runs affected tests.
+Monitors the solution file, its compose files, and their parent directories for
+changes. Uses `fsnotify` with a 300ms debounce to collapse rapid successive
+writes into a single re-run. Clears the screen on TTY terminals before each
+re-run. Combines with `--tag` and `--filter` for scoped watch runs. Exit cleanly
+with Ctrl-C. Implementation in `pkg/solution/soltesting/watch.go`.
 
 ---
 

--- a/docs/design/future-enhancements.md
+++ b/docs/design/future-enhancements.md
@@ -168,11 +168,11 @@ A future command that executes functional tests across solutions in a remote cat
 
 ### Test Scaffolding (`scafctl test init`)
 
-A future command that generates a starter test suite for an existing solution by analyzing its structure — parsing resolvers with defaults and outputting skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before running anything.
+✅ **Implemented.** Generates a starter test suite for an existing solution by analyzing its structure — parsing resolvers with defaults, validation rules, and workflow actions, then outputting skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before running anything. See `pkg/solution/soltesting/scaffold.go` and `pkg/cmd/scafctl/test/init.go`.
 
 ### Watch Mode (`--watch`)
 
-A future flag for `scafctl test functional` that re-runs tests when solution files change. Monitors the solution file and its bundle/compose files for changes, then re-runs affected tests.
+✅ **Implemented.** The `--watch` / `-w` flag for `scafctl test functional` monitors solution files for changes and automatically re-runs affected tests. Uses `fsnotify` with debounce. See `pkg/solution/soltesting/watch.go`.
 
 ---
 

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -974,6 +974,8 @@ scafctl test l -f solution.yaml
 | `--fail-fast` | | `false` | Stop remaining tests per solution on first failure |
 | `--verbose` | `-v` | `false` | Show full command, init output, and assertion counts |
 | `--keep-sandbox` | | `false` | Preserve sandbox directories after test execution |
+| `--no-progress` | | `false` | Disable live progress spinners during test execution |
+| `--watch` | `-w` | `false` | Watch solution files for changes and re-run tests |
 
 ### `scafctl test list`
 
@@ -987,6 +989,312 @@ scafctl test l -f solution.yaml
 | `--solution` | | — | Filter by solution name glob (repeatable) |
 | `--filter` | | — | Filter by test name glob (repeatable) |
 
+
+## Watch Mode
+
+Watch mode monitors your solution files for changes and automatically re-runs
+tests, giving you a tight feedback loop during development.
+
+### Basic Usage
+
+```bash
+scafctl test functional -f solution.yaml --watch
+```
+
+The `--watch` (or `-w`) flag:
+1. Runs all matched tests immediately
+2. Watches the solution file, compose files, and parent directories
+3. On file change, debounces rapid writes (300ms), then re-runs tests
+4. Clears the terminal before each re-run (on TTY terminals)
+5. Repeats until you press **Ctrl-C**
+
+### Scoped Watches
+
+Combine `--watch` with filters to focus on specific tests:
+
+```bash
+# Only re-run smoke tests
+scafctl test functional -f solution.yaml --watch --tag smoke
+
+# Only re-run tests matching a name pattern
+scafctl test functional -f solution.yaml --watch --filter "render-*"
+
+# Watch an entire directory of solutions
+scafctl test functional --tests-path ./solutions/ --watch
+```
+
+### What Gets Watched
+
+The watcher monitors:
+- The solution file itself (e.g., `solution.yaml`)
+- All compose files referenced by the solution's `compose` field
+- Parent directories of solution files (to detect new/renamed files)
+
+Only `.yaml` and `.yml` file changes trigger re-runs. Non-YAML files are ignored.
+
+### Debouncing
+
+When an editor saves a file, it often writes multiple times in quick succession
+(rename-write-rename, or write-then-format). The watcher collapses these into a
+single re-run by waiting 300ms after the last change event before triggering.
+
+### Example Session
+
+```
+$ scafctl test functional -f solution.yaml --watch --tag smoke
+[watch] watching solution.yaml for changes...
+[watch] (initial run) — running tests...
+SOLUTION            TEST              STATUS   DURATION
+tested-solution     builtin:parse     PASS     2ms
+tested-solution     render-basic      PASS     9ms
+
+2 passed, 0 failed, 0 errors, 0 skipped (11ms)
+[watch] waiting for file changes... (Ctrl-C to exit)
+
+# ...edit solution.yaml, save...
+
+[watch] solution.yaml — running tests...
+SOLUTION            TEST              STATUS   DURATION
+tested-solution     builtin:parse     PASS     1ms
+tested-solution     render-basic      PASS     8ms
+
+2 passed, 0 failed, 0 errors, 0 skipped (9ms)
+[watch] waiting for file changes... (Ctrl-C to exit)
+
+^C
+[watch] stopped
+```
+
+### Watch Mode with Compose Files
+
+When a solution uses `compose` to split tests across files, the watcher
+automatically monitors all referenced compose files:
+
+```yaml
+# solution.yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-solution
+compose:
+  - tests/*.yaml
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+```
+
+```bash
+# All compose files under tests/ are watched automatically
+scafctl test functional -f solution.yaml --watch
+```
+
+Editing any file under `tests/` triggers a re-run. Creating a new compose file
+in the directory also triggers re-discovery and a new run.
+
+### Tips
+
+- **Use with `--verbose`** to see full assertion counts on each re-run:
+  ```bash
+  scafctl test functional -f solution.yaml --watch -v
+  ```
+- **Combine with `--fail-fast`** to stop early when iterating on a broken test:
+  ```bash
+  scafctl test functional -f solution.yaml --watch --fail-fast
+  ```
+- **CI environments** should not use `--watch` — it's designed for interactive
+  development only.
+- **Progress output** is automatically re-created for each watch cycle on TTY
+  terminals. Use `--no-progress` if you find the spinners distracting:
+  ```bash
+  scafctl test functional -f solution.yaml --watch --no-progress
+  ```
+
+---
+
+## Test Scaffolding (`scafctl test init`)
+
+Writing tests from scratch can be tedious — especially for solutions with many resolvers and
+validation rules. The `test init` command generates a starter test suite by analyzing your
+solution's structure. No commands are executed; it performs structural analysis only.
+
+### Basic Usage
+
+```bash
+scafctl test init -f solution.yaml
+```
+
+This outputs YAML to stdout that you can paste into your solution's `spec.tests` section or
+redirect to a file:
+
+```bash
+# Save to a file
+scafctl test init -f solution.yaml > tests.yaml
+
+# Append to an existing compose test file
+scafctl test init -f solution.yaml >> solution-tests.yaml
+```
+
+### What Gets Generated
+
+The command analyzes your solution and generates:
+
+| Test Category | What It Creates |
+|---------------|-----------------|
+| **Smoke tests** | `resolve-defaults` — verifies all resolvers resolve with defaults |
+| | `render-defaults` — verifies the solution renders with defaults |
+| | `lint` — verifies the solution has no lint errors |
+| **Per-resolver tests** | `resolver-<name>` — verifies each resolver produces non-null output |
+| **Validation failure tests** | `resolver-<name>-invalid` — verifies resolvers with validation rules reject invalid input (`expectFailure: true`) |
+| **Per-action tests** | `action-<name>` — verifies each workflow action executes successfully |
+
+### Example
+
+Given this solution:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-app
+  version: 1.0.0
+spec:
+  resolvers:
+    repo:
+      description: Repository name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+
+    version:
+      description: Version to build
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version
+          - provider: static
+            inputs:
+              value: dev
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: '^(dev|\d+\.\d+\.\d+.*)$'
+            message: "Invalid version format"
+```
+
+Running `scafctl test init -f solution.yaml` produces:
+
+```yaml
+# Generated test scaffold for solution.yaml
+# Paste this into your solution's spec section or a compose test file.
+# Customize assertions and parameters to match your expected behavior.
+
+tests:
+    lint:
+        description: Verify solution has no lint errors
+        command:
+            - lint
+        tags:
+            - smoke
+            - lint
+        exitCode: 0
+    render-defaults:
+        description: Verify solution renders with default values
+        command:
+            - render
+            - solution
+        tags:
+            - smoke
+            - render
+        exitCode: 0
+    resolve-defaults:
+        description: Verify all resolvers resolve with default values
+        command:
+            - run
+            - resolver
+        args:
+            - -o
+            - json
+        tags:
+            - smoke
+            - resolvers
+        exitCode: 0
+    resolver-repo:
+        description: Verify resolver "repo" produces expected output
+        command:
+            - run
+            - resolver
+        args:
+            - --resolver
+            - repo
+            - -o
+            - json
+        tags:
+            - resolvers
+        exitCode: 0
+        assertions:
+            - expression: __output.repo != null
+              message: Resolver "repo" should produce a non-null value
+    resolver-version:
+        description: Verify resolver "version" produces expected output
+        command:
+            - run
+            - resolver
+        args:
+            - --resolver
+            - version
+            - -o
+            - json
+        tags:
+            - resolvers
+        exitCode: 0
+        assertions:
+            - expression: __output.version != null
+              message: Resolver "version" should produce a non-null value
+    resolver-version-invalid:
+        description: Verify resolver "version" rejects values not matching pattern
+        command:
+            - run
+            - resolver
+        args:
+            - --resolver
+            - version
+            - --param
+            - version=___invalid___
+        tags:
+            - resolvers
+            - validation
+            - negative
+        expectFailure: true
+```
+
+### Customizing Generated Tests
+
+The scaffold is a starting point. After generating, you should:
+
+1. **Add specific assertions** — replace generic `__output.X != null` with checks matching your expected values
+2. **Tune validation failure inputs** — replace `___invalid___` with realistic bad inputs
+3. **Add tags** — organize tests with domain-specific tags like `smoke`, `integration`
+4. **Add test templates** — extract common command/assertion patterns into `_`-prefixed templates and use `extends`
+5. **Remove unnecessary tests** — if some resolvers don't need individual tests, remove them
+
+### Difference from `-o test`
+
+| Feature | `test init` | `-o test` (future) |
+|---------|------------|-------------------|
+| **Execution** | No commands run — structural analysis only | Executes the command and captures output |
+| **Output** | Skeleton tests with generic assertions | Complete tests with output-derived assertions + snapshots |
+| **Use case** | Bootstrapping a new test suite | Capturing known-good behavior |
+
+---
 
 ## Future Enhancements
 
@@ -1032,44 +1340,6 @@ This is the primary use case for requiring test files to be bundled and why `sca
 
 ### Test Scaffolding (`scafctl test init`)
 
-A future command that generates a starter test suite for an existing solution by analyzing its structure:
-
-~~~bash
-scafctl test init -f solution.yaml
-~~~
-
-Would parse the solution, identify resolvers with defaults, and output skeleton test YAML. Unlike `-o test` (which captures actual output), `test init` generates a starting point before you run anything.
-
----
-
-### Watch Mode (`--watch`)
-
-A future flag that re-runs tests when solution files change:
-
-~~~bash
-scafctl test functional -f solution.yaml --watch
-~~~
-
-Monitors the solution file and its bundle/compose files for changes, then re-runs affected tests.
-
----
-
-### Tutorial Outline
-
-The planned tutorial at `docs/tutorials/functional-testing.md` should cover:
-
-1. **Writing your first test** — minimal solution with one test case, `scafctl test functional` invocation, reading output
-2. **Assertions deep dive** — CEL expressions vs regex/contains, `target` field, `output` variable structure per command, negation assertions
-3. **Test inheritance** — `_`-prefixed templates, `extends` chains, merge behavior for args/assertions/tags
-4. **Snapshots** — golden file workflow, `--update-snapshots`, normalization pipeline
-5. **CI integration** — JUnit XML reporting with `--report-file`, exit codes, `--fail-fast` patterns
-6. **Advanced features** — init/cleanup steps, test files, `skipExpression`, retries, suite-level setup
-
-The example solution at `examples/solutions/tested-solution/` should include:
-
-- A solution with 2-3 resolvers and a template action
-- 3-4 inline tests covering: CEL expression assertion, contains/regex assertion, `expectFailure` for validation, and a snapshot test
-- A `testdata/` directory with a golden file
-- A `bundle.include` covering the test files
+✅ **Implemented.** See the [Test Scaffolding](#test-scaffolding-scafctl-test-init) section above.
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -116,6 +116,8 @@ Complete solutions demonstrating real-world use cases.
 | [email-notifier/](solutions/email-notifier/) | Email notification workflow |
 | [k8s-clusters/](solutions/k8s-clusters/) | Read a Go template file, iterate 10 K8s clusters, render and write unique manifests |
 | [bad-solution-yaml/](solutions/bad-solution-yaml/) | Invalid solution demonstrating error handling for conflicting ValueRef keys |
+| [tested-solution/](solutions/tested-solution/) | Functional testing features: assertions, inheritance, tags, watch mode |
+| [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` — generates starter test suites |
 
 ---
 

--- a/examples/solutions/scaffold-demo/README.md
+++ b/examples/solutions/scaffold-demo/README.md
@@ -1,0 +1,62 @@
+# Test Scaffolding Demo
+
+Demonstrates `scafctl test init` — a command that generates a starter test suite by
+analyzing a solution's resolvers, validation rules, and workflow actions.
+
+## Quick Start
+
+```bash
+# Generate a test scaffold from the solution
+scafctl test init -f solution.yaml
+
+# Save the scaffold to a file
+scafctl test init -f solution.yaml > generated-tests.yaml
+```
+
+## What Gets Generated
+
+For this solution, `test init` produces:
+
+| Test | Description |
+|------|-------------|
+| `lint` | Verify solution has no lint errors |
+| `render-defaults` | Verify solution renders with default values |
+| `resolve-defaults` | Verify all resolvers resolve with default values |
+| `resolver-language` | Verify resolver "language" produces expected output |
+| `resolver-language-invalid` | Verify language validation rejects bad input |
+| `resolver-outputDir` | Verify resolver "outputDir" produces expected output |
+| `resolver-projectName` | Verify resolver "projectName" produces expected output |
+| `resolver-version` | Verify resolver "version" produces expected output |
+| `resolver-version-invalid` | Verify version validation rejects bad input |
+| `action-create-dir` | Verify action "create-dir" executes successfully |
+| `action-generate` | Verify action "generate" executes successfully |
+| `action-release` | Verify conditional action "release" (tagged `conditional`) |
+
+## Workflow
+
+1. **Generate** the scaffold:
+   ```bash
+   scafctl test init -f solution.yaml
+   ```
+
+2. **Review and customize** the output — add specific assertions, tune invalid inputs,
+   and remove tests you don't need.
+
+3. **Paste** the `tests:` section into your solution YAML under `spec`, or save it as a
+   separate compose file.
+
+4. **Run** the tests:
+   ```bash
+   scafctl test functional -f solution.yaml
+   ```
+
+## Difference from `-o test`
+
+- `test init` performs **structural analysis only** — no commands are executed
+- `-o test` (future) would **execute** a command and capture its output to generate assertions
+- Use `test init` to bootstrap; use `-o test` to capture known-good behavior
+
+## Tutorial
+
+See the [Functional Testing Tutorial](../../../docs/tutorials/functional-testing.md#test-scaffolding-scafctl-test-init)
+for a comprehensive guide.

--- a/examples/solutions/scaffold-demo/solution.yaml
+++ b/examples/solutions/scaffold-demo/solution.yaml
@@ -1,0 +1,111 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: scaffold-demo
+  version: 1.0.0
+  description: Demonstrates test scaffolding with `scafctl test init`
+
+spec:
+  resolvers:
+    projectName:
+      description: Name of the project
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: projectName
+          - provider: static
+            inputs:
+              value: my-project
+
+    language:
+      description: Programming language
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: language
+          - provider: static
+            inputs:
+              value: go
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: '__self in ["go", "python", "typescript", "rust"]'
+            message: "Must be one of: go, python, typescript, rust"
+
+    version:
+      description: Project version
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version
+          - provider: static
+            inputs:
+              value: "0.1.0"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: '^\d+\.\d+\.\d+$'
+            message: "Version must follow semver (e.g., 1.2.3)"
+
+    outputDir:
+      description: Output directory
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: dist
+
+  workflow:
+    actions:
+      create-dir:
+        description: Create output directory
+        provider: exec
+        inputs:
+          cmd:
+            - mkdir
+            - -p
+          args:
+            dir:
+              rslvr: outputDir
+
+      generate:
+        description: Generate project files
+        provider: exec
+        dependsOn: [create-dir]
+        inputs:
+          cmd:
+            - echo
+          args:
+            msg:
+              tmpl: "Generating {{ .projectName }} ({{ .language }} v{{ .version }})"
+          context:
+            projectName:
+              rslvr: projectName
+            language:
+              rslvr: language
+            version:
+              rslvr: version
+
+      release:
+        description: Create a release
+        provider: exec
+        dependsOn: [generate]
+        when:
+          expr: '_.version != "0.1.0"'
+        inputs:
+          cmd:
+            - echo
+          args:
+            msg:
+              tmpl: "Releasing {{ .projectName }} v{{ .version }}"
+          context:
+            projectName:
+              rslvr: projectName
+            version:
+              rslvr: version

--- a/examples/solutions/tested-solution/README.md
+++ b/examples/solutions/tested-solution/README.md
@@ -33,6 +33,12 @@ scafctl test functional -f solution.yaml
 # Run only smoke-tagged tests
 scafctl test functional -f solution.yaml --tag smoke
 
+# Watch mode - re-run tests on file changes
+scafctl test functional -f solution.yaml --watch
+
+# Watch with tag filter
+scafctl test functional -f solution.yaml --watch --tag smoke
+
 # List tests without running
 scafctl test list -f solution.yaml
 

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -41,6 +43,7 @@ type FunctionalOptions struct {
 	Verbose         bool
 	KeepSandbox     bool
 	NoProgress      bool
+	Watch           bool
 }
 
 // CommandFunctional creates the 'test functional' subcommand.
@@ -77,7 +80,11 @@ Examples:
   scafctl test functional -f ./solution.yaml --report-file results.xml
 
   # Dry run (validate only)
-  scafctl test functional -f ./solution.yaml --dry-run`,
+  scafctl test functional -f ./solution.yaml --dry-run
+
+  # Watch mode - re-run on file changes
+  scafctl test functional -f ./solution.yaml --watch
+  scafctl test functional -f ./solution.yaml --watch --tag smoke`,
 		SilenceUsage: true,
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
@@ -109,6 +116,7 @@ Examples:
 	cCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output (assertion counts, details)")
 	cCmd.Flags().BoolVar(&opts.KeepSandbox, "keep-sandbox", false, "Keep sandbox directories after test execution")
 	cCmd.Flags().BoolVar(&opts.NoProgress, "no-progress", false, "Disable live progress output during test execution")
+	cCmd.Flags().BoolVarP(&opts.Watch, "watch", "w", false, "Watch solution files for changes and re-run affected tests")
 
 	return cCmd
 }
@@ -130,10 +138,15 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	// Discover solutions
+	// Determine the path to discover solutions from.
 	testsPath := opts.TestsPath
 	if testsPath == "" {
 		testsPath = opts.File
+	}
+
+	// Watch mode — delegate to the watcher loop.
+	if opts.Watch {
+		return runWatchMode(ctx, opts, w, testsPath)
 	}
 
 	solutions, err := soltesting.DiscoverSolutions(testsPath)
@@ -263,4 +276,130 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 	}
 
 	return nil
+}
+
+// runWatchMode starts the file watcher and re-runs tests on changes.
+// It blocks until Ctrl-C (SIGINT/SIGTERM) is received.
+func runWatchMode(ctx context.Context, opts *FunctionalOptions, w *writer.Writer, testsPath string) error {
+	// Set up signal handling for clean shutdown.
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	concurrency := opts.Concurrency
+	if opts.Sequential {
+		concurrency = 1
+	}
+
+	skipBuiltins := soltesting.SkipBuiltinsValue{}
+	if opts.SkipBuiltins {
+		skipBuiltins.All = true
+	}
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		if w != nil {
+			w.Errorf("failed to resolve executable path: %s", err)
+		}
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	runner := &soltesting.Runner{
+		BinaryPath:      binaryPath,
+		Concurrency:     concurrency,
+		FailFast:        opts.FailFast,
+		UpdateSnapshots: opts.UpdateSnapshots,
+		Verbose:         opts.Verbose,
+		KeepSandbox:     opts.KeepSandbox,
+		TestTimeout:     opts.TestTimeout,
+		GlobalTimeout:   opts.Timeout,
+		DryRun:          opts.DryRun,
+		IOStreams:       opts.IOStreams,
+		Filter: soltesting.FilterOptions{
+			NamePatterns:     opts.Filter,
+			Tags:             opts.Tag,
+			SolutionPatterns: opts.Solution,
+		},
+	}
+
+	// Unused in watch mode — skip builtins are applied per-run via
+	// the solution's TestConfig, which DiscoverSolutions populates.
+	_ = skipBuiltins
+
+	isTTY := kvx.IsTerminal(opts.IOStreams.ErrOut)
+
+	watcher := &soltesting.Watcher{
+		Runner:    runner,
+		TestsPath: testsPath,
+		Options: soltesting.WatchOptions{
+			OnRunStart: func(triggerFile string) {
+				// Set up progress for each run (mpb instances are single-use).
+				if !opts.NoProgress && !opts.DryRun {
+					format, _ := kvx.ParseOutputFormat(opts.Output)
+					if kvx.IsTableFormat(format) || opts.Output == "" {
+						if isTTY {
+							runner.Progress = NewMPBTestProgress(opts.IOStreams.ErrOut)
+						} else {
+							runner.Progress = NewLineTestProgress(opts.IOStreams.ErrOut)
+						}
+					}
+				}
+
+				if w != nil {
+					if isTTY {
+						// ANSI clear screen + cursor home for clean re-display.
+						fmt.Fprint(opts.IOStreams.ErrOut, "\033[2J\033[H")
+					}
+					w.Infof("[watch] %s — running tests...", triggerFile)
+				}
+			},
+			OnRunComplete: func(results []soltesting.TestResult, elapsed time.Duration, runErr error) {
+				if runErr != nil {
+					if w != nil {
+						w.Errorf("[watch] run error: %s", runErr)
+					}
+					return
+				}
+
+				if len(results) == 0 {
+					if w != nil {
+						w.Info("[watch] no tests found")
+					}
+					return
+				}
+
+				// Report results.
+				format, _ := kvx.ParseOutputFormat(opts.Output)
+				outputOpts := kvx.NewOutputOptions(opts.IOStreams)
+				outputOpts.Format = format
+				outputOpts.Ctx = ctx
+
+				if reportErr := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed); reportErr != nil {
+					if w != nil {
+						w.Errorf("[watch] reporting failed: %s", reportErr)
+					}
+				}
+
+				summary := soltesting.Summarize(results)
+				if w != nil {
+					w.Infof("[watch] waiting for file changes... (Ctrl-C to exit)")
+					_ = summary // summary already printed by ReportResults
+				}
+			},
+		},
+	}
+
+	if w != nil {
+		w.Infof("[watch] watching %s for changes...", testsPath)
+	}
+
+	err = watcher.Watch(ctx)
+	if err != nil && ctx.Err() != nil {
+		// Context cancelled via signal — this is a clean exit.
+		if w != nil {
+			fmt.Fprintln(opts.IOStreams.ErrOut)
+			w.Info("[watch] stopped")
+		}
+		return nil
+	}
+	return err
 }

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -1,0 +1,114 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// InitOptions holds configuration for the test init command.
+type InitOptions struct {
+	IOStreams *terminal.IOStreams
+	CliParams *settings.Run
+	File      string
+}
+
+// CommandInit creates the 'test init' subcommand that generates a starter test suite.
+func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &InitOptions{}
+
+	cCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generate a starter test suite from a solution",
+		Long: `Generate skeleton test cases by analyzing a solution's structure.
+
+This command parses the solution YAML and generates starter test definitions
+based on the resolvers, validation rules, and workflow actions it finds.
+No commands are executed — this is structural analysis only.
+
+The generated YAML is written to stdout and can be pasted into the solution's
+spec.tests section or saved to a separate test file.
+
+Examples:
+  # Generate tests from a solution file
+  scafctl test init -f solution.yaml
+
+  # Save generated tests to a file
+  scafctl test init -f solution.yaml > tests.yaml
+
+  # Pipe into a compose file
+  scafctl test init -f solution.yaml >> solution-tests.yaml`,
+		SilenceUsage: true,
+		RunE: func(cCmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return runInit(ctx, opts)
+		},
+	}
+
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to the solution file (required)")
+	_ = cCmd.MarkFlagRequired("file")
+
+	return cCmd
+}
+
+// runInit implements the test init command logic.
+func runInit(ctx context.Context, opts *InitOptions) error {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		w = writer.New(opts.IOStreams, opts.CliParams)
+	}
+
+	// Read and parse the solution
+	data, err := os.ReadFile(opts.File)
+	if err != nil {
+		w.Errorf("reading solution file: %s", err)
+		return exitcode.WithCode(fmt.Errorf("reading solution file: %w", err), exitcode.FileNotFound)
+	}
+
+	var sol solution.Solution
+	if err := sol.UnmarshalFromBytes(data); err != nil {
+		w.Errorf("parsing solution: %s", err)
+		return exitcode.WithCode(fmt.Errorf("parsing solution: %w", err), exitcode.InvalidInput)
+	}
+
+	// Build scaffold input from the parsed solution
+	input := &soltesting.ScaffoldInput{
+		Resolvers: sol.Spec.Resolvers,
+		Workflow:  sol.Spec.Workflow,
+	}
+
+	// Generate scaffold
+	result := soltesting.Scaffold(input)
+
+	// Marshal to YAML and write to stdout
+	out, err := soltesting.ScaffoldToYAML(result)
+	if err != nil {
+		w.Errorf("marshalling test YAML: %s", err)
+		return fmt.Errorf("marshalling test YAML: %w", err)
+	}
+
+	// Write YAML header comment
+	fmt.Fprintf(opts.IOStreams.Out, "# Generated test scaffold for %s\n", opts.File)
+	fmt.Fprintf(opts.IOStreams.Out, "# Paste this into your solution's spec section or a compose test file.\n")
+	fmt.Fprintf(opts.IOStreams.Out, "# Customize assertions and parameters to match your expected behavior.\n\n")
+	fmt.Fprint(opts.IOStreams.Out, string(out))
+
+	return nil
+}

--- a/pkg/cmd/scafctl/test/test.go
+++ b/pkg/cmd/scafctl/test/test.go
@@ -21,6 +21,7 @@ func CommandTest(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 SUBCOMMANDS:
   functional  Run functional tests against solutions
+  init        Generate a starter test suite from a solution
   list        List available tests without executing them
 
 Functional tests validate that solutions behave correctly by executing
@@ -32,6 +33,7 @@ under a tests/ directory.`, settings.CliBinaryName),
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 	cCmd.AddCommand(CommandFunctional(cliParams, ioStreams, cmdPath))
+	cCmd.AddCommand(CommandInit(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 
 	return cCmd

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -1,0 +1,200 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"gopkg.in/yaml.v3"
+)
+
+// ScaffoldResult holds the generated test scaffold for a solution.
+type ScaffoldResult struct {
+	// Tests is a map of generated test cases keyed by name.
+	Tests map[string]*TestCase `json:"tests" yaml:"tests"`
+}
+
+// ScaffoldInput provides the solution data needed for scaffold generation,
+// avoiding a direct dependency on the solution package (which imports soltesting).
+type ScaffoldInput struct {
+	// Resolvers is the map of resolver definitions from the solution spec.
+	Resolvers map[string]*resolver.Resolver
+
+	// Workflow is the action workflow from the solution spec (may be nil).
+	Workflow *action.Workflow
+}
+
+// Scaffold generates a skeleton test suite from the provided solution data.
+// It performs structural analysis only — no commands are executed.
+func Scaffold(input *ScaffoldInput) *ScaffoldResult {
+	result := &ScaffoldResult{
+		Tests: make(map[string]*TestCase),
+	}
+
+	// Always generate builtin-style tests
+	addResolveDefaultsTest(result)
+	addRenderDefaultsTest(result)
+	addLintTest(result)
+
+	// Generate resolver-specific tests
+	if input.Resolvers != nil {
+		addResolverTests(result, input.Resolvers)
+	}
+
+	// Generate action-specific tests
+	if input.Workflow != nil && input.Workflow.Actions != nil {
+		addActionTests(result, input.Workflow)
+	}
+
+	return result
+}
+
+// addResolveDefaultsTest adds a test that verifies all resolvers resolve with defaults.
+func addResolveDefaultsTest(result *ScaffoldResult) {
+	exitCodeZero := 0
+	result.Tests["resolve-defaults"] = &TestCase{
+		Description: "Verify all resolvers resolve with default values",
+		Command:     []string{"run", "resolver"},
+		Args:        []string{"-o", "json"},
+		Tags:        []string{"smoke", "resolvers"},
+		ExitCode:    &exitCodeZero,
+	}
+}
+
+// addRenderDefaultsTest adds a test that verifies the solution renders with defaults.
+func addRenderDefaultsTest(result *ScaffoldResult) {
+	exitCodeZero := 0
+	result.Tests["render-defaults"] = &TestCase{
+		Description: "Verify solution renders with default values",
+		Command:     []string{"render", "solution"},
+		Tags:        []string{"smoke", "render"},
+		ExitCode:    &exitCodeZero,
+	}
+}
+
+// addLintTest adds a lint test.
+func addLintTest(result *ScaffoldResult) {
+	exitCodeZero := 0
+	result.Tests["lint"] = &TestCase{
+		Description: "Verify solution has no lint errors",
+		Command:     []string{"lint"},
+		Tags:        []string{"smoke", "lint"},
+		ExitCode:    &exitCodeZero,
+	}
+}
+
+// addResolverTests generates per-resolver tests, including validation failure tests.
+func addResolverTests(result *ScaffoldResult, resolvers map[string]*resolver.Resolver) {
+	// Sort resolver names for deterministic output
+	names := make([]string, 0, len(resolvers))
+	for name := range resolvers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		r := resolvers[name]
+		if r == nil {
+			continue
+		}
+
+		// Generate a basic resolver output test
+		exitCodeZero := 0
+		testName := fmt.Sprintf("resolver-%s", name)
+		result.Tests[testName] = &TestCase{
+			Description: fmt.Sprintf("Verify resolver %q produces expected output", name),
+			Command:     []string{"run", "resolver"},
+			Args:        []string{"--resolver", name, "-o", "json"},
+			Tags:        []string{"resolvers"},
+			ExitCode:    &exitCodeZero,
+			Assertions: []Assertion{
+				{
+					Expression: celexp.Expression(fmt.Sprintf(`__output.%s != null`, name)),
+					Message:    fmt.Sprintf("Resolver %q should produce a non-null value", name),
+				},
+			},
+		}
+
+		// If the resolver has validation rules, generate an expectFailure test
+		if r.Validate != nil && len(r.Validate.With) > 0 {
+			failTestName := fmt.Sprintf("resolver-%s-invalid", name)
+			tc := &TestCase{
+				Description:   fmt.Sprintf("Verify resolver %q rejects invalid input", name),
+				Command:       []string{"run", "resolver"},
+				Args:          []string{"--resolver", name},
+				Tags:          []string{"resolvers", "validation", "negative"},
+				ExpectFailure: true,
+			}
+
+			// Try to generate a meaningful invalid input based on validation provider inputs
+			for _, pv := range r.Validate.With {
+				if pv.Inputs != nil {
+					if matchRef, ok := pv.Inputs["match"]; ok && matchRef != nil {
+						tc.Description = fmt.Sprintf("Verify resolver %q rejects values not matching pattern", name)
+					}
+					if exprRef, ok := pv.Inputs["expression"]; ok && exprRef != nil {
+						tc.Description = fmt.Sprintf("Verify resolver %q rejects values failing validation expression", name)
+					}
+				}
+			}
+
+			// Add parameter override with obviously invalid value
+			tc.Args = append(tc.Args, "--param", fmt.Sprintf("%s=___invalid___", name))
+			result.Tests[failTestName] = tc
+		}
+	}
+}
+
+// addActionTests generates skeleton tests for workflow actions.
+func addActionTests(result *ScaffoldResult, wf *action.Workflow) {
+	// Sort action names for deterministic output
+	names := make([]string, 0, len(wf.Actions))
+	for name := range wf.Actions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		act := wf.Actions[name]
+		if act == nil {
+			continue
+		}
+
+		testName := fmt.Sprintf("action-%s", name)
+		tc := &TestCase{
+			Description: fmt.Sprintf("Verify action %q executes successfully", name),
+			Command:     []string{"run", "action"},
+			Args:        []string{"--action", name},
+			Tags:        []string{"actions"},
+		}
+
+		if act.Provider != "" {
+			tc.Tags = append(tc.Tags, act.Provider)
+		}
+
+		// For actions with conditions, add a note in the description
+		if act.When != nil {
+			tc.Description = fmt.Sprintf("Verify action %q executes when condition is met (provider: %s)", name, act.Provider)
+			tc.Tags = append(tc.Tags, "conditional")
+		}
+
+		exitCodeZero := 0
+		tc.ExitCode = &exitCodeZero
+		result.Tests[testName] = tc
+	}
+}
+
+// ScaffoldToYAML marshals the scaffold result to YAML suitable for embedding
+// in a solution's spec.tests section.
+func ScaffoldToYAML(result *ScaffoldResult) ([]byte, error) {
+	// Build a wrapper that produces spec-level YAML: tests: { ... }
+	wrapper := map[string]any{
+		"tests": result.Tests,
+	}
+	return yaml.Marshal(wrapper)
+}

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScaffold_EmptyInput(t *testing.T) {
+	result := Scaffold(&ScaffoldInput{})
+
+	require.NotNil(t, result)
+	assert.Len(t, result.Tests, 3, "should contain resolve-defaults, render-defaults, and lint")
+	assert.Contains(t, result.Tests, "resolve-defaults")
+	assert.Contains(t, result.Tests, "render-defaults")
+	assert.Contains(t, result.Tests, "lint")
+}
+
+func TestScaffold_WithResolvers(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"repo": {
+				Description: "Repository name",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "static"},
+					},
+				},
+			},
+			"version": {
+				Description: "Version to build",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "parameter"},
+						{Provider: "static"},
+					},
+				},
+				Validate: &resolver.ValidatePhase{
+					With: []resolver.ProviderValidation{
+						{
+							Provider: "validation",
+							Inputs: map[string]*spec.ValueRef{
+								"match": {Literal: `^(dev|\d+\.\d+\.\d+.*)$`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	require.NotNil(t, result)
+
+	// 3 base tests + 2 resolver tests + 1 validation failure test = 6
+	assert.Len(t, result.Tests, 6)
+
+	// Base tests
+	assert.Contains(t, result.Tests, "resolve-defaults")
+	assert.Contains(t, result.Tests, "render-defaults")
+	assert.Contains(t, result.Tests, "lint")
+
+	// Resolver tests
+	assert.Contains(t, result.Tests, "resolver-repo")
+	assert.Contains(t, result.Tests, "resolver-version")
+
+	// Validation failure test for version
+	assert.Contains(t, result.Tests, "resolver-version-invalid")
+	assert.True(t, result.Tests["resolver-version-invalid"].ExpectFailure)
+	assert.Contains(t, result.Tests["resolver-version-invalid"].Tags, "negative")
+}
+
+func TestScaffold_WithActions(t *testing.T) {
+	input := &ScaffoldInput{
+		Workflow: &action.Workflow{
+			Actions: map[string]*action.Action{
+				"build": {
+					Description: "Build binary",
+					Provider:    "exec",
+				},
+				"test": {
+					Description: "Run tests",
+					Provider:    "exec",
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	require.NotNil(t, result)
+
+	// 3 base tests + 2 action tests = 5
+	assert.Len(t, result.Tests, 5)
+	assert.Contains(t, result.Tests, "action-build")
+	assert.Contains(t, result.Tests, "action-test")
+
+	// Action tests should include provider tag
+	assert.Contains(t, result.Tests["action-build"].Tags, "exec")
+	assert.Contains(t, result.Tests["action-build"].Tags, "actions")
+}
+
+func TestScaffold_ConditionalAction(t *testing.T) {
+	input := &ScaffoldInput{
+		Workflow: &action.Workflow{
+			Actions: map[string]*action.Action{
+				"release": {
+					Description: "Create release",
+					Provider:    "api",
+					When: &spec.Condition{
+						Expr: exprPtr(`_.version != "dev"`),
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.Tests, "action-release")
+	assert.Contains(t, result.Tests["action-release"].Tags, "conditional")
+}
+
+func TestScaffold_ResolverWithValidationExpression(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"goos": {
+				Description: "Target OS",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "static"},
+					},
+				},
+				Validate: &resolver.ValidatePhase{
+					With: []resolver.ProviderValidation{
+						{
+							Provider: "validation",
+							Inputs: map[string]*spec.ValueRef{
+								"expression": {Literal: `__self in ["linux", "darwin", "windows"]`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	assert.Contains(t, result.Tests, "resolver-goos-invalid")
+	tc := result.Tests["resolver-goos-invalid"]
+	assert.True(t, tc.ExpectFailure)
+	assert.Contains(t, tc.Description, "expression")
+}
+
+func TestScaffold_DeterministicOrder(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"zulu":  {Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}},
+			"alpha": {Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}},
+			"mike":  {Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}},
+		},
+	}
+
+	result1 := Scaffold(input)
+	result2 := Scaffold(input)
+
+	yaml1, err1 := ScaffoldToYAML(result1)
+	require.NoError(t, err1)
+	yaml2, err2 := ScaffoldToYAML(result2)
+	require.NoError(t, err2)
+
+	assert.Equal(t, string(yaml1), string(yaml2), "scaffold output should be deterministic")
+}
+
+func TestScaffoldToYAML_ContainsExpectedContent(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"repo": {
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "static"},
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+	out, err := ScaffoldToYAML(result)
+
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "tests:")
+	assert.Contains(t, string(out), "resolve-defaults")
+	assert.Contains(t, string(out), "resolver-repo")
+}
+
+func exprPtr(s string) *celexp.Expression {
+	e := celexp.Expression(s)
+	return &e
+}

--- a/pkg/solution/soltesting/watch.go
+++ b/pkg/solution/soltesting/watch.go
@@ -1,0 +1,363 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/fsnotify/fsnotify"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultDebounceDuration is the default debounce interval for file changes.
+	// Rapid successive writes (e.g. editor save-all) are collapsed into a single re-run.
+	DefaultDebounceDuration = 300 * time.Millisecond
+)
+
+// WatchOptions configures the watch mode behaviour.
+type WatchOptions struct {
+	// DebounceDuration controls how long to wait after the last file change
+	// before triggering a re-run. Defaults to DefaultDebounceDuration.
+	DebounceDuration time.Duration
+
+	// OnRunStart is called just before each test re-run.
+	// The string argument identifies the triggering file (relative path when possible).
+	OnRunStart func(triggerFile string)
+
+	// OnRunComplete is called after each test re-run with the results.
+	OnRunComplete func(results []TestResult, elapsed time.Duration, err error)
+}
+
+// WatchResult captures the outcome of a single watch-triggered test run.
+type WatchResult struct {
+	// TriggerFile is the file change that caused the re-run.
+	TriggerFile string
+	// Results contains the test outcomes.
+	Results []TestResult
+	// Elapsed is the wall-clock duration of the run.
+	Elapsed time.Duration
+	// Err is set when the run fails for infrastructure reasons.
+	Err error
+}
+
+// Watcher monitors solution files for changes and re-runs affected tests.
+type Watcher struct {
+	// Runner is the test runner to use for re-runs.
+	Runner *Runner
+
+	// TestsPath is the path to the solution file or directory being tested.
+	TestsPath string
+
+	// Options configures watch behaviour.
+	Options WatchOptions
+
+	// mu protects watchedFiles and solutionFileMap.
+	mu              sync.Mutex
+	watchedFiles    map[string]bool          // set of files currently monitored
+	solutionFileMap map[string]*SolutionInfo // watched file → owning solution info
+}
+
+// SolutionInfo tracks the files associated with a single solution.
+type SolutionInfo struct {
+	// SolutionPath is the absolute path to the main solution file.
+	SolutionPath string
+	// ComposeFiles are the absolute paths of the compose files referenced by
+	// the solution's compose field.
+	ComposeFiles []string
+}
+
+// Watch starts monitoring files and re-running tests on changes. It blocks
+// until ctx is cancelled (typically via Ctrl-C). The initial test run is
+// executed immediately before entering the watch loop.
+func (w *Watcher) Watch(ctx context.Context) error {
+	debounce := w.Options.DebounceDuration
+	if debounce == 0 {
+		debounce = DefaultDebounceDuration
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating file watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	// Initial discovery and first run.
+	if err := w.discoverAndWatch(watcher); err != nil {
+		return fmt.Errorf("initial discovery: %w", err)
+	}
+
+	// Run tests once immediately.
+	w.triggerRun(ctx, "(initial run)")
+
+	// Watch loop with debounce.
+	var (
+		debounceTimer *time.Timer
+		triggerFile   string
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return ctx.Err()
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			// Only react to writes, creates, and renames (which look like creates).
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) {
+				continue
+			}
+
+			// Only care about YAML files.
+			ext := strings.ToLower(filepath.Ext(event.Name))
+			if ext != ".yaml" && ext != ".yml" {
+				continue
+			}
+
+			triggerFile = event.Name
+
+			// On Create or Rename, try to add the new file to the watcher.
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+				_ = watcher.Add(event.Name)
+			}
+
+			// Reset the debounce timer.
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.NewTimer(debounce)
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Log watcher errors but don't abort — the filesystem watcher
+			// can recover from transient errors.
+			if w.Options.OnRunComplete != nil {
+				w.Options.OnRunComplete(nil, 0, fmt.Errorf("file watcher error: %w", err))
+			}
+
+		case <-func() <-chan time.Time {
+			if debounceTimer != nil {
+				return debounceTimer.C
+			}
+			// Never fires if no timer is set.
+			return make(chan time.Time)
+		}():
+			debounceTimer = nil
+
+			// Re-discover files (picks up new compose files, renamed solutions).
+			if discoverErr := w.discoverAndWatch(watcher); discoverErr != nil {
+				if w.Options.OnRunComplete != nil {
+					w.Options.OnRunComplete(nil, 0, fmt.Errorf("re-discovery failed: %w", discoverErr))
+				}
+				continue
+			}
+
+			w.triggerRun(ctx, triggerFile)
+		}
+	}
+}
+
+// triggerRun performs a single test run cycle.
+func (w *Watcher) triggerRun(ctx context.Context, triggerFile string) {
+	if w.Options.OnRunStart != nil {
+		w.Options.OnRunStart(triggerFile)
+	}
+
+	solutions, err := DiscoverSolutions(w.TestsPath)
+	if err != nil {
+		if w.Options.OnRunComplete != nil {
+			w.Options.OnRunComplete(nil, 0, fmt.Errorf("discovery failed: %w", err))
+		}
+		return
+	}
+
+	if len(solutions) == 0 {
+		if w.Options.OnRunComplete != nil {
+			w.Options.OnRunComplete(nil, 0, nil)
+		}
+		return
+	}
+
+	start := time.Now()
+	results, runErr := w.Runner.Run(ctx, solutions)
+	elapsed := time.Since(start)
+
+	// Wait for progress output to flush.
+	if w.Runner.Progress != nil {
+		w.Runner.Progress.Wait()
+	}
+
+	if w.Options.OnRunComplete != nil {
+		w.Options.OnRunComplete(results, elapsed, runErr)
+	}
+}
+
+// discoverAndWatch discovers all solution and compose files, adds them to the
+// fsnotify watcher, and updates the internal tracking maps.
+func (w *Watcher) discoverAndWatch(watcher *fsnotify.Watcher) error {
+	infos, err := discoverWatchableFiles(w.TestsPath)
+	if err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	newFiles := make(map[string]bool)
+	newMap := make(map[string]*SolutionInfo)
+
+	for _, info := range infos {
+		// Watch the solution file itself.
+		newFiles[info.SolutionPath] = true
+		newMap[info.SolutionPath] = info
+
+		// Watch compose files.
+		for _, cf := range info.ComposeFiles {
+			newFiles[cf] = true
+			newMap[cf] = info
+		}
+
+		// Watch the directory containing the solution so we catch new files.
+		dir := filepath.Dir(info.SolutionPath)
+		newFiles[dir] = true
+	}
+
+	// Remove watches for files no longer relevant.
+	for f := range w.watchedFiles {
+		if !newFiles[f] {
+			_ = watcher.Remove(f)
+		}
+	}
+
+	// Add watches for new files.
+	for f := range newFiles {
+		if !w.watchedFiles[f] {
+			if addErr := watcher.Add(f); addErr != nil {
+				// Skip files/dirs that no longer exist.
+				if !os.IsNotExist(addErr) {
+					return fmt.Errorf("watching %q: %w", f, addErr)
+				}
+			}
+		}
+	}
+
+	w.watchedFiles = newFiles
+	w.solutionFileMap = newMap
+	return nil
+}
+
+// discoverWatchableFiles returns the set of files to watch for the given path.
+func discoverWatchableFiles(testsPath string) ([]*SolutionInfo, error) {
+	info, err := os.Stat(testsPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat %q: %w", testsPath, err)
+	}
+
+	if !info.IsDir() {
+		si, err := discoverSolutionFiles(testsPath)
+		if err != nil {
+			return nil, err
+		}
+		if si == nil {
+			return nil, nil
+		}
+		return []*SolutionInfo{si}, nil
+	}
+
+	var results []*SolutionInfo
+	err = filepath.Walk(testsPath, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if fi.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		si, parseErr := discoverSolutionFiles(path)
+		if parseErr != nil || si == nil {
+			return nil //nolint:nilerr // skip non-solution files
+		}
+		results = append(results, si)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %q: %w", testsPath, err)
+	}
+
+	return results, nil
+}
+
+// discoverSolutionFiles parses a single solution file to extract its path and
+// any compose file paths for watching.
+func discoverSolutionFiles(filePath string) (*SolutionInfo, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", filePath, err)
+	}
+
+	var doc struct {
+		APIVersion string   `yaml:"apiVersion"`
+		Kind       string   `yaml:"kind"`
+		Compose    []string `yaml:"compose"`
+		Spec       struct {
+			Tests map[string]any `yaml:"tests"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, nil //nolint:nilerr // not a valid YAML file for our purposes
+	}
+
+	// Only watch solution files (must be a Solution kind or have tests).
+	if doc.Kind != "Solution" && len(doc.Spec.Tests) == 0 {
+		return nil, nil
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		absPath = filePath
+	}
+
+	si := &SolutionInfo{
+		SolutionPath: absPath,
+	}
+
+	// Resolve compose file globs.
+	if len(doc.Compose) > 0 {
+		solutionDir := filepath.Dir(absPath)
+		for _, pattern := range doc.Compose {
+			absPattern := pattern
+			if !filepath.IsAbs(pattern) {
+				absPattern = filepath.Join(solutionDir, pattern)
+			}
+			matches, globErr := doublestar.FilepathGlob(absPattern)
+			if globErr != nil {
+				continue // skip invalid globs
+			}
+			si.ComposeFiles = append(si.ComposeFiles, matches...)
+		}
+	}
+
+	return si, nil
+}

--- a/pkg/solution/soltesting/watch_test.go
+++ b/pkg/solution/soltesting/watch_test.go
@@ -1,0 +1,365 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverWatchableFiles_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	solutionFile := filepath.Join(dir, "solution.yaml")
+	err := os.WriteFile(solutionFile, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+spec:
+  tests:
+    basic-test:
+      command: [render, solution]
+      assertions:
+        - contains: "hello"
+`), 0o644)
+	require.NoError(t, err)
+
+	infos, err := discoverWatchableFiles(solutionFile)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, solutionFile, infos[0].SolutionPath)
+	assert.Empty(t, infos[0].ComposeFiles)
+}
+
+func TestDiscoverWatchableFiles_WithCompose(t *testing.T) {
+	dir := t.TempDir()
+
+	composeFile := filepath.Join(dir, "tests.yaml")
+	err := os.WriteFile(composeFile, []byte(`
+spec:
+  tests:
+    extra-test:
+      command: [render, solution]
+      assertions:
+        - contains: "world"
+`), 0o644)
+	require.NoError(t, err)
+
+	solutionFile := filepath.Join(dir, "solution.yaml")
+	err = os.WriteFile(solutionFile, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: compose-solution
+compose:
+  - tests.yaml
+spec:
+  tests:
+    basic-test:
+      command: [render, solution]
+      assertions:
+        - contains: "hello"
+`), 0o644)
+	require.NoError(t, err)
+
+	infos, err := discoverWatchableFiles(solutionFile)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, solutionFile, infos[0].SolutionPath)
+	require.Len(t, infos[0].ComposeFiles, 1)
+	assert.Equal(t, composeFile, infos[0].ComposeFiles[0])
+}
+
+func TestDiscoverWatchableFiles_Directory(t *testing.T) {
+	dir := t.TempDir()
+
+	sol1 := filepath.Join(dir, "sol1.yaml")
+	err := os.WriteFile(sol1, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: solution-one
+spec:
+  tests:
+    test-one:
+      command: [render, solution]
+      assertions:
+        - contains: "one"
+`), 0o644)
+	require.NoError(t, err)
+
+	sol2 := filepath.Join(dir, "sol2.yaml")
+	err = os.WriteFile(sol2, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: solution-two
+spec:
+  tests:
+    test-two:
+      command: [render, solution]
+      assertions:
+        - contains: "two"
+`), 0o644)
+	require.NoError(t, err)
+
+	// Non-solution file should be ignored
+	err = os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# Not a solution"), 0o644)
+	require.NoError(t, err)
+
+	infos, err := discoverWatchableFiles(dir)
+	require.NoError(t, err)
+	assert.Len(t, infos, 2)
+}
+
+func TestDiscoverWatchableFiles_SkipsNonSolution(t *testing.T) {
+	dir := t.TempDir()
+
+	// File with no tests and no Solution kind
+	nonsol := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(nonsol, []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: something
+`), 0o644)
+	require.NoError(t, err)
+
+	infos, err := discoverWatchableFiles(dir)
+	require.NoError(t, err)
+	assert.Empty(t, infos)
+}
+
+func TestDiscoverWatchableFiles_NonexistentPath(t *testing.T) {
+	_, err := discoverWatchableFiles("/nonexistent/path/solution.yaml")
+	assert.Error(t, err)
+}
+
+func TestWatcher_DebounceCollapses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping debounce test in short mode")
+	}
+
+	dir := t.TempDir()
+	solutionFile := filepath.Join(dir, "solution.yaml")
+	writeSolution := func() {
+		err := os.WriteFile(solutionFile, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: debounce-test
+spec:
+  tests:
+    basic:
+      command: [render, solution]
+      assertions:
+        - contains: "hello"
+`), 0o644)
+		require.NoError(t, err)
+	}
+	writeSolution()
+
+	var mu sync.Mutex
+	runStartCount := 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	w := &Watcher{
+		Runner: &Runner{
+			Concurrency: 1,
+			DryRun:      true, // don't actually execute commands
+		},
+		TestsPath: solutionFile,
+		Options: WatchOptions{
+			DebounceDuration: 200 * time.Millisecond,
+			OnRunStart: func(_ string) {
+				mu.Lock()
+				runStartCount++
+				mu.Unlock()
+			},
+			OnRunComplete: func(_ []TestResult, _ time.Duration, _ error) {
+				mu.Lock()
+				count := runStartCount
+				mu.Unlock()
+				// After initial run + 1 debounced run = 2, cancel
+				if count >= 2 {
+					cancel()
+				}
+			},
+		},
+	}
+
+	// Start watching in background
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Watch(ctx)
+	}()
+
+	// Wait for initial run to complete
+	time.Sleep(500 * time.Millisecond)
+
+	// Rapid successive writes — should be debounced into one run
+	for i := 0; i < 5; i++ {
+		writeSolution()
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for completion or timeout
+	select {
+	case err := <-done:
+		// context.Canceled is expected
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(6 * time.Second):
+		t.Fatal("watcher did not complete within timeout")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Initial run = 1, debounced run = 1, total = 2
+	assert.Equal(t, 2, runStartCount, "expected exactly 2 runs: initial + 1 debounced")
+}
+
+func TestWatcher_CancelStopsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	solutionFile := filepath.Join(dir, "solution.yaml")
+	err := os.WriteFile(solutionFile, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cancel-test
+spec:
+  tests:
+    basic:
+      command: [render, solution]
+      assertions:
+        - contains: "hello"
+`), 0o644)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w := &Watcher{
+		Runner: &Runner{
+			Concurrency: 1,
+			DryRun:      true,
+		},
+		TestsPath: solutionFile,
+		Options: WatchOptions{
+			DebounceDuration: 100 * time.Millisecond,
+			OnRunComplete: func(_ []TestResult, _ time.Duration, _ error) {
+				// Cancel after initial run
+				cancel()
+			},
+		},
+	}
+
+	err = w.Watch(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWatcher_FileCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping file creation test in short mode")
+	}
+
+	dir := t.TempDir()
+	solutionFile := filepath.Join(dir, "solution.yaml")
+	err := os.WriteFile(solutionFile, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: creation-test
+spec:
+  tests:
+    basic:
+      command: [render, solution]
+      assertions:
+        - contains: "hello"
+`), 0o644)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	runCount := 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	w := &Watcher{
+		Runner: &Runner{
+			Concurrency: 1,
+			DryRun:      true,
+		},
+		TestsPath: dir, // watch directory
+		Options: WatchOptions{
+			DebounceDuration: 200 * time.Millisecond,
+			OnRunStart: func(_ string) {
+				mu.Lock()
+				runCount++
+				mu.Unlock()
+			},
+			OnRunComplete: func(_ []TestResult, _ time.Duration, _ error) {
+				mu.Lock()
+				count := runCount
+				mu.Unlock()
+				if count >= 2 {
+					cancel()
+				}
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Watch(ctx)
+	}()
+
+	// Wait for initial run
+	time.Sleep(500 * time.Millisecond)
+
+	// Create a new solution file in the watched directory
+	newSol := filepath.Join(dir, "new-solution.yaml")
+	err = os.WriteFile(newSol, []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: new-solution
+spec:
+  tests:
+    new-test:
+      command: [render, solution]
+      assertions:
+        - contains: "new"
+`), 0o644)
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(6 * time.Second):
+		t.Fatal("watcher did not react to new file within timeout")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, runCount, 2, "expected at least 2 runs (initial + file creation)")
+}
+
+func TestDiscoverSolutionFiles_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	badFile := filepath.Join(dir, "bad.yaml")
+	err := os.WriteFile(badFile, []byte(`{{{not valid yaml`), 0o644)
+	require.NoError(t, err)
+
+	si, err := discoverSolutionFiles(badFile)
+	assert.NoError(t, err) // should not error, just return nil
+	assert.Nil(t, si)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3380,3 +3380,69 @@ spec:
 	assert.Equal(t, 0, exitCode, "expected exit code 0 for composed tests\nstdout: %s\nstderr: %s", stdout, stderr)
 	assert.Contains(t, stdout, "composed-test", "composed test should appear in output")
 }
+
+func TestIntegration_Test_Init(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-init-example
+  version: 1.0.0
+spec:
+  resolvers:
+    repo:
+      description: Repository name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+    version:
+      description: Version
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "1.0.0"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: '^\d+\.\d+\.\d+$'
+            message: "Invalid version format"
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"test", "init",
+		"-f", solutionFile,
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0")
+	assert.Contains(t, stdout, "tests:")
+	assert.Contains(t, stdout, "resolve-defaults")
+	assert.Contains(t, stdout, "render-defaults")
+	assert.Contains(t, stdout, "lint")
+	assert.Contains(t, stdout, "resolver-repo")
+	assert.Contains(t, stdout, "resolver-version")
+	assert.Contains(t, stdout, "resolver-version-invalid")
+	assert.Contains(t, stdout, "expectFailure: true")
+}
+
+func TestIntegration_Test_Init_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runScafctl(t,
+		"test", "init",
+		"-f", "/nonexistent/solution.yaml",
+	)
+
+	assert.NotEqual(t, 0, exitCode, "expected non-zero exit code")
+	assert.Contains(t, stderr, "reading solution file")
+}


### PR DESCRIPTION
- Add 'scafctl test init' command that generates starter test suites by analyzing solution structure (resolvers, validation rules, workflow actions)
- Add '--watch' flag to 'scafctl test functional' for automatic re-runs on file changes with fsnotify-based file watching and 300ms debounce
- Generate smoke tests (resolve-defaults, render-defaults, lint), per-resolver tests with non-null assertions, validation failure tests (expectFailure), and per-action tests with provider tags
- Add scaffold-demo example and tested-solution watch mode documentation
- Update tutorials, design docs, and future-enhancements to reflect new features

Closes #61 
Closes #62 