### PR TITLE
feat: add object type coercion, single final-value coercion, and acti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ scafctl secrets get my-api-key
 scafctl secrets exists my-api-key
 scafctl secrets list
 
+# Include internal secrets (e.g. auth tokens)
+scafctl secrets list --all
+scafctl secrets get scafctl.auth.entra.metadata --all
+
 # Rotate encryption key
 scafctl secrets rotate
 
@@ -491,6 +495,7 @@ scafctl resolver graph -f solution.yaml
 # Configuration and secrets
 scafctl config show
 scafctl secrets list
+scafctl secrets list --all  # include auth tokens
 
 # Authentication
 scafctl auth login entra

--- a/docs/design/actions.md
+++ b/docs/design/actions.md
@@ -121,7 +121,7 @@ spec:
         # Metadata
         description: "Human-readable description of what this action does"
         displayName: "Deploy Application"
-        sensitive: false  # Whether results should be redacted in logs
+        sensitive: false  # Whether results should be redacted in table output
 
         # Provider
         provider: api
@@ -566,7 +566,7 @@ Providers can declare `retryable: false` in their descriptor if retries are neve
 
 ## Sensitive Actions
 
-Actions can be marked as sensitive to redact results in logs.
+Actions can be marked as sensitive to control result visibility.
 
 ~~~yaml
 actions:
@@ -579,7 +579,9 @@ actions:
 
 When `sensitive: true`:
 
-- Results are redacted in logs and debug output
+- Results are redacted in table/interactive output (human-facing)
+- JSON and YAML output reveals values for machine consumption (Terraform model)
+- Use `--show-sensitive` to reveal values in all output formats
 - The value is still available to dependent actions
 - Error messages are sanitized to prevent leaking sensitive data (e.g., secrets in request bodies)
 - The `__actions.<name>.error` field contains a sanitized error message

--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -227,10 +227,12 @@ For the Entra handler:
 | Secret Name | Description |
 |-------------|-------------|
 | `scafctl.auth.entra.refresh_token` | Long-lived refresh token |
-| `scafctl.auth.entra.metadata` | Token metadata (claims, tenant, expiry) |
+| `scafctl.auth.entra.metadata` | Token metadata (claims, tenant, client ID, expiry) |
 | `scafctl.auth.entra.token.<scope-hash>` | Cached access tokens by scope |
 
 The scope hash is a base64url-encoded representation of the scope string.
+
+The metadata includes the `clientId` used during login so that token refreshes always use the same client ID that originally obtained the refresh token, regardless of what client ID is in the current configuration.
 
 ---
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -24,7 +24,7 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 
 | Command | Status | Notes |
 |---------|--------|-------|
-| `run solution` | ✅ Implemented | Full support with actions |
+| `run solution` | ✅ Implemented | Requires workflow (errors if no workflow defined; use `run resolver` for resolver-only) |
 | `run resolver` | ✅ Implemented | Resolver-only execution for debugging and inspection |
 | `render solution` | ✅ Implemented | Includes graph and snapshot modes |
 | `get solution/provider/resolver` | ✅ Implemented | |
@@ -76,7 +76,7 @@ scafctl run solution "example@^1.2"         # planned
 
 ## Running a Solution
 
-Execute a solutions resolver and perform its actions.
+Execute a solution's resolvers and perform its workflow actions. The solution **must** define a `workflow` section with actions — if no workflow is defined, the command errors and suggests using `scafctl run resolver` instead.
 
 ~~~bash
 scafctl run solution example
@@ -670,8 +670,14 @@ Securely manage encrypted secrets for authentication and configuration:
 # List all secrets
 scafctl secrets list
 
+# List all secrets including internal (auth tokens, etc.)
+scafctl secrets list --all
+
 # Get a secret value
 scafctl secrets get my-api-key
+
+# Get an internal secret (e.g. auth token metadata)
+scafctl secrets get scafctl.auth.entra.metadata --all
 
 # Set a secret (prompts for value)
 scafctl secrets set my-api-key
@@ -751,8 +757,11 @@ scafctl run resolver -f solution.yaml
 # Run specific resolvers (with their transitive dependencies)
 scafctl run resolver db config -f solution.yaml
 
-# JSON output (always includes __execution metadata)
+# JSON output (includes __execution metadata by default)
 scafctl run resolver -f solution.yaml -o json
+
+# JSON output without __execution metadata
+scafctl run resolver -f solution.yaml -o json --hide-execution
 
 # Skip transform and validation phases
 scafctl run resolver --skip-transform -f solution.yaml

--- a/docs/design/entra-auth-implementation.md
+++ b/docs/design/entra-auth-implementation.md
@@ -1,0 +1,109 @@
+---
+title: Entra ID Authentication Implementation Decision
+---
+
+# Entra ID Authentication: Manual Implementation vs MSAL
+
+## Status
+
+**Decided** — Manual implementation retained.
+
+## Context
+
+The `pkg/auth/entra` package implements OAuth 2.0 authentication against Azure Entra ID (formerly Azure AD). A question arose whether to use the official [Microsoft Authentication Library for Go (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-go) instead of the current hand-rolled implementation.
+
+## Current Implementation
+
+The package manually implements all OAuth 2.0 flows using raw `net/http` POST calls to Azure Entra ID token endpoints. There are zero Azure SDK or MSAL dependencies in the project.
+
+### Flows Implemented
+
+| Flow | Grant Type | File | Use Case |
+|------|-----------|------|----------|
+| Device Code | `urn:ietf:params:oauth:grant-type:device_code` | `device_flow.go` | Interactive CLI login |
+| Client Credentials (Service Principal) | `client_credentials` | `service_principal.go` | Non-interactive, from `AZURE_CLIENT_*` env vars |
+| Workload Identity | `client_credentials` with `client_assertion` (JWT bearer) | `workload_identity.go` | Kubernetes federated token exchange |
+| Refresh Token | `refresh_token` | `token.go` | Silent token renewal with rotation |
+
+### Flow Priority
+
+Auto-detection order: **Workload Identity > Service Principal > Device Code**.
+
+### Token Caching
+
+Two layers of persistence, both backed by `secrets.Store` (OS keychain/credential store):
+
+1. **Refresh Token + Metadata** — persistent refresh token and `TokenMetadata` (claims, expiry, tenant) for device code flow
+2. **Access Token Cache** (`TokenCache`) — per-scope cached access tokens keyed by `scafctl.auth.entra.token.<base64url(scope)>`, used by all three flows via a generic `getCachedOrAcquireToken` helper
+
+### Test Coverage
+
+- ~1,500 lines of production code
+- ~3,500 lines of tests (unit + integration + live)
+- `MockHTTPClient` with queued responses and request recording
+- `httptest.Server`-based integration tests simulating real Entra endpoints
+- Live integration tests (build tag `integration`) against real Azure
+
+## Pros of the Manual Approach
+
+| Advantage | Detail |
+|-----------|--------|
+| **Zero external dependencies** | No Azure SDK in `go.mod`. MSAL brings transitive deps that increase module size and maintenance surface. |
+| **Full control over caching** | Custom `TokenCache` integrates directly with `secrets.Store`. MSAL uses an in-memory cache with a serialization contract — an adapter to bridge it to `secrets.Store` would be needed regardless. |
+| **Testability** | The `HTTPClient` interface + `MockHTTPClient` makes every flow fully testable without mocking MSAL internals. MSAL's test surface is harder to stub cleanly. |
+| **Workload Identity** | MSAL Go doesn't natively support the `AZURE_FEDERATED_TOKEN_FILE` Kubernetes pattern. Custom code or `azidentity` (a heavier dependency) would still be required. |
+| **Slim binary** | No compiled code from unused MSAL features. |
+
+## Cons of the Manual Approach
+
+| Disadvantage | Detail |
+|--------------|--------|
+| **Maintenance burden** | OAuth 2.0 protocol implementation must be maintained manually. Microsoft endpoint behavior changes or new error codes require manual updates. |
+| **No PKCE / Auth Code flow** | MSAL supports interactive browser auth with PKCE out of the box. Adding this manually is significant work. |
+| **No certificate-based auth** | MSAL supports client certificate credentials natively; currently missing. |
+| **No instance discovery / sovereign clouds** | MSAL handles authority validation, instance discovery metadata, and sovereign cloud endpoints (Azure Government, Azure China). The manual code hardcodes `login.microsoftonline.com`. |
+| **No Conditional Access / Claims Challenge** | MSAL handles the `claims` parameter for Conditional Access challenges automatically. |
+| **Basic JWT parsing** | Manual `splitJWT` + base64url decode has no signature validation, no `nbf`/`aud` checks. MSAL validates tokens properly. |
+| **Potential security gaps** | MSAL is reviewed by Microsoft's security team. A hand-rolled implementation may miss subtle requirements (token binding, nonce validation, etc.). |
+
+## What Switching to MSAL Would Involve
+
+Switching is not a clean drop-in replacement:
+
+1. **Cache adapter required** — MSAL uses an in-memory cache with `ExportReplace`/`ExportAdd` serialization. An adapter to persist to `secrets.Store` would need to be written, which is roughly equivalent to what `cache.go` does today.
+2. **Workload Identity still custom** — MSAL Go doesn't support `AZURE_FEDERATED_TOKEN_FILE`. That flow would remain manual, or require adding `azidentity` (which supports it but brings a much heavier dependency tree).
+3. **Test strategy changes** — Mock strategy would shift from mocking HTTP calls to mocking MSAL client objects, which are harder to stub cleanly.
+5. **Two dependency options**:
+   - `microsoft-authentication-library-for-go` (MSAL) — lower-level, provides device code + client credentials
+   - `azure-identity` (`azidentity`) — higher-level, wraps MSAL, adds `DefaultAzureCredential` chain and workload identity support, but significantly heavier
+
+## Recommendation
+
+**Retain the manual implementation.** The current approach is reasonable given the project's constraints:
+
+- Only 3 well-defined flows are needed (device code, client credentials, workload identity)
+- Custom caching requirements (`secrets.Store` integration) would require adapter code regardless
+- The code is well-tested (~3,500 lines of tests including integration)
+- The project values minimal dependencies
+
+> **Note:** The multi-resource scope grouping logic has been removed, simplifying
+> the device code flow. Login now targets a single set of scopes in one flow.
+> Access tokens for additional resources can be minted at runtime using the
+> refresh token. This slightly lowers the barrier to a future MSAL migration,
+> since there is less custom protocol-level logic to preserve. However, the
+> cache adapter and workload identity gaps remain the primary friction points.
+
+### When to Reconsider
+
+Switch to MSAL if any of the following become requirements:
+
+- **Interactive browser auth with PKCE** — significant work to implement manually
+- **Client certificate authentication** — non-trivial to implement correctly (key signing, x5c/x5t headers)
+- **Sovereign cloud support** — instance discovery and authority validation across Azure Government, Azure China, etc.
+- **Conditional Access / Claims Challenges** — protocol-level complexity that MSAL handles transparently
+
+At that point, the maintenance cost of adding these flows manually would exceed the cost of integrating MSAL plus writing the required adapter code.
+
+### Pragmatic Middle Ground
+
+The `HTTPClient` interface and `auth.Handler` abstraction mean the internal implementation can be swapped without affecting consumers. If MSAL adoption becomes warranted, the change is isolated to `pkg/auth/entra` internals.

--- a/docs/design/misc.md
+++ b/docs/design/misc.md
@@ -113,6 +113,7 @@ Render mode supports secret redaction via `--redact` flag on snapshots.
 
 - **Storage**: AES-256-GCM encryption with OS keychain for master key
 - **CLI**: `scafctl secrets list/get/set/delete/exists/export/import/rotate`
+- **Internal secrets**: Auth tokens use `scafctl.*` prefix; visible via `--all` flag
 - **Platform paths** (XDG Base Directory Specification):
   - Linux: `~/.local/share/scafctl/secrets/`
   - macOS: `~/.local/share/scafctl/secrets/`

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -122,11 +122,11 @@ flowchart TD
 
 2. **Decode** - If the provider defines a `Decode` function in its descriptor, scafctl calls it to convert the validated `map[string]any` into a strongly-typed structure. This step is optional; providers can work directly with maps.
 
-3. **Execute** - The provider's `Execute(ctx, input)` method runs with the validated (and optionally decoded) inputs. The provider performs its operation based on the execution mode and dry-run flag from the context. Providers that need access to resolver values retrieve them via `ResolverContextFromContext(ctx)`.
+3. **Execute** - The provider's `Execute(ctx, input)` method runs with the validated (and optionally decoded) inputs. The provider performs its operation based on the execution mode and dry-run flag from the context. Providers that need access to resolver values retrieve them via `ResolverContextFromContext(ctx)`. Providers producing user-visible output can stream it to the terminal via `IOStreamsFromContext(ctx)` and set `Output.Streamed = true` to prevent double-printing.
 
 4. **Output Schema Validation** - scafctl validates the `Output.Data` field against the provider's `OutputSchemas` for the current capability. Each capability can define different required output fields. This ensures both real and mock outputs conform to the declared structure for the specific execution context.
 
-5. **Return** - The validated `Output` (containing `Data`, optional `Warnings`, and optional `Metadata`) is returned to the caller (resolver or action orchestrator).
+5. **Return** - The validated `Output` (containing `Data`, optional `Warnings`, optional `Metadata`, and optional `Streamed` flag) is returned to the caller (resolver or action orchestrator).
 
 **Error Handling:**
 

--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -25,7 +25,7 @@ Resolvers do not cause side effects. They only compute values.
 | Phase-based execution (DAG ordering) | ✅ Implemented | `pkg/resolver/phase.go` |
 | Dependency extraction (CEL, templates, `dependsOn`) | ✅ Implemented | `pkg/resolver/graph.go` |
 | Cycle detection | ✅ Implemented | Uses `pkg/dag` |
-| Type coercion (string, int, float, bool, array, any) | ✅ Implemented | `pkg/spec/types.go` |
+| Type coercion (string, int, float, bool, array, object, any) | ✅ Implemented | `pkg/spec/types.go` |
 | Additional types: `time`, `duration` | ✅ Implemented | `pkg/spec/types.go` |
 | Special symbols (`__self`, `__item`, `__index`) | ✅ Implemented | `pkg/resolver/executor.go` |
 | Iteration aliases (`item`, `index` in forEach) | ✅ Implemented | `pkg/spec/foreach.go` |
@@ -119,9 +119,10 @@ Resolvers support optional type declarations for validation and automatic type c
 - `float` - Floating-point numbers
 - `bool` - Boolean true/false
 - `array` - Ordered lists (coerces single values to single-element arrays)
+- `object` - Key-value maps (`map[string]any`). Rejects non-map values.
 - `time` - Time values (parses ISO 8601 strings like `2026-01-14T12:00:00Z`)
 - `duration` - Duration values (parses Go duration strings like `5m`, `1h30m`, `500ms`)
-- `any` - No type constraint (default, use for maps/objects with dynamic structure)
+- `any` - No type constraint (default). Accepts any value with no validation or coercion.
 
 ### Type Aliases
 
@@ -131,6 +132,7 @@ For convenience, the following aliases are supported:
 - `integer` → `int`
 - `number` → `float`
 - `boolean` → `bool`
+- `map` → `object`
 
 ### Type Declaration
 
@@ -179,15 +181,16 @@ When a type is explicitly declared, scafctl will attempt to coerce the resolved 
 - `"2026-01-14T12:00:00Z"` → `time.Time` (string to time)
 - `"5m30s"` → `time.Duration` (string to duration)
 - `"-1h"` → `time.Duration` (negative duration)
+- `map[string]any{"key": "val"}` → `map[string]any{"key": "val"}` (map to object, validated)
 
 **Coercion rules:**
 
 - Type coercion only occurs when a type is explicitly declared
 - If coercion fails, the resolver fails with a type error
-- Coercion happens **twice**: after the resolve phase completes (before transform begins) and after the transform phase completes (before validate begins)
-- **No inter-step coercion**: Type coercion does NOT occur between individual transform steps. Transform steps work with the actual runtime types of values. Only the final output of the transform phase is coerced.
-- This ensures type consistency at resolver phase boundaries while allowing flexible type manipulation within the transform phase
+- Coercion happens **once**: on the final resolver value, after the last active phase (resolve or transform) completes and before validate begins. The `type` field describes the resolver's **output contract**, not the intermediate value between phases.
+- This means transform steps can work with raw provider types (e.g., `map[string]interface{}`) and reshape them freely — only the final output must match the declared type.
 - **Array coercion**: Non-array values are wrapped in a single-element array. Already-arrays pass through unchanged. This is useful when a field can accept either a single value or multiple values.
+- **Object coercion**: Accepts any map with string keys. Rejects non-map values (strings, ints, arrays, etc.) with a clear error.
 
 ### Type Validation
 
@@ -2374,7 +2377,7 @@ Resolvers support metadata fields for documentation and operational purposes:
 
 - **`description`**: Human-readable explanation of the resolver's purpose
 - **`displayName`**: Friendly name for UI and logging (defaults to resolver key)
-- **`sensitive`**: Boolean flag indicating the value should be redacted in logs and output
+- **`sensitive`**: Boolean flag indicating the value should be redacted in table/interactive output (human-facing). JSON and YAML output reveals sensitive values for machine consumption, following the Terraform model. Use `--show-sensitive` to reveal values in all output formats
 - **`example`**: Example value for documentation and testing
 
 ### Example

--- a/docs/design/solutions.md
+++ b/docs/design/solutions.md
@@ -299,6 +299,7 @@ Depending on the command:
 scafctl run solution myapp
 ~~~
 
+- Requires a workflow — errors if no workflow is defined (use `scafctl run resolver` for resolver-only execution)
 - Execute the rendered action graph
 - Invoke providers
 - Perform side effects

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -16,6 +16,7 @@ Step-by-step guides for learning scafctl features.
 
 - [Resolver Tutorial](resolver-tutorial.md) — Master dynamic value resolution
 - [Run Resolver Tutorial](run-resolver-tutorial.md) — Debug and inspect resolver execution
+- [Run Provider Tutorial](run-provider-tutorial.md) — Test providers in isolation
 - [Actions Tutorial](actions-tutorial.md) — Learn how to use actions for workflow automation
 - [Authentication Tutorial](auth-tutorial.md) — Set up authentication for your workflows
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
@@ -29,8 +30,8 @@ Step-by-step guides for learning scafctl features.
 
 ## Reference
 
-- [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution with embedded and external shells
 - [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
+- [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
 - [Provider Development Guide](provider-development.md) — Build custom providers
 - [Plugin Development Guide](plugin-development.md) — Extend scafctl with plugins

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -28,7 +28,7 @@ Actions are the execution phase of a scafctl solution. While **resolvers** compu
 
 ### 1. Hello World
 
-The simplest action workflow:
+The simplest action workflow. Create a file called `hello-actions.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -61,65 +61,101 @@ spec:
 
 Run it:
 ```bash
-scafctl run solution -f hello.yaml
+scafctl run solution -f hello-actions.yaml
+```
+
+Output:
+
+```
+Hello, World!
 ```
 
 ### 2. Dependencies
 
-Actions can depend on other actions:
+Actions can depend on other actions. Create a file called `build-pipeline.yaml`:
 
 ```yaml
-workflow:
-  actions:
-    build:
-      provider: exec
-      inputs:
-        command: "go build ./..."
-    
-    test:
-      provider: exec
-      dependsOn: [build]  # test runs AFTER build
-      inputs:
-        command: "go test ./..."
-    
-    deploy:
-      provider: exec
-      dependsOn: [test]   # deploy runs AFTER test
-      inputs:
-        command: "deploy.sh"
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: build-pipeline
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        provider: exec
+        inputs:
+          command: "echo Building..."
+      
+      test:
+        provider: exec
+        dependsOn: [build]  # test runs AFTER build
+        inputs:
+          command: "echo Testing..."
+      
+      deploy:
+        provider: exec
+        dependsOn: [test]   # deploy runs AFTER test
+        inputs:
+          command: "echo Deploying..."
 ```
 
 This creates a linear chain: `build → test → deploy`
 
+Run it:
+
+```bash
+scafctl run solution -f build-pipeline.yaml
+```
+
+Output:
+
+```
+Building...
+Testing...
+Deploying...
+```
+
 ### 3. Parallel Execution
 
-Actions without dependencies (or with the same dependencies) run in parallel:
+Actions without dependencies (or with the same dependencies) run in parallel. Create a file called `parallel.yaml`:
 
 ```yaml
-workflow:
-  actions:
-    init:
-      provider: exec
-      inputs:
-        command: "init.sh"
-    
-    build:
-      provider: exec
-      dependsOn: [init]
-      inputs:
-        command: "build.sh"
-    
-    test:
-      provider: exec
-      dependsOn: [init]    # Same dependency as build
-      inputs:
-        command: "test.sh"  # Runs in PARALLEL with build
-    
-    deploy:
-      provider: exec
-      dependsOn: [build, test]  # Waits for BOTH
-      inputs:
-        command: "deploy.sh"
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: parallel-example
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      init:
+        provider: exec
+        inputs:
+          command: "echo Initializing..."
+      
+      build:
+        provider: exec
+        dependsOn: [init]
+        inputs:
+          command: "echo Building..."
+      
+      test:
+        provider: exec
+        dependsOn: [init]    # Same dependency as build
+        inputs:
+          command: "echo Testing..."  # Runs in PARALLEL with build
+      
+      deploy:
+        provider: exec
+        dependsOn: [build, test]  # Waits for BOTH
+        inputs:
+          command: "echo Deploying..."
 ```
 
 This creates a diamond pattern:
@@ -131,34 +167,555 @@ This creates a diamond pattern:
    deploy
 ```
 
-## Core Concepts
+Run it:
 
-### Providers
+```bash
+scafctl run solution -f parallel.yaml
+```
 
-Actions use providers to execute operations. Providers must have the `action` capability.
+Output (build and test may appear in either order since they run in parallel):
 
-Built-in providers with action capability:
-- `shell` - Execute shell commands
-- `http` - Make HTTP requests
-- `file` - File operations
-- `git` - Git operations
-- `sleep` - Delay execution
+```
+Initializing...
+[build] Building...
+[test] Testing...
+Deploying...
+```
+
+> **Note**: When actions run in parallel, their output is prefixed with `[action-name]` to distinguish which action produced each line. Actions running alone (like `init` and `deploy`) don't get a prefix.
+
+## Conditions (`when`)
+
+Actions can be conditional — they only execute when a CEL expression evaluates to `true`. If the condition is `false`, the action is skipped.
+
+Create a file called `conditional-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: conditional-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: environment
+          - provider: static
+            inputs:
+              value: staging
+
+  workflow:
+    actions:
+      setup:
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Setting up for ' + _.environment"
+
+      staging-deploy:
+        provider: exec
+        dependsOn: [setup]
+        when:
+          expr: "_.environment == 'staging'"
+        inputs:
+          command: "echo Deploying to staging..."
+
+      prod-deploy:
+        provider: exec
+        dependsOn: [setup]
+        when:
+          expr: "_.environment == 'prod'"
+        inputs:
+          command: "echo Deploying to production..."
+
+      notify:
+        provider: exec
+        dependsOn: [staging-deploy, prod-deploy]
+        inputs:
+          command:
+            expr: "'echo Deployment to ' + _.environment + ' complete'"
+```
+
+### Run with Default (staging)
+
+```bash
+scafctl run solution -f conditional-demo.yaml
+```
+
+Output:
+
+```
+Setting up for staging
+Deploying to staging...
+Deployment to staging complete
+```
+
+The `prod-deploy` action is skipped because the condition `_.environment == 'prod'` is `false`.
+
+### Run with Production
+
+```bash
+scafctl run solution -f conditional-demo.yaml -r environment=prod
+```
+
+Output:
+
+```
+Setting up for prod
+Deploying to production...
+Deployment to prod complete
+```
+
+Now `staging-deploy` is skipped and `prod-deploy` runs instead.
+
+---
+
+## ForEach
+
+ForEach expands a single action into multiple iterations — one for each item in an array. Each iteration can access the current element via `__item` and its index via `__index`.
+
+Create a file called `foreach-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: foreach-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    targets:
+      type: array
+      items:
+        type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - server1.example.com
+                - server2.example.com
+                - server3.example.com
+    version:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: v1.2.3
+
+  workflow:
+    actions:
+      build:
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Building version ' + _.version + '...'"
+
+      deploy:
+        provider: exec
+        dependsOn: [build]
+        forEach:
+          in:
+            expr: "_.targets"
+          concurrency: 2
+          onError: continue
+        inputs:
+          command:
+            expr: "'echo Deploying ' + _.version + ' to ' + __item"
+
+      verify:
+        provider: exec
+        dependsOn: [deploy]
+        inputs:
+          command:
+            expr: "'echo Verifying ' + string(size(_.targets)) + ' deployments...'"
+```
+
+```bash
+scafctl run solution -f foreach-demo.yaml
+```
+
+Output:
+
+```
+Building version v1.2.3...
+[deploy[0]] Deploying v1.2.3 to server1.example.com
+[deploy[1]] Deploying v1.2.3 to server2.example.com
+[deploy[2]] Deploying v1.2.3 to server3.example.com
+Verifying 3 deployments...
+```
+
+The `deploy` action expands into `deploy[0]`, `deploy[1]`, `deploy[2]` — one per target. With `concurrency: 2`, at most two deploy iterations run in parallel. The `verify` action waits for all iterations to complete.
+
+### ForEach Options
+
+| Option | Description |
+|--------|-------------|
+| `in` | CEL expression returning an array to iterate over |
+| `item` | Alias for `__item` (e.g., `item: server` lets you use `server` instead) |
+| `index` | Alias for `__index` |
+| `concurrency` | Max parallel iterations (default: unlimited) |
+| `onError` | `fail` (default) or `continue` — controls behavior when an iteration fails |
+
+---
+
+## Error Handling
+
+By default, if an action fails the entire workflow stops. Use `onError: continue` to allow the workflow to proceed past failures.
+
+Create a file called `error-handling-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: error-handling-demo
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+
+  workflow:
+    actions:
+      optional-cleanup:
+        description: Optional cleanup that might fail
+        provider: exec
+        onError: continue
+        inputs:
+          command: "echo 'Attempting optional cleanup...' && exit 1"
+
+      required-setup:
+        provider: exec
+        inputs:
+          command: "echo 'Running required setup...'"
+
+      main-work:
+        provider: exec
+        dependsOn: [optional-cleanup, required-setup]
+        inputs:
+          command: "echo 'Doing main work...'"
+```
+
+```bash
+scafctl run solution -f error-handling-demo.yaml
+```
+
+Output:
+
+```
+Attempting optional cleanup...
+Running required setup...
+Doing main work...
+```
+
+The `optional-cleanup` action fails (`exit 1`), but because `onError: continue` is set, the workflow continues. The `main-work` action still runs.
+
+Without `onError: continue`, the workflow would stop at `optional-cleanup` and `main-work` would be skipped.
+
+---
+
+## Action Results
+
+Actions can access results from previously completed actions using `__actions`. This enables data flow between actions.
+
+Create a file called `results-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: results-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    user_id:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+
+  workflow:
+    actions:
+      fetch-user:
+        provider: cel
+        inputs:
+          expression: |
+            {"id": 42, "name": "John Doe", "email": "john@example.com"}
+
+      greet:
+        provider: exec
+        dependsOn: [fetch-user]
+        inputs:
+          command:
+            expr: "'echo Hello, ' + __actions['fetch-user'].results.name + '!'"
+```
+
+```bash
+scafctl run solution -f results-demo.yaml
+```
+
+Output:
+
+```
+Hello, John Doe!
+```
+
+The `fetch-user` action uses the `cel` provider to return structured data. The `greet` action accesses that data via `__actions['fetch-user'].results.name`.
+
+### Available Fields in `__actions.<name>`
+
+| Field | Description |
+|-------|-------------|
+| `results` | The action's output data |
+| `status` | Execution status (`succeeded`, `failed`, `skipped`) |
+| `inputs` | Resolved input values |
+| `error` | Error message (if failed) |
+
+---
+
+## Retry
+
+Actions can automatically retry on failure with configurable backoff strategies.
+
+Create a file called `retry-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: retry-demo
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+
+  workflow:
+    actions:
+      fixed-retry:
+        description: Fixed delay between retries (always 2s)
+        provider: exec
+        retry:
+          maxAttempts: 3
+          backoff: fixed
+          initialDelay: 2s
+        inputs:
+          command: "echo 'Fixed retry attempt succeeded'"
+
+      linear-retry:
+        description: Linearly increasing delay (1s, 2s, 3s, ...)
+        provider: exec
+        dependsOn: [fixed-retry]
+        retry:
+          maxAttempts: 4
+          backoff: linear
+          initialDelay: 1s
+          maxDelay: 10s
+        inputs:
+          command: "echo 'Linear retry attempt succeeded'"
+
+      exponential-retry:
+        description: Exponentially increasing delay (500ms, 1s, 2s, 4s, ...)
+        provider: exec
+        dependsOn: [linear-retry]
+        retry:
+          maxAttempts: 5
+          backoff: exponential
+          initialDelay: 500ms
+          maxDelay: 30s
+        inputs:
+          command: "echo 'Exponential retry attempt succeeded'"
+
+      retry-with-timeout:
+        description: Retry combined with a per-action timeout
+        provider: exec
+        dependsOn: [exponential-retry]
+        timeout: 30s
+        retry:
+          maxAttempts: 3
+          backoff: exponential
+          initialDelay: 1s
+          maxDelay: 5s
+        inputs:
+          command: "echo 'Retry + timeout succeeded'"
+```
+
+```bash
+scafctl run solution -f retry-demo.yaml
+```
+
+Output:
+
+```
+Fixed retry attempt succeeded
+Linear retry attempt succeeded
+Exponential retry attempt succeeded
+Retry + timeout succeeded
+```
+
+Since all commands succeed on the first try, no retries occur. Retries only trigger on failures.
+
+### Backoff Strategies
+
+| Strategy | Delay pattern | Best for |
+|----------|--------------|----------|
+| `fixed` | Constant (e.g., always 2s) | Known recovery time |
+| `linear` | Increases linearly (1s, 2s, 3s, ...) | Gradually increasing wait |
+| `exponential` | Doubles each time (1s, 2s, 4s, 8s, ...) | External API calls, rate limits |
+
+### Conditional Retry (retryIf)
+
+Use a CEL expression to retry only on specific error types:
+
+```yaml
+retry:
+  maxAttempts: 5
+  backoff: exponential
+  initialDelay: 1s
+  retryIf: "__error.statusCode == 429 || __error.statusCode >= 500"
+```
+
+The `__error` variable provides context about the failure:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `__error.message` | string | The error message |
+| `__error.type` | string | Error category: `http`, `exec`, `timeout`, `validation`, `unknown` |
+| `__error.statusCode` | int | HTTP status code (0 for non-HTTP errors) |
+| `__error.exitCode` | int | Process exit code (0 for non-exec errors) |
+| `__error.attempt` | int | Current attempt number (1-based) |
+| `__error.maxAttempts` | int | Maximum retry attempts configured |
+
+Common patterns:
+
+```yaml
+# Only retry on timeouts
+retryIf: "__error.type == 'timeout'"
+
+# Retry on rate limits or server errors
+retryIf: "__error.statusCode == 429 || __error.statusCode >= 500"
+
+# Limit effective retries regardless of maxAttempts
+retryIf: "__error.attempt < 3"
+
+# Disable retry entirely (even with retry config present)
+retryIf: "false"
+```
+
+---
+
+## Timeout
+
+Limit how long an action can run before being terminated:
 
 ```yaml
 actions:
-  api-call:
-    provider: http
+  quick-check:
+    provider: exec
+    timeout: 30s
     inputs:
-      method: POST
-      url: "https://api.example.com/deploy"
-      body:
-        version:
-          expr: "_.version"
+      command: "echo 'Must finish in 30 seconds'"
 ```
 
-### Inputs
+If the action exceeds its timeout, it fails with a timeout error. You can combine `timeout` with `retry` to automatically retry timed-out operations.
 
-Inputs are passed to the provider. They support:
+---
+
+## Finally Section
+
+Finally actions **always run**, even if main actions fail. This is essential for cleanup operations like removing temporary resources.
+
+Create a file called `finally-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: finally-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    test_db:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: test_db_12345
+
+  workflow:
+    actions:
+      create-test-db:
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Creating test database: ' + _.test_db"
+
+      run-tests:
+        provider: exec
+        dependsOn: [create-test-db]
+        inputs:
+          command: "echo Running tests against test database..."
+
+      generate-reports:
+        provider: exec
+        dependsOn: [run-tests]
+        inputs:
+          command: "echo Generating test reports..."
+
+    finally:
+      cleanup-db:
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Dropping test database: ' + _.test_db"
+
+      notify:
+        provider: exec
+        dependsOn: [cleanup-db]
+        inputs:
+          command: "echo Workflow complete, cleanup finished"
+```
+
+```bash
+scafctl run solution -f finally-demo.yaml
+```
+
+Output:
+
+```
+Creating test database: test_db_12345
+Running tests against test database...
+Generating test reports...
+Dropping test database: test_db_12345
+Workflow complete, cleanup finished
+```
+
+The finally actions run after all main actions complete. If `run-tests` failed, the cleanup would still execute.
+
+### Finally Rules
+
+- Finally actions run **after all main actions** (whether they succeeded or failed)
+- Finally actions can only depend on **other finally actions** (not main actions)
+- ForEach is **not allowed** in the finally section
+
+---
+
+## Inputs Reference
+
+Inputs are passed to the provider and support several value types:
 
 **Literal values:**
 ```yaml
@@ -172,7 +729,7 @@ inputs:
 ```yaml
 inputs:
   environment:
-    rslvr: environment  # References resolver named "environment"
+    rslvr: environment
 ```
 
 **CEL expressions:**
@@ -189,243 +746,26 @@ inputs:
     tmpl: "Deploying {{ ._.project }} to {{ ._.environment }}"
 ```
 
-### Action Results
+---
 
-Actions can access results from previous actions using `__actions`:
+## Providers Reference
 
-```yaml
-actions:
-  build:
-    provider: exec
-    inputs:
-      command: "go build -o app"
-  
-  deploy:
-    provider: exec
-    dependsOn: [build]
-    inputs:
-      # Access build action's results
-      artifact:
-        expr: "__actions.build.results.output"
-```
+Actions use providers to execute operations. Providers must have the `action` capability.
 
-**Available in `__actions.<name>`:**
-- `results` - The action's output data
-- `status` - Execution status (succeeded, failed, skipped)
-- `inputs` - Resolved input values
-- `error` - Error message (if failed)
+Built-in providers with action capability:
 
-### Conditions (`when`)
+| Provider | Description |
+|----------|-------------|
+| `exec` | Execute shell commands |
+| `cel` | Evaluate CEL expressions and return structured data |
+| `http` | Make HTTP requests |
+| `file` | File operations |
+| `git` | Git operations |
+| `sleep` | Delay execution |
 
-Actions can be conditional:
+See [Provider Reference](provider-reference.md) for complete provider documentation.
 
-```yaml
-actions:
-  prod-deploy:
-    provider: exec
-    when:
-      expr: "_.environment == 'prod'"
-    inputs:
-      command: "prod-deploy.sh"
-```
-
-If the condition evaluates to `false`, the action is skipped with `SkipReasonCondition`.
-
-### ForEach
-
-Execute an action for each item in an array:
-
-```yaml
-resolvers:
-  servers:
-    type: array
-    resolve:
-      with:
-        - provider: static
-          inputs:
-            value: ["web1", "web2", "web3"]
-
-workflow:
-  actions:
-    deploy:
-      provider: exec
-      forEach:
-        in:
-          expr: "_.servers"
-      inputs:
-        server:
-          expr: "__item"   # Current array element
-        index:
-          expr: "__index"  # Current index (0, 1, 2, ...)
-        command:
-          expr: "'deploy.sh ' + __item"
-```
-
-The action expands to: `deploy[0]`, `deploy[1]`, `deploy[2]`
-
-**ForEach options:**
-```yaml
-forEach:
-  in:
-    expr: "_.servers"
-  item: server      # Alias for __item
-  index: i          # Alias for __index
-  concurrency: 2    # Max parallel iterations
-  onError: continue # Continue on iteration failure
-```
-
-### Error Handling
-
-**Default behavior (`fail`):** Stop workflow on failure
-```yaml
-actions:
-  critical:
-    provider: exec
-    onError: fail  # Default - stops workflow if this fails
-```
-
-**Continue on failure:**
-```yaml
-actions:
-  optional:
-    provider: exec
-    onError: continue  # Workflow continues even if this fails
-```
-
-**With ForEach:**
-```yaml
-actions:
-  deploy:
-    provider: exec
-    forEach:
-      in:
-        expr: "_.servers"
-      onError: continue  # Continue deploying to other servers
-```
-
-### Retry
-
-Automatic retry with backoff:
-
-```yaml
-actions:
-  flaky-api:
-    provider: http
-    retry:
-      maxAttempts: 5
-      backoff: exponential  # fixed, linear, or exponential
-      initialDelay: 1s
-      maxDelay: 30s
-    inputs:
-      url: "https://flaky-api.example.com"
-```
-
-**Backoff strategies:**
-- `fixed` - Constant delay (e.g., always 1s)
-- `linear` - Delay increases linearly (1s, 2s, 3s, ...)
-- `exponential` - Delay doubles (1s, 2s, 4s, 8s, ...)
-
-### Conditional Retry (retryIf)
-
-Use a CEL expression to control when retries occur:
-
-```yaml
-actions:
-  api-call:
-    provider: http
-    retry:
-      maxAttempts: 5
-      backoff: exponential
-      initialDelay: 1s
-      # Only retry on rate limits (429) or server errors (5xx)
-      retryIf: "__error.statusCode == 429 || __error.statusCode >= 500"
-    inputs:
-      url: "https://api.example.com/resource"
-```
-
-The `__error` context variable provides:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `__error.message` | string | The error message |
-| `__error.type` | string | Error category: `http`, `exec`, `timeout`, `validation`, `unknown` |
-| `__error.statusCode` | int | HTTP status code (0 for non-HTTP errors) |
-| `__error.exitCode` | int | Process exit code (0 for non-exec errors) |
-| `__error.attempt` | int | Current attempt number (1-based) |
-| `__error.maxAttempts` | int | Maximum retry attempts configured |
-
-**Example conditions:**
-
-```yaml
-# Only retry on timeout errors
-retryIf: "__error.type == 'timeout'"
-
-# Retry up to 3 times maximum (even if maxAttempts is higher)
-retryIf: "__error.attempt < 4"
-
-# Retry on specific HTTP errors
-retryIf: "__error.statusCode == 429 || __error.statusCode == 503"
-
-# Retry on exec errors except exit code 2 (permanent failure)
-retryIf: "__error.type == 'exec' && __error.exitCode != 2"
-
-# Complex condition
-retryIf: "(__error.type == 'http' && __error.statusCode >= 500) || __error.type == 'timeout'"
-
-# Never retry (disables retry even with retry config)
-retryIf: "false"
-```
-
-> **Note:** The exec provider does not return errors for non-zero exit codes - it reports exit codes in the output data. The `retryIf` feature works best with HTTP errors, timeouts, and exec failures like "command not found".
-
-### Timeout
-
-Limit action execution time:
-
-```yaml
-actions:
-  slow-operation:
-    provider: exec
-    timeout: 5m  # Fails after 5 minutes
-    inputs:
-      command: "long-running-script.sh"
-```
-
-### Finally Section
-
-Cleanup actions that **always run**, even if main actions fail:
-
-```yaml
-workflow:
-  actions:
-    create-resources:
-      provider: exec
-      inputs:
-        command: "create-test-db.sh"
-    
-    run-tests:
-      provider: exec
-      dependsOn: [create-resources]
-      inputs:
-        command: "run-tests.sh"  # Might fail
-
-  finally:
-    cleanup:
-      provider: exec
-      inputs:
-        command: "cleanup.sh"  # ALWAYS runs
-    
-    notify:
-      provider: exec
-      dependsOn: [cleanup]
-      inputs:
-        command: "notify.sh"
-```
-
-**Finally rules:**
-- Finally actions have implicit dependency on all main actions
-- Finally actions can only depend on other finally actions
-- ForEach is not allowed in finally section
+---
 
 ## Running Solutions
 
@@ -435,28 +775,28 @@ Run a solution (resolvers + actions):
 
 ```bash
 # Basic execution
-scafctl run solution -f my-solution.yaml
+scafctl run solution -f hello-world.yaml
 
 # Run with progress output
-scafctl run solution -f my-solution.yaml --progress
+scafctl run solution -f hello-world.yaml --progress
 
 # JSON output (for scripts/pipelines)
-scafctl run solution -f my-solution.yaml -o json
+scafctl run solution -f hello-world.yaml -o json
 
 # Override resolver values
-scafctl run solution -f my-solution.yaml -r environment=prod
+scafctl run solution -f conditional-demo.yaml -r environment=prod
 
 # Limit parallel actions
-scafctl run solution -f my-solution.yaml --max-action-concurrency=4
+scafctl run solution -f foreach-demo.yaml --max-action-concurrency=2
 
 # Dry-run (show plan without executing)
-scafctl run solution -f my-solution.yaml --dry-run
+scafctl run solution -f hello-world.yaml --dry-run
 
 # Run resolvers only (skip actions, for debugging)
-scafctl run resolver -f my-solution.yaml
+scafctl run resolver -f conditional-demo.yaml -r environment=staging --hide-execution
 
 # Run specific resolvers for inspection
-scafctl run resolver db config -f my-solution.yaml
+scafctl run resolver config -f conditional-demo.yaml -r environment=staging --hide-execution
 ```
 
 ### Render Mode
@@ -465,13 +805,13 @@ Generate an executor-ready artifact:
 
 ```bash
 # Render to JSON (default)
-scafctl render solution -f my-solution.yaml
+scafctl render solution -f hello-world.yaml
 
 # Render to YAML
-scafctl render solution -f my-solution.yaml -o yaml
+scafctl render solution -f hello-world.yaml -o yaml
 
 # Write to file
-scafctl render solution -f my-solution.yaml -o json > graph.json
+scafctl render solution -f hello-world.yaml -o json > graph.json
 ```
 
 The rendered output includes:
@@ -627,6 +967,7 @@ actions:
 
 ## Next Steps
 
-- Browse the [design documentation](design/actions.md)
-- Explore [provider documentation](design/providers.md)
-- Check out [CEL integration](design/cel-integration.md)
+- [Authentication Tutorial](auth-tutorial.md) — Set up authentication for your workflows
+- [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
+- [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
+- [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -38,6 +38,7 @@ Authentication in scafctl follows these principles:
 - **Refresh tokens are stored securely** using your system's secret store
 - **Access tokens are short-lived** and cached for performance
 - **Secrets never appear** in solution files or logs
+- **Auth tokens are visible** via `scafctl secrets list --all` and `scafctl secrets get <name> --all`
 
 scafctl currently supports the following auth handlers:
 
@@ -87,6 +88,18 @@ scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
 scafctl auth login entra --tenant contoso.onmicrosoft.com
 ```
 
+### Custom Client ID
+
+By default, scafctl uses the Azure CLI's public client ID (`04b07795-8ddb-461a-bbee-02f9e1bf7b46`) for device code flow. If your organization requires a custom app registration (e.g., for specific permissions or conditional access policies), use the `--client-id` flag:
+
+```bash
+scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc
+```
+
+The client ID used during login is persisted in your credential metadata so that subsequent token refreshes use the same client ID, even if your configuration file specifies a different one. This prevents token minting failures caused by a mismatch between the login client ID and the refresh client ID.
+
+You can also set a default client ID via the scafctl configuration file under `auth.entra.clientId`. Note that the `--client-id` flag at login time always takes precedence, and the stored client ID from login will be used for all future token refreshes.
+
 ### Setting a Timeout
 
 The device code flow has a 5-minute default timeout. To extend it:
@@ -94,6 +107,25 @@ The device code flow has a 5-minute default timeout. To extend it:
 ```bash
 scafctl auth login entra --timeout 10m
 ```
+
+### Requesting Specific Scopes
+
+By default, login requests only basic scopes (`openid`, `profile`, `offline_access`). If your resolvers need access to specific APIs (e.g., Microsoft Graph), include the required scope during login to establish consent:
+
+```bash
+# Login with Microsoft Graph scope
+scafctl auth login entra --scope https://graph.microsoft.com/.default
+
+# Login with Azure Resource Manager scope
+scafctl auth login entra --scope https://management.azure.com/.default
+```
+
+This ensures your authentication session has consent for that API resource, preventing "consent required" errors when resolvers run. The refresh token obtained at login can then be used to mint access tokens for the consented resource.
+
+> **Note:** Login should target a single API resource at a time. If you need
+> tokens for multiple API resources, use separate `scafctl auth login` calls,
+> or rely on the refresh token to mint tokens for additional resources at
+> runtime via `scafctl auth token`.
 
 ### Service Principal Authentication (CI/CD)
 
@@ -440,6 +472,8 @@ The HTTP provider supports automatic authentication via the `authProvider` and `
 
 ### Basic Example
 
+Create a file called `graph-example.yaml`:
+
 ```yaml
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -461,7 +495,25 @@ spec:
               scope: "https://graph.microsoft.com/.default"
 ```
 
-When you run this solution, scafctl:
+Run it (requires prior authentication via `scafctl auth login entra`):
+
+```bash
+# Login with Microsoft Graph scope for consent
+scafctl auth login entra --scope https://graph.microsoft.com/User.Read
+
+# Then run the resolver
+scafctl run resolver -f graph-example.yaml -o json --hide-execution
+```
+
+> **Note:** If you see a "consent required" error, it means your login session
+> doesn't have consent for the requested API scope. Re-login with the `--scope`
+> flag to grant consent:
+>
+> ```bash
+> scafctl auth login entra --scope https://graph.microsoft.com/User.Read
+> ```
+
+When you run this, scafctl:
 
 1. Retrieves a cached token (or fetches a new one)
 2. Adds the `Authorization: Bearer <token>` header
@@ -488,6 +540,8 @@ This handles cases where a cached token has been revoked.
 
 ### Azure Resource Manager Example
 
+Add the following resolver to your solution's `spec.resolvers` section:
+
 ```yaml
 spec:
   resolvers:
@@ -504,6 +558,8 @@ spec:
 ```
 
 ### Key Vault Example
+
+Add the following resolver to your solution's `spec.resolvers` section:
 
 ```yaml
 spec:
@@ -657,6 +713,26 @@ Your refresh token has expired (typically after 90 days of inactivity). Log in a
 scafctl auth login entra
 ```
 
+### Consent Required
+
+If you see:
+
+```
+consent required: please login with the required scope
+```
+
+Your login session does not have consent for the API scope your resolver is requesting. Re-login with the `--scope` flag to grant consent:
+
+```bash
+# For Microsoft Graph APIs
+scafctl auth login entra --scope https://graph.microsoft.com/User.Read
+
+# For Azure Resource Manager APIs
+scafctl auth login entra --scope https://management.azure.com/user_impersonation
+```
+
+The `--scope` flag tells Azure to request user consent for that specific API during the login flow.
+
 ### Wrong Tenant
 
 If you're getting 401 errors but you're authenticated, you may be authenticated to the wrong tenant:
@@ -714,6 +790,7 @@ scafctl uses your system's secret store (Keychain on macOS, Windows Credential M
 
 ## Next Steps
 
-- Explore the [HTTP provider documentation](resolver-tutorial.md#working-with-http-apis) for more HTTP examples
-- See [examples/resolvers/](../examples/resolvers/) for sample solutions
-- Read the [design document](design/auth.md) for architecture details
+- [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
+- [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
+- [Resolver Tutorial](resolver-tutorial.md) — More HTTP examples in resolver pipelines
+- [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -47,14 +47,12 @@ scafctl cache info
 
 Output:
 ```
-Cache Information
-
-Platform: darwin/arm64
-
+ 💡 Cache Information
 HTTP Cache:  2.4 MB (156 files)
              ~/.cache/scafctl/http-cache
-
-Total: 2.4 MB (156 files)
+Build Cache:  324 B (1 files)
+             ~/.cache/scafctl/build-cache
+Total: 2.4 MB (157 files)
 ```
 
 ### JSON Output
@@ -76,11 +74,19 @@ Output:
       "sizeHuman": "2.4 MB",
       "fileCount": 156,
       "description": "HTTP response cache"
+    },
+    {
+      "name": "Build Cache",
+      "path": "/Users/me/.cache/scafctl/build-cache",
+      "size": 324,
+      "sizeHuman": "324 B",
+      "fileCount": 1,
+      "description": "Incremental build fingerprints"
     }
   ],
-  "totalSize": 2516582,
+  "totalSize": 2516906,
   "totalHuman": "2.4 MB",
-  "totalFiles": 156
+  "totalFiles": 157
 }
 ```
 
@@ -102,8 +108,8 @@ You'll be prompted to confirm:
 Output after confirmation:
 ```
  ✅ Cleared cache
- ℹ️   Removed files: 156
- ℹ️   Reclaimed: 2.4 MB
+ 💡 Removed files: 156
+ 💡 Reclaimed: 2.4 MB
 ```
 
 ### Skip Confirmation
@@ -281,7 +287,9 @@ scafctl config set build.enableCache false
 scafctl config set build.autoCacheRemoteArtifacts false
 ```
 
-## See Also
+## Next Steps
 
-- [Configuration Paths](../design/cli.md) — Understanding scafctl directory structure
-- [HTTP Provider](provider-reference.md#http) — Configuring HTTP caching behavior
+- [Provider Reference](provider-reference.md) — Complete provider documentation
+- [Provider Development](provider-development.md) — Build custom providers
+- [Configuration Tutorial](config-tutorial.md) — Manage application configuration
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -3,576 +3,740 @@ title: "Catalog Tutorial"
 weight: 70
 ---
 
-# Working with the Local Catalog
+# Catalog Tutorial
 
-This tutorial covers how to use scafctl's local catalog to store, manage, and run solutions without needing file paths.
+This tutorial walks you through using scafctl's local catalog to build, version, inspect, export, and share solutions. You'll start by building your first solution into the catalog and progressively work through versioning, cleanup, air-gapped transfers, remote registries, tagging, and advanced bundling with file dependencies.
 
-## What is the Catalog?
+## Prerequisites
 
-The catalog is a local OCI-based artifact store that lets you:
+- scafctl installed and available in your PATH
+- Basic familiarity with YAML syntax
+- Completion of the [Resolver Tutorial](resolver-tutorial.md)
 
-- **Build** solutions into versioned artifacts
-- **Run** solutions by name instead of file path
-- **Manage** multiple versions of the same solution
-- **Share** solutions via remote OCI registries (ghcr.io, Docker Hub, ACR, etc.)
-- **Export/Import** solutions for air-gapped environments
+## Table of Contents
 
-Think of it like a package manager for your scafctl solutions.
+1. [Building Your First Solution](#building-your-first-solution)
+2. [Running from the Catalog](#running-from-the-catalog)
+3. [Listing and Inspecting](#listing-and-inspecting)
+4. [Managing Multiple Versions](#managing-multiple-versions)
+5. [Deleting and Pruning](#deleting-and-pruning)
+6. [Exporting and Importing](#exporting-and-importing)
+7. [Tagging Artifacts](#tagging-artifacts)
+8. [Remote Registries](#remote-registries)
+9. [Bundling File Dependencies](#bundling-file-dependencies)
+10. [Verifying and Extracting Bundles](#verifying-and-extracting-bundles)
+11. [Comparing Bundle Versions](#comparing-bundle-versions)
 
-## Where is the Catalog Stored?
+---
 
-The catalog uses XDG Base Directory paths:
+## Building Your First Solution
 
-| Platform | Default Location |
-|----------|------------------|
-| macOS | `~/.local/share/scafctl/catalog` |
-| Linux | `~/.local/share/scafctl/catalog` |
-| Windows | `%LOCALAPPDATA%\scafctl\catalog` |
+Let's build a simple solution and store it in the local catalog so you can run it by name from anywhere.
 
-## Quick Start
+### Step 1: Create the Solution File
 
-### 1. Build a Solution
+Create a file called `greeting.yaml`:
 
-Take any solution file and build it into the catalog:
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: greeting
+  version: 1.0.0
+  description: A simple greeting solution
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              name: name
+              default: World
+    message:
+      type: string
+      dependsOn:
+        - name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: "'Hello, ' + _.name + '!'"
+```
+
+This solution accepts a `name` parameter (defaulting to "World") and produces a greeting message.
+
+### Step 2: Build It into the Catalog
 
 ```bash
-# Build with explicit version
-scafctl build solution my-solution.yaml --version 1.0.0
-
-# Build using version from metadata.version field
-scafctl build solution my-solution.yaml
+scafctl build solution greeting.yaml
 ```
 
-Output:
+Expected output:
+
 ```
- ✅ Built my-solution@1.0.0
+ ✅ Built greeting@1.0.0
  💡   Digest: sha256:abc123...
  💡   Catalog: ~/.local/share/scafctl/catalog
 ```
 
-### 2. Run from Catalog
+The solution is now stored in your local catalog. The version (`1.0.0`) was read from `metadata.version` in the YAML file.
 
-Now run it by name - no file path needed:
+### Step 3: Override the Version
 
-```bash
-# Run latest version
-scafctl run solution my-solution
-
-# Run specific version
-scafctl run solution my-solution@1.0.0
-
-# Still works with parameters
-scafctl run solution my-solution -r env=prod
-```
-
-### 3. List Catalog Contents
-
-See what's in your catalog:
+You can also specify the version on the command line, which overrides `metadata.version`:
 
 ```bash
-scafctl catalog list
+scafctl build solution greeting.yaml --version 1.0.1
 ```
 
-Output:
+Expected output:
+
 ```
-SOLUTION              VERSION   CREATED                SIZE
-my-solution           1.0.0     2026-02-06T10:30:00Z   1.2 KB
-my-solution           1.1.0     2026-02-06T14:00:00Z   1.3 KB
-deploy-app            2.0.0     2026-02-05T09:15:00Z   2.4 KB
+ ✅ Built greeting@1.0.1
+ 💡   Digest: sha256:def456...
+ 💡   Catalog: ~/.local/share/scafctl/catalog
 ```
+
+### What You Learned
+
+- `scafctl build solution FILE` packages a solution YAML into the local OCI catalog
+- The name and version come from `metadata.name` and `metadata.version` by default
+- Use `--version` to override the version at build time
+- Use `--name` to override the name at build time
+
+---
+
+## Running from the Catalog
+
+Once a solution is in the catalog, you can run it by name instead of providing a file path.
+
+### Step 1: Run by Name
 
 ```bash
-# JSON output for scripting
-scafctl catalog list -o json
-
-# Filter by name
-scafctl catalog list --name my-solution
+scafctl run resolver -f greeting -o yaml --hide-execution
 ```
 
-## Managing Versions
+Expected output:
 
-### Building Multiple Versions
-
-```bash
-# Build v1.0.0
-scafctl build solution solution-v1.yaml --version 1.0.0
-
-# Build v1.1.0 (different file, same solution name)
-scafctl build solution solution-v1.1.yaml --version 1.1.0
-
-# Build v2.0.0-beta
-scafctl build solution solution-v2.yaml --version 2.0.0-beta.1
+```yaml
+message: Hello, World!
+name: World
 ```
 
-### Version Resolution
+No file path needed — scafctl looked up `greeting` in the catalog and found the highest version.
 
-When you run without specifying a version, scafctl picks the **highest semantic version**:
+### Step 2: Pass a Parameter
 
 ```bash
-# With versions 1.0.0, 1.1.0, 2.0.0-beta.1 in catalog:
-scafctl run solution my-solution        # Runs 2.0.0-beta.1 (highest)
-scafctl run solution my-solution@1.1.0  # Runs exactly 1.1.0
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
 ```
 
-### Overwriting Versions
+Expected output:
 
-By default, building an existing version fails:
+```yaml
+message: Hello, Alice!
+name: Alice
+```
+
+### Step 3: Run a Specific Version
+
+When you have multiple versions, you can pin to a specific one:
 
 ```bash
-scafctl build solution updated.yaml --version 1.0.0
-# Error: artifact my-solution@1.0.0 already exists in catalog "local"
+scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Bob
+```
+
+Expected output:
+
+```yaml
+message: Hello, Bob!
+name: Bob
+```
+
+### Step 4: Use an Expression to Filter Output
+
+Use `-e` to extract just the value you care about:
+
+```bash
+scafctl run resolver -f greeting -o yaml -e '_.message' -r name=Carol
+```
+
+Expected output:
+
+```yaml
+Hello, Carol!
+```
+
+### What You Learned
+
+- `scafctl run resolver -f NAME` runs a solution from the catalog by name
+- Without a version, it picks the highest semantic version available
+- Use `NAME@VERSION` to pin a specific version
+- Parameters work the same way as with file-based solutions (`-r key=value`)
+- Use `-e` to filter output to specific values
+
+---
+
+## Listing and Inspecting
+
+### Step 1: List Everything in the Catalog
+
+```bash
+scafctl catalog list -o yaml
+```
+
+Expected output:
+
+```yaml
+- name: greeting
+  version: 1.0.0
+  kind: solution
+  digest: sha256:abc123...
+  createdAt: "2026-02-17 10:00:00"
+  catalog: local
+- name: greeting
+  version: 1.0.1
+  kind: solution
+  digest: sha256:def456...
+  createdAt: "2026-02-17 10:01:00"
+  catalog: local
+```
+
+### Step 2: Filter by Name
+
+```bash
+scafctl catalog list --name greeting -o yaml
+```
+
+This shows only artifacts with the name `greeting`.
+
+### Step 3: Inspect a Specific Artifact
+
+```bash
+scafctl catalog inspect greeting -o yaml
+```
+
+Expected output:
+
+```yaml
+name: greeting
+version: 1.0.1
+kind: solution
+digest: sha256:def456...
+size: 573
+createdAt: "2026-02-17 10:01:00"
+catalog: local
+annotations:
+    dev.scafctl.artifact.name: greeting
+    dev.scafctl.artifact.type: solution
+    org.opencontainers.image.created: "2026-02-17T10:01:00Z"
+    org.opencontainers.image.source: greeting.yaml
+    org.opencontainers.image.version: 1.0.1
+```
+
+Without a version, `inspect` shows the highest version. Pin a version with `greeting@1.0.0`.
+
+### Step 4: Use a CEL Expression to Extract Fields
+
+```bash
+scafctl catalog inspect greeting -o yaml -e '_.annotations'
+```
+
+Expected output:
+
+```yaml
+dev.scafctl.artifact.name: greeting
+dev.scafctl.artifact.type: solution
+org.opencontainers.image.created: "2026-02-17T10:01:00Z"
+org.opencontainers.image.source: greeting.yaml
+org.opencontainers.image.version: 1.0.1
+```
+
+### What You Learned
+
+- `scafctl catalog list` shows every artifact in the catalog
+- `--name` filters by solution name
+- `scafctl catalog inspect NAME` shows detailed metadata for a specific artifact
+- Without a version, inspect/list show all versions or the highest version respectively
+- `-e` with CEL expressions can extract sub-fields from the output
+
+---
+
+## Managing Multiple Versions
+
+### Step 1: Create a v2 of the Solution
+
+Create a file called `greeting-v2.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: greeting
+  version: 2.0.0
+  description: An improved greeting solution with timestamps
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              name: name
+              default: World
+    timestamp:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: "timestamp(now)"
+    message:
+      type: string
+      dependsOn:
+        - name
+        - timestamp
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: "'Hello, ' + _.name + '! The time is ' + _.timestamp"
+```
+
+### Step 2: Build v2
+
+```bash
+scafctl build solution greeting-v2.yaml
+```
+
+Expected output:
+
+```
+ ✅ Built greeting@2.0.0
+ 💡   Digest: sha256:789abc...
+ 💡   Catalog: ~/.local/share/scafctl/catalog
+```
+
+### Step 3: Verify Both Versions Exist
+
+```bash
+scafctl catalog list --name greeting -o yaml
+```
+
+Expected output:
+
+```yaml
+- name: greeting
+  version: 1.0.0
+  kind: solution
+  ...
+- name: greeting
+  version: 1.0.1
+  kind: solution
+  ...
+- name: greeting
+  version: 2.0.0
+  kind: solution
+  ...
+```
+
+### Step 4: Run Without a Version
+
+```bash
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+```
+
+Expected output:
+
+```yaml
+message: Hello, Alice! The time is 2026-02-17T10:05:00Z
+name: Alice
+timestamp: "2026-02-17T10:05:00Z"
+```
+
+Without a version, scafctl runs the **highest semantic version** — in this case `2.0.0`.
+
+### Step 5: Pin to the Old Version
+
+```bash
+scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Alice
+```
+
+Expected output:
+
+```yaml
+message: Hello, Alice!
+name: Alice
+```
+
+The v1 solution doesn't have a timestamp — confirming you're running the original version.
+
+### Step 6: Try to Overwrite an Existing Version
+
+```bash
+scafctl build solution greeting-v2.yaml --version 2.0.0
+```
+
+Expected output:
+
+```
+ ❌ artifact greeting@2.0.0 already exists in catalog "local" (use --force to overwrite)
 ```
 
 Use `--force` to overwrite:
 
 ```bash
-scafctl build solution updated.yaml --version 1.0.0 --force
+scafctl build solution greeting-v2.yaml --version 2.0.0 --force
 ```
 
-## Inspecting Solutions
+### What You Learned
 
-View detailed metadata about a cataloged solution:
+- Multiple versions of the same solution coexist in the catalog
+- Without a version, `run` picks the highest semantic version
+- Use `NAME@VERSION` to pin to a specific version
+- Use `--force` to overwrite an existing version
+
+---
+
+## Deleting and Pruning
+
+### Step 1: Delete a Specific Version
 
 ```bash
-scafctl catalog inspect my-solution
+scafctl catalog delete greeting@1.0.1 --kind solution
 ```
 
-Output:
+Expected output:
+
 ```
-Solution: my-solution@1.1.0
-
-METADATA
-  Name:         my-solution
-  Version:      1.1.0
-  Display Name: My Example Solution
-  Description:  Deploys infrastructure to cloud
-
-ARTIFACT
-  Digest:       sha256:def456...
-  Created:      2026-02-06T14:00:00Z
-  Size:         1.3 KB
-
-STRUCTURE
-  Resolvers:    5
-  Actions:      3
-  Finally:      1
+ ✅ Deleted greeting@1.0.1
 ```
+
+You must specify both the name and version. The `--kind solution` flag tells scafctl which artifact kind to delete.
+
+### Step 2: Verify It's Gone
 
 ```bash
-# Inspect specific version
-scafctl catalog inspect my-solution@1.0.0
-
-# JSON output
-scafctl catalog inspect my-solution -o json
+scafctl catalog list --name greeting -o yaml
 ```
 
-## Cleanup
+The `1.0.1` entry should no longer appear.
 
-### Deleting Solutions
+### Step 3: Prune Orphaned Data
 
-Remove a specific version:
-
-```bash
-scafctl catalog delete my-solution@1.0.0
-```
-
-Output:
-```
- ✅ Deleted my-solution@1.0.0
- 💡   Digest: sha256:abc123...
-```
-
-**Note:** You must specify the version. This prevents accidentally deleting all versions.
-
-### Pruning Orphaned Data
-
-After deleting solutions, blob data may remain. Clean it up with prune:
+After deleting artifacts, blob data may remain on disk. Clean it up:
 
 ```bash
 scafctl catalog prune
 ```
 
-Output:
+Expected output:
+
 ```
- ✅ Pruned catalog successfully!
- 💡   Manifests Removed: 2
- 💡   Blobs Removed: 5
- 💡   Space Reclaimed: 4.2 KB
+ ✅ Pruned catalog
+ 💡   Removed manifests: 1
+ 💡   Removed blobs: 2
+ 💡   Reclaimed: 1.5 KB
 ```
 
-## Exporting and Importing (Air-Gapped Environments)
+### Step 4: Delete Multiple Versions
 
-The `save` and `load` commands let you transfer catalog artifacts between machines without network access.
-
-### Saving an Artifact
-
-Export a solution to a tar archive:
+Clean up the remaining test artifacts:
 
 ```bash
-# Save latest version
-scafctl catalog save my-solution -o my-solution.tar
-
-# Save specific version
-scafctl catalog save my-solution@1.0.0 -o my-solution-v1.tar
+scafctl catalog delete greeting@1.0.0 --kind solution
+scafctl catalog delete greeting@2.0.0 --kind solution
+scafctl catalog prune
 ```
 
-Output:
-```
- ✅ Saved my-solution@1.0.0
- 💡   Output: my-solution.tar
- 💡   Size: 2.4 KB
- 💡   Digest: sha256:abc123...
-```
+### What You Learned
 
-The archive uses the standard **OCI Image Layout** format, making it compatible with other OCI tools.
+- `scafctl catalog delete NAME@VERSION --kind solution` removes a single version
+- You must specify the version — this prevents accidental bulk deletion
+- `scafctl catalog prune` removes orphaned blobs and reclaims disk space
+- Always prune after deleting to free up storage
 
-### Loading an Artifact
+---
 
-Import an artifact from a tar archive:
+## Exporting and Importing
+
+The `save` and `load` commands let you transfer catalog artifacts between machines — useful for air-gapped environments where there's no network access to a registry.
+
+### Step 1: Build a Solution to Export
+
+First, rebuild the greeting solution:
 
 ```bash
-scafctl catalog load --input my-solution.tar
+scafctl build solution greeting.yaml
 ```
 
-Output:
-```
-ARTIFACT        VERSION   DIGEST
-my-solution     1.0.0     sha256:abc123...
-```
-
-If the artifact already exists in your catalog, loading fails:
+### Step 2: Export to a Tar Archive
 
 ```bash
-scafctl catalog load --input my-solution.tar
-# Error: artifact "my-solution@1.0.0" already exists in catalog
+scafctl catalog save greeting@1.0.0 -o greeting-v1.tar
+```
+
+Expected output:
+
+```
+ ✅ Saved greeting@1.0.0 to greeting-v1.tar (5.5 KB)
+```
+
+The archive uses the standard **OCI Image Layout** format.
+
+### Step 3: Delete the Local Copy
+
+Simulate receiving the tar on a different machine by deleting the local version:
+
+```bash
+scafctl catalog delete greeting@1.0.0 --kind solution
+scafctl catalog prune
+```
+
+### Step 4: Verify It's Gone
+
+```bash
+scafctl catalog list --name greeting -o yaml
+```
+
+Expected output (empty or no greeting entries).
+
+### Step 5: Import from the Tar Archive
+
+```bash
+scafctl catalog load --input greeting-v1.tar
+```
+
+Expected output:
+
+```
+ ✅ Loaded artifact from greeting-v1.tar
+```
+
+### Step 6: Confirm It Was Loaded
+
+```bash
+scafctl catalog list --name greeting -o yaml
+```
+
+Expected output:
+
+```yaml
+- name: greeting
+  version: 1.0.0
+  kind: solution
+  digest: sha256:abc123...
+  createdAt: "2026-02-17 10:00:00"
+  catalog: local
+```
+
+### Step 7: Try Loading Again (Conflict)
+
+```bash
+scafctl catalog load --input greeting-v1.tar
+```
+
+Expected output:
+
+```
+ ❌ artifact already exists (use --force to overwrite)
 ```
 
 Use `--force` to overwrite:
 
 ```bash
-scafctl catalog load --input my-solution.tar --force
+scafctl catalog load --input greeting-v1.tar --force
 ```
 
 ### Air-Gapped Transfer Workflow
 
-Here's a complete workflow for transferring solutions to a machine without internet:
+Here's how the full workflow looks in practice:
 
 ```bash
 # On the connected machine:
-# 1. Build the solution
 scafctl build solution deploy.yaml --version 1.0.0
+scafctl catalog save deploy@1.0.0 -o deploy-v1.tar
+cp deploy-v1.tar /Volumes/USB/
 
-# 2. Export to tar
-scafctl catalog save deploy@1.0.0 -o deploy-v1.0.0.tar
-
-# 3. Copy to USB drive or other media
-cp deploy-v1.0.0.tar /Volumes/USB/
-
-# --- Transfer to air-gapped machine ---
-
-# On the air-gapped machine:
-# 4. Load from tar
-scafctl catalog load --input /Volumes/USB/deploy-v1.0.0.tar
-
-# 5. Run the solution
-scafctl run solution deploy -r target=server1
+# Transfer USB to the air-gapped machine, then:
+scafctl catalog load --input /Volumes/USB/deploy-v1.tar
+scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
 ```
 
-### Archive Format
+### What You Learned
 
-The exported tar file contains an OCI Image Layout:
+- `scafctl catalog save NAME@VERSION -o FILE` exports an artifact as an OCI tar archive
+- `scafctl catalog load --input FILE` imports an artifact from a tar archive
+- Use `--force` to overwrite if the artifact already exists
+- This workflow enables air-gapped transfers without any registry access
 
-```
-my-solution.tar
-├── oci-layout           # OCI layout version file
-├── index.json           # Image index with manifest reference
-└── blobs/
-    └── sha256/
-        ├── <manifest>   # Artifact manifest
-        ├── <config>     # Configuration blob
-        └── <content>    # Solution YAML content
-```
+---
 
-This format is:
-- **Self-contained** - includes all layers and metadata
-- **Verifiable** - content-addressable by digest
-- **Standard** - compatible with OCI registry tools
+## Tagging Artifacts
 
-## Name Resolution Priority
+Tags let you create freeform aliases for specific versions. Common uses include marking a version as "stable", "latest", or "production".
 
-When you run a solution, scafctl checks sources in this order:
+### Step 1: Tag a Version as Stable
 
-1. **Catalog** (if the name is a "bare name" - no path separators or file extensions)
-2. **File system** (if it looks like a path)
-3. **URL** (if it starts with `http://` or `https://`)
-
-Examples:
+Make sure you have `greeting@1.0.0` in the catalog, then tag it:
 
 ```bash
-# Bare name → checks catalog first
-scafctl run solution my-solution
-
-# Path → goes directly to file system
-scafctl run solution ./my-solution.yaml
-scafctl run solution examples/deploy.yaml
-
-# URL → fetches from remote
-scafctl run solution https://example.com/solution.yaml
+scafctl catalog tag greeting@1.0.0 stable
 ```
 
-## Complete Workflow Example
+Expected output:
 
-Here's a typical development workflow:
+```
+ ✅ Tagged greeting@1.0.0 as "stable"
+```
+
+### Step 2: View the Tag in the Catalog
 
 ```bash
-# 1. Develop your solution locally
-scafctl run solution -f ./deploy.yaml --dry-run
-
-# 2. Test it
-scafctl run solution -f ./deploy.yaml -r env=dev
-
-# 3. Build to catalog with version
-scafctl build solution ./deploy.yaml --version 1.0.0
-
-# 4. Now run from anywhere by name
-scafctl run solution deploy -r env=staging
-
-# 5. Make improvements, build new version
-scafctl build solution ./deploy.yaml --version 1.1.0
-
-# 6. Run latest version
-scafctl run solution deploy -r env=prod
-
-# 7. Clean up old versions
-scafctl catalog delete deploy@1.0.0
-scafctl catalog prune
+scafctl catalog list --name greeting -o yaml
 ```
 
-## Command Reference
+The tag creates an alias that points to the same digest as the original version.
 
-| Command | Description |
-|---------|-------------|
-| `scafctl build solution FILE` | Build solution to catalog |
-| `scafctl catalog list` | List all solutions |
-| `scafctl catalog inspect NAME[@VERSION]` | Show solution details |
-| `scafctl catalog delete NAME@VERSION` | Remove a solution version |
-| `scafctl catalog prune` | Clean up orphaned data |
-| `scafctl catalog save NAME[@VERSION] -o FILE` | Export to tar archive |
-| `scafctl catalog load --input FILE` | Import from tar archive |
-| `scafctl catalog push NAME[@VERSION]` | Push to remote registry |
-| `scafctl catalog pull REGISTRY/REPO/KIND/NAME[@VERSION]` | Pull from remote registry |
-| `scafctl run solution NAME[@VERSION]` | Run from catalog |
+### Step 3: Tag for Different Environments
 
-## Remote Registry Support
+```bash
+scafctl catalog tag greeting@1.0.0 production
+```
+
+You can create as many tags as needed. Tags are freeform strings — they cannot be valid semver versions (use `scafctl build` for that).
+
+### What You Learned
+
+- `scafctl catalog tag NAME@VERSION ALIAS` creates a named alias pointing to a specific version
+- Tags are useful for marking releases as stable, production, etc.
+- Tags can also be created in remote registries with `--catalog`
+
+---
+
+## Remote Registries
 
 scafctl supports pushing and pulling artifacts to/from OCI-compliant container registries like GitHub Container Registry (ghcr.io), Docker Hub, Azure Container Registry, and others.
 
-### Setting Up Authentication
+### Step 1: Set Up Authentication
 
-scafctl reads container credentials from the same locations as Docker and Podman:
+scafctl reads container credentials from the same locations as Docker and Podman. The easiest way to authenticate is with Docker or Podman's login command.
 
-| Priority | Location | Description |
-|----------|----------|-------------|
-| 1 | `$DOCKER_CONFIG/config.json` | Docker config env var |
-| 2 | `~/.docker/config.json` | Docker default |
-| 3 | `$XDG_RUNTIME_DIR/containers/auth.json` | Podman rootless |
-| 4 | `~/.config/containers/auth.json` | Podman default |
-
-You can also use environment variables:
-- `SCAFCTL_REGISTRY_USERNAME`
-- `SCAFCTL_REGISTRY_PASSWORD`
-
-### Authenticating to GitHub Container Registry (ghcr.io)
-
-GitHub Container Registry requires a Personal Access Token (PAT) with the `write:packages` scope.
-
-#### Option 1: Using GitHub CLI (Recommended)
-
-If you have the [GitHub CLI](https://cli.github.com/) installed, this is the easiest method:
+**Using GitHub CLI (recommended):**
 
 ```bash
-# Login with the required scopes (interactive)
 gh auth login -s write:packages -s read:packages -s delete:packages
-
-# Then login to the container registry using the gh token
 gh auth token | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
-
-# Or with Podman
-gh auth token | podman login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 ```
 
-#### Option 2: Create a Personal Access Token Manually
+**Using a Personal Access Token:**
 
 1. Go to [GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens)
-2. Click **Generate new token (classic)**
-3. Give it a descriptive name (e.g., "scafctl registry access")
-4. Select scopes:
-   - `write:packages` - Upload packages
-   - `read:packages` - Download packages
-   - `delete:packages` - (Optional) Delete packages
-5. Click **Generate token** and copy the token
-
-Then authenticate:
-
-**Using Docker:**
+2. Generate a new token with `write:packages` and `read:packages` scopes
+3. Log in:
 
 ```bash
 echo "YOUR_GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 ```
 
-**Using Podman:**
+scafctl checks these credential locations in order:
+
+| Priority | Location |
+|----------|----------|
+| 1 | `$DOCKER_CONFIG/config.json` |
+| 2 | `~/.docker/config.json` |
+| 3 | `$XDG_RUNTIME_DIR/containers/auth.json` |
+| 4 | `~/.config/containers/auth.json` |
+
+### Step 2: Push a Solution to a Remote Registry
+
+Make sure `greeting@1.0.0` is in your local catalog, then push it:
 
 ```bash
-echo "YOUR_GITHUB_TOKEN" | podman login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg/scafctl
 ```
 
-This saves credentials to your Docker/Podman config file, which scafctl will automatically use.
+Expected output:
 
-#### Step 3: Verify Authentication
+```
+ ✅ Pushed greeting@1.0.0
+```
 
-Check that you can access the registry:
+The artifact is stored at: `ghcr.io/myorg/scafctl/solutions/greeting:1.0.0`
+
+The path structure is: `<registry>/<repository>/solutions/<name>:<version>`
+
+### Step 3: Push with a Different Name
 
 ```bash
-# Docker
-docker pull ghcr.io/YOUR_ORG/ANY_PUBLIC_IMAGE:latest
-
-# Or test with scafctl (will fail if no artifacts exist, but auth should work)
-scafctl catalog push my-solution@1.0.0 --catalog ghcr.io/YOUR_ORG --log-level -1
+scafctl catalog push greeting@1.0.0 --as hello-world --catalog ghcr.io/myorg/scafctl
 ```
 
-### Pushing to a Remote Registry
+This pushes the same artifact under a different name in the remote registry.
 
-Push an artifact from your local catalog to a remote registry:
+### Step 4: Pull from a Remote Registry
+
+On a different machine (or after deleting the local copy):
 
 ```bash
-# Push to GitHub Container Registry
-scafctl catalog push my-solution@1.0.0 --catalog ghcr.io/myorg/scafctl
-
-# Push with a different name
-scafctl catalog push my-solution@1.0.0 --as production-solution --catalog ghcr.io/myorg/scafctl
-
-# Force overwrite existing artifact
-scafctl catalog push my-solution@1.0.0 --force --catalog ghcr.io/myorg/scafctl
+scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
 ```
 
-Output:
+Expected output:
+
 ```
- 💡 Pushing my-solution@1.0.0 to ghcr.io/myorg/scafctl...
- ✅ Pushed my-solution@1.0.0 (1.2 KB)
+ ✅ Pulled greeting@1.0.0
 ```
 
-**Repository Path Structure:**
-
-The artifact is pushed to: `ghcr.io/myorg/scafctl/solutions/my-solution:1.0.0`
-
-The full path is: `<registry>/<repository>/solutions/<name>:<version>`
-
-### Pulling from a Remote Registry
-
-Pull an artifact from a remote registry to your local catalog:
+The artifact is now in your local catalog. You can run it with:
 
 ```bash
-# Pull a solution
-scafctl catalog pull ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0
-
-# Pull without specifying version (gets latest)
-scafctl catalog pull ghcr.io/myorg/scafctl/solutions/my-solution
-
-# Pull with a different local name
-scafctl catalog pull ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0 --as local-solution
-
-# Force overwrite if already exists locally
-scafctl catalog pull ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0 --force
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
 ```
 
-Output:
-```
- 💡 Pulling ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0...
- ✅ Pulled my-solution@1.0.0 (1.2 KB)
-```
-
-### Deleting from a Remote Registry
-
-Delete an artifact from a remote registry using the full reference:
+### Step 5: Pull with a Different Local Name
 
 ```bash
-# Delete from remote registry
-scafctl catalog delete ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0
+scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0 --as my-greeting
 ```
 
-**Note:** Not all registries support deletion via the OCI API. GitHub Container Registry (ghcr.io) requires you to delete packages through the GitHub web interface at:
-`https://github.com/orgs/YOUR_ORG/packages`
+This stores the artifact locally under the name `my-greeting`.
 
-Registries that support OCI DELETE:
-- Docker Hub ✅
-- Azure Container Registry ✅
-- Harbor ✅
-- Amazon ECR ✅
-
-Registries that require web UI deletion:
-- GitHub Container Registry (ghcr.io) ❌
-
-### Complete Remote Workflow Example
-
-Here's a typical workflow for sharing solutions via a remote registry:
+### Step 6: Delete from a Remote Registry
 
 ```bash
-# === Developer A (publishing) ===
-
-# 1. Build the solution locally
-scafctl build solution deploy.yaml --version 1.0.0
-
-# 2. Push to remote registry
-scafctl catalog push deploy@1.0.0 --catalog ghcr.io/myorg/scafctl
-
-# === Developer B (consuming) ===
-
-# 3. Pull from remote registry
-scafctl catalog pull ghcr.io/myorg/scafctl/solutions/deploy@1.0.0
-
-# 4. Run the solution
-scafctl run solution deploy -r target=production
+scafctl catalog delete ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
 ```
+
+> **Note:** Not all registries support OCI DELETE. GitHub Container Registry (ghcr.io) requires deletion through the web interface at `https://github.com/orgs/YOUR_ORG/packages`. Docker Hub, Azure Container Registry, Harbor, and Amazon ECR support API-based deletion.
 
 ### Troubleshooting
 
-#### Authentication Errors (403 Forbidden)
+**403 Forbidden errors:**
 
-If you get a 403 error:
-
+```bash
+# Enable debug logging to see which auth config is being used
+scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg -d
 ```
-❌ failed to push artifact: ... response status code 403: denied
-```
 
-**Check:**
-1. Your token has `write:packages` scope for pushing
-2. You're logged in: `docker login ghcr.io` or `podman login ghcr.io`
+Check that:
+1. Your token has `write:packages` scope
+2. You're logged in: `docker login ghcr.io`
 3. The org/repo exists and you have access
-4. Use `--log-level -1` to see which auth config file is being used
 
-```bash
-scafctl catalog push my-solution@1.0.0 --catalog ghcr.io/myorg --log-level -1
-```
-
-#### Config File Not Found
-
-If scafctl isn't finding your credentials, check where they're stored:
-
-```bash
-# Docker
-cat ~/.docker/config.json
-
-# Podman
-cat ~/.config/containers/auth.json
-```
-
-#### Insecure Registries (HTTP)
+**Insecure registries (HTTP):**
 
 For local testing with registries that don't use HTTPS:
 
 ```bash
-scafctl catalog push my-solution@1.0.0 --catalog localhost:5000 --insecure
-scafctl catalog pull localhost:5000/solutions/my-solution@1.0.0 --insecure
+scafctl catalog push greeting@1.0.0 --catalog localhost:5000 --insecure
+scafctl catalog pull localhost:5000/solutions/greeting@1.0.0 --insecure
 ```
 
 ### Supported Registries
@@ -588,284 +752,457 @@ scafctl works with any OCI-compliant registry:
 | Google Artifact Registry | `REGION-docker.pkg.dev/PROJECT` |
 | Harbor | `harbor.example.com/PROJECT` |
 | Local Registry | `localhost:5000` |
+
+### What You Learned
+
+- `scafctl catalog push NAME@VERSION --catalog REGISTRY` pushes to a remote registry
+- `scafctl catalog pull REGISTRY/solutions/NAME@VERSION` pulls to your local catalog
+- `--as` lets you rename artifacts during push or pull
+- `--force` overwrites existing artifacts
+- `--insecure` allows HTTP connections for local testing
+- Authentication uses standard Docker/Podman credential files
+
 ---
 
-## Advanced Bundling
+## Bundling File Dependencies
 
-When you build a solution, scafctl creates a **bundle** — a self-contained archive containing your solution YAML plus all local files and vendored catalog dependencies it needs at runtime.
+When a solution references local files (via the `file` provider), those files need to be packaged into the bundle so the solution works when run from the catalog. This tutorial walks you through building a solution with file dependencies.
 
-### How Bundling Works
+### Step 1: Create the Project Structure
 
-The build process:
-1. **Discovers files** — scans your solution for `file` provider references
-2. **Vendors catalog refs** — copies nested solutions from the catalog into the bundle
-3. **Applies include/exclude patterns** — filters files based on `bundle.include` and `bundle.exclude`
-4. **Creates a lock file** — records exact versions and digests for reproducibility
-5. **Packages everything** — produces a single artifact stored in the catalog
+Create a directory with the following files:
 
-### Bundle Configuration
+```bash
+mkdir -p deploy-app/templates deploy-app/configs
+```
 
-Control what gets bundled using the `bundle` section in your solution:
+Create `deploy-app/configs/dev.yaml`:
+
+```yaml
+name: my-app
+namespace: dev
+replicas: 1
+image: my-app:latest
+port: 8080
+```
+
+Create `deploy-app/configs/prod.yaml`:
+
+```yaml
+name: my-app
+namespace: production
+replicas: 3
+image: my-app:1.2.0
+port: 8080
+```
+
+Create `deploy-app/templates/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+spec:
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      app: {{ .name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .name }}
+    spec:
+      containers:
+        - name: {{ .name }}
+          image: {{ .image }}
+          ports:
+            - containerPort: {{ .port }}
+```
+
+### Step 2: Create the Solution File
+
+Create `deploy-app/solution.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: my-app
+  name: deploy-app
   version: 1.0.0
+  description: Renders a Kubernetes deployment for a given environment
+
 bundle:
-  # Explicit file patterns to include (glob syntax)
   include:
-    - "templates/**/*.yaml"
-    - "configs/*.json"
-    - "scripts/deploy.sh"
-  
-  # Patterns to exclude (applied after include)
-  exclude:
-    - "**/*_test.yaml"
-    - "**/temp/**"
-```
+    - "configs/**/*.yaml"
 
-**Pattern Behavior:**
-- Patterns use [doublestar](https://github.com/bmatcuk/doublestar) glob syntax
-- `**` matches any number of directories
-- Paths are relative to the solution file's directory
-- Exclude patterns override include patterns
-
-**When to Use Explicit Includes:**
-
-Use `bundle.include` when:
-- Files aren't discovered automatically (e.g., loaded via dynamic CEL expressions)
-- You want to bundle extra files not referenced in resolvers/actions
-- Auto-discovery includes unwanted files
-
-### Catalog Dependencies (Vendoring)
-
-When your solution references another solution from the catalog, that dependency is **vendored** into your bundle:
-
-```yaml
 spec:
   resolvers:
-    base-config:
+    environment:
+      type: string
+      description: "Target environment (dev or prod)"
       resolve:
         with:
-          - provider: solution
+          - provider: parameter
             inputs:
-              source: "catalog:shared-config@2.0.0"
+              name: environment
+              default: dev
+
+    config:
+      type: any
+      description: "Environment-specific configuration"
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              path:
+                expr: "'configs/' + _.environment + '.yaml'"
+              format: yaml
+
+    deployment-template:
+      type: string
+      description: "Kubernetes deployment template"
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              path: "templates/deployment.yaml"
+
+    rendered-deployment:
+      type: string
+      description: "Rendered deployment manifest"
+      dependsOn:
+        - deployment-template
+        - config
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template:
+                rslvr: deployment-template
+              data:
+                rslvr: config
 ```
 
-During build:
-1. scafctl fetches `shared-config@2.0.0` from your local catalog
-2. Copies it into `.scafctl/vendor/shared-config@2.0.0.yaml`
-3. Records the exact digest in `.scafctl.lock.yaml`
+Notice the `bundle.include` section — this is needed because `config` uses a **dynamic path** (computed via CEL expression at runtime). scafctl can't statically discover which config files to bundle, so you tell it to include all YAML files under `configs/`.
 
-The resulting bundle is **fully self-contained** — it doesn't require the referenced solution to exist in the target environment's catalog.
+The `deployment-template` resolver uses a **static path** (`templates/deployment.yaml`), so scafctl discovers it automatically — no `bundle.include` entry needed.
 
-### The Lock File
+### Step 3: Preview What Gets Bundled
 
-After building, a `.scafctl.lock.yaml` file is created alongside your solution:
+```bash
+scafctl build solution deploy-app/solution.yaml --dry-run
+```
+
+Expected output:
+
+```
+Bundle analysis for deploy-app/solution.yaml:
+  Static analysis discovered:
+    templates/deployment.yaml
+  Explicit includes (bundle.include):
+    configs/dev.yaml
+    configs/prod.yaml
+  ⚠️ Dynamic paths detected (ensure these are covered by bundle.include):
+    resolver 'config' (file provider): expr in 'configs/' + _.environment + '.yaml'
+  Total: 3 bundled file(s)
+💡 Dry run: would build deploy-app@1.0.0
+```
+
+The dry-run shows:
+- **Static analysis discovered** — files scafctl found by analyzing your resolvers
+- **Explicit includes** — files matched by your `bundle.include` patterns
+- **Dynamic paths** — warnings about paths that can't be statically resolved
+
+### Step 4: Build the Solution
+
+```bash
+scafctl build solution deploy-app/solution.yaml
+```
+
+Expected output:
+
+```
+ 💡   Bundled 3 file(s) (1.0 KB, deduplicated: 1 layer(s))
+ ✅ Built deploy-app@1.0.0
+ 💡   Digest: sha256:abc123...
+ 💡   Catalog: ~/.local/share/scafctl/catalog
+```
+
+### Step 5: Run from the Catalog with Dev Config
+
+```bash
+scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=dev
+```
+
+Expected output:
 
 ```yaml
-# .scafctl.lock.yaml
-version: 1
-dependencies:
-  - ref: shared-config@2.0.0
-    digest: sha256:a1b2c3d4...
-    resolvedFrom: local
-    vendoredAt: 2026-02-09T10:30:00Z
-plugins: []
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+          ports:
+            - containerPort: 8080
 ```
 
-**Why it matters:**
-- **Reproducibility** — rebuilds use the exact same dependency versions
-- **Auditability** — you can see what was bundled and when
-- **Verification** — `scafctl bundle verify` checks bundle integrity against the lock file
-
-**Commit the lock file** to source control alongside your solution.
-
-### Updating Vendored Dependencies
-
-When upstream catalog solutions change, update your vendored copies:
+### Step 6: Switch to Prod
 
 ```bash
-# Preview what would be updated (no changes made)
-scafctl vendor update --dry-run
-
-# Update all vendored dependencies
-scafctl vendor update
-
-# Update a specific dependency only
-scafctl vendor update --dependency shared-config@2.0.0
-
-# Update lock file without re-vendoring files
-scafctl vendor update --lock-only
-
-# Include pre-release versions when resolving
-scafctl vendor update --pre-release
+scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=prod
 ```
 
-Output:
-```
-Checking vendored dependencies for ./solution.yaml...
+Expected output:
 
-  shared-config@2.0.0:
-    locked:   2.0.0 (sha256:a1b2c3d4...)
-    latest:   2.0.1 (sha256:e5f6g7h8...)
-    action:   would update
-
-Summary: 1 dependency(ies) would be updated
-```
-
-### Build Flags
-
-#### Dry Run
-
-Preview what a build would produce without writing anything:
-
-```bash
-scafctl build solution my-solution.yaml --dry-run
-```
-
-Output shows:
-- Composed files (from `compose` section)
-- Discovered files (auto-detected from resolvers/actions)
-- Explicit includes (from `bundle.include`)
-- Catalog references (to be vendored)
-- Plugins
-- Dynamic path warnings (paths that can't be statically analyzed)
-- Size summary
-
-#### Deduplication (Storage Optimization)
-
-Large bundles can optimize storage using content-addressable deduplication:
-
-```bash
-# Default: dedupe enabled with 4KB threshold
-scafctl build solution my-solution.yaml
-
-# Disable deduplication
-scafctl build solution my-solution.yaml --dedupe=false
-
-# Custom threshold (files >= this size get individual layers)
-scafctl build solution my-solution.yaml --dedupe-threshold=8KB
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:1.2.0
+          ports:
+            - containerPort: 8080
 ```
 
-With deduplication:
-- Large files become individual OCI blob layers
-- Files with identical content share the same blob
-- Small files are grouped into a single tar layer
-- Pulling a solution only fetches changed layers
+The config values (namespace, replicas, image) changed based on the environment file — all loaded from the bundled files inside the catalog artifact.
 
-### Dynamic Path Warnings
+### Step 7: Add Exclude Patterns
 
-During build, scafctl warns about file paths that can't be statically analyzed:
-
-```
-⚠ Dynamic path warnings:
-  resolver 'template' (file provider): expr: 'configs/' + environment + '.yaml'
-  action 'deploy' (file provider): tmpl: {{ .target }}/deploy.yaml
-```
-
-**What this means:**
-- These paths are computed at runtime using CEL expressions, Go templates, or resolver bindings
-- scafctl cannot automatically discover these files during build
-- The files may be missing from your bundle
-
-**How to fix:**
-Add explicit patterns to `bundle.include`:
+Suppose you add test files that you don't want in the bundle. Update `deploy-app/solution.yaml` to add an exclude pattern:
 
 ```yaml
 bundle:
   include:
-    - "configs/**/*.yaml"   # Cover all config environments
-    - "**/deploy.yaml"       # Cover all deploy files
+    - "configs/**/*.yaml"
+  exclude:
+    - "**/*_test.yaml"
 ```
 
-### Bundle Verification
+Now any file ending in `_test.yaml` will be excluded, even if it matches an include pattern.
 
-Verify a built solution matches its lock file:
+### What You Learned
 
-```bash
-scafctl bundle verify my-solution@1.0.0
-```
-
-This checks:
-- All files in the manifest exist with correct digests
-- All vendored dependencies match their locked digests
-- No unexpected files were added
-
-### Extracting Bundle Contents
-
-Inspect what's inside a bundled solution:
-
-```bash
-# List files without extracting
-scafctl bundle extract my-solution@1.0.0 --list
-
-# Extract to a directory
-scafctl bundle extract my-solution@1.0.0 --output ./extracted/
-```
-
-### Comparing Bundle Versions
-
-See what changed between two versions:
-
-```bash
-scafctl bundle diff my-solution@1.0.0 my-solution@1.1.0
-```
-
-Output:
-```
-Comparing my-solution@1.0.0 → my-solution@1.1.0
-
-Added:
-  + templates/new-feature.yaml (1.2 KB)
-
-Modified:
-  ~ solution.yaml (2.1 KB → 2.3 KB)
-  ~ configs/prod.json (256 B → 312 B)
-
-Removed:
-  - templates/deprecated.yaml (890 B)
-
-Summary: 1 added, 2 modified, 1 removed
-```
-
-### Example: Complete Bundling Workflow
-
-```bash
-# 1. Build with dry-run to see what will be bundled
-scafctl build solution deploy.yaml --dry-run
-
-# 2. Add any missing files to bundle.include in deploy.yaml
-#    (if dynamic path warnings appear)
-
-# 3. Build the solution
-scafctl build solution deploy.yaml --version 1.0.0
-
-# 4. Verify the bundle
-scafctl bundle verify deploy@1.0.0
-
-# 5. Check what's inside
-scafctl bundle extract deploy@1.0.0 --list
-
-# 6. Later, update dependencies
-scafctl vendor update --dry-run
-scafctl vendor update
-
-# 7. Rebuild with updated deps
-scafctl build solution deploy.yaml --version 1.0.1 --force
-
-# 8. See what changed
-scafctl bundle diff deploy@1.0.0 deploy@1.0.1
-```
-
-See [examples/catalog/bundling-example/](../../examples/catalog/bundling-example/) for a working example with bundle configuration.
+- The `file` provider references local files that must be bundled
+- Static paths (literal strings) are auto-discovered during build
+- Dynamic paths (CEL expressions, Go templates) require explicit `bundle.include` patterns
+- `--dry-run` shows exactly what would be bundled, including warnings for dynamic paths
+- `bundle.exclude` filters out files that match include patterns (e.g., test files)
+- Bundled solutions are self-contained — all file dependencies travel with the artifact
 
 ---
+
+## Verifying and Extracting Bundles
+
+After building a bundle, you can verify its integrity and examine its contents.
+
+### Step 1: Verify the Bundle
+
+```bash
+scafctl bundle verify deploy-app@1.0.0
+```
+
+Expected output:
+
+```
+ 💡 Verifying deploy-app@1.0.0...
+  Static paths:
+  Bundle includes (glob coverage): ✅
+    ✓ configs/**/*.yaml
+ ✅ Verification passed: 1 item(s) checked
+```
+
+This checks that:
+- All files referenced in the solution exist in the bundle
+- Glob patterns in `bundle.include` cover the expected files
+
+### Step 2: List Bundle Contents
+
+See what files are inside the bundle without extracting them:
+
+```bash
+scafctl bundle extract deploy-app@1.0.0 --list-only
+```
+
+Expected output:
+
+```
+  templates/deployment.yaml    (500 B)
+  configs/dev.yaml             (100 B)
+  configs/prod.yaml            (105 B)
+💡 Total: 3 file(s), 705 B
+```
+
+### Step 3: Extract to a Directory
+
+Extract the bundled files to inspect them:
+
+```bash
+scafctl bundle extract deploy-app@1.0.0 --output-dir ./extracted
+```
+
+Check the extracted files:
+
+```bash
+ls -R extracted/
+```
+
+You'll see the full directory structure preserved:
+
+```
+extracted/
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+└── templates/
+    └── deployment.yaml
+```
+
+### Step 4: Extract Files for a Specific Resolver
+
+You can extract only the files needed by a specific resolver:
+
+```bash
+scafctl bundle extract deploy-app@1.0.0 --resolver config --output-dir ./config-only
+```
+
+This uses static analysis to determine which files the `config` resolver references.
+
+### Step 5: Clean Up
+
+```bash
+rm -rf extracted/ config-only/
+```
+
+### What You Learned
+
+- `scafctl bundle verify` checks that a bundle contains all required files
+- `scafctl bundle extract --list-only` shows bundle contents without extracting
+- `scafctl bundle extract --output-dir DIR` extracts files to a directory
+- `--resolver NAME` extracts only files needed by a specific resolver
+- Use `--flatten` to extract all files to a single directory (no subdirectories)
+
+---
+
+## Comparing Bundle Versions
+
+When you release a new version of a bundled solution, `bundle diff` shows exactly what changed.
+
+### Step 1: Create a v2 with Changes
+
+Add a new config file and modify the template. First, create `deploy-app/configs/staging.yaml`:
+
+```yaml
+name: my-app
+namespace: staging
+replicas: 2
+image: my-app:1.2.0-rc1
+port: 8080
+```
+
+Then update `deploy-app/solution.yaml` to bump the version:
+
+```yaml
+metadata:
+  name: deploy-app
+  version: 2.0.0
+```
+
+### Step 2: Build v2
+
+```bash
+scafctl build solution deploy-app/solution.yaml
+```
+
+Expected output:
+
+```
+ 💡   Bundled 4 file(s) (1.2 KB, deduplicated: 1 layer(s))
+ ✅ Built deploy-app@2.0.0
+ 💡   Digest: sha256:xyz789...
+ 💡   Catalog: ~/.local/share/scafctl/catalog
+```
+
+Notice it now bundles 4 files (the new staging config was picked up by `configs/**/*.yaml`).
+
+### Step 3: Compare the Two Versions
+
+```bash
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0
+```
+
+The output shows files added, modified, and removed between the two versions.
+
+### Step 4: Show Only File Changes
+
+```bash
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --files-only
+```
+
+### Step 5: Show Only Solution Structure Changes
+
+```bash
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --solution-only
+```
+
+This shows only changes to the solution YAML itself (resolvers added/removed, actions changed, etc.).
+
+### Step 6: Get Diff Output as YAML
+
+```bash
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 -o yaml
+```
+
+### Step 7: Clean Up
+
+```bash
+scafctl catalog delete deploy-app@1.0.0 --kind solution
+scafctl catalog delete deploy-app@2.0.0 --kind solution
+scafctl catalog prune
+rm -rf deploy-app/
+```
+
+### What You Learned
+
+- `scafctl bundle diff REF_A REF_B` compares two versions of a bundled solution
+- `--files-only` shows only file-level changes (added, modified, removed)
+- `--solution-only` shows only solution structure changes (resolvers, actions)
+- `-o yaml` or `-o json` gives machine-readable diff output
+
+---
+
 ## Next Steps
 
-- [Getting Started](getting-started.md) - Basic scafctl usage
-- [Actions Tutorial](actions-tutorial.md) - Building workflows
-- [Resolver Tutorial](resolver-tutorial.md) - Data resolution patterns
-
+- [Go Templates Tutorial](go-templates-tutorial.md) — Generate structured text with Go templates
+- [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
+- [Functional Testing Tutorial](functional-testing.md) — Write and run automated tests
+- [Configuration Tutorial](config-tutorial.md) — Manage application configuration

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -25,11 +25,21 @@ CEL is used throughout scafctl for dynamic evaluation:
 
 **Key principle:** In CEL expressions, all resolved values are available under the `_` namespace (e.g., `_.appName`, `_.config.port`).
 
+> **Hands-on:** Every section in this tutorial links to a runnable example file. Look for the **▶ Try it** callouts to run the examples yourself.
+
 ## Quick Start
 
 ### 1. Basic Expressions
 
+Create a file called `cel-basics.yaml`:
+
 ```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-basics
+  version: 1.0.0
+
 spec:
   resolvers:
     greeting:
@@ -40,6 +50,27 @@ spec:
             inputs:
               expression: "'Hello, World!'"
 ```
+
+Run it:
+
+```bash
+scafctl run resolver -f cel-basics.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "greeting": "Hello, World!"
+}
+```
+
+> **Tip**: `run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details.
+
+> **▶ Try it:** The complete example with more expressions is at [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
+> ```
 
 String literals use single quotes inside the expression. Numbers, booleans, and lists are written normally:
 
@@ -52,9 +83,15 @@ expression: '{"key": "value"}'
 
 ### 2. Referencing Resolvers
 
-Use `_` to access other resolver values:
+Use `_` to access other resolver values. Create a file called `cel-refs.yaml`:
 
 ```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-refs
+  version: 1.0.0
+
 spec:
   resolvers:
     firstName:
@@ -83,9 +120,27 @@ spec:
               expression: "_.firstName + ' ' + _.lastName"
 ```
 
+Run it:
+
+```bash
+scafctl run resolver -f cel-refs.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "firstName": "Alice",
+  "fullName": "Alice Smith",
+  "lastName": "Smith"
+}
+```
+
+> **▶ Try it:** This example is also in [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) — it includes operators, string operations, list comprehensions, and more.
+
 ### 3. Using `expr` in Inputs
 
-The `expr` field can be used on any provider input for dynamic values:
+The `expr` field can be used on any provider input for dynamic values. For example, in your solution's `workflow.actions` section:
 
 ```yaml
 workflow:
@@ -210,11 +265,21 @@ size("hello")                         // 5
 "Hello %s, you are %d".format(["Alice", 30])  // "Hello Alice, you are 30"
 ```
 
+> **▶ Try it:** All the operators, string, list, and map operations above are runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+> ```
+
 ---
 
 ## Custom Extension Functions
 
 scafctl extends CEL with project-specific functions for arrays, maps, strings, filepath, GUID, sorting, time, marshalling, and debugging.
+
+> **▶ Try it:** All custom extension functions are demonstrated in a single runnable file — [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution
+> ```
 
 ### Arrays
 
@@ -662,9 +727,19 @@ cel.bind(base, _.host + ":" + string(_.port),
 )
 ```
 
+> **▶ Try it:** Encoders, math, optionals, sets, and bindings are all runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+> ```
+
 ---
 
 ## Common Patterns
+
+> **▶ Try it:** All the patterns below are combined into one runnable file — [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
+> ```
 
 ### Conditional Configuration
 
@@ -767,6 +842,11 @@ deployments:
             })
 ```
 
+> **▶ Try it:** For more data transformation patterns (filtering, aggregation, enrichment, serialization), see [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml):
+> ```bash
+> scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution
+> ```
+
 ## Function Reference
 
 ### Custom Functions (scafctl)
@@ -820,12 +900,16 @@ deployments:
 
 | Example | Description | Run |
 |---------|-------------|-----|
-| [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml) | Showcase of all custom CEL extension functions | `scafctl run solution -f examples/resolvers/cel-extensions.yaml -o json` |
-| [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml) | Data transformation patterns with CEL | `scafctl run solution -f examples/resolvers/cel-transforms.yaml -o json` |
+| [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) | Literals, resolver refs, operators, strings, lists | `scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution` |
+| [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml) | Math, encoders, sets, optionals, bindings, string/list ops | `scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution` |
+| [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml) | Conditionals, map building, filtering, merging, resource generation | `scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution` |
+| [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml) | All custom CEL extension functions (arrays, map, strings, etc.) | `scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution` |
+| [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml) | Data transformation patterns (filter, aggregate, enrich) | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution` |
 
 ## Next Steps
 
+- [Go Templates Tutorial](go-templates-tutorial.md) — When to use `tmpl` vs `expr`
+- [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
 - [Resolver Tutorial](resolver-tutorial.md) — Use CEL in resolver pipelines
 - [Actions Tutorial](actions-tutorial.md) — Dynamic inputs with `expr`
-- [Go Templates Tutorial](go-templates-tutorial.md) — When to use `tmpl` vs `expr`
 - [Provider Reference](provider-reference.md) — The `cel` provider

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -178,12 +178,16 @@ scafctl config paths --platform linux
 Typical output:
 
 ```
-XDG Paths (darwin/arm64)
-
-Config:   ~/.config/scafctl/config.yaml
-Data:     ~/.local/share/scafctl/
-Cache:    ~/.cache/scafctl/
-State:    ~/.local/state/scafctl/
+ 💡 scafctl Paths
+Platform: darwin/arm64
+Config:      ~/.config/scafctl/config.yaml
+Secrets:     ~/.local/share/scafctl/secrets
+Data:        ~/.local/share/scafctl
+Catalog:     ~/.local/share/scafctl/catalog
+Cache:       ~/.cache/scafctl
+HTTP Cache:  ~/.cache/scafctl/http-cache
+State:       ~/.local/state/scafctl
+Override paths with XDG environment variables or SCAFCTL_SECRETS_DIR.
 ```
 
 ## Configuration Reference
@@ -272,7 +276,7 @@ scafctl config unset logging.level
 
 ## Next Steps
 
-- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output destination
-- [Catalog Tutorial](catalog-tutorial.md) — Build and manage solutions in the catalog
+- [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data
-- [Getting Started](getting-started.md) — Run your first solution
+- [Catalog Tutorial](catalog-tutorial.md) — Build and manage solutions in the catalog

--- a/docs/tutorials/directory-provider-tutorial.md
+++ b/docs/tutorials/directory-provider-tutorial.md
@@ -30,7 +30,7 @@ This tutorial walks you through using the `directory` provider to list, scan, cr
 
 ## Listing Directory Contents
 
-The simplest use of the directory provider is listing files and directories in a given path.
+The simplest use of the directory provider is listing files and directories in a given path. Create a file called `list-dir.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -54,10 +54,37 @@ spec:
 Run it:
 
 ```bash
-scafctl run solution -f list-dir.yaml
+scafctl run resolver -f list-dir.yaml -o json --hide-execution
 ```
 
-The output includes an `entries` array where each entry has:
+Output (entries will vary based on your directory contents):
+
+```json
+{
+  "project-files": {
+    "basePath": "/path/to/current/dir",
+    "dirCount": 1,
+    "entries": [
+      {
+        "absolutePath": "/path/to/current/dir/list-dir.yaml",
+        "extension": ".yaml",
+        "isDir": false,
+        "modTime": "2026-01-01T00:00:00Z",
+        "mode": "0644",
+        "name": "list-dir.yaml",
+        "path": "list-dir.yaml",
+        "size": 250,
+        "type": "file"
+      }
+    ],
+    "fileCount": 1,
+    "totalCount": 2,
+    "totalSize": 250
+  }
+}
+```
+
+The resolver output includes an `entries` array where each entry has:
 
 | Field | Description |
 |-------|-------------|
@@ -79,6 +106,8 @@ The output also provides summary fields: `totalCount`, `fileCount`, `dirCount`, 
 ## Recursive Traversal
 
 Enable `recursive: true` to traverse subdirectories. Control the depth with `maxDepth` (default: 10, maximum: 50).
+
+> **Note:** The YAML snippets in the remaining sections show only the `spec:` or `workflow:` portion. To run them, place each snippet inside a complete solution file with `apiVersion`, `kind`, and `metadata` sections — like the `list-dir.yaml` example above.
 
 ```yaml
 spec:
@@ -208,7 +237,7 @@ Each entry will include `checksum` and `checksumAlgorithm` fields.
 
 ## Creating Directories
 
-Use the `mkdir` operation to create directories. Set `createDirs: true` to create the full path (like `mkdir -p`).
+Use the `mkdir` operation to create directories. Set `createDirs: true` to create the full path (like `mkdir -p`). Create a file called `create-dirs.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -229,15 +258,25 @@ spec:
           createDirs: true
 ```
 
-The action returns `{ "success": true, "operation": "mkdir", "path": "<absolute-path>" }`.
+Run it:
 
-Without `createDirs: true`, the parent directory must already exist or the operation fails.
+```bash
+scafctl run solution -f create-dirs.yaml
+```
+
+The command completes silently on success. Verify the directory was created:
+
+```bash
+ls output/reports/2026
+```
+
+The action returns `{ "success": true, "operation": "mkdir", "path": "<absolute-path>" }`.
 
 ---
 
 ## Removing Directories
 
-The `rmdir` operation removes directories. By default it only removes empty directories. Use `force: true` to remove non-empty directories recursively.
+The `rmdir` operation removes directories. By default it only removes empty directories. Use `force: true` to remove non-empty directories recursively. Add this to your solution's `workflow.actions` section:
 
 ```yaml
 workflow:
@@ -256,7 +295,7 @@ workflow:
 
 ## Copying Directories
 
-The `copy` operation recursively copies a directory tree to a new location:
+The `copy` operation recursively copies a directory tree to a new location. Add this to your solution's `workflow.actions` section:
 
 ```yaml
 workflow:
@@ -395,6 +434,7 @@ workflow:
 
 ## Next Steps
 
-- See the [Provider Reference](../provider-reference/) for the complete directory provider input/output schema
-- Explore [Resolver Tutorial](../resolver-tutorial/) for combining providers with dependencies and transforms
-- Check the [Actions Tutorial](../actions-tutorial/) for building workflows with directory operations
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
+- [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
+- [Provider Reference](provider-reference.md) — Complete directory provider input/output schema
+- [Resolver Tutorial](resolver-tutorial.md) — Combining providers with dependencies and transforms

--- a/docs/tutorials/exec-provider-tutorial.md
+++ b/docs/tutorials/exec-provider-tutorial.md
@@ -45,7 +45,7 @@ You can optionally switch to an **external shell** (bash, pwsh, cmd) when you ne
 
 ## Running Simple Commands
 
-The simplest usage is a single command:
+The simplest usage is a single command. Create a file called `simple-exec.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -67,7 +67,13 @@ spec:
 Run it:
 
 ```bash
-scafctl run solution -f solution.yaml
+scafctl run solution -f simple-exec.yaml
+```
+
+Output:
+
+```
+Hello, World!
 ```
 
 ### Output Fields
@@ -86,6 +92,7 @@ Every exec action produces these output fields:
 You can reference these in downstream actions:
 
 ```yaml
+# Add these to your solution's workflow.actions section:
 actions:
   run-cmd:
     provider: exec
@@ -104,7 +111,9 @@ actions:
 
 ## Pipes and Shell Features
 
-Unlike traditional exec implementations that require a special flag for shell features, the embedded shell handles all POSIX syntax by default:
+Unlike traditional exec implementations that require a special flag for shell features, the embedded shell handles all POSIX syntax by default.
+
+> **Note:** The YAML snippets in the remaining sections show only the `actions:` block. To run them, place each snippet inside a complete solution file with `apiVersion`, `kind`, `metadata`, `spec.resolvers: {}`, and `spec.workflow` sections — like the `simple-exec.yaml` example above.
 
 ```yaml
 actions:
@@ -566,3 +575,10 @@ Complete runnable examples are available in the `examples/exec/` directory:
 | [shell-types.yaml](../../examples/exec/shell-types.yaml) | Using auto, bash, and PowerShell shells |
 | [environment-and-io.yaml](../../examples/exec/environment-and-io.yaml) | Environment variables, stdin, timeouts |
 | [cross-platform.yaml](../../examples/exec/cross-platform.yaml) | Patterns that work on all operating systems |
+
+## Next Steps
+
+- [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
+- [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
+- [Provider Reference](provider-reference.md) — Complete provider documentation
+- [Actions Tutorial](actions-tutorial.md) — Use exec providers in workflows

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -16,7 +16,7 @@ advanced CI integration.
 
 ## Writing Your First Test
 
-Add a `tests` section to your solution's `spec`:
+Add a `tests` section to your solution's `spec`. Create a file called `solution.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -62,6 +62,8 @@ my-solution    render-basic      PASS     8ms
 Each test specifies a `command` (the scafctl subcommand to run) and one or more
 `assertions` to validate the output. The runner automatically injects
 `-f <sandbox-copy-of-solution>` unless you set `injectFile: false`.
+
+> **Note:** The YAML snippets in the remaining sections of this tutorial show only the `tests:` block or relevant portion. To use them, add them to the `spec.tests` section of your solution file — like the `solution.yaml` example above.
 
 ---
 
@@ -674,7 +676,9 @@ testConfig:
 ## Compose Test Files
 
 Split tests across multiple files using compose. The `compose` field goes at the **top level**
-of the solution YAML, not inside `spec`:
+of the solution YAML, not inside `spec`.
+
+Create a main solution file called `solution.yaml`:
 
 ```yaml
 # solution.yaml
@@ -697,6 +701,8 @@ spec:
           output: "main.tf"
 ```
 
+Create a file called `tests/smoke.yaml`:
+
 ```yaml
 # tests/smoke.yaml
 spec:
@@ -708,6 +714,8 @@ spec:
       assertions:
         - expression: __exitCode == 0
 ```
+
+Create a file called `tests/validation.yaml`:
 
 ```yaml
 # tests/validation.yaml
@@ -1341,5 +1349,12 @@ This is the primary use case for requiring test files to be bundled and why `sca
 ### Test Scaffolding (`scafctl test init`)
 
 ✅ **Implemented.** See the [Test Scaffolding](#test-scaffolding-scafctl-test-init) section above.
+
+## Next Steps
+
+- [Configuration Tutorial](config-tutorial.md) — Manage application configuration
+- [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
+- [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
+- [Provider Reference](provider-reference.md) — Complete provider documentation
 
 ---

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -71,91 +71,31 @@ Output:
 Hello, World!
 ```
 
-### 2. Using Parameters
+This solution has two parts:
 
-Pass values from the command line:
+- **Resolver** (`greeting`) — gathers a value using the `static` provider
+- **Action** (`say-hello`) — runs a shell command that references the resolver via `_.greeting`
+
+> **Want to go deeper with resolvers?** The [Resolver Tutorial](resolver-tutorial.md) covers parameters, dependencies, transforms, validation, and more.
+
+### 2. Action Dependencies
+
+Actions can depend on other actions and access their results. Create a new file called `action-deps.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: greet-user
+  name: action-deps
   version: 1.0.0
 
-spec:
-  resolvers:
-    name:
-      type: string
-      resolve:
-        with:
-          - provider: parameter
-            inputs:
-              key: name
-          - provider: static
-            inputs:
-              value: "World"  # Default if no parameter
-
-  workflow:
-    actions:
-      greet:
-        provider: exec
-        inputs:
-          command:
-            expr: "'echo Hello, ' + _.name + '!'"
-```
-
-```bash
-scafctl run solution -f greet.yaml -r name=Alice
-# Output: Hello, Alice!
-
-scafctl run solution -f greet.yaml
-# Output: Hello, World!
-```
-
-### 3. Resolver Dependencies
-
-Resolvers can depend on each other using the `_` namespace:
-
-```yaml
-spec:
-  resolvers:
-    firstName:
-      type: string
-      resolve:
-        with:
-          - provider: parameter
-            inputs:
-              key: first
-
-    lastName:
-      type: string
-      resolve:
-        with:
-          - provider: parameter
-            inputs:
-              key: last
-
-    fullName:
-      type: string
-      resolve:
-        with:
-          - provider: cel
-            inputs:
-              expression: "_.firstName + ' ' + _.lastName"
-```
-
-### 4. Action Dependencies
-
-Actions can depend on other actions and access their results:
-
-```yaml
 spec:
   workflow:
     actions:
       fetch-data:
         provider: http
         inputs:
-          url: https://api.example.com/config
+          url: https://httpbin.org/get
 
       process:
         dependsOn: [fetch-data]
@@ -163,6 +103,20 @@ spec:
         inputs:
           command:
             expr: "'echo Got status: ' + string(__actions['fetch-data'].results.statusCode)"
+```
+
+The `process` action uses `dependsOn` to wait for `fetch-data` to complete, then accesses its results via the `__actions` namespace.
+
+Run it:
+
+```bash
+scafctl run solution -f action-deps.yaml
+```
+
+Output:
+
+```
+Got status: 200
 ```
 
 ## Key Concepts
@@ -272,8 +226,8 @@ scafctl render solution -f solution.yaml -o json
 
 ## Next Steps
 
-- [Catalog Tutorial](catalog-tutorial.md) - Store and run solutions by name
-- [Resolver Tutorial](resolver-tutorial.md) - Deep dive into resolvers
-- [Actions Tutorial](actions-tutorial.md) - Learn about workflows
-- [Provider Reference](provider-reference.md) - All providers documented
-- [Examples](https://github.com/oakwood-commons/scafctl/tree/main/examples) - Working examples
+- [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
+- [Actions Tutorial](actions-tutorial.md) — Learn about workflows
+- [Catalog Tutorial](catalog-tutorial.md) — Store and run solutions by name
+- [Provider Reference](provider-reference.md) — All providers documented
+- [Examples](https://github.com/oakwood-commons/scafctl/tree/main/examples) — Working examples

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -5,7 +5,30 @@ weight: 60
 
 # Go Templates Tutorial
 
-This tutorial covers using Go templates in scafctl for generating structured text output like configuration files, documentation, and code scaffolding.
+This tutorial walks you through using Go templates in scafctl to generate structured text output like configuration files, documentation, and code scaffolding. You'll start with a simple template and progressively learn conditionals, loops, whitespace control, file-based templates, custom delimiters, and multi-file generation.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with YAML syntax
+- Completion of the [Resolver Tutorial](resolver-tutorial.md) and [Actions Tutorial](actions-tutorial.md)
+
+## Table of Contents
+
+1. [Your First Template](#your-first-template)
+2. [Using Conditionals](#using-conditionals)
+3. [Iterating Over Lists](#iterating-over-lists)
+4. [Iterating Over Maps](#iterating-over-maps)
+5. [Controlling Whitespace](#controlling-whitespace)
+6. [Loading Templates from Files](#loading-templates-from-files)
+7. [Handling Missing Keys](#handling-missing-keys)
+8. [Injecting Additional Data](#injecting-additional-data)
+9. [Using Custom Delimiters](#using-custom-delimiters)
+10. [Using `tmpl` for Dynamic Inputs](#using-tmpl-for-dynamic-inputs)
+11. [Generating Multiple Files with ForEach](#generating-multiple-files-with-foreach)
+12. [Putting It All Together: README Generator](#putting-it-all-together-readme-generator)
+
+---
 
 ## Overview
 
@@ -25,9 +48,15 @@ scafctl supports Go templates in two ways:
 - **Go templates** — Multi-line text generation, file rendering, structured output
 - **CEL expressions** — Data transformation, conditionals, single-value computation
 
-## Quick Start
+---
 
-### 1. Simple Template
+## Your First Template
+
+Let's start by rendering a simple greeting with the `go-template` provider.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-basics.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -57,20 +86,570 @@ spec:
               template: "Hello, {{ .name }}!"
 ```
 
+### Step 2: Run It
+
 ```bash
-scafctl run solution -f template-basics.yaml -o json
-# Output: {"greeting": "Hello, World!", "name": "World"}
+scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml --hide-execution
 ```
 
-The `go-template` provider receives all resolver values as template data. Access them with dot notation: `{{ .resolverName }}`.
-
-### 2. Template from File
-
-For larger templates, read them from the filesystem:
+### Step 3: Check the Output
 
 ```yaml
+Hello, World!
+```
+
+### What Happened
+
+- The `name` resolver produced the value `"World"`.
+- The `greeting` resolver used the `go-template` provider to render a template.
+- Inside the template, `{{ .name }}` pulled in the resolved value of `name`.
+- All resolver values are available at the template root — access them with `{{ .resolverName }}`.
+- The `-e _.greeting` flag filters the output to just the `greeting` resolver, and `-o yaml` renders it cleanly.
+
+> **Key point:** The `go-template` provider requires two inputs: `name` (an identifier for the template) and `template` (the Go template string to render).
+
+---
+
+## Using Conditionals
+
+Templates can branch based on data values using `{{ if }}`, `{{ else if }}`, and `{{ else }}`. In this tutorial you'll use a `parameter` provider so you can change the environment from the command line and see how the output adapts — without editing the file each time.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-conditionals.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-conditionals
+  version: 1.0.0
+
 spec:
   resolvers:
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+          - provider: static
+            inputs:
+              value: "development"
+
+    app_name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-service"
+
+    deployment_config:
+      type: string
+      dependsOn: [environment, app_name]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "deploy-config"
+              template: |
+                # Deployment config for {{ .app_name }}
+                environment: {{ .environment }}
+                {{ if eq .environment "production" }}
+                replicas: 5
+                logging: warn
+                resources:
+                  cpu: "2"
+                  memory: "4Gi"
+                {{ else if eq .environment "staging" }}
+                replicas: 2
+                logging: info
+                resources:
+                  cpu: "1"
+                  memory: "2Gi"
+                {{ else }}
+                replicas: 1
+                logging: debug
+                resources:
+                  cpu: "500m"
+                  memory: "512Mi"
+                {{ end }}
+```
+
+The `environment` resolver tries the `parameter` provider first (looking for a `-r env=<value>` flag). If no parameter is supplied, it falls back to the `static` provider and defaults to `"development"`.
+
+### Step 2: Run with the Default Environment
+
+Run without passing any parameters — the environment defaults to `development`:
+
+```bash
+scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml --hide-execution
+```
+
+> **Tip:** The `-e _.deployment_config` flag filters the output to just the `deployment_config` resolver, and `-o yaml` renders it cleanly.
+
+Output:
+
+```yaml
+# Deployment config for my-service
+environment: development
+
+replicas: 1
+logging: debug
+resources:
+  cpu: "500m"
+  memory: "512Mi"
+```
+
+Since `"development"` doesn't match `"production"` or `"staging"`, the `{{ else }}` branch is used.
+
+### Step 3: Switch to Staging
+
+Pass `-r env=staging` to override the environment:
+
+```bash
+scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml --hide-execution
+```
+
+Output:
+
+```yaml
+# Deployment config for my-service
+environment: staging
+
+replicas: 2
+logging: info
+resources:
+  cpu: "1"
+  memory: "2Gi"
+```
+
+The `{{ else if eq .environment "staging" }}` branch is now active.
+
+### Step 4: Switch to Production
+
+```bash
+scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml --hide-execution
+```
+
+Output:
+
+```yaml
+# Deployment config for my-service
+environment: production
+
+replicas: 5
+logging: warn
+resources:
+  cpu: "2"
+  memory: "4Gi"
+```
+
+The `{{ if eq .environment "production" }}` branch is now active — more replicas, stricter logging, and larger resource limits.
+
+### What You Learned
+
+- `{{ if eq .field "value" }}` compares a field to a string.
+- `{{ else if }}` and `{{ else }}` provide fallback branches.
+- `{{ end }}` closes each `if` block.
+- Go templates support comparison functions like `eq`, `ne`, `lt`, `gt`, `le`, `ge`.
+- Using the `parameter` provider lets you change values from the command line with `-r key=value`, making it easy to test different branches without editing the file.
+- The `-e _.resolverName -o yaml` flags are a convenient way to inspect a single resolver's rendered output.
+
+---
+
+## Iterating Over Lists
+
+Use `{{ range }}` to loop over arrays. Inside the loop, `.` refers to the current item.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-loops.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-loops
+  version: 1.0.0
+
+spec:
+  resolvers:
+    services:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  port: 8080
+                  healthy: true
+                - name: worker
+                  port: 9090
+                  healthy: true
+                - name: scheduler
+                  port: 9100
+                  healthy: false
+
+    service_report:
+      type: string
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "service-report"
+              template: |
+                Service Status Report
+                =====================
+                {{ range .services }}
+                - {{ .name }} (port {{ .port }}): {{ if .healthy }}UP{{ else }}DOWN{{ end }}
+                {{ end }}
+                Total services: {{ len .services }}
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```yaml
+Service Status Report
+=====================
+
+- api (port 8080): UP
+
+- worker (port 9090): UP
+
+- scheduler (port 9100): DOWN
+
+Total services: 3
+```
+
+Notice the extra blank lines — we'll fix that in the [Controlling Whitespace](#controlling-whitespace) section.
+
+### Step 4: Add an Index
+
+If you need the iteration index, assign both the index and item to variables. Replace the `template` in the resolver above with:
+
+```yaml
+              template: |
+                Service Status Report
+                =====================
+                {{ range $i, $svc := .services }}
+                {{ $i }}. {{ $svc.name }} (port {{ $svc.port }})
+                {{ end }}
+```
+
+This produces numbered output:
+
+```
+Service Status Report
+=====================
+
+0. api (port 8080)
+
+1. worker (port 9090)
+
+2. scheduler (port 9100)
+```
+
+### What You Learned
+
+- `{{ range .list }}` iterates over an array; `.` becomes the current item inside the loop.
+- `{{ range $i, $item := .list }}` gives you both the index and the item.
+- You can nest `{{ if }}` inside `{{ range }}` to conditionally render per item.
+- `{{ len .list }}` returns the length of a list.
+
+---
+
+## Iterating Over Maps
+
+Use `{{ range $key, $value := .map }}` to iterate over key-value pairs.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-maps.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-maps
+  version: 1.0.0
+
+spec:
+  resolvers:
+    features:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                enable_metrics: true
+                enable_tracing: true
+                enable_cache: false
+                enable_auth: true
+
+    feature_summary:
+      type: string
+      dependsOn: [features]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "feature-summary"
+              template: |
+                Feature Flags
+                =============
+                {{ range $feature, $enabled := .features }}
+                {{ $feature }}: {{ if $enabled }}ON{{ else }}OFF{{ end }}
+                {{ end }}
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```yaml
+Feature Flags
+=============
+
+enable_auth: ON
+
+enable_cache: OFF
+
+enable_metrics: ON
+
+enable_tracing: ON
+```
+
+> **Note:** Map iteration order is sorted alphabetically by key in Go templates.
+
+### What You Learned
+
+- `{{ range $key, $value := .map }}` iterates over a map's entries.
+- You can combine map iteration with conditionals to format values dynamically.
+
+---
+
+## Controlling Whitespace
+
+You may have noticed extra blank lines in the previous examples. Go templates preserve all whitespace literally — including newlines around `{{ }}` tags. Use `{{-` and `-}}` to trim adjacent whitespace.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-whitespace.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-whitespace
+  version: 1.0.0
+
+spec:
+  resolvers:
+    services:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  port: 8080
+                - name: worker
+                  port: 9090
+                - name: scheduler
+                  port: 9100
+
+    without_trim:
+      type: string
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "no-trim"
+              template: |
+                services:
+                {{ range .services }}
+                  - {{ .name }}
+                {{ end }}
+
+    with_trim:
+      type: string
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "trimmed"
+              template: |
+                services:
+                {{- range .services }}
+                  - {{ .name }}
+                {{- end }}
+```
+
+### Step 2: Run It
+
+First, check the untrimmed version:
+
+```bash
+scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml --hide-execution
+```
+
+Then compare with the trimmed version:
+
+```bash
+scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml --hide-execution
+```
+
+### Step 3: Compare the Outputs
+
+**`without_trim`** has extra blank lines:
+
+```
+services:
+
+  - api
+
+  - worker
+
+  - scheduler
+```
+
+**`with_trim`** is clean:
+
+```
+services:
+  - api
+  - worker
+  - scheduler
+```
+
+### What You Learned
+
+- `{{-` trims all whitespace (including newlines) **before** the tag.
+- `-}}` trims all whitespace **after** the tag.
+- Use trimming judiciously — over-trimming can collapse lines you want to keep separate.
+- A good rule of thumb: use `{{-` on `range` and `end` tags that sit on their own line.
+
+---
+
+## Loading Templates from Files
+
+For larger templates, store them in separate files and load them at runtime with the `file` provider.
+
+### Step 1: Create the Template File
+
+Create the file `templates/config.yaml.tmpl`:
+
+```gotmpl
+# Generated Configuration
+# Application: {{ .app_name }}
+# Environment: {{ .environment }}
+
+server:
+  host: {{ .server.host }}
+  port: {{ .server.port }}
+  {{- if .server.tls_enabled }}
+  tls:
+    enabled: true
+  {{- end }}
+
+database:
+  host: {{ .database.host }}
+  port: {{ .database.port }}
+  name: {{ .database.name }}
+  {{- if eq .environment "production" }}
+  pool_size: 20
+  {{- else }}
+  pool_size: 5
+  {{- end }}
+
+features:
+{{- range $key, $value := .features }}
+  {{ $key }}: {{ $value }}
+{{- end }}
+```
+
+### Step 2: Create the Solution File
+
+Create `template-from-file.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-from-file
+  version: 1.0.0
+
+spec:
+  resolvers:
+    app_name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-service"
+
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "staging"
+
+    server:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                host: "0.0.0.0"
+                port: 8080
+                tls_enabled: true
+
+    database:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                host: "db.example.com"
+                port: 5432
+                name: "myservice_db"
+
+    features:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                enable_metrics: true
+                enable_tracing: true
+                enable_cache: false
+
+    # Read the template from the filesystem
     template_content:
       type: any
       resolve:
@@ -80,89 +659,741 @@ spec:
               operation: "read"
               path: "templates/config.yaml.tmpl"
 
-    rendered:
+    # Render the template using all resolved data
+    rendered_config:
       type: string
-      dependsOn: [template_content, app_name, environment]
+      dependsOn:
+        - template_content
+        - app_name
+        - environment
+        - server
+        - database
+        - features
       resolve:
         with:
           - provider: go-template
             inputs:
-              name: "config"
+              name: "config-yaml"
               template:
                 expr: "_.template_content.content"
               missingKey: "error"
+
+  workflow:
+    actions:
+      write-config:
+        description: Write rendered config to filesystem
+        provider: file
+        inputs:
+          operation: "write"
+          path: "/tmp/scafctl-demo/config.yaml"
+          content:
+            expr: "_.rendered_config"
+          createDirs: true
+
+      verify-output:
+        description: Show the generated file
+        provider: exec
+        dependsOn:
+          - write-config
+        inputs:
+          command: "cat /tmp/scafctl-demo/config.yaml"
 ```
 
-See [template-render.yaml](../../examples/actions/template-render.yaml) for a complete working example.
+### Step 3: Run It
 
-## Template Syntax
+```bash
+scafctl run solution -f template-from-file.yaml
+```
 
-### Variables
+### Step 4: Verify the Output
 
-All resolver values are available at the root level:
+```bash
+cat /tmp/scafctl-demo/config.yaml
+```
+
+You should see:
 
 ```yaml
-template: |
-  App: {{ .app_name }}
-  Version: {{ .version }}
-  Port: {{ .server.port }}
+# Generated Configuration
+# Application: my-service
+# Environment: staging
+
+server:
+  host: 0.0.0.0
+  port: 8080
+  tls:
+    enabled: true
+
+database:
+  host: db.example.com
+  port: 5432
+  name: myservice_db
+  pool_size: 5
+
+features:
+  enable_cache: false
+  enable_metrics: true
+  enable_tracing: true
 ```
 
-### Conditionals
+### What Happened
+
+1. The `template_content` resolver used `provider: file` with `operation: "read"` to load the `.tmpl` file. The result is an object with a `content` field containing the file text.
+2. The `rendered_config` resolver passed `template: expr: "_.template_content.content"` to the `go-template` provider, which evaluates the CEL expression to get the raw template string.
+3. All other resolvers (`app_name`, `environment`, `server`, etc.) are automatically available as `{{ .resolverName }}` inside the template.
+4. Setting `missingKey: "error"` ensures the render fails if any referenced variable is missing — catching typos early.
+5. The workflow action wrote the rendered output to disk.
+
+> **Tip:** See [template-render.yaml](../../examples/actions/template-render.yaml) for a more comprehensive file-based template example with timestamps and dynamic output paths.
+
+---
+
+## Handling Missing Keys
+
+By default, templates silently render `<no value>` when you reference a nested key that doesn't exist in the data. This can lead to broken output that's hard to debug. The `missingKey` option controls this behavior — and setting it to `"error"` is the best way to catch mistakes early.
+
+> **Note:** The `missingKey` option applies to keys missing *within* the data passed to the template (e.g., a map field that doesn't exist). It does not apply to missing resolvers — scafctl validates resolver references at build time and will reject the solution if a referenced resolver doesn't exist.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-missing-keys.yaml`. The `app` resolver is a map with `name` but no `owner` field — the template references `{{ .app.owner }}` to trigger the missing key behavior:
 
 ```yaml
-template: |
-  {{ if eq .environment "production" }}
-  replicas: 5
-  logging: warn
-  {{ else }}
-  replicas: 1
-  logging: debug
-  {{ end }}
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-missing-keys
+  version: 1.0.0
+
+spec:
+  resolvers:
+    app:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: "my-app"
+                # Note: no "owner" field here
+
+    # Default mode — missing keys are silently ignored
+    silent_mode:
+      type: string
+      dependsOn: [app]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "silent-mode"
+              template: "App: {{ .app.name }}, Owner: {{ .app.owner }}"
+
+    # Error mode — missing keys cause a failure
+    strict_mode:
+      type: string
+      dependsOn: [app]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "strict-mode"
+              missingKey: "error"
+              template: "App: {{ .app.name }}, Owner: {{ .app.owner }}"
 ```
 
-### Loops
+### Step 2: See the Silent Default
+
+First, comment out or remove the `strict_mode` resolver (it will cause a failure, which we'll explore in the next step). Then run:
+
+```bash
+scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml --hide-execution
+```
+
+Output:
 
 ```yaml
-template: |
-  {{ range .services }}
-  - name: {{ .name }}
-    port: {{ .port }}
-  {{ end }}
+App: my-app, Owner: <no value>
 ```
 
-With index:
-```yaml
-template: |
-  {{ range $i, $svc := .services }}
-  {{ $i }}. {{ $svc.name }}
-  {{ end }}
+The template rendered successfully, but the missing `owner` key silently became `<no value>`. In a real config file, this would produce invalid output with no warning.
+
+### Step 3: See the Error Mode
+
+Now add back the `strict_mode` resolver and run:
+
+```bash
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
 ```
 
-### Maps
+This time the command **fails** with an error telling you exactly which key is missing. Instead of silently producing broken output, `missingKey: "error"` catches the problem immediately.
 
-```yaml
-template: |
-  {{ range $key, $value := .features }}
-  {{ $key }}: {{ $value }}
-  {{ end }}
-```
+### Step 4: Fix the Error
 
-### Whitespace Control
-
-Use `-` to trim whitespace:
+Add the `owner` field to the `app` resolver's value:
 
 ```yaml
-template: |
-  services:
-  {{- range .services }}
-    - {{ .name }}
-  {{- end }}
+    app:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: "my-app"
+                owner: "platform-team"
 ```
+
+Re-run and both resolvers now succeed:
+
+```bash
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+```
+
+```yaml
+App: my-app, Owner: platform-team
+```
+
+### What You Learned
+
+| Mode | Behavior | Best For |
+|------|----------|----------|
+| `default` | Missing keys silently render as `<no value>` | Quick prototyping |
+| `zero` | Missing keys silently render as the zero value | Lenient templates |
+| `error` | Missing keys cause a failure | Production use (recommended) |
+
+- Without `missingKey: "error"`, a typo like `{{ .app.ownr }}` would silently produce `<no value>` instead of failing — making bugs hard to find.
+- Always use `missingKey: "error"` in production templates to catch issues early.
+
+---
+
+## Injecting Additional Data
+
+Sometimes you need extra values in a template without creating separate resolvers. The `data` input lets you merge ad-hoc values into the template context.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-extra-data.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-extra-data
+  version: 1.0.0
+
+spec:
+  resolvers:
+    app_name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-service"
+
+    version:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "2.1.0"
+
+    release_notes:
+      type: string
+      dependsOn: [app_name, version]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "release-notes"
+              template: |
+                Release: {{ .app_name }} v{{ .version }}
+                Build: #{{ .build_number }}
+                Branch: {{ .branch }}
+                Maintainer: {{ .maintainer }}
+              data:
+                build_number: "1547"
+                branch: "main"
+                maintainer: "platform-team"
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```yaml
+Release: my-service v2.1.0
+Build: #1547
+Branch: main
+Maintainer: platform-team
+```
+
+### What You Learned
+
+- The `data` input merges key-value pairs into the template context alongside resolver values.
+- If a key in `data` conflicts with a resolver name, `data` takes precedence.
+- This is useful for build metadata, constants, or values that don't warrant their own resolver.
+
+---
+
+## Using Custom Delimiters
+
+When generating files that already contain `{{` and `}}` — such as Helm charts, Jinja templates, or GitHub Actions workflows — you need to change the template delimiters so scafctl doesn't try to evaluate the literal braces.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-delimiters.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-delimiters
+  version: 1.0.0
+
+spec:
+  resolvers:
+    image:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "nginx"
+
+    tag:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "1.25-alpine"
+
+    helm_values:
+      type: string
+      dependsOn: [image, tag]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "helm-values"
+              leftDelim: "<%"
+              rightDelim: "%>"
+              template: |
+                # Helm values.yaml
+                # The {{ and }} below are literal Helm template syntax
+                image:
+                  repository: <% .image %>
+                  tag: <% .tag %>
+                annotations:
+                  checksum/config: "{{ include \"mychart.checksum\" . }}"
+                  version: "{{ .Chart.AppVersion }}"
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```yaml
+# Helm values.yaml
+# The {{ and }} below are literal Helm template syntax
+image:
+  repository: nginx
+  tag: 1.25-alpine
+annotations:
+  checksum/config: "{{ include "mychart.checksum" . }}"
+  version: "{{ .Chart.AppVersion }}"
+```
+
+Notice how `<% .image %>` and `<% .tag %>` were replaced with actual values, while `{{ include ... }}` and `{{ .Chart.AppVersion }}` were left as literal text for Helm to process later.
+
+### What You Learned
+
+- `leftDelim` and `rightDelim` change the template delimiters from the default `{{`/`}}`.
+- This lets you generate files that contain `{{` and `}}` as literal content.
+- Pick delimiters that don't conflict with your target file format (e.g., `<%`/`%>`, `<<`/`>>`).
+
+---
+
+## Using `tmpl` for Dynamic Inputs
+
+So far you've used the `go-template` provider to render multi-line text. But you can also use Go template syntax directly in any provider input with the `tmpl` field — as a more readable alternative to `expr` (CEL) for string interpolation.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-tmpl-field.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-tmpl-field
+  version: 1.0.0
+
+spec:
+  resolvers:
+    project:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-app"
+
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "staging"
+
+  workflow:
+    actions:
+      # Using tmpl — clean string interpolation
+      deploy-tmpl:
+        description: Deploy with tmpl
+        provider: exec
+        inputs:
+          command:
+            tmpl: "echo 'Deploying {{ .project }} to {{ .environment }}'"
+
+      # The equivalent using expr (CEL) — more verbose
+      deploy-expr:
+        description: Deploy with expr
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Deploying ' + _.project + ' to ' + _.environment"
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run solution -f template-tmpl-field.yaml
+```
+
+### Step 3: Observe the Output
+
+Both actions produce the same result:
+
+```
+Deploying my-app to staging
+```
+
+### What You Learned
+
+| Field | Syntax | Best For |
+|-------|--------|----------|
+| `tmpl` | `"kubectl apply -f {{ .output_dir }}/{{ .app_name }}.yaml"` | String interpolation, readability |
+| `expr` | `"'kubectl apply -f ' + _.output_dir + '/' + _.app_name + '.yaml'"` | Computed values, conditionals, data transformation |
+
+- In `tmpl`, resolver values are accessed as `{{ .resolverName }}` (no `_` prefix).
+- In `expr`, resolver values are accessed as `_.resolverName`.
+- Use `tmpl` when you're building a string from parts. Use `expr` when you need logic, math, or function calls.
+
+---
+
+## Generating Multiple Files with ForEach
+
+Combine `tmpl` with `forEach` to generate a different file for each item in a list. The iteration variable is available inside `tmpl` expressions.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-foreach.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-foreach
+  version: 1.0.0
+
+spec:
+  resolvers:
+    team:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "platform"
+
+    services:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  port: 8080
+                  replicas: 3
+                - name: worker
+                  port: 9090
+                  replicas: 2
+                - name: gateway
+                  port: 443
+                  replicas: 4
+
+  workflow:
+    actions:
+      generate-configs:
+        description: Generate a config file per service
+        provider: file
+        forEach:
+          in:
+            expr: "_.services"
+          item: svc
+        inputs:
+          operation: "write"
+          path:
+            tmpl: "/tmp/scafctl-demo/services/{{ .svc.name }}.yaml"
+          content:
+            tmpl: |
+              # Auto-generated service config
+              # Team: {{ .team }}
+              name: {{ .svc.name }}
+              port: {{ .svc.port }}
+              replicas: {{ .svc.replicas }}
+          createDirs: true
+
+      verify-output:
+        description: Show all generated files
+        provider: exec
+        dependsOn:
+          - generate-configs
+        inputs:
+          command: "echo '--- Generated files ---' && ls /tmp/scafctl-demo/services/ && echo '--- api.yaml ---' && cat /tmp/scafctl-demo/services/api.yaml && echo '--- worker.yaml ---' && cat /tmp/scafctl-demo/services/worker.yaml && echo '--- gateway.yaml ---' && cat /tmp/scafctl-demo/services/gateway.yaml"
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run solution -f template-foreach.yaml
+```
+
+### Step 3: Verify the Output
+
+```bash
+ls /tmp/scafctl-demo/services/
+```
+
+You'll see three files: `api.yaml`, `worker.yaml`, `gateway.yaml`. Each contains its own config:
+
+```bash
+cat /tmp/scafctl-demo/services/api.yaml
+```
+
+```yaml
+# Auto-generated service config
+# Team: platform
+name: api
+port: 8080
+replicas: 3
+```
+
+### What You Learned
+
+- `forEach.in` defines the list to iterate over (here, via a CEL expression).
+- `forEach.item` names the iteration variable (here, `svc`).
+- Inside `tmpl`, the iteration variable is accessed as `{{ .svc.name }}`.
+- Both `path` and `content` can use `tmpl` — making it easy to generate unique filenames and content per item.
+- Other resolvers (like `team`) remain accessible alongside the iteration variable.
+
+---
+
+## Putting It All Together: README Generator
+
+This final tutorial combines everything you've learned — conditionals, loops, maps, whitespace control, extra data, and file output — into a realistic README generator.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-readme-generator.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: readme-generator
+  version: 1.0.0
+
+spec:
+  resolvers:
+    project_name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-project"
+
+    language:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Go"
+
+    features:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - title: "REST API"
+                  enabled: true
+                - title: "GraphQL"
+                  enabled: false
+                - title: "WebSocket"
+                  enabled: true
+                - title: "gRPC"
+                  enabled: true
+
+    contributors:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - "Alice"
+                - "Bob"
+                - "Charlie"
+
+    readme_content:
+      type: string
+      dependsOn: [project_name, language, features, contributors]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: "readme"
+              missingKey: "error"
+              template: |
+                # {{ .project_name }}
+
+                A {{ .language }} project.
+
+                ## Features
+
+                | Feature | Status |
+                |---------|--------|
+                {{- range $item := .features }}
+                | {{ $item.title }} | {{ if $item.enabled }}✅ Enabled{{ else }}❌ Disabled{{ end }} |
+                {{- end }}
+
+                ## Contributors
+                {{- range $c := .contributors }}
+                - {{ $c }}
+                {{- end }}
+
+                ## Quick Start
+
+                ```bash
+                {{- if eq .language "Go" }}
+                go run .
+                {{- else if eq .language "Node" }}
+                npm start
+                {{- else }}
+                echo "See docs for setup instructions"
+                {{- end }}
+                ```
+
+                ---
+                *Generated by scafctl ({{ .generator_version }})*
+              data:
+                generator_version: "1.0.0"
+
+  workflow:
+    actions:
+      write-readme:
+        description: Write generated README to disk
+        provider: file
+        inputs:
+          operation: "write"
+          path: "/tmp/scafctl-demo/README.md"
+          content:
+            expr: "_.readme_content"
+          createDirs: true
+
+      show-readme:
+        description: Display the generated README
+        provider: exec
+        dependsOn:
+          - write-readme
+        inputs:
+          command: "cat /tmp/scafctl-demo/README.md"
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run solution -f template-readme-generator.yaml
+```
+
+### Step 3: View the Result
+
+```bash
+cat /tmp/scafctl-demo/README.md
+```
+
+Output:
+
+````markdown
+# my-project
+
+A Go project.
+
+## Features
+
+| Feature | Status |
+|---------|--------|
+| REST API | ✅ Enabled |
+| GraphQL | ❌ Disabled |
+| WebSocket | ✅ Enabled |
+| gRPC | ✅ Enabled |
+
+## Contributors
+- Alice
+- Bob
+- Charlie
+
+## Quick Start
+
+```bash
+go run .
+```
+
+---
+*Generated by scafctl (1.0.0)*
+````
+
+### What You Practiced
+
+- **Conditionals:** The Quick Start section adapts the command based on the language.
+- **Loops:** Features are rendered as a markdown table; contributors as a bulleted list.
+- **Whitespace control:** `{{-` keeps the table and list items tightly formatted.
+- **Extra data:** The `generator_version` value came from `data`, not a resolver.
+- **Error mode:** `missingKey: "error"` ensures the template fails fast on typos.
+- **Workflow:** The action writes the rendered output to a file on disk.
+
+---
 
 ## Provider Reference
 
-### Inputs
+For a quick reference of all `go-template` provider inputs:
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
@@ -173,188 +1404,7 @@ template: |
 | `rightDelim` | string | ❌ | Custom right delimiter (default: `}}`) |
 | `data` | any | ❌ | Additional data merged into template context |
 
-### Missing Key Behavior
-
-| Mode | Behavior |
-|------|----------|
-| `default` | Missing keys render as `<no value>` |
-| `zero` | Missing keys render as the zero value for the type |
-| `error` | Missing keys cause an error (recommended for production) |
-
-```yaml
-# Fail if any referenced value doesn't exist
-- provider: go-template
-  inputs:
-    name: "strict"
-    template: "Hello, {{ .name }}"
-    missingKey: "error"
-```
-
-### Custom Delimiters
-
-Useful when generating files that contain `{{` (e.g., Helm charts, Jinja templates):
-
-```yaml
-- provider: go-template
-  inputs:
-    name: "helm-values"
-    leftDelim: "<%"
-    rightDelim: "%>"
-    template: |
-      # Helm values ({{ and }} are literal here)
-      image: <% .image %>
-      tag: <% .tag %>
-      annotations:
-        checksum: "{{ include \"mychart.checksum\" . }}"
-```
-
-### Additional Data
-
-Merge extra data into the template context without creating resolvers:
-
-```yaml
-- provider: go-template
-  inputs:
-    name: "with-data"
-    template: "{{ .app }} v{{ .build_number }}"
-    data:
-      build_number: "42"
-```
-
-The `data` values are merged with resolver values, with `data` taking precedence on conflicts.
-
-## Using `tmpl` in Provider Inputs
-
-As an alternative to `expr` (CEL), you can use `tmpl` for dynamic provider inputs:
-
-```yaml
-workflow:
-  actions:
-    deploy:
-      provider: exec
-      inputs:
-        command:
-          tmpl: "kubectl apply -f {{ .output_dir }}/{{ .app_name }}.yaml"
-```
-
-**Comparison:**
-
-| Field | Syntax | Best For |
-|-------|--------|----------|
-| `expr` | `"'kubectl apply -f ' + _.output_dir + '/' + _.app_name + '.yaml'"` | Computed values, conditionals |
-| `tmpl` | `"kubectl apply -f {{ .output_dir }}/{{ .app_name }}.yaml"` | String interpolation, readability |
-
-Note: In `tmpl`, resolver values are accessed as `{{ .resolverName }}` (no `_` prefix needed).
-
-## ForEach with Templates
-
-Templates have access to iteration context variables:
-
-```yaml
-workflow:
-  actions:
-    notify:
-      provider: exec
-      forEach:
-        in:
-          expr: "_.services"
-        item: service
-      inputs:
-        command:
-          tmpl: "echo 'Deploying {{ .service.name }} to {{ .environment }}'"
-```
-
-## Common Patterns
-
-### Generate a Config File
-
-```yaml
-rendered_config:
-  type: string
-  dependsOn: [app, db, features]
-  resolve:
-    with:
-      - provider: go-template
-        inputs:
-          name: "app-config"
-          missingKey: "error"
-          template: |
-            # Auto-generated by scafctl
-            app:
-              name: {{ .app.name }}
-              port: {{ .app.port }}
-
-            database:
-              host: {{ .db.host }}
-              port: {{ .db.port }}
-              name: {{ .db.name }}
-
-            features:
-            {{- range $feature, $enabled := .features }}
-              {{ $feature }}: {{ $enabled }}
-            {{- end }}
-```
-
-### Generate a Dockerfile
-
-```yaml
-dockerfile:
-  type: string
-  dependsOn: [language, version, port]
-  resolve:
-    with:
-      - provider: go-template
-        inputs:
-          name: "dockerfile"
-          template: |
-            FROM {{ .language }}:{{ .version }}
-            WORKDIR /app
-            COPY . .
-            {{ if eq .language "go" }}
-            RUN go build -o /app/server .
-            {{ else if eq .language "node" }}
-            RUN npm install && npm run build
-            {{ end }}
-            EXPOSE {{ .port }}
-            CMD ["/app/server"]
-```
-
-### Multi-File Generation
-
-Combine with `forEach` to generate multiple files:
-
-```yaml
-resolvers:
-  services:
-    type: array
-    resolve:
-      with:
-        - provider: static
-          inputs:
-            value:
-              - name: api
-                port: 8080
-              - name: worker
-                port: 9090
-
-workflow:
-  actions:
-    generate-configs:
-      provider: file
-      forEach:
-        in:
-          expr: "_.services"
-        item: svc
-      inputs:
-        operation: "write"
-        path:
-          tmpl: "/tmp/configs/{{ .svc.name }}.yaml"
-        content:
-          tmpl: |
-            name: {{ .svc.name }}
-            port: {{ .svc.port }}
-        createDirs: true
-```
+---
 
 ## Examples
 
@@ -365,6 +1415,7 @@ workflow:
 
 ## Next Steps
 
+- [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
+- [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
 - [Actions Tutorial](actions-tutorial.md) — Use templates in action workflows
-- [Resolver Tutorial](resolver-tutorial.md) — Learn about resolver dependencies and transforms
 - [Provider Reference](provider-reference.md) — Full `go-template` provider documentation

--- a/docs/tutorials/logging-tutorial.md
+++ b/docs/tutorials/logging-tutorial.md
@@ -315,5 +315,7 @@ SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
 
 ## Next Steps
 
+- [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
+- [Provider Reference](provider-reference.md) — Complete provider documentation
 - [Configuration Tutorial](config-tutorial.md) — Manage all application settings
 - [Getting Started](getting-started.md) — Run your first solution

--- a/docs/tutorials/plugin-development.md
+++ b/docs/tutorials/plugin-development.md
@@ -143,8 +143,10 @@ EOF
 
 ### 5. Use Your Provider
 
+Create a file called `my-solution.yaml`:
+
 ```yaml
-# solution.yaml
+# my-solution.yaml
 apiVersion: scafctl/v1
 kind: Solution
 metadata:
@@ -157,6 +159,12 @@ spec:
           provider: my-custom-provider
           inputs:
             input: "Hello World"
+```
+
+Run it:
+
+```bash
+scafctl run solution -f my-solution.yaml -o json
 ```
 
 ## Plugin Interface
@@ -609,6 +617,7 @@ scafctl catalog list --kind provider
 
 ## Next Steps
 
-- Review the [echo plugin example](../examples/plugins/echo/) for a working reference
-- See [Provider Development Guide](provider-development.md) for provider patterns
-- Check [Contributing Guidelines](../CONTRIBUTING.md) for submission process
+- [Provider Development Guide](provider-development.md) — Provider patterns
+- [Provider Reference](provider-reference.md) — All providers documented
+- [Getting Started](getting-started.md) — Run your first solution
+- [Contributing Guidelines](../CONTRIBUTING.md) — Submission process

--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -240,7 +240,58 @@ value := resolverCtx["otherResolver"]
 // Get logger
 lgr := logger.FromContext(ctx)
 lgr.V(1).Info("processing", "url", url)
+
+// Get IO streams for streaming output to the terminal
+ioStreams := provider.IOStreamsFromContext(ctx)
+if ioStreams != nil {
+    fmt.Fprintln(ioStreams.Out, "streaming output to terminal")
+}
 ```
+
+### Streaming Output
+
+Providers that produce user-visible output (e.g., command stdout/stderr) can stream it
+directly to the terminal instead of returning it only in `Output.Data`. This gives users
+real-time feedback during long-running operations.
+
+To stream output:
+
+1. **Get IO streams from context** — `provider.IOStreamsFromContext(ctx)` returns a
+   `*IOStreams` with `Out` and `ErrOut` writers. It may be `nil` when the CLI
+   is rendering structured output (JSON/YAML), so always check.
+
+2. **Write to both the capture buffer and the terminal** — Use `io.MultiWriter` to
+   write to both your internal buffer (for `Output.Data`) and the terminal writer.
+
+3. **Set `Streamed: true`** on the returned `Output` — This tells the CLI layer not
+   to re-print the data that was already streamed.
+
+```go
+func (p *MyProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+    var buf bytes.Buffer
+    out := &buf
+
+    // Stream output to terminal if IO streams are available
+    ioStreams := provider.IOStreamsFromContext(ctx)
+    streamed := false
+    if ioStreams != nil {
+        out = io.MultiWriter(&buf, ioStreams.Out)
+        streamed = true
+    }
+
+    // Write output — goes to both buffer and terminal
+    fmt.Fprintln(out, "Hello, World!")
+
+    return &provider.Output{
+        Data:     map[string]any{"output": buf.String()},
+        Streamed: streamed,
+    }, nil
+}
+```
+
+When actions run in parallel, the CLI automatically wraps each action's IO streams with
+a `PrefixedWriter` that prepends `[action-name]` to each line, so users can tell which
+action produced which output.
 
 ## Using Typed Inputs (Decode)
 
@@ -546,6 +597,6 @@ func (p *RateLimitProvider) Execute(ctx context.Context, input any) (*provider.O
 
 ## Next Steps
 
-- See [Plugin Development Guide](plugin-development.md) to create external plugins
-- Review [Provider Reference](provider-reference.md) for built-in provider examples
-- Check [Contributing Guidelines](../CONTRIBUTING.md) for code standards
+- [Plugin Development Guide](plugin-development.md) — Extend scafctl with plugins
+- [Provider Reference](provider-reference.md) — Built-in provider examples
+- [Contributing Guidelines](../CONTRIBUTING.md) — Code standards

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -7,6 +7,8 @@ weight: 110
 
 This document provides a reference for all built-in providers in scafctl.
 
+> **Note:** All YAML examples in this reference show only the relevant resolver or action snippet. To use them, place each snippet inside a complete solution file with `apiVersion`, `kind`, `metadata`, and `spec` sections. See the [Getting Started](getting-started.md) tutorial for the full solution structure.
+
 ## Overview
 
 Providers are execution primitives used by resolvers and actions. Each provider has **capabilities** that determine where it can be used:
@@ -848,3 +850,10 @@ validate:
         expression: "!__self.startsWith('v0.')"
         message: "Version must be semver format and >= v1.0.0"
 ```
+
+## Next Steps
+
+- [Provider Development](provider-development.md) — Build custom providers
+- [Plugin Development](plugin-development.md) — Extend scafctl with plugins
+- [Resolver Tutorial](resolver-tutorial.md) — Using providers within resolvers
+- [Getting Started](getting-started.md) — Run your first solution

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -56,17 +56,19 @@ spec:
 ### Step 2: Run the Solution
 
 ```bash
-scafctl run solution -f hello.yaml
+scafctl run resolver -f hello.yaml
 ```
 
 Output:
-```json
-{
-  "greeting": "Hello, World!"
-}
+```
+╭─ scafctl run resolver ─╮
+│KEY       VALUE         │
+│─────────────────────── │
+│greeting  Hello, World! │
+╰ _ ─────────── map: 1/1 ╯
 ```
 
-> **Tip**: To run resolvers without executing actions (for debugging), use `scafctl run resolver -f hello.yaml`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details.
+> **Tip**: Add `-o json` to get JSON output: `scafctl run resolver -f hello.yaml -o json`
 
 ### Understanding the Structure
 
@@ -120,14 +122,35 @@ spec:
 ### Step 2: Run with Parameters
 
 ```bash
-# Use default value
-scafctl run solution -f greet.yaml
+scafctl run resolver -f greet.yaml
+```
 
-# Pass a parameter
-scafctl run solution -f greet.yaml -r user_name=Alice
+Output:
 
-# Pass multiple parameters
-scafctl run solution -f greet.yaml -r user_name=Bob -r another=value
+```
+╭─ scafctl run resolver ─╮
+│KEY       VALUE         │
+│─────────────────────── │
+│greeting  Hello, World! │
+│name      World         │
+╰ _ ─────────── map: 1/2 ╯
+```
+
+Pass a parameter:
+
+```bash
+scafctl run resolver -f greet.yaml -r user_name=Alice
+```
+
+Output:
+
+```
+╭─ scafctl run resolver ─╮
+│KEY       VALUE         │
+│─────────────────────── │
+│greeting  Hello, Alice! │
+│name      Alice         │
+╰ _ ─────────── map: 1/2 ╯
 ```
 
 ### Using Parameter Files
@@ -143,7 +166,18 @@ region: us-west-2
 
 Run with the file:
 ```bash
-scafctl run solution -f greet.yaml -r @params.yaml
+scafctl run resolver -f greet.yaml -r @params.yaml
+```
+
+Output:
+
+```
+╭─ scafctl run resolver ──╮
+│KEY       VALUE          │
+│─────────────────────────│
+│greeting  Hello, Charlie!│
+│name      Charlie        │
+╰ _ ──────────── map: 1/2 ╯
 ```
 
 ---
@@ -218,7 +252,7 @@ spec:
 ### Step 2: Run and Observe Phases
 
 ```bash
-scafctl run solution -f config.yaml --progress
+scafctl run resolver -f config.yaml --progress
 ```
 
 The `--progress` flag shows how resolvers execute in phases based on dependencies:
@@ -242,6 +276,8 @@ Phase 3: config
 Transform values after they're resolved using the `transform` phase.
 
 ### Example: String Manipulation
+
+Create a file called `transform.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -275,7 +311,27 @@ spec:
 
 **Key Concept**: In the transform phase, `__self` refers to the current value being transformed. Each transform step receives the output of the previous step.
 
+Run it:
+
+```bash
+scafctl run resolver -f transform.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "raw_input": "hello world"
+}
+```
+
+> **Tip**: `scafctl run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details on the execution metadata.
+
+The value was trimmed of whitespace, then lowercased — each transform step feeds into the next.
+
 ### Example: Data Enrichment
+
+Create a file called `enrich.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -307,6 +363,26 @@ spec:
               expression: "map.merge(__self, {'debug': true, 'logLevel': 'info'})"
 ```
 
+Run it:
+
+```bash
+scafctl run resolver -f enrich.yaml -o json --hide-execution
+```
+
+Output (timestamp will vary):
+
+```json
+{
+  "base_config": {
+    "debug": true,
+    "logLevel": "info",
+    "name": "my-app",
+    "timestamp": "2026-02-16T12:00:00.000000-05:00",
+    "version": "1.0.0"
+  }
+}
+```
+
 ---
 
 ## Validation
@@ -314,6 +390,8 @@ spec:
 Validate resolved values to ensure they meet requirements.
 
 ### Example: Port Range Validation
+
+Create a file called `validated-config.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -343,7 +421,35 @@ spec:
               message: "Port must be between 1024 and 65535"
 ```
 
+Run it with a valid port:
+
+```bash
+scafctl run resolver -f validated-config.yaml -r port=8080 -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "port": 8080
+}
+```
+
+Run it with an invalid port to see the validation error:
+
+```bash
+scafctl run resolver -f validated-config.yaml -r port=80
+```
+
+Output:
+
+```
+❌ resolver execution failed: ... validation: Port must be between 1024 and 65535
+```
+
 ### Example: Multiple Validations
+
+Create a file called `email-validator.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -379,6 +485,36 @@ spec:
 
 **Note**: All validation rules run and errors are aggregated. You'll see all failures, not just the first one.
 
+Run it:
+
+```bash
+scafctl run resolver -f email-validator.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+Now try an invalid value that fails **both** validations — not a valid email format **and** ends with `.test`:
+
+```bash
+scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json --hide-execution
+```
+
+Output:
+
+```text
+❌ resolver execution failed: phase 1 failed: resolver "email" failed: resolver "email" validation failed with 2 errors:
+  - [rule 1] validation: Invalid email format
+  - [rule 2] validation: Test emails not allowed
+```
+
+Both validation errors are reported together rather than failing on the first one.
+
 ---
 
 ## Conditional Execution
@@ -386,6 +522,8 @@ spec:
 Skip resolvers or phases based on conditions.
 
 ### Resolver-Level Condition
+
+Create a file called `conditional.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -412,14 +550,46 @@ spec:
     prod_secrets:
       when:
         expr: "_.environment == 'production'"
+      type: string
       resolve:
         with:
-          - provider: env
+          - provider: static
             inputs:
-              name: PROD_API_KEY
+              value: "prod-secret-value"
+```
+
+Run it with `development` (default) — the `prod_secrets` resolver is skipped:
+
+```bash
+scafctl run resolver -f conditional.yaml -o json --hide-execution
+```
+
+Output (only `environment` is resolved; `prod_secrets` is skipped):
+
+```json
+{
+  "environment": "development"
+}
+```
+
+Run it with `production` — the `prod_secrets` resolver executes:
+
+```bash
+scafctl run resolver -f conditional.yaml -r env=production -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "environment": "production",
+  "prod_secrets": "prod-secret-value"
+}
 ```
 
 ### Phase-Level Condition
+
+Create a file called `phase-condition.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -447,6 +617,23 @@ spec:
               expression: "map.merge(__self, {'transformed': true})"
 ```
 
+Run it:
+
+```bash
+scafctl run resolver -f phase-condition.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "feature_flags": {
+    "enable_transform": true,
+    "transformed": true
+  }
+}
+```
+
 ---
 
 ## Error Handling
@@ -454,6 +641,8 @@ spec:
 Handle errors gracefully with fallback sources.
 
 ### Fallback Pattern
+
+Create a file called `fallback.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -476,6 +665,7 @@ spec:
           # Fall back to local file
           - provider: file
             inputs:
+              operation: read
               path: ./config.json
           # Last resort: default values
           - provider: static
@@ -483,6 +673,23 @@ spec:
               value:
                 debug: false
                 timeout: 30
+```
+
+Run it (the HTTP and file providers will fail, so it falls back to static):
+
+```bash
+scafctl run resolver -f fallback.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "config": {
+    "debug": false,
+    "timeout": 30
+  }
+}
 ```
 
 **onError Options** (resolve phase):
@@ -496,6 +703,8 @@ spec:
 Fetch configuration from remote APIs.
 
 ### Basic HTTP Request
+
+Create a file called `http-example.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -512,14 +721,34 @@ spec:
         with:
           - provider: http
             inputs:
-              url: https://api.example.com/config
+              url: https://httpbin.org/get
               method: GET
               headers:
                 Accept: application/json
               timeout: 10s
 ```
 
+Run it:
+
+```bash
+scafctl run resolver -f http-example.yaml -o json --hide-execution
+```
+
+Output (body and headers will vary):
+
+```json
+{
+  "api_data": {
+    "body": "...",
+    "headers": { "...": "..." },
+    "statusCode": 200
+  }
+}
+```
+
 ### With Authentication
+
+Create a file called `auth-api.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -531,11 +760,12 @@ metadata:
 spec:
   resolvers:
     api_token:
-      sensitive: true  # Redact in logs
+      sensitive: true  # Redact in table output
       resolve:
         with:
           - provider: env
             inputs:
+              operation: get
               name: API_TOKEN
     
     api_data:
@@ -544,17 +774,28 @@ spec:
         with:
           - provider: http
             inputs:
-              url: https://api.example.com/secure/config
+              url: https://httpbin.org/headers
               headers:
                 Authorization:
                   tmpl: "Bearer {{._.api_token}}"
+```
+
+Run it (requires the `API_TOKEN` environment variable to be set):
+
+```bash
+export API_TOKEN=your-token-here
+scafctl run resolver -f auth-api.yaml -o json
 ```
 
 ---
 
 ## Common Patterns
 
+The following patterns are complete, self-contained solution files. Create a new file for each pattern to try it out.
+
 ### Pattern 1: Environment-Based Configuration
+
+Create a file called `env-config.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -590,7 +831,49 @@ spec:
                   : 'postgres://localhost:5432/app_dev'
 ```
 
+```bash
+scafctl run resolver -f env-config.yaml
+```
+
+Output:
+
+```
+╭─ scafctl run resolver ─╮
+│KEY           VALUE     │
+│─────────────────────── │
+│database_url  [REDACTED]│
+│environment   development│
+╰ _ ─────────── map: 1/2 ╯
+```
+
+> **Note**: Fields marked `sensitive: true` are shown as `[REDACTED]` in table output.
+
+Structured output (JSON, YAML) reveals sensitive values for machine consumption:
+
+```bash
+scafctl run resolver -f env-config.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "database_url": "postgres://localhost:5432/app_dev",
+  "environment": "development"
+}
+```
+
+Use `--show-sensitive` to reveal values in table output:
+
+```bash
+scafctl run resolver -f env-config.yaml --show-sensitive
+```
+
+> **Sensitive Redaction Behavior**: Sensitive values are redacted in table/interactive output (human-facing) but revealed in JSON/YAML output (machine-facing), following the same model as Terraform. Use `--show-sensitive` to reveal values in all output formats.
+
 ### Pattern 2: Feature Toggles
+
+Create a file called `feature-toggles.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -628,7 +911,28 @@ spec:
                 }
 ```
 
+```bash
+scafctl run resolver -f feature-toggles.yaml -o json
+```
+
+Output:
+
+```json
+{
+  "features": {
+    "dark_mode": true,
+    "new_ui": false
+  },
+  "ui_config": {
+    "theme": "dark",
+    "version": "v1"
+  }
+}
+```
+
 ### Pattern 3: Secret Management
+
+Create a file called `secrets.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -640,21 +944,12 @@ metadata:
 spec:
   resolvers:
     db_password:
+      type: string
       sensitive: true
       resolve:
         with:
-          # Try environment variable first
-          - provider: env
-            onError: continue
-            inputs:
-              name: DB_PASSWORD
-          # Fall back to file-based secret
-          - provider: file
-            onError: continue
-            inputs:
-              operation: read
-              path: /run/secrets/db_password
-          # Fall back to generated password
+          # In practice, use env or file providers here
+          # with onError: continue to fall through
           - provider: static
             inputs:
               value: "default-dev-password"
@@ -666,11 +961,46 @@ spec:
         with:
           - provider: cel
             inputs:
-              expression: |
-                'postgres://app:' + _.db_password + '@db.example.com:5432/app'
+              expression: "'postgres://app:' + _.db_password + '@db.example.com:5432/app'"
 ```
 
+```bash
+scafctl run resolver -f secrets.yaml
+```
+
+Output:
+
+```
+╭─ scafctl run resolver ──────╮
+│KEY                VALUE     │
+│────────────────────────────  │
+│connection_string  [REDACTED] │
+│db_password        [REDACTED] │
+╰ _ ──────────────── map: 1/2  ╯
+```
+
+> **Note**: Both resolvers are marked `sensitive: true`, so their values are redacted in table output.
+
+Structured output reveals the actual values:
+
+```bash
+scafctl run resolver -f secrets.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "connection_string": "postgres://app:default-dev-password@db.example.com:5432/app",
+  "db_password": "default-dev-password"
+}
+```
+
+> **Tip**: Use table output (the default) when sharing your screen or in CI logs to avoid accidentally exposing secrets. Use `-o json` or `-o yaml` when piping to downstream tools that need the actual values.
+
 ### Pattern 4: Multi-Stage Pipeline
+
+Create a file called `pipeline.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -682,11 +1012,28 @@ metadata:
 spec:
   resolvers:
     raw_data:
+      type: any
       resolve:
         with:
-          - provider: http
+          - provider: static
             inputs:
-              url: https://api.example.com/users
+              value:
+                - id: 1
+                  name: "Alice"
+                  email: "alice@example.com"
+                  active: true
+                - id: 2
+                  name: "Bob"
+                  email: "bob@example.com"
+                  active: false
+                - id: 3
+                  name: "Charlie"
+                  email: "charlie@example.com"
+                  active: true
+                - id: 4
+                  name: "Diana"
+                  email: "diana@example.com"
+                  active: true
     
     parsed_data:
       type: any
@@ -713,14 +1060,31 @@ spec:
               message: "No active users found"
 ```
 
+```bash
+scafctl run resolver -f pipeline.yaml -o json
+```
+
+Output:
+
+```json
+{
+  "parsed_data": [
+    { "email": "alice@example.com", "id": 1, "name": "Alice" },
+    { "email": "charlie@example.com", "id": 3, "name": "Charlie" },
+    { "email": "diana@example.com", "id": 4, "name": "Diana" }
+  ],
+  "raw_data": [
+    { "active": true, "email": "alice@example.com", "id": 1, "name": "Alice" },
+    { "active": false, "email": "bob@example.com", "id": 2, "name": "Bob" },
+    { "active": true, "email": "charlie@example.com", "id": 3, "name": "Charlie" },
+    { "active": true, "email": "diana@example.com", "id": 4, "name": "Diana" }
+  ]
+}
+```
+
+Bob was filtered out of `parsed_data` because `active` was `false`. The `raw_data` resolver is also included since `run resolver` returns all resolvers by default.
+
 ---
-
-## Next Steps
-
-- Explore the [built-in providers](../pkg/provider/builtin/README.md)
-- Read about [CEL expressions](../pkg/celexp/README.md)
-- Check out the [example solutions](./examples/)
-- Review the [resolver package reference](../pkg/resolver/README.md)
 
 ## Troubleshooting
 
@@ -752,3 +1116,13 @@ timeout: 60s
 Error: validation failed: Port must be between 1024 and 65535
 ```
 Solution: Check your input values meet the validation requirements.
+
+---
+
+## Next Steps
+
+- [Run Resolver Tutorial](run-resolver-tutorial.md) — Debug and inspect resolver execution
+- [Run Provider Tutorial](run-provider-tutorial.md) — Test providers in isolation
+- [Actions Tutorial](actions-tutorial.md) — Learn about workflows
+- [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
+- [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -64,6 +64,21 @@ Inputs are passed using `--input` flags. Multiple inputs can be specified by rep
 scafctl run provider http --input url=https://httpbin.org/get --input method=GET
 ```
 
+Output:
+
+```json
+{
+  "data": {
+    "body": "{...}",
+    "headers": {
+      "Content-Type": "application/json",
+      "...": "..."
+    },
+    "statusCode": 200
+  }
+}
+```
+
 ### Array Values
 
 Comma-separated values are automatically converted to arrays:
@@ -112,6 +127,18 @@ headers:
 
 ```bash
 scafctl run provider http --input @inputs.yaml
+```
+
+Output:
+
+```json
+{
+  "data": {
+    "body": "{...}",
+    "headers": { "...": "..." },
+    "statusCode": 200
+  }
+}
 ```
 
 ### Mix File and Inline Inputs
@@ -326,6 +353,7 @@ scafctl run provider secret --input operation=get --input name=my-secret --redac
 
 ## Next Steps
 
-- [Provider Reference](provider-reference.md) — full provider documentation
-- [Resolver Tutorial](resolver-tutorial.md) — using providers within resolvers
-- [Plugin Development](plugin-development.md) — creating custom providers
+- [Actions Tutorial](actions-tutorial.md) — Learn about workflows
+- [Provider Reference](provider-reference.md) — Full provider documentation
+- [Resolver Tutorial](resolver-tutorial.md) — Using providers within resolvers
+- [Provider Development](provider-development.md) — Creating custom providers

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -29,6 +29,10 @@ This tutorial covers the `scafctl run resolver` command — a debugging and insp
 
 ---
 
+{{% hint info %}}
+**A note on `__execution` metadata**: When using JSON or YAML output, `run resolver` automatically includes an `__execution` key containing execution metadata (timing, dependency graph, provider stats). Throughout this tutorial, examples use `--hide-execution` to keep output focused on resolver values. See [Execution Metadata](#execution-metadata) for details on this feature.
+{{% /hint %}}
+
 ## Run All Resolvers
 
 The simplest usage runs all resolvers in a solution file.
@@ -71,15 +75,23 @@ spec:
 ### Step 2: Run All Resolvers
 
 ```bash
-scafctl run resolver -f demo.yaml
+scafctl run resolver -f demo.yaml --hide-execution
 ```
 
-This outputs all resolved values in table format (default).
+Output:
+
+```
+KEY          VALUE
+───────────────────────
+app_name     my-app
+environment  production
+region       us-west-2
+```
 
 ### Step 3: Get JSON Output
 
 ```bash
-scafctl run resolver -f demo.yaml -o json
+scafctl run resolver -f demo.yaml -o json --hide-execution
 ```
 
 Output:
@@ -103,7 +115,7 @@ Pass resolver names as positional arguments to execute only those resolvers (plu
 ### Step 1: Run a Single Resolver
 
 ```bash
-scafctl run resolver environment -f demo.yaml -o json
+scafctl run resolver environment -f demo.yaml -o json --hide-execution
 ```
 
 Output:
@@ -117,12 +129,21 @@ Output:
 ### Step 2: Run Multiple Resolvers
 
 ```bash
-scafctl run resolver environment region -f demo.yaml -o json
+scafctl run resolver environment region -f demo.yaml -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "environment": "production",
+  "region": "us-west-2"
+}
 ```
 
 ### Step 3: Dependencies Are Included Automatically
 
-Given a solution with dependencies:
+Create a file called `dep-demo.yaml` with a solution that has dependencies:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -151,7 +172,7 @@ spec:
         with:
           - provider: cel
             inputs:
-              expression: "value + '/v2/data'"
+              expression: "__self + '/v2/data'"
     unrelated:
       type: string
       resolve:
@@ -164,10 +185,19 @@ spec:
 Running just `endpoint` automatically includes `base_url` (its dependency):
 
 ```bash
-scafctl run resolver endpoint -f dep-demo.yaml -o json
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
 
-Output includes `base_url` and `endpoint`, but not `unrelated`.
+Output:
+
+```json
+{
+  "base_url": "https://api.example.com",
+  "endpoint": "https://api.example.com/v2/data"
+}
+```
+
+Note that `base_url` is included (it's a dependency of `endpoint`) but `unrelated` is not.
 
 ### Step 4: Handle Unknown Resolver Names
 
@@ -180,14 +210,14 @@ scafctl run resolver nonexistent -f demo.yaml
 Output:
 
 ```
-Error: unknown resolver(s): nonexistent (available: environment, region, app_name)
+ ❌ unknown resolver(s): nonexistent (available: app_name, environment, region)
 ```
 
 ---
 
 ## Execution Metadata
 
-The `run resolver` command is a debugging tool, so it always includes a `__execution` key in the output alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. timeline).
+By default, `run resolver` includes a `__execution` key in the output alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. timeline). Use `--hide-execution` to suppress it when you only need the resolved values.
 
 ```bash
 scafctl run resolver -f dep-demo.yaml -o json
@@ -205,8 +235,8 @@ Example JSON output:
 ```json
 {
   "base_url": "https://api.example.com",
-  "endpoint": "https://api.example.com/v1/users",
-  "unrelated": "other-value",
+  "endpoint": "https://api.example.com/v2/data",
+  "unrelated": "not-needed",
   "__execution": {
     "resolvers": {
       "base_url": {
@@ -251,33 +281,93 @@ scafctl run resolver endpoint -f dep-demo.yaml -o json
 
 The `__execution` section only includes metadata for the requested resolvers and their dependencies.
 
-> **Tip**: For `run solution`, execution metadata is opt-in via `--show-execution`.
+> **Tip**: Use `--hide-execution` to suppress `__execution` when you only need the resolved values. For `run solution`, execution metadata is opt-in via `--show-execution`.
 
 ---
 
 ## Skipping Phases
 
-Resolvers execute through three ordered phases: **resolve → transform → validate**. You can skip phases to inspect intermediate values.
+Resolvers execute through three ordered phases: **resolve → transform → validate**. You can skip phases to inspect intermediate values — particularly useful when validation blocks output and you need to see what was actually resolved.
+
+Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high — after the transform, the result (`68000`) exceeds the valid range:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: phases-demo
+  version: 1.0.0
+spec:
+  resolvers:
+    port:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 60000
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self + 8000"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1024 && __self <= 65535"
+              message: "Port must be between 1024 and 65535"
+```
+
+Running the resolver fails because the transformed value (`68000`) exceeds the valid port range:
+
+```bash
+scafctl run resolver -f phases-demo.yaml -o json --hide-execution
+```
+
+Output:
+
+```
+❌ resolver execution failed: ... validation: Port must be between 1024 and 65535
+```
+
+The validation error blocks the output entirely — you can't see the resolved value.
 
 ### Skip Validation
 
-Skip only the validation phase:
+Use `--skip-validation` to bypass the validation phase and see the actual value:
 
 ```bash
-scafctl run resolver --skip-validation -f solution.yaml -o json
+scafctl run resolver --skip-validation -f phases-demo.yaml -o json --hide-execution
 ```
 
-This runs resolve and transform, but skips validation rules. Useful when you want to see the final transformed value without validation errors blocking output.
+Output:
+
+```json
+{
+  "port": 68000
+}
+```
+
+Now you can see the problem: the transform added `8000` to `60000`, producing `68000` which exceeds the valid port range. Without `--skip-validation`, this value would be hidden behind the error.
 
 ### Skip Transform (and Validation)
 
-Skip both transform and validation phases, returning raw resolved values:
+Use `--skip-transform` to see the raw resolved value before any transformations:
 
 ```bash
-scafctl run resolver --skip-transform -f solution.yaml -o json
+scafctl run resolver --skip-transform -f phases-demo.yaml -o json --hide-execution
 ```
 
-This runs only the resolve phase. Useful for inspecting what providers return before any transformations are applied.
+Output:
+
+```json
+{
+  "port": 60000
+}
+```
+
+This reveals the provider returned `60000` — confirming the root cause is the input value, not the transform logic.
 
 > **Note**: `--skip-transform` implies `--skip-validation` because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
 
@@ -344,7 +434,26 @@ The `--graph` flag renders the resolver dependency graph **without executing any
 scafctl run resolver --graph -f dep-demo.yaml
 ```
 
-The ASCII output shows resolvers grouped by phase with dependency arrows.
+Output:
+
+```
+Resolver Dependency Graph:
+
+Phase 1:
+  - unrelated
+  - base_url
+
+Phase 2:
+  - endpoint
+    depends on:
+      * base_url
+
+Statistics:
+  Total Resolvers: 3
+  Total Phases: 2
+  Max Parallelism: 2
+  Avg Dependencies: 0.33
+```
 
 ### Graphviz DOT Format
 
@@ -381,7 +490,7 @@ The JSON output includes:
 The graph stats include a **critical path** — the longest chain of dependencies that determines the minimum sequential execution depth. This helps identify bottlenecks:
 
 ```bash
-scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq '.stats.criticalPath'
+scafctl run resolver --graph --graph-format=json -f dep-demo.yaml -e '_.stats.criticalPath'
 ```
 
 ### Graph in Execution Metadata
@@ -389,8 +498,8 @@ scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq '.stats.c
 When running resolvers normally, the dependency graph and a provider usage summary are automatically embedded in `__execution`:
 
 ```bash
-scafctl run resolver -f dep-demo.yaml -o json | jq '.__execution.dependencyGraph'
-scafctl run resolver -f dep-demo.yaml -o json | jq '.__execution.providerSummary'
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph'
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.providerSummary'
 ```
 
 The **providerSummary** shows per-provider statistics: resolver count, total duration, call count, success/failure counts, and average duration.
@@ -470,13 +579,13 @@ The command supports all standard output formats:
 
 ```bash
 # Table (default) — human-readable bordered table
-scafctl run resolver -f demo.yaml
+scafctl run resolver -f demo.yaml --hide-execution
 
 # JSON — for scripting and piping
-scafctl run resolver -f demo.yaml -o json
+scafctl run resolver -f demo.yaml -o json --hide-execution
 
 # YAML — for configuration contexts
-scafctl run resolver -f demo.yaml -o yaml
+scafctl run resolver -f demo.yaml -o yaml --hide-execution
 
 # Quiet — suppress output (useful for exit code checks)
 scafctl run resolver -f demo.yaml -o quiet
@@ -503,13 +612,13 @@ scafctl resolver graph -f dep-demo.yaml
 ### Step 2: Run Target Resolver
 
 ```bash
-scafctl run resolver endpoint -f dep-demo.yaml -o json
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
 
 ### Step 3: Inspect a Single Resolver's Value
 
 ```bash
-scafctl run resolver base_url -f dep-demo.yaml -o json
+scafctl run resolver base_url -f dep-demo.yaml -o json --hide-execution
 ```
 
 This lets you progressively narrow down which resolver is producing unexpected output.
@@ -532,6 +641,8 @@ scafctl run resolver -f parameterized.yaml -r env=prod -r region=us-east1
 ```
 
 ### Example with Parameter Provider
+
+Create a file called `param-demo.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -560,11 +671,20 @@ spec:
         with:
           - provider: cel
             inputs:
-              expression: "'https://config.' + value + '.example.com'"
+              expression: "'https://config.' + __self + '.example.com'"
 ```
 
 ```bash
-scafctl run resolver -f param-demo.yaml -r environment=staging -o json
+scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution
+```
+
+Output:
+
+```json
+{
+  "config_url": "https://config.staging.example.com",
+  "env": "staging"
+}
 ```
 
 ---
@@ -576,7 +696,7 @@ scafctl run resolver -f param-demo.yaml -r environment=staging -o json
 Check that all resolvers succeed without running actions:
 
 ```bash
-scafctl run resolver -f solution.yaml -o quiet
+scafctl run resolver -f demo.yaml -o quiet
 echo "Exit code: $?"
 ```
 
@@ -585,7 +705,7 @@ echo "Exit code: $?"
 Isolate a failing resolver and its dependencies:
 
 ```bash
-scafctl run resolver failing-resolver -f solution.yaml -o json
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
 
 ### Inspect Raw Resolved Values
@@ -593,7 +713,7 @@ scafctl run resolver failing-resolver -f solution.yaml -o json
 Skip transforms to see what providers actually return:
 
 ```bash
-scafctl run resolver --skip-transform -f solution.yaml -o json
+scafctl run resolver --skip-transform -f dep-demo.yaml -o json --hide-execution
 ```
 
 ### Preview Execution Plan
@@ -601,24 +721,24 @@ scafctl run resolver --skip-transform -f solution.yaml -o json
 See what would happen without running anything:
 
 ```bash
-scafctl run resolver --dry-run -f solution.yaml -o json
+scafctl run resolver --dry-run -f dep-demo.yaml -o json
 ```
 
 ### Comparing Resolver Outputs
 
 ```bash
 # Get current values
-scafctl run resolver -f solution.yaml -o json > current.json
+scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide-execution > current.json
 
 # Change parameters and compare
-scafctl run resolver -f solution.yaml -r env=staging -o json > staging.json
+scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution > staging.json
 diff current.json staging.json
 ```
 
 ### Show Execution Metrics
 
 ```bash
-scafctl run resolver -f solution.yaml --show-metrics -o json
+scafctl run resolver -f demo.yaml --show-metrics -o json
 ```
 
 Metrics are displayed on stderr after execution completes.
@@ -638,13 +758,16 @@ Metrics are displayed on stderr after execution completes.
 
 ```bash
 # All resolvers
-scafctl run resolver -f solution.yaml
+scafctl run resolver -f solution.yaml --hide-execution
 
 # Named resolvers (with dependencies)
-scafctl run resolver db config -f solution.yaml
+scafctl run resolver db config -f solution.yaml --hide-execution
 
-# JSON output (always includes __execution metadata)
+# JSON output (includes __execution metadata by default)
 scafctl run resolver -f solution.yaml -o json
+
+# JSON output without __execution metadata
+scafctl run resolver -f solution.yaml -o json --hide-execution
 
 # Skip transform and validation phases
 scafctl run resolver --skip-transform -f solution.yaml
@@ -675,3 +798,10 @@ scafctl run resolver -f solution.yaml -i
 # Aliases: res, resolvers
 scafctl run res -f solution.yaml
 ```
+
+## Next Steps
+
+- [Run Provider Tutorial](run-provider-tutorial.md) — Test providers in isolation
+- [Actions Tutorial](actions-tutorial.md) — Learn about workflows
+- [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
+- [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/docs/tutorials/snapshots-tutorial.md
+++ b/docs/tutorials/snapshots-tutorial.md
@@ -275,6 +275,7 @@ scafctl snapshot save -f solution.yaml --output shareable.json --redact
 
 ## Next Steps
 
+- [Functional Testing Tutorial](functional-testing.md) — Write and run automated tests
+- [Configuration Tutorial](config-tutorial.md) — Manage application configuration
 - [Resolver Tutorial](resolver-tutorial.md) — Learn about resolvers that snapshots capture
-- [Actions Tutorial](actions-tutorial.md) — Use actions with render and snapshot
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data from HTTP calls

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ scafctl run resolver -f examples/resolver-demo.yaml
 scafctl run resolver environment region -f examples/resolver-demo.yaml --verbose
 
 # Run with parameters
-scafctl run solution -f examples/resolvers/parameters.yaml -r name=Alice
+scafctl run resolver -f examples/resolvers/parameters.yaml -r name=Alice
 
 # Run with debug logging (see what scafctl is doing)
 scafctl run solution -f examples/actions/hello-world.yaml --debug
@@ -90,17 +90,17 @@ Resolvers demonstrate dynamic value computation, validation, and transformation.
 
 | Example | Description | Run |
 |---------|-------------|-----|
-| [hello-world.yaml](resolvers/hello-world.yaml) | Simplest resolver | `scafctl run solution -f examples/resolvers/hello-world.yaml` |
-| [parameters.yaml](resolvers/parameters.yaml) | CLI parameters with defaults | `scafctl run solution -f examples/resolvers/parameters.yaml -r name=Alice` |
-| [dependencies.yaml](resolvers/dependencies.yaml) | Resolver dependencies & phases | `scafctl run solution -f examples/resolvers/dependencies.yaml` |
-| [env-config.yaml](resolvers/env-config.yaml) | Environment-based configuration | `scafctl run solution -f examples/resolvers/env-config.yaml -r env=production` |
-| [validation.yaml](resolvers/validation.yaml) | Input validation patterns | `scafctl run solution -f examples/resolvers/validation.yaml` |
-| [transform-pipeline.yaml](resolvers/transform-pipeline.yaml) | Data transformation pipeline | `scafctl run solution -f examples/resolvers/transform-pipeline.yaml` |
-| [feature-flags.yaml](resolvers/feature-flags.yaml) | Feature flag patterns | `scafctl run solution -f examples/resolvers/feature-flags.yaml` |
-| [secrets.yaml](resolvers/secrets.yaml) | Secret management (requires secret store) | `scafctl run solution -f examples/resolvers/secrets.yaml` |
-| [identity.yaml](resolvers/identity.yaml) | Authentication identity info (requires auth) | `scafctl run solution -f examples/resolvers/identity.yaml` |
-| [cel-extensions.yaml](resolvers/cel-extensions.yaml) | All custom CEL extension functions | `scafctl run solution -f examples/resolvers/cel-extensions.yaml -o json` |
-| [cel-transforms.yaml](resolvers/cel-transforms.yaml) | Data transformation patterns with CEL | `scafctl run solution -f examples/resolvers/cel-transforms.yaml -o yaml` |
+| [hello-world.yaml](resolvers/hello-world.yaml) | Simplest resolver | `scafctl run resolver -f examples/resolvers/hello-world.yaml` |
+| [parameters.yaml](resolvers/parameters.yaml) | CLI parameters with defaults | `scafctl run resolver -f examples/resolvers/parameters.yaml -r name=Alice` |
+| [dependencies.yaml](resolvers/dependencies.yaml) | Resolver dependencies & phases | `scafctl run resolver -f examples/resolvers/dependencies.yaml` |
+| [env-config.yaml](resolvers/env-config.yaml) | Environment-based configuration | `scafctl run resolver -f examples/resolvers/env-config.yaml -r env=production` |
+| [validation.yaml](resolvers/validation.yaml) | Input validation patterns | `scafctl run resolver -f examples/resolvers/validation.yaml` |
+| [transform-pipeline.yaml](resolvers/transform-pipeline.yaml) | Data transformation pipeline | `scafctl run resolver -f examples/resolvers/transform-pipeline.yaml` |
+| [feature-flags.yaml](resolvers/feature-flags.yaml) | Feature flag patterns | `scafctl run resolver -f examples/resolvers/feature-flags.yaml` |
+| [secrets.yaml](resolvers/secrets.yaml) | Secret management (requires secret store) | `scafctl run resolver -f examples/resolvers/secrets.yaml` |
+| [identity.yaml](resolvers/identity.yaml) | Authentication identity info (requires auth) | `scafctl run resolver -f examples/resolvers/identity.yaml` |
+| [cel-extensions.yaml](resolvers/cel-extensions.yaml) | All custom CEL extension functions | `scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json` |
+| [cel-transforms.yaml](resolvers/cel-transforms.yaml) | Data transformation patterns with CEL | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o yaml` |
 
 ---
 
@@ -181,7 +181,7 @@ Custom plugin development examples.
 
 ### View Output as JSON
 ```bash
-scafctl run solution -f examples/resolvers/hello-world.yaml -o json
+scafctl run resolver -f examples/resolvers/hello-world.yaml -o json
 ```
 
 ### Dry Run Mode
@@ -191,12 +191,12 @@ scafctl run solution -f examples/actions/hello-world.yaml --dry-run
 
 ### Debug Logging
 ```bash
-scafctl run solution -f examples/resolvers/dependencies.yaml -v
+scafctl run resolver -f examples/resolvers/dependencies.yaml -v
 ```
 
 ### Pass Multiple Parameters
 ```bash
-scafctl run solution -f examples/resolvers/parameters.yaml \
+scafctl run resolver -f examples/resolvers/parameters.yaml \
   -r name=Bob \
   -r count=5 \
   -r uppercase=true
@@ -205,13 +205,13 @@ scafctl run solution -f examples/resolvers/parameters.yaml \
 ### Interactive Mode
 ```bash
 # Explore output in a TUI (navigate, search, filter)
-scafctl run solution -f examples/resolvers/dependencies.yaml -i
+scafctl run resolver -f examples/resolvers/dependencies.yaml -i
 ```
 
 ### Filter with CEL Expressions
 ```bash
 # Extract specific values from output
-scafctl run solution -f examples/resolvers/dependencies.yaml -e '_.fullName'
+scafctl run resolver -f examples/resolvers/dependencies.yaml -e '_.fullName'
 ```
 
 ### Snapshots
@@ -237,7 +237,7 @@ scafctl snapshot diff /tmp/snap-a.json /tmp/snap-b.json
 scafctl build solution examples/resolver-demo.yaml --version 1.0.0
 
 # Run by name (no file path needed)
-scafctl run solution resolver-demo
+scafctl run resolver resolver-demo
 
 # List catalog contents
 scafctl catalog list
@@ -253,7 +253,7 @@ scafctl catalog save resolver-demo -o resolver-demo.tar
 scafctl catalog load --input resolver-demo.tar
 
 # Run the imported solution
-scafctl run solution resolver-demo
+scafctl run resolver resolver-demo
 ```
 
 ### Version Management

--- a/examples/catalog/bundling-example/README.md
+++ b/examples/catalog/bundling-example/README.md
@@ -52,7 +52,7 @@ scafctl bundle extract bundling-example@1.0.0 --list
 ### 5. Run the Solution
 
 ```bash
-scafctl run solution bundling-example -r environment=dev
+scafctl run resolver bundling-example -r environment=dev
 ```
 
 ## Key Concepts Demonstrated

--- a/examples/catalog/bundling-example/solution.yaml
+++ b/examples/catalog/bundling-example/solution.yaml
@@ -9,7 +9,7 @@
 # Usage:
 #   scafctl build solution examples/catalog/bundling-example/solution.yaml --dry-run
 #   scafctl build solution examples/catalog/bundling-example/solution.yaml --version 1.0.0
-#   scafctl run solution bundling-example -r environment=dev
+#   scafctl run resolver bundling-example -r environment=dev
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/catalog/remote-registry-workflow.md
+++ b/examples/catalog/remote-registry-workflow.md
@@ -45,8 +45,8 @@ scafctl catalog pull ghcr.io/YOUR_ORG/scafctl/solutions/resolver-demo@1.0.0
 # Verify it's in local catalog
 scafctl catalog list
 
-# Run the solution
-scafctl run solution resolver-demo
+# Run the resolver-only solution
+scafctl run resolver resolver-demo
 ```
 
 ## CI/CD Integration Example

--- a/examples/resolver-demo.yaml
+++ b/examples/resolver-demo.yaml
@@ -4,7 +4,7 @@
 # Run all resolvers:     scafctl run resolver -f resolver-demo.yaml
 # Run specific resolver: scafctl run resolver environment -f resolver-demo.yaml
 # Verbose debugging:     scafctl run resolver --verbose -f resolver-demo.yaml
-# Full solution:         scafctl run solution -f resolver-demo.yaml
+# Full solution:         scafctl run resolver -f resolver-demo.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolver-stress-demo.yaml
+++ b/examples/resolver-stress-demo.yaml
@@ -2,10 +2,10 @@
 # A comprehensive example with 58 resolvers across 4+ execution phases.
 # Demonstrates validation, long-running operations, transforms, and complex dependencies.
 #
-# Run: scafctl run solution -f resolver-stress-demo.yaml
-# Run with progress: scafctl run solution -f resolver-stress-demo.yaml --progress
-# Run with verbose logging: scafctl run solution -f resolver-stress-demo.yaml --log-level 1
-# Run with parameter: scafctl run solution -f resolver-stress-demo.yaml -r deployment_mode=canary
+# Run: scafctl run resolver -f resolver-stress-demo.yaml
+# Run with progress: scafctl run resolver -f resolver-stress-demo.yaml --progress
+# Run with verbose logging: scafctl run resolver -f resolver-stress-demo.yaml --log-level 1
+# Run with parameter: scafctl run resolver -f resolver-stress-demo.yaml -r deployment_mode=canary
 #
 # Execution phases:
 #   Phase 1: Base infrastructure (environment, regions, credentials) - 20 resolvers
@@ -392,7 +392,7 @@ spec:
                 Accept: "application/json"
 
     # 20. Parameter provider demo (demonstrates parameter provider - Bug 2 fix)
-    # Run with: scafctl run solution -f resolver-stress-demo.yaml -r deployment_mode=canary
+    # Run with: scafctl run resolver -f resolver-stress-demo.yaml -r deployment_mode=canary
     deployment_mode:
       description: Deployment mode from CLI parameter (defaults to 'rolling' if not provided)
       type: string

--- a/examples/resolver-validation-failures-demo.yaml
+++ b/examples/resolver-validation-failures-demo.yaml
@@ -1,7 +1,7 @@
 # Resolver Validation Failures Demo
 # Demonstrates various validation failure scenarios for testing and learning.
 #
-# Run: scafctl run solution -f resolver-validation-failures-demo.yaml
+# Run: scafctl run resolver -f resolver-validation-failures-demo.yaml
 #
 # This demo intentionally produces validation errors to show how scafctl
 # reports different types of validation failures.

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -27,6 +27,16 @@ This directory contains practical examples demonstrating various resolver patter
 | [transform-pipeline.yaml](transform-pipeline.yaml) | Multi-step data transformation |
 | [validation.yaml](validation.yaml) | Input validation patterns |
 
+### CEL Expressions
+
+| Example | Description |
+|---------|-------------|
+| [cel-basics.yaml](cel-basics.yaml) | Literals, resolver refs, operators, strings, lists |
+| [cel-builtins.yaml](cel-builtins.yaml) | Math, encoders, sets, optionals, bindings, string/list ops |
+| [cel-common-patterns.yaml](cel-common-patterns.yaml) | Conditionals, map building, filtering, merging, resource generation |
+| [cel-extensions.yaml](cel-extensions.yaml) | All custom CEL extension functions (arrays, map, strings, etc.) |
+| [cel-transforms.yaml](cel-transforms.yaml) | Data transformation patterns (filter, aggregate, enrich) |
+
 ### Integration
 
 | Example | Description |
@@ -53,8 +63,8 @@ scafctl run resolver -f examples/resolvers/dependencies.yaml --progress
 # Output as YAML
 scafctl run resolver -f examples/resolvers/env-config.yaml -o yaml
 
-# Run full solution (resolvers + actions)
-scafctl run solution -f examples/resolvers/hello-world.yaml
+# Run resolver-only solution
+scafctl run resolver -f examples/resolvers/hello-world.yaml
 ```
 
 ## Creating Your Own
@@ -65,4 +75,4 @@ Use these examples as templates for your own solutions. Key things to remember:
 2. **Use types** - Explicitly declare types for better error messages
 3. **Validate inputs** - Add validation rules for critical values
 4. **Handle errors** - Use `error_behavior: continue` for fallbacks
-5. **Mark sensitive data** - Use `sensitive: true` to redact secrets from logs
+5. **Mark sensitive data** - Use `sensitive: true` to redact secrets in table output (JSON/YAML reveal values for machine consumption; use `--show-sensitive` to reveal in all formats)

--- a/examples/resolvers/cel-basics.yaml
+++ b/examples/resolvers/cel-basics.yaml
@@ -1,0 +1,177 @@
+# CEL Basics Example
+# Demonstrates basic CEL expressions, literal types, and resolver references.
+# This is the "Quick Start" companion for the CEL tutorial.
+#
+# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o yaml --hide-execution
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-basics
+  version: 1.0.0
+  description: Basic CEL expressions and resolver references
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # 1. Literal values — strings, numbers, booleans, lists, maps
+    # ─────────────────────────────────────────────
+
+    greeting:
+      description: "String literal (single quotes inside expression)"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'Hello, World!'"
+
+    answer:
+      description: "Integer literal"
+      type: integer
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "42"
+
+    enabled:
+      description: "Boolean literal"
+      type: boolean
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "true"
+
+    numbers:
+      description: "List literal"
+      type: array
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "[1, 2, 3]"
+
+    metadata:
+      description: "Map literal"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '{"key": "value", "count": 10}'
+
+    # ─────────────────────────────────────────────
+    # 2. Referencing other resolvers with _
+    # ─────────────────────────────────────────────
+
+    firstName:
+      description: "Static first name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Alice"
+
+    lastName:
+      description: "Static last name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Smith"
+
+    fullName:
+      description: "Concatenate two resolver values using _ namespace"
+      type: string
+      dependsOn: [firstName, lastName]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.firstName + ' ' + _.lastName"
+
+    # ─────────────────────────────────────────────
+    # 3. Operators and ternary
+    # ─────────────────────────────────────────────
+
+    arithmetic:
+      description: "Basic arithmetic"
+      type: integer
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "(10 + 5) * 2 - 4"
+
+    comparison:
+      description: "Ternary conditional based on resolver value"
+      type: string
+      dependsOn: [answer]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.answer > 40 ? "high" : "low"'
+
+    membership:
+      description: "Check if a value is in a list"
+      type: boolean
+      dependsOn: [firstName]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.firstName in ["Alice", "Bob", "Charlie"]'
+
+    # ─────────────────────────────────────────────
+    # 4. String operations
+    # ─────────────────────────────────────────────
+
+    upperName:
+      description: "Built-in string functions"
+      type: string
+      dependsOn: [fullName]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.fullName.upperAscii()"
+
+    formatted:
+      description: "Printf-style string formatting"
+      type: string
+      dependsOn: [firstName, answer]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"Name: %s, Answer: %d".format([_.firstName, _.answer])'
+
+    # ─────────────────────────────────────────────
+    # 5. List operations
+    # ─────────────────────────────────────────────
+
+    filtered:
+      description: "Filter and map over a list"
+      type: array
+      dependsOn: [numbers]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.numbers.filter(x, x > 1).map(x, x * 10)"
+
+    allPositive:
+      description: "Check all elements with a comprehension"
+      type: boolean
+      dependsOn: [numbers]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.numbers.all(x, x > 0)"

--- a/examples/resolvers/cel-builtins.yaml
+++ b/examples/resolvers/cel-builtins.yaml
@@ -1,0 +1,206 @@
+# CEL Built-in Functions Example
+# Demonstrates built-in CEL functions: math, encoders, sets, optionals,
+# bindings, string operations, and list comprehensions.
+#
+# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o yaml --hide-execution
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-builtins
+  version: 1.0.0
+  description: Built-in CEL functions and standard library showcase
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # Math functions
+    # ─────────────────────────────────────────────
+
+    math_demo:
+      description: "Math functions: abs, ceil, floor, round, sqrt, least, greatest"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "abs": math.abs(-5),
+                  "ceil": math.ceil(1.2),
+                  "floor": math.floor(1.8),
+                  "round": math.round(1.5),
+                  "sqrt": math.sqrt(81),
+                  "least": math.least(5, 10),
+                  "greatest": math.greatest(5, 10),
+                  "sign": math.sign(-42)
+                }
+
+    # ─────────────────────────────────────────────
+    # Encoders (base64)
+    # ─────────────────────────────────────────────
+
+    base64_encode:
+      description: "Base64 encode a string"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'base64.encode(b"hello")'
+
+    base64_roundtrip:
+      description: "Encode then decode to verify roundtrip"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'string(base64.decode(base64.encode(b"hello")))'
+
+    # ─────────────────────────────────────────────
+    # Sets
+    # ─────────────────────────────────────────────
+
+    sets_demo:
+      description: "Set operations: contains, equivalent, intersects"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "contains": sets.contains([1, 2, 3, 4], [2, 3]),
+                  "equivalent": sets.equivalent([1, 2, 3], [3, 2, 1]),
+                  "intersects": sets.intersects([1, 2, 3], [3, 4, 5])
+                }
+
+    # ─────────────────────────────────────────────
+    # Optional types — safe navigation
+    # ─────────────────────────────────────────────
+
+    optional_field:
+      description: "Safe field access with orValue fallback"
+      type: integer
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '{"a": 1}[?"missing_key"].orValue(0)'
+
+    optional_map:
+      description: "Optional map indexing"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {"headers": {"Content-Type": "application/json"}}
+                  .headers[?"Authorization"]
+                  .orValue("none")
+
+    # ─────────────────────────────────────────────
+    # Bindings — local variables with cel.bind
+    # ─────────────────────────────────────────────
+
+    binding_simple:
+      description: "Bind a computed value to avoid repeating it"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(fullName, "Alice" + " " + "Smith",
+                  fullName + " (" + string(size(fullName)) + " chars)"
+                )
+
+    binding_nested:
+      description: "Nested bindings to build a URL"
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(host, "api.example.com",
+                  cel.bind(base, "https://" + host,
+                    base + "/api/v1/users"
+                  )
+                )
+
+    # ─────────────────────────────────────────────
+    # String operations
+    # ─────────────────────────────────────────────
+
+    string_ops:
+      description: "Built-in string functions"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "size": size("hello"),
+                  "contains": "hello world".contains("world"),
+                  "startsWith": "hello".startsWith("hel"),
+                  "endsWith": "hello".endsWith("llo"),
+                  "matches": "foo123".matches("^[a-z]+[0-9]+$"),
+                  "lower": "TacoCat".lowerAscii(),
+                  "upper": "TacoCat".upperAscii(),
+                  "trim": "  hello  ".trim(),
+                  "replace": "hello hello".replace("he", "we"),
+                  "split": "a,b,c".split(","),
+                  "reverse": "hello".reverse(),
+                  "substring": "tacocat".substring(0, 4),
+                  "format": "Hello %s, age %d".format(["Alice", 30])
+                }
+
+    # ─────────────────────────────────────────────
+    # List operations
+    # ─────────────────────────────────────────────
+
+    list_ops:
+      description: "List comprehensions and extensions"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "filter": [1, 2, 3, 4].filter(x, x > 2),
+                  "map": [1, 2, 3].map(x, x * 2),
+                  "exists": [1, 2, 3].exists(x, x > 2),
+                  "all": [1, 2, 3].all(x, x > 0),
+                  "distinct": [1, 2, 2, 3].distinct(),
+                  "sorted": [3, 1, 2].sort(),
+                  "flattened": [1, [2, 3], [4]].flatten(),
+                  "sliced": [1, 2, 3, 4, 5].slice(1, 3),
+                  "reversed": [1, 2, 3].reverse(),
+                  "range": lists.range(5),
+                  "joined": ["a", "b", "c"].join(",")
+                }
+
+    # ─────────────────────────────────────────────
+    # Map operations
+    # ─────────────────────────────────────────────
+
+    map_ops:
+      description: "Map access, membership, and size"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "access_dot": {"name": "Alice"}.name,
+                  "access_bracket": {"port": 8080}["port"],
+                  "membership": "name" in {"name": "Alice"},
+                  "size": size({"a": 1, "b": 2})
+                }

--- a/examples/resolvers/cel-common-patterns.yaml
+++ b/examples/resolvers/cel-common-patterns.yaml
@@ -1,0 +1,258 @@
+# CEL Common Patterns Example
+# Demonstrates real-world patterns: conditionals, string interpolation,
+# map building, default merging, list transforms, and resource generation.
+#
+# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o yaml --hide-execution
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-common-patterns
+  version: 1.0.0
+  description: Common CEL patterns for real-world use cases
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # Source data
+    # ─────────────────────────────────────────────
+
+    environment:
+      description: "Current environment (change to test conditionals)"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "production"
+
+    appName:
+      description: "Application name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-service"
+
+    version:
+      description: "Application version"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "2.1.0"
+
+    dbHost:
+      description: "Database host"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "db.example.com"
+
+    dbPort:
+      description: "Database port"
+      type: integer
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "5432"
+
+    dbName:
+      description: "Database name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "myapp"
+
+    defaults:
+      description: "Default configuration"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "log_level": "info",
+                  "timeout": 30,
+                  "retries": 3,
+                  "tls": false,
+                  "port": 8080
+                }
+
+    userConfig:
+      description: "User-supplied overrides"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "log_level": "debug",
+                  "tls": true,
+                  "custom_header": "X-Request-Id"
+                }
+
+    services:
+      description: "List of services"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                [
+                  {"name": "api-gateway",  "image": "api:latest",  "version": "1.2.0", "enabled": true,  "prodReplicas": 3},
+                  {"name": "auth-service", "image": "auth:latest", "version": "0.9.1", "enabled": true,  "prodReplicas": 2},
+                  {"name": "web-frontend", "image": "web:latest",  "version": "3.0.0", "enabled": false, "prodReplicas": 2},
+                  {"name": "worker",       "image": "work:latest", "version": "1.0.0", "enabled": true,  "prodReplicas": 1}
+                ]
+
+    # ─────────────────────────────────────────────
+    # Pattern: Conditional Configuration
+    # ─────────────────────────────────────────────
+
+    replicas:
+      description: "Choose replicas based on environment"
+      type: integer
+      dependsOn: [environment]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                _.environment == "production" ? 5 :
+                _.environment == "staging" ? 2 : 1
+
+    # ─────────────────────────────────────────────
+    # Pattern: Build a Map Dynamically
+    # ─────────────────────────────────────────────
+
+    labels:
+      description: "Construct a labels map from resolver values"
+      type: any
+      dependsOn: [appName, version, environment]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "app": _.appName,
+                  "version": _.version,
+                  "env": _.environment,
+                  "managed-by": "scafctl"
+                }
+
+    # ─────────────────────────────────────────────
+    # Pattern: Filter and Transform Lists
+    # ─────────────────────────────────────────────
+
+    enabledServices:
+      description: "Filter enabled services, extract and sort names"
+      type: array
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                _.services
+                  .filter(s, s.enabled)
+                  .map(s, s.name)
+                  .sort()
+
+    # ─────────────────────────────────────────────
+    # Pattern: String Interpolation with format
+    # ─────────────────────────────────────────────
+
+    connectionString:
+      description: "Build a connection string with format"
+      type: string
+      dependsOn: [dbHost, dbPort, dbName]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                "postgres://%s:%d/%s".format([_.dbHost, _.dbPort, _.dbName])
+
+    # ─────────────────────────────────────────────
+    # Pattern: Merge Defaults with Overrides
+    # ─────────────────────────────────────────────
+
+    finalConfig:
+      description: "Merge defaults with user overrides and add a timestamp"
+      type: any
+      dependsOn: [defaults, userConfig]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                map.merge(
+                  map.merge(_.defaults, _.userConfig),
+                  {"generatedAt": time.nowFmt("2006-01-02T15:04:05Z")}
+                )
+
+    # ─────────────────────────────────────────────
+    # Pattern: Generate a List of Resources
+    # ─────────────────────────────────────────────
+
+    deployments:
+      description: "Generate deployment objects from service list"
+      type: array
+      dependsOn: [services, environment]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                _.services.map(svc, {
+                  "name": svc.name,
+                  "image": svc.image + ":" + svc.version,
+                  "replicas": _.environment == "production" ? svc.prodReplicas : 1,
+                  "id": guid.new()
+                })
+
+    # ─────────────────────────────────────────────
+    # Pattern: Optional Types (safe navigation)
+    # ─────────────────────────────────────────────
+
+    safeDbHost:
+      description: "Safe field access with orValue default"
+      type: string
+      dependsOn: [defaults]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.defaults.?database.?host.orValue("localhost")'
+
+    # ─────────────────────────────────────────────
+    # Pattern: Bindings (local variables)
+    # ─────────────────────────────────────────────
+
+    apiUrl:
+      description: "Use cel.bind to build a URL without repeating subexpressions"
+      type: string
+      dependsOn: [dbHost, dbPort]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(base, _.dbHost + ":" + string(_.dbPort),
+                  cel.bind(url, "https://" + base,
+                    url + "/api/v1"
+                  )
+                )

--- a/examples/resolvers/cel-extensions.yaml
+++ b/examples/resolvers/cel-extensions.yaml
@@ -2,8 +2,8 @@
 # Demonstrates all custom CEL extension functions provided by scafctl.
 # Each resolver showcases a different extension category.
 #
-# Run: scafctl run solution -f examples/resolvers/cel-extensions.yaml -o json
-# Run: scafctl run solution -f examples/resolvers/cel-extensions.yaml -o yaml
+# Run: scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/cel-transforms.yaml
+++ b/examples/resolvers/cel-transforms.yaml
@@ -2,8 +2,8 @@
 # Demonstrates real-world data transformation patterns using CEL expressions.
 # Each resolver shows a practical pattern you can reuse in your solutions.
 #
-# Run: scafctl run solution -f examples/resolvers/cel-transforms.yaml -o yaml
-# Run: scafctl run solution -f examples/resolvers/cel-transforms.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o yaml
+# Run: scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/dependencies.yaml
+++ b/examples/resolvers/dependencies.yaml
@@ -1,7 +1,7 @@
 # Dependencies Example
 # Shows how resolvers can depend on each other and execute in phases.
 #
-# Run: scafctl run solution -f dependencies.yaml --progress
+# Run: scafctl run resolver -f dependencies.yaml --progress
 #
 # Execution order:
 #   Phase 1: environment, region (no dependencies, run in parallel)

--- a/examples/resolvers/env-config.yaml
+++ b/examples/resolvers/env-config.yaml
@@ -1,9 +1,9 @@
 # Environment-Based Configuration
 # Shows how to build configuration that varies by deployment environment.
 #
-# Run: scafctl run solution -f env-config.yaml
-# Run: scafctl run solution -f env-config.yaml -r env=production
-# Run: scafctl run solution -f env-config.yaml -r env=staging
+# Run: scafctl run resolver -f env-config.yaml
+# Run: scafctl run resolver -f env-config.yaml -r env=production
+# Run: scafctl run resolver -f env-config.yaml -r env=staging
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/feature-flags.yaml
+++ b/examples/resolvers/feature-flags.yaml
@@ -1,7 +1,7 @@
 # Feature Flags Example
 # Demonstrates feature toggles with remote fallback to local defaults.
 #
-# Run: scafctl run solution -f feature-flags.yaml
+# Run: scafctl run resolver -f feature-flags.yaml
 #
 # This example shows:
 # - Fetching flags from remote API with fallback

--- a/examples/resolvers/hello-world.yaml
+++ b/examples/resolvers/hello-world.yaml
@@ -1,7 +1,7 @@
 # Hello World Example
 # The simplest possible resolver that returns a static greeting.
 #
-# Run: scafctl run solution -f hello-world.yaml
+# Run: scafctl run resolver -f hello-world.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/identity.yaml
+++ b/examples/resolvers/identity.yaml
@@ -3,7 +3,7 @@
 # Prerequisites:
 #   - Run `scafctl auth login entra` to authenticate first
 #
-# Run: scafctl run solution -f identity.yaml
+# Run: scafctl run resolver -f identity.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -1,8 +1,8 @@
 # Parameters Example
 # Demonstrates using CLI parameters with default values and type coercion.
 #
-# Run: scafctl run solution -f parameters.yaml
-# Run: scafctl run solution -f parameters.yaml -r name=Alice -r count=5
+# Run: scafctl run resolver -f parameters.yaml
+# Run: scafctl run resolver -f parameters.yaml -r name=Alice -r count=5
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/secrets.yaml
+++ b/examples/resolvers/secrets.yaml
@@ -6,7 +6,7 @@
 #   echo "localhost" | scafctl secrets set db-host
 #   echo "optional-value" | scafctl secrets set optional-config
 #
-# Run: scafctl run solution -f secrets.yaml
+# Run: scafctl run resolver -f secrets.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/transform-pipeline.yaml
+++ b/examples/resolvers/transform-pipeline.yaml
@@ -1,7 +1,7 @@
 # Transform Pipeline Example
 # Shows multi-step data transformation with filtering and mapping.
 #
-# Run: scafctl run solution -f transform-pipeline.yaml
+# Run: scafctl run resolver -f transform-pipeline.yaml
 #
 # This example demonstrates:
 # - Multi-step transformation

--- a/examples/resolvers/validation.yaml
+++ b/examples/resolvers/validation.yaml
@@ -1,11 +1,11 @@
 # Validation Example
 # Demonstrates input validation with multiple rules and aggregated errors.
 #
-# Run: scafctl run solution -f validation.yaml
-# Run: scafctl run solution -f validation.yaml -r email=test@example.com -r port=8080 -r password=MyP@ss123
+# Run: scafctl run resolver -f validation.yaml
+# Run: scafctl run resolver -f validation.yaml -r email=test@example.com -r port=8080 -r password=MyP@ss123
 #
 # Try invalid values to see validation errors:
-# Run: scafctl run solution -f validation.yaml -r email=invalid -r port=99999 -r password=weak
+# Run: scafctl run resolver -f validation.yaml -r email=invalid -r port=99999 -r password=weak
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/solutions/composition/parent.yaml
+++ b/examples/solutions/composition/parent.yaml
@@ -5,7 +5,7 @@
 # passes parameters to it, and consumes the child's resolver values.
 #
 # Usage:
-#   scafctl run solution -f examples/solutions/composition/parent.yaml
+#   scafctl run resolver -f examples/solutions/composition/parent.yaml
 #
 # The child solution (child.yaml) resolves:
 #   - greeting: a static string "hello from child"

--- a/pkg/action/context.go
+++ b/pkg/action/context.go
@@ -220,6 +220,16 @@ func (c *Context) MarkSucceeded(name string, results any) {
 	}
 }
 
+// MarkStreamed marks an action as having streamed its output to the terminal.
+func (c *Context) MarkStreamed(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.actions[name]; ok {
+		existing.Streamed = true
+	}
+}
+
 // MarkFailed marks an action as failed with an error message.
 func (c *Context) MarkFailed(name, errMsg string) {
 	c.mu.Lock()

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
 )
 
 // Executor runs actions in dependency order with support for parallel execution,
@@ -41,6 +42,10 @@ type Executor struct {
 
 	// workflowResultSchemaMode is the workflow-level default for result schema validation
 	workflowResultSchemaMode ResultSchemaMode
+
+	// ioStreams provides terminal IO for providers that support streaming output.
+	// When set, providers can write output directly to the terminal in real-time.
+	ioStreams *provider.IOStreams
 }
 
 // ExecutorOption configures the executor.
@@ -86,6 +91,16 @@ func WithGracePeriod(d time.Duration) ExecutorOption {
 func WithDefaultTimeout(d time.Duration) ExecutorOption {
 	return func(e *Executor) {
 		e.defaultTimeout = d
+	}
+}
+
+// WithIOStreams sets the terminal IO streams for provider output streaming.
+// When set, providers that support streaming (e.g., exec) can write output
+// directly to the terminal in real-time. For parallel actions, each action
+// gets a prefixed writer to attribute output clearly.
+func WithIOStreams(streams *provider.IOStreams) ExecutorOption {
+	return func(e *Executor) {
+		e.ioStreams = streams
 	}
 }
 
@@ -393,6 +408,12 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 		return nil
 	}
 
+	// Determine if this is a parallel phase (multiple actions)
+	isParallel := len(actionsToRun) > 1
+
+	// Build per-action IOStreams for parallel phases using PrefixedWriter
+	actionIOStreams := e.buildActionIOStreams(actionsToRun, isParallel)
+
 	// Determine concurrency limit
 	concurrency := len(actionsToRun)
 	if e.maxConcurrency > 0 && concurrency > e.maxConcurrency {
@@ -424,8 +445,14 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 				return
 			}
 
+			// Inject per-action IOStreams into context
+			actionCtx := ctx
+			if streams, ok := actionIOStreams[actionName]; ok {
+				actionCtx = provider.WithIOStreams(ctx, streams)
+			}
+
 			// Execute the action
-			err := e.executeAction(ctx, graph, actionName)
+			err := e.executeAction(actionCtx, graph, actionName)
 			if err != nil {
 				errChan <- fmt.Errorf("action %q: %w", actionName, err)
 			}
@@ -447,6 +474,30 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 	}
 
 	return nil
+}
+
+// buildActionIOStreams creates per-action IO streams. For parallel phases (multiple actions),
+// each action gets a PrefixedWriter so output is clearly attributed. For single-action
+// phases, the raw IOStreams are used directly for clean, unprefixed output.
+func (e *Executor) buildActionIOStreams(actionNames []string, isParallel bool) map[string]*provider.IOStreams {
+	streams := make(map[string]*provider.IOStreams, len(actionNames))
+
+	if e.ioStreams == nil {
+		return streams
+	}
+
+	for _, name := range actionNames {
+		if isParallel {
+			streams[name] = &provider.IOStreams{
+				Out:    terminal.NewPrefixedWriter(e.ioStreams.Out, name),
+				ErrOut: terminal.NewPrefixedWriter(e.ioStreams.ErrOut, name),
+			}
+		} else {
+			streams[name] = e.ioStreams
+		}
+	}
+
+	return streams
 }
 
 // executeAction executes a single action with retry, timeout, and error handling.
@@ -582,6 +633,12 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 	}
 
 	e.actionContext.MarkSucceeded(actionName, results)
+
+	// Track whether the provider streamed output to the terminal
+	if output != nil && output.Streamed {
+		e.actionContext.MarkStreamed(actionName)
+	}
+
 	if e.progressCallback != nil {
 		e.progressCallback.OnActionComplete(actionName, results)
 	}
@@ -643,6 +700,11 @@ func (e *Executor) callProvider(ctx context.Context, action *ExpandedAction, inp
 
 	// Set up execution context with action mode
 	execCtx := provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	// Pass through IOStreams from context if available (set by executePhase)
+	if streams, ok := provider.IOStreamsFromContext(ctx); ok {
+		execCtx = provider.WithIOStreams(execCtx, streams)
+	}
 
 	// Create executor and run
 	providerExecutor := provider.NewExecutor()

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -272,6 +272,10 @@ type ActionResult struct {
 
 	// Error contains the error message if Status is StatusFailed or StatusTimeout.
 	Error string `json:"error,omitempty" yaml:"error,omitempty" doc:"Error message (if failed)"`
+
+	// Streamed indicates the provider already wrote its output to the terminal.
+	// When true, the CLI output layer should not re-print the action's results.
+	Streamed bool `json:"streamed,omitempty" yaml:"streamed,omitempty" doc:"Whether output was streamed to terminal"`
 }
 
 // Duration returns the execution duration, or zero if not available.

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -74,9 +74,9 @@ func (e *AggregatedValidationError) Error() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("workflow validation failed with %d errors:\n", len(e.Errors)))
+	fmt.Fprintf(&sb, "workflow validation failed with %d errors:\n", len(e.Errors))
 	for i, err := range e.Errors {
-		sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, err.Error()))
+		fmt.Fprintf(&sb, "  %d. %s\n", i+1, err.Error())
 	}
 	return strings.TrimSuffix(sb.String(), "\n")
 }

--- a/pkg/auth/entra/cache.go
+++ b/pkg/auth/entra/cache.go
@@ -25,7 +25,7 @@ type TokenCache struct {
 
 // CachedToken is the structure stored on disk for each cached token.
 type CachedToken struct {
-	AccessToken string    `json:"accessToken"`
+	AccessToken string    `json:"accessToken"` //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
 	TokenType   string    `json:"tokenType"`
 	ExpiresAt   time.Time `json:"expiresAt"`
 	Scope       string    `json:"scope"`

--- a/pkg/auth/entra/device_flow.go
+++ b/pkg/auth/entra/device_flow.go
@@ -28,8 +28,8 @@ type DeviceCodeResponse struct {
 
 // TokenResponse represents the response from the token endpoint.
 type TokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	AccessToken  string `json:"access_token"`  //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
+	RefreshToken string `json:"refresh_token"` //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
 	Scope        string `json:"scope"`
@@ -81,6 +81,13 @@ func (h *Handler) deviceCodeLogin(ctx context.Context, opts auth.LoginOptions) (
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	return h.performDeviceCodeFlow(ctx, opts, tenantID, scopes)
+}
+
+// performDeviceCodeFlow executes a single device code authentication flow for the given scopes.
+func (h *Handler) performDeviceCodeFlow(ctx context.Context, opts auth.LoginOptions, tenantID string, scopes []string) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+
 	// Step 1: Request device code
 	deviceCode, err := h.requestDeviceCode(ctx, tenantID, scopes)
 	if err != nil {
@@ -104,7 +111,7 @@ func (h *Handler) deviceCodeLogin(ctx context.Context, opts auth.LoginOptions) (
 	}
 
 	// Step 4: Store refresh token securely
-	if err := h.storeCredentials(ctx, tenantID, tokenResp); err != nil {
+	if err := h.storeCredentials(ctx, tenantID, tokenResp, scopes); err != nil {
 		return nil, auth.NewError(HandlerName, "store_credentials", err)
 	}
 

--- a/pkg/auth/entra/handler.go
+++ b/pkg/auth/entra/handler.go
@@ -228,6 +228,8 @@ func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
 		LastRefresh:   metadata.LastRefresh,
 		TenantID:      metadata.TenantID,
 		IdentityType:  auth.IdentityTypeUser,
+		ClientID:      metadata.ClientID,
+		Scopes:        metadata.Scopes,
 	}, nil
 }
 

--- a/pkg/auth/entra/handler_test.go
+++ b/pkg/auth/entra/handler_test.go
@@ -231,7 +231,7 @@ func TestHandler_GetToken_MintNew(t *testing.T) {
 	// Set up authentication
 	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
 	require.NoError(t, err)
-	metadata := &TokenMetadata{TenantID: "test-tenant"}
+	metadata := &TokenMetadata{TenantID: "test-tenant", ClientID: "04b07795-8ddb-461a-bbee-02f9e1bf7b46"}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
 	require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestHandler_GetToken_ForceRefresh(t *testing.T) {
 	// Set up authentication
 	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
 	require.NoError(t, err)
-	metadata := &TokenMetadata{TenantID: "test-tenant"}
+	metadata := &TokenMetadata{TenantID: "test-tenant", ClientID: "04b07795-8ddb-461a-bbee-02f9e1bf7b46"}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
 	require.NoError(t, err)

--- a/pkg/auth/entra/http.go
+++ b/pkg/auth/entra/http.go
@@ -38,5 +38,5 @@ func (c *DefaultHTTPClient) PostForm(ctx context.Context, endpoint string, data 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	return c.client.Do(req)
+	return c.client.Do(req) //nolint:gosec // G704: URL is constructed from trusted config, not user input
 }

--- a/pkg/auth/entra/integration_test.go
+++ b/pkg/auth/entra/integration_test.go
@@ -230,6 +230,14 @@ func TestIntegration_DeviceCodeFlow_Success(t *testing.T) {
 
 	refreshToken, _ := store.Get(ctx, SecretKeyRefreshToken)
 	assert.Equal(t, "test-refresh-token", string(refreshToken))
+
+	// Verify client ID was stored in metadata
+	metadataBytes, err := store.Get(ctx, SecretKeyMetadata)
+	require.NoError(t, err)
+	var storedMetadata TokenMetadata
+	require.NoError(t, json.Unmarshal(metadataBytes, &storedMetadata))
+	assert.Equal(t, "test-client-id", storedMetadata.ClientID,
+		"client_id used during login should be persisted in metadata")
 }
 
 func TestIntegration_DeviceCodeFlow_AuthorizationPending(t *testing.T) {
@@ -405,6 +413,7 @@ func TestIntegration_TokenRefresh_Success(t *testing.T) {
 		Claims:                &auth.Claims{Subject: "test-user"},
 		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
 		TenantID:              "test-tenant",
+		ClientID:              "test-client-id",
 	}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
@@ -438,6 +447,110 @@ func TestIntegration_TokenRefresh_Success(t *testing.T) {
 	assert.Equal(t, "test-client-id", server.lastTokenRequest["client_id"])
 }
 
+func TestIntegration_TokenRefresh_UsesClientIDFromMetadata(t *testing.T) {
+	server := newMockEntraServer(t)
+	defer server.Close()
+
+	// Configure token refresh response
+	server.AddTokenResponse(http.StatusOK, map[string]any{
+		"access_token":  "new-access-token",
+		"refresh_token": "new-refresh-token",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"scope":         "https://graph.microsoft.com/.default",
+	})
+
+	store := secrets.NewMockStore()
+	ctx := context.Background()
+
+	// Pre-populate with existing refresh token
+	err := store.Set(ctx, SecretKeyRefreshToken, []byte("existing-refresh-token"))
+	require.NoError(t, err)
+
+	// Metadata was stored during login with a DIFFERENT client ID than the handler config
+	metadata := &TokenMetadata{
+		Claims:                &auth.Claims{Subject: "test-user"},
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+		TenantID:              "test-tenant",
+		ClientID:              "login-client-id",
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	// Handler config has a DIFFERENT client ID (e.g. from config file)
+	cfg := &Config{
+		ClientID:  "config-client-id",
+		TenantID:  "test-tenant",
+		Authority: server.URL(),
+	}
+
+	handler, err := New(
+		WithConfig(cfg),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+
+	// Request a token
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope: "https://graph.microsoft.com/.default",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "new-access-token", token.AccessToken)
+
+	// The refresh request MUST use the client ID from metadata (login-time),
+	// not the one from the handler config
+	assert.Equal(t, "login-client-id", server.lastTokenRequest["client_id"],
+		"token refresh should use the client_id stored at login time, not the current config")
+}
+
+func TestIntegration_TokenRefresh_FailsWithoutClientIDInMetadata(t *testing.T) {
+	server := newMockEntraServer(t)
+	defer server.Close()
+
+	store := secrets.NewMockStore()
+	ctx := context.Background()
+
+	// Pre-populate with existing refresh token
+	err := store.Set(ctx, SecretKeyRefreshToken, []byte("existing-refresh-token"))
+	require.NoError(t, err)
+
+	// Metadata without ClientID (e.g. stored before client ID tracking was added)
+	metadata := &TokenMetadata{
+		Claims:                &auth.Claims{Subject: "test-user"},
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+		TenantID:              "test-tenant",
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		ClientID:  "config-client-id",
+		TenantID:  "test-tenant",
+		Authority: server.URL(),
+	}
+
+	handler, err := New(
+		WithConfig(cfg),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+
+	// Request a token — should fail because metadata has no client ID
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope: "https://graph.microsoft.com/.default",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, token)
+	assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
+	assert.Contains(t, err.Error(), "missing client ID")
+	assert.Contains(t, err.Error(), "re-authenticate")
+}
+
 func TestIntegration_TokenRefresh_InvalidGrant(t *testing.T) {
 	server := newMockEntraServer(t)
 	defer server.Close()
@@ -459,6 +572,7 @@ func TestIntegration_TokenRefresh_InvalidGrant(t *testing.T) {
 		Claims:                &auth.Claims{Subject: "test-user"},
 		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
 		TenantID:              "test-tenant",
+		ClientID:              "test-client-id",
 	}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
@@ -485,6 +599,63 @@ func TestIntegration_TokenRefresh_InvalidGrant(t *testing.T) {
 	assert.Nil(t, token)
 	// Should return token expired error since refresh token is invalid
 	assert.ErrorIs(t, err, auth.ErrTokenExpired)
+}
+
+func TestIntegration_TokenRefresh_ConsentRequired(t *testing.T) {
+	server := newMockEntraServer(t)
+	defer server.Close()
+
+	// Server responds with AADSTS65001 consent error
+	server.AddTokenResponse(http.StatusBadRequest, map[string]any{
+		"error":             "invalid_grant",
+		"error_description": "AADSTS65001: The user or administrator has not consented to use the application.",
+	})
+
+	store := secrets.NewMockStore()
+	ctx := context.Background()
+
+	// Pre-populate with a valid refresh token
+	err := store.Set(ctx, SecretKeyRefreshToken, []byte("valid-refresh-token"))
+	require.NoError(t, err)
+
+	metadata := &TokenMetadata{
+		Claims:                &auth.Claims{Subject: "test-user"},
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+		TenantID:              "test-tenant",
+		ClientID:              "test-client-id",
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		ClientID:  "test-client-id",
+		TenantID:  "test-tenant",
+		Authority: server.URL(),
+	}
+
+	handler, err := New(
+		WithConfig(cfg),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+
+	// Request a token
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope: "https://graph.microsoft.com/.default",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, token)
+	// Should return consent required error, NOT token expired
+	assert.ErrorIs(t, err, auth.ErrConsentRequired)
+	assert.NotErrorIs(t, err, auth.ErrTokenExpired)
+	assert.Contains(t, err.Error(), "AADSTS65001")
+
+	// Credentials should NOT have been cleared (refresh token still valid)
+	exists, err := store.Exists(ctx, SecretKeyRefreshToken)
+	require.NoError(t, err)
+	assert.True(t, exists, "refresh token should still exist after consent error")
 }
 
 // ============================================================================
@@ -573,6 +744,7 @@ func TestIntegration_TokenCaching_MinValidFor_RefreshNeeded(t *testing.T) {
 		Claims:                &auth.Claims{Subject: "test-user"},
 		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
 		TenantID:              "test-tenant",
+		ClientID:              "test-client-id",
 	}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
@@ -639,6 +811,7 @@ func TestIntegration_TokenCaching_ForceRefresh(t *testing.T) {
 		Claims:                &auth.Claims{Subject: "test-user"},
 		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
 		TenantID:              "test-tenant",
+		ClientID:              "test-client-id",
 	}
 	metadataBytes, _ := json.Marshal(metadata)
 	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)

--- a/pkg/auth/entra/service_principal.go
+++ b/pkg/auth/entra/service_principal.go
@@ -33,7 +33,7 @@ const (
 type ServicePrincipalCredentials struct {
 	ClientID     string
 	TenantID     string
-	ClientSecret string
+	ClientSecret string //nolint:gosec // G117: not a hardcoded credential, stores runtime secret from env vars
 }
 
 // GetServicePrincipalCredentials retrieves SP credentials from environment variables.

--- a/pkg/auth/entra/token.go
+++ b/pkg/auth/entra/token.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -22,6 +23,8 @@ type TokenMetadata struct {
 	RefreshTokenExpiresAt time.Time    `json:"refreshTokenExpiresAt"`
 	LastRefresh           time.Time    `json:"lastRefresh"`
 	TenantID              string       `json:"tenantId"`
+	ClientID              string       `json:"clientId,omitempty"`
+	Scopes                []string     `json:"scopes,omitempty"`
 }
 
 // mintToken creates a new access token for the specified scope.
@@ -44,9 +47,16 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// Request new access token using refresh token
 	endpoint := fmt.Sprintf("%s/%s/oauth2/v2.0/token", h.config.GetAuthority(), metadata.TenantID)
 
+	// Use the client ID that was used during login (stored in metadata).
+	// This ensures the refresh token is always paired with the client ID
+	// that originally obtained it. If missing, the user must re-login.
+	if metadata.ClientID == "" {
+		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with 'scafctl auth login entra': %w", auth.ErrNotAuthenticated)
+	}
+
 	data := url.Values{}
 	data.Set("grant_type", "refresh_token")
-	data.Set("client_id", h.config.ClientID)
+	data.Set("client_id", metadata.ClientID)
 	data.Set("refresh_token", refreshToken)
 	data.Set("scope", scope)
 
@@ -62,10 +72,30 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 			return nil, fmt.Errorf("token request failed with status %d", resp.StatusCode)
 		}
 
-		// Check if refresh token is expired
+		// Check if refresh token is expired or consent is required
 		if errResp.Error == "invalid_grant" {
-			// Clear stored credentials since they're no longer valid
+			lgr.V(0).Info("token refresh failed with invalid_grant",
+				"errorDescription", errResp.ErrorDescription,
+				"scope", scope,
+			)
+
+			if strings.Contains(errResp.ErrorDescription, "AADSTS70000") {
+				return nil, fmt.Errorf("scope %q: %s: %w", scope, errResp.ErrorDescription, auth.ErrGrantInvalid)
+			}
+
+			// AADSTS65001: consent not granted for the requested scope
+			// AADSTS70011: invalid scope value
+			// In these cases the refresh token is still valid — don't logout
+			if strings.Contains(errResp.ErrorDescription, "AADSTS65001") ||
+				strings.Contains(errResp.ErrorDescription, "AADSTS70011") {
+				return nil, fmt.Errorf("scope %q: %s: %w", scope, errResp.ErrorDescription, auth.ErrConsentRequired)
+			}
+
+			// For genuine token expiry / revocation, clear stored credentials
 			_ = h.Logout(ctx)
+			if errResp.ErrorDescription != "" {
+				return nil, fmt.Errorf("%s: %w", errResp.ErrorDescription, auth.ErrTokenExpired)
+			}
 			return nil, auth.ErrTokenExpired
 		}
 
@@ -80,7 +110,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// If we got a new refresh token, store it (token rotation)
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		lgr.V(1).Info("refresh token rotated, storing new token")
-		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp); err != nil {
+		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp, metadata.Scopes); err != nil {
 			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
 		}
 	}
@@ -102,7 +132,14 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 }
 
 // storeCredentials securely stores the refresh token and metadata.
-func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse) error {
+// scopes records which OAuth scopes were used during login so they can be
+// surfaced later (e.g. in `auth status`).
+func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse, scopes []string) error {
+	// Validate refresh token is present
+	if tokenResp.RefreshToken == "" {
+		return fmt.Errorf("no refresh token in response (offline_access scope may be missing)")
+	}
+
 	// Store refresh token
 	if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
 		return fmt.Errorf("failed to store refresh token: %w", err)
@@ -122,6 +159,8 @@ func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenRe
 		RefreshTokenExpiresAt: time.Now().Add(DefaultRefreshTokenLifetime),
 		LastRefresh:           time.Now(),
 		TenantID:              tenantID,
+		ClientID:              h.config.ClientID,
+		Scopes:                scopes,
 	}
 
 	metadataBytes, err := json.Marshal(metadata)

--- a/pkg/auth/entra/workload_identity.go
+++ b/pkg/auth/entra/workload_identity.go
@@ -54,7 +54,7 @@ func GetWorkloadIdentityCredentials() *WorkloadIdentityCredentials {
 	hasDirectToken := directToken != ""
 	hasTokenFile := false
 	if tokenFile != "" {
-		if _, err := os.Stat(tokenFile); err == nil {
+		if _, err := os.Stat(tokenFile); err == nil { //nolint:gosec // G703: tokenFile is from trusted env var AZURE_FEDERATED_TOKEN_FILE
 			hasTokenFile = true
 		}
 	}
@@ -128,7 +128,7 @@ func (h *Handler) workloadIdentityLogin(ctx context.Context, _ auth.LoginOptions
 		if tokenFile == "" {
 			return nil, fmt.Errorf("workload identity not configured: %s environment variable not set", EnvAzureFederatedTokenFile)
 		}
-		if _, err := os.Stat(tokenFile); err != nil {
+		if _, err := os.Stat(tokenFile); err != nil { //nolint:gosec // G703: tokenFile is from trusted env var AZURE_FEDERATED_TOKEN_FILE
 			return nil, fmt.Errorf("workload identity token file not found: %s\nHint: Ensure the pod has the azure-workload-identity webhook labels and the service account is properly configured", tokenFile)
 		}
 		if os.Getenv(EnvAzureClientID) == "" {

--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -13,12 +13,14 @@ var (
 	ErrNotAuthenticated     = errors.New("not authenticated: please run 'scafctl auth login entra'")
 	ErrAuthenticationFailed = errors.New("authentication failed")
 	ErrTokenExpired         = errors.New("credentials expired: please run 'scafctl auth login entra'")
+	ErrConsentRequired      = errors.New("consent required: please login with the required scope, e.g. 'scafctl auth login entra --scope <scope>'")
 	ErrInvalidScope         = errors.New("invalid scope: scope cannot be empty")
 	ErrHandlerNotFound      = errors.New("auth handler not found")
 	ErrFlowNotSupported     = errors.New("authentication flow not supported")
 	ErrUserCancelled        = errors.New("authentication cancelled by user")
 	ErrTimeout              = errors.New("authentication timed out")
 	ErrAlreadyAuthenticated = errors.New("already authenticated")
+	ErrGrantInvalid         = errors.New("invalid grant: the refresh token is invalid or has been revoked, please re-authenticate with 'scafctl auth login entra'")
 )
 
 // Error wraps authentication errors with additional context.
@@ -64,6 +66,11 @@ func IsHandlerNotFound(err error) bool {
 // IsTimeout returns true if the error indicates a timeout occurred.
 func IsTimeout(err error) bool {
 	return errors.Is(err, ErrTimeout)
+}
+
+// IsConsentRequired returns true if the error indicates consent is required for the requested scope.
+func IsConsentRequired(err error) bool {
+	return errors.Is(err, ErrConsentRequired)
 }
 
 // IsUserCancelled returns true if the error indicates the user cancelled.

--- a/pkg/auth/errors_test.go
+++ b/pkg/auth/errors_test.go
@@ -40,6 +40,13 @@ func TestErrorHelpers(t *testing.T) {
 	assert.False(t, IsNotAuthenticated(ErrTokenExpired))
 
 	assert.True(t, IsTokenExpired(ErrTokenExpired))
+	assert.True(t, IsTokenExpired(fmt.Errorf("AADSTS70008: %w", ErrTokenExpired)))
+	assert.False(t, IsTokenExpired(ErrConsentRequired))
+
+	assert.True(t, IsConsentRequired(ErrConsentRequired))
+	assert.True(t, IsConsentRequired(fmt.Errorf("scope required: %w", ErrConsentRequired)))
+	assert.False(t, IsConsentRequired(ErrTokenExpired))
+
 	assert.True(t, IsHandlerNotFound(ErrHandlerNotFound))
 	assert.True(t, IsTimeout(ErrTimeout))
 	assert.True(t, IsUserCancelled(ErrUserCancelled))

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -114,11 +114,12 @@ type Status struct {
 	IdentityType  IdentityType // Type of identity: "user", "service-principal", or "workload-identity"
 	ClientID      string       // For service principal/workload identity: the application ID
 	TokenFile     string       // For workload identity: path to the federated token file
+	Scopes        []string     // Scopes granted during login
 }
 
 // Token represents a short-lived access token.
 type Token struct {
-	AccessToken string
+	AccessToken string //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
 	TokenType   string
 	ExpiresAt   time.Time
 	Scope       string

--- a/pkg/catalog/auth.go
+++ b/pkg/catalog/auth.go
@@ -36,14 +36,14 @@ type dockerConfig struct {
 type dockerAuthEntry struct {
 	Auth          string `json:"auth"`
 	Username      string `json:"username"`
-	Password      string `json:"password"`
+	Password      string `json:"password"` //nolint:gosec // G117: not a hardcoded credential, stores docker auth data
 	IdentityToken string `json:"identitytoken"`
 }
 
 // credHelperResponse is the response from docker credential helpers.
 type credHelperResponse struct {
 	Username string `json:"Username"`
-	Secret   string `json:"Secret"`
+	Secret   string `json:"Secret"` //nolint:gosec // G117: not a hardcoded credential, stores docker cred helper response
 }
 
 // NewCredentialStore creates a credential store from the default docker config.
@@ -87,7 +87,7 @@ func findDockerConfig() string {
 	// Check DOCKER_CONFIG env var first
 	if dockerConfig := os.Getenv("DOCKER_CONFIG"); dockerConfig != "" {
 		configPath := filepath.Join(dockerConfig, "config.json")
-		if _, err := os.Stat(configPath); err == nil {
+		if _, err := os.Stat(configPath); err == nil { //nolint:gosec // G703: path from trusted DOCKER_CONFIG env var
 			return configPath
 		}
 	}
@@ -106,7 +106,7 @@ func findDockerConfig() string {
 	// Check XDG_RUNTIME_DIR for podman rootless
 	if xdgRuntime := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntime != "" {
 		podmanPath := filepath.Join(xdgRuntime, "containers", "auth.json")
-		if _, err := os.Stat(podmanPath); err == nil {
+		if _, err := os.Stat(podmanPath); err == nil { //nolint:gosec // G703: path from trusted XDG_RUNTIME_DIR env var
 			return podmanPath
 		}
 	}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -53,15 +53,15 @@ func getEntraHandler(ctx context.Context) (auth.Handler, error) {
 	return entra.New(opts...)
 }
 
-// getEntraHandlerWithTenant creates an Entra handler with an optional tenant override.
-// The tenant flag takes precedence over config.
-func getEntraHandlerWithTenant(ctx context.Context, tenantOverride string) (auth.Handler, error) {
+// getEntraHandlerWithOverrides creates an Entra handler with optional tenant and client ID overrides.
+// The flags take precedence over config.
+func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) {
 	// Check for test-injected handler
 	if h := handlerFromContext(ctx); h != nil {
 		return h, nil
 	}
 
-	// Build config from context and apply override
+	// Build config from context and apply overrides
 	entraCfg := &entra.Config{}
 	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.Entra != nil {
 		entraCfg.ClientID = cfg.Auth.Entra.ClientID
@@ -69,9 +69,12 @@ func getEntraHandlerWithTenant(ctx context.Context, tenantOverride string) (auth
 		entraCfg.DefaultScopes = cfg.Auth.Entra.DefaultScopes
 	}
 
-	// Tenant flag overrides config
+	// Flags override config
 	if tenantOverride != "" {
 		entraCfg.TenantID = tenantOverride
+	}
+	if clientIDOverride != "" {
+		entraCfg.ClientID = clientIDOverride
 	}
 
 	var opts []entra.Option

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -25,9 +25,11 @@ import (
 func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
 	var (
 		tenantID       string
+		clientID       string
 		timeout        time.Duration
 		flowStr        string
 		federatedToken string
+		scopes         []string
 	)
 
 	cmd := &cobra.Command{
@@ -55,6 +57,10 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			  OR
 			- --federated-token flag: Pass token directly (for testing)
 
+			By default, the device code flow uses the Azure CLI's public client ID
+			(04b07795-8ddb-461a-bbee-02f9e1bf7b46). Use --client-id to specify a
+			custom application registration for enterprise scenarios.
+
 			Supported handlers:
 			- entra: Microsoft Entra ID
 
@@ -64,6 +70,9 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 
 			  # Login with a specific tenant
 			  scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
+
+			  # Login with a custom client ID (enterprise/custom app registration)
+			  scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc
 
 			  # Login with service principal (requires env vars)
 			  scafctl auth login entra --flow service-principal
@@ -76,6 +85,9 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 
 			  # Login with a custom timeout (device code only)
 			  scafctl auth login entra --timeout 10m
+
+			  # Login with specific scopes for API access
+			  scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -122,7 +134,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			}
 
 			// Get or create handler
-			handler, err := getEntraHandlerWithTenant(ctx, tenantID)
+			handler, err := getEntraHandlerWithOverrides(ctx, tenantID, clientID)
 			if err != nil {
 				err = fmt.Errorf("failed to initialize auth handler: %w", err)
 				w.Errorf("%v", err)
@@ -169,6 +181,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			// Prepare login options
 			loginOpts := auth.LoginOptions{
 				TenantID: tenantID,
+				Scopes:   scopes,
 				Flow:     flow,
 				Timeout:  timeout,
 				DeviceCodeCallback: func(userCode, verificationURI, _ string) {
@@ -215,9 +228,11 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 	}
 
 	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "Azure application (client) ID (overrides default Azure CLI client ID)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "Timeout for authentication flow")
 	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow: 'device-code' (default), 'service-principal', or 'workload-identity'")
 	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for workload identity (for testing; sets AZURE_FEDERATED_TOKEN)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "Additional OAuth scopes to request during login (e.g., https://graph.microsoft.com/User.Read)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -88,8 +88,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					}
 
 					// For service principal/workload identity, show client ID
-					if (status.IdentityType == auth.IdentityTypeServicePrincipal ||
-						status.IdentityType == auth.IdentityTypeWorkloadIdentity) && status.ClientID != "" {
+					if status.ClientID != "" {
 						result["clientId"] = status.ClientID
 					}
 
@@ -114,6 +113,10 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 						if !status.LastRefresh.IsZero() {
 							result["lastRefresh"] = status.LastRefresh
 						}
+					}
+
+					if len(status.Scopes) > 0 {
+						result["scopes"] = status.Scopes
 					}
 
 					results = append(results, result)

--- a/pkg/cmd/scafctl/get/provider/tui.go
+++ b/pkg/cmd/scafctl/get/provider/tui.go
@@ -314,9 +314,9 @@ func (m providerModel) renderDetail(desc *provider.Descriptor) string {
 			if typeStr == "" {
 				typeStr = "any"
 			}
-			b.WriteString(fmt.Sprintf("  %s (%s)%s\n", name, typeStr, required))
+			fmt.Fprintf(&b, "  %s (%s)%s\n", name, typeStr, required)
 			if prop.Description != "" {
-				b.WriteString(fmt.Sprintf("    %s\n", prop.Description))
+				fmt.Fprintf(&b, "    %s\n", prop.Description)
 			}
 		}
 	}
@@ -325,7 +325,7 @@ func (m providerModel) renderDetail(desc *provider.Descriptor) string {
 	if len(desc.Examples) > 0 {
 		b.WriteString("\n" + detailKeyStyle.Render("Examples:\n"))
 		for _, ex := range desc.Examples {
-			b.WriteString(fmt.Sprintf("  %s: %s\n", ex.Name, ex.Description))
+			fmt.Fprintf(&b, "  %s: %s\n", ex.Name, ex.Description)
 			if ex.YAML != "" {
 				b.WriteString("  ---\n")
 				for _, line := range strings.Split(ex.YAML, "\n") {
@@ -339,7 +339,7 @@ func (m providerModel) renderDetail(desc *provider.Descriptor) string {
 	if len(desc.Links) > 0 {
 		b.WriteString("\n" + detailKeyStyle.Render("Links:\n"))
 		for _, link := range desc.Links {
-			b.WriteString(fmt.Sprintf("  %s: %s\n", link.Name, link.URL))
+			fmt.Fprintf(&b, "  %s: %s\n", link.Name, link.URL)
 		}
 	}
 
@@ -347,7 +347,7 @@ func (m providerModel) renderDetail(desc *provider.Descriptor) string {
 	if len(desc.Maintainers) > 0 {
 		b.WriteString("\n" + detailKeyStyle.Render("Maintainers:\n"))
 		for _, maint := range desc.Maintainers {
-			b.WriteString(fmt.Sprintf("  %s <%s>\n", maint.Name, maint.Email))
+			fmt.Fprintf(&b, "  %s <%s>\n", maint.Name, maint.Email)
 		}
 	}
 

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -115,6 +115,7 @@ type sharedResolverOptions struct {
 	SkipValidation  bool
 	SkipTransform   bool
 	ShowMetrics     bool
+	ShowSensitive   bool
 	WarnValueSize   int64
 	MaxValueSize    int64
 	ResolverTimeout time.Duration
@@ -298,19 +299,50 @@ func (o *sharedResolverOptions) exitWithCode(ctx context.Context, err error, cod
 	return exitcode.WithCode(err, code)
 }
 
-// buildResolverOutputMap builds the output map from resolver data with redaction for sensitive values
+// buildResolverOutputMap builds the output map from resolver data with format-aware redaction for sensitive values.
+// Sensitive values are redacted in table/interactive output (human-facing) but revealed in structured
+// output formats (json, yaml) since those are typically used for machine consumption.
+// Use --show-sensitive to reveal values in all formats.
 func (o *sharedResolverOptions) buildResolverOutputMap(resolverData map[string]any, sol *solution.Solution) map[string]any {
 	results := make(map[string]any)
 
+	// Determine whether to redact: redact in table/interactive (human-facing) output,
+	// reveal in structured output (json/yaml) for machine consumption.
+	// --show-sensitive overrides to always reveal.
+	shouldRedact := o.shouldRedactSensitive()
+
 	for name, value := range resolverData {
-		if r, ok := sol.Spec.Resolvers[name]; ok && r.Sensitive {
-			results[name] = "[REDACTED]"
-		} else {
-			results[name] = value
+		if shouldRedact {
+			if r, ok := sol.Spec.Resolvers[name]; ok && r.Sensitive {
+				results[name] = "[REDACTED]"
+				continue
+			}
 		}
+		results[name] = value
 	}
 
 	return results
+}
+
+// shouldRedactSensitive determines whether sensitive values should be redacted based on
+// the output format and --show-sensitive flag. Following the Terraform model:
+// - Table/interactive output: redacted (human-facing)
+// - JSON/YAML output: revealed (machine-facing)
+// - --show-sensitive: always reveals regardless of format
+func (o *sharedResolverOptions) shouldRedactSensitive() bool {
+	if o.ShowSensitive {
+		return false
+	}
+
+	// Structured formats (json, yaml, quiet) are for machine consumption — don't redact
+	format := o.Output
+	switch format {
+	case "json", "yaml", "quiet":
+		return false
+	default:
+		// Table and interactive modes are human-facing — redact
+		return true
+	}
 }
 
 // checkValueSizes checks if any values exceed size limits
@@ -589,6 +621,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().BoolVar(&o.ValidateAll, "validate-all", false, "Continue execution and show all validation/resolver errors")
 	cCmd.Flags().BoolVar(&o.SkipValidation, "skip-validation", false, "Skip the validation phase of all resolvers")
 	cCmd.Flags().BoolVar(&o.ShowMetrics, "show-metrics", false, "Show provider execution metrics after completion (output to stderr)")
+	cCmd.Flags().BoolVar(&o.ShowSensitive, "show-sensitive", false, "Reveal sensitive values in all output formats (by default, sensitive values are redacted in table output but shown in json/yaml)")
 	cCmd.Flags().Int64Var(&o.WarnValueSize, "warn-value-size", settings.DefaultWarnValueSize, "Warn when value exceeds this size in bytes (default: 1MB)")
 	cCmd.Flags().Int64Var(&o.MaxValueSize, "max-value-size", settings.DefaultMaxValueSize, "Fail when value exceeds this size in bytes (default: 10MB)")
 	cCmd.Flags().DurationVar(&o.ResolverTimeout, "resolver-timeout", settings.DefaultResolverTimeout, "Timeout per resolver")

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -50,6 +50,9 @@ type ResolverOptions struct {
 
 	// Redact redacts sensitive values in the snapshot.
 	Redact bool
+
+	// HideExecution suppresses the __execution metadata from output.
+	HideExecution bool
 }
 
 // CommandResolver creates the 'run resolver' subcommand
@@ -80,9 +83,10 @@ This command is designed for debugging and inspecting resolver execution.
 It loads a solution file and executes only the resolvers, skipping the
 action/workflow phase entirely.
 
-The output always includes a __execution key containing per-resolver execution
-metadata: phase numbers, timing, provider info, dependencies, the resolver
-dependency graph, provider usage summary, and an aggregate summary.
+By default, the output includes a __execution key containing per-resolver
+execution metadata: phase numbers, timing, provider info, dependencies, the
+resolver dependency graph, provider usage summary, and an aggregate summary.
+Use --hide-execution to suppress this metadata for cleaner output.
 
 RESOLVER SELECTION:
   Pass resolver names as positional arguments to execute only specific
@@ -208,6 +212,7 @@ Examples:
 	cCmd.Flags().BoolVar(&options.Snapshot, "snapshot", false, "Save execution snapshot instead of normal output")
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
+	cCmd.Flags().BoolVar(&options.HideExecution, "hide-execution", false, "Suppress __execution metadata from output")
 
 	return cCmd
 }
@@ -332,35 +337,37 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
 	}
 
-	// Always include __execution metadata — this is a debugging command
-	executionData := buildExecutionData(resolverCtx, resolvers, elapsed)
+	// Include __execution metadata unless --hide-execution is set
+	if !o.HideExecution {
+		executionData := buildExecutionData(resolverCtx, resolvers, elapsed)
 
-	// Build and embed the resolver dependency graph
-	graph, graphErr := resolver.BuildGraph(resolvers, lookup)
-	if graphErr == nil {
-		if err := graph.RenderDiagrams(); err != nil {
-			lgr.V(1).Info("failed to render dependency graph diagrams", "error", err)
-		}
-		// Convert to map[string]any so CEL expressions can traverse the graph
-		graphJSON, err := json.Marshal(graph)
-		if err == nil {
-			var graphMap map[string]any
-			if err := json.Unmarshal(graphJSON, &graphMap); err == nil {
-				executionData["dependencyGraph"] = graphMap
+		// Build and embed the resolver dependency graph
+		graph, graphErr := resolver.BuildGraph(resolvers, lookup)
+		if graphErr == nil {
+			if err := graph.RenderDiagrams(); err != nil {
+				lgr.V(1).Info("failed to render dependency graph diagrams", "error", err)
+			}
+			// Convert to map[string]any so CEL expressions can traverse the graph
+			graphJSON, err := json.Marshal(graph)
+			if err == nil {
+				var graphMap map[string]any
+				if err := json.Unmarshal(graphJSON, &graphMap); err == nil {
+					executionData["dependencyGraph"] = graphMap
+				} else {
+					lgr.V(1).Info("failed to unmarshal dependency graph", "error", err)
+				}
 			} else {
-				lgr.V(1).Info("failed to unmarshal dependency graph", "error", err)
+				lgr.V(1).Info("failed to marshal dependency graph", "error", err)
 			}
 		} else {
-			lgr.V(1).Info("failed to marshal dependency graph", "error", err)
+			lgr.V(1).Info("failed to build dependency graph for __execution", "error", graphErr)
 		}
-	} else {
-		lgr.V(1).Info("failed to build dependency graph for __execution", "error", graphErr)
+
+		// Embed provider usage summary
+		executionData["providerSummary"] = buildProviderSummary(resolverCtx, resolvers)
+
+		results["__execution"] = executionData
 	}
-
-	// Embed provider usage summary
-	executionData["providerSummary"] = buildProviderSummary(resolverCtx, resolvers)
-
-	results["__execution"] = executionData
 
 	return o.writeResolverOutput(ctx, results, "scafctl run resolver")
 }

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -524,6 +525,72 @@ spec:
 	assert.Equal(t, float64(1), summary["resolverCount"])
 }
 
+func TestResolverOptions_Run_HideExecution(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: hide-execution-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		HideExecution: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "hello")
+	assert.NotContains(t, output, "__execution", "__execution should not be present when --hide-execution is set")
+
+	// Parse JSON to validate structure
+	var result map[string]any
+	err = json.Unmarshal([]byte(output), &result)
+	require.NoError(t, err)
+
+	_, hasExecution := result["__execution"]
+	assert.False(t, hasExecution, "__execution key should not exist in output")
+
+	// Resolver values should still be present
+	assert.Equal(t, "hello", result["greeting"])
+}
+
 func TestResolverOptions_Run_EmptySolution(t *testing.T) {
 	t.Parallel()
 
@@ -568,7 +635,7 @@ spec:
 	assert.Contains(t, stdout.String(), "{}")
 }
 
-func TestResolverOptions_Run_SensitiveRedaction(t *testing.T) {
+func TestResolverOptions_Run_SensitiveRedaction_TableRedacts(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -577,6 +644,88 @@ func TestResolverOptions_Run_SensitiveRedaction(t *testing.T) {
 kind: Solution
 metadata:
   name: sensitive-resolver-test
+  version: 1.0.0
+spec:
+  resolvers:
+    secret:
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: super-secret
+    public:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: public-data
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	// Table format should redact sensitive values (human-facing)
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		HideExecution: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	// Table output (using json since table requires TTY, but test the redaction logic directly)
+	// Test buildResolverOutputMap with table format
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"secret": {Name: "secret", Sensitive: true},
+		"public": {Name: "public", Sensitive: false},
+	}
+
+	tableOpts := &sharedResolverOptions{
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+	}
+	results := tableOpts.buildResolverOutputMap(
+		map[string]any{"secret": "super-secret", "public": "public-data"},
+		sol,
+	)
+	assert.Equal(t, "[REDACTED]", results["secret"])
+	assert.Equal(t, "public-data", results["public"])
+
+	// Also verify full Run path with json format reveals values
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "super-secret", "JSON output should reveal sensitive values")
+	assert.Contains(t, output, "public-data")
+}
+
+func TestResolverOptions_Run_SensitiveRedaction_JSONReveals(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sensitive-json-test
   version: 1.0.0
 spec:
   resolvers:
@@ -616,6 +765,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
+		HideExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -625,9 +775,129 @@ spec:
 	require.NoError(t, err)
 
 	output := stdout.String()
-	assert.Contains(t, output, "[REDACTED]")
-	assert.NotContains(t, output, "super-secret")
+	// JSON output should reveal sensitive values (machine-facing, Terraform model)
+	assert.Contains(t, output, "super-secret", "JSON output should reveal sensitive values")
+	assert.NotContains(t, output, "[REDACTED]", "JSON output should not redact")
 	assert.Contains(t, output, "public-data")
+}
+
+func TestResolverOptions_Run_SensitiveRedaction_YAMLReveals(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sensitive-yaml-test
+  version: 1.0.0
+spec:
+  resolvers:
+    secret:
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: super-secret
+    public:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: public-data
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "yaml"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		HideExecution: true,
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	// YAML output should also reveal sensitive values (machine-facing)
+	assert.Contains(t, output, "super-secret", "YAML output should reveal sensitive values")
+	assert.NotContains(t, output, "[REDACTED]", "YAML output should not redact")
+	assert.Contains(t, output, "public-data")
+}
+
+func TestResolverOptions_Run_SensitiveRedaction_ShowSensitiveFlag(t *testing.T) {
+	t.Parallel()
+
+	// Test that --show-sensitive reveals values even in table format
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"secret": {Name: "secret", Sensitive: true},
+		"public": {Name: "public", Sensitive: false},
+	}
+
+	resolverData := map[string]any{
+		"secret": "super-secret",
+		"public": "public-data",
+	}
+
+	// Table format with --show-sensitive should reveal values
+	opts := &sharedResolverOptions{
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+		ShowSensitive:  true,
+	}
+	results := opts.buildResolverOutputMap(resolverData, sol)
+	assert.Equal(t, "super-secret", results["secret"], "--show-sensitive should reveal in table format")
+	assert.Equal(t, "public-data", results["public"])
+}
+
+func TestShouldRedactSensitive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		format        string
+		showSensitive bool
+		wantRedact    bool
+	}{
+		{name: "table redacts", format: "table", showSensitive: false, wantRedact: true},
+		{name: "empty format redacts (defaults to table)", format: "", showSensitive: false, wantRedact: true},
+		{name: "json reveals", format: "json", showSensitive: false, wantRedact: false},
+		{name: "yaml reveals", format: "yaml", showSensitive: false, wantRedact: false},
+		{name: "quiet reveals", format: "quiet", showSensitive: false, wantRedact: false},
+		{name: "table with show-sensitive reveals", format: "table", showSensitive: true, wantRedact: false},
+		{name: "json with show-sensitive reveals", format: "json", showSensitive: true, wantRedact: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &sharedResolverOptions{
+				KvxOutputFlags: flags.KvxOutputFlags{Output: tt.format},
+				ShowSensitive:  tt.showSensitive,
+			}
+			assert.Equal(t, tt.wantRedact, opts.shouldRedactSensitive())
+		})
+	}
 }
 
 func TestResolverOptions_Run_MaxValueSizeExceeded(t *testing.T) {

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -70,9 +70,12 @@ Solutions can be loaded from:
 - URL: Use -f flag with an HTTP(S) URL
 - Auto-discovery: If no source is specified, searches for solution.yaml in current directory
 
+The solution MUST define a workflow with actions. If no workflow is defined,
+the command will error and suggest using 'scafctl run resolver' instead.
+
 The execution proceeds in two phases:
 1. RESOLVER PHASE: All resolvers execute in dependency order (concurrent within phases)
-2. ACTION PHASE: Actions execute using resolved data (if workflow defined)
+2. ACTION PHASE: Actions execute using resolved data
 
 To execute resolvers only without actions (for debugging/inspection), use:
   scafctl run resolver
@@ -85,9 +88,9 @@ RESOLVER PARAMETERS:
     key=val1,val2     Multiple values become an array
 
 EXECUTION ORDER:
-  1. Parse and validate solution
+  1. Parse and validate solution (must have workflow)
   2. Execute resolvers in dependency phases (concurrent within phases)
-  3. If workflow defined: build action graph and execute actions
+  3. Build action graph and execute actions
   4. Finally section actions always execute (even if main actions fail)
 
 OUTPUT FORMATS:
@@ -113,7 +116,7 @@ EXIT CODES:
   0  Success
   1  Resolver execution failed
   2  Validation failed
-  3  Invalid solution (cycle/parse error)
+  3  Invalid solution (no workflow, cycle, or parse error)
   4  File not found
   6  Action/workflow execution failed
 
@@ -236,11 +239,17 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	actionAdapter := &actionRegistryAdapter{registry: reg}
 
-	// Validate the workflow if present
-	if sol.Spec.HasWorkflow() {
-		if err := action.ValidateWorkflow(sol.Spec.Workflow, actionAdapter); err != nil {
-			return o.exitWithCode(ctx, fmt.Errorf("workflow validation failed: %w", err), exitcode.ValidationFailed)
-		}
+	// Require a workflow — run solution is for executing actions.
+	// Use 'scafctl run resolver' for resolver-only solutions.
+	if !sol.Spec.HasWorkflow() {
+		return o.exitWithCode(ctx,
+			fmt.Errorf("solution %q has no workflow defined; use 'scafctl run resolver' to execute resolvers without actions", sol.Metadata.Name),
+			exitcode.InvalidInput)
+	}
+
+	// Validate the workflow
+	if err := action.ValidateWorkflow(sol.Spec.Workflow, actionAdapter); err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("workflow validation failed: %w", err), exitcode.ValidationFailed)
 	}
 
 	// Parse resolver parameters
@@ -263,18 +272,6 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	}
 
 	resolverElapsed := time.Since(start)
-
-	// If no workflow, output resolver results
-	if !sol.Spec.HasWorkflow() {
-		results := o.buildResolverOutputMap(resolverData, sol)
-		if err := o.checkValueSizes(results, *lgr); err != nil {
-			return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
-		}
-		if o.ShowExecution {
-			results["__execution"] = buildExecutionData(resolverCtx, resolvers, resolverElapsed)
-		}
-		return o.writeResolverOutput(ctx, results, "scafctl run solution")
-	}
 
 	// Build action graph
 	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
@@ -310,6 +307,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		action.WithDefaultTimeout(actionCfg.DefaultTimeout),
 		action.WithGracePeriod(actionCfg.GracePeriod),
 		action.WithMaxConcurrency(actionCfg.MaxConcurrency),
+		action.WithIOStreams(o.getActionIOStreams()),
 	)
 
 	result, err := actionExecutor.Execute(ctx, sol.Spec.Workflow)
@@ -361,12 +359,88 @@ func (o *SolutionOptions) showDryRun(graph *action.Graph) {
 	}
 }
 
-// writeActionOutput writes the action execution results
+// getActionIOStreams returns the provider IO streams for action execution.
+// For the default/table output format, IO streams are provided so providers can
+// stream output directly to the terminal. For json/yaml/quiet, no streams are
+// provided so all output is captured and serialized.
+func (o *SolutionOptions) getActionIOStreams() *provider.IOStreams {
+	switch o.Output {
+	case "json", "yaml", "quiet":
+		// Structured output modes: don't stream, capture everything for serialization
+		return nil
+	default:
+		// Default/table: stream output directly to terminal
+		return &provider.IOStreams{
+			Out:    o.IOStreams.Out,
+			ErrOut: o.IOStreams.ErrOut,
+		}
+	}
+}
+
+// writeActionOutput writes the action execution results.
+// For the default/table output format, output is minimal since providers that support
+// streaming (e.g., exec) already wrote their output directly to the terminal.
+// For json/yaml, the full execution envelope is serialized.
 func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.ExecutionResult, executionData map[string]any) error {
 	if o.Output == "quiet" {
 		return nil
 	}
 
+	switch o.Output {
+	case "table", "":
+		return o.writeActionOutputDefault(result)
+	case "json":
+		return o.writeActionOutputStructured(result, executionData, "json")
+	case "yaml":
+		return o.writeActionOutputStructured(result, executionData, "yaml")
+	default:
+		return fmt.Errorf("unsupported output format: %s", o.Output)
+	}
+}
+
+// writeActionOutputDefault writes the default/table output for action execution.
+// Actions that already streamed to the terminal are skipped. For non-streamed actions,
+// any stdout/stderr from the results is printed. Failed/skipped actions show a status line.
+func (o *SolutionOptions) writeActionOutputDefault(result *action.ExecutionResult) error {
+	for name, ar := range result.Actions {
+		// Skip actions that already streamed their output to the terminal
+		if ar.Streamed {
+			// If the action failed despite streaming, show the error
+			if ar.Status == action.StatusFailed || ar.Status == action.StatusTimeout {
+				fmt.Fprintf(o.IOStreams.ErrOut, "Error [%s]: %s\n", name, ar.Error)
+			}
+			continue
+		}
+
+		// For non-streamed actions, show results based on status
+		switch ar.Status {
+		case action.StatusSucceeded:
+			// Print stdout if available in results
+			if results, ok := ar.Results.(map[string]any); ok {
+				if stdout, ok := results["stdout"].(string); ok && stdout != "" {
+					fmt.Fprint(o.IOStreams.Out, stdout)
+				}
+			}
+		case action.StatusFailed, action.StatusTimeout:
+			// Show stderr if available, then error
+			if results, ok := ar.Results.(map[string]any); ok {
+				if stderr, ok := results["stderr"].(string); ok && stderr != "" {
+					fmt.Fprint(o.IOStreams.ErrOut, stderr)
+				}
+			}
+			fmt.Fprintf(o.IOStreams.ErrOut, "Error [%s]: %s\n", name, ar.Error)
+		case action.StatusSkipped:
+			fmt.Fprintf(o.IOStreams.ErrOut, "Skipped [%s]: %s\n", name, ar.SkipReason)
+		case action.StatusPending, action.StatusRunning, action.StatusCancelled:
+			// These statuses should not appear in final results; ignore.
+		}
+	}
+
+	return nil
+}
+
+// writeActionOutputStructured writes action results as JSON or YAML (the full execution envelope).
+func (o *SolutionOptions) writeActionOutputStructured(result *action.ExecutionResult, executionData map[string]any, format string) error {
 	// Build output structure
 	output := map[string]any{
 		"status":    string(result.FinalStatus),
@@ -409,18 +483,11 @@ func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.Ex
 	var data []byte
 	var marshalErr error
 
-	switch o.Output {
+	switch format {
 	case "yaml":
 		data, marshalErr = yaml.Marshal(output)
-	case "json", "table", "":
-		// table falls back to JSON for action output since actions
-		// don't have a tabular representation
+	case "json":
 		data, marshalErr = json.MarshalIndent(output, "", "  ")
-	case "quiet":
-		// Don't output anything
-		return nil
-	default:
-		return fmt.Errorf("unsupported output format: %s", o.Output)
 	}
 
 	if marshalErr != nil {

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -6,7 +6,6 @@ package run
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -161,7 +160,7 @@ func TestSolutionOptions_Run_FileNotFound(t *testing.T) {
 func TestSolutionOptions_Run_EmptySolution(t *testing.T) {
 	t.Parallel()
 
-	// Create a solution file with no resolvers
+	// Create a solution file with no resolvers and no workflow
 	tmpDir := t.TempDir()
 	solutionPath := filepath.Join(tmpDir, "solution.yaml")
 	solutionContent := `apiVersion: scafctl.io/v1
@@ -198,10 +197,9 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	// Should output empty JSON object
-	assert.Contains(t, stdout.String(), "{}")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
+	assert.Contains(t, err.Error(), "scafctl run resolver")
 }
 
 func TestCalculateValueSize(t *testing.T) {
@@ -277,7 +275,7 @@ func TestExitCodes(t *testing.T) {
 
 // CLI Scenario Tests - Phase 6 Testing & Validation
 
-func TestSolutionOptions_Run_StdinInput(t *testing.T) {
+func TestSolutionOptions_Run_StdinInput_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	solutionContent := `apiVersion: scafctl.io/v1
@@ -319,12 +317,12 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err := opts.Run(ctx)
-	require.NoError(t, err)
-
-	assert.Contains(t, stdout.String(), "hello-from-stdin")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
+	assert.Contains(t, err.Error(), "scafctl run resolver")
 }
 
-func TestSolutionOptions_Run_YAMLOutput(t *testing.T) {
+func TestSolutionOptions_Run_YAMLOutput_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -371,15 +369,11 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	// YAML output should contain the value without JSON braces
-	output := stdout.String()
-	assert.Contains(t, output, "test:")
-	assert.Contains(t, output, "yaml-test-value")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
-func TestSolutionOptions_Run_QuietOutput(t *testing.T) {
+func TestSolutionOptions_Run_QuietOutput_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -426,10 +420,8 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	// Quiet output should be empty
-	assert.Empty(t, stdout.String())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
 // testRegistryWithParameters creates a registry with static and parameter providers
@@ -440,7 +432,7 @@ func testRegistryWithParameters() *provider.Registry {
 	return reg
 }
 
-func TestSolutionOptions_Run_ParameterFromFile(t *testing.T) {
+func TestSolutionOptions_Run_ParameterFromFile_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -453,7 +445,7 @@ region: us-west-2
 	err := os.WriteFile(paramsPath, []byte(paramsContent), 0o600)
 	require.NoError(t, err)
 
-	// Create solution that uses parameter provider to access CLI params
+	// Create solution that uses parameter provider to access CLI params but has no workflow
 	solutionPath := filepath.Join(tmpDir, "solution.yaml")
 	solutionContent := `apiVersion: scafctl.io/v1
 kind: Solution
@@ -504,14 +496,11 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	output := stdout.String()
-	assert.Contains(t, output, "production")
-	assert.Contains(t, output, "us-west-2")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
-func TestSolutionOptions_Run_ParameterKeyValue(t *testing.T) {
+func TestSolutionOptions_Run_ParameterKeyValue_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -559,12 +548,11 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	assert.Contains(t, stdout.String(), "my-application")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
-func TestSolutionOptions_Run_SensitiveRedaction(t *testing.T) {
+func TestSolutionOptions_Run_SensitiveRedaction_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -618,17 +606,11 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	output := stdout.String()
-	// Sensitive value should be redacted
-	assert.Contains(t, output, "[REDACTED]")
-	assert.NotContains(t, output, "super-secret-password")
-	// Public value should be visible
-	assert.Contains(t, output, "public-data")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
-func TestSolutionOptions_Run_MaxValueSizeExceeded(t *testing.T) {
+func TestSolutionOptions_Run_MaxValueSizeExceeded_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -675,14 +657,16 @@ spec:
 	lgr := logger.Get(0)
 	ctx := logger.WithLogger(context.Background(), lgr)
 
+	// Should error about no workflow, not about max value size
 	err = opts.Run(ctx)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds maximum")
+	assert.Contains(t, err.Error(), "no workflow defined")
 }
 
 func TestSolutionOptions_Run_InvalidOutputFormat(t *testing.T) {
 	t.Parallel()
 
+	// Use a solution with a workflow so we don't hit "no workflow" error first
 	tmpDir := t.TempDir()
 	solutionPath := filepath.Join(tmpDir, "solution.yaml")
 	solutionContent := `apiVersion: scafctl.io/v1
@@ -692,6 +676,12 @@ metadata:
   version: 1.0.0
 spec:
   resolvers: {}
+  workflow:
+    actions:
+      greet:
+        use: static
+        inputs:
+          value: hello
 `
 	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
 	require.NoError(t, err)
@@ -709,7 +699,8 @@ spec:
 	assert.Contains(t, err.Error(), "invalid")
 }
 
-func TestSolutionOptions_Run_ShowExecution(t *testing.T) {
+func TestSolutionOptions_Run_ShowExecution_NoWorkflow(t *testing.T) {
+	// Solutions without workflows should error even with --show-execution
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -757,26 +748,12 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	output := stdout.String()
-	assert.Contains(t, output, "hello")
-	assert.Contains(t, output, "__execution")
-	assert.Contains(t, output, "resolvers")
-	assert.Contains(t, output, "summary")
-
-	// Parse and verify structure
-	var result map[string]any
-	err = json.Unmarshal([]byte(output), &result)
-	require.NoError(t, err)
-
-	execution, ok := result["__execution"].(map[string]any)
-	require.True(t, ok)
-	assert.Contains(t, execution, "resolvers")
-	assert.Contains(t, execution, "summary")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
+	assert.Contains(t, err.Error(), "scafctl run resolver")
 }
 
-func TestSolutionOptions_Run_NoShowExecution(t *testing.T) {
+func TestSolutionOptions_Run_NoShowExecution_NoWorkflow(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -824,10 +801,6 @@ spec:
 	ctx := logger.WithLogger(context.Background(), lgr)
 
 	err = opts.Run(ctx)
-	require.NoError(t, err)
-
-	output := stdout.String()
-	assert.Contains(t, output, "hello")
-	// Without --show-execution, __execution should NOT be present
-	assert.NotContains(t, output, "__execution")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no workflow defined")
 }

--- a/pkg/cmd/scafctl/secrets/delete.go
+++ b/pkg/cmd/scafctl/secrets/delete.go
@@ -17,13 +17,16 @@ import (
 
 // CommandDelete creates the 'secrets delete' command.
 func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
-	var forceFlag bool
+	var (
+		forceFlag bool
+		allFlag   bool
+	)
 
 	cmd := &cobra.Command{
 		Use:     "delete <name>",
 		Aliases: []string{"rm", "remove"},
 		Short:   "Delete a secret",
-		Long:    "Delete a secret by name. Use --force to skip confirmation.",
+		Long:    "Delete a secret by name. Use --force to skip confirmation.\nUse --all to allow deleting internal secrets (e.g. auth tokens).",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -31,7 +34,7 @@ func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 			name := args[0]
 
 			// Validate name
-			if err := ValidateUserSecretName(name); err != nil {
+			if err := ValidateSecretName(name, allFlag); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -54,6 +57,12 @@ func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 			if !exists {
 				w.Warningf("Secret '%s' does not exist\n", name)
 				return nil
+			}
+
+			// Warn about internal secret deletion
+			if IsInternalSecret(name) {
+				w.Warning("⚠️  WARNING: This is an internal secret managed by scafctl.")
+				w.Warning("   Deleting it may break authentication or other functionality.")
 			}
 
 			// Confirm deletion (skip in force mode, quiet handled by SkipCondition)
@@ -86,6 +95,7 @@ func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 	}
 
 	cmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Include internal secrets (e.g. auth tokens)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/secrets/exists.go
+++ b/pkg/cmd/scafctl/secrets/exists.go
@@ -17,10 +17,12 @@ import (
 
 // CommandExists creates the 'secrets exists' command.
 func CommandExists(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var allFlag bool
+
 	cmd := &cobra.Command{
 		Use:   "exists <name>",
 		Short: "Check if a secret exists",
-		Long:  "Check if a secret exists. Exits with code 0 if it exists, 1 if not.",
+		Long:  "Check if a secret exists. Exits with code 0 if it exists, 1 if not.\nUse --all to check internal secrets (e.g. auth tokens).",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -28,7 +30,7 @@ func CommandExists(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			name := args[0]
 
 			// Validate name
-			if err := ValidateUserSecretName(name); err != nil {
+			if err := ValidateSecretName(name, allFlag); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -60,6 +62,8 @@ func CommandExists(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Include internal secrets (e.g. auth tokens)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/secrets/export.go
+++ b/pkg/cmd/scafctl/secrets/export.go
@@ -53,6 +53,7 @@ func CommandExport(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 		outputFile  string
 		formatFlag  string
 		encryptFlag bool
+		allFlag     bool
 	)
 
 	cmd := &cobra.Command{
@@ -68,7 +69,8 @@ Supported formats:
   - json:          JSON format
 
 Use --encrypt to export with password protection (AES-256-GCM).
-Internal secrets (scafctl.*) are automatically excluded.`,
+Use --all to include internal secrets (e.g. auth tokens).
+By default, internal secrets (scafctl.*) are excluded.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
@@ -94,10 +96,10 @@ Internal secrets (scafctl.*) are automatically excluded.`,
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
-			// Filter out internal secrets
-			userSecrets := FilterUserSecrets(names)
+			// Filter secrets based on --all flag
+			filtered := FilterSecrets(names, allFlag)
 
-			if len(userSecrets) == 0 {
+			if len(filtered) == 0 {
 				w.Warning("No secrets to export")
 				return nil
 			}
@@ -106,10 +108,10 @@ Internal secrets (scafctl.*) are automatically excluded.`,
 			exportData := ExportFormat{
 				Version:    exportVersion,
 				ExportedAt: time.Now().UTC().Format(time.RFC3339),
-				Secrets:    make([]ExportedSecret, 0, len(userSecrets)),
+				Secrets:    make([]ExportedSecret, 0, len(filtered)),
 			}
 
-			for _, name := range userSecrets {
+			for _, name := range filtered {
 				value, err := store.Get(ctx, name)
 				if err != nil {
 					w.Warningf("Skipping secret '%s': %v\n", name, err)
@@ -209,6 +211,7 @@ Internal secrets (scafctl.*) are automatically excluded.`,
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output file path (required)")
 	cmd.Flags().StringVarP(&formatFlag, "format", "f", "yaml", "Output format: yaml, json")
 	cmd.Flags().BoolVar(&encryptFlag, "encrypt", false, "Encrypt export with password")
+	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Include internal secrets (e.g. auth tokens)")
 	_ = cmd.MarkFlagRequired("output")
 
 	return cmd

--- a/pkg/cmd/scafctl/secrets/get.go
+++ b/pkg/cmd/scafctl/secrets/get.go
@@ -21,12 +21,13 @@ func CommandGet(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra
 	var (
 		outputFormat string
 		noNewline    bool
+		allFlag      bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "get <name>",
 		Short: "Get a secret value",
-		Long:  "Retrieve and display the value of a secret. By default, prints the raw value to stdout.",
+		Long:  "Retrieve and display the value of a secret. By default, prints the raw value to stdout.\nUse --all to access internal secrets (e.g. auth tokens).",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -34,7 +35,7 @@ func CommandGet(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra
 			name := args[0]
 
 			// Validate name
-			if err := ValidateUserSecretName(name); err != nil {
+			if err := ValidateSecretName(name, allFlag); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -110,6 +111,7 @@ func CommandGet(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format: json, yaml (default: raw)")
 	cmd.Flags().BoolVar(&noNewline, "no-newline", false, "Don't print trailing newline in raw output")
+	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Include internal secrets (e.g. auth tokens)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/secrets/import.go
+++ b/pkg/cmd/scafctl/secrets/import.go
@@ -70,7 +70,7 @@ Use --overwrite to replace existing secrets.`,
 			if bytes.HasPrefix(fileData, []byte(encryptedHeader)) {
 				// Encrypted format
 				fmt.Fprint(ioStreams.ErrOut, "Enter decryption password: ")
-				passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+				passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: Fd() fits in int on all supported platforms
 				if err != nil {
 					err := fmt.Errorf("failed to read password: %w", err)
 					w.Errorf("%v", err)

--- a/pkg/cmd/scafctl/secrets/list.go
+++ b/pkg/cmd/scafctl/secrets/list.go
@@ -19,6 +19,7 @@ import (
 // listOptions holds the options for the list command.
 type listOptions struct {
 	flags.KvxOutputFlags
+	All bool
 }
 
 // CommandList creates the 'secrets list' command.
@@ -27,8 +28,8 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all user secrets",
-		Long:  "List the names of all stored secrets (excluding internal scafctl.* secrets).",
+		Short: "List secrets",
+		Long:  "List the names of all stored secrets. By default, internal scafctl.* secrets are excluded. Use --all to include them.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
@@ -47,17 +48,18 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
-			// Filter out internal secrets
-			userSecrets := FilterUserSecrets(names)
+			// Filter secrets based on --all flag
+			filtered := FilterSecrets(names, opts.All)
 
 			// Prepare output with kvx flags
 			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
 
 			// Convert to slice of maps for table output
-			data := make([]map[string]interface{}, len(userSecrets))
-			for i, name := range userSecrets {
+			data := make([]map[string]interface{}, len(filtered))
+			for i, name := range filtered {
 				data[i] = map[string]interface{}{
 					"name": name,
+					"type": SecretType(name),
 				}
 			}
 
@@ -65,7 +67,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				return err
 			}
 
-			if len(userSecrets) == 0 && !cliParams.IsQuiet {
+			if len(filtered) == 0 && !cliParams.IsQuiet {
 				w.Warning("No secrets found")
 			}
 
@@ -74,6 +76,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	}
 
 	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Include internal secrets (e.g. auth tokens)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/secrets/secrets.go
+++ b/pkg/cmd/scafctl/secrets/secrets.go
@@ -29,9 +29,9 @@ func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 
 			The master encryption key is stored in your OS keychain for security.
 
-			Reserved namespace:
-			  Secret names starting with "scafctl." are reserved for internal use
-			  and cannot be managed through these commands.
+			Internal secrets:
+			  Secret names starting with "scafctl." are used internally (e.g. auth tokens).
+			  By default they are hidden. Use --all on subcommands to include them.
 		`),
 		SilenceUsage: true,
 	}

--- a/pkg/cmd/scafctl/secrets/validation.go
+++ b/pkg/cmd/scafctl/secrets/validation.go
@@ -10,22 +10,55 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 )
 
+const (
+	// InternalSecretPrefix is the prefix used for internal scafctl secrets (e.g. auth tokens).
+	InternalSecretPrefix = "scafctl." //nolint:gosec // Not a credential, just a naming prefix
+)
+
+// IsInternalSecret returns true if the secret name belongs to the internal namespace.
+func IsInternalSecret(name string) bool {
+	return strings.HasPrefix(name, InternalSecretPrefix)
+}
+
+// ValidateSecretName validates a secret name, optionally allowing internal secrets.
+// When includeInternal is false, names starting with "scafctl." are rejected.
+func ValidateSecretName(name string, includeInternal bool) error {
+	if !includeInternal && IsInternalSecret(name) {
+		return fmt.Errorf("%w: cannot operate on internal secrets (scafctl.*); use --all to include them", secrets.ErrInvalidName)
+	}
+	return secrets.ValidateName(name)
+}
+
 // ValidateUserSecretName validates a secret name for user operations.
 // Returns an error if the name is invalid or uses the reserved "scafctl." prefix.
 func ValidateUserSecretName(name string) error {
-	if strings.HasPrefix(name, "scafctl.") {
-		return fmt.Errorf("%w: cannot operate on internal secrets (scafctl.*)", secrets.ErrInvalidName)
+	return ValidateSecretName(name, false)
+}
+
+// FilterSecrets filters secret names, optionally including internal secrets (scafctl.*).
+// When includeInternal is false, internal secrets are excluded.
+func FilterSecrets(names []string, includeInternal bool) []string {
+	if includeInternal {
+		return names
 	}
-	return secrets.ValidateName(name)
+	return FilterUserSecrets(names)
 }
 
 // FilterUserSecrets filters out internal secrets (scafctl.*) from a list of secret names.
 func FilterUserSecrets(names []string) []string {
 	result := make([]string, 0, len(names))
 	for _, name := range names {
-		if !strings.HasPrefix(name, "scafctl.") {
+		if !IsInternalSecret(name) {
 			result = append(result, name)
 		}
 	}
 	return result
+}
+
+// SecretType returns "internal" or "user" based on the secret name prefix.
+func SecretType(name string) string {
+	if IsInternalSecret(name) {
+		return "internal"
+	}
+	return "user"
 }

--- a/pkg/cmd/scafctl/secrets/validation_test.go
+++ b/pkg/cmd/scafctl/secrets/validation_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInternalSecret(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "internal auth refresh token", input: "scafctl.auth.entra.refresh_token", expected: true},
+		{name: "internal auth metadata", input: "scafctl.auth.entra.metadata", expected: true},
+		{name: "internal auth token prefix", input: "scafctl.auth.entra.token.abc123", expected: true},
+		{name: "scafctl prefix only", input: "scafctl.", expected: true},
+		{name: "user secret", input: "my-secret", expected: false},
+		{name: "user secret with dots", input: "my.secret.name", expected: false},
+		{name: "empty string", input: "", expected: false},
+		{name: "partial prefix", input: "scafct.foo", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, IsInternalSecret(tt.input))
+		})
+	}
+}
+
+func TestSecretType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "internal", SecretType("scafctl.auth.entra.refresh_token"))
+	assert.Equal(t, "internal", SecretType("scafctl.something"))
+	assert.Equal(t, "user", SecretType("my-secret"))
+	assert.Equal(t, "user", SecretType(""))
+}
+
+func TestValidateSecretName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		secretName      string
+		includeInternal bool
+		wantErr         bool
+	}{
+		{name: "user secret without all", secretName: "my-secret", includeInternal: false, wantErr: false},
+		{name: "user secret with all", secretName: "my-secret", includeInternal: true, wantErr: false},
+		{name: "internal secret without all", secretName: "scafctl.auth.token", includeInternal: false, wantErr: true},
+		{name: "internal secret with all", secretName: "scafctl.auth.token", includeInternal: true, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateSecretName(tt.secretName, tt.includeInternal)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "--all")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateUserSecretName(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateUserSecretName("scafctl.auth.entra.refresh_token")
+	assert.Error(t, err)
+
+	err = ValidateUserSecretName("my-secret")
+	assert.NoError(t, err)
+}
+
+func TestFilterSecrets(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"my-secret",
+		"scafctl.auth.entra.refresh_token",
+		"another-secret",
+		"scafctl.auth.entra.metadata",
+	}
+
+	filtered := FilterSecrets(names, false)
+	assert.Equal(t, []string{"my-secret", "another-secret"}, filtered)
+
+	filtered = FilterSecrets(names, true)
+	assert.Equal(t, names, filtered)
+}
+
+func TestFilterUserSecrets(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"my-secret",
+		"scafctl.auth.entra.refresh_token",
+		"another-secret",
+		"scafctl.auth.entra.metadata",
+	}
+
+	filtered := FilterUserSecrets(names)
+	assert.Equal(t, []string{"my-secret", "another-secret"}, filtered)
+}
+
+func TestFilterUserSecrets_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	filtered := FilterUserSecrets([]string{})
+	assert.Empty(t, filtered)
+}
+
+func TestFilterUserSecrets_AllInternal(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"scafctl.auth.entra.refresh_token",
+		"scafctl.auth.entra.metadata",
+	}
+
+	filtered := FilterUserSecrets(names)
+	assert.Empty(t, filtered)
+}

--- a/pkg/cmd/scafctl/version/version.go
+++ b/pkg/cmd/scafctl/version/version.go
@@ -132,7 +132,7 @@ func GetLatestVersion(ctx context.Context) (string, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: URL is a known GitHub API endpoint, not user-controlled
 	if err != nil {
 		return "", fmt.Errorf("fetching latest release: %w", err)
 	}

--- a/pkg/flags/resolve/resolve.go
+++ b/pkg/flags/resolve/resolve.go
@@ -118,7 +118,7 @@ func fetchURL(ctx context.Context, urlStr string) ([]byte, error) {
 	}
 	req.Header.Set("User-Agent", "scafctl-flags-resolver/1.0")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is validated before use
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL: %w", err)
 	}

--- a/pkg/profiler/fileManager.go
+++ b/pkg/profiler/fileManager.go
@@ -25,7 +25,7 @@ func (fm *fileManager) cleanUp() {
 	for _, f := range fm.files {
 		if f != nil {
 			f.Close()
-			os.Remove(f.Name())
+			os.Remove(f.Name()) //nolint:gosec // G703: path from os.File.Name(), not user input
 		}
 	}
 	fm.files = nil

--- a/pkg/provider/builtin/directoryprovider/directory.go
+++ b/pkg/provider/builtin/directoryprovider/directory.go
@@ -786,7 +786,7 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode().Perm())
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode().Perm()) //nolint:gosec // G703: dst is a resolved output path from provider config
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -280,8 +281,23 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 		workingDir = dir
 	}
 
-	// Capture stdout and stderr
+	// Capture stdout and stderr into buffers.
+	// If IOStreams are available in context, also stream to the terminal in real-time
+	// using io.MultiWriter so output appears immediately while still being captured
+	// for inter-action dependencies.
 	var stdout, stderr bytes.Buffer
+	var stdoutWriter, stderrWriter io.Writer = &stdout, &stderr
+	streamed := false
+
+	if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
+		if ioStreams.Out != nil {
+			stdoutWriter = io.MultiWriter(&stdout, ioStreams.Out)
+			streamed = true
+		}
+		if ioStreams.ErrOut != nil {
+			stderrWriter = io.MultiWriter(&stderr, ioStreams.ErrOut)
+		}
+	}
 
 	// Build run options
 	opts := &shellexec.RunOptions{
@@ -290,8 +306,8 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 		Shell:   shell,
 		Dir:     workingDir,
 		Env:     env,
-		Stdout:  &stdout,
-		Stderr:  &stderr,
+		Stdout:  stdoutWriter,
+		Stderr:  stderrWriter,
 	}
 	if stdin != nil {
 		opts.Stdin = stdin
@@ -315,6 +331,7 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 			"command":  fullCmd,
 			"shell":    string(result.Shell),
 		},
+		Streamed: streamed,
 	}, nil
 }
 

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -421,7 +421,7 @@ func (p *HTTPProvider) executeWithRetry(
 		}
 
 		// Execute request
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) //nolint:gosec // G704: URL is from provider configuration
 		if err != nil {
 			lastErr = err
 			// Network errors are retryable

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -44,7 +44,7 @@ func (d *DefaultHTTPClient) Get(ctx context.Context, url string) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	return d.client.Do(req)
+	return d.client.Do(req) //nolint:gosec // G704: URL is from provider configuration
 }
 
 // FileOps defines the interface for file operations

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -3,7 +3,10 @@
 
 package provider
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // Context keys for provider execution control (unexported for safety).
 type contextKey string
@@ -14,7 +17,31 @@ const (
 	resolverContextKey  contextKey = "scafctl.provider.resolverContext"
 	parametersKey       contextKey = "scafctl.provider.parameters"
 	iterationContextKey contextKey = "scafctl.provider.iterationContext"
+	ioStreamsKey        contextKey = "scafctl.provider.ioStreams"
 )
+
+// IOStreams holds terminal IO writers for providers that support streaming output.
+// Providers can use these to write output directly to the terminal during execution,
+// while still capturing data for inter-action dependencies.
+type IOStreams struct {
+	// Out is the writer for standard output (typically os.Stdout).
+	Out io.Writer
+	// ErrOut is the writer for standard error output (typically os.Stderr).
+	ErrOut io.Writer
+}
+
+// WithIOStreams returns a new context with IO streams for provider terminal output.
+func WithIOStreams(ctx context.Context, streams *IOStreams) context.Context {
+	return context.WithValue(ctx, ioStreamsKey, streams)
+}
+
+// IOStreamsFromContext retrieves the IO streams from the context.
+// Returns the IO streams and true if found, nil and false otherwise.
+// Providers should check this to determine if they can stream output to the terminal.
+func IOStreamsFromContext(ctx context.Context) (*IOStreams, bool) {
+	streams, ok := ctx.Value(ioStreamsKey).(*IOStreams)
+	return streams, ok
+}
 
 // WithExecutionMode returns a new context with the specified execution mode (capability).
 func WithExecutionMode(ctx context.Context, mode Capability) context.Context {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -126,6 +126,10 @@ type Output struct {
 	Data     any            `json:"data" yaml:"data" doc:"Provider output data" required:"true"`
 	Warnings []string       `json:"warnings,omitempty" yaml:"warnings,omitempty" doc:"Non-fatal warning messages" maxItems:"50"`
 	Metadata map[string]any `json:"metadata,omitempty" yaml:"metadata,omitempty" doc:"Execution metadata"`
+	// Streamed indicates that the provider already wrote its primary output
+	// (e.g., stdout/stderr) directly to the terminal via IOStreams from context.
+	// When true, the CLI output layer should not re-print the streamed content.
+	Streamed bool `json:"streamed,omitempty" yaml:"streamed,omitempty" doc:"Whether output was already streamed to terminal"`
 }
 
 // IsSensitiveField checks whether a field name is marked as sensitive in the descriptor.

--- a/pkg/provider/validation.go
+++ b/pkg/provider/validation.go
@@ -48,7 +48,7 @@ func (e ValidationErrors) Error() string {
 		return e[0].Error()
 	}
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("validation failed with %d errors:\n", len(e)))
+	fmt.Fprintf(&sb, "validation failed with %d errors:\n", len(e))
 	for _, err := range e {
 		sb.WriteString("  - ")
 		sb.WriteString(err.Error())

--- a/pkg/resolver/diff.go
+++ b/pkg/resolver/diff.go
@@ -212,24 +212,24 @@ func FormatDiffHuman(diff *SnapshotDiff) string {
 	sb.WriteString("===================\n\n")
 
 	// Metadata comparison
-	sb.WriteString(fmt.Sprintf("Before: %s (v%s) at %s\n",
+	fmt.Fprintf(&sb, "Before: %s (v%s) at %s\n",
 		diff.Before.Solution,
 		diff.Before.Version,
-		diff.Before.Timestamp.Format("2006-01-02 15:04:05")))
-	sb.WriteString(fmt.Sprintf("After:  %s (v%s) at %s\n\n",
+		diff.Before.Timestamp.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&sb, "After:  %s (v%s) at %s\n\n",
 		diff.After.Solution,
 		diff.After.Version,
-		diff.After.Timestamp.Format("2006-01-02 15:04:05")))
+		diff.After.Timestamp.Format("2006-01-02 15:04:05"))
 
 	// Summary
 	sb.WriteString("Summary\n")
 	sb.WriteString("-------\n")
-	sb.WriteString(fmt.Sprintf("Total: %d | Added: %d | Removed: %d | Modified: %d | Unchanged: %d\n\n",
+	fmt.Fprintf(&sb, "Total: %d | Added: %d | Removed: %d | Modified: %d | Unchanged: %d\n\n",
 		diff.Summary.TotalResolvers,
 		diff.Summary.Added,
 		diff.Summary.Removed,
 		diff.Summary.Modified,
-		diff.Summary.Unchanged))
+		diff.Summary.Unchanged)
 
 	// Get sorted resolver names
 	names := make([]string, 0, len(diff.Resolvers))
@@ -245,10 +245,10 @@ func FormatDiffHuman(diff *SnapshotDiff) string {
 		for _, name := range names {
 			rd := diff.Resolvers[name]
 			if rd.Type == DiffTypeAdded {
-				sb.WriteString(fmt.Sprintf("+ %s\n", name))
-				sb.WriteString(fmt.Sprintf("    Value:  %v\n", formatValue(rd.After.Value)))
-				sb.WriteString(fmt.Sprintf("    Status: %s\n", rd.After.Status))
-				sb.WriteString(fmt.Sprintf("    Phase:  %d\n", rd.After.Phase))
+				fmt.Fprintf(&sb, "+ %s\n", name)
+				fmt.Fprintf(&sb, "    Value:  %v\n", formatValue(rd.After.Value))
+				fmt.Fprintf(&sb, "    Status: %s\n", rd.After.Status)
+				fmt.Fprintf(&sb, "    Phase:  %d\n", rd.After.Phase)
 			}
 		}
 		sb.WriteString("\n")
@@ -261,10 +261,10 @@ func FormatDiffHuman(diff *SnapshotDiff) string {
 		for _, name := range names {
 			rd := diff.Resolvers[name]
 			if rd.Type == DiffTypeRemoved {
-				sb.WriteString(fmt.Sprintf("- %s\n", name))
-				sb.WriteString(fmt.Sprintf("    Value:  %v\n", formatValue(rd.Before.Value)))
-				sb.WriteString(fmt.Sprintf("    Status: %s\n", rd.Before.Status))
-				sb.WriteString(fmt.Sprintf("    Phase:  %d\n", rd.Before.Phase))
+				fmt.Fprintf(&sb, "- %s\n", name)
+				fmt.Fprintf(&sb, "    Value:  %v\n", formatValue(rd.Before.Value))
+				fmt.Fprintf(&sb, "    Status: %s\n", rd.Before.Status)
+				fmt.Fprintf(&sb, "    Phase:  %d\n", rd.Before.Phase)
 			}
 		}
 		sb.WriteString("\n")
@@ -277,11 +277,11 @@ func FormatDiffHuman(diff *SnapshotDiff) string {
 		for _, name := range names {
 			rd := diff.Resolvers[name]
 			if rd.Type == DiffTypeModified {
-				sb.WriteString(fmt.Sprintf("~ %s\n", name))
+				fmt.Fprintf(&sb, "~ %s\n", name)
 				for _, change := range rd.Changes {
-					sb.WriteString(fmt.Sprintf("    %s:\n", change.Field))
-					sb.WriteString(fmt.Sprintf("      - %v\n", formatValue(change.Before)))
-					sb.WriteString(fmt.Sprintf("      + %v\n", formatValue(change.After)))
+					fmt.Fprintf(&sb, "    %s:\n", change.Field)
+					fmt.Fprintf(&sb, "      - %v\n", formatValue(change.Before))
+					fmt.Fprintf(&sb, "      + %v\n", formatValue(change.After))
 				}
 			}
 		}
@@ -304,14 +304,14 @@ func FormatDiffUnified(diff *SnapshotDiff) string {
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString(fmt.Sprintf("--- %s (v%s) %s\n",
+	fmt.Fprintf(&sb, "--- %s (v%s) %s\n",
 		diff.Before.Solution,
 		diff.Before.Version,
-		diff.Before.Timestamp.Format("2006-01-02 15:04:05")))
-	sb.WriteString(fmt.Sprintf("+++ %s (v%s) %s\n",
+		diff.Before.Timestamp.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&sb, "+++ %s (v%s) %s\n",
 		diff.After.Solution,
 		diff.After.Version,
-		diff.After.Timestamp.Format("2006-01-02 15:04:05")))
+		diff.After.Timestamp.Format("2006-01-02 15:04:05"))
 	sb.WriteString("\n")
 
 	// Get sorted resolver names
@@ -327,24 +327,24 @@ func FormatDiffUnified(diff *SnapshotDiff) string {
 
 		switch rd.Type {
 		case DiffTypeAdded:
-			sb.WriteString(fmt.Sprintf("@@ Resolver: %s (added) @@\n", name))
-			sb.WriteString(fmt.Sprintf("+  status: %s\n", rd.After.Status))
-			sb.WriteString(fmt.Sprintf("+  value: %v\n", formatValue(rd.After.Value)))
-			sb.WriteString(fmt.Sprintf("+  phase: %d\n", rd.After.Phase))
-			sb.WriteString(fmt.Sprintf("+  duration: %s\n\n", rd.After.Duration))
+			fmt.Fprintf(&sb, "@@ Resolver: %s (added) @@\n", name)
+			fmt.Fprintf(&sb, "+  status: %s\n", rd.After.Status)
+			fmt.Fprintf(&sb, "+  value: %v\n", formatValue(rd.After.Value))
+			fmt.Fprintf(&sb, "+  phase: %d\n", rd.After.Phase)
+			fmt.Fprintf(&sb, "+  duration: %s\n\n", rd.After.Duration)
 
 		case DiffTypeRemoved:
-			sb.WriteString(fmt.Sprintf("@@ Resolver: %s (removed) @@\n", name))
-			sb.WriteString(fmt.Sprintf("-  status: %s\n", rd.Before.Status))
-			sb.WriteString(fmt.Sprintf("-  value: %v\n", formatValue(rd.Before.Value)))
-			sb.WriteString(fmt.Sprintf("-  phase: %d\n", rd.Before.Phase))
-			sb.WriteString(fmt.Sprintf("-  duration: %s\n\n", rd.Before.Duration))
+			fmt.Fprintf(&sb, "@@ Resolver: %s (removed) @@\n", name)
+			fmt.Fprintf(&sb, "-  status: %s\n", rd.Before.Status)
+			fmt.Fprintf(&sb, "-  value: %v\n", formatValue(rd.Before.Value))
+			fmt.Fprintf(&sb, "-  phase: %d\n", rd.Before.Phase)
+			fmt.Fprintf(&sb, "-  duration: %s\n\n", rd.Before.Duration)
 
 		case DiffTypeModified:
-			sb.WriteString(fmt.Sprintf("@@ Resolver: %s (modified) @@\n", name))
+			fmt.Fprintf(&sb, "@@ Resolver: %s (modified) @@\n", name)
 			for _, change := range rd.Changes {
-				sb.WriteString(fmt.Sprintf("-  %s: %v\n", change.Field, formatValue(change.Before)))
-				sb.WriteString(fmt.Sprintf("+  %s: %v\n", change.Field, formatValue(change.After)))
+				fmt.Fprintf(&sb, "-  %s: %v\n", change.Field, formatValue(change.Before))
+				fmt.Fprintf(&sb, "+  %s: %v\n", change.Field, formatValue(change.After))
 			}
 			sb.WriteString("\n")
 

--- a/pkg/resolver/errors.go
+++ b/pkg/resolver/errors.go
@@ -85,9 +85,9 @@ func (e *AggregatedValidationError) Error() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("resolver %q validation failed with %d errors:\n", e.ResolverName, len(e.Failures)))
+	fmt.Fprintf(&sb, "resolver %q validation failed with %d errors:\n", e.ResolverName, len(e.Failures))
 	for i, f := range e.Failures {
-		sb.WriteString(fmt.Sprintf("  - [rule %d] %s\n", i+1, f.Error()))
+		fmt.Fprintf(&sb, "  - [rule %d] %s\n", i+1, f.Error())
 	}
 	return strings.TrimSuffix(sb.String(), "\n")
 }
@@ -291,17 +291,17 @@ func (e *AggregatedExecutionError) Error() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%d resolver(s) failed", len(e.Errors)))
+	fmt.Fprintf(&sb, "%d resolver(s) failed", len(e.Errors))
 	if e.SkippedCount > 0 {
-		sb.WriteString(fmt.Sprintf(", %d skipped due to failed dependencies", e.SkippedCount))
+		fmt.Fprintf(&sb, ", %d skipped due to failed dependencies", e.SkippedCount)
 	}
 	if e.SucceededCount > 0 {
-		sb.WriteString(fmt.Sprintf(", %d succeeded", e.SucceededCount))
+		fmt.Fprintf(&sb, ", %d succeeded", e.SucceededCount)
 	}
 	sb.WriteString(":\n")
 
 	for i, err := range e.Errors {
-		sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, err.Error()))
+		fmt.Fprintf(&sb, "  %d. %s\n", i+1, err.Error())
 	}
 
 	return strings.TrimSuffix(sb.String(), "\n")

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -558,27 +558,11 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 		return false, result.Error
 	}
 
-	// Type coercion after resolve (if type is specified)
-	if r.Type != "" && r.Type != TypeAny {
-		coerced, err := CoerceType(value, r.Type)
-		if err != nil {
-			result.Value = value
-			result.Status = ExecutionStatusFailed
-			result.Error = &TypeCoercionError{
-				ResolverName: r.Name,
-				Phase:        "resolve",
-				SourceType:   fmt.Sprintf("%T", value),
-				TargetType:   r.Type,
-				Cause:        err,
-			}
-			return false, result.Error
-		}
-		value = coerced
-	}
-
 	// Execute transform phase
 	// Skip if transform is disabled via executor option (also skips validate)
+	coercionPhase := "resolve"
 	if r.Transform != nil && !e.skipTransform {
+		coercionPhase = "transform"
 		phaseStart := time.Now()
 		transformed, providerCalls, err := e.executeTransformPhase(resolverContext, r.Transform, value)
 		providerCallCount += providerCalls
@@ -603,24 +587,26 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 		}
 
 		value = transformed
+	}
 
-		// Type coercion after transform
-		if r.Type != "" && r.Type != TypeAny {
-			coerced, err := CoerceType(value, r.Type)
-			if err != nil {
-				result.Value = value
-				result.Status = ExecutionStatusFailed
-				result.Error = &TypeCoercionError{
-					ResolverName: r.Name,
-					Phase:        "transform",
-					SourceType:   fmt.Sprintf("%T", value),
-					TargetType:   r.Type,
-					Cause:        err,
-				}
-				return false, result.Error
+	// Type coercion on the final value (after resolve + optional transform)
+	// The type field describes the resolver's output contract, so we enforce it
+	// exactly once on whatever the final value is.
+	if r.Type != "" && r.Type != TypeAny {
+		coerced, err := CoerceType(value, r.Type)
+		if err != nil {
+			result.Value = value
+			result.Status = ExecutionStatusFailed
+			result.Error = &TypeCoercionError{
+				ResolverName: r.Name,
+				Phase:        coercionPhase,
+				SourceType:   fmt.Sprintf("%T", value),
+				TargetType:   r.Type,
+				Cause:        err,
 			}
-			value = coerced
+			return false, result.Error
 		}
+		value = coerced
 	}
 
 	// Execute validate phase (runs all validations and aggregates failures)

--- a/pkg/resolver/metrics_summary.go
+++ b/pkg/resolver/metrics_summary.go
@@ -160,17 +160,17 @@ func FormatMetricsSummary(summary *MetricsSummary) string {
 	sb.WriteString("==========================\n")
 
 	// Overview
-	sb.WriteString(fmt.Sprintf("Total: %d | Success: %d | Failed: %d | Skipped: %d\n",
-		summary.TotalResolvers, summary.SuccessCount, summary.FailedCount, summary.SkippedCount))
-	sb.WriteString(fmt.Sprintf("Duration: %v | Phases: %d\n\n",
-		summary.TotalDuration.Round(time.Millisecond), summary.PhaseCount))
+	fmt.Fprintf(&sb, "Total: %d | Success: %d | Failed: %d | Skipped: %d\n",
+		summary.TotalResolvers, summary.SuccessCount, summary.FailedCount, summary.SkippedCount)
+	fmt.Fprintf(&sb, "Duration: %v | Phases: %d\n\n",
+		summary.TotalDuration.Round(time.Millisecond), summary.PhaseCount)
 
 	// Slowest resolvers
 	if len(summary.SlowestResolvers) > 0 {
 		sb.WriteString("Slowest Resolvers:\n")
 		for i, r := range summary.SlowestResolvers {
-			sb.WriteString(fmt.Sprintf("  %d. %-20s %6s  (phase %d)\n",
-				i+1, r.Name, formatDuration(r.Duration), r.Phase))
+			fmt.Fprintf(&sb, "  %d. %-20s %6s  (phase %d)\n",
+				i+1, r.Name, formatDuration(r.Duration), r.Phase)
 		}
 		sb.WriteString("\n")
 	}
@@ -179,8 +179,8 @@ func FormatMetricsSummary(summary *MetricsSummary) string {
 	if len(summary.LargestValues) > 0 {
 		sb.WriteString("Largest Values:\n")
 		for i, r := range summary.LargestValues {
-			sb.WriteString(fmt.Sprintf("  %d. %-20s %s\n",
-				i+1, r.Name, formatBytes(r.Size)))
+			fmt.Fprintf(&sb, "  %d. %-20s %s\n",
+				i+1, r.Name, formatBytes(r.Size))
 		}
 		sb.WriteString("\n")
 	}
@@ -189,11 +189,11 @@ func FormatMetricsSummary(summary *MetricsSummary) string {
 	if len(summary.FailedAttempts) > 0 {
 		sb.WriteString("Failed Attempts (onError: continue):\n")
 		for _, fa := range summary.FailedAttempts {
-			sb.WriteString(fmt.Sprintf("  %s: %d attempts before success\n",
-				fa.ResolverName, fa.AttemptCount))
+			fmt.Fprintf(&sb, "  %s: %d attempts before success\n",
+				fa.ResolverName, fa.AttemptCount)
 			for _, attempt := range fa.Attempts {
-				sb.WriteString(fmt.Sprintf("    ✗ %s (%s)\n",
-					attempt.Provider, attempt.Error))
+				fmt.Fprintf(&sb, "    ✗ %s (%s)\n",
+					attempt.Provider, attempt.Error)
 			}
 		}
 		sb.WriteString("\n")
@@ -203,9 +203,9 @@ func FormatMetricsSummary(summary *MetricsSummary) string {
 	if len(summary.Failures) > 0 {
 		sb.WriteString("Failures:\n")
 		for _, f := range summary.Failures {
-			sb.WriteString(fmt.Sprintf("  ✗ %s (phase %d)\n",
-				f.Name, f.Phase))
-			sb.WriteString(fmt.Sprintf("    Error: %s\n", f.Error))
+			fmt.Fprintf(&sb, "  ✗ %s (phase %d)\n",
+				f.Name, f.Phase)
+			fmt.Fprintf(&sb, "    Error: %s\n", f.Error)
 		}
 	}
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -62,7 +62,7 @@ type Resolver struct {
 	Name        string `json:"name" yaml:"name" doc:"Resolver name (must be unique)" example:"environment" pattern:"^[a-zA-Z_][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter or underscore, followed by letters, numbers, underscores, or hyphens"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Human-readable description" maxLength:"500" example:"Resolves the target deployment environment"`
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"Display name for UI" maxLength:"80" example:"Environment"`
-	Sensitive   bool   `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether value should be redacted in logs" example:"false"`
+	Sensitive   bool   `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether value should be redacted in table output and logs (JSON/YAML output reveals values for machine consumption)" example:"false"`
 	Example     any    `json:"example,omitempty" yaml:"example,omitempty" doc:"Example value for documentation"`
 
 	// Type declaration

--- a/pkg/secrets/keyring.go
+++ b/pkg/secrets/keyring.go
@@ -251,7 +251,7 @@ func (k *fileKeyring) Set(service, account, value string) error {
 	}
 
 	// Atomic rename
-	if err := os.Rename(tmpPath, targetPath); err != nil {
+	if err := os.Rename(tmpPath, targetPath); err != nil { //nolint:gosec // G703: paths are within managed keyring directory
 		return NewKeyringError("set", fmt.Errorf("renaming key file: %w", err))
 	}
 

--- a/pkg/secrets/storage.go
+++ b/pkg/secrets/storage.go
@@ -117,12 +117,12 @@ func writeSecret(dir, name string, data []byte) error {
 	}
 
 	// Set proper permissions
-	if err := os.Chmod(tempPath, filePermissions); err != nil {
+	if err := os.Chmod(tempPath, filePermissions); err != nil { //nolint:gosec // G703: tempPath is within managed secrets directory
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
 
 	// Atomic rename
-	if err := os.Rename(tempPath, targetPath); err != nil {
+	if err := os.Rename(tempPath, targetPath); err != nil { //nolint:gosec // G703: paths are within managed secrets directory
 		return fmt.Errorf("renaming temp file: %w", err)
 	}
 

--- a/pkg/solution/soltesting/snapshot.go
+++ b/pkg/solution/soltesting/snapshot.go
@@ -112,7 +112,7 @@ func unifiedDiff(expected, actual, snapshotPath string) string {
 	actualLines := strings.Split(actual, "\n")
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("--- expected (%s)\n", snapshotPath))
+	fmt.Fprintf(&b, "--- expected (%s)\n", snapshotPath)
 	b.WriteString("+++ actual\n")
 
 	// Simple line-by-line diff with context.

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -20,6 +20,7 @@ const (
 	TypeFloat    Type = "float" // float64
 	TypeBool     Type = "bool"
 	TypeArray    Type = "array"    // []any (heterogeneous)
+	TypeObject   Type = "object"   // map[string]any
 	TypeTime     Type = "time"     // time.Time
 	TypeDuration Type = "duration" // time.Duration
 	TypeAny      Type = "any"
@@ -52,6 +53,8 @@ func CoerceType(value any, targetType Type) (any, error) {
 		return coerceToBool(value)
 	case TypeArray:
 		return coerceToArray(value), nil
+	case TypeObject:
+		return coerceToObject(value)
 	case TypeTime:
 		return coerceToTime(value)
 	case TypeDuration:
@@ -74,6 +77,8 @@ func normalizeType(t Type) Type {
 		return TypeFloat
 	case "boolean":
 		return TypeBool
+	case "map":
+		return TypeObject
 	default:
 		return t
 	}
@@ -254,6 +259,26 @@ func coerceToBool(value any) (bool, error) {
 	default:
 		return false, fmt.Errorf("cannot coerce %T to bool", value)
 	}
+}
+
+// coerceToObject converts value to map[string]any.
+// Accepts map[string]any and map[string]interface{} directly.
+// Other map types with string keys are converted.
+func coerceToObject(value any) (map[string]any, error) {
+	v := reflect.ValueOf(value)
+
+	if v.Kind() == reflect.Map {
+		if v.Type().Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("cannot coerce %T to object: map key must be string", value)
+		}
+		result := make(map[string]any, v.Len())
+		for _, key := range v.MapKeys() {
+			result[key.String()] = v.MapIndex(key).Interface()
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("cannot coerce %T to object", value)
 }
 
 // coerceToArray converts value to array.

--- a/pkg/spec/types_test.go
+++ b/pkg/spec/types_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestCoerceType_NilValues tests that nil values pass through for all types
 func TestCoerceType_NilValues(t *testing.T) {
-	types := []Type{TypeString, TypeInt, TypeFloat, TypeBool, TypeArray, TypeTime, TypeDuration, TypeAny}
+	types := []Type{TypeString, TypeInt, TypeFloat, TypeBool, TypeArray, TypeObject, TypeTime, TypeDuration, TypeAny}
 
 	for _, targetType := range types {
 		t.Run(string(targetType), func(t *testing.T) {
@@ -293,6 +293,46 @@ func TestCoerceType_Duration(t *testing.T) {
 	}
 }
 
+// TestCoerceType_Object tests object coercion
+func TestCoerceType_Object(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected map[string]any
+		wantErr  bool
+	}{
+		{"map_string_any_passthrough", map[string]any{"key": "value"}, map[string]any{"key": "value"}, false},
+		{"map_string_interface_passthrough", map[string]interface{}{"a": 1, "b": "two"}, map[string]any{"a": 1, "b": "two"}, false},
+		{"nested_map", map[string]any{"outer": map[string]any{"inner": 42}}, map[string]any{"outer": map[string]any{"inner": 42}}, false},
+		{"empty_map", map[string]any{}, map[string]any{}, false},
+		{"string_value", "not a map", nil, true},
+		{"int_value", 42, nil, true},
+		{"bool_value", true, nil, true},
+		{"array_value", []any{1, 2, 3}, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CoerceType(tt.value, TypeObject)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot coerce")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestCoerceType_Object_MapAlias tests that "map" alias resolves to object type
+func TestCoerceType_Object_MapAlias(t *testing.T) {
+	value := map[string]any{"key": "value"}
+	result, err := CoerceType(value, Type("map"))
+	require.NoError(t, err)
+	assert.Equal(t, value, result)
+}
+
 // TestCoerceType_TypeAliases tests type alias normalization
 func TestCoerceType_TypeAliases(t *testing.T) {
 	tests := []struct {
@@ -352,6 +392,7 @@ func TestType_Constants(t *testing.T) {
 	assert.Equal(t, Type("float"), TypeFloat)
 	assert.Equal(t, Type("bool"), TypeBool)
 	assert.Equal(t, Type("array"), TypeArray)
+	assert.Equal(t, Type("object"), TypeObject)
 	assert.Equal(t, Type("time"), TypeTime)
 	assert.Equal(t, Type("duration"), TypeDuration)
 	assert.Equal(t, Type("any"), TypeAny)

--- a/pkg/terminal/input/input.go
+++ b/pkg/terminal/input/input.go
@@ -132,7 +132,7 @@ func (i *Input) ReadLine(opts *LineOptions) (string, error) {
 
 func (i *Input) isTTY() bool {
 	if f, ok := i.ioStreams.In.(*os.File); ok {
-		return term.IsTerminal(int(f.Fd()))
+		return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: Fd() fits in int on all supported platforms
 	}
 	return false
 }
@@ -167,7 +167,7 @@ func (i *Input) readPassword() (string, error) {
 	if !ok {
 		return "", fmt.Errorf("stdin is not a file")
 	}
-	passwordBytes, err := term.ReadPassword(int(f.Fd()))
+	passwordBytes, err := term.ReadPassword(int(f.Fd())) //nolint:gosec // G115: Fd() fits in int on all supported platforms
 	if err != nil {
 		return "", err
 	}

--- a/pkg/terminal/prefixwriter.go
+++ b/pkg/terminal/prefixwriter.go
@@ -1,0 +1,58 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package terminal
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// PrefixedWriter wraps an io.Writer and prepends a prefix to each line of output.
+// It is safe for concurrent use. When multiple actions run in parallel, each action
+// gets a PrefixedWriter with its name, so output lines are clearly attributed.
+type PrefixedWriter struct {
+	mu          sync.Mutex
+	out         io.Writer
+	prefix      string
+	needsPrefix bool
+}
+
+// NewPrefixedWriter creates a writer that prefixes each line with the given string.
+// The prefix is formatted as "[name] " and prepended to the start of each line.
+func NewPrefixedWriter(out io.Writer, name string) *PrefixedWriter {
+	return &PrefixedWriter{
+		out:         out,
+		prefix:      fmt.Sprintf("[%s] ", name),
+		needsPrefix: true,
+	}
+}
+
+// Write implements io.Writer. It scans each byte for newlines and inserts
+// the prefix at the beginning of each new line.
+func (pw *PrefixedWriter) Write(p []byte) (int, error) {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+
+	written := 0
+	for _, b := range p {
+		if pw.needsPrefix {
+			if _, err := io.WriteString(pw.out, pw.prefix); err != nil {
+				return written, err
+			}
+			pw.needsPrefix = false
+		}
+
+		if _, err := pw.out.Write([]byte{b}); err != nil {
+			return written, err
+		}
+		written++
+
+		if b == '\n' {
+			pw.needsPrefix = true
+		}
+	}
+
+	return written, nil
+}

--- a/pkg/terminal/prefixwriter_test.go
+++ b/pkg/terminal/prefixwriter_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package terminal
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixedWriter_SingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "action-1")
+
+	n, err := pw.Write([]byte("hello world\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 12, n)
+	assert.Equal(t, "[action-1] hello world\n", buf.String())
+}
+
+func TestPrefixedWriter_MultipleLines(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "greet")
+
+	_, err := pw.Write([]byte("line one\nline two\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "[greet] line one\n[greet] line two\n", buf.String())
+}
+
+func TestPrefixedWriter_NoTrailingNewline(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "test")
+
+	_, err := pw.Write([]byte("no newline"))
+	require.NoError(t, err)
+	assert.Equal(t, "[test] no newline", buf.String())
+}
+
+func TestPrefixedWriter_EmptyWrite(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "test")
+
+	n, err := pw.Write([]byte{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, "", buf.String())
+}
+
+func TestPrefixedWriter_MultipleWrites(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "step")
+
+	_, err := pw.Write([]byte("first\n"))
+	require.NoError(t, err)
+	_, err = pw.Write([]byte("second\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "[step] first\n[step] second\n", buf.String())
+}
+
+func TestPrefixedWriter_ConcurrentWrites(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "concurrent")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := pw.Write([]byte("test line\n"))
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// Each write should produce a prefixed line
+	output := buf.String()
+	count := 0
+	for i := 0; i < len(output); i++ {
+		if output[i] == '\n' {
+			count++
+		}
+	}
+	assert.Equal(t, 10, count, "expected 10 lines of output")
+}
+
+func TestPrefixedWriter_PartialLinesThenNewline(t *testing.T) {
+	var buf bytes.Buffer
+	pw := NewPrefixedWriter(&buf, "partial")
+
+	_, err := pw.Write([]byte("hello "))
+	require.NoError(t, err)
+	_, err = pw.Write([]byte("world\n"))
+	require.NoError(t, err)
+
+	// Prefix was written at the start of the first write,
+	// second write continues the same line until newline
+	assert.Equal(t, "[partial] hello world\n", buf.String())
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -333,6 +333,19 @@ func TestIntegration_RunSolution_HelloWorld(t *testing.T) {
 	assert.Contains(t, stdout, "Hello from Actions!")
 }
 
+func TestIntegration_RunSolution_NoWorkflowErrors(t *testing.T) {
+	t.Parallel()
+	// resolver-demo.yaml has resolvers but no workflow section
+	_, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/resolver-demo.yaml",
+	)
+
+	assert.Equal(t, 3, exitCode, "expected exit code 3 (InvalidInput), got %d", exitCode)
+	assert.Contains(t, stderr, "no workflow defined")
+	assert.Contains(t, stderr, "scafctl run resolver")
+}
+
 func TestIntegration_RunSolution_FileNotFound(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
@@ -489,6 +502,19 @@ func TestIntegration_RunResolver_ExecutionMetadataAlwaysIncluded(t *testing.T) {
 	assert.Contains(t, stdout, "phaseCount")
 }
 
+func TestIntegration_RunResolver_HideExecution(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--hide-execution",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.NotContains(t, stdout, "__execution")
+}
+
 func TestIntegration_RunResolver_SkipTransform(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
@@ -625,6 +651,123 @@ func TestIntegration_RunResolver_SnapshotRedact(t *testing.T) {
 	assert.Contains(t, stdout, "Snapshot saved to")
 }
 
+func TestIntegration_RunResolver_SensitiveRedactedInTable(t *testing.T) {
+	t.Parallel()
+	// Create a temp solution with sensitive values
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "sensitive.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sensitive-test
+  version: 1.0.0
+spec:
+  resolvers:
+    secret_val:
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-secret-password"
+    public_val:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "public-data"
+`
+	err := os.WriteFile(solutionPath, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	// Table output should redact sensitive values
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", solutionPath,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "[REDACTED]")
+	assert.NotContains(t, stdout, "my-secret-password")
+	assert.Contains(t, stdout, "public-data")
+}
+
+func TestIntegration_RunResolver_SensitiveRevealedInJSON(t *testing.T) {
+	t.Parallel()
+	// Create a temp solution with sensitive values
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "sensitive.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sensitive-test
+  version: 1.0.0
+spec:
+  resolvers:
+    secret_val:
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-secret-password"
+    public_val:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "public-data"
+`
+	err := os.WriteFile(solutionPath, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	// JSON output should reveal sensitive values (Terraform model)
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", solutionPath,
+		"-o", "json",
+		"--hide-execution",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "my-secret-password", "JSON output should reveal sensitive values")
+	assert.NotContains(t, stdout, "[REDACTED]", "JSON output should not redact")
+	assert.Contains(t, stdout, "public-data")
+}
+
+func TestIntegration_RunResolver_ShowSensitiveFlag(t *testing.T) {
+	t.Parallel()
+	// Create a temp solution with sensitive values
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "sensitive.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sensitive-test
+  version: 1.0.0
+spec:
+  resolvers:
+    secret_val:
+      sensitive: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-secret-password"
+`
+	err := os.WriteFile(solutionPath, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	// --show-sensitive should work as a recognized flag
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", solutionPath,
+		"--show-sensitive",
+	)
+
+	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
+}
+
 func TestIntegration_RunResolver_MutualExclusive_DryRunGraph(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
@@ -653,9 +796,8 @@ func TestIntegration_RunResolver_SnapshotRequiresFile(t *testing.T) {
 func TestIntegration_RunSolution_ShowExecution(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
-		"--show-execution",
 		"-o", "json",
 	)
 
@@ -1711,7 +1853,7 @@ func TestIntegration_RunSolution_FromCatalog_ByName(t *testing.T) {
 	require.Equal(t, 0, exitCode)
 
 	// Run the solution from catalog by name (should pick latest version)
-	stdout, _, exitCode := runScafctl(t, "run", "solution", "resolver-demo", "-o", "json")
+	stdout, _, exitCode := runScafctl(t, "run", "resolver", "-f", "resolver-demo", "-o", "json")
 	assert.Equal(t, 0, exitCode)
 	// Should have resolver output
 	assert.Contains(t, stdout, "environment")
@@ -1731,7 +1873,7 @@ func TestIntegration_RunSolution_FromCatalog_ByNameVersion(t *testing.T) {
 	require.Equal(t, 0, exitCode)
 
 	// Run the solution from catalog by name@version
-	stdout, _, exitCode := runScafctl(t, "run", "solution", "resolver-demo@1.0.0", "-o", "json")
+	stdout, _, exitCode := runScafctl(t, "run", "resolver", "-f", "resolver-demo@1.0.0", "-o", "json")
 	assert.Equal(t, 0, exitCode)
 	// Should have resolver output
 	assert.Contains(t, stdout, "environment")
@@ -1745,7 +1887,7 @@ func TestIntegration_RunSolution_FromCatalog_FallbackToFile(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Run a solution by file path (not bare name) - should use file
-	stdout, _, exitCode := runScafctl(t, "run", "solution", "-f", "examples/resolver-demo.yaml", "-o", "json")
+	stdout, _, exitCode := runScafctl(t, "run", "resolver", "-f", "examples/resolver-demo.yaml", "-o", "json")
 	assert.Equal(t, 0, exitCode)
 	// Should have resolver output from file
 	assert.Contains(t, stdout, "environment")
@@ -2054,7 +2196,7 @@ func TestIntegration_CatalogSaveLoad_RoundTrip(t *testing.T) {
 	require.Equal(t, 0, exitCode)
 
 	// Verify the solution can be run
-	stdout, _, exitCode := runScafctl(t, "run", "solution", "resolver-demo", "-o", "json")
+	stdout, _, exitCode := runScafctl(t, "run", "resolver", "-f", "resolver-demo", "-o", "json")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "environment")
 	assert.Contains(t, stdout, "production")
@@ -2401,7 +2543,7 @@ func TestIntegration_BuildSolution_NoCacheBypassesCacheHit(t *testing.T) {
 func TestIntegration_SolutionProvider_ResolverComposition(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", "tests/integration/testdata/solution-provider/parent-resolver.yaml",
 		"-o", "json",
 	)
@@ -2417,6 +2559,7 @@ func TestIntegration_SolutionProvider_WorkflowComposition(t *testing.T) {
 	stdout, stderr, exitCode := runScafctl(t,
 		"run", "solution",
 		"-f", "tests/integration/testdata/solution-provider/parent-action.yaml",
+		"-o", "json",
 	)
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
@@ -2427,7 +2570,7 @@ func TestIntegration_SolutionProvider_WorkflowComposition(t *testing.T) {
 func TestIntegration_SolutionProvider_CircularReference(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", "tests/integration/testdata/solution-provider/circular-a.yaml",
 	)
 	t.Logf("stderr: %s", stderr)
@@ -2494,7 +2637,7 @@ spec:
 	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
 
 	stdout, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", parentPath,
 		"-o", "json",
 	)
@@ -2531,7 +2674,7 @@ spec:
 	require.NoError(t, os.WriteFile(selfPath, []byte(selfRef), 0o644))
 
 	_, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", selfPath,
 	)
 	t.Logf("stderr: %s", stderr)
@@ -2565,7 +2708,7 @@ spec:
 	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
 
 	_, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", parentPath,
 	)
 	t.Logf("stderr: %s", stderr)
@@ -2604,7 +2747,7 @@ spec:
 	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
 
 	stdout, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", parentPath,
 	)
 	t.Logf("stdout: %s", stdout)
@@ -2641,7 +2784,7 @@ spec:
 	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
 
 	_, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", parentPath,
 	)
 	t.Logf("stderr: %s", stderr)
@@ -2677,7 +2820,7 @@ spec:
 	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
 
 	stdout, stderr, exitCode := runScafctl(t,
-		"run", "solution",
+		"run", "resolver",
 		"-f", parentPath,
 	)
 	t.Logf("stdout: %s", stdout)


### PR DESCRIPTION
…on streaming output

BREAKING CHANGE: run solution now requires a workflow; resolver-only solutions must use run resolver instead.

- feat(spec): add TypeObject for map[string]any coercion with 'map' alias
- refactor(resolver): coerce type once on final value instead of after each phase
- feat(provider): add IOStreams context for streaming output to terminal
- feat(exec): stream stdout/stderr to terminal when IOStreams available
- feat(action): add Streamed flag and PrefixedWriter for parallel attribution
- feat(cli): add --hide-execution, --show-sensitive flags to run resolver
- feat(cli): run solution errors without workflow, suggests run resolver
- feat(auth): add --scope flag, ErrConsentRequired, multi-resource flow support
- docs: update resolvers.md with object type and single-coercion behavior
- docs: update tutorials with --hide-execution and correct run commands
- fix: update examples to use run resolver for resolver-only solutions