### PR TITLE
feat(auth): add builtin GitHub authentication handler

### DIFF
--- a/docs/design/github-auth-handler.md
+++ b/docs/design/github-auth-handler.md
@@ -1,0 +1,331 @@
+---
+title: "GitHub Auth Handler"
+weight: 6
+---
+
+# GitHub Auth Handler Implementation Plan
+
+## Overview
+
+Implement a builtin GitHub auth handler (`github`) following the established patterns from the Entra handler. The handler will support OAuth device code flow for interactive use and PAT (Personal Access Token) from environment variables for CI/CD.
+
+---
+
+## Design Decisions
+
+### Authentication Flows
+
+| Flow | Use Case | Mechanism |
+|------|----------|-----------|
+| **Device Code** | Interactive CLI use | OAuth 2.0 device authorization grant via GitHub OAuth App |
+| **PAT** | CI/CD pipelines, automation | Read `GITHUB_TOKEN` or `GH_TOKEN` from environment variables |
+
+**Rationale**: Device code flow is the standard for CLI tools (`gh`, `az`, `gcloud` all use it). PAT from environment mirrors the Entra handler's service principal pattern and aligns with GitHub Actions' `GITHUB_TOKEN` injection.
+
+### OAuth App Client ID
+
+**Decision**: Ship with a default public OAuth App client ID, allow override via `--client-id` flag and config.
+
+**Rationale**: This matches industry practice:
+- `gh` CLI ships with a hardcoded OAuth App client ID
+- Azure CLI ships with its public client ID
+- `gcloud` ships with a default client ID
+
+Requiring users to register their own OAuth App before login creates unacceptable friction.
+
+**Setup**: Create a GitHub OAuth App for scafctl with device flow enabled. The client ID will be hardcoded as the default in `config.go`.
+
+### Default Scopes
+
+**Decision**: Default to `repo` and `read:user`.
+
+| Scope | Purpose |
+|-------|---------|
+| `read:user` | Verify identity, populate claims (username, email, name) |
+| `repo` | Access repositories (catalog, solutions, templates) |
+
+**Rationale**: `gh` CLI requests `repo`, `read:org`, `gist`, `workflow` by default but that's broader than needed. `repo` + `read:user` covers the primary use cases. Users can add more via `--scope` at login time.
+
+### Token Storage
+
+**Decision**: Support refresh token rotation (OAuth token expiration + refresh tokens).
+
+**Rationale**: GitHub OAuth Apps can optionally enable token expiration with refresh tokens. This is the modern best practice and matches the Entra handler pattern. If the OAuth App does not have token expiration enabled, the handler gracefully falls back to long-lived access tokens.
+
+### GitHub Enterprise Server (GHES)
+
+**Decision**: Support custom hostnames via `--hostname` flag and config.
+
+**Rationale**: Many organizations use GHES. The handler should allow configuring a custom hostname that changes the OAuth and API base URLs:
+- OAuth endpoints: `https://<hostname>/login/device/code`, `https://<hostname>/login/oauth/access_token`
+- API endpoint: `https://<hostname>/api/v3/user`
+
+Default hostname is `github.com`.
+
+---
+
+## GitHub OAuth Endpoints
+
+| Endpoint | URL |
+|----------|-----|
+| Device code request | `POST https://github.com/login/device/code` |
+| Token poll / exchange | `POST https://github.com/login/oauth/access_token` |
+| Token refresh | `POST https://github.com/login/oauth/access_token` (with `grant_type=refresh_token`) |
+| User info (claims) | `GET https://api.github.com/user` |
+
+All endpoints accept and return JSON when `Accept: application/json` is set.
+
+### Device Code Flow Sequence
+
+```
+1. POST /login/device/code
+   Body: client_id=<id>&scope=repo read:user
+   Response: { device_code, user_code, verification_uri, expires_in, interval }
+
+2. Display: "Enter code ABCD-1234 at https://github.com/login/device"
+
+3. Poll POST /login/oauth/access_token
+   Body: client_id=<id>&device_code=<code>&grant_type=urn:ietf:params:oauth:grant-type:device_code
+   Until: access_token is returned (or error/timeout)
+
+4. Response: { access_token, token_type, scope, refresh_token?, refresh_token_expires_in? }
+
+5. GET /user with Authorization: Bearer <access_token>
+   Extract claims: login, name, email, id
+```
+
+### PAT Flow Sequence
+
+```
+1. Read GITHUB_TOKEN or GH_TOKEN from environment
+2. GET /user with Authorization: Bearer <token>
+3. Extract claims: login, name, email, id
+4. Validate token is functional
+```
+
+---
+
+## File Structure
+
+```
+pkg/auth/github/
+├── cache.go              # Token caching (reuse Entra pattern)
+├── cache_test.go
+├── claims.go             # GitHub user → auth.Claims mapping
+├── claims_test.go
+├── config.go             # Config struct, defaults, validation
+├── config_test.go
+├── device_flow.go        # Device code OAuth flow
+├── device_flow_test.go
+├── handler.go            # Main handler implementing auth.Handler
+├── handler_test.go
+├── http.go               # HTTP client interface for testability
+├── http_test.go
+├── mock.go               # Test mocks
+├── pat.go                # PAT flow (env var based)
+├── pat_test.go
+└── token.go              # Token response types and helpers
+```
+
+---
+
+## Implementation Tasks
+
+### Phase 1: Core Handler (Tasks 1-6)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 1 | Create handler skeleton | `config.go`, `handler.go` | `Config` struct with defaults, `Handler` struct implementing `auth.Handler` interface, `New()` constructor with options pattern |
+| 2 | Implement HTTP client abstraction | `http.go` | Testable `HTTPClient` interface matching Entra pattern |
+| 3 | Implement device code flow | `device_flow.go` | Request device code, poll for token, handle `slow_down`/`authorization_pending`/`expired_token` errors |
+| 4 | Implement PAT flow | `pat.go` | Read `GITHUB_TOKEN`/`GH_TOKEN` from env, validate via API, detect credentials |
+| 5 | Implement token cache | `cache.go`, `token.go` | Disk-based token caching with `scafctl.auth.github.token.<scope-hash>` naming, refresh token support |
+| 6 | Implement claims extraction | `claims.go` | Call `/user` endpoint, map to `auth.Claims` (Subject=login, Email, Name, ObjectID=user ID) |
+
+### Phase 2: Wiring (Tasks 7-11)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 7 | Add `FlowPAT` flow constant | `pkg/auth/handler.go` | Add `FlowPAT Flow = "pat"` |
+| 8 | Add GitHub config to global config | `pkg/config/types.go` | Add `GitHub *GitHubAuthConfig` to `GlobalAuthConfig` |
+| 9 | Wire into root command | `pkg/cmd/scafctl/root.go` | Instantiate and register GitHub handler alongside Entra |
+| 10 | Wire into CLI auth commands | `pkg/cmd/scafctl/auth/handler.go` | Add `"github"` to `SupportedHandlers()`, add `getGitHubHandler()` |
+| 11 | Update login command | `pkg/cmd/scafctl/auth/login.go` | Route `github` handler, add `--hostname` flag, update help text and examples |
+
+### Phase 3: Testing (Tasks 12-13)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 12 | Write unit tests | `pkg/auth/github/*_test.go` | Mock HTTP for all flows, test cache, test claims, test config validation |
+| 13 | Write CLI integration tests | `tests/integration/cli_test.go` | Add `auth login github`, `auth status`, `auth logout github` |
+
+### Phase 4: Documentation (Tasks 14-16)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 14 | Update auth design doc | `docs/design/auth.md` | Update handler table (mark `github` as implemented), add GitHub-specific sections |
+| 15 | Create auth tutorial | `docs/tutorials/github-auth-tutorial.md` | Step-by-step guide for GitHub authentication |
+| 16 | Add examples | `examples/` | Example configs using `authProvider: github` |
+
+---
+
+## Configuration
+
+### Config Struct
+
+```go
+type Config struct {
+    ClientID      string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+    Hostname      string   `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+    DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty"`
+}
+```
+
+### Defaults
+
+```go
+func DefaultConfig() *Config {
+    return &Config{
+        ClientID:      "Ov23li6xn492GhPmt4YG",
+        Hostname:      "github.com",
+        DefaultScopes: []string{"repo", "read:user"},
+    }
+}
+```
+
+### Global Config Addition
+
+```go
+type GlobalAuthConfig struct {
+    Entra  *EntraAuthConfig  `json:"entra,omitempty" ...`
+    GitHub *GitHubAuthConfig `json:"github,omitempty" ...`
+}
+
+type GitHubAuthConfig struct {
+    ClientID      string   `json:"clientId,omitempty" ...`
+    Hostname      string   `json:"hostname,omitempty" ...`
+    DefaultScopes []string `json:"defaultScopes,omitempty" ...`
+}
+```
+
+---
+
+## Secret Naming Convention
+
+Following the established pattern from the Entra handler:
+
+```
+scafctl.auth.github.<type>
+```
+
+| Secret Name | Description |
+|-------------|-------------|
+| `scafctl.auth.github.refresh_token` | OAuth refresh token (if token expiration is enabled) |
+| `scafctl.auth.github.metadata` | Token metadata (claims, hostname, client ID, expiry) |
+| `scafctl.auth.github.token.<scope-hash>` | Cached access tokens by scope |
+
+---
+
+## Environment Variables
+
+### PAT Flow
+
+| Variable | Description | Priority |
+|----------|-------------|----------|
+| `GITHUB_TOKEN` | GitHub personal access token or Actions token | 1 (highest) |
+| `GH_TOKEN` | GitHub personal access token (gh CLI convention) | 2 |
+
+### GHES Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `GH_HOST` | GitHub hostname (alternative to `--hostname` flag) |
+
+---
+
+## Claims Mapping
+
+GitHub `/user` API response mapped to `auth.Claims`:
+
+| Claims Field | GitHub Field | Example |
+|-------------|-------------|---------|
+| `Subject` | `login` | `"octocat"` |
+| `Name` | `name` | `"The Octocat"` |
+| `Email` | `email` | `"octocat@github.com"` |
+| `ObjectID` | `id` (as string) | `"1"` |
+| `Username` | `login` | `"octocat"` |
+| `Issuer` | `"github.com"` or GHES hostname | `"github.com"` |
+
+---
+
+## CLI UX
+
+### Login
+
+```bash
+# Interactive login with device code flow (default)
+scafctl auth login github
+
+# Login to GitHub Enterprise Server
+scafctl auth login github --hostname github.example.com
+
+# Login with custom client ID
+scafctl auth login github --client-id abc123
+
+# Login with specific scopes
+scafctl auth login github --scope repo --scope read:org
+
+# Login with PAT (requires env var)
+scafctl auth login github --flow pat
+```
+
+### Status
+
+```bash
+scafctl auth status
+# Handler: github
+# Status: Authenticated
+# Identity: octocat
+# Hostname: github.com
+# Scopes: repo, read:user
+```
+
+### Token
+
+```bash
+# Get access token for debugging
+scafctl auth token github
+```
+
+### Logout
+
+```bash
+scafctl auth logout github
+```
+
+---
+
+## Error Handling
+
+| Error | Condition | User Message |
+|-------|-----------|-------------|
+| `ErrNotAuthenticated` | No stored credentials / no env var | `not authenticated: please run 'scafctl auth login github'` |
+| `ErrTokenExpired` | Refresh token expired | `credentials expired: please run 'scafctl auth login github'` |
+| `ErrAuthenticationFailed` | Invalid PAT or OAuth failure | `authentication failed: <details>` |
+| `ErrTimeout` | Device code flow timed out | `authentication timed out` |
+| `ErrUserCancelled` | User cancelled device code flow | `authentication cancelled by user` |
+
+---
+
+## Suggested Implementation Order
+
+Start with **Phase 1 (tasks 1-6)** since they're the core and self-contained. Tasks 1-2 are prerequisites; tasks 3-6 can progress in parallel after that. Then **Phase 2 (tasks 7-11)** for wiring, **Phase 3 (tasks 12-13)** for tests, and **Phase 4 (tasks 14-16)** for docs.
+
+---
+
+## References
+
+- [GitHub OAuth Device Flow Docs](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
+- [GitHub Token Expiration](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/refreshing-user-access-tokens)
+- [GitHub REST API - Users](https://docs.github.com/en/rest/users/users#get-the-authenticated-user)
+- [Entra Handler (reference implementation)](../pkg/auth/entra/)

--- a/pkg/auth/github/cache.go
+++ b/pkg/auth/github/cache.go
@@ -1,0 +1,151 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+)
+
+// TokenCache provides disk-based caching for access tokens using the secret store.
+// Tokens are stored with a key prefix and the scope encoded in base64url.
+type TokenCache struct {
+	secretStore secrets.Store
+}
+
+// CachedToken represents a token stored in the disk cache.
+type CachedToken struct {
+	AccessToken string    `json:"accessToken"` //nolint:gosec // Not a hardcoded credential
+	TokenType   string    `json:"tokenType"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	Scope       string    `json:"scope"`
+	CachedAt    time.Time `json:"cachedAt"`
+}
+
+// NewTokenCache creates a new disk-based token cache.
+func NewTokenCache(secretStore secrets.Store) *TokenCache {
+	return &TokenCache{
+		secretStore: secretStore,
+	}
+}
+
+// Get retrieves a token for the given scope from disk cache.
+// Returns nil, nil if no token is cached for this scope.
+// Returns nil, error if there was an error reading the cache.
+func (c *TokenCache) Get(ctx context.Context, scope string) (*auth.Token, error) {
+	key := c.scopeToKey(scope)
+	data, err := c.secretStore.Get(ctx, key)
+	if err != nil {
+		// Check if it's a "not found" error - that's expected
+		if errors.Is(err, secrets.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cached token: %w", err)
+	}
+
+	var cached CachedToken
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cached token: %w", err)
+	}
+
+	return &auth.Token{
+		AccessToken: cached.AccessToken,
+		TokenType:   cached.TokenType,
+		ExpiresAt:   cached.ExpiresAt,
+		Scope:       cached.Scope,
+	}, nil
+}
+
+// Set stores a token for the given scope to disk cache.
+func (c *TokenCache) Set(ctx context.Context, scope string, token *auth.Token) error {
+	key := c.scopeToKey(scope)
+	cached := CachedToken{
+		AccessToken: token.AccessToken,
+		TokenType:   token.TokenType,
+		ExpiresAt:   token.ExpiresAt,
+		Scope:       scope,
+		CachedAt:    time.Now(),
+	}
+
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token for cache: %w", err)
+	}
+
+	if err := c.secretStore.Set(ctx, key, data); err != nil {
+		return fmt.Errorf("failed to write cached token: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a cached token for the given scope.
+func (c *TokenCache) Delete(ctx context.Context, scope string) error {
+	key := c.scopeToKey(scope)
+	return c.secretStore.Delete(ctx, key)
+}
+
+// Clear removes all cached tokens by listing secrets with the token prefix
+// and deleting them.
+func (c *TokenCache) Clear(ctx context.Context) error {
+	names, err := c.secretStore.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	var lastErr error
+	for _, name := range names {
+		if strings.HasPrefix(name, SecretKeyTokenPrefix) {
+			if err := c.secretStore.Delete(ctx, name); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}
+
+// ListCachedScopes returns a list of scopes that have cached tokens.
+func (c *TokenCache) ListCachedScopes(ctx context.Context) ([]string, error) {
+	names, err := c.secretStore.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	scopes := make([]string, 0)
+	for _, name := range names {
+		if scope := c.keyToScope(name); scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes, nil
+}
+
+// scopeToKey converts a scope to a secret key.
+// Uses base64url encoding for the scope to create a valid key.
+func (c *TokenCache) scopeToKey(scope string) string {
+	encoded := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(scope))
+	return SecretKeyTokenPrefix + encoded
+}
+
+// keyToScope converts a secret key back to a scope.
+// Returns empty string if the key is not a valid token cache key.
+func (c *TokenCache) keyToScope(key string) string {
+	if !strings.HasPrefix(key, SecretKeyTokenPrefix) {
+		return ""
+	}
+	encoded := strings.TrimPrefix(key, SecretKeyTokenPrefix)
+	decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(encoded)
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
+}

--- a/pkg/auth/github/cache_test.go
+++ b/pkg/auth/github/cache_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCache_GetSet(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	scope := "repo read:user"
+	token := &auth.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       scope,
+	}
+
+	got, err := cache.Get(ctx, scope)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	err = cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	got, err = cache.Get(ctx, scope)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, token.AccessToken, got.AccessToken)
+	assert.Equal(t, token.TokenType, got.TokenType)
+	assert.Equal(t, token.Scope, got.Scope)
+}
+
+func TestTokenCache_Delete(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	scope := "repo"
+	token := &auth.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       scope,
+	}
+
+	err := cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	err = cache.Delete(ctx, scope)
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, scope)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestTokenCache_Clear(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	for _, scope := range []string{"repo", "read:user", "read:org"} {
+		err := cache.Set(ctx, scope, &auth.Token{
+			AccessToken: "token-" + scope,
+			TokenType:   "Bearer",
+			ExpiresAt:   time.Now().Add(1 * time.Hour),
+			Scope:       scope,
+		})
+		require.NoError(t, err)
+	}
+
+	err := cache.Clear(ctx)
+	require.NoError(t, err)
+
+	for _, scope := range []string{"repo", "read:user", "read:org"} {
+		got, err := cache.Get(ctx, scope)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	}
+}
+
+func TestTokenCache_ListCachedScopes(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	scopes, err := cache.ListCachedScopes(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+
+	for _, scope := range []string{"repo", "read:user"} {
+		err := cache.Set(ctx, scope, &auth.Token{
+			AccessToken: "token-" + scope,
+			TokenType:   "Bearer",
+			ExpiresAt:   time.Now().Add(1 * time.Hour),
+			Scope:       scope,
+		})
+		require.NoError(t, err)
+	}
+
+	scopes, err = cache.ListCachedScopes(ctx)
+	require.NoError(t, err)
+	assert.Len(t, scopes, 2)
+	assert.Contains(t, scopes, "repo")
+	assert.Contains(t, scopes, "read:user")
+}
+
+func TestTokenCache_ScopeToKeyRoundtrip(t *testing.T) {
+	cache := &TokenCache{}
+
+	testScopes := []string{
+		"repo",
+		"read:user",
+		"repo read:user read:org",
+	}
+
+	for _, scope := range testScopes {
+		key := cache.scopeToKey(scope)
+		assert.True(t, len(key) > len(SecretKeyTokenPrefix))
+
+		roundtripped := cache.keyToScope(key)
+		assert.Equal(t, scope, roundtripped)
+	}
+}
+
+func TestTokenCache_KeyToScope_InvalidKey(t *testing.T) {
+	cache := &TokenCache{}
+	assert.Equal(t, "", cache.keyToScope("not.a.token.key"))
+}
+
+func TestTokenCache_ClearDoesNotDeleteOtherSecrets(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	err := store.Set(ctx, SecretKeyRefreshToken, []byte("refresh-token"))
+	require.NoError(t, err)
+
+	err = cache.Set(ctx, "repo", &auth.Token{
+		AccessToken: "cached",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "repo",
+	})
+	require.NoError(t, err)
+
+	err = cache.Clear(ctx)
+	require.NoError(t, err)
+
+	exists, err := store.Exists(ctx, SecretKeyRefreshToken)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/pkg/auth/github/claims.go
+++ b/pkg/auth/github/claims.go
@@ -1,0 +1,67 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// User represents the relevant fields from the GitHub /user API response.
+type User struct {
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// fetchUserClaims calls the GitHub /user API and returns normalized auth.Claims.
+func (h *Handler) fetchUserClaims(ctx context.Context, accessToken string) (*auth.Claims, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("fetching user claims from GitHub API")
+
+	endpoint := fmt.Sprintf("%s/user", h.config.GetAPIBaseURL())
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+	}
+
+	resp, err := h.httpClient.Get(ctx, endpoint, headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch user info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var user User
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("failed to parse user response: %w", err)
+	}
+
+	lgr.V(1).Info("user claims fetched",
+		"login", user.Login,
+		"name", user.Name,
+		"id", user.ID,
+	)
+
+	return &auth.Claims{
+		Issuer:    h.config.Hostname,
+		Subject:   user.Login,
+		ObjectID:  strconv.FormatInt(user.ID, 10),
+		Email:     user.Email,
+		Name:      user.Name,
+		Username:  user.Login,
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Time{}, // Populated by caller if known
+	}, nil
+}

--- a/pkg/auth/github/claims_test.go
+++ b/pkg/auth/github/claims_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchUserClaims_Success(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login":      "octocat",
+		"id":         1,
+		"name":       "The Octocat",
+		"email":      "octocat@github.com",
+		"avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+	})
+
+	ctx := context.Background()
+	claims, err := handler.fetchUserClaims(ctx, "test-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "octocat", claims.Subject)
+	assert.Equal(t, "octocat", claims.Username)
+	assert.Equal(t, "The Octocat", claims.Name)
+	assert.Equal(t, "octocat@github.com", claims.Email)
+	assert.Equal(t, "1", claims.ObjectID)
+	assert.Equal(t, "github.com", claims.Issuer)
+}
+
+func TestFetchUserClaims_APIError(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	mockHTTP.AddResponse(http.StatusUnauthorized, map[string]any{
+		"message": "Bad credentials",
+	})
+
+	ctx := context.Background()
+	_, err = handler.fetchUserClaims(ctx, "bad-token")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 401")
+}
+
+func TestFetchUserClaims_GHES(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+		WithConfig(&Config{
+			Hostname: "github.example.com",
+		}),
+	)
+	require.NoError(t, err)
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "ghes-user",
+		"id":    100,
+		"name":  "GHES User",
+	})
+
+	ctx := context.Background()
+	claims, err := handler.fetchUserClaims(ctx, "test-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "ghes-user", claims.Subject)
+	assert.Equal(t, "github.example.com", claims.Issuer)
+
+	reqs := mockHTTP.GetRequests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "https://github.example.com/api/v3/user", reqs[0].Endpoint)
+}
+
+func TestFetchUserClaims_AuthorizationHeader(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "testuser",
+		"id":    1,
+	})
+
+	ctx := context.Background()
+	_, err = handler.fetchUserClaims(ctx, "my-secret-token")
+	require.NoError(t, err)
+
+	reqs := mockHTTP.GetRequests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer my-secret-token", reqs[0].Headers["Authorization"])
+}

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -1,0 +1,71 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultClientID is the OAuth App client ID shipped with scafctl.
+const DefaultClientID = "Ov23li6xn492GhPmt4YG"
+
+// DefaultHostname is the default GitHub hostname.
+const DefaultHostname = "github.com"
+
+// Config holds configuration for the GitHub auth handler.
+type Config struct {
+	// ClientID is the GitHub OAuth App client ID.
+	ClientID string `json:"clientId" yaml:"clientId" doc:"GitHub OAuth App client ID" example:"Ov23li6xn492GhPmt4YG"`
+
+	// Hostname is the GitHub hostname (e.g. github.com or github.example.com for GHES).
+	Hostname string `json:"hostname" yaml:"hostname" doc:"GitHub hostname" example:"github.com"`
+
+	// DefaultScopes is the list of OAuth scopes to request by default.
+	DefaultScopes []string `json:"defaultScopes" yaml:"defaultScopes" doc:"Default OAuth scopes to request" maxItems:"20"`
+
+	// MinPollInterval is the minimum polling interval for device code flow.
+	MinPollInterval time.Duration `json:"-" yaml:"-"`
+
+	// SlowDownIncrement is the amount to add to polling interval on slow_down.
+	SlowDownIncrement time.Duration `json:"-" yaml:"-"`
+}
+
+// DefaultConfig returns the default GitHub auth configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		ClientID:          DefaultClientID,
+		Hostname:          DefaultHostname,
+		DefaultScopes:     []string{"repo", "read:user"},
+		MinPollInterval:   5 * time.Second,
+		SlowDownIncrement: 5 * time.Second,
+	}
+}
+
+// Validate checks the configuration for required fields.
+func (c *Config) Validate() error {
+	if c.ClientID == "" {
+		return fmt.Errorf("github auth: client ID is required")
+	}
+	if c.Hostname == "" {
+		return fmt.Errorf("github auth: hostname is required")
+	}
+	return nil
+}
+
+// GetOAuthBaseURL returns the base URL for GitHub OAuth endpoints.
+func (c *Config) GetOAuthBaseURL() string {
+	if c.Hostname == DefaultHostname {
+		return "https://github.com"
+	}
+	return fmt.Sprintf("https://%s", c.Hostname)
+}
+
+// GetAPIBaseURL returns the base URL for GitHub API endpoints.
+func (c *Config) GetAPIBaseURL() string {
+	if c.Hostname == DefaultHostname {
+		return "https://api.github.com"
+	}
+	return fmt.Sprintf("https://%s/api/v3", c.Hostname)
+}

--- a/pkg/auth/github/config_test.go
+++ b/pkg/auth/github/config_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, DefaultClientID, cfg.ClientID)
+	assert.Equal(t, DefaultHostname, cfg.Hostname)
+	assert.Equal(t, []string{"repo", "read:user"}, cfg.DefaultScopes)
+	assert.Equal(t, 5*time.Second, cfg.MinPollInterval)
+	assert.Equal(t, 5*time.Second, cfg.SlowDownIncrement)
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid default config",
+			config:  DefaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "missing client ID",
+			config: &Config{
+				Hostname: "github.com",
+			},
+			wantErr: true,
+			errMsg:  "client ID is required",
+		},
+		{
+			name: "missing hostname",
+			config: &Config{
+				ClientID: "test-id",
+			},
+			wantErr: true,
+			errMsg:  "hostname is required",
+		},
+		{
+			name: "custom values are valid",
+			config: &Config{
+				ClientID:      "custom-id",
+				Hostname:      "github.example.com",
+				DefaultScopes: []string{"repo"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_GetOAuthBaseURL(t *testing.T) {
+	cfg := &Config{Hostname: "github.com"}
+	assert.Equal(t, "https://github.com", cfg.GetOAuthBaseURL())
+
+	cfg = &Config{Hostname: "github.example.com"}
+	assert.Equal(t, "https://github.example.com", cfg.GetOAuthBaseURL())
+}
+
+func TestConfig_GetAPIBaseURL(t *testing.T) {
+	cfg := &Config{Hostname: "github.com"}
+	assert.Equal(t, "https://api.github.com", cfg.GetAPIBaseURL())
+
+	cfg = &Config{Hostname: "github.example.com"}
+	assert.Equal(t, "https://github.example.com/api/v3", cfg.GetAPIBaseURL())
+}

--- a/pkg/auth/github/device_flow.go
+++ b/pkg/auth/github/device_flow.go
@@ -1,0 +1,214 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// DeviceCodeResponse represents the response from GitHub's device code endpoint.
+type DeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// deviceCodeLogin performs the device code authentication flow.
+func (h *Handler) deviceCodeLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting GitHub device code authentication flow")
+
+	// Determine scopes
+	scopes := opts.Scopes
+	if len(scopes) == 0 {
+		scopes = h.config.DefaultScopes
+	}
+
+	// Determine timeout
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return h.performDeviceCodeFlow(ctx, opts, scopes)
+}
+
+// performDeviceCodeFlow executes the device code authentication flow.
+func (h *Handler) performDeviceCodeFlow(ctx context.Context, opts auth.LoginOptions, scopes []string) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Step 1: Request device code
+	deviceCode, err := h.requestDeviceCode(ctx, scopes)
+	if err != nil {
+		return nil, auth.NewError(HandlerName, "device_code_request", err)
+	}
+
+	lgr.V(1).Info("device code obtained",
+		"userCode", deviceCode.UserCode,
+		"verificationURI", deviceCode.VerificationURI,
+	)
+
+	// Step 2: Notify callback with device code info
+	if opts.DeviceCodeCallback != nil {
+		opts.DeviceCodeCallback(deviceCode.UserCode, deviceCode.VerificationURI, "")
+	}
+
+	// Step 3: Poll for token
+	tokenResp, err := h.pollForToken(ctx, deviceCode)
+	if err != nil {
+		return nil, auth.NewError(HandlerName, "token_poll", err)
+	}
+
+	// Step 4: Store credentials securely and fetch claims
+	claims, err := h.storeCredentials(ctx, tokenResp, scopes)
+	if err != nil {
+		return nil, auth.NewError(HandlerName, "store_credentials", err)
+	}
+
+	lgr.V(1).Info("authentication successful",
+		"subject", claims.Subject,
+		"name", claims.Name,
+	)
+
+	// Determine expiry
+	expiresAt := time.Now().Add(8 * time.Hour) // Default for non-expiring tokens
+	if tokenResp.RefreshTokenExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(tokenResp.RefreshTokenExpiresIn) * time.Second)
+	}
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// requestDeviceCode requests a device code from GitHub.
+func (h *Handler) requestDeviceCode(ctx context.Context, scopes []string) (*DeviceCodeResponse, error) {
+	endpoint := fmt.Sprintf("%s/login/device/code", h.config.GetOAuthBaseURL())
+
+	data := makeFormData(map[string]string{
+		"client_id": h.config.ClientID,
+		"scope":     strings.Join(scopes, " "),
+	})
+
+	resp, err := h.httpClient.PostForm(ctx, endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("device code request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp TokenErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			return nil, fmt.Errorf("device code request failed with status %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("device code request failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var deviceCode DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceCode); err != nil {
+		return nil, fmt.Errorf("failed to parse device code response: %w", err)
+	}
+
+	return &deviceCode, nil
+}
+
+// pollForToken polls GitHub's token endpoint until the user completes authentication.
+func (h *Handler) pollForToken(ctx context.Context, deviceCode *DeviceCodeResponse) (*TokenResponse, error) {
+	lgr := logger.FromContext(ctx)
+	endpoint := fmt.Sprintf("%s/login/oauth/access_token", h.config.GetOAuthBaseURL())
+
+	minPollInterval := h.config.MinPollInterval
+	if minPollInterval == 0 {
+		minPollInterval = DefaultMinPollInterval
+	}
+
+	interval := time.Duration(deviceCode.Interval) * time.Second
+	if interval < minPollInterval {
+		interval = minPollInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, auth.ErrTimeout
+		case <-ticker.C:
+			data := makeFormData(map[string]string{
+				"client_id":   h.config.ClientID,
+				"device_code": deviceCode.DeviceCode,
+				"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+			})
+
+			resp, err := h.httpClient.PostForm(ctx, endpoint, data)
+			if err != nil {
+				// Network error, log and continue polling
+				lgr.V(1).Info("transient network error during token poll, continuing", "error", err)
+				continue
+			}
+
+			// GitHub returns 200 even for errors, and includes the error in JSON body
+			body := struct {
+				TokenResponse
+				TokenErrorResponse
+			}{}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				resp.Body.Close()
+				return nil, fmt.Errorf("failed to parse token response: %w", err)
+			}
+			resp.Body.Close()
+
+			// Check for success (access_token present)
+			if body.AccessToken != "" {
+				return &TokenResponse{
+					AccessToken:           body.AccessToken,
+					RefreshToken:          body.RefreshToken,
+					TokenType:             body.TokenType,
+					Scope:                 body.Scope,
+					ExpiresIn:             body.ExpiresIn,
+					RefreshTokenExpiresIn: body.RefreshTokenExpiresIn,
+				}, nil
+			}
+
+			// Handle errors
+			switch body.Error {
+			case "authorization_pending":
+				// User hasn't completed authentication yet, continue polling
+				continue
+			case "slow_down":
+				// Increase polling interval
+				slowDownIncr := h.config.SlowDownIncrement
+				if slowDownIncr == 0 {
+					slowDownIncr = 5 * time.Second
+				}
+				interval += slowDownIncr
+				ticker.Reset(interval)
+				lgr.V(1).Info("slow_down received, increasing poll interval", "newInterval", interval)
+				continue
+			case "expired_token":
+				return nil, auth.ErrTimeout
+			case "access_denied":
+				return nil, auth.ErrUserCancelled
+			default:
+				return nil, fmt.Errorf("token request failed: %s - %s", body.Error, body.ErrorDescription)
+			}
+		}
+	}
+}

--- a/pkg/auth/github/handler.go
+++ b/pkg/auth/github/handler.go
@@ -1,0 +1,372 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+)
+
+const (
+	// HandlerName is the unique identifier for the GitHub auth handler.
+	HandlerName = "github"
+
+	// HandlerDisplayName is the human-readable name for the handler.
+	HandlerDisplayName = "GitHub"
+
+	// SecretKeyRefreshToken is the secret key for storing the refresh token.
+	SecretKeyRefreshToken = "scafctl.auth.github.refresh_token" //nolint:gosec // This is a key name, not a credential
+
+	// SecretKeyAccessToken is the secret key for storing the access token.
+	SecretKeyAccessToken = "scafctl.auth.github.access_token" //nolint:gosec // This is a key name, not a credential
+
+	// SecretKeyMetadata is the secret key for storing token metadata.
+	SecretKeyMetadata = "scafctl.auth.github.metadata" //nolint:gosec // This is a key name, not a credential
+
+	// SecretKeyTokenPrefix is the prefix for cached access tokens.
+	// Full key format: scafctl.auth.github.token.<base64url-encoded-scope>
+	SecretKeyTokenPrefix = "scafctl.auth.github.token." //nolint:gosec // This is a key prefix, not a credential
+
+	// DefaultTimeout is the default timeout for device code flow.
+	DefaultTimeout = 5 * time.Minute
+
+	// DefaultMinPollInterval is the minimum polling interval for device code flow.
+	DefaultMinPollInterval = 5 * time.Second
+)
+
+// Handler implements auth.Handler for GitHub.
+type Handler struct {
+	config      *Config
+	secretStore secrets.Store
+	httpClient  HTTPClient
+	tokenCache  *TokenCache
+}
+
+// Option configures the Handler.
+type Option func(*Handler)
+
+// WithConfig sets the GitHub configuration.
+func WithConfig(cfg *Config) Option {
+	return func(h *Handler) {
+		if cfg != nil {
+			if cfg.ClientID != "" {
+				h.config.ClientID = cfg.ClientID
+			}
+			if cfg.Hostname != "" {
+				h.config.Hostname = cfg.Hostname
+			}
+			if len(cfg.DefaultScopes) > 0 {
+				h.config.DefaultScopes = cfg.DefaultScopes
+			}
+			if cfg.MinPollInterval > 0 {
+				h.config.MinPollInterval = cfg.MinPollInterval
+			}
+			if cfg.SlowDownIncrement > 0 {
+				h.config.SlowDownIncrement = cfg.SlowDownIncrement
+			}
+		}
+	}
+}
+
+// WithSecretStore sets a custom secrets store.
+func WithSecretStore(store secrets.Store) Option {
+	return func(h *Handler) {
+		h.secretStore = store
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for API requests.
+func WithHTTPClient(client HTTPClient) Option {
+	return func(h *Handler) {
+		h.httpClient = client
+	}
+}
+
+// New creates a new GitHub auth handler.
+func New(opts ...Option) (*Handler, error) {
+	h := &Handler{
+		config: DefaultConfig(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	// Initialize secret store if not provided
+	if h.secretStore == nil {
+		store, err := secrets.New()
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize secrets store: %w", err)
+		}
+		h.secretStore = store
+	}
+
+	// Initialize HTTP client if not provided
+	if h.httpClient == nil {
+		h.httpClient = NewDefaultHTTPClient()
+	}
+
+	// Initialize token cache with secret store
+	h.tokenCache = NewTokenCache(h.secretStore)
+
+	return h, nil
+}
+
+// Name returns the handler identifier.
+func (h *Handler) Name() string {
+	return HandlerName
+}
+
+// DisplayName returns the human-readable name.
+func (h *Handler) DisplayName() string {
+	return HandlerDisplayName
+}
+
+// SupportedFlows returns the authentication flows this handler supports.
+func (h *Handler) SupportedFlows() []auth.Flow {
+	return []auth.Flow{
+		auth.FlowDeviceCode,
+		auth.FlowPAT,
+	}
+}
+
+// Login initiates the authentication flow.
+// For device code flow, this initiates interactive authentication.
+// For PAT flow, this validates the token from environment.
+func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	// Check if PAT flow is requested or detected
+	if opts.Flow == auth.FlowPAT || (opts.Flow == "" && HasPATCredentials()) {
+		return h.patLogin(ctx, opts)
+	}
+
+	return h.deviceCodeLogin(ctx, opts)
+}
+
+// Logout clears stored credentials and cached tokens.
+func (h *Handler) Logout(ctx context.Context) error {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("logging out", "handler", HandlerName)
+
+	// Clear all cached tokens
+	if err := h.tokenCache.Clear(ctx); err != nil {
+		lgr.V(1).Info("failed to clear token cache (may be empty)", "error", err)
+	}
+
+	// Delete refresh token
+	if err := h.secretStore.Delete(ctx, SecretKeyRefreshToken); err != nil {
+		lgr.V(1).Info("failed to delete refresh token (may not exist)", "error", err)
+	}
+
+	// Delete access token
+	if err := h.secretStore.Delete(ctx, SecretKeyAccessToken); err != nil {
+		lgr.V(1).Info("failed to delete access token (may not exist)", "error", err)
+	}
+
+	// Delete metadata
+	if err := h.secretStore.Delete(ctx, SecretKeyMetadata); err != nil {
+		lgr.V(1).Info("failed to delete metadata (may not exist)", "error", err)
+	}
+
+	return nil
+}
+
+// Status returns the current authentication status.
+func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
+	// Check for PAT credentials first (highest priority)
+	if HasPATCredentials() {
+		return h.patStatus(ctx)
+	}
+
+	// Check if we have stored credentials (refresh token or access token)
+	hasRefresh, err := h.secretStore.Exists(ctx, SecretKeyRefreshToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check credentials: %w", err)
+	}
+
+	hasAccess, err := h.secretStore.Exists(ctx, SecretKeyAccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check credentials: %w", err)
+	}
+
+	if !hasRefresh && !hasAccess {
+		return &auth.Status{Authenticated: false}, nil
+	}
+
+	// Load and validate metadata
+	metadata, err := h.loadMetadata(ctx)
+	if err != nil {
+		return &auth.Status{Authenticated: false}, nil //nolint:nilerr // Treat corrupted metadata as not authenticated
+	}
+
+	// Check if refresh token is expired (if applicable)
+	if !metadata.RefreshTokenExpiresAt.IsZero() && time.Now().After(metadata.RefreshTokenExpiresAt) {
+		return &auth.Status{
+			Authenticated: false,
+			Claims:        metadata.Claims,
+		}, nil
+	}
+
+	return &auth.Status{
+		Authenticated: true,
+		Claims:        metadata.Claims,
+		ExpiresAt:     metadata.RefreshTokenExpiresAt,
+		LastRefresh:   metadata.LastRefresh,
+		IdentityType:  auth.IdentityTypeUser,
+		ClientID:      metadata.ClientID,
+		Scopes:        metadata.Scopes,
+	}, nil
+}
+
+// GetToken returns a valid access token for the specified options.
+func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Use PAT flow if credentials are present (highest priority)
+	if HasPATCredentials() {
+		return h.getPATToken(ctx, opts)
+	}
+
+	if opts.Scope == "" {
+		return nil, auth.ErrInvalidScope
+	}
+
+	// Determine minimum validity duration
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
+	lgr.V(1).Info("getting token",
+		"handler", HandlerName,
+		"scope", opts.Scope,
+		"minValidFor", minValidFor,
+		"forceRefresh", opts.ForceRefresh,
+	)
+
+	// Check disk cache first (unless force refresh)
+	if !opts.ForceRefresh {
+		token, err := h.tokenCache.Get(ctx, opts.Scope)
+		if err == nil && token != nil && token.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached token",
+				"scope", opts.Scope,
+				"expiresAt", token.ExpiresAt,
+				"remainingValidity", token.TimeUntilExpiry(),
+			)
+			return token, nil
+		}
+		if err != nil {
+			lgr.V(1).Info("cache lookup failed, will mint new token", "error", err)
+		} else if token != nil {
+			lgr.V(1).Info("cached token insufficient validity",
+				"expiresAt", token.ExpiresAt,
+				"remainingValidity", token.TimeUntilExpiry(),
+				"requiredValidity", minValidFor,
+			)
+		}
+	}
+
+	// Check if we have a stored access token (non-expiring OAuth App)
+	accessToken, err := h.loadAccessToken(ctx)
+	if err == nil && accessToken != "" {
+		// For non-expiring tokens, just use the stored access token
+		token := &auth.Token{
+			AccessToken: accessToken,
+			TokenType:   "Bearer",
+			ExpiresAt:   farFuture(),
+			Scope:       opts.Scope,
+		}
+		if cacheErr := h.tokenCache.Set(ctx, opts.Scope, token); cacheErr != nil {
+			lgr.V(1).Info("failed to cache token", "error", cacheErr)
+		}
+		return token, nil
+	}
+
+	// Try to mint new token using refresh token
+	token, err := h.mintToken(ctx, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token to disk
+	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+		lgr.V(1).Info("failed to cache token", "error", err)
+	}
+
+	return token, nil
+}
+
+// InjectAuth adds authentication to an HTTP request.
+func (h *Handler) InjectAuth(ctx context.Context, req *http.Request, opts auth.TokenOptions) error {
+	token, err := h.GetToken(ctx, opts)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("%s %s", token.TokenType, token.AccessToken))
+	return nil
+}
+
+// tokenAcquireFunc is a function that acquires a token given credentials and scope.
+type tokenAcquireFunc[T any] func(ctx context.Context, creds T, scope string) (*auth.Token, error)
+
+// getCachedOrAcquireToken is a generic helper that handles the common pattern of:
+// 1. Checking if credentials exist
+// 2. Checking the cache (unless ForceRefresh)
+// 3. Acquiring a new token if needed
+// 4. Caching the new token
+func getCachedOrAcquireToken[T any](
+	ctx context.Context,
+	h *Handler,
+	opts auth.TokenOptions,
+	getCreds func() T,
+	isCredsNil func(T) bool,
+	acquireToken tokenAcquireFunc[T],
+	logPrefix string,
+) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+	creds := getCreds()
+
+	if isCredsNil(creds) {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	if opts.Scope == "" {
+		return nil, auth.ErrInvalidScope
+	}
+
+	// Check cache first (unless ForceRefresh)
+	if !opts.ForceRefresh {
+		cached, err := h.tokenCache.Get(ctx, opts.Scope)
+		if err == nil && cached != nil && cached.IsValidFor(opts.MinValidFor) {
+			lgr.V(1).Info("using cached "+logPrefix+" token", "scope", opts.Scope)
+			return cached, nil
+		}
+	}
+
+	// Acquire new token
+	token, err := acquireToken(ctx, creds, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token
+	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+		lgr.V(1).Info("failed to cache "+logPrefix+" token", "error", err)
+	}
+
+	return token, nil
+}
+
+// farFuture returns a time far in the future for tokens with no defined expiry.
+func farFuture() time.Time {
+	return time.Now().Add(365 * 24 * time.Hour)
+}
+
+// Compile-time check that Handler implements auth.Handler.
+var _ auth.Handler = (*Handler)(nil)

--- a/pkg/auth/github/handler_test.go
+++ b/pkg/auth/github/handler_test.go
@@ -1,0 +1,460 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_NewWithDefaults(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+
+	require.NoError(t, err)
+	assert.NotNil(t, handler)
+	assert.Equal(t, HandlerName, handler.Name())
+	assert.Equal(t, HandlerDisplayName, handler.DisplayName())
+	assert.Contains(t, handler.SupportedFlows(), auth.FlowDeviceCode)
+	assert.Contains(t, handler.SupportedFlows(), auth.FlowPAT)
+}
+
+func TestHandler_NewWithOptions(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	customConfig := &Config{
+		ClientID: "custom-client-id",
+		Hostname: "github.example.com",
+	}
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+		WithConfig(customConfig),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "custom-client-id", handler.config.ClientID)
+	assert.Equal(t, "github.example.com", handler.config.Hostname)
+}
+
+func TestHandler_NewWithPartialConfig(t *testing.T) {
+	store := secrets.NewMockStore()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithConfig(&Config{
+			Hostname: "github.example.com",
+		}),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultClientID, handler.config.ClientID)
+	assert.Equal(t, "github.example.com", handler.config.Hostname)
+}
+
+func TestHandler_NewWithNilConfig(t *testing.T) {
+	store := secrets.NewMockStore()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithConfig(nil),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultClientID, handler.config.ClientID)
+	assert.Equal(t, DefaultHostname, handler.config.Hostname)
+}
+
+func TestHandler_Status_NotAuthenticated(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	status, err := handler.Status(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+}
+
+func TestHandler_Status_Authenticated(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
+	require.NoError(t, err)
+
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Subject:  "testuser",
+			Email:    "test@example.com",
+			Name:     "Test User",
+			Username: "testuser",
+			Issuer:   "github.com",
+		},
+		RefreshTokenExpiresAt: time.Now().Add(6 * 30 * 24 * time.Hour),
+		LastRefresh:           time.Now(),
+		Hostname:              "github.com",
+		ClientID:              DefaultClientID,
+		Scopes:                []string{"repo", "read:user"},
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	status, err := handler.Status(ctx)
+	require.NoError(t, err)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, "testuser", status.Claims.Subject)
+	assert.Equal(t, "test@example.com", status.Claims.Email)
+	assert.Equal(t, auth.IdentityTypeUser, status.IdentityType)
+	assert.Equal(t, []string{"repo", "read:user"}, status.Scopes)
+}
+
+func TestHandler_Status_ExpiredRefreshToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("expired-refresh-token"))
+	require.NoError(t, err)
+
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Subject: "testuser",
+		},
+		RefreshTokenExpiresAt: time.Now().Add(-time.Hour),
+		LastRefresh:           time.Now().Add(-8 * time.Hour),
+		Hostname:              "github.com",
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	status, err := handler.Status(ctx)
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+}
+
+func TestHandler_Logout(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("refresh-token"))
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("access-token"))
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, []byte("{}"))
+	require.NoError(t, err)
+
+	err = handler.Logout(ctx)
+	require.NoError(t, err)
+
+	exists, err := store.Exists(ctx, SecretKeyRefreshToken)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = store.Exists(ctx, SecretKeyAccessToken)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = store.Exists(ctx, SecretKeyMetadata)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestHandler_GetToken_NotAuthenticated(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
+}
+
+func TestHandler_GetToken_EmptyScope(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = handler.GetToken(ctx, auth.TokenOptions{Scope: ""})
+	assert.ErrorIs(t, err, auth.ErrInvalidScope)
+}
+
+func TestHandler_GetToken_WithStoredAccessToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("gho_testtoken"))
+	require.NoError(t, err)
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "gho_testtoken", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	assert.Equal(t, "repo", token.Scope)
+	assert.True(t, token.ExpiresAt.After(time.Now().Add(364*24*time.Hour)))
+}
+
+func TestHandler_GetToken_CachedToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	cachedToken := &auth.Token{
+		AccessToken: "cached-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       "repo",
+	}
+	err = handler.tokenCache.Set(ctx, "repo", cachedToken)
+	require.NoError(t, err)
+
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("stored-token"))
+	require.NoError(t, err)
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "cached-token", token.AccessToken)
+}
+
+func TestHandler_GetToken_ForceRefresh(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	cachedToken := &auth.Token{
+		AccessToken: "cached-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       "repo",
+	}
+	err = handler.tokenCache.Set(ctx, "repo", cachedToken)
+	require.NoError(t, err)
+
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("stored-token"))
+	require.NoError(t, err)
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope:        "repo",
+		ForceRefresh: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "stored-token", token.AccessToken)
+}
+
+func TestHandler_InjectAuth(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("inject-test-token"))
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/test", nil)
+	require.NoError(t, err)
+
+	err = handler.InjectAuth(ctx, req, auth.TokenOptions{Scope: "repo"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer inject-test-token", req.Header.Get("Authorization"))
+}
+
+func TestHandler_CompileTimeCheck(t *testing.T) {
+	var _ auth.Handler = (*Handler)(nil)
+}
+
+func TestHandler_DeviceCodeLogin(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"device_code":      "test-device-code",
+		"user_code":        "ABCD-1234",
+		"verification_uri": "https://github.com/login/device",
+		"expires_in":       900,
+		"interval":         5,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"access_token": "gho_testtoken123",
+		"token_type":   "Bearer",
+		"scope":        "repo read:user",
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login":      "octocat",
+		"id":         1,
+		"name":       "The Octocat",
+		"email":      "octocat@github.com",
+		"avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+	})
+
+	var receivedCode, receivedURI string
+	result, err := handler.Login(ctx, auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Scopes:  []string{"repo", "read:user"},
+		Timeout: 10 * time.Second,
+		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
+			receivedCode = userCode
+			receivedURI = verificationURI
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "octocat", result.Claims.Subject)
+	assert.Equal(t, "The Octocat", result.Claims.Name)
+	assert.Equal(t, "octocat@github.com", result.Claims.Email)
+	assert.Equal(t, "ABCD-1234", receivedCode)
+	assert.Equal(t, "https://github.com/login/device", receivedURI)
+
+	stored, err := store.Get(ctx, SecretKeyAccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "gho_testtoken123", string(stored))
+}
+
+func TestHandler_DeviceCodeLogin_WithRefreshToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"device_code":      "test-device-code",
+		"user_code":        "EFGH-5678",
+		"verification_uri": "https://github.com/login/device",
+		"expires_in":       900,
+		"interval":         5,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"access_token":             "ghu_access123",
+		"token_type":               "Bearer",
+		"scope":                    "repo",
+		"expires_in":               28800,
+		"refresh_token":            "ghr_refresh456",
+		"refresh_token_expires_in": 15897600,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "testuser",
+		"id":    42,
+		"name":  "Test User",
+		"email": "test@example.com",
+	})
+
+	result, err := handler.Login(ctx, auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Scopes:  []string{"repo"},
+		Timeout: 10 * time.Second,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "testuser", result.Claims.Subject)
+
+	stored, err := store.Get(ctx, SecretKeyRefreshToken)
+	require.NoError(t, err)
+	assert.Equal(t, "ghr_refresh456", string(stored))
+
+	metadataBytes, err := store.Get(ctx, SecretKeyMetadata)
+	require.NoError(t, err)
+	var metadata TokenMetadata
+	err = json.Unmarshal(metadataBytes, &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultClientID, metadata.ClientID)
+	assert.Equal(t, "github.com", metadata.Hostname)
+	assert.Equal(t, []string{"repo"}, metadata.Scopes)
+}
+
+func TestHandler_MintToken_RefreshFlow(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("ghr_refresh456"))
+	require.NoError(t, err)
+
+	metadata := &TokenMetadata{
+		Claims:   &auth.Claims{Subject: "testuser"},
+		ClientID: DefaultClientID,
+		Hostname: "github.com",
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"access_token":             "ghu_new_access",
+		"token_type":               "Bearer",
+		"scope":                    "repo",
+		"expires_in":               28800,
+		"refresh_token":            "ghr_new_refresh",
+		"refresh_token_expires_in": 15897600,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "testuser",
+		"id":    42,
+		"name":  "Test User",
+	})
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "ghu_new_access", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+}

--- a/pkg/auth/github/http.go
+++ b/pkg/auth/github/http.go
@@ -1,0 +1,57 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// HTTPClient abstracts HTTP calls for testability.
+type HTTPClient interface {
+	// PostForm sends a POST request with form-encoded body and returns the response.
+	PostForm(ctx context.Context, url string, data url.Values) (*http.Response, error)
+
+	// Get sends a GET request with the given headers and returns the response.
+	Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error)
+}
+
+// DefaultHTTPClient is the standard HTTP client implementation.
+type DefaultHTTPClient struct {
+	client *http.Client
+}
+
+// NewDefaultHTTPClient creates a new DefaultHTTPClient.
+func NewDefaultHTTPClient() *DefaultHTTPClient {
+	return &DefaultHTTPClient{
+		client: &http.Client{},
+	}
+}
+
+// PostForm sends a POST request with form-encoded body.
+func (c *DefaultHTTPClient) PostForm(ctx context.Context, reqURL string, data url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating POST request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.URL.RawQuery = data.Encode()
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}
+
+// Get sends a GET request with custom headers.
+func (c *DefaultHTTPClient) Get(ctx context.Context, reqURL string, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GET request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}

--- a/pkg/auth/github/mock.go
+++ b/pkg/auth/github/mock.go
@@ -1,0 +1,141 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+// MockHTTPClient is a configurable mock of HTTPClient for unit tests.
+type MockHTTPClient struct {
+	mu        sync.Mutex
+	Requests  []*MockRequest
+	Responses []*MockResponse
+	callIndex int
+}
+
+// MockRequest records a request made via the mock client.
+type MockRequest struct {
+	Method   string
+	Endpoint string
+	Data     url.Values
+	Headers  map[string]string
+}
+
+// MockResponse defines a canned response.
+type MockResponse struct {
+	StatusCode int
+	Body       any // Will be JSON-encoded
+	Err        error
+}
+
+// NewMockHTTPClient creates a new mock HTTP client.
+func NewMockHTTPClient() *MockHTTPClient {
+	return &MockHTTPClient{
+		Requests:  make([]*MockRequest, 0),
+		Responses: make([]*MockResponse, 0),
+	}
+}
+
+// AddResponse adds a response to the queue.
+func (m *MockHTTPClient) AddResponse(statusCode int, body any) *MockHTTPClient {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Responses = append(m.Responses, &MockResponse{
+		StatusCode: statusCode,
+		Body:       body,
+	})
+	return m
+}
+
+// AddError adds an error response to the queue.
+func (m *MockHTTPClient) AddError(err error) *MockHTTPClient {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Responses = append(m.Responses, &MockResponse{
+		Err: err,
+	})
+	return m
+}
+
+// nextResponse records the request and returns the next canned response.
+func (m *MockHTTPClient) nextResponse(method, endpoint string, data url.Values, headers map[string]string) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Record the request
+	m.Requests = append(m.Requests, &MockRequest{
+		Method:   method,
+		Endpoint: endpoint,
+		Data:     data,
+		Headers:  headers,
+	})
+
+	// Get the next response
+	if m.callIndex >= len(m.Responses) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error": "no mock response configured"}`)),
+		}, nil
+	}
+
+	resp := m.Responses[m.callIndex]
+	m.callIndex++
+
+	if resp.Err != nil {
+		return nil, resp.Err
+	}
+
+	var bodyBytes []byte
+	if resp.Body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &http.Response{
+		StatusCode: resp.StatusCode,
+		Body:       io.NopCloser(bytes.NewBuffer(bodyBytes)),
+	}, nil
+}
+
+// PostForm implements HTTPClient.PostForm.
+func (m *MockHTTPClient) PostForm(ctx context.Context, endpoint string, data url.Values) (*http.Response, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return m.nextResponse("POST", endpoint, data, nil)
+}
+
+// Get implements HTTPClient.Get.
+func (m *MockHTTPClient) Get(ctx context.Context, endpoint string, headers map[string]string) (*http.Response, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return m.nextResponse("GET", endpoint, nil, headers)
+}
+
+// GetRequests returns all recorded requests.
+func (m *MockHTTPClient) GetRequests() []*MockRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.Requests
+}
+
+// Reset clears all recorded requests and responses.
+func (m *MockHTTPClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Requests = make([]*MockRequest, 0)
+	m.Responses = make([]*MockResponse, 0)
+	m.callIndex = 0
+}

--- a/pkg/auth/github/mock_test.go
+++ b/pkg/auth/github/mock_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockHTTPClient_PostForm(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(http.StatusOK, map[string]string{"status": "ok"})
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://github.com/login/device/code", nil)
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	reqs := mock.GetRequests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "POST", reqs[0].Method)
+	assert.Equal(t, "https://github.com/login/device/code", reqs[0].Endpoint)
+}
+
+func TestMockHTTPClient_Get(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(http.StatusOK, map[string]string{"login": "octocat"})
+
+	ctx := context.Background()
+	headers := map[string]string{"Authorization": "Bearer test"}
+	resp, err := mock.Get(ctx, "https://api.github.com/user", headers)
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	reqs := mock.GetRequests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "GET", reqs[0].Method)
+	assert.Equal(t, "Bearer test", reqs[0].Headers["Authorization"])
+}
+
+func TestMockHTTPClient_AddError(t *testing.T) {
+	mock := NewMockHTTPClient()
+	expectedErr := errors.New("network error")
+	mock.AddError(expectedErr)
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://example.com", nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestMockHTTPClient_MultipleResponses(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(http.StatusOK, map[string]string{"step": "1"})
+	mock.AddResponse(http.StatusOK, map[string]string{"step": "2"})
+	mock.AddResponse(http.StatusOK, map[string]string{"step": "3"})
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		resp, err := mock.PostForm(ctx, "https://example.com", nil)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	assert.Len(t, mock.GetRequests(), 3)
+}
+
+func TestMockHTTPClient_NoResponseConfigured(t *testing.T) {
+	mock := NewMockHTTPClient()
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://example.com", nil)
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestMockHTTPClient_Reset(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(http.StatusOK, nil)
+	ctx := context.Background()
+	resp, _ := mock.PostForm(ctx, "https://example.com", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	assert.Len(t, mock.GetRequests(), 1)
+
+	mock.Reset()
+	assert.Empty(t, mock.GetRequests())
+}
+
+func TestMockHTTPClient_CancelledContext(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(http.StatusOK, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := mock.PostForm(ctx, "https://example.com", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	assert.Error(t, err)
+
+	resp, err = mock.Get(ctx, "https://example.com", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	assert.Error(t, err)
+}

--- a/pkg/auth/github/pat.go
+++ b/pkg/auth/github/pat.go
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package github provides GitHub authentication for scafctl.
+// This file implements the personal access token (PAT) flow.
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// PAT environment variable names (following GitHub CLI conventions).
+const (
+	// EnvGitHubToken is the environment variable for the GitHub token.
+	// Used by GitHub Actions and many CI systems.
+	EnvGitHubToken = "GITHUB_TOKEN" //nolint:gosec // This is the env var name, not a credential
+
+	// EnvGHToken is the environment variable used by the GitHub CLI (gh).
+	EnvGHToken = "GH_TOKEN" //nolint:gosec // This is the env var name, not a credential
+
+	// EnvGHHost is the environment variable for the GitHub hostname (for GHES).
+	EnvGHHost = "GH_HOST"
+)
+
+// GetPATFromEnv retrieves a personal access token from environment variables.
+// Returns empty string if no token is configured.
+// GITHUB_TOKEN takes precedence over GH_TOKEN.
+func GetPATFromEnv() string {
+	if token := os.Getenv(EnvGitHubToken); token != "" {
+		return token
+	}
+	return os.Getenv(EnvGHToken)
+}
+
+// HasPATCredentials checks if PAT credentials are configured in environment.
+func HasPATCredentials() bool {
+	return GetPATFromEnv() != ""
+}
+
+// GetHostnameFromEnv retrieves the GitHub hostname from environment variables.
+// Returns empty string if not configured.
+func GetHostnameFromEnv() string {
+	return os.Getenv(EnvGHHost)
+}
+
+// patLogin validates a PAT by calling the GitHub API.
+func (h *Handler) patLogin(ctx context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting PAT login", "handler", HandlerName)
+
+	token := GetPATFromEnv()
+	if token == "" {
+		return nil, fmt.Errorf("personal access token not configured: set %s or %s environment variable",
+			EnvGitHubToken, EnvGHToken)
+	}
+
+	// Validate the token by fetching user info
+	claims, err := h.fetchUserClaims(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("PAT authentication failed: %w", err)
+	}
+
+	lgr.V(1).Info("PAT authentication successful",
+		"login", claims.Subject,
+		"name", claims.Name,
+	)
+
+	return &auth.Result{
+		Claims: claims,
+		// PATs don't have a defined expiry via the API
+		// They are valid until revoked
+	}, nil
+}
+
+// patStatus returns auth status when PAT credentials are present.
+func (h *Handler) patStatus(ctx context.Context) (*auth.Status, error) {
+	token := GetPATFromEnv()
+	if token == "" {
+		return &auth.Status{Authenticated: false}, nil
+	}
+
+	// Validate the token
+	claims, err := h.fetchUserClaims(ctx, token)
+	if err != nil {
+		return &auth.Status{Authenticated: false}, nil //nolint:nilerr // invalid token means not authenticated
+	}
+
+	return &auth.Status{
+		Authenticated: true,
+		Claims:        claims,
+		IdentityType:  auth.IdentityTypeServicePrincipal, // PAT acts like a service principal
+		Scopes:        h.config.DefaultScopes,
+	}, nil
+}
+
+// getPATToken returns a token from the PAT environment variable.
+func (h *Handler) getPATToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	return getCachedOrAcquireToken(
+		ctx,
+		h,
+		opts,
+		GetPATFromEnv,
+		func(s string) bool { return s == "" },
+		func(ctx context.Context, token, _ string) (*auth.Token, error) {
+			// Validate the PAT
+			_, err := h.fetchUserClaims(ctx, token)
+			if err != nil {
+				return nil, fmt.Errorf("PAT validation failed: %w", err)
+			}
+			return &auth.Token{
+				AccessToken: token,
+				TokenType:   "Bearer",
+				// PATs don't expire via API, set a long validity
+				ExpiresAt: farFuture(),
+				Scope:     opts.Scope,
+			}, nil
+		},
+		"pat",
+	)
+}

--- a/pkg/auth/github/token.go
+++ b/pkg/auth/github/token.go
@@ -1,0 +1,223 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// TokenMetadata stores information about the stored credentials.
+type TokenMetadata struct {
+	Claims                *auth.Claims `json:"claims"`
+	RefreshTokenExpiresAt time.Time    `json:"refreshTokenExpiresAt,omitempty"`
+	LastRefresh           time.Time    `json:"lastRefresh"`
+	Hostname              string       `json:"hostname"`
+	ClientID              string       `json:"clientId,omitempty"`
+	Scopes                []string     `json:"scopes,omitempty"`
+	IdentityType          string       `json:"identityType,omitempty"`
+}
+
+// TokenResponse represents the response from the GitHub OAuth token endpoint.
+type TokenResponse struct {
+	AccessToken           string `json:"access_token"`            //nolint:gosec // Not a hardcoded credential
+	RefreshToken          string `json:"refresh_token,omitempty"` //nolint:gosec // Not a hardcoded credential
+	TokenType             string `json:"token_type"`
+	Scope                 string `json:"scope"`
+	ExpiresIn             int    `json:"expires_in,omitempty"`               // Present when token expiration is enabled
+	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in,omitempty"` // Present when token expiration is enabled
+}
+
+// TokenErrorResponse represents an error from the GitHub OAuth token endpoint.
+type TokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	ErrorURI         string `json:"error_uri,omitempty"`
+}
+
+// mintToken creates a new access token using the refresh token.
+func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("minting access token", "scope", scope)
+
+	// Load refresh token
+	refreshToken, err := h.loadRefreshToken(ctx)
+	if err != nil {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	// Load metadata for client info
+	metadata, err := h.loadMetadata(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+
+	// Use the client ID that was used during login
+	if metadata.ClientID == "" {
+		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with 'scafctl auth login github': %w", auth.ErrNotAuthenticated)
+	}
+
+	// Refresh the token
+	token, err := h.refreshAccessToken(ctx, refreshToken, metadata.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// refreshAccessToken refreshes an access token using the refresh token.
+func (h *Handler) refreshAccessToken(ctx context.Context, refreshToken, clientID string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+	endpoint := fmt.Sprintf("%s/login/oauth/access_token", h.config.GetOAuthBaseURL())
+
+	data := makeFormData(map[string]string{
+		"client_id":     clientID,
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	})
+
+	resp, err := h.httpClient.PostForm(ctx, endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("token refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	// GitHub returns errors in the JSON body even with 200 status
+	if tokenResp.AccessToken == "" {
+		lgr.V(1).Info("token refresh returned empty access token, possible error")
+		_ = h.Logout(ctx)
+		return nil, fmt.Errorf("refresh token expired or revoked: %w", auth.ErrTokenExpired)
+	}
+
+	// If we got a new refresh token, update stored credentials
+	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
+		lgr.V(1).Info("refresh token rotated, storing new token")
+		metadata, _ := h.loadMetadata(ctx)
+		var scopes []string
+		if metadata != nil {
+			scopes = metadata.Scopes
+		}
+		if _, err := h.storeCredentials(ctx, &tokenResp, scopes); err != nil {
+			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
+		}
+	}
+
+	expiresAt := time.Now().Add(8 * time.Hour) // Default if no expiry info
+	if tokenResp.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+
+	return &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       tokenResp.Scope,
+	}, nil
+}
+
+// storeCredentials securely stores the refresh token (or access token) and metadata.
+func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, scopes []string) (*auth.Claims, error) {
+	// Store refresh token if present (OAuth App with token expiration enabled)
+	if tokenResp.RefreshToken != "" {
+		if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
+			return nil, fmt.Errorf("failed to store refresh token: %w", err)
+		}
+	}
+
+	// Store access token for PAT-like usage or when no refresh token
+	if tokenResp.AccessToken != "" {
+		if err := h.secretStore.Set(ctx, SecretKeyAccessToken, []byte(tokenResp.AccessToken)); err != nil {
+			return nil, fmt.Errorf("failed to store access token: %w", err)
+		}
+	}
+
+	// Fetch claims from the GitHub API
+	claims, err := h.fetchUserClaims(ctx, tokenResp.AccessToken)
+	if err != nil {
+		// Use minimal claims if extraction fails
+		claims = &auth.Claims{
+			Issuer: h.config.Hostname,
+		}
+	}
+
+	// Determine refresh token expiry
+	var refreshTokenExpiresAt time.Time
+	if tokenResp.RefreshTokenExpiresIn > 0 {
+		refreshTokenExpiresAt = time.Now().Add(time.Duration(tokenResp.RefreshTokenExpiresIn) * time.Second)
+	}
+
+	metadata := &TokenMetadata{
+		Claims:                claims,
+		RefreshTokenExpiresAt: refreshTokenExpiresAt,
+		LastRefresh:           time.Now(),
+		Hostname:              h.config.Hostname,
+		ClientID:              h.config.ClientID,
+		Scopes:                scopes,
+		IdentityType:          string(auth.IdentityTypeUser),
+	}
+
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := h.secretStore.Set(ctx, SecretKeyMetadata, metadataBytes); err != nil {
+		return nil, fmt.Errorf("failed to store metadata: %w", err)
+	}
+
+	return claims, nil
+}
+
+// loadRefreshToken loads the stored refresh token.
+func (h *Handler) loadRefreshToken(ctx context.Context) (string, error) {
+	data, err := h.secretStore.Get(ctx, SecretKeyRefreshToken)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// loadAccessToken loads the stored access token.
+func (h *Handler) loadAccessToken(ctx context.Context) (string, error) {
+	data, err := h.secretStore.Get(ctx, SecretKeyAccessToken)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// loadMetadata loads the stored token metadata.
+func (h *Handler) loadMetadata(ctx context.Context) (*TokenMetadata, error) {
+	data, err := h.secretStore.Get(ctx, SecretKeyMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata TokenMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+
+	return &metadata, nil
+}
+
+// makeFormData is a helper to create url.Values from a string map.
+func makeFormData(params map[string]string) map[string][]string {
+	data := make(map[string][]string, len(params))
+	for k, v := range params {
+		data[k] = []string{v}
+	}
+	return data
+}

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -65,6 +65,9 @@ const (
 
 	// FlowWorkloadIdentity is authentication using Azure Workload Identity (Kubernetes).
 	FlowWorkloadIdentity Flow = "workload_identity"
+
+	// FlowPAT is authentication using a personal access token from environment variables.
+	FlowPAT Flow = "pat"
 )
 
 // DefaultMinValidFor is the default minimum validity duration for tokens.

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 )
 
@@ -55,13 +56,12 @@ func getEntraHandler(ctx context.Context) (auth.Handler, error) {
 
 // getEntraHandlerWithOverrides creates an Entra handler with optional tenant and client ID overrides.
 // The flags take precedence over config.
-func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) {
+func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) { //nolint:dupl // Entra and GitHub handlers have intentionally similar structure but different types
 	// Check for test-injected handler
 	if h := handlerFromContext(ctx); h != nil {
 		return h, nil
 	}
 
-	// Build config from context and apply overrides
 	entraCfg := &entra.Config{}
 	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.Entra != nil {
 		entraCfg.ClientID = cfg.Auth.Entra.ClientID
@@ -69,13 +69,8 @@ func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDO
 		entraCfg.DefaultScopes = cfg.Auth.Entra.DefaultScopes
 	}
 
-	// Flags override config
-	if tenantOverride != "" {
-		entraCfg.TenantID = tenantOverride
-	}
-	if clientIDOverride != "" {
-		entraCfg.ClientID = clientIDOverride
-	}
+	applyOverride(&entraCfg.TenantID, tenantOverride)
+	applyOverride(&entraCfg.ClientID, clientIDOverride)
 
 	var opts []entra.Option
 	if entraCfg.ClientID != "" || entraCfg.TenantID != "" || len(entraCfg.DefaultScopes) > 0 {
@@ -87,7 +82,7 @@ func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDO
 
 // SupportedHandlers returns the list of supported auth handler names.
 func SupportedHandlers() []string {
-	return []string{"entra"}
+	return []string{"entra", "github"}
 }
 
 // IsSupportedHandler returns true if the handler name is supported.
@@ -98,4 +93,71 @@ func IsSupportedHandler(name string) bool {
 		}
 	}
 	return false
+}
+
+// getGitHubHandler creates or retrieves a GitHub handler.
+// If a handler was injected via context (for testing), returns that.
+// Otherwise creates a new handler with configuration from context.
+func getGitHubHandler(ctx context.Context) (auth.Handler, error) {
+	// Check for test-injected handler
+	if h := handlerFromContext(ctx); h != nil {
+		return h, nil
+	}
+
+	// Build options from config
+	var opts []ghauth.Option
+	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GitHub != nil {
+		opts = append(opts, ghauth.WithConfig(&ghauth.Config{
+			ClientID:      cfg.Auth.GitHub.ClientID,
+			Hostname:      cfg.Auth.GitHub.Hostname,
+			DefaultScopes: cfg.Auth.GitHub.DefaultScopes,
+		}))
+	}
+
+	return ghauth.New(opts...)
+}
+
+// getGitHubHandlerWithOverrides creates a GitHub handler with optional hostname and client ID overrides.
+// The flags take precedence over config.
+func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, clientIDOverride string) (auth.Handler, error) { //nolint:dupl // Entra and GitHub handlers have intentionally similar structure but different types
+	// Check for test-injected handler
+	if h := handlerFromContext(ctx); h != nil {
+		return h, nil
+	}
+
+	ghCfg := &ghauth.Config{}
+	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GitHub != nil {
+		ghCfg.ClientID = cfg.Auth.GitHub.ClientID
+		ghCfg.Hostname = cfg.Auth.GitHub.Hostname
+		ghCfg.DefaultScopes = cfg.Auth.GitHub.DefaultScopes
+	}
+
+	applyOverride(&ghCfg.Hostname, hostnameOverride)
+	applyOverride(&ghCfg.ClientID, clientIDOverride)
+
+	var opts []ghauth.Option
+	if ghCfg.ClientID != "" || ghCfg.Hostname != "" || len(ghCfg.DefaultScopes) > 0 {
+		opts = append(opts, ghauth.WithConfig(ghCfg))
+	}
+
+	return ghauth.New(opts...)
+}
+
+// applyOverride sets the target to the override value if it is non-empty.
+func applyOverride(target *string, override string) {
+	if override != "" {
+		*target = override
+	}
+}
+
+// getHandler creates a handler for the given handler name.
+func getHandler(ctx context.Context, handlerName string) (auth.Handler, error) {
+	switch handlerName {
+	case "entra":
+		return getEntraHandler(ctx)
+	case "github":
+		return getGitHubHandler(ctx)
+	default:
+		return nil, auth.ErrHandlerNotFound
+	}
 }

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -49,5 +49,6 @@ func TestIsSupportedHandler(t *testing.T) {
 func TestSupportedHandlers(t *testing.T) {
 	handlers := SupportedHandlers()
 	assert.Contains(t, handlers, "entra")
-	assert.Len(t, handlers, 1)
+	assert.Contains(t, handlers, "github")
+	assert.Len(t, handlers, 2)
 }

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -26,6 +27,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 	var (
 		tenantID       string
 		clientID       string
+		hostname       string
 		timeout        time.Duration
 		flowStr        string
 		federatedToken string
@@ -43,12 +45,16 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			- service-principal: Non-interactive authentication for CI/CD
 			- workload-identity: Kubernetes workload identity (AKS)
 
-			For service principal flow, set these environment variables:
+			For the 'github' handler, this supports:
+			- device-code: Interactive authentication via browser (default)
+			- pat: Personal access token from environment variables (GITHUB_TOKEN or GH_TOKEN)
+
+			For Entra service principal flow, set these environment variables:
 			- AZURE_CLIENT_ID: Application (client) ID
 			- AZURE_TENANT_ID: Directory (tenant) ID
 			- AZURE_CLIENT_SECRET: Client secret value
 
-			For workload identity flow, set these environment variables:
+			For Entra workload identity flow, set these environment variables:
 			- AZURE_CLIENT_ID: Application (client) ID
 			- AZURE_TENANT_ID: Directory (tenant) ID
 			- AZURE_FEDERATED_TOKEN_FILE: Path to projected token file
@@ -57,37 +63,45 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			  OR
 			- --federated-token flag: Pass token directly (for testing)
 
-			By default, the device code flow uses the Azure CLI's public client ID
-			(04b07795-8ddb-461a-bbee-02f9e1bf7b46). Use --client-id to specify a
-			custom application registration for enterprise scenarios.
+			By default, the Entra device code flow uses the Azure CLI's public client ID.
+			The GitHub device code flow uses the scafctl OAuth App client ID.
+			Use --client-id to specify a custom application registration.
 
 			Supported handlers:
 			- entra: Microsoft Entra ID
+			- github: GitHub
 
 			Examples:
 			  # Login with Entra ID using device code flow (default)
 			  scafctl auth login entra
 
-			  # Login with a specific tenant
+			  # Login with GitHub using device code flow (default)
+			  scafctl auth login github
+
+			  # Login with GitHub Enterprise Server
+			  scafctl auth login github --hostname github.example.com
+
+			  # Login with GitHub PAT (requires GITHUB_TOKEN or GH_TOKEN env var)
+			  scafctl auth login github --flow pat
+
+			  # Login with a specific Entra tenant
 			  scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
 
-			  # Login with a custom client ID (enterprise/custom app registration)
+			  # Login with a custom client ID
 			  scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc
 
-			  # Login with service principal (requires env vars)
+			  # Login with Entra service principal (requires env vars)
 			  scafctl auth login entra --flow service-principal
 
-			  # Login with workload identity (Kubernetes)
+			  # Login with Entra workload identity (Kubernetes)
 			  scafctl auth login entra --flow workload-identity
-
-			  # Test workload identity with a direct token
-			  scafctl auth login entra --flow workload-identity --federated-token "eyJ..."
 
 			  # Login with a custom timeout (device code only)
 			  scafctl auth login entra --timeout 10m
 
-			  # Login with specific scopes for API access
+			  # Login with specific scopes
 			  scafctl auth login entra --scope https://graph.microsoft.com/User.Read
+			  scafctl auth login github --scope repo --scope read:org
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -104,143 +118,212 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			}
 
 			// Parse flow
-			flow, err := parseFlow(flowStr)
+			flow, err := parseFlow(flowStr, handlerName)
 			if err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			// If --federated-token is provided, set the env var for workload identity
-			if federatedToken != "" {
-				if err := os.Setenv(entra.EnvAzureFederatedToken, federatedToken); err != nil {
-					err = fmt.Errorf("failed to set federated token: %w", err)
-					w.Errorf("%v", err)
-					return exitcode.WithCode(err, exitcode.GeneralError)
-				}
-				// Auto-select workload identity flow if not explicitly set
-				if flowStr == "" {
-					flow = auth.FlowWorkloadIdentity
-				}
+			// Route to handler-specific login logic
+			switch handlerName {
+			case "github":
+				return loginGitHub(ctx, w, flow, hostname, clientID, timeout, scopes)
+			default:
+				return loginEntra(ctx, w, flow, tenantID, clientID, timeout, federatedToken, flowStr, scopes)
 			}
-
-			// Auto-detect workload identity if env vars are set and no explicit flow (highest priority)
-			if flowStr == "" && entra.HasWorkloadIdentityCredentials() {
-				flow = auth.FlowWorkloadIdentity
-				w.Info("Detected workload identity credentials in environment")
-			} else if flowStr == "" && entra.HasServicePrincipalCredentials() {
-				// Auto-detect service principal if env vars are set and no explicit flow
-				flow = auth.FlowServicePrincipal
-				w.Info("Detected service principal credentials in environment variables")
-			}
-
-			// Get or create handler
-			handler, err := getEntraHandlerWithOverrides(ctx, tenantID, clientID)
-			if err != nil {
-				err = fmt.Errorf("failed to initialize auth handler: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			// Check if already authenticated (skip for service principal)
-			if flow != auth.FlowServicePrincipal {
-				status, err := handler.Status(ctx)
-				if err != nil {
-					err = fmt.Errorf("failed to check auth status: %w", err)
-					w.Errorf("%v", err)
-					return exitcode.WithCode(err, exitcode.GeneralError)
-				}
-
-				if status.Authenticated {
-					identity := status.Claims.Email
-					if identity == "" {
-						identity = status.Claims.Name
-					}
-					if identity == "" {
-						identity = status.Claims.Subject
-					}
-					w.Infof("Already authenticated as %s", identity)
-					w.Info("Use 'scafctl auth logout entra' to sign out first, or continue to re-authenticate.")
-					w.Info("")
-				}
-			}
-
-			// Set up cancellation handling
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			sigChan := make(chan os.Signal, 1)
-			signal.Notify(sigChan, os.Interrupt)
-			go func() {
-				<-sigChan
-				w.Info("")
-				w.Warning("Authentication cancelled by user.")
-				cancel()
-			}()
-			defer signal.Stop(sigChan)
-
-			// Prepare login options
-			loginOpts := auth.LoginOptions{
-				TenantID: tenantID,
-				Scopes:   scopes,
-				Flow:     flow,
-				Timeout:  timeout,
-				DeviceCodeCallback: func(userCode, verificationURI, _ string) {
-					w.Info("")
-					w.Info("To sign in, use a web browser to open the page:")
-					w.Infof("  %s", verificationURI)
-					w.Info("")
-					w.Infof("Enter the code: %s", userCode)
-					w.Info("")
-					w.Info("Waiting for authentication...")
-				},
-			}
-
-			result, err := handler.Login(ctx, loginOpts)
-			if err != nil {
-				if ctx.Err() != nil {
-					return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-				}
-				err = fmt.Errorf("authentication failed: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			w.Info("")
-			w.Success("Authentication successful!")
-			if result.Claims.Name != "" {
-				w.Infof("  Name:   %s", result.Claims.Name)
-			}
-			if result.Claims.Email != "" {
-				w.Infof("  Email:  %s", result.Claims.Email)
-			}
-			if result.Claims.TenantID != "" {
-				w.Infof("  Tenant: %s", result.Claims.TenantID)
-			}
-			if flow == auth.FlowServicePrincipal {
-				w.Info("  Flow:   Service Principal")
-			}
-			if flow == auth.FlowWorkloadIdentity {
-				w.Info("  Flow:   Workload Identity")
-			}
-
-			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config)")
-	cmd.Flags().StringVar(&clientID, "client-id", "", "Azure application (client) ID (overrides default Azure CLI client ID)")
+	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config, Entra only)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth application/client ID (overrides default)")
+	cmd.Flags().StringVar(&hostname, "hostname", "", "GitHub hostname for GHES (GitHub only, e.g. github.example.com)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "Timeout for authentication flow")
-	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow: 'device-code' (default), 'service-principal', or 'workload-identity'")
-	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for workload identity (for testing; sets AZURE_FEDERATED_TOKEN)")
-	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "Additional OAuth scopes to request during login (e.g., https://graph.microsoft.com/User.Read)")
+	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow (handler-specific)")
+	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for Entra workload identity (sets AZURE_FEDERATED_TOKEN)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scopes to request during login")
 
 	return cmd
 }
 
+// loginGitHub handles the login flow for the GitHub auth handler.
+func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname, clientID string, timeout time.Duration, scopes []string) error {
+	// Auto-detect PAT if env vars are set and no explicit flow
+	if flow == "" && ghauth.HasPATCredentials() {
+		flow = auth.FlowPAT
+		w.Info("Detected GitHub token in environment variables")
+	}
+
+	// Default to device code
+	if flow == "" {
+		flow = auth.FlowDeviceCode
+	}
+
+	// Get or create handler
+	handler, err := getGitHubHandlerWithOverrides(ctx, hostname, clientID)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize auth handler: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Check if already authenticated (skip for PAT)
+	if flow != auth.FlowPAT {
+		status, err := handler.Status(ctx)
+		if err != nil {
+			err = fmt.Errorf("failed to check auth status: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+
+		if status.Authenticated {
+			identity := status.Claims.DisplayIdentity()
+			w.Infof("Already authenticated as %s", identity)
+			w.Info("Use 'scafctl auth logout github' to sign out first, or continue to re-authenticate.")
+			w.Info("")
+		}
+	}
+
+	return executeLogin(ctx, w, handler, flow, "", timeout, scopes)
+}
+
+// loginEntra handles the login flow for the Entra auth handler.
+func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID, clientID string, timeout time.Duration, federatedToken, flowStr string, scopes []string) error {
+	// If --federated-token is provided, set the env var for workload identity
+	if federatedToken != "" {
+		if err := os.Setenv(entra.EnvAzureFederatedToken, federatedToken); err != nil {
+			err = fmt.Errorf("failed to set federated token: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+		// Auto-select workload identity flow if not explicitly set
+		if flowStr == "" {
+			flow = auth.FlowWorkloadIdentity
+		}
+	}
+
+	// Auto-detect workload identity if env vars are set and no explicit flow (highest priority)
+	if flowStr == "" && entra.HasWorkloadIdentityCredentials() {
+		flow = auth.FlowWorkloadIdentity
+		w.Info("Detected workload identity credentials in environment")
+	} else if flowStr == "" && entra.HasServicePrincipalCredentials() {
+		// Auto-detect service principal if env vars are set and no explicit flow
+		flow = auth.FlowServicePrincipal
+		w.Info("Detected service principal credentials in environment variables")
+	}
+
+	// Default to device code if no flow detected
+	if flow == "" {
+		flow = auth.FlowDeviceCode
+	}
+
+	// Get or create handler
+	handler, err := getEntraHandlerWithOverrides(ctx, tenantID, clientID)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize auth handler: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Check if already authenticated (skip for service principal)
+	if flow != auth.FlowServicePrincipal {
+		status, err := handler.Status(ctx)
+		if err != nil {
+			err = fmt.Errorf("failed to check auth status: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+
+		if status.Authenticated {
+			identity := status.Claims.Email
+			if identity == "" {
+				identity = status.Claims.Name
+			}
+			if identity == "" {
+				identity = status.Claims.Subject
+			}
+			w.Infof("Already authenticated as %s", identity)
+			w.Info("Use 'scafctl auth logout entra' to sign out first, or continue to re-authenticate.")
+			w.Info("")
+		}
+	}
+
+	return executeLogin(ctx, w, handler, flow, tenantID, timeout, scopes)
+}
+
+// executeLogin runs the common login logic for any auth handler.
+func executeLogin(ctx context.Context, w *writer.Writer, handler auth.Handler, flow auth.Flow, tenantID string, timeout time.Duration, scopes []string) error {
+	// Set up cancellation handling
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		w.Info("")
+		w.Warning("Authentication cancelled by user.")
+		cancel()
+	}()
+	defer signal.Stop(sigChan)
+
+	// Prepare login options
+	loginOpts := auth.LoginOptions{
+		TenantID: tenantID,
+		Scopes:   scopes,
+		Flow:     flow,
+		Timeout:  timeout,
+		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
+			w.Info("")
+			w.Info("To sign in, use a web browser to open the page:")
+			w.Infof("  %s", verificationURI)
+			w.Info("")
+			w.Infof("Enter the code: %s", userCode)
+			w.Info("")
+			w.Info("Waiting for authentication...")
+		},
+	}
+
+	result, err := handler.Login(ctx, loginOpts)
+	if err != nil {
+		if ctx.Err() != nil {
+			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+		}
+		err = fmt.Errorf("authentication failed: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	w.Info("")
+	w.Success("Authentication successful!")
+	if result.Claims.Name != "" {
+		w.Infof("  Name:     %s", result.Claims.Name)
+	}
+	if result.Claims.Username != "" && result.Claims.Username != result.Claims.Name {
+		w.Infof("  Username: %s", result.Claims.Username)
+	}
+	if result.Claims.Email != "" {
+		w.Infof("  Email:    %s", result.Claims.Email)
+	}
+	if result.Claims.TenantID != "" {
+		w.Infof("  Tenant:   %s", result.Claims.TenantID)
+	}
+	if flow == auth.FlowServicePrincipal {
+		w.Info("  Flow:     Service Principal")
+	}
+	if flow == auth.FlowWorkloadIdentity {
+		w.Info("  Flow:     Workload Identity")
+	}
+	if flow == auth.FlowPAT {
+		w.Info("  Flow:     Personal Access Token")
+	}
+
+	return nil
+}
+
 // parseFlow converts a flow string to an auth.Flow constant.
-func parseFlow(flowStr string) (auth.Flow, error) {
+func parseFlow(flowStr, handlerName string) (auth.Flow, error) {
 	if flowStr == "" {
-		return auth.FlowDeviceCode, nil
+		return "", nil // Will be auto-detected per handler
 	}
 	switch strings.ToLower(flowStr) {
 	case "device-code", "devicecode":
@@ -249,7 +332,12 @@ func parseFlow(flowStr string) (auth.Flow, error) {
 		return auth.FlowServicePrincipal, nil
 	case "workload-identity", "workloadidentity", "wi":
 		return auth.FlowWorkloadIdentity, nil
+	case "pat":
+		return auth.FlowPAT, nil
 	default:
-		return "", fmt.Errorf("unknown flow: %s (valid: device-code, service-principal, workload-identity)", flowStr)
+		if handlerName == "github" {
+			return "", fmt.Errorf("unknown flow: %s (valid for github: device-code, pat)", flowStr)
+		}
+		return "", fmt.Errorf("unknown flow: %s (valid for entra: device-code, service-principal, workload-identity)", flowStr)
 	}
 }

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -27,10 +27,14 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 
 			Supported handlers:
 			- entra: Microsoft Entra ID
+			- github: GitHub
 
 			Examples:
 			  # Logout from Entra ID
 			  scafctl auth logout entra
+
+			  # Logout from GitHub
+			  scafctl auth logout github
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -46,7 +50,7 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			handler, err := getEntraHandler(ctx)
+			handler, err := getHandler(ctx, handlerName)
 			if err != nil {
 				err = fmt.Errorf("failed to initialize auth handler: %w", err)
 				w.Errorf("%v", err)
@@ -62,7 +66,7 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 			}
 
 			if !status.Authenticated {
-				w.Info("Not currently authenticated with Entra ID.")
+				w.Infof("Not currently authenticated with %s.", handler.DisplayName())
 				return nil
 			}
 
@@ -72,7 +76,7 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
-			w.Success("Successfully logged out from Entra ID.")
+			w.Successf("Successfully logged out from %s.", handler.DisplayName())
 			return nil
 		},
 	}

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -31,6 +31,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			Supported handlers:
 			- entra: Microsoft Entra ID
+			- github: GitHub
 
 			Examples:
 			  # Show all auth status
@@ -38,6 +39,9 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			  # Show Entra auth status
 			  scafctl auth status entra
+
+			  # Show GitHub auth status
+			  scafctl auth status github
 
 			  # Output as JSON
 			  scafctl auth status -o json
@@ -62,67 +66,65 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			results := make([]map[string]any, 0, len(handlers))
 
 			for _, handlerName := range handlers {
-				switch handlerName {
-				case "entra":
-					handler, err := getEntraHandler(ctx)
-					if err != nil {
-						w.Warningf("Failed to initialize %s: %v", handlerName, err)
-						continue
-					}
-
-					status, err := handler.Status(ctx)
-					if err != nil {
-						w.Warningf("Failed to check %s status: %v", handlerName, err)
-						continue
-					}
-
-					result := map[string]any{
-						"handler":       handlerName,
-						"displayName":   handler.DisplayName(),
-						"authenticated": status.Authenticated,
-					}
-
-					// Add identity type
-					if status.IdentityType != "" {
-						result["identityType"] = string(status.IdentityType)
-					}
-
-					// For service principal/workload identity, show client ID
-					if status.ClientID != "" {
-						result["clientId"] = status.ClientID
-					}
-
-					// For workload identity, show token file path
-					if status.IdentityType == auth.IdentityTypeWorkloadIdentity && status.TokenFile != "" {
-						result["tokenFile"] = status.TokenFile
-					}
-
-					if status.Authenticated && status.Claims != nil {
-						if status.Claims.Email != "" {
-							result["email"] = status.Claims.Email
-						}
-						if status.Claims.Name != "" {
-							result["name"] = status.Claims.Name
-						}
-						if status.TenantID != "" {
-							result["tenantId"] = status.TenantID
-						}
-						if !status.ExpiresAt.IsZero() {
-							result["expiresAt"] = status.ExpiresAt
-						}
-						if !status.LastRefresh.IsZero() {
-							result["lastRefresh"] = status.LastRefresh
-						}
-					}
-
-					if len(status.Scopes) > 0 {
-						result["scopes"] = status.Scopes
-					}
-
-					results = append(results, result)
-				default:
-					w.Warningf("Unknown auth handler: %s", handlerName)
+				handler, err := getHandler(ctx, handlerName)
+				if err != nil {
+					w.Warningf("Failed to initialize %s: %v", handlerName, err)
+					continue
 				}
+
+				status, err := handler.Status(ctx)
+				if err != nil {
+					w.Warningf("Failed to check %s status: %v", handlerName, err)
+					continue
+				}
+
+				result := map[string]any{
+					"handler":       handlerName,
+					"displayName":   handler.DisplayName(),
+					"authenticated": status.Authenticated,
+				}
+
+				// Add identity type
+				if status.IdentityType != "" {
+					result["identityType"] = string(status.IdentityType)
+				}
+
+				// For service principal/workload identity, show client ID
+				if status.ClientID != "" {
+					result["clientId"] = status.ClientID
+				}
+
+				// For workload identity, show token file path
+				if status.IdentityType == auth.IdentityTypeWorkloadIdentity && status.TokenFile != "" {
+					result["tokenFile"] = status.TokenFile
+				}
+
+				if status.Authenticated && status.Claims != nil {
+					if status.Claims.Email != "" {
+						result["email"] = status.Claims.Email
+					}
+					if status.Claims.Name != "" {
+						result["name"] = status.Claims.Name
+					}
+					if status.Claims.Username != "" {
+						result["username"] = status.Claims.Username
+					}
+					if status.TenantID != "" {
+						result["tenantId"] = status.TenantID
+					}
+					if !status.ExpiresAt.IsZero() {
+						result["expiresAt"] = status.ExpiresAt
+					}
+					if !status.LastRefresh.IsZero() {
+						result["lastRefresh"] = status.LastRefresh
+					}
+				}
+
+				if len(status.Scopes) > 0 {
+					result["scopes"] = status.Scopes
+				}
+
+				results = append(results, result)
 			}
 
 			if len(results) == 0 {

--- a/pkg/cmd/scafctl/auth/status_test.go
+++ b/pkg/cmd/scafctl/auth/status_test.go
@@ -48,8 +48,8 @@ func TestCommandStatus_AllHandlers(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	// Verify status was checked
-	assert.Equal(t, 1, mock.StatusCalls)
+	// Verify status was checked (once per supported handler: entra, github)
+	assert.Equal(t, 2, mock.StatusCalls)
 }
 
 func TestCommandStatus_SpecificHandler(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -5,6 +5,8 @@ package auth
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -22,7 +24,7 @@ import (
 func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
 	var (
-		scope       string
+		scopes      []string
 		minValidFor time.Duration
 	)
 
@@ -42,10 +44,14 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			Supported handlers:
 			- entra: Microsoft Entra ID
+			- github: GitHub
 
 			Examples:
 			  # Get a token for Microsoft Graph
 			  scafctl auth token entra --scope "https://graph.microsoft.com/.default"
+
+			  # Get a GitHub token
+			  scafctl auth token github --scope "repo"
 
 			  # Get a token that will be valid for at least 5 minutes
 			  scafctl auth token entra --scope "https://graph.microsoft.com/.default" --min-valid-for 5m
@@ -67,13 +73,19 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			if scope == "" {
+			if len(scopes) == 0 {
 				err := fmt.Errorf("--scope is required")
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			handler, err := getEntraHandler(ctx)
+			// Sort scopes for deterministic cache key
+			sorted := make([]string, len(scopes))
+			copy(sorted, scopes)
+			sort.Strings(sorted)
+			scope := strings.Join(sorted, " ")
+
+			handler, err := getHandler(ctx, handlerName)
 			if err != nil {
 				err = fmt.Errorf("failed to initialize auth handler: %w", err)
 				w.Errorf("%v", err)
@@ -131,9 +143,8 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		},
 	}
 
-	cmd.Flags().StringVar(&scope, "scope", "", "OAuth scope for the token (required)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scope(s) for the token (required, can specify multiple)")
 	cmd.Flags().DurationVar(&minValidFor, "min-valid-for", auth.DefaultMinValidFor, "Minimum time the token should be valid for")
-	_ = cmd.MarkFlagRequired("scope")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	authcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/build"
 	bundlecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/bundle"
@@ -217,6 +218,24 @@ func Root(opts *RootOptions) *cobra.Command {
 			} else {
 				if regErr := authRegistry.Register(entraHandler); regErr != nil {
 					lgr.V(1).Info("warning: failed to register Entra auth handler", "error", regErr)
+				}
+			}
+
+			// Initialize GitHub auth handler
+			var ghOpts []ghauth.Option
+			if cfg.Auth.GitHub != nil {
+				ghOpts = append(ghOpts, ghauth.WithConfig(&ghauth.Config{
+					ClientID:      cfg.Auth.GitHub.ClientID,
+					Hostname:      cfg.Auth.GitHub.Hostname,
+					DefaultScopes: cfg.Auth.GitHub.DefaultScopes,
+				}))
+			}
+			ghHandler, err := ghauth.New(ghOpts...)
+			if err != nil {
+				lgr.V(1).Info("warning: failed to initialize GitHub auth handler", "error", err)
+			} else {
+				if regErr := authRegistry.Register(ghHandler); regErr != nil {
+					lgr.V(1).Info("warning: failed to register GitHub auth handler", "error", regErr)
 				}
 			}
 			ctx = auth.WithRegistry(ctx, authRegistry)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -244,6 +244,9 @@ type ActionConfig struct {
 type GlobalAuthConfig struct {
 	// Entra contains Microsoft Entra ID configuration.
 	Entra *EntraAuthConfig `json:"entra,omitempty" yaml:"entra,omitempty" mapstructure:"entra" doc:"Microsoft Entra ID configuration"`
+
+	// GitHub contains GitHub authentication configuration.
+	GitHub *GitHubAuthConfig `json:"github,omitempty" yaml:"github,omitempty" mapstructure:"github" doc:"GitHub authentication configuration"`
 }
 
 // EntraAuthConfig contains Entra-specific configuration.
@@ -256,6 +259,20 @@ type EntraAuthConfig struct {
 	// Use "common" for multi-tenant, "organizations" for work/school only,
 	// or a specific tenant GUID.
 	TenantID string `json:"tenantId,omitempty" yaml:"tenantId,omitempty" mapstructure:"tenantId" doc:"Default Azure tenant ID" example:"common" maxLength:"36"`
+
+	// DefaultScopes are requested during login if not specified on command line.
+	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" mapstructure:"defaultScopes" doc:"Default OAuth scopes" maxItems:"20"`
+}
+
+// GitHubAuthConfig contains GitHub-specific configuration.
+type GitHubAuthConfig struct {
+	// ClientID overrides the default GitHub OAuth App client ID.
+	// If not set, uses the default scafctl OAuth App client ID.
+	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty" mapstructure:"clientId" doc:"GitHub OAuth App client ID" maxLength:"40"`
+
+	// Hostname sets the GitHub hostname for enterprise server (GHES).
+	// Defaults to "github.com".
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty" mapstructure:"hostname" doc:"GitHub hostname" example:"github.com" maxLength:"253"`
 
 	// DefaultScopes are requested during login if not specified on command line.
 	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" mapstructure:"defaultScopes" doc:"Default OAuth scopes" maxItems:"20"`


### PR DESCRIPTION
Implement GitHub authentication with Device Code OAuth flow and Personal Access Token (PAT) support, following the existing Entra handler patterns.

Key additions:
- pkg/auth/github/: Complete GitHub auth handler implementation
  - Device code flow with polling and slow_down handling
  - PAT flow via GITHUB_TOKEN/GH_TOKEN environment variables
  - GitHub Enterprise Server (GHES) support via hostname config
  - Disk-based token caching with scope-based keys
  - User claims fetching from /user API endpoint

- CLI integration:
  - auth login github: Interactive device code or PAT auth
  - auth logout github: Clear stored credentials
  - auth status github: Display authentication status
  - auth token github: Retrieve access tokens (debugging)
  - Multi-scope support for token command (-scope flag)

- Configuration:
  - pkg/config/types.go: Add GitHubAuthConfig to GlobalAuthConfig
  - Default client ID: Ov23li6xn492GhPmt4YG
  - Configurable hostname, client ID, and default scopes

- Handler registration in root.go for auth registry

BREAKING CHANGE: auth token command now requires --scope flag as a slice instead of a required string flag
