### PR TITLE
fix(auth): preserve login-time client ID during token rotation

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -31,7 +31,7 @@ scafctl provides built-in auth handlers for common identity providers:
 | Handler | Status | Description |
 |---------|--------|-------------|
 | `entra` | ✅ Implemented | Microsoft Entra ID (Azure AD) |
-| `github` | 🔜 Planned | GitHub OAuth |
+| `github` | ✅ Implemented | GitHub OAuth (Device Code + PAT) |
 | `gcp` | 🔜 Planned | Google Cloud Platform |
 
 **External Auth Handlers** can be distributed via the catalog for custom identity providers:
@@ -78,8 +78,36 @@ Auth handlers are responsible for:
 - Managing refresh tokens or equivalent credentials
 - Minting execution tokens for providers
 - Normalizing token metadata and claims
+- Declaring their capabilities for CLI flag validation
 
 Auth handlers are not action providers and do not perform side effects outside authentication.
+
+### Handler Capabilities
+
+Each handler declares a set of capabilities that describe which features it supports. CLI commands use these capabilities to dynamically validate flags and provide meaningful errors.
+
+| Capability | Description | Entra | GitHub |
+|------------|-------------|-------|--------|
+| `scopes_on_login` | Supports specifying scopes at login time | ✅ | ✅ |
+| `scopes_on_token_request` | Supports per-request scopes when acquiring tokens | ✅ | ❌ |
+| `tenant_id` | Supports tenant ID parameter | ✅ | ❌ |
+| `hostname` | Supports hostname parameter (enterprise/self-hosted) | ❌ | ✅ |
+| `federated_token` | Supports federated token input (workload identity) | ✅ | ❌ |
+
+**Why capabilities matter**: GitHub's OAuth does not support changing scopes on token refresh — scopes are fixed at login time. Entra ID supports requesting different resource scopes per token request. Instead of hardcoding these differences in CLI commands, each handler declares its capabilities, and the CLI validates flags accordingly.
+
+This design makes plugin-loaded auth handlers work without CLI code changes — a plugin handler declares its capabilities, and the CLI dynamically adapts.
+
+**Example**: Running `scafctl auth token github --scope repo` returns an error:
+> the "github" auth handler does not support per-request scopes; scopes are fixed at login time. Use 'scafctl auth login github --scope <scope>' to change scopes
+
+### Handler Registry
+
+Auth handlers are managed via a thread-safe registry (`auth.Registry`). CLI commands look up handlers by name from the registry in context, rather than using hardcoded switch statements. This supports:
+
+- Built-in handlers registered at startup
+- Plugin-loaded handlers registered after discovery
+- Dynamic handler enumeration for commands like `auth list` and `auth status` (shows all registered handlers)
 
 ---
 
@@ -136,6 +164,40 @@ Behavior:
 | Service Principal | `--flow service-principal` | CI/CD pipelines, automation |
 | Workload Identity | `--flow workload-identity` | Kubernetes (AKS) workload identity |
 
+### GitHub Device Code Flow
+
+~~~bash
+scafctl auth login github
+~~~
+
+Behavior:
+
+- Initiates GitHub OAuth device code flow
+- User authenticates in a browser at https://github.com/login/device
+- An access token (and optionally refresh token) is obtained
+- Credentials are stored securely
+- Supports GitHub Enterprise Server via `--hostname`
+
+### GitHub PAT Flow (CI/CD)
+
+~~~bash
+# Set token in environment
+export GITHUB_TOKEN="ghp_..."
+
+# Auto-detects PAT from env vars
+scafctl auth login github
+
+# Or explicitly specify the flow
+scafctl auth login github --flow pat
+~~~
+
+Behavior:
+
+- Reads `GITHUB_TOKEN` or `GH_TOKEN` from environment
+- Validates the token by calling the GitHub API
+- No user interaction required
+- Token is cached for performance
+
 ### Workload Identity Flow (Kubernetes)
 
 For Kubernetes workloads running in AKS with workload identity enabled:
@@ -183,11 +245,21 @@ Rules:
 - Credentials are never embedded in solutions
 - Credentials are never exposed to providers directly
 
-### Device Code Flow Storage
+### Device Code Flow Storage (Entra)
 
 Uses the system secret store for long-lived credentials.
 
-### Service Principal Flow Storage
+### Device Code Flow Storage (GitHub)
+
+Uses the system secret store for access tokens and optional refresh tokens.
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | GitHub personal access token or Actions token |
+| `GH_TOKEN` | GitHub personal access token (gh CLI convention) |
+| `GH_HOST` | GitHub hostname for Enterprise Server |
+
+### Service Principal Flow Storage (Entra)
 
 Credentials are read from environment variables (never stored):
 
@@ -229,6 +301,15 @@ For the Entra handler:
 | `scafctl.auth.entra.refresh_token` | Long-lived refresh token |
 | `scafctl.auth.entra.metadata` | Token metadata (claims, tenant, client ID, expiry) |
 | `scafctl.auth.entra.token.<scope-hash>` | Cached access tokens by scope |
+
+For the GitHub handler:
+
+| Secret Name | Description |
+|-------------|-------------|
+| `scafctl.auth.github.refresh_token` | OAuth refresh token (if token expiration is enabled) |
+| `scafctl.auth.github.access_token` | OAuth access token (non-expiring apps) |
+| `scafctl.auth.github.metadata` | Token metadata (claims, hostname, client ID, expiry) |
+| `scafctl.auth.github.token.<scope-hash>` | Cached access tokens by scope |
 
 The scope hash is a base64url-encoded representation of the scope string.
 

--- a/docs/design/gcp-auth-handler.md
+++ b/docs/design/gcp-auth-handler.md
@@ -1,0 +1,768 @@
+---
+title: "GCP Auth Handler"
+weight: 7
+---
+
+# GCP Auth Handler Implementation Plan
+
+## Overview
+
+Implement a builtin GCP auth handler (`gcp`) following the established patterns from the Entra and GitHub handlers. The handler will support four authentication flows: Application Default Credentials (ADC) for interactive use, Service Account Key for CI/CD, Workload Identity Federation for GKE/cross-cloud, and GCE Metadata Server for cloud-hosted workloads. Service account impersonation will be supported across all flows.
+
+---
+
+## Design Decisions
+
+### Authentication Flows
+
+| Flow | Use Case | Mechanism |
+|------|----------|-----------|
+| **ADC (Application Default Credentials)** | Interactive CLI use | OAuth 2.0 authorization code + PKCE via browser, with gcloud ADC fallback |
+| **Service Account Key** | CI/CD pipelines, automation | JWT assertion from JSON key file via `GOOGLE_APPLICATION_CREDENTIALS` |
+| **Workload Identity Federation** | GKE, cross-cloud (AWS/Azure/OIDC) | STS token exchange for federated external tokens |
+| **Metadata Server** | GCE, Cloud Run, GKE | Token from `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token` |
+
+**Flow auto-detection priority**: Workload Identity Federation > Metadata Server > Service Account Key > ADC (stored credentials).
+
+**Rationale**: This mirrors the Entra handler's priority pattern (most specific/restricted first) and aligns with Google's own [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) resolution order.
+
+### ADC Strategy
+
+**Decision**: Implement our own OAuth browser flow (authorization code + PKCE) as the primary interactive flow, with automatic fallback to detect existing gcloud ADC credentials from `~/.config/gcloud/application_default_credentials.json`.
+
+**Rationale**:
+- Own OAuth flow gives full control over the experience, token caching, and removes the gcloud CLI dependency
+- gcloud ADC fallback provides a zero-friction onboarding path for users who already have `gcloud auth application-default login` configured
+- This matches how the Entra handler works: its own device code flow is primary, but it could detect Azure CLI credentials as a fallback
+
+**OAuth Flow Details**: Unlike GitHub and Entra (which use device code), GCP's recommended interactive flow for CLI tools is authorization code + PKCE with a local redirect URI:
+
+```
+1. Start local HTTP server on random port (e.g., http://localhost:PORT)
+2. Open browser to https://accounts.google.com/o/oauth2/v2/auth
+   ?client_id=<id>&redirect_uri=http://localhost:PORT
+   &response_type=code&scope=<scopes>
+   &code_challenge=<challenge>&code_challenge_method=S256
+   &access_type=offline
+3. User authenticates in browser, Google redirects to localhost with ?code=<code>
+4. Exchange code for tokens: POST https://oauth2.googleapis.com/token
+5. Receive: { access_token, refresh_token, expires_in, token_type, scope, id_token }
+```
+
+**gcloud ADC Fallback**: When no stored scafctl credentials exist, check for gcloud ADC at:
+- `$CLOUDSDK_CONFIG/application_default_credentials.json` (if `CLOUDSDK_CONFIG` set)
+- `~/.config/gcloud/application_default_credentials.json` (Linux/macOS default)
+- `%APPDATA%/gcloud/application_default_credentials.json` (Windows)
+
+The ADC file contains a refresh token and client ID/secret that can be used to mint access tokens.
+
+### New Flow Constant: `FlowMetadata`
+
+**Decision**: Add `FlowMetadata Flow = "metadata"` to `pkg/auth/handler.go`.
+
+**Rationale**: The GCE Metadata Server flow is semantically distinct from both workload identity federation and service account key:
+- **Workload Identity Federation** exchanges an external OIDC/SAML token for a GCP token via the STS endpoint — an explicit token exchange
+- **Metadata Server** returns a token for the VM's attached service account with no token exchange involved — it's implicit, ambient credential retrieval
+- Users on GCE who also have a service account key in env need `--flow metadata` to force metadata-based auth
+- This matches the existing pattern where Entra distinguishes `--flow workload-identity` from `--flow service-principal`
+
+### OAuth Client ID
+
+**Decision**: Ship with a default public OAuth client ID for interactive (ADC) flow. Allow override via `--client-id` flag and config.
+
+**Rationale**: This matches industry practice:
+- `gcloud` CLI ships with its own client ID
+- `gh` CLI and Azure CLI ship with hardcoded default client IDs
+- Requiring users to create their own OAuth credentials before login creates unacceptable friction
+
+**Setup**: Create a Google Cloud OAuth 2.0 client ID (Desktop application type) for scafctl. The client ID and secret will be hardcoded as defaults in `config.go`. Note: Google's Desktop OAuth clients have a "secret" that is [not actually confidential](https://developers.google.com/identity/protocols/oauth2/native-app) and is expected to be embedded in distributed applications.
+
+### Default Scopes
+
+**Decision**: Default to `openid`, `email`, `profile`, and `https://www.googleapis.com/auth/cloud-platform`.
+
+| Scope | Purpose |
+|-------|---------|
+| `openid` | OpenID Connect, enables ID token for claims extraction |
+| `email` | Access user's email address for claims |
+| `profile` | Access user's name for claims |
+| `https://www.googleapis.com/auth/cloud-platform` | Full access to GCP APIs (standard for CLI tools) |
+
+**Rationale**: `gcloud` requests `cloud-platform` scope by default, giving broad API access. The OIDC scopes (`openid`, `email`, `profile`) are needed to populate `auth.Claims` from the ID token. Users can override via `--scope` at login time.
+
+### Service Account Impersonation
+
+**Decision**: Include in v1.
+
+Service account impersonation allows any authenticated identity (user, service account, workload identity) to generate short-lived tokens for a target service account via the [IAM Credentials API](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken).
+
+**Use cases**:
+- Developer uses their own identity but needs to act as a service account for specific API calls
+- CI/CD pipeline's SA impersonates a more privileged SA for specific operations
+- Cross-project access where the calling identity impersonates an SA in the target project
+
+**Mechanism**:
+```
+1. Acquire source token (from any flow: ADC, SA key, WI, metadata)
+2. POST https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<target>:generateAccessToken
+   Authorization: Bearer <source_token>
+   Body: { scope: [...], lifetime: "3600s" }
+3. Response: { accessToken, expireTime }
+```
+
+**CLI UX**:
+```bash
+scafctl auth login gcp --impersonate-service-account deploy@my-project.iam.gserviceaccount.com
+scafctl auth token gcp --scope https://www.googleapis.com/auth/cloud-platform
+# → returns a token for deploy@my-project.iam.gserviceaccount.com
+```
+
+The impersonation target is stored in metadata so subsequent `token` and `InjectAuth` calls automatically impersonate without re-specifying.
+
+### Token Storage
+
+**Decision**: Follow the Entra/GitHub pattern — refresh tokens and metadata in `secrets.Store`, access tokens cached per scope.
+
+**Rationale**: The `secrets.Store` abstraction with OS keychain backing is already proven. GCP refresh tokens (from ADC flow) are long-lived and need secure persistent storage. Access tokens from all flows are cached for performance.
+
+### Capabilities
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| `scopes_on_login` | Yes | Scopes specified during OAuth consent |
+| `scopes_on_token_request` | Yes | Can request different scopes per token via impersonation or scope-limited token exchange |
+| `tenant_id` | No | GCP has no tenant concept |
+| `hostname` | No | Only `googleapis.com` endpoints |
+| `federated_token` | Yes | Workload identity federation |
+
+---
+
+## GCP OAuth / Token Endpoints
+
+| Endpoint | URL |
+|----------|-----|
+| Authorization | `GET https://accounts.google.com/o/oauth2/v2/auth` |
+| Token exchange | `POST https://oauth2.googleapis.com/token` |
+| Token refresh | `POST https://oauth2.googleapis.com/token` (with `grant_type=refresh_token`) |
+| Token revocation | `POST https://oauth2.googleapis.com/revoke` |
+| Token info | `GET https://oauth2.googleapis.com/tokeninfo?access_token=<token>` |
+| User info (claims) | `GET https://openidconnect.googleapis.com/v1/userinfo` |
+| STS (WI Federation) | `POST https://sts.googleapis.com/v1/token` |
+| IAM Credentials (impersonation) | `POST https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<sa>:generateAccessToken` |
+| Metadata server | `GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token` |
+
+### ADC Flow Sequence (Authorization Code + PKCE)
+
+```
+1. Generate PKCE code_verifier (43-128 char random string)
+   Compute code_challenge = BASE64URL(SHA256(code_verifier))
+
+2. Start local HTTP server on random available port
+
+3. Open browser to:
+   https://accounts.google.com/o/oauth2/v2/auth
+     ?client_id=<id>
+     &redirect_uri=http://localhost:<port>
+     &response_type=code
+     &scope=openid email profile https://www.googleapis.com/auth/cloud-platform
+     &code_challenge=<challenge>
+     &code_challenge_method=S256
+     &access_type=offline
+     &prompt=consent
+
+4. User authenticates in browser → redirect to localhost with ?code=<auth_code>
+
+5. POST https://oauth2.googleapis.com/token
+   Body: code=<auth_code>&client_id=<id>&client_secret=<secret>
+         &redirect_uri=http://localhost:<port>
+         &grant_type=authorization_code&code_verifier=<verifier>
+   Response: {
+     access_token, refresh_token, expires_in, token_type,
+     scope, id_token
+   }
+
+6. Parse ID token (JWT) for claims: sub, email, name
+7. Store refresh token and metadata via secrets.Store
+8. Cache access token
+```
+
+### gcloud ADC Fallback Sequence
+
+```
+1. Check for gcloud ADC file at well-known location
+2. Parse JSON: { client_id, client_secret, refresh_token, type }
+3. If type == "authorized_user":
+   POST https://oauth2.googleapis.com/token
+     Body: client_id=<adc_client_id>&client_secret=<adc_client_secret>
+           &refresh_token=<adc_refresh_token>&grant_type=refresh_token
+4. Response: { access_token, expires_in, token_type, scope, id_token }
+5. Cache access token (do NOT store gcloud's refresh token — it stays in gcloud's file)
+```
+
+### Service Account Key Flow Sequence
+
+```
+1. Read JSON key from $GOOGLE_APPLICATION_CREDENTIALS
+   Parse: { type, project_id, private_key_id, private_key, client_email, client_id, ... }
+
+2. Create JWT assertion:
+   Header: { "alg": "RS256", "typ": "JWT", "kid": "<private_key_id>" }
+   Payload: {
+     "iss": "<client_email>",
+     "sub": "<client_email>",
+     "aud": "https://oauth2.googleapis.com/token",
+     "iat": <now>,
+     "exp": <now + 3600>,
+     "scope": "<requested_scopes>"
+   }
+   Sign with private_key (RSA SHA-256)
+
+3. POST https://oauth2.googleapis.com/token
+   Body: grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<signed_jwt>
+   Response: { access_token, expires_in, token_type }
+
+4. Cache access token
+```
+
+### Workload Identity Federation Sequence
+
+```
+1. Read external credential config from $GOOGLE_EXTERNAL_ACCOUNT or detect GKE projected token
+   Config contains: { type, audience, subject_token_type, token_url, credential_source }
+
+2. Read subject token from credential_source (file, URL, or environment variable)
+
+3. POST https://sts.googleapis.com/v1/token
+   Body: {
+     grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+     audience: "<workload_identity_pool_provider>",
+     scope: "https://www.googleapis.com/auth/cloud-platform",
+     requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+     subject_token_type: "<type from config>",
+     subject_token: "<external_token>"
+   }
+   Response: { access_token, issued_token_type, token_type, expires_in }
+
+4. (Optional) If impersonation configured, exchange STS token for SA token:
+   POST iamcredentials.googleapis.com/.../generateAccessToken
+
+5. Cache access token
+```
+
+### Metadata Server Flow Sequence
+
+```
+1. GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+   Header: Metadata-Flavor: Google
+   Response: { access_token, expires_in, token_type }
+
+2. (Optional) GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
+   Header: Metadata-Flavor: Google
+   Response: <service-account-email>
+
+3. Cache access token
+```
+
+---
+
+## File Structure
+
+```
+pkg/auth/gcp/
+├── handler.go              # Main handler implementing auth.Handler, flow routing, impersonation
+├── handler_test.go         # Handler-level tests
+├── config.go               # Config struct, defaults, validation
+├── config_test.go
+├── adc_flow.go             # Browser OAuth (authorization code + PKCE), local redirect server
+├── adc_flow_test.go
+├── gcloud_adc.go           # Detect/load existing gcloud ADC credentials
+├── gcloud_adc_test.go
+├── service_account.go      # Service account key JWT assertion flow
+├── service_account_test.go
+├── workload_identity.go    # STS token exchange for federated tokens
+├── workload_identity_test.go
+├── metadata.go             # GCE metadata server token acquisition
+├── metadata_test.go
+├── impersonation.go        # SA impersonation via IAM Credentials API
+├── impersonation_test.go
+├── token.go                # TokenMetadata, credentials storage, claims extraction, JWT helpers
+├── token_test.go
+├── cache.go                # Token caching (reuse Entra/GitHub pattern)
+├── cache_test.go
+├── http.go                 # HTTP client interface for testability
+├── http_test.go
+└── mock.go                 # Test mocks (MockHTTPClient)
+```
+
+---
+
+## Implementation Tasks
+
+### Phase 1: Core Handler Skeleton (Tasks 1-3)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 1 | Create handler skeleton | `config.go`, `handler.go` | `Config` struct with defaults (client ID, scopes), `Handler` struct implementing `auth.Handler` interface, `New()` constructor with functional options pattern (`WithConfig`, `WithSecretStore`, `WithHTTPClient`) |
+| 2 | Implement HTTP client abstraction | `http.go`, `mock.go` | Testable `HTTPClient` interface with `PostForm`, `Get`, `Do` methods. `DefaultHTTPClient` with 30s timeout. `MockHTTPClient` with request recording and response queue |
+| 3 | Implement token cache | `cache.go`, `token.go` | Disk-based token caching via `secrets.Store` with `scafctl.auth.gcp.token.<base64url(scope)>` naming. `TokenMetadata` struct. Generic `getCachedOrAcquireToken` helper for cache-check → acquire → cache pattern |
+
+### Phase 2: Authentication Flows (Tasks 4-7)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 4 | Implement Service Account Key flow | `service_account.go` | Read JSON key from `GOOGLE_APPLICATION_CREDENTIALS`, create JWT assertion (RS256), exchange for access token. `HasServiceAccountCredentials()` detection. Uses `getCachedOrAcquireToken` |
+| 5 | Implement Metadata Server flow | `metadata.go` | GET token from `http://metadata.google.internal/...` with `Metadata-Flavor: Google` header. Probe-based detection (HEAD request with short timeout). `GCE_METADATA_HOST` override for testing. Uses `getCachedOrAcquireToken` |
+| 6 | Implement Workload Identity Federation flow | `workload_identity.go` | Read external credential config from `GOOGLE_EXTERNAL_ACCOUNT` or detect GKE projected token. STS token exchange via `sts.googleapis.com/v1/token`. Uses `getCachedOrAcquireToken` |
+| 7 | Implement ADC (browser OAuth) flow | `adc_flow.go`, `gcloud_adc.go` | Authorization code + PKCE with local redirect server. PKCE code verifier/challenge generation. Browser launch via `open`/`xdg-open`. gcloud ADC file detection and refresh token extraction as fallback. ID token (JWT) parsing for claims |
+
+### Phase 3: Impersonation (Task 8)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 8 | Implement service account impersonation | `impersonation.go` | POST to `iamcredentials.googleapis.com/.../generateAccessToken`. Wraps any source token. Separate cache keys for impersonated tokens. Store impersonation target in `TokenMetadata` |
+
+### Phase 4: CLI Wiring (Tasks 9-14)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 9 | Add `FlowMetadata` flow constant | `pkg/auth/handler.go` | Add `FlowMetadata Flow = "metadata"` constant |
+| 10 | Add GCP config to global config | `pkg/config/types.go` | Add `GCP *GCPAuthConfig` to `GlobalAuthConfig` with `ClientID`, `ClientSecret`, `DefaultScopes`, `ImpersonateServiceAccount` fields |
+| 11 | Wire into root command | `pkg/cmd/scafctl/root.go` | Instantiate and register GCP handler alongside Entra and GitHub |
+| 12 | Wire into run command | `pkg/cmd/scafctl/run/common.go` | Register GCP handler for provider auth injection |
+| 13 | Wire into CLI auth commands | `pkg/cmd/scafctl/auth/handler.go` | Add `"gcp"` to `SupportedHandlers()`, add `getGCPHandler()` and `getGCPHandlerWithOverrides()` |
+| 14 | Update login command | `pkg/cmd/scafctl/auth/login.go` | Route `gcp` handler, add `--impersonate-service-account` flag, handle `parseFlow()` for `metadata`, update help text and examples |
+
+### Phase 5: Testing (Tasks 15-16)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 15 | Write unit tests | `pkg/auth/gcp/*_test.go` | Mock HTTP for all flows, test cache, test claims extraction, test JWT assertion creation, test PKCE generation, test config validation, test impersonation chaining, test flow auto-detection priority |
+| 16 | Write CLI integration tests | `tests/integration/cli_test.go` | Add `auth login gcp`, `auth status`, `auth logout gcp`, `auth token gcp` test cases |
+
+### Phase 6: Documentation (Tasks 17-19)
+
+| # | Task | Files | Description |
+|---|------|-------|-------------|
+| 17 | Update auth design doc | `docs/design/auth.md` | Mark `gcp` as implemented in handler table, add GCP-specific sections for all four flows, impersonation, and environment variables |
+| 18 | Create auth tutorial | `docs/tutorials/gcp-auth-tutorial.md` | Step-by-step guide covering ADC login, service account key, workload identity, metadata server, impersonation, and token debugging |
+| 19 | Add examples | `examples/` | Example configs using `authProvider: gcp`, impersonation examples |
+
+---
+
+## Configuration
+
+### Config Struct
+
+```go
+type Config struct {
+    // ClientID is the OAuth 2.0 client ID for the ADC browser flow.
+    ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+
+    // ClientSecret is the OAuth 2.0 client secret (not confidential for desktop apps).
+    ClientSecret string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+
+    // DefaultScopes are the default OAuth scopes requested during login.
+    DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty"`
+
+    // ImpersonateServiceAccount is the target service account email for impersonation.
+    // When set, all token requests will impersonate this service account.
+    ImpersonateServiceAccount string `json:"impersonateServiceAccount,omitempty" yaml:"impersonateServiceAccount,omitempty"`
+
+    // Project is the default GCP project (informational, not used for auth).
+    Project string `json:"project,omitempty" yaml:"project,omitempty"`
+}
+```
+
+### Defaults
+
+```go
+func DefaultConfig() *Config {
+    return &Config{
+        ClientID:      "<scafctl-registered-client-id>",
+        ClientSecret:  "<scafctl-registered-client-secret>",
+        DefaultScopes: []string{
+            "openid",
+            "email",
+            "profile",
+            "https://www.googleapis.com/auth/cloud-platform",
+        },
+    }
+}
+```
+
+### Global Config Addition
+
+```go
+type GlobalAuthConfig struct {
+    Entra  *EntraAuthConfig  `json:"entra,omitempty" ...`
+    GitHub *GitHubAuthConfig `json:"github,omitempty" ...`
+    GCP    *GCPAuthConfig    `json:"gcp,omitempty" ...`
+}
+
+type GCPAuthConfig struct {
+    ClientID                  string   `json:"clientId,omitempty" yaml:"clientId,omitempty" doc:"OAuth 2.0 client ID for interactive authentication" example:"123456789.apps.googleusercontent.com"`
+    ClientSecret              string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty" doc:"OAuth 2.0 client secret (not confidential for desktop apps)"`
+    DefaultScopes             []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" doc:"Default OAuth scopes for GCP authentication" maxItems:"20"`
+    ImpersonateServiceAccount string   `json:"impersonateServiceAccount,omitempty" yaml:"impersonateServiceAccount,omitempty" doc:"Service account email to impersonate" example:"deploy@my-project.iam.gserviceaccount.com"`
+    Project                   string   `json:"project,omitempty" yaml:"project,omitempty" doc:"Default GCP project ID" example:"my-project-123"`
+}
+```
+
+---
+
+## Secret Naming Convention
+
+Following the established pattern from the Entra and GitHub handlers:
+
+```
+scafctl.auth.gcp.<type>
+```
+
+| Secret Name | Description |
+|-------------|-------------|
+| `scafctl.auth.gcp.refresh_token` | OAuth refresh token (from ADC browser flow) |
+| `scafctl.auth.gcp.metadata` | Token metadata (claims, flow type, impersonation target, client ID, expiry) |
+| `scafctl.auth.gcp.token.<scope-hash>` | Cached access tokens by scope (base64url-encoded scope string) |
+
+### TokenMetadata Struct
+
+```go
+type TokenMetadata struct {
+    Claims                    *auth.Claims  `json:"claims"`
+    RefreshTokenExpiresAt     time.Time     `json:"refreshTokenExpiresAt,omitempty"`
+    Flow                      auth.Flow     `json:"flow"`
+    ClientID                  string        `json:"clientId,omitempty"`
+    Project                   string        `json:"project,omitempty"`
+    ImpersonateServiceAccount string        `json:"impersonateServiceAccount,omitempty"`
+    Scopes                    []string      `json:"scopes,omitempty"`
+    ServiceAccountEmail       string        `json:"serviceAccountEmail,omitempty"`
+}
+```
+
+---
+
+## Environment Variables
+
+### Service Account Key Flow
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON key file |
+
+### Workload Identity Federation Flow
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_EXTERNAL_ACCOUNT` | Path to external account credential configuration JSON |
+
+### Metadata Server Flow
+
+| Variable | Description |
+|----------|-------------|
+| `GCE_METADATA_HOST` | Override metadata server host (for testing). Defaults to `metadata.google.internal` |
+
+### ADC gcloud Fallback
+
+| Variable | Description |
+|----------|-------------|
+| `CLOUDSDK_CONFIG` | Custom gcloud config directory. Defaults to `~/.config/gcloud` |
+
+---
+
+## Claims Mapping
+
+### From ID Token (ADC Browser Flow)
+
+GCP ID tokens are standard OIDC JWTs. Claims are extracted the same way as Entra:
+
+| Claims Field | JWT Claim | Example |
+|-------------|-----------|---------|
+| `Issuer` | `iss` | `"https://accounts.google.com"` |
+| `Subject` | `sub` | `"110169484474386276334"` |
+| `Email` | `email` | `"user@example.com"` |
+| `Name` | `name` | `"John Doe"` |
+| `Username` | `email` (before @) | `"user"` |
+| `IssuedAt` | `iat` | `2026-02-17T10:00:00Z` |
+| `ExpiresAt` | `exp` | `2026-02-17T11:00:00Z` |
+
+### From Userinfo Endpoint (Fallback)
+
+When an ID token is unavailable (e.g., gcloud ADC fallback):
+
+| Claims Field | Userinfo Field | Example |
+|-------------|----------------|---------|
+| `Issuer` | `"https://accounts.google.com"` (static) | `"https://accounts.google.com"` |
+| `Subject` | `sub` | `"110169484474386276334"` |
+| `Email` | `email` | `"user@example.com"` |
+| `Name` | `name` | `"John Doe"` |
+| `Username` | `email` (before @) | `"user"` |
+
+### From Service Account Key
+
+| Claims Field | JSON Key Field | Example |
+|-------------|----------------|---------|
+| `Issuer` | `"https://accounts.google.com"` (static) | `"https://accounts.google.com"` |
+| `Subject` | `client_email` | `"my-sa@my-project.iam.gserviceaccount.com"` |
+| `Email` | `client_email` | `"my-sa@my-project.iam.gserviceaccount.com"` |
+| `ClientID` | `client_id` | `"123456789"` |
+| `ObjectID` | `client_id` | `"123456789"` |
+
+### From Metadata Server
+
+| Claims Field | Source | Example |
+|-------------|--------|---------|
+| `Issuer` | `"https://accounts.google.com"` (static) | `"https://accounts.google.com"` |
+| `Subject` | `email` from metadata | `"123-compute@developer.gserviceaccount.com"` |
+| `Email` | `email` from metadata | `"123-compute@developer.gserviceaccount.com"` |
+
+---
+
+## CLI UX
+
+### Login
+
+```bash
+# Interactive login with browser OAuth (default)
+scafctl auth login gcp
+
+# Login with specific scopes
+scafctl auth login gcp --scope https://www.googleapis.com/auth/cloud-platform --scope https://www.googleapis.com/auth/compute
+
+# Login with service account key (auto-detected from env)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+scafctl auth login gcp
+
+# Explicitly specify service account flow
+scafctl auth login gcp --flow service-principal
+
+# Login using GCE metadata server
+scafctl auth login gcp --flow metadata
+
+# Login with workload identity federation
+scafctl auth login gcp --flow workload-identity
+
+# Login with service account impersonation
+scafctl auth login gcp --impersonate-service-account deploy@my-project.iam.gserviceaccount.com
+```
+
+### Status
+
+```bash
+scafctl auth status
+# Handler: gcp
+# Display Name: Google Cloud Platform
+# Status: Authenticated
+# Identity Type: user
+# Email: user@example.com
+# Name: John Doe
+# Scopes: openid, email, profile, https://www.googleapis.com/auth/cloud-platform
+# Impersonating: deploy@my-project.iam.gserviceaccount.com
+
+scafctl auth status gcp -o json
+```
+
+### Token
+
+```bash
+# Get access token for debugging
+scafctl auth token gcp --scope https://www.googleapis.com/auth/cloud-platform
+
+# Get token with minimum validity
+scafctl auth token gcp --scope https://www.googleapis.com/auth/cloud-platform --min-valid-for 5m
+
+# Force refresh (bypass cache)
+scafctl auth token gcp --scope https://www.googleapis.com/auth/cloud-platform --force-refresh
+```
+
+### Logout
+
+```bash
+# Revoke tokens and clear stored credentials
+scafctl auth logout gcp
+```
+
+---
+
+## Service Account Impersonation Details
+
+Impersonation is implemented as a transparent wrapper layer that intercepts all `GetToken` and `InjectAuth` calls:
+
+### Flow
+
+```
+Any source flow (ADC, SA Key, WI, Metadata)
+  → Acquire source access token
+  → POST iamcredentials.googleapis.com/.../generateAccessToken
+    Authorization: Bearer <source_token>
+    Body: {
+      scope: [<requested_scopes>],
+      lifetime: "3600s"
+    }
+  → Response: { accessToken, expireTime }
+  → Return impersonated token to caller
+```
+
+### Caching
+
+Impersonated tokens are cached with a distinct key pattern to avoid conflicts with direct tokens:
+
+```
+scafctl.auth.gcp.token.impersonate.<target-sa-hash>.<scope-hash>
+```
+
+### Claims for Impersonated Identity
+
+When impersonation is active, `Status()` shows both the source identity and the impersonated identity:
+
+| Field | Value |
+|-------|-------|
+| `IdentityType` | Source identity type (e.g., `user`) |
+| `Email` | Source email (from source token claims) |
+| `ClientID` | Impersonated SA email |
+
+### IAM Permissions Required
+
+The source identity must have `roles/iam.serviceAccountTokenCreator` on the target service account.
+
+---
+
+## Token Revocation (Logout)
+
+Unlike Entra and GitHub, GCP supports explicit token revocation:
+
+```
+POST https://oauth2.googleapis.com/revoke?token=<refresh_token>
+Content-Type: application/x-www-form-urlencoded
+```
+
+The `Logout()` method will:
+1. Revoke the refresh token (if stored, ADC flow only)
+2. Clear all cached access tokens matching `scafctl.auth.gcp.token.*`
+3. Clear metadata from `scafctl.auth.gcp.metadata`
+
+For SA key and metadata server flows, logout only clears cached tokens (no refresh token to revoke).
+
+---
+
+## Error Handling
+
+| Error | Condition | User Message |
+|-------|-----------|-------------|
+| `ErrNotAuthenticated` | No stored credentials, no env vars, no metadata server | `not authenticated: please run 'scafctl auth login gcp'` |
+| `ErrTokenExpired` | Refresh token expired / revoked | `credentials expired: please run 'scafctl auth login gcp'` |
+| `ErrFlowNotSupported` | Invalid flow for GCP | `flow "<flow>" is not supported by the gcp handler` |
+| `ErrTimeout` | Browser OAuth timed out (user didn't complete) | `authentication timed out: no response received from browser` |
+| `ErrUserCancelled` | User closed browser / cancelled | `authentication cancelled by user` |
+| `ErrInvalidScope` | Scope not available for handler | Per-request scopes only available with impersonation or STS |
+| API error | GCP returns 401/403 | `authentication failed: <GCP error message>` |
+| Metadata unavailable | Not running on GCE / metadata server unreachable | `metadata server not available: not running on Google Cloud?` |
+| Impersonation denied | Missing `serviceAccountTokenCreator` role | `impersonation denied: ensure source identity has roles/iam.serviceAccountTokenCreator on <target>` |
+
+---
+
+## Differences from Entra and GitHub Handlers
+
+| Aspect | Entra | GitHub | GCP |
+|--------|-------|--------|-----|
+| **Interactive flow** | Device code | Device code | Authorization code + PKCE (browser redirect) |
+| **CI/CD flow** | Service principal (client_credentials) | PAT (env var) | Service account key (JWT assertion) |
+| **Workload identity** | Federated token (client_assertion) | — | STS token exchange |
+| **Cloud-native ambient** | — | — | Metadata server (new `FlowMetadata`) |
+| **Token revocation** | Not supported | Not supported | Supported (explicit revoke endpoint) |
+| **Claims extraction** | JWT ID token parsing | `/user` API call | JWT ID token parsing OR `/userinfo` API |
+| **Impersonation** | — | — | SA impersonation via IAM Credentials API |
+| **Client secret** | Not needed (public client) | Not needed (public client) | Needed but not confidential (desktop app) |
+| **Scopes per request** | Yes (resource-based) | No (fixed at login) | Yes (scope-based + impersonation) |
+
+---
+
+## Dependencies
+
+### No New External Dependencies (Preferred)
+
+Following the Entra handler's approach of manual OAuth implementation with raw `net/http`:
+
+- JWT assertion signing: use Go stdlib `crypto/rsa`, `crypto/x509`, `encoding/pem`
+- PKCE: use Go stdlib `crypto/sha256`, `crypto/rand`, `encoding/base64`
+- Browser launch: use `os/exec` with `open` (macOS), `xdg-open` (Linux), `rundll32` (Windows)
+- Local HTTP server: use Go stdlib `net/http`
+
+This keeps the zero-external-dependency pattern established by the Entra handler.
+
+### If Dependencies Are Acceptable (Alternative)
+
+- `golang.org/x/oauth2/google` — provides ADC resolution, JWT config, and service account auth
+- This would significantly reduce implementation effort but break the zero-dependency pattern
+
+**Recommendation**: Stay with manual implementation for consistency with the existing handlers.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Mock HTTP)
+
+Every flow will be tested with `MockHTTPClient` + `secrets.MockStore`:
+
+- **ADC flow**: Mock OAuth endpoints, test PKCE generation, test local redirect server, test gcloud ADC file parsing
+- **Service account flow**: Test JWT assertion generation (verify header, payload, signature), test token exchange
+- **Workload identity flow**: Test STS token exchange, test credential config parsing, test projected token file reading
+- **Metadata server flow**: Test token acquisition, test metadata server detection (probe), test `GCE_METADATA_HOST` override
+- **Impersonation**: Test impersonation wrapping for all flows, test cache key separation, test IAM API error handling
+- **Token cache**: Test scope-based caching, test expiry checking, test `MinValidFor`, test `ForceRefresh` bypass
+- **Config**: Test defaults, test validation, test overrides
+- **Flow auto-detection**: Test priority ordering with various env var combinations
+
+### Integration Tests (httptest.Server)
+
+`httptest.Server`-based tests simulating real GCP endpoints (same pattern as Entra handler).
+
+### CLI Integration Tests
+
+Non-destructive tests in `tests/integration/cli_test.go`:
+- `TestIntegration_AuthStatusGCP` — runs `auth status gcp`, checks it doesn't crash
+- `TestIntegration_AuthLogoutGCPNotLoggedIn` — runs `auth logout gcp` when not logged in
+- `TestIntegration_AuthLoginGCPHelp` — runs `auth login gcp --help`, verifies flags
+
+---
+
+## Suggested Implementation Order
+
+1. **Phase 1 (Tasks 1-3)**: Core skeleton — handler, HTTP client, cache. All subsequent phases depend on this.
+2. **Phase 2 (Tasks 4-7)**: Authentication flows. Start with Service Account Key (simplest, easiest to test with mock JWT), then Metadata Server (simple HTTP GET), then Workload Identity (STS exchange), then ADC (most complex due to browser + PKCE).
+3. **Phase 3 (Task 8)**: Impersonation — wraps the flows from Phase 2.
+4. **Phase 4 (Tasks 9-14)**: CLI wiring — connects everything to the CLI commands.
+5. **Phase 5 (Tasks 15-16)**: Testing — unit tests should be written alongside each phase, but dedicated test hardening goes here.
+6. **Phase 6 (Tasks 17-19)**: Documentation and examples.
+
+---
+
+## Estimated Effort
+
+| Phase | Files | Estimated LOC (prod) | Estimated LOC (test) |
+|-------|-------|---------------------|---------------------|
+| Phase 1: Core skeleton | 5 | ~400 | ~300 |
+| Phase 2: Auth flows | 8 | ~1,200 | ~2,000 |
+| Phase 3: Impersonation | 2 | ~250 | ~400 |
+| Phase 4: CLI wiring | 6 (modified) | ~200 | ~100 |
+| Phase 5: Testing | — | — | ~500 (hardening) |
+| Phase 6: Documentation | 3 | ~300 (docs) | — |
+| **Total** | **~24 files** | **~2,350** | **~3,300** |
+
+This is comparable to the Entra handler (~1,500 LOC prod, ~3,500 LOC test) plus the impersonation layer.
+
+---
+
+## References
+
+- [Google OAuth 2.0 for Desktop Apps](https://developers.google.com/identity/protocols/oauth2/native-app)
+- [Google OAuth 2.0 PKCE](https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server)
+- [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+- [Service Account Key Auth](https://cloud.google.com/iam/docs/keys-create-delete)
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [GCE Metadata Server](https://cloud.google.com/compute/docs/metadata/overview)
+- [IAM Credentials API (Impersonation)](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken)
+- [Token Revocation](https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke)
+- [Google OpenID Connect](https://developers.google.com/identity/openid-connect/openid-connect)
+- [Entra Handler (reference implementation)](../../pkg/auth/entra/)
+- [GitHub Handler (reference implementation)](../../pkg/auth/github/)

--- a/docs/design/github-auth-handler.md
+++ b/docs/design/github-auth-handler.md
@@ -37,14 +37,22 @@ Requiring users to register their own OAuth App before login creates unacceptabl
 
 ### Default Scopes
 
-**Decision**: Default to `repo` and `read:user`.
+**Decision**: Default to `gist`, `read:org`, `repo`, and `workflow` (matching the `gh` CLI).
 
 | Scope | Purpose |
-|-------|---------|
-| `read:user` | Verify identity, populate claims (username, email, name) |
+|-------|--------|
+| `gist` | Create and manage gists |
+| `read:org` | Read organization membership and teams |
 | `repo` | Access repositories (catalog, solutions, templates) |
+| `workflow` | Update GitHub Actions workflows |
 
-**Rationale**: `gh` CLI requests `repo`, `read:org`, `gist`, `workflow` by default but that's broader than needed. `repo` + `read:user` covers the primary use cases. Users can add more via `--scope` at login time.
+**Rationale**: Matching the `gh` CLI defaults ensures a consistent experience and avoids permission gaps when using scafctl alongside `gh`. Users can customize via `--scope` at login time.
+
+> **Note:** GitHub's OAuth token refresh endpoint does not accept a `scope`
+> parameter — scopes are fixed at login time. The GitHub handler therefore
+> declares `CapScopesOnLogin` but NOT `CapScopesOnTokenRequest`. Running
+> `scafctl auth token github --scope ...` will return an error. See the
+> [auth design doc](auth.md#handler-capabilities) for more on capabilities.
 
 ### Token Storage
 
@@ -79,7 +87,7 @@ All endpoints accept and return JSON when `Accept: application/json` is set.
 
 ```
 1. POST /login/device/code
-   Body: client_id=<id>&scope=repo read:user
+   Body: client_id=<id>&scope=gist read:org repo workflow
    Response: { device_code, user_code, verification_uri, expires_in, interval }
 
 2. Display: "Enter code ABCD-1234 at https://github.com/login/device"
@@ -131,41 +139,43 @@ pkg/auth/github/
 
 ## Implementation Tasks
 
-### Phase 1: Core Handler (Tasks 1-6)
+> **Status**: All phases complete. Implementation merged.
 
-| # | Task | Files | Description |
-|---|------|-------|-------------|
-| 1 | Create handler skeleton | `config.go`, `handler.go` | `Config` struct with defaults, `Handler` struct implementing `auth.Handler` interface, `New()` constructor with options pattern |
-| 2 | Implement HTTP client abstraction | `http.go` | Testable `HTTPClient` interface matching Entra pattern |
-| 3 | Implement device code flow | `device_flow.go` | Request device code, poll for token, handle `slow_down`/`authorization_pending`/`expired_token` errors |
-| 4 | Implement PAT flow | `pat.go` | Read `GITHUB_TOKEN`/`GH_TOKEN` from env, validate via API, detect credentials |
-| 5 | Implement token cache | `cache.go`, `token.go` | Disk-based token caching with `scafctl.auth.github.token.<scope-hash>` naming, refresh token support |
-| 6 | Implement claims extraction | `claims.go` | Call `/user` endpoint, map to `auth.Claims` (Subject=login, Email, Name, ObjectID=user ID) |
+### Phase 1: Core Handler (Tasks 1-6) — ✅ Complete
 
-### Phase 2: Wiring (Tasks 7-11)
+| # | Task | Files | Status |
+|---|------|-------|--------|
+| 1 | Create handler skeleton | `config.go`, `handler.go` | ✅ |
+| 2 | Implement HTTP client abstraction | `http.go` | ✅ |
+| 3 | Implement device code flow | `device_flow.go` | ✅ |
+| 4 | Implement PAT flow | `pat.go` | ✅ |
+| 5 | Implement token cache | `cache.go`, `token.go` | ✅ |
+| 6 | Implement claims extraction | `claims.go` | ✅ |
 
-| # | Task | Files | Description |
-|---|------|-------|-------------|
-| 7 | Add `FlowPAT` flow constant | `pkg/auth/handler.go` | Add `FlowPAT Flow = "pat"` |
-| 8 | Add GitHub config to global config | `pkg/config/types.go` | Add `GitHub *GitHubAuthConfig` to `GlobalAuthConfig` |
-| 9 | Wire into root command | `pkg/cmd/scafctl/root.go` | Instantiate and register GitHub handler alongside Entra |
-| 10 | Wire into CLI auth commands | `pkg/cmd/scafctl/auth/handler.go` | Add `"github"` to `SupportedHandlers()`, add `getGitHubHandler()` |
-| 11 | Update login command | `pkg/cmd/scafctl/auth/login.go` | Route `github` handler, add `--hostname` flag, update help text and examples |
+### Phase 2: Wiring (Tasks 7-11) — ✅ Complete
 
-### Phase 3: Testing (Tasks 12-13)
+| # | Task | Files | Status |
+|---|------|-------|--------|
+| 7 | Add `FlowPAT` flow constant | `pkg/auth/handler.go` | ✅ |
+| 8 | Add GitHub config to global config | `pkg/config/types.go` | ✅ |
+| 9 | Wire into root command | `pkg/cmd/scafctl/root.go` | ✅ |
+| 10 | Wire into CLI auth commands | `pkg/cmd/scafctl/auth/handler.go` | ✅ |
+| 11 | Update login command | `pkg/cmd/scafctl/auth/login.go` | ✅ |
 
-| # | Task | Files | Description |
-|---|------|-------|-------------|
-| 12 | Write unit tests | `pkg/auth/github/*_test.go` | Mock HTTP for all flows, test cache, test claims, test config validation |
-| 13 | Write CLI integration tests | `tests/integration/cli_test.go` | Add `auth login github`, `auth status`, `auth logout github` |
+### Phase 3: Testing (Tasks 12-13) — ✅ Complete
 
-### Phase 4: Documentation (Tasks 14-16)
+| # | Task | Files | Status |
+|---|------|-------|--------|
+| 12 | Write unit tests | `pkg/auth/github/*_test.go` | ✅ (31 tests) |
+| 13 | Write CLI integration tests | `tests/integration/cli_test.go` | ✅ |
 
-| # | Task | Files | Description |
-|---|------|-------|-------------|
-| 14 | Update auth design doc | `docs/design/auth.md` | Update handler table (mark `github` as implemented), add GitHub-specific sections |
-| 15 | Create auth tutorial | `docs/tutorials/github-auth-tutorial.md` | Step-by-step guide for GitHub authentication |
-| 16 | Add examples | `examples/` | Example configs using `authProvider: github` |
+### Phase 4: Documentation (Tasks 14-16) — ✅ Complete
+
+| # | Task | Files | Status |
+|---|------|-------|--------|
+| 14 | Update auth design doc | `docs/design/auth.md` | ✅ |
+| 15 | Update auth tutorial | `docs/tutorials/auth-tutorial.md` | ✅ |
+| 16 | Add examples | `examples/` | ✅ |
 
 ---
 
@@ -188,7 +198,7 @@ func DefaultConfig() *Config {
     return &Config{
         ClientID:      "Ov23li6xn492GhPmt4YG",
         Hostname:      "github.com",
-        DefaultScopes: []string{"repo", "read:user"},
+        DefaultScopes: []string{"gist", "read:org", "repo", "workflow"},
     }
 }
 ```
@@ -287,7 +297,7 @@ scafctl auth status
 # Status: Authenticated
 # Identity: octocat
 # Hostname: github.com
-# Scopes: repo, read:user
+# Scopes: gist, read:org, repo, workflow
 ```
 
 ### Token
@@ -317,9 +327,9 @@ scafctl auth logout github
 
 ---
 
-## Suggested Implementation Order
+## Implementation Order (Completed)
 
-Start with **Phase 1 (tasks 1-6)** since they're the core and self-contained. Tasks 1-2 are prerequisites; tasks 3-6 can progress in parallel after that. Then **Phase 2 (tasks 7-11)** for wiring, **Phase 3 (tasks 12-13)** for tests, and **Phase 4 (tasks 14-16)** for docs.
+All phases were implemented in order: **Phase 1 (core handler)** → **Phase 2 (CLI wiring)** → **Phase 3 (testing)** → **Phase 4 (docs & examples)**.
 
 ---
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -5,21 +5,24 @@ weight: 40
 
 # Authentication Tutorial
 
-This tutorial walks you through setting up and using authentication in scafctl. You'll learn how to authenticate with Microsoft Entra ID, manage credentials, and use authenticated HTTP requests in your solutions.
+This tutorial walks you through setting up and using authentication in scafctl. You'll learn how to authenticate with Microsoft Entra ID and GitHub, manage credentials, and use authenticated HTTP requests in your solutions.
 
 ## Prerequisites
 
 - scafctl installed and available in your PATH
-- Access to a Microsoft Entra ID tenant
+- For Entra: Access to a Microsoft Entra ID tenant
+- For GitHub: A GitHub account (or GitHub Enterprise Server instance)
 - A web browser for completing the device code flow
 
 ## Table of Contents
 
 1. [Understanding Auth in scafctl](#understanding-auth-in-scafctl)
 2. [Logging In](#logging-in)
-   - [Device Code Flow](#example-output)
-   - [Service Principal](#service-principal-authentication-cicd)
-   - [Workload Identity](#workload-identity-authentication-kubernetes)
+   - [Entra Device Code Flow](#example-output)
+   - [Entra Service Principal](#service-principal-authentication-cicd)
+   - [Entra Workload Identity](#workload-identity-authentication-kubernetes)
+   - [GitHub Device Code Flow](#github-device-code-flow)
+   - [GitHub PAT Flow](#github-pat-authentication-cicd)
 3. [Checking Auth Status](#checking-auth-status)
 4. [Using Auth in HTTP Providers](#using-auth-in-http-providers)
 5. [Getting Tokens for Debugging](#getting-tokens-for-debugging)
@@ -45,6 +48,17 @@ scafctl currently supports the following auth handlers:
 | Handler | Description | Flows |
 |---------|-------------|-------|
 | `entra` | Microsoft Entra ID (Azure AD) | Device Code, Service Principal, Workload Identity |
+| `github` | GitHub (github.com and GHES) | Device Code, PAT (Personal Access Token) |
+
+You can always discover registered handlers and their capabilities at runtime:
+
+```bash
+# List all handlers with flows and capabilities
+scafctl auth list
+
+# Output as JSON for scripting
+scafctl auth list -o json
+```
 
 ---
 
@@ -428,6 +442,115 @@ curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_ur
 
 ---
 
+## GitHub Device Code Flow
+
+To authenticate with GitHub, use the `auth login` command:
+
+```bash
+scafctl auth login github
+```
+
+This initiates a device code flow:
+
+1. scafctl displays a code and URL
+2. Open the URL in your browser
+3. Enter the code when prompted
+4. Authorize the scafctl OAuth App
+5. scafctl stores your credentials securely
+
+### Example Output
+
+```
+To sign in, use a web browser to open the page:
+  https://github.com/login/device
+
+Enter the code: ABCD-1234
+
+Waiting for authentication...
+
+✓ Authentication successful!
+  Name:     The Octocat
+  Username: octocat
+  Email:    octocat@github.com
+  Flow:     Device Code
+```
+
+### GitHub Enterprise Server
+
+To authenticate with a GitHub Enterprise Server instance:
+
+```bash
+scafctl auth login github --hostname github.example.com
+```
+
+This adjusts all OAuth and API endpoints to use your GHES instance.
+
+### Custom Client ID
+
+By default, scafctl uses its own OAuth App client ID (`Ov23li6xn492GhPmt4YG`). If your organization requires a custom OAuth App:
+
+```bash
+scafctl auth login github --client-id your-custom-client-id
+```
+
+### Requesting Specific Scopes
+
+By default, login requests `gist`, `read:org`, `repo`, and `workflow` scopes (matching the `gh` CLI). To request different scopes:
+
+```bash
+# Login with additional scopes
+scafctl auth login github --scope repo --scope read:org --scope write:packages
+
+# Or comma-separated
+scafctl auth login github --scope "repo,read:org,write:packages"
+```
+
+> **Important:** GitHub scopes are fixed at login time. Unlike Entra ID, GitHub's
+> OAuth token refresh does not support changing scopes per-request. The `--scope`
+> flag on `scafctl auth token github` is not supported. If you need different
+> scopes, you must log out and log in again with the desired scopes.
+
+### Setting a Timeout
+
+The device code flow has a 5-minute default timeout. To extend it:
+
+```bash
+scafctl auth login github --timeout 10m
+```
+
+---
+
+## GitHub PAT Authentication (CI/CD)
+
+For non-interactive scenarios like CI/CD pipelines, use a Personal Access Token:
+
+```bash
+# Set token in environment (GITHUB_TOKEN takes precedence)
+export GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Login with PAT (auto-detected from env vars)
+scafctl auth login github
+
+# Or explicitly specify the flow
+scafctl auth login github --flow pat
+```
+
+**Environment Variables:**
+
+| Variable | Description | Priority |
+|----------|-------------|----------|
+| `GITHUB_TOKEN` | GitHub personal access token or Actions token | 1 (highest) |
+| `GH_TOKEN` | GitHub personal access token (gh CLI convention) | 2 |
+| `GH_HOST` | GitHub hostname for Enterprise Server | — |
+
+**Notes:**
+- In GitHub Actions, `GITHUB_TOKEN` is automatically injected
+- When either token env var is set, scafctl automatically uses the PAT flow
+- PATs don't have a defined expiry, so status shows as authenticated until the token is revoked
+- The PAT identity type shows as `service-principal` since it acts like a non-interactive credential
+
+---
+
 ## Checking Auth Status
 
 To see your current authentication status:
@@ -438,6 +561,9 @@ scafctl auth status
 
 # Show status for a specific handler
 scafctl auth status entra
+
+# Show GitHub auth status
+scafctl auth status github
 
 # Output as JSON
 scafctl auth status -o json
@@ -457,11 +583,24 @@ Handler   Status         Identity                          IdentityType        T
 entra     Authenticated  Service Principal (12345678...)   service-principal   tenant-id    12345678-1234-...
 ```
 
+**GitHub Device Code Authentication:**
+```
+Handler   Status         Identity   Username   Hostname      Scopes
+github    Authenticated  octocat    octocat    github.com    gist, read:org, repo, workflow
+```
+
+**GitHub PAT Authentication:**
+```
+Handler   Status         Identity   Username   IdentityType        Scopes
+github    Authenticated  octocat    octocat    service-principal   gist, read:org, repo, workflow
+```
+
 When not authenticated:
 
 ```
 Handler   Status            Identity   Tenant   Expires
 entra     Not Authenticated -          -        -
+github    Not Authenticated -          -        -
 ```
 
 ---
@@ -576,6 +715,51 @@ spec:
               scope: "https://vault.azure.net/.default"
 ```
 
+### GitHub API Example
+
+Use the GitHub auth handler to authenticate API requests. Note that `scope` is not
+needed for GitHub — scopes are fixed at login time:
+
+```yaml
+spec:
+  resolvers:
+    repos:
+      type: object
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://api.github.com/user/repos?per_page=10&sort=updated"
+              method: GET
+              authProvider: github
+```
+
+Run it (requires prior authentication):
+
+```bash
+# Login with GitHub
+scafctl auth login github
+
+# Run the resolver
+scafctl run resolver -f github-repos.yaml -o json --hide-execution
+```
+
+### GitHub Enterprise Server API Example
+
+```yaml
+spec:
+  resolvers:
+    ghesRepos:
+      type: object
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://github.example.com/api/v3/user/repos"
+              method: GET
+              authProvider: github
+```
+
 ---
 
 ## Getting Tokens for Debugging
@@ -583,9 +767,17 @@ spec:
 The `auth token` command retrieves a valid access token for debugging:
 
 ```bash
-# Get a token for Microsoft Graph
+# Get a token for Microsoft Graph (Entra supports per-request scopes)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default"
+
+# Get a GitHub token (uses scopes from login; --scope is not supported)
+scafctl auth token github
 ```
+
+> **Note:** The `--scope` flag is only supported on `auth token` for handlers
+> with the `scopes-on-token-request` capability (e.g., Entra ID). GitHub scopes
+> are fixed at login time — use `scafctl auth login github --scope <scope>` to
+> change them.
 
 ### Example Output
 
@@ -609,14 +801,27 @@ Access tokens are cached to disk (encrypted) and reused if they have sufficient 
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --min-valid-for 5m
 ```
 
+### Force Refresh
+
+If you need a fresh token regardless of cache state (e.g., after permission changes), use `--force-refresh`:
+
+```bash
+# Force acquiring a new token, bypassing the cache
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --force-refresh
+```
+
 ### Using the Token Directly
 
 You can use the token in other tools:
 
 ```bash
-# Use with curl
+# Use with curl (Entra / Microsoft Graph)
 TOKEN=$(scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json | jq -r '.accessToken')
 curl -H "Authorization: Bearer $TOKEN" https://graph.microsoft.com/v1.0/me
+
+# Use with curl (GitHub API)
+TOKEN=$(scafctl auth token github -o json | jq -r '.accessToken')
+curl -H "Authorization: Bearer $TOKEN" https://api.github.com/user/repos
 
 # Use with httpie
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json | \
@@ -670,12 +875,16 @@ If you need to use your own Azure application registration:
 To clear stored credentials:
 
 ```bash
+# Logout from Entra ID
 scafctl auth logout entra
+
+# Logout from GitHub
+scafctl auth logout github
 ```
 
 This removes:
 
-- The stored refresh token
+- The stored refresh token (or access token for GitHub)
 - All cached access tokens
 - Token metadata
 
@@ -698,6 +907,14 @@ not authenticated: please run 'scafctl auth login entra'
 ```
 
 Solution: Run `scafctl auth login entra` to authenticate.
+
+For GitHub:
+
+```
+not authenticated: please run 'scafctl auth login github'
+```
+
+Solution: Run `scafctl auth login github` or set `GITHUB_TOKEN` environment variable.
 
 ### Token Expired
 
@@ -782,9 +999,39 @@ scafctl --log-level -1 run solution -f mysolution.yaml
 
 scafctl uses your system's secret store (Keychain on macOS, Windows Credential Manager, or Secret Service on Linux). If you're having issues:
 
-- **macOS**: Check Keychain Access for `scafctl.auth.entra.*` entries
-- **Windows**: Check Credential Manager for `scafctl.auth.entra.*` entries
+- **macOS**: Check Keychain Access for `scafctl.auth.entra.*` or `scafctl.auth.github.*` entries
+- **Windows**: Check Credential Manager for `scafctl.auth.entra.*` or `scafctl.auth.github.*` entries
 - **Linux**: Ensure `gnome-keyring` or `kwallet` is running
+
+### GitHub: "Bad credentials" Error
+
+If you see a 401 error with "Bad credentials" when using GitHub auth:
+
+1. Your PAT may have expired or been revoked
+2. Generate a new PAT at https://github.com/settings/tokens
+3. Set the new token: `export GITHUB_TOKEN="ghp_..."`
+4. Re-login: `scafctl auth login github`
+
+### GitHub: Insufficient Scopes
+
+If you get 403 (Forbidden) errors on GitHub API calls:
+
+1. Check what scopes your token has: `scafctl auth status github`
+2. GitHub scopes are fixed at login time and cannot be changed per-request. Login again with the required scopes:
+   ```bash
+   scafctl auth logout github
+   scafctl auth login github --scope repo --scope read:org
+   ```
+3. For PATs, ensure the token was created with sufficient scopes
+
+### GitHub Enterprise Server: Connection Issues
+
+If you can't connect to your GHES instance:
+
+1. Verify the hostname is correct: `scafctl auth status github`
+2. Ensure the GHES instance has the device flow enabled
+3. Check network connectivity to the GHES instance
+4. Try with explicit hostname: `scafctl auth login github --hostname github.example.com`
 
 ---
 

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -206,6 +206,10 @@ Override paths with XDG environment variables or SCAFCTL_SECRETS_DIR.
 | `resolver.concurrency` | int | `4` | Max parallel resolver execution |
 | `action.timeout` | duration | `10m` | Overall action timeout |
 | `action.concurrency` | int | `4` | Max parallel action execution |
+| `auth.entra.*` | object | — | Entra (Azure AD) auth handler config |
+| `auth.github.hostname` | string | `github.com` | GitHub hostname (or GHES hostname) |
+| `auth.github.clientId` | string | built-in | OAuth App client ID |
+| `auth.github.defaultScopes` | []string | `[gist, read:org, repo, workflow]` | Default OAuth scopes |
 
 ### Config File Location
 
@@ -276,6 +280,7 @@ scafctl config unset logging.level
 
 ## Next Steps
 
+- [Authentication Tutorial](auth-tutorial.md) — Set up GitHub and Entra authentication
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -540,7 +540,7 @@ HTTP client for API calls.
 | `body` | string | ❌ | Request body |
 | `timeout` | int | ❌ | Timeout in seconds (max 300) |
 | `retry` | object | ❌ | Retry configuration |
-| `auth` | string | ❌ | Auth provider (e.g., `entra`) |
+| `auth` | string | ❌ | Auth provider (e.g., `entra`, `github`) |
 | `scope` | string | ❌ | OAuth scope for authentication |
 
 ### Output
@@ -583,6 +583,17 @@ inputs:
     maxAttempts: 3
     backoff: exponential
     initialDelay: 1s
+
+# Authenticated GitHub API request
+resolve:
+  with:
+    - provider: http
+      inputs:
+        url: https://api.github.com/user/repos
+        headers:
+          Accept: application/json
+        auth: github
+        scope: repo
 ```
 
 ---
@@ -600,7 +611,7 @@ Get authentication identity information without exposing tokens.
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
 | `operation` | string | ✅ | Operation: `status`, `claims`, `list` |
-| `handler` | string | ❌ | Auth handler name (e.g., `entra`) |
+| `handler` | string | ❌ | Auth handler name (e.g., `entra`, `github`) |
 
 ### Output
 
@@ -616,13 +627,21 @@ Get authentication identity information without exposing tokens.
 ### Examples
 
 ```yaml
-# Check if authenticated
+# Check if authenticated (Entra)
 resolve:
   with:
     - provider: identity
       inputs:
         operation: status
         handler: entra
+
+# Check if authenticated (GitHub)
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: status
+        handler: github
 
 # Get claims
 resolve:
@@ -631,6 +650,14 @@ resolve:
       inputs:
         operation: claims
         handler: entra
+
+# Get GitHub claims (login, name, email)
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: claims
+        handler: github
 ```
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,6 +118,7 @@ Complete solutions demonstrating real-world use cases.
 | [bad-solution-yaml/](solutions/bad-solution-yaml/) | Invalid solution demonstrating error handling for conflicting ValueRef keys |
 | [tested-solution/](solutions/tested-solution/) | Functional testing features: assertions, inheritance, tags, watch mode |
 | [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` — generates starter test suites |
+| [github-auth/](solutions/github-auth/) | GitHub authentication — identity, API calls, and status checks |
 
 ---
 

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -240,6 +240,37 @@ action:
   maxConcurrency: 0
 
 # =============================================================================
+# Auth - Authentication handler configuration
+# =============================================================================
+auth:
+  # --- GitHub Auth Handler ---
+  github:
+    # GitHub hostname (default: github.com)
+    # Set to your GitHub Enterprise Server hostname for GHES
+    # Can also be set via GH_HOST environment variable
+    # Default: "github.com"
+    hostname: "github.com"
+
+    # OAuth App client ID
+    # Override the built-in default if you want to use your own OAuth App
+    # Default: "Ov23li6xn492GhPmt4YG" (built-in scafctl OAuth App)
+    # clientId: "your-custom-client-id"
+
+    # Default OAuth scopes requested during login
+    # Users can add more scopes at login time with --scope flags
+    # Default: ["gist", "read:org", "repo", "workflow"]
+    defaultScopes:
+      - gist
+      - read:org
+      - repo
+      - workflow
+
+  # --- Entra (Azure AD) Auth Handler ---
+  # entra:
+  #   tenantId: "your-tenant-id"
+  #   clientId: "your-client-id"
+
+# =============================================================================
 # Catalogs - Registered solution catalogs
 # =============================================================================
 # Catalogs are sources for solutions, resolvers, and actions.

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -8,6 +8,7 @@ Example input files for use with `scafctl run provider --input @<file>`.
 |------|----------|-------------|
 | [static-hello.yaml](static-hello.yaml) | `static` | Simple static string value |
 | [http-get.yaml](http-get.yaml) | `http` | HTTP GET request |
+| [github-api.yaml](github-api.yaml) | `http` | GitHub API call with authentication |
 | [exec-ls.yaml](exec-ls.yaml) | `exec` | Execute `ls -la` command |
 
 ## Usage

--- a/examples/providers/github-api.yaml
+++ b/examples/providers/github-api.yaml
@@ -1,0 +1,13 @@
+# HTTP provider input - GitHub API call with authentication
+#
+# Prerequisites:
+#   - Run `scafctl auth login github` to authenticate first
+#
+# Usage:
+#   scafctl run provider http --input @examples/providers/github-api.yaml
+url: https://api.github.com/user
+method: GET
+headers:
+  Accept: application/json
+auth: github
+scope: "read:user"

--- a/examples/resolvers/identity.yaml
+++ b/examples/resolvers/identity.yaml
@@ -1,7 +1,7 @@
 # Identity Provider Examples
 #
 # Prerequisites:
-#   - Run `scafctl auth login entra` to authenticate first
+#   - Run `scafctl auth login entra` or `scafctl auth login github` to authenticate first
 #
 # Run: scafctl run resolver -f identity.yaml
 
@@ -44,6 +44,17 @@ spec:
             inputs:
               operation: status
               handler: entra
+
+    # Example 3b: Get status from GitHub handler
+    github_status:
+      description: Get status from GitHub handler specifically
+      type: any
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: status
+              handler: github
 
     # Example 4: List all available auth handlers
     available_handlers:

--- a/examples/solutions/github-auth/solution.yaml
+++ b/examples/solutions/github-auth/solution.yaml
@@ -1,0 +1,126 @@
+# GitHub Authentication Examples
+#
+# Demonstrates using GitHub authentication with resolvers and actions.
+# Shows the identity provider with the GitHub handler and authenticated
+# HTTP requests to the GitHub API.
+#
+# Prerequisites:
+#   - Run `scafctl auth login github` to authenticate first
+#
+# Run: scafctl run solution -f examples/solutions/github-auth/solution.yaml
+# Run resolvers only: scafctl run resolver -f examples/solutions/github-auth/solution.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: github-auth-example
+  version: 1.0.0
+  description: GitHub authentication examples - identity, API calls, and status checks
+
+spec:
+  resolvers:
+    # Check GitHub authentication status
+    github_status:
+      description: Get authentication status from the GitHub handler
+      type: any
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: status
+              handler: github
+
+    # Get GitHub user claims (login, name, email, etc.)
+    github_claims:
+      description: Get identity claims from the GitHub handler
+      type: any
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: claims
+              handler: github
+
+    # List all available auth handlers
+    available_handlers:
+      description: List all registered authentication handlers
+      type: any
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: list
+
+    # Fetch authenticated user profile from GitHub API
+    user_profile:
+      description: Fetch the authenticated user profile using the GitHub API
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.github.com/user
+              headers:
+                Accept: application/json
+              auth: github
+              scope: "read:user"
+
+    # Fetch user repositories from GitHub API
+    user_repos:
+      description: Fetch repositories for the authenticated user
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.github.com/user/repos?per_page=5&sort=updated
+              headers:
+                Accept: application/json
+              auth: github
+              scope: repo
+
+    # Extract username from claims
+    username:
+      description: Extract the GitHub username from claims
+      type: string
+      dependsOn:
+        - github_claims
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                has(_.github_claims.claims) && has(_.github_claims.claims.username)
+                  ? _.github_claims.claims.username
+                  : "unknown"
+
+    # Extract repo names from API response
+    repo_names:
+      description: Extract repository names from the API response
+      type: any
+      dependsOn:
+        - user_repos
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                has(_.user_repos.body) 
+                  ? fromJson(_.user_repos.body).map(r, r.full_name)
+                  : []
+
+  workflow:
+    actions:
+      show_identity:
+        description: Display authenticated GitHub identity
+        displayName: Show GitHub Identity
+        provider: debug
+        inputs:
+          label: "GitHub Identity"
+          format: yaml
+          expression: |
+            {
+              "username": _.username,
+              "authenticated": _.github_status.authenticated,
+              "repos": _.repo_names
+            }

--- a/pkg/auth/capability.go
+++ b/pkg/auth/capability.go
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+// Capability represents a feature or behavior that an auth handler supports.
+// Capabilities allow CLI commands to dynamically adapt their flags and validation
+// based on what each handler supports, enabling plugin-loaded handlers to work
+// without hardcoded knowledge of their features.
+type Capability string
+
+const (
+	// CapScopesOnLogin indicates the handler supports specifying OAuth scopes at login time.
+	// Both GitHub (device code) and Entra (device code/SP/WI) support this.
+	CapScopesOnLogin Capability = "scopes_on_login"
+
+	// CapScopesOnTokenRequest indicates the handler supports specifying per-request scopes
+	// when acquiring tokens. Entra supports this (different resource scopes per request),
+	// but GitHub does not (scopes are fixed at login time).
+	CapScopesOnTokenRequest Capability = "scopes_on_token_request"
+
+	// CapTenantID indicates the handler supports a tenant ID parameter.
+	// Entra uses this for Azure AD tenant selection.
+	CapTenantID Capability = "tenant_id"
+
+	// CapHostname indicates the handler supports a hostname parameter.
+	// GitHub uses this for GitHub Enterprise Server (GHES) support.
+	CapHostname Capability = "hostname"
+
+	// CapFederatedToken indicates the handler supports federated token input.
+	// Entra uses this for workload identity (Kubernetes) authentication.
+	CapFederatedToken Capability = "federated_token"
+)
+
+// HasCapability checks if a set of capabilities includes the specified capability.
+func HasCapability(capabilities []Capability, capability Capability) bool {
+	for _, c := range capabilities {
+		if c == capability {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/auth/capability_test.go
+++ b/pkg/auth/capability_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasCapability(t *testing.T) {
+	caps := []Capability{CapScopesOnLogin, CapTenantID}
+
+	assert.True(t, HasCapability(caps, CapScopesOnLogin))
+	assert.True(t, HasCapability(caps, CapTenantID))
+	assert.False(t, HasCapability(caps, CapScopesOnTokenRequest))
+	assert.False(t, HasCapability(caps, CapHostname))
+	assert.False(t, HasCapability(caps, CapFederatedToken))
+}
+
+func TestHasCapability_Empty(t *testing.T) {
+	assert.False(t, HasCapability(nil, CapScopesOnLogin))
+	assert.False(t, HasCapability([]Capability{}, CapScopesOnLogin))
+}
+
+func TestCapabilityConstants(t *testing.T) {
+	// Verify capability constants are distinct
+	caps := []Capability{
+		CapScopesOnLogin,
+		CapScopesOnTokenRequest,
+		CapTenantID,
+		CapHostname,
+		CapFederatedToken,
+	}
+
+	seen := make(map[Capability]bool)
+	for _, c := range caps {
+		assert.False(t, seen[c], "duplicate capability: %s", c)
+		seen[c] = true
+	}
+}

--- a/pkg/auth/entra/device_flow.go
+++ b/pkg/auth/entra/device_flow.go
@@ -111,7 +111,7 @@ func (h *Handler) performDeviceCodeFlow(ctx context.Context, opts auth.LoginOpti
 	}
 
 	// Step 4: Store refresh token securely
-	if err := h.storeCredentials(ctx, tenantID, tokenResp, scopes); err != nil {
+	if err := h.storeCredentials(ctx, tenantID, tokenResp, h.config.ClientID, scopes); err != nil {
 		return nil, auth.NewError(HandlerName, "store_credentials", err)
 	}
 

--- a/pkg/auth/entra/handler.go
+++ b/pkg/auth/entra/handler.go
@@ -43,6 +43,7 @@ const (
 type Handler struct {
 	config      *Config
 	secretStore secrets.Store
+	secretErr   error // deferred error from secrets initialization
 	httpClient  HTTPClient
 	tokenCache  *TokenCache
 }
@@ -92,6 +93,10 @@ func WithHTTPClient(client HTTPClient) Option {
 }
 
 // New creates a new Entra auth handler.
+// Secret store initialization is deferred — if it fails, the handler is still
+// created so that metadata operations (Name, SupportedFlows, etc.) work.
+// Operations requiring secrets (Login, Logout, Status, GetToken) will return
+// the deferred error.
 func New(opts ...Option) (*Handler, error) {
 	h := &Handler{
 		config: DefaultConfig(),
@@ -105,9 +110,11 @@ func New(opts ...Option) (*Handler, error) {
 	if h.secretStore == nil {
 		store, err := secrets.New()
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize secrets store: %w", err)
+			// Defer the error — metadata-only operations still work
+			h.secretErr = fmt.Errorf("failed to initialize secrets store: %w", err)
+		} else {
+			h.secretStore = store
 		}
-		h.secretStore = store
 	}
 
 	// Initialize HTTP client if not provided
@@ -115,10 +122,23 @@ func New(opts ...Option) (*Handler, error) {
 		h.httpClient = NewDefaultHTTPClient()
 	}
 
-	// Initialize token cache with secret store
-	h.tokenCache = NewTokenCache(h.secretStore)
+	// Initialize token cache with secret store (nil-safe: checked before use)
+	if h.secretStore != nil {
+		h.tokenCache = NewTokenCache(h.secretStore)
+	}
 
 	return h, nil
+}
+
+// ensureSecrets returns an error if the secret store is not available.
+func (h *Handler) ensureSecrets() error {
+	if h.secretStore == nil {
+		if h.secretErr != nil {
+			return h.secretErr
+		}
+		return fmt.Errorf("secrets store not initialized")
+	}
+	return nil
 }
 
 // Name returns the handler identifier.
@@ -141,11 +161,28 @@ func (h *Handler) SupportedFlows() []auth.Flow {
 	return flows
 }
 
+// Capabilities returns the set of capabilities this handler supports.
+// Entra supports scopes at both login time and per-request (different
+// resource scopes), tenant ID selection, and federated tokens for
+// workload identity.
+func (h *Handler) Capabilities() []auth.Capability {
+	return []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
+}
+
 // Login initiates the authentication flow.
 // For device code flow, this initiates interactive authentication.
 // For service principal flow, this validates the credentials.
 // For workload identity flow, this validates the federated token.
 func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
 	// Check if workload identity flow is requested or detected (highest priority)
 	if opts.Flow == auth.FlowWorkloadIdentity || (opts.Flow == "" && HasWorkloadIdentityCredentials()) {
 		return h.workloadIdentityLogin(ctx, opts)
@@ -161,6 +198,10 @@ func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Resu
 
 // Logout clears stored credentials and cached tokens.
 func (h *Handler) Logout(ctx context.Context) error {
+	if err := h.ensureSecrets(); err != nil {
+		return err
+	}
+
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("logging out", "handler", HandlerName)
 
@@ -184,6 +225,10 @@ func (h *Handler) Logout(ctx context.Context) error {
 
 // Status returns the current authentication status.
 func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
 	// Check for workload identity credentials first (highest priority)
 	if HasWorkloadIdentityCredentials() {
 		return h.workloadIdentityStatus(ctx)
@@ -235,6 +280,10 @@ func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
 
 // GetToken returns a valid access token for the specified options.
 func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
 	// Use workload identity flow if credentials are present (highest priority)
 	if HasWorkloadIdentityCredentials() {
 		return h.getWorkloadIdentityToken(ctx, opts)
@@ -340,10 +389,16 @@ func getCachedOrAcquireToken[T any](
 		return nil, auth.ErrNotAuthenticated
 	}
 
+	// Apply default minimum validity to match the user-flow behavior.
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
 	// Check cache first (unless ForceRefresh)
 	if !opts.ForceRefresh {
 		cached, err := h.tokenCache.Get(ctx, opts.Scope)
-		if err == nil && cached != nil && cached.IsValidFor(opts.MinValidFor) {
+		if err == nil && cached != nil && cached.IsValidFor(minValidFor) {
 			lgr.V(1).Info("using cached "+logPrefix+" token", "scope", opts.Scope)
 			return cached, nil
 		}

--- a/pkg/auth/entra/integration_test.go
+++ b/pkg/auth/entra/integration_test.go
@@ -506,6 +506,89 @@ func TestIntegration_TokenRefresh_UsesClientIDFromMetadata(t *testing.T) {
 		"token refresh should use the client_id stored at login time, not the current config")
 }
 
+func TestIntegration_TokenRefresh_PreservesClientIDAfterRotation(t *testing.T) {
+	server := newMockEntraServer(t)
+	defer server.Close()
+
+	// First refresh: rotates the refresh token (new-refresh-token != existing-refresh-token)
+	server.AddTokenResponse(http.StatusOK, map[string]any{
+		"access_token":  "access-token-1",
+		"refresh_token": "rotated-refresh-token",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"scope":         "https://graph.microsoft.com/.default",
+	})
+
+	// Second refresh: uses the rotated refresh token
+	server.AddTokenResponse(http.StatusOK, map[string]any{
+		"access_token":  "access-token-2",
+		"refresh_token": "rotated-refresh-token-2",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"scope":         "https://graph.microsoft.com/.default",
+	})
+
+	store := secrets.NewMockStore()
+	ctx := context.Background()
+
+	// Pre-populate with existing refresh token
+	err := store.Set(ctx, SecretKeyRefreshToken, []byte("existing-refresh-token"))
+	require.NoError(t, err)
+
+	// Metadata was stored during login with a DIFFERENT client ID than the handler config
+	metadata := &TokenMetadata{
+		Claims:                &auth.Claims{Subject: "test-user"},
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+		TenantID:              "test-tenant",
+		ClientID:              "login-client-id",
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	// Handler config has a DIFFERENT client ID
+	cfg := &Config{
+		ClientID:  "config-client-id",
+		TenantID:  "test-tenant",
+		Authority: server.URL(),
+	}
+
+	handler, err := New(
+		WithConfig(cfg),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+
+	// First GetToken: triggers refresh + rotation
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope: "https://graph.microsoft.com/.default",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-1", token.AccessToken)
+
+	// Verify first request used the login-time client ID
+	assert.Equal(t, "login-client-id", server.lastTokenRequest["client_id"],
+		"first refresh should use login-time client_id")
+
+	// Verify metadata still has the login-time client ID after rotation
+	updatedMetadata, err := handler.loadMetadata(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "login-client-id", updatedMetadata.ClientID,
+		"metadata should preserve login-time client_id after rotation")
+
+	// Second GetToken with ForceRefresh: should STILL use login-time client ID
+	token, err = handler.GetToken(ctx, auth.TokenOptions{
+		Scope:        "https://graph.microsoft.com/.default",
+		ForceRefresh: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-2", token.AccessToken)
+
+	// The second refresh request must also use the login-time client ID
+	assert.Equal(t, "login-client-id", server.lastTokenRequest["client_id"],
+		"second refresh after rotation should still use login-time client_id, not config client_id")
+}
+
 func TestIntegration_TokenRefresh_FailsWithoutClientIDInMetadata(t *testing.T) {
 	server := newMockEntraServer(t)
 	defer server.Close()

--- a/pkg/auth/entra/token.go
+++ b/pkg/auth/entra/token.go
@@ -110,7 +110,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// If we got a new refresh token, store it (token rotation)
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		lgr.V(1).Info("refresh token rotated, storing new token")
-		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp, metadata.Scopes); err != nil {
+		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp, metadata.ClientID, metadata.Scopes); err != nil {
 			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
 		}
 	}
@@ -132,9 +132,12 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 }
 
 // storeCredentials securely stores the refresh token and metadata.
+// clientID is the application client ID that was used to obtain the token —
+// this MUST be the same value that was used during the original login so that
+// future refresh-token exchanges continue to use the correct client.
 // scopes records which OAuth scopes were used during login so they can be
 // surfaced later (e.g. in `auth status`).
-func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse, scopes []string) error {
+func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse, clientID string, scopes []string) error {
 	// Validate refresh token is present
 	if tokenResp.RefreshToken == "" {
 		return fmt.Errorf("no refresh token in response (offline_access scope may be missing)")
@@ -159,7 +162,7 @@ func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenRe
 		RefreshTokenExpiresAt: time.Now().Add(DefaultRefreshTokenLifetime),
 		LastRefresh:           time.Now(),
 		TenantID:              tenantID,
-		ClientID:              h.config.ClientID,
+		ClientID:              clientID,
 		Scopes:                scopes,
 	}
 

--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -10,17 +10,18 @@ import (
 
 // Sentinel errors for the auth package.
 var (
-	ErrNotAuthenticated     = errors.New("not authenticated: please run 'scafctl auth login entra'")
-	ErrAuthenticationFailed = errors.New("authentication failed")
-	ErrTokenExpired         = errors.New("credentials expired: please run 'scafctl auth login entra'")
-	ErrConsentRequired      = errors.New("consent required: please login with the required scope, e.g. 'scafctl auth login entra --scope <scope>'")
-	ErrInvalidScope         = errors.New("invalid scope: scope cannot be empty")
-	ErrHandlerNotFound      = errors.New("auth handler not found")
-	ErrFlowNotSupported     = errors.New("authentication flow not supported")
-	ErrUserCancelled        = errors.New("authentication cancelled by user")
-	ErrTimeout              = errors.New("authentication timed out")
-	ErrAlreadyAuthenticated = errors.New("already authenticated")
-	ErrGrantInvalid         = errors.New("invalid grant: the refresh token is invalid or has been revoked, please re-authenticate with 'scafctl auth login entra'")
+	ErrNotAuthenticated       = errors.New("not authenticated: please run 'scafctl auth login entra'")
+	ErrAuthenticationFailed   = errors.New("authentication failed")
+	ErrTokenExpired           = errors.New("credentials expired: please run 'scafctl auth login entra'")
+	ErrConsentRequired        = errors.New("consent required: please login with the required scope, e.g. 'scafctl auth login entra --scope <scope>'")
+	ErrInvalidScope           = errors.New("invalid scope: scope cannot be empty")
+	ErrHandlerNotFound        = errors.New("auth handler not found")
+	ErrFlowNotSupported       = errors.New("authentication flow not supported")
+	ErrUserCancelled          = errors.New("authentication cancelled by user")
+	ErrTimeout                = errors.New("authentication timed out")
+	ErrAlreadyAuthenticated   = errors.New("already authenticated")
+	ErrGrantInvalid           = errors.New("invalid grant: the refresh token is invalid or has been revoked, please re-authenticate with 'scafctl auth login entra'")
+	ErrCapabilityNotSupported = errors.New("capability not supported by this auth handler")
 )
 
 // Error wraps authentication errors with additional context.
@@ -76,4 +77,9 @@ func IsConsentRequired(err error) bool {
 // IsUserCancelled returns true if the error indicates the user cancelled.
 func IsUserCancelled(err error) bool {
 	return errors.Is(err, ErrUserCancelled)
+}
+
+// IsCapabilityNotSupported returns true if the error indicates a capability is not supported.
+func IsCapabilityNotSupported(err error) bool {
+	return errors.Is(err, ErrCapabilityNotSupported)
 }

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -37,7 +37,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		ClientID:          DefaultClientID,
 		Hostname:          DefaultHostname,
-		DefaultScopes:     []string{"repo", "read:user"},
+		DefaultScopes:     []string{"gist", "read:org", "repo", "workflow"},
 		MinPollInterval:   5 * time.Second,
 		SlowDownIncrement: 5 * time.Second,
 	}

--- a/pkg/auth/github/config_test.go
+++ b/pkg/auth/github/config_test.go
@@ -15,7 +15,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal(t, DefaultClientID, cfg.ClientID)
 	assert.Equal(t, DefaultHostname, cfg.Hostname)
-	assert.Equal(t, []string{"repo", "read:user"}, cfg.DefaultScopes)
+	assert.Equal(t, []string{"gist", "read:org", "repo", "workflow"}, cfg.DefaultScopes)
 	assert.Equal(t, 5*time.Second, cfg.MinPollInterval)
 	assert.Equal(t, 5*time.Second, cfg.SlowDownIncrement)
 }

--- a/pkg/auth/github/handler.go
+++ b/pkg/auth/github/handler.go
@@ -45,6 +45,7 @@ const (
 type Handler struct {
 	config      *Config
 	secretStore secrets.Store
+	secretErr   error // deferred error from secrets initialization
 	httpClient  HTTPClient
 	tokenCache  *TokenCache
 }
@@ -90,6 +91,10 @@ func WithHTTPClient(client HTTPClient) Option {
 }
 
 // New creates a new GitHub auth handler.
+// Secret store initialization is deferred — if it fails, the handler is still
+// created so that metadata operations (Name, SupportedFlows, etc.) work.
+// Operations requiring secrets (Login, Logout, Status, GetToken) will return
+// the deferred error.
 func New(opts ...Option) (*Handler, error) {
 	h := &Handler{
 		config: DefaultConfig(),
@@ -103,9 +108,11 @@ func New(opts ...Option) (*Handler, error) {
 	if h.secretStore == nil {
 		store, err := secrets.New()
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize secrets store: %w", err)
+			// Defer the error — metadata-only operations still work
+			h.secretErr = fmt.Errorf("failed to initialize secrets store: %w", err)
+		} else {
+			h.secretStore = store
 		}
-		h.secretStore = store
 	}
 
 	// Initialize HTTP client if not provided
@@ -113,10 +120,23 @@ func New(opts ...Option) (*Handler, error) {
 		h.httpClient = NewDefaultHTTPClient()
 	}
 
-	// Initialize token cache with secret store
-	h.tokenCache = NewTokenCache(h.secretStore)
+	// Initialize token cache with secret store (nil-safe: checked before use)
+	if h.secretStore != nil {
+		h.tokenCache = NewTokenCache(h.secretStore)
+	}
 
 	return h, nil
+}
+
+// ensureSecrets returns an error if the secret store is not available.
+func (h *Handler) ensureSecrets() error {
+	if h.secretStore == nil {
+		if h.secretErr != nil {
+			return h.secretErr
+		}
+		return fmt.Errorf("secrets store not initialized")
+	}
+	return nil
 }
 
 // Name returns the handler identifier.
@@ -137,12 +157,29 @@ func (h *Handler) SupportedFlows() []auth.Flow {
 	}
 }
 
+// Capabilities returns the set of capabilities this handler supports.
+// GitHub supports scopes at login time (device code flow) and hostname
+// for GHES, but does NOT support per-request scopes (scopes are fixed
+// at login time and cannot be changed on token refresh).
+func (h *Handler) Capabilities() []auth.Capability {
+	return []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapHostname,
+	}
+}
+
 // Login initiates the authentication flow.
 // For device code flow, this initiates interactive authentication.
 // For PAT flow, this validates the token from environment.
 func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
-	// Check if PAT flow is requested or detected
-	if opts.Flow == auth.FlowPAT || (opts.Flow == "" && HasPATCredentials()) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	// Check if PAT flow is requested or detected.
+	// Skip PAT auto-detection when scopes are explicitly provided, since
+	// PAT scopes are fixed at creation time and can't be changed at login.
+	if opts.Flow == auth.FlowPAT || (opts.Flow == "" && HasPATCredentials() && len(opts.Scopes) == 0) {
 		return h.patLogin(ctx, opts)
 	}
 
@@ -151,6 +188,10 @@ func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Resu
 
 // Logout clears stored credentials and cached tokens.
 func (h *Handler) Logout(ctx context.Context) error {
+	if err := h.ensureSecrets(); err != nil {
+		return err
+	}
+
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("logging out", "handler", HandlerName)
 
@@ -179,6 +220,10 @@ func (h *Handler) Logout(ctx context.Context) error {
 
 // Status returns the current authentication status.
 func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
 	// Check for PAT credentials first (highest priority)
 	if HasPATCredentials() {
 		return h.patStatus(ctx)
@@ -224,17 +269,24 @@ func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
 	}, nil
 }
 
+// defaultCacheKey is the fixed cache key for GitHub tokens.
+// GitHub scopes are fixed at login time and cannot be changed per-request,
+// so every token request uses the same cache entry.
+const defaultCacheKey = "_github"
+
 // GetToken returns a valid access token for the specified options.
+// Unlike Entra, GitHub does not support per-request scopes — the scope field
+// in opts is ignored. Scopes are fixed at login time.
 func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	// Use PAT flow if credentials are present (highest priority)
 	if HasPATCredentials() {
 		return h.getPATToken(ctx, opts)
-	}
-
-	if opts.Scope == "" {
-		return nil, auth.ErrInvalidScope
 	}
 
 	// Determine minimum validity duration
@@ -245,17 +297,15 @@ func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.T
 
 	lgr.V(1).Info("getting token",
 		"handler", HandlerName,
-		"scope", opts.Scope,
 		"minValidFor", minValidFor,
 		"forceRefresh", opts.ForceRefresh,
 	)
 
 	// Check disk cache first (unless force refresh)
 	if !opts.ForceRefresh {
-		token, err := h.tokenCache.Get(ctx, opts.Scope)
+		token, err := h.tokenCache.Get(ctx, defaultCacheKey)
 		if err == nil && token != nil && token.IsValidFor(minValidFor) {
 			lgr.V(1).Info("using cached token",
-				"scope", opts.Scope,
 				"expiresAt", token.ExpiresAt,
 				"remainingValidity", token.TimeUntilExpiry(),
 			)
@@ -280,22 +330,21 @@ func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.T
 			AccessToken: accessToken,
 			TokenType:   "Bearer",
 			ExpiresAt:   farFuture(),
-			Scope:       opts.Scope,
 		}
-		if cacheErr := h.tokenCache.Set(ctx, opts.Scope, token); cacheErr != nil {
+		if cacheErr := h.tokenCache.Set(ctx, defaultCacheKey, token); cacheErr != nil {
 			lgr.V(1).Info("failed to cache token", "error", cacheErr)
 		}
 		return token, nil
 	}
 
 	// Try to mint new token using refresh token
-	token, err := h.mintToken(ctx, opts.Scope)
+	token, err := h.mintToken(ctx, defaultCacheKey)
 	if err != nil {
 		return nil, err
 	}
 
 	// Cache the token to disk
-	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+	if err := h.tokenCache.Set(ctx, defaultCacheKey, token); err != nil {
 		lgr.V(1).Info("failed to cache token", "error", err)
 	}
 
@@ -336,27 +385,32 @@ func getCachedOrAcquireToken[T any](
 		return nil, auth.ErrNotAuthenticated
 	}
 
-	if opts.Scope == "" {
-		return nil, auth.ErrInvalidScope
+	// Use fixed cache key — GitHub scopes are determined at login, not per-request.
+	cacheKey := defaultCacheKey
+
+	// Apply default minimum validity to match the user-flow behavior.
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
 	}
 
 	// Check cache first (unless ForceRefresh)
 	if !opts.ForceRefresh {
-		cached, err := h.tokenCache.Get(ctx, opts.Scope)
-		if err == nil && cached != nil && cached.IsValidFor(opts.MinValidFor) {
-			lgr.V(1).Info("using cached "+logPrefix+" token", "scope", opts.Scope)
+		cached, err := h.tokenCache.Get(ctx, cacheKey)
+		if err == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached "+logPrefix+" token", "cacheKey", cacheKey)
 			return cached, nil
 		}
 	}
 
 	// Acquire new token
-	token, err := acquireToken(ctx, creds, opts.Scope)
+	token, err := acquireToken(ctx, creds, cacheKey)
 	if err != nil {
 		return nil, err
 	}
 
 	// Cache the token
-	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+	if err := h.tokenCache.Set(ctx, cacheKey, token); err != nil {
 		lgr.V(1).Info("failed to cache "+logPrefix+" token", "error", err)
 	}
 

--- a/pkg/auth/github/handler_test.go
+++ b/pkg/auth/github/handler_test.go
@@ -189,7 +189,7 @@ func TestHandler_GetToken_NotAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	_, err = handler.GetToken(ctx, auth.TokenOptions{})
 	assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
 }
 
@@ -199,8 +199,15 @@ func TestHandler_GetToken_EmptyScope(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = handler.GetToken(ctx, auth.TokenOptions{Scope: ""})
-	assert.ErrorIs(t, err, auth.ErrInvalidScope)
+
+	// With a stored access token, empty scope should succeed
+	// because GitHub scopes are fixed at login time.
+	err = store.Set(ctx, SecretKeyAccessToken, []byte("gho_testtoken"))
+	require.NoError(t, err)
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: ""})
+	require.NoError(t, err)
+	assert.Equal(t, "gho_testtoken", token.AccessToken)
 }
 
 func TestHandler_GetToken_WithStoredAccessToken(t *testing.T) {
@@ -213,11 +220,10 @@ func TestHandler_GetToken_WithStoredAccessToken(t *testing.T) {
 	err = store.Set(ctx, SecretKeyAccessToken, []byte("gho_testtoken"))
 	require.NoError(t, err)
 
-	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	token, err := handler.GetToken(ctx, auth.TokenOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "gho_testtoken", token.AccessToken)
 	assert.Equal(t, "Bearer", token.TokenType)
-	assert.Equal(t, "repo", token.Scope)
 	assert.True(t, token.ExpiresAt.After(time.Now().Add(364*24*time.Hour)))
 }
 
@@ -232,15 +238,14 @@ func TestHandler_GetToken_CachedToken(t *testing.T) {
 		AccessToken: "cached-token",
 		TokenType:   "Bearer",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
-		Scope:       "repo",
 	}
-	err = handler.tokenCache.Set(ctx, "repo", cachedToken)
+	err = handler.tokenCache.Set(ctx, defaultCacheKey, cachedToken)
 	require.NoError(t, err)
 
 	err = store.Set(ctx, SecretKeyAccessToken, []byte("stored-token"))
 	require.NoError(t, err)
 
-	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	token, err := handler.GetToken(ctx, auth.TokenOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "cached-token", token.AccessToken)
 }
@@ -256,16 +261,14 @@ func TestHandler_GetToken_ForceRefresh(t *testing.T) {
 		AccessToken: "cached-token",
 		TokenType:   "Bearer",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
-		Scope:       "repo",
 	}
-	err = handler.tokenCache.Set(ctx, "repo", cachedToken)
+	err = handler.tokenCache.Set(ctx, defaultCacheKey, cachedToken)
 	require.NoError(t, err)
 
 	err = store.Set(ctx, SecretKeyAccessToken, []byte("stored-token"))
 	require.NoError(t, err)
 
 	token, err := handler.GetToken(ctx, auth.TokenOptions{
-		Scope:        "repo",
 		ForceRefresh: true,
 	})
 	require.NoError(t, err)
@@ -285,7 +288,7 @@ func TestHandler_InjectAuth(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/test", nil)
 	require.NoError(t, err)
 
-	err = handler.InjectAuth(ctx, req, auth.TokenOptions{Scope: "repo"})
+	err = handler.InjectAuth(ctx, req, auth.TokenOptions{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "Bearer inject-test-token", req.Header.Get("Authorization"))
@@ -453,8 +456,117 @@ func TestHandler_MintToken_RefreshFlow(t *testing.T) {
 		"name":  "Test User",
 	})
 
-	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: "repo"})
+	token, err := handler.GetToken(ctx, auth.TokenOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "ghu_new_access", token.AccessToken)
 	assert.Equal(t, "Bearer", token.TokenType)
+}
+
+func TestHandler_Login_DeviceCodeUsedWhenScopesProvided(t *testing.T) {
+	// When scopes are explicitly provided, Login should use device code flow
+	// even if PAT credentials exist in the environment.
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Set up mock responses for device code flow
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"device_code":      "test-device-code",
+		"user_code":        "SCOP-1234",
+		"verification_uri": "https://github.com/login/device",
+		"expires_in":       900,
+		"interval":         5,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"access_token": "gho_scoped_token",
+		"token_type":   "Bearer",
+		"scope":        "admin:org workflow",
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "scopeuser",
+		"id":    99,
+		"name":  "Scope User",
+		"email": "scope@example.com",
+	})
+
+	// Login with explicit scopes; should use device code flow
+	result, err := handler.Login(ctx, auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Scopes:  []string{"admin:org", "workflow"},
+		Timeout: 10 * time.Second,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "scopeuser", result.Claims.Subject)
+
+	// Verify the token stored has the user-provided scopes, not the defaults
+	metadataBytes, err := store.Get(ctx, SecretKeyMetadata)
+	require.NoError(t, err)
+	var metadata TokenMetadata
+	err = json.Unmarshal(metadataBytes, &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"admin:org", "workflow"}, metadata.Scopes)
+}
+
+func TestHandler_Login_ScopesNotOverriddenByDefaults(t *testing.T) {
+	// Verify that when user provides scopes, the defaults are NOT used
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"device_code":      "test-device-code",
+		"user_code":        "CUST-5678",
+		"verification_uri": "https://github.com/login/device",
+		"expires_in":       900,
+		"interval":         5,
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"access_token": "gho_custom_token",
+		"token_type":   "Bearer",
+		"scope":        "notifications",
+	})
+
+	mockHTTP.AddResponse(http.StatusOK, map[string]any{
+		"login": "customuser",
+		"id":    77,
+		"name":  "Custom User",
+	})
+
+	// Provide scopes that differ from defaults ("gist", "read:org", "repo", "workflow")
+	customScopes := []string{"notifications"}
+	result, err := handler.Login(ctx, auth.LoginOptions{
+		Scopes:  customScopes,
+		Timeout: 10 * time.Second,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Verify stored metadata has the custom scopes, not the defaults
+	metadataBytes, err := store.Get(ctx, SecretKeyMetadata)
+	require.NoError(t, err)
+	var metadata TokenMetadata
+	err = json.Unmarshal(metadataBytes, &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, customScopes, metadata.Scopes)
+	assert.NotEqual(t, []string{"gist", "read:org", "repo", "workflow"}, metadata.Scopes)
 }

--- a/pkg/auth/github/pat.go
+++ b/pkg/auth/github/pat.go
@@ -49,7 +49,7 @@ func GetHostnameFromEnv() string {
 }
 
 // patLogin validates a PAT by calling the GitHub API.
-func (h *Handler) patLogin(ctx context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+func (h *Handler) patLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("starting PAT login", "handler", HandlerName)
 
@@ -69,6 +69,10 @@ func (h *Handler) patLogin(ctx context.Context, _ auth.LoginOptions) (*auth.Resu
 		"login", claims.Subject,
 		"name", claims.Name,
 	)
+
+	if len(opts.Scopes) > 0 {
+		lgr.V(0).Info("WARNING: --scope flags are ignored for PAT authentication; PAT scopes are fixed at token creation time on GitHub")
+	}
 
 	return &auth.Result{
 		Claims: claims,
@@ -117,7 +121,6 @@ func (h *Handler) getPATToken(ctx context.Context, opts auth.TokenOptions) (*aut
 				TokenType:   "Bearer",
 				// PATs don't expire via API, set a long validity
 				ExpiresAt: farFuture(),
-				Scope:     opts.Scope,
 			}, nil
 		},
 		"pat",

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -48,6 +48,11 @@ type Handler interface {
 
 	// SupportedFlows returns the authentication flows this handler supports.
 	SupportedFlows() []Flow
+
+	// Capabilities returns the set of capabilities this handler supports.
+	// Commands use capabilities to dynamically determine which flags and
+	// validation rules apply for a given handler.
+	Capabilities() []Capability
 }
 
 // Flow represents an authentication flow type.

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -13,9 +13,10 @@ import (
 type MockHandler struct {
 	mu sync.Mutex
 
-	NameValue        string
-	DisplayNameValue string
-	FlowsValue       []Flow
+	NameValue         string
+	DisplayNameValue  string
+	FlowsValue        []Flow
+	CapabilitiesValue []Capability
 
 	LoginResult    *Result
 	LoginErr       error
@@ -50,6 +51,10 @@ func (m *MockHandler) SupportedFlows() []Flow {
 		return []Flow{FlowDeviceCode}
 	}
 	return m.FlowsValue
+}
+
+func (m *MockHandler) Capabilities() []Capability {
+	return m.CapabilitiesValue
 }
 
 func (m *MockHandler) Login(_ context.Context, opts LoginOptions) (*Result, error) {

--- a/pkg/auth/mock_test.go
+++ b/pkg/auth/mock_test.go
@@ -19,6 +19,14 @@ func TestMockHandler_Basics(t *testing.T) {
 	assert.Equal(t, "entra", mock.Name())
 	assert.Equal(t, "entra", mock.DisplayName())
 	assert.Contains(t, mock.SupportedFlows(), FlowDeviceCode)
+	assert.Empty(t, mock.Capabilities()) // Default: no capabilities
+
+	// Set capabilities
+	mock.CapabilitiesValue = []Capability{CapScopesOnLogin, CapScopesOnTokenRequest}
+	assert.Len(t, mock.Capabilities(), 2)
+	assert.True(t, HasCapability(mock.Capabilities(), CapScopesOnLogin))
+	assert.True(t, HasCapability(mock.Capabilities(), CapScopesOnTokenRequest))
+	assert.False(t, HasCapability(mock.Capabilities(), CapHostname))
 }
 
 func TestMockHandler_Login(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -22,10 +22,14 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			Manage authentication for scafctl.
 
 			Authentication handlers manage identity verification and token acquisition
-			for accessing protected resources. scafctl supports the following auth handlers:
+			for accessing protected resources. Handlers are loaded from the auth registry
+			and can be extended via plugins.
 
-			- entra: Microsoft Entra ID (formerly Azure AD)
+			Each handler declares its capabilities, which determine which flags and
+			features are available. For example, some handlers support per-request
+			scopes while others fix scopes at login time.
 
+			Use 'scafctl auth list' to see all registered handlers and their capabilities.
 			Use 'scafctl auth login <handler>' to authenticate.
 			Use 'scafctl auth status' to check current authentication status.
 			Use 'scafctl auth logout <handler>' to clear credentials.
@@ -35,6 +39,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	}
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandStatus(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -25,12 +25,13 @@ func TestCommandAuth(t *testing.T) {
 
 	// Verify subcommands are added
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 4)
+	require.Len(t, subCmds, 5)
 
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
 		cmdNames[i] = c.Use
 	}
+	assert.Contains(t, cmdNames, "list")
 	assert.Contains(t, cmdNames, "login <handler>")
 	assert.Contains(t, cmdNames, "logout <handler>")
 	assert.Contains(t, cmdNames, "status [handler]")

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
@@ -32,31 +33,69 @@ func handlerFromContext(ctx context.Context) auth.Handler {
 	return nil
 }
 
-// getEntraHandler creates or retrieves an Entra handler.
-// If a handler was injected via context (for testing), returns that.
-// Otherwise creates a new handler with configuration from context.
-func getEntraHandler(ctx context.Context) (auth.Handler, error) {
-	// Check for test-injected handler
+// getHandler retrieves an auth handler from the registry or test context.
+// For production use, it looks up the handler by name from the auth registry.
+// For tests, it returns the test-injected handler.
+func getHandler(ctx context.Context, handlerName string) (auth.Handler, error) {
+	// Check for test-injected handler first
 	if h := handlerFromContext(ctx); h != nil {
 		return h, nil
 	}
 
-	// Build options from config
-	var opts []entra.Option
-	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.Entra != nil {
-		opts = append(opts, entra.WithConfig(&entra.Config{
-			ClientID:      cfg.Auth.Entra.ClientID,
-			TenantID:      cfg.Auth.Entra.TenantID,
-			DefaultScopes: cfg.Auth.Entra.DefaultScopes,
-		}))
+	registry := auth.RegistryFromContext(ctx)
+	if registry == nil {
+		return nil, fmt.Errorf("%w: no auth registry in context", auth.ErrHandlerNotFound)
+	}
+	return registry.Get(handlerName)
+}
+
+// listHandlers returns the names of all registered handlers.
+// Falls back to the registry in context, or returns nil.
+func listHandlers(ctx context.Context) []string {
+	// If a test handler is injected, we can't enumerate all handlers.
+	// Return the known built-in names for the test context.
+	if h := handlerFromContext(ctx); h != nil {
+		return []string{h.Name()}
 	}
 
-	return entra.New(opts...)
+	registry := auth.RegistryFromContext(ctx)
+	if registry == nil {
+		return nil
+	}
+	return registry.List()
+}
+
+// isHandlerRegistered checks if a handler name is registered.
+func isHandlerRegistered(ctx context.Context, name string) bool {
+	// Test-injected handlers match any name (since tests inject a single mock)
+	if h := handlerFromContext(ctx); h != nil {
+		return true // Let the test handler respond regardless of name
+	}
+
+	registry := auth.RegistryFromContext(ctx)
+	if registry == nil {
+		return false
+	}
+	return registry.Has(name)
+}
+
+// validateHandlerName checks if a handler name is valid and returns a formatted error if not.
+func validateHandlerName(ctx context.Context, handlerName string) error {
+	if isHandlerRegistered(ctx, handlerName) {
+		return nil
+	}
+	handlers := listHandlers(ctx)
+	if len(handlers) == 0 {
+		return fmt.Errorf("unknown auth handler: %s (no handlers registered)", handlerName)
+	}
+	return fmt.Errorf("unknown auth handler: %s (registered: %v)", handlerName, handlers)
 }
 
 // getEntraHandlerWithOverrides creates an Entra handler with optional tenant and client ID overrides.
 // The flags take precedence over config.
-func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) { //nolint:dupl // Entra and GitHub handlers have intentionally similar structure but different types
+//
+//nolint:dupl // Entra and GitHub handler construction share structure but use different types and config paths.
+func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) {
 	// Check for test-injected handler
 	if h := handlerFromContext(ctx); h != nil {
 		return h, nil
@@ -80,46 +119,11 @@ func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDO
 	return entra.New(opts...)
 }
 
-// SupportedHandlers returns the list of supported auth handler names.
-func SupportedHandlers() []string {
-	return []string{"entra", "github"}
-}
-
-// IsSupportedHandler returns true if the handler name is supported.
-func IsSupportedHandler(name string) bool {
-	for _, h := range SupportedHandlers() {
-		if h == name {
-			return true
-		}
-	}
-	return false
-}
-
-// getGitHubHandler creates or retrieves a GitHub handler.
-// If a handler was injected via context (for testing), returns that.
-// Otherwise creates a new handler with configuration from context.
-func getGitHubHandler(ctx context.Context) (auth.Handler, error) {
-	// Check for test-injected handler
-	if h := handlerFromContext(ctx); h != nil {
-		return h, nil
-	}
-
-	// Build options from config
-	var opts []ghauth.Option
-	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GitHub != nil {
-		opts = append(opts, ghauth.WithConfig(&ghauth.Config{
-			ClientID:      cfg.Auth.GitHub.ClientID,
-			Hostname:      cfg.Auth.GitHub.Hostname,
-			DefaultScopes: cfg.Auth.GitHub.DefaultScopes,
-		}))
-	}
-
-	return ghauth.New(opts...)
-}
-
 // getGitHubHandlerWithOverrides creates a GitHub handler with optional hostname and client ID overrides.
 // The flags take precedence over config.
-func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, clientIDOverride string) (auth.Handler, error) { //nolint:dupl // Entra and GitHub handlers have intentionally similar structure but different types
+//
+//nolint:dupl // GitHub and Entra handler construction share structure but use different types and config paths.
+func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, clientIDOverride string) (auth.Handler, error) {
 	// Check for test-injected handler
 	if h := handlerFromContext(ctx); h != nil {
 		return h, nil
@@ -147,17 +151,5 @@ func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, client
 func applyOverride(target *string, override string) {
 	if override != "" {
 		*target = override
-	}
-}
-
-// getHandler creates a handler for the given handler name.
-func getHandler(ctx context.Context, handlerName string) (auth.Handler, error) {
-	switch handlerName {
-	case "entra":
-		return getEntraHandler(ctx)
-	case "github":
-		return getGitHubHandler(ctx)
-	default:
-		return nil, auth.ErrHandlerNotFound
 	}
 }

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -27,28 +27,92 @@ func TestWithTestHandler(t *testing.T) {
 	assert.Equal(t, "test", h.Name())
 }
 
-func TestIsSupportedHandler(t *testing.T) {
-	tests := []struct {
-		name      string
-		handler   string
-		supported bool
-	}{
-		{"entra is supported", "entra", true},
-		{"unknown is not supported", "unknown", false},
-		{"empty is not supported", "", false},
-		{"azure is not supported", "azure", false},
-	}
+func TestIsHandlerRegistered_WithRegistry(t *testing.T) {
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("entra")
+	require.NoError(t, registry.Register(mock))
+	ctx := auth.WithRegistry(context.Background(), registry)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.supported, IsSupportedHandler(tt.handler))
-		})
-	}
+	assert.True(t, isHandlerRegistered(ctx, "entra"))
+	assert.False(t, isHandlerRegistered(ctx, "unknown"))
 }
 
-func TestSupportedHandlers(t *testing.T) {
-	handlers := SupportedHandlers()
+func TestIsHandlerRegistered_WithTestHandler(t *testing.T) {
+	mock := auth.NewMockHandler("test")
+	ctx := withTestHandler(context.Background(), mock)
+
+	// Test-injected handler matches any name
+	assert.True(t, isHandlerRegistered(ctx, "test"))
+	assert.True(t, isHandlerRegistered(ctx, "anything"))
+}
+
+func TestIsHandlerRegistered_NoContext(t *testing.T) {
+	ctx := context.Background()
+	assert.False(t, isHandlerRegistered(ctx, "entra"))
+}
+
+func TestListHandlers_WithRegistry(t *testing.T) {
+	registry := auth.NewRegistry()
+	mockEntra := auth.NewMockHandler("entra")
+	mockGH := auth.NewMockHandler("github")
+	require.NoError(t, registry.Register(mockEntra))
+	require.NoError(t, registry.Register(mockGH))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	handlers := listHandlers(ctx)
 	assert.Contains(t, handlers, "entra")
 	assert.Contains(t, handlers, "github")
 	assert.Len(t, handlers, 2)
+}
+
+func TestListHandlers_WithTestHandler(t *testing.T) {
+	mock := auth.NewMockHandler("test")
+	ctx := withTestHandler(context.Background(), mock)
+
+	handlers := listHandlers(ctx)
+	assert.Equal(t, []string{"test"}, handlers)
+}
+
+func TestValidateHandlerName(t *testing.T) {
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("entra")
+	require.NoError(t, registry.Register(mock))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	assert.NoError(t, validateHandlerName(ctx, "entra"))
+
+	err := validateHandlerName(ctx, "unknown")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown auth handler")
+	assert.Contains(t, err.Error(), "entra")
+}
+
+func TestGetHandler_FromRegistry(t *testing.T) {
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("entra")
+	require.NoError(t, registry.Register(mock))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	handler, err := getHandler(ctx, "entra")
+	require.NoError(t, err)
+	assert.Equal(t, "entra", handler.Name())
+
+	_, err = getHandler(ctx, "unknown")
+	assert.Error(t, err)
+}
+
+func TestGetHandler_FromTestContext(t *testing.T) {
+	mock := auth.NewMockHandler("test")
+	ctx := withTestHandler(context.Background(), mock)
+
+	handler, err := getHandler(ctx, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "test", handler.Name())
+}
+
+func TestGetHandler_NoContext(t *testing.T) {
+	ctx := context.Background()
+	_, err := getHandler(ctx, "entra")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth registry in context")
 }

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -1,0 +1,130 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandList creates the 'auth list' command.
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered auth handlers",
+		Long: heredoc.Doc(`
+			List all registered authentication handlers and their metadata.
+
+			Displays handler name, display name, supported authentication flows,
+			and capabilities for each registered handler. This is useful for
+			discovering which handlers are available and what features they support.
+
+			Examples:
+			  # List all auth handlers
+			  scafctl auth list
+
+			  # Output as JSON
+			  scafctl auth list -o json
+
+			  # Output as YAML
+			  scafctl auth list -o yaml
+		`),
+		Aliases:      []string{"ls"},
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.MustFromContext(ctx)
+
+			handlerNames := listHandlers(ctx)
+			if len(handlerNames) == 0 {
+				err := fmt.Errorf("no auth handlers registered")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			results := make([]map[string]any, 0, len(handlerNames))
+
+			for _, name := range handlerNames {
+				handler, err := getHandler(ctx, name)
+				if err != nil {
+					w.Warningf("Failed to initialize %s: %v", name, err)
+					continue
+				}
+
+				flows := handler.SupportedFlows()
+				flowStrs := make([]string, len(flows))
+				for i, f := range flows {
+					flowStrs[i] = string(f)
+				}
+
+				capabilities := handler.Capabilities()
+				capStrs := make([]string, len(capabilities))
+				for i, c := range capabilities {
+					capStrs[i] = string(c)
+				}
+
+				result := map[string]any{
+					"name":         handler.Name(),
+					"displayName":  handler.DisplayName(),
+					"flows":        strings.Join(flowStrs, ", "),
+					"capabilities": strings.Join(capStrs, ", "),
+				}
+
+				results = append(results, result)
+			}
+
+			if len(results) == 0 {
+				err := fmt.Errorf("no auth handlers could be loaded")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			outputOpts := flags.NewKvxOutputOptionsFromFlags(
+				outputFlags.Output,
+				outputFlags.Interactive,
+				outputFlags.Expression,
+				kvx.WithOutputContext(ctx),
+				kvx.WithOutputNoColor(cliParams.NoColor),
+				kvx.WithOutputAppName("scafctl auth list"),
+			)
+			outputOpts.IOStreams = ioStreams
+
+			return outputOpts.Write(results)
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}
+
+// flowsToStrings converts a slice of Flow to a slice of strings.
+func flowsToStrings(flows []auth.Flow) []string {
+	strs := make([]string, len(flows))
+	for i, f := range flows {
+		strs[i] = string(f)
+	}
+	return strs
+}
+
+// capabilitiesToStrings converts a slice of Capability to a slice of strings.
+func capabilitiesToStrings(caps []auth.Capability) []string {
+	strs := make([]string, len(caps))
+	for i, c := range caps {
+		strs[i] = string(c)
+	}
+	return strs
+}

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandList_Success(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode, auth.FlowServicePrincipal}
+	mock.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapTenantID}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "entra")
+	assert.Contains(t, output, "Microsoft Entra ID")
+	assert.Contains(t, output, "device_code")
+	assert.Contains(t, output, "service_principal")
+	assert.Contains(t, output, "scopes_on_login")
+	assert.Contains(t, output, "tenant_id")
+}
+
+func TestCommandList_NoHandlers(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth handlers registered")
+}
+
+func TestCommandList_JSONOutput(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("github")
+	mock.DisplayNameValue = "GitHub"
+	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode, auth.FlowPAT}
+	mock.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapHostname}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, `"name"`)
+	assert.Contains(t, output, `"github"`)
+	assert.Contains(t, output, `"displayName"`)
+	assert.Contains(t, output, `"flows"`)
+	assert.Contains(t, output, `"capabilities"`)
+}
+
+func TestCommandList_NoArgs(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("test")
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"extra-arg"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestCommandList_EmptyCapabilities(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("custom")
+	mock.DisplayNameValue = "Custom Handler"
+	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode}
+	mock.CapabilitiesValue = nil
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "custom")
+	assert.Contains(t, output, "Custom Handler")
+}
+
+func TestFlowsToStrings(t *testing.T) {
+	flows := []auth.Flow{auth.FlowDeviceCode, auth.FlowServicePrincipal, auth.FlowPAT}
+	result := flowsToStrings(flows)
+
+	assert.Equal(t, []string{"device_code", "service_principal", "pat"}, result)
+}
+
+func TestFlowsToStrings_Empty(t *testing.T) {
+	result := flowsToStrings(nil)
+	assert.Len(t, result, 0)
+}
+
+func TestCapabilitiesToStrings(t *testing.T) {
+	caps := []auth.Capability{auth.CapScopesOnLogin, auth.CapTenantID, auth.CapHostname}
+	result := capabilitiesToStrings(caps)
+
+	assert.Equal(t, []string{"scopes_on_login", "tenant_id", "hostname"}, result)
+}
+
+func TestCapabilitiesToStrings_Empty(t *testing.T) {
+	result := capabilitiesToStrings(nil)
+	assert.Len(t, result, 0)
+}

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -110,9 +110,40 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			w := writer.MustFromContext(ctx)
 			handlerName := args[0]
 
-			// Validate handler name
-			if !IsSupportedHandler(handlerName) {
-				err := fmt.Errorf("unknown auth handler: %s (supported: %v)", handlerName, SupportedHandlers())
+			// Validate handler name against registry
+			if err := validateHandlerName(ctx, handlerName); err != nil {
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Get handler to check capabilities
+			handler, err := getHandler(ctx, handlerName)
+			if err != nil {
+				err = fmt.Errorf("failed to initialize auth handler: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			caps := handler.Capabilities()
+
+			// Validate capability-gated flags
+			if tenantID != "" && !auth.HasCapability(caps, auth.CapTenantID) {
+				err := fmt.Errorf("--tenant is not supported by the %q auth handler", handlerName)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if hostname != "" && !auth.HasCapability(caps, auth.CapHostname) {
+				err := fmt.Errorf("--hostname is not supported by the %q auth handler", handlerName)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if federatedToken != "" && !auth.HasCapability(caps, auth.CapFederatedToken) {
+				err := fmt.Errorf("--federated-token is not supported by the %q auth handler", handlerName)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if len(scopes) > 0 && !auth.HasCapability(caps, auth.CapScopesOnLogin) {
+				err := fmt.Errorf("--scope is not supported at login time by the %q auth handler", handlerName)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -134,21 +165,23 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 		},
 	}
 
-	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config, Entra only)")
+	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config, requires tenant_id capability)")
 	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth application/client ID (overrides default)")
-	cmd.Flags().StringVar(&hostname, "hostname", "", "GitHub hostname for GHES (GitHub only, e.g. github.example.com)")
+	cmd.Flags().StringVar(&hostname, "hostname", "", "Hostname for enterprise/self-hosted instances (requires hostname capability)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "Timeout for authentication flow")
 	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow (handler-specific)")
-	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for Entra workload identity (sets AZURE_FEDERATED_TOKEN)")
-	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scopes to request during login")
+	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for workload identity (requires federated_token capability)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scopes to request during login (requires scopes_on_login capability)")
 
 	return cmd
 }
 
 // loginGitHub handles the login flow for the GitHub auth handler.
 func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname, clientID string, timeout time.Duration, scopes []string) error {
-	// Auto-detect PAT if env vars are set and no explicit flow
-	if flow == "" && ghauth.HasPATCredentials() {
+	// Auto-detect PAT if env vars are set and no explicit flow.
+	// Skip auto-detection when user provides --scope flags, since scopes
+	// only apply to the device code flow (PAT scopes are fixed at creation).
+	if flow == "" && ghauth.HasPATCredentials() && len(scopes) == 0 {
 		flow = auth.FlowPAT
 		w.Info("Detected GitHub token in environment variables")
 	}

--- a/pkg/cmd/scafctl/auth/login_test.go
+++ b/pkg/cmd/scafctl/auth/login_test.go
@@ -39,7 +39,6 @@ func TestCommandLogin_UnknownHandler(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown auth handler")
-	assert.Contains(t, err.Error(), "entra")
 }
 
 func TestCommandLogin_MissingHandler(t *testing.T) {
@@ -59,9 +58,15 @@ func TestCommandLogin_MissingHandler(t *testing.T) {
 func TestCommandLogin_Success(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	// Set up mock handler
+	// Set up mock handler with Entra-like capabilities
 	mock := auth.NewMockHandler("entra")
 	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
 	mock.SetNotAuthenticated()
 	mock.LoginResult = &auth.Result{
 		Claims: &auth.Claims{
@@ -100,6 +105,12 @@ func TestCommandLogin_AlreadyAuthenticated(t *testing.T) {
 
 	// Set up mock handler as already authenticated
 	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
 	mock.SetAuthenticated(&auth.Claims{
 		Email: "existing@example.com",
 	})
@@ -130,6 +141,12 @@ func TestCommandLogin_WithTenant(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
 	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
 	mock.SetNotAuthenticated()
 	mock.LoginResult = &auth.Result{
 		Claims: &auth.Claims{
@@ -159,6 +176,12 @@ func TestCommandLogin_Failure(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
 	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
 	mock.SetNotAuthenticated()
 	mock.LoginErr = errors.New("network error")
 
@@ -181,6 +204,12 @@ func TestCommandLogin_DeviceCodeCallback(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
 	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
 	mock.SetNotAuthenticated()
 
 	// Capture the callback

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -25,10 +25,6 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 			This removes the stored refresh token, clears any cached access tokens,
 			and removes metadata.
 
-			Supported handlers:
-			- entra: Microsoft Entra ID
-			- github: GitHub
-
 			Examples:
 			  # Logout from Entra ID
 			  scafctl auth logout entra
@@ -43,9 +39,8 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 			w := writer.MustFromContext(ctx)
 			handlerName := args[0]
 
-			// Validate handler name
-			if !IsSupportedHandler(handlerName) {
-				err := fmt.Errorf("unknown auth handler: %s (supported: %v)", handlerName, SupportedHandlers())
+			// Validate handler name against registry
+			if err := validateHandlerName(ctx, handlerName); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -27,11 +27,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 		Long: heredoc.Doc(`
 			Show the current authentication status for auth handlers.
 
-			If no handler is specified, shows status for all known handlers.
-
-			Supported handlers:
-			- entra: Microsoft Entra ID
-			- github: GitHub
+			If no handler is specified, shows status for all registered handlers.
 
 			Examples:
 			  # Show all auth status
@@ -52,11 +48,10 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
 
-			handlers := SupportedHandlers()
+			handlers := listHandlers(ctx)
 			if len(args) > 0 {
 				handlerName := args[0]
-				if !IsSupportedHandler(handlerName) {
-					err := fmt.Errorf("unknown auth handler: %s (supported: %v)", handlerName, SupportedHandlers())
+				if err := validateHandlerName(ctx, handlerName); err != nil {
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}

--- a/pkg/cmd/scafctl/auth/status_test.go
+++ b/pkg/cmd/scafctl/auth/status_test.go
@@ -48,8 +48,8 @@ func TestCommandStatus_AllHandlers(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	// Verify status was checked (once per supported handler: entra, github)
-	assert.Equal(t, 2, mock.StatusCalls)
+	// With test handler injection, listHandlers returns only the mock's name
+	assert.Equal(t, 1, mock.StatusCalls)
 }
 
 func TestCommandStatus_SpecificHandler(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -24,8 +24,9 @@ import (
 func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
 	var (
-		scopes      []string
-		minValidFor time.Duration
+		scopes       []string
+		minValidFor  time.Duration
+		forceRefresh bool
 	)
 
 	cmd := &cobra.Command{
@@ -35,26 +36,33 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			Get an access token from an auth handler.
 
 			This command is primarily for debugging and testing. It retrieves
-			a valid access token for the specified scope.
+			a valid access token from the specified handler.
+
+			For handlers that support per-request scopes (e.g., Entra), the --scope
+			flag is required and specifies which resource scope to request.
+
+			For handlers that do NOT support per-request scopes (e.g., GitHub),
+			the --scope flag is not accepted. Scopes for these handlers are fixed
+			at login time. Use 'scafctl auth login <handler> --scope <scope>' to
+			change scopes.
 
 			The token is cached to disk and will be reused if it has sufficient
 			remaining validity for the specified --min-valid-for duration.
 
 			WARNING: The token is sensitive and should not be shared or logged.
 
-			Supported handlers:
-			- entra: Microsoft Entra ID
-			- github: GitHub
-
 			Examples:
-			  # Get a token for Microsoft Graph
+			  # Get a token for Microsoft Graph (Entra - supports per-request scopes)
 			  scafctl auth token entra --scope "https://graph.microsoft.com/.default"
 
-			  # Get a GitHub token
-			  scafctl auth token github --scope "repo"
+			  # Get a GitHub token (no --scope needed, scopes fixed at login)
+			  scafctl auth token github
 
 			  # Get a token that will be valid for at least 5 minutes
 			  scafctl auth token entra --scope "https://graph.microsoft.com/.default" --min-valid-for 5m
+
+			  # Force a fresh token, bypassing the cache
+			  scafctl auth token entra --scope "https://graph.microsoft.com/.default" --force-refresh
 
 			  # Output as JSON (includes full token)
 			  scafctl auth token entra --scope "https://management.azure.com/.default" -o json
@@ -66,24 +74,11 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			w := writer.MustFromContext(ctx)
 			handlerName := args[0]
 
-			// Validate handler name
-			if !IsSupportedHandler(handlerName) {
-				err := fmt.Errorf("unknown auth handler: %s (supported: %v)", handlerName, SupportedHandlers())
+			// Validate handler name against registry
+			if err := validateHandlerName(ctx, handlerName); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
-
-			if len(scopes) == 0 {
-				err := fmt.Errorf("--scope is required")
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.InvalidInput)
-			}
-
-			// Sort scopes for deterministic cache key
-			sorted := make([]string, len(scopes))
-			copy(sorted, scopes)
-			sort.Strings(sorted)
-			scope := strings.Join(sorted, " ")
 
 			handler, err := getHandler(ctx, handlerName)
 			if err != nil {
@@ -92,9 +87,39 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
+			caps := handler.Capabilities()
+
+			// Validate --scope against capabilities
+			if len(scopes) > 0 && !auth.HasCapability(caps, auth.CapScopesOnTokenRequest) {
+				err := fmt.Errorf(
+					"the %q auth handler does not support per-request scopes; "+
+						"scopes are fixed at login time. Use 'scafctl auth login %s --scope <scope>' to change scopes",
+					handlerName, handlerName,
+				)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Scope is required only for handlers that support per-request scopes
+			if len(scopes) == 0 && auth.HasCapability(caps, auth.CapScopesOnTokenRequest) {
+				err := fmt.Errorf("--scope is required for the %q auth handler", handlerName)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Sort scopes for deterministic cache key
+			var scope string
+			if len(scopes) > 0 {
+				sorted := make([]string, len(scopes))
+				copy(sorted, scopes)
+				sort.Strings(sorted)
+				scope = strings.Join(sorted, " ")
+			}
+
 			token, err := handler.GetToken(ctx, auth.TokenOptions{
-				Scope:       scope,
-				MinValidFor: minValidFor,
+				Scope:        scope,
+				MinValidFor:  minValidFor,
+				ForceRefresh: forceRefresh,
 			})
 			if err != nil {
 				err = fmt.Errorf("failed to get token: %w", err)
@@ -143,8 +168,9 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scope(s) for the token (required, can specify multiple)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scope(s) for the token (required for handlers with scopes_on_token_request capability)")
 	cmd.Flags().DurationVar(&minValidFor, "min-valid-for", auth.DefaultMinValidFor, "Minimum time the token should be valid for")
+	cmd.Flags().BoolVarP(&forceRefresh, "force-refresh", "f", false, "Force acquiring a new token, ignoring any cached token")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -15,6 +15,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newEntraMock creates a mock handler with Entra-like capabilities (supports per-request scopes).
+func newEntraMock() *auth.MockHandler {
+	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
+	return mock
+}
+
+// newGitHubMock creates a mock handler with GitHub-like capabilities (no per-request scopes).
+func newGitHubMock() *auth.MockHandler {
+	mock := auth.NewMockHandler("github")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapHostname,
+	}
+	return mock
+}
+
 func TestCommandToken_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
 	cliParams := settings.NewCliParams()
@@ -43,8 +65,12 @@ func TestCommandToken_MissingHandler(t *testing.T) {
 	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
 }
 
-func TestCommandToken_MissingScope(t *testing.T) {
+func TestCommandToken_MissingScopeForEntra(t *testing.T) {
 	ctx, _ := newTestContext(t)
+
+	mock := newEntraMock()
+	ctx = withTestHandler(ctx, mock)
+
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 
@@ -55,12 +81,63 @@ func TestCommandToken_MissingScope(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "scope")
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestCommandToken_ScopeRejectedForGitHub(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	mock := newGitHubMock()
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github", "--scope", "repo"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support per-request scopes")
+	assert.Contains(t, err.Error(), "scafctl auth login")
+}
+
+func TestCommandToken_GitHubSuccessWithoutScope(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := newGitHubMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "repo read:user",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify GetToken was called with empty scope
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "", mock.GetTokenCalls[0].Scope)
+
+	output := buf.String()
+	assert.Contains(t, output, "Handler:")
+	assert.Contains(t, output, "github")
 }
 
 func TestCommandToken_Success(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetToken(&auth.Token{
 		AccessToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBP",
 		TokenType:   "Bearer",
@@ -98,7 +175,7 @@ func TestCommandToken_Success(t *testing.T) {
 func TestCommandToken_JSONOutput(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetToken(&auth.Token{
 		AccessToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBP",
 		TokenType:   "Bearer",
@@ -127,7 +204,7 @@ func TestCommandToken_JSONOutput(t *testing.T) {
 func TestCommandToken_WithMinValidFor(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetToken(&auth.Token{
 		AccessToken: "test-token",
 		TokenType:   "Bearer",
@@ -152,10 +229,38 @@ func TestCommandToken_WithMinValidFor(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, mock.GetTokenCalls[0].MinValidFor)
 }
 
+func TestCommandToken_ForceRefresh(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "fresh-token-value-that-is-long-enough",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "test-scope",
+	})
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--scope", "test-scope", "--force-refresh"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify GetToken was called with ForceRefresh=true
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.True(t, mock.GetTokenCalls[0].ForceRefresh)
+}
+
 func TestCommandToken_NotAuthenticated(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetTokenError(auth.ErrNotAuthenticated)
 
 	ctx = withTestHandler(ctx, mock)
@@ -175,7 +280,7 @@ func TestCommandToken_NotAuthenticated(t *testing.T) {
 func TestCommandToken_TokenError(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetTokenError(errors.New("token refresh failed"))
 
 	ctx = withTestHandler(ctx, mock)
@@ -196,7 +301,7 @@ func TestCommandToken_TokenError(t *testing.T) {
 func TestCommandToken_ShortToken(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("entra")
+	mock := newEntraMock()
 	mock.SetToken(&auth.Token{
 		AccessToken: "short", // Less than 20 chars
 		TokenType:   "Bearer",

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -184,7 +184,7 @@ func NewHTTPProvider() *HTTPProvider {
 				"authProvider": schemahelper.StringProp("Authentication provider to use for this request (e.g., 'entra'). When set, the provider will automatically obtain and inject an access token.",
 					schemahelper.WithExample("entra"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(50))),
-				"scope": schemahelper.StringProp("OAuth scope for authentication (required when authProvider is set). The token will be valid for the request timeout plus a 60-second buffer.",
+				"scope": schemahelper.StringProp("OAuth scope for authentication. Required for auth providers that support per-request scopes (e.g., Entra). Not used for providers with scopes fixed at login time (e.g., GitHub).",
 					schemahelper.WithExample("https://graph.microsoft.com/.default"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
 			}),
@@ -329,14 +329,23 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 	scope, _ := inputs["scope"].(string)
 
 	if authProvider != "" {
-		if scope == "" {
-			return nil, fmt.Errorf("%s: scope is required when authProvider is set", ProviderName)
-		}
-
 		// Get auth handler from context
 		handler, err := auth.GetHandler(ctx, authProvider)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ProviderName, err)
+		}
+
+		// Validate scope requirement based on handler capabilities
+		requiresScope := auth.HasCapability(handler.Capabilities(), auth.CapScopesOnTokenRequest)
+		if scope == "" && requiresScope {
+			return nil, fmt.Errorf("%s: scope is required when authProvider %q is set (handler supports per-request scopes)", ProviderName, authProvider)
+		}
+		if scope != "" && !requiresScope {
+			lgr.V(1).Info("ignoring scope for auth provider that does not support per-request scopes",
+				"authProvider", authProvider,
+				"scope", scope,
+			)
+			scope = ""
 		}
 
 		// Calculate minimum token validity: request timeout + 60 second buffer

--- a/pkg/provider/builtin/httpprovider/http_test.go
+++ b/pkg/provider/builtin/httpprovider/http_test.go
@@ -733,6 +733,7 @@ func TestHTTPProvider_Execute_AuthProvider_Success(t *testing.T) {
 
 	// Set up mock auth handler
 	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
 	mockHandler.SetToken(&auth.Token{
 		AccessToken: "test-access-token-12345",
 		TokenType:   "Bearer",
@@ -772,8 +773,15 @@ func TestHTTPProvider_Execute_AuthProvider_Success(t *testing.T) {
 }
 
 func TestHTTPProvider_Execute_AuthProvider_MissingScope(t *testing.T) {
+	// Scope is required for handlers with CapScopesOnTokenRequest (e.g., entra)
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
 	p := NewHTTPProvider()
-	ctx := context.Background()
 
 	inputs := map[string]any{
 		"url":          "https://example.com/api",
@@ -786,7 +794,49 @@ func TestHTTPProvider_Execute_AuthProvider_MissingScope(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, output)
-	assert.Contains(t, err.Error(), "scope is required when authProvider is set")
+	assert.Contains(t, err.Error(), "scope is required")
+}
+
+func TestHTTPProvider_Execute_AuthProvider_GitHubNoScope(t *testing.T) {
+	var receivedAuthHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer server.Close()
+
+	// GitHub handler does NOT have CapScopesOnTokenRequest
+	mockHandler := auth.NewMockHandler("github")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapHostname}
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: "gho_github_token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	p := NewHTTPProvider()
+	inputs := map[string]any{
+		"url":          server.URL,
+		"method":       "GET",
+		"authProvider": "github",
+		// No scope — GitHub scopes are fixed at login time
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "Bearer gho_github_token", receivedAuthHeader)
+
+	// Verify GetToken was called with empty scope
+	require.Len(t, mockHandler.GetTokenCalls, 1)
+	assert.Empty(t, mockHandler.GetTokenCalls[0].Scope)
 }
 
 func TestHTTPProvider_Execute_AuthProvider_MissingRegistry(t *testing.T) {
@@ -831,6 +881,7 @@ func TestHTTPProvider_Execute_AuthProvider_UnknownHandler(t *testing.T) {
 func TestHTTPProvider_Execute_AuthProvider_TokenError(t *testing.T) {
 	// Set up mock auth handler that returns error
 	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
 	mockHandler.SetTokenError(auth.ErrNotAuthenticated)
 
 	registry := auth.NewRegistry()
@@ -873,6 +924,7 @@ func TestHTTPProvider_Execute_AuthProvider_401Retry(t *testing.T) {
 
 	// Set up mock handler
 	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
 	mockHandler.SetToken(&auth.Token{
 		AccessToken: "test-token",
 		TokenType:   "Bearer",
@@ -920,6 +972,7 @@ func TestHTTPProvider_Execute_AuthProvider_401RetryOnlyOnce(t *testing.T) {
 	defer server.Close()
 
 	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
 	mockHandler.SetToken(&auth.Token{
 		AccessToken: "test-token",
 		TokenType:   "Bearer",

--- a/pkg/provider/builtin/identityprovider/identity.go
+++ b/pkg/provider/builtin/identityprovider/identity.go
@@ -320,9 +320,10 @@ func (p *IdentityProvider) executeList(ctx context.Context) (*provider.Output, e
 		}
 
 		info := map[string]any{
-			"name":        handler.Name(),
-			"displayName": handler.DisplayName(),
-			"flows":       flowsToStrings(handler.SupportedFlows()),
+			"name":         handler.Name(),
+			"displayName":  handler.DisplayName(),
+			"flows":        flowsToStrings(handler.SupportedFlows()),
+			"capabilities": capabilitiesToStrings(handler.Capabilities()),
 		}
 
 		// Check authentication status
@@ -378,6 +379,15 @@ func flowsToStrings(flows []auth.Flow) []string {
 	result := make([]string, len(flows))
 	for i, f := range flows {
 		result[i] = string(f)
+	}
+	return result
+}
+
+// capabilitiesToStrings converts auth capabilities to string slice for output.
+func capabilitiesToStrings(caps []auth.Capability) []string {
+	result := make([]string, len(caps))
+	for i, c := range caps {
+		result[i] = string(c)
 	}
 	return result
 }

--- a/pkg/provider/builtin/identityprovider/identity_test.go
+++ b/pkg/provider/builtin/identityprovider/identity_test.go
@@ -233,6 +233,7 @@ func TestIdentityProvider_ExecuteList(t *testing.T) {
 	// Setup multiple handlers
 	entraHandler := auth.NewMockHandler("entra")
 	entraHandler.DisplayNameValue = "Microsoft Entra ID"
+	entraHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapScopesOnTokenRequest, auth.CapTenantID}
 	entraHandler.StatusResult = &auth.Status{
 		Authenticated: true,
 		Claims:        &auth.Claims{Email: "user@example.com"},
@@ -240,6 +241,7 @@ func TestIdentityProvider_ExecuteList(t *testing.T) {
 
 	githubHandler := auth.NewMockHandler("github")
 	githubHandler.DisplayNameValue = "GitHub"
+	githubHandler.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapHostname}
 	githubHandler.StatusResult = &auth.Status{Authenticated: false}
 
 	registry := auth.NewRegistry()
@@ -273,6 +275,12 @@ func TestIdentityProvider_ExecuteList(t *testing.T) {
 	assert.Equal(t, "Microsoft Entra ID", entraInfo["displayName"])
 	assert.Equal(t, true, entraInfo["authenticated"])
 	assert.Equal(t, "user@example.com", entraInfo["identity"])
+
+	// Verify capabilities are included in handler info
+	entraCapabilities, ok := entraInfo["capabilities"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, entraCapabilities, string(auth.CapScopesOnTokenRequest))
+	assert.Contains(t, entraCapabilities, string(auth.CapTenantID))
 }
 
 func TestIdentityProvider_ExecuteDryRun(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1170,9 +1170,40 @@ func TestIntegration_AuthHelp(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "auth", "--help")
 
 	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "list")
 	assert.Contains(t, stdout, "login")
 	assert.Contains(t, stdout, "logout")
 	assert.Contains(t, stdout, "status")
+}
+
+func TestIntegration_AuthList(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "list")
+
+	assert.Equal(t, 0, exitCode)
+	// Should show the built-in handlers
+	assert.Contains(t, stdout, "entra")
+	assert.Contains(t, stdout, "github")
+}
+
+func TestIntegration_AuthListJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "list", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, `"name"`)
+	assert.Contains(t, stdout, `"flows"`)
+	assert.Contains(t, stdout, `"capabilities"`)
+}
+
+func TestIntegration_AuthTokenHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "token", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--scope")
+	assert.Contains(t, stdout, "--min-valid-for")
+	assert.Contains(t, stdout, "--force-refresh")
 }
 
 // ============================================================================


### PR DESCRIPTION
storeCredentials was using h.config.ClientID instead of preserving the login-time client ID from metadata. This caused token refresh failures when the handler's config differed from the original login (e.g., user changed config file between sessions).

Changes:
- Add clientID parameter to storeCredentials to explicitly track origin
- Pass metadata.ClientID during token rotation in mintToken
- Pass h.config.ClientID during initial login in deviceCodeLogin
- Apply DefaultMinValidFor in getCachedOrAcquireToken for SP/WI/PAT flows
- Add test for client ID preservation across refresh token rotation