### PR TITLE
feat(auth): add GCP authentication handler

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,12 +45,13 @@ jobs:
       - name: Run tests
         run: task test
         env:
-          # Test-only key ("test-secret-key-for-ci-12345678") — not a real secret.
+          # Test-only key ("test-secret-key-for-ci-123456789") — not a real secret.
+          # Must be exactly 32 bytes when base64-decoded (AES-256 master key).
           # Kept inline so CI works for fork PRs (secrets are unavailable to forks).
-          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=
 
       - name: Run functional integration tests
         run: task integration
         env:
           # Test-only key — see comment above.
-          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,22 +50,23 @@ jobs:
       - name: Run tests
         run: task test
         env:
-          # Test-only key ("test-secret-key-for-ci-12345678") — not a real secret.
+          # Test-only key ("test-secret-key-for-ci-123456789") — not a real secret.
+          # Must be exactly 32 bytes when base64-decoded (AES-256 master key).
           # Kept inline so CI works for fork PRs (secrets are unavailable to forks).
-          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=
       
       - name: Run functional integration tests
         run: task integration
         env:
           # Test-only key — see comment above.
-          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=
 
       - name: Run tests with coverage
         run: task test-cover
         if: matrix.os == 'ubuntu-latest'
         env:
           # Test-only key — see comment above.
-          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3OA==
+          SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=
       
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -5,13 +5,14 @@ weight: 40
 
 # Authentication Tutorial
 
-This tutorial walks you through setting up and using authentication in scafctl. You'll learn how to authenticate with Microsoft Entra ID and GitHub, manage credentials, and use authenticated HTTP requests in your solutions.
+This tutorial walks you through setting up and using authentication in scafctl. You'll learn how to authenticate with Microsoft Entra ID, GitHub, and Google Cloud Platform, manage credentials, and use authenticated HTTP requests in your solutions.
 
 ## Prerequisites
 
 - scafctl installed and available in your PATH
 - For Entra: Access to a Microsoft Entra ID tenant
 - For GitHub: A GitHub account (or GitHub Enterprise Server instance)
+- For GCP: A Google Cloud account
 - A web browser for completing the device code flow
 
 ## Table of Contents
@@ -23,6 +24,10 @@ This tutorial walks you through setting up and using authentication in scafctl. 
    - [Entra Workload Identity](#workload-identity-authentication-kubernetes)
    - [GitHub Device Code Flow](#github-device-code-flow)
    - [GitHub PAT Flow](#github-pat-authentication-cicd)
+   - [GCP Interactive Login](#gcp-interactive-login-browser-oauth)
+   - [GCP Service Account Key](#gcp-service-account-key-authentication-cicd)
+   - [GCP Workload Identity Federation](#gcp-workload-identity-federation)
+   - [GCP Metadata Server](#gcp-metadata-server-gcegkecloud-run)
 3. [Checking Auth Status](#checking-auth-status)
 4. [Using Auth in HTTP Providers](#using-auth-in-http-providers)
 5. [Getting Tokens for Debugging](#getting-tokens-for-debugging)
@@ -49,6 +54,7 @@ scafctl currently supports the following auth handlers:
 |---------|-------------|-------|
 | `entra` | Microsoft Entra ID (Azure AD) | Device Code, Service Principal, Workload Identity |
 | `github` | GitHub (github.com and GHES) | Device Code, PAT (Personal Access Token) |
+| `gcp` | Google Cloud Platform | Interactive (Browser OAuth), Service Account Key, Workload Identity Federation, Metadata Server |
 
 You can always discover registered handlers and their capabilities at runtime:
 
@@ -551,6 +557,68 @@ scafctl auth login github --flow pat
 
 ---
 
+## GCP Interactive Login (Browser OAuth)
+
+For local development, use the interactive browser OAuth flow:
+
+```bash
+# Login with GCP using browser OAuth (default)
+scafctl auth login gcp
+
+# Login with specific scopes
+scafctl auth login gcp --scope https://www.googleapis.com/auth/bigquery
+
+# Login with service account impersonation
+scafctl auth login gcp --impersonate-service-account my-sa@my-project.iam.gserviceaccount.com
+```
+
+This will:
+1. Start a local HTTP server
+2. Open your browser to Google's OAuth consent page
+3. Exchange the authorization code for refresh + access tokens
+4. Store the refresh token in your system's secret store
+
+## GCP Service Account Key Authentication (CI/CD)
+
+For non-interactive scenarios, use a service account key file:
+
+```bash
+# Point to your service account key JSON file
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/sa-key.json"
+
+# Login with service account (auto-detected from env var)
+scafctl auth login gcp
+
+# Or choose the flow explicitly
+scafctl auth login gcp --flow service-principal
+```
+
+## GCP Workload Identity Federation
+
+For Kubernetes and other cloud platforms:
+
+```bash
+# Point to external account JSON config
+export GOOGLE_EXTERNAL_ACCOUNT="/path/to/external-account.json"
+
+# Login (auto-detected)
+scafctl auth login gcp
+
+# Or explicitly
+scafctl auth login gcp --flow workload-identity
+```
+
+## GCP Metadata Server (GCE/GKE/Cloud Run)
+
+On Google Compute Engine, GKE, and Cloud Run:
+
+```bash
+# Login via metadata server (auto-detected on GCE)
+scafctl auth login gcp --flow metadata
+```
+
+---
+
 ## Checking Auth Status
 
 To see your current authentication status:
@@ -601,6 +669,7 @@ When not authenticated:
 Handler   Status            Identity   Tenant   Expires
 entra     Not Authenticated -          -        -
 github    Not Authenticated -          -        -
+gcp       Not Authenticated -          -        -
 ```
 
 ---

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -1,0 +1,333 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements the ADC (Application Default Credentials) browser OAuth flow
+// using authorization code + PKCE with a local redirect server.
+package gcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// Google OAuth 2.0 endpoints.
+	authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+	revokeEndpoint        = "https://oauth2.googleapis.com/revoke"
+)
+
+// adcLogin performs the ADC browser OAuth flow (authorization code + PKCE).
+func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting ADC browser OAuth flow", "handler", HandlerName)
+
+	if h.config.ClientID == "" {
+		// Try gcloud ADC fallback
+		lgr.V(1).Info("no client ID configured, trying gcloud ADC fallback")
+		return h.gcloudADCLogin(ctx, opts)
+	}
+
+	// Determine scopes
+	scopes := opts.Scopes
+	if len(scopes) == 0 {
+		scopes = h.config.DefaultScopes
+	}
+	scopeStr := strings.Join(scopes, " ")
+
+	// Generate PKCE code verifier and challenge
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("generating PKCE code verifier: %w", err)
+	}
+	codeChallenge := generateCodeChallenge(codeVerifier)
+
+	// Start local HTTP server for redirect
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", "localhost:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting local redirect server: %w", err)
+	}
+	defer listener.Close()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return nil, fmt.Errorf("unexpected listener address type: %T", listener.Addr())
+	}
+	port := tcpAddr.Port
+	redirectURI := fmt.Sprintf("http://localhost:%d", port)
+
+	// Channel to receive the authorization code
+	codeChan := make(chan string, 1)
+	errChan := make(chan error, 1)
+
+	// Set up the redirect handler
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errMsg := r.URL.Query().Get("error")
+			if errMsg == "" {
+				errMsg = "no authorization code received"
+			}
+			errChan <- fmt.Errorf("OAuth error: %s", errMsg)
+			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p><p>You can close this window.</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // G705: input is escaped via html.EscapeString
+			return
+		}
+		codeChan <- code
+		fmt.Fprint(w, "<html><body><h1>Authentication Successful</h1><p>You can close this window and return to the terminal.</p></body></html>")
+	})
+
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 30 * time.Second}
+	go func() {
+		if sErr := server.Serve(listener); sErr != nil && sErr != http.ErrServerClosed {
+			errChan <- fmt.Errorf("redirect server error: %w", sErr)
+		}
+	}()
+	defer server.Close()
+
+	// Build authorization URL
+	authURL := fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&code_challenge=%s&code_challenge_method=S256&access_type=offline&prompt=consent",
+		authorizationEndpoint,
+		url.QueryEscape(h.config.ClientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scopeStr),
+		url.QueryEscape(codeChallenge),
+	)
+
+	// Open browser
+	lgr.V(1).Info("opening browser for authentication", "url", authURL)
+	if err := openBrowser(ctx, authURL); err != nil {
+		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
+	}
+
+	// Wait for authorization code or timeout
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+
+	var authCode string
+	select {
+	case authCode = <-codeChan:
+		lgr.V(1).Info("received authorization code")
+	case err := <-errChan:
+		return nil, err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("authentication timed out: no response received from browser: %w", auth.ErrTimeout)
+	case <-ctx.Done():
+		return nil, fmt.Errorf("authentication cancelled: %w", auth.ErrUserCancelled)
+	}
+
+	// Exchange code for tokens
+	data := url.Values{}
+	data.Set("code", authCode)
+	data.Set("client_id", h.config.ClientID)
+	if h.config.ClientSecret != "" {
+		data.Set("client_secret", h.config.ClientSecret)
+	}
+	data.Set("redirect_uri", redirectURI)
+	data.Set("grant_type", "authorization_code")
+	data.Set("code_verifier", codeVerifier)
+
+	resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("token exchange failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	// Store credentials
+	if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, scopes); err != nil {
+		return nil, fmt.Errorf("failed to store credentials: %w", err)
+	}
+
+	// Cache the access token
+	if tokenResp.AccessToken != "" {
+		expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		_ = h.tokenCache.Set(ctx, scopeStr, &auth.Token{
+			AccessToken: tokenResp.AccessToken,
+			TokenType:   tokenResp.TokenType,
+			ExpiresAt:   expiresAt,
+			Scope:       scopeStr,
+		})
+	}
+
+	// Extract claims
+	claims, err := extractClaims(&tokenResp)
+	if err != nil {
+		// Try userinfo endpoint as fallback
+		if tokenResp.AccessToken != "" {
+			claims, err = h.fetchUserinfoClaims(ctx, tokenResp.AccessToken)
+			if err != nil {
+				claims = &auth.Claims{Issuer: "https://accounts.google.com"}
+			}
+		} else {
+			claims = &auth.Claims{Issuer: "https://accounts.google.com"}
+		}
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	lgr.V(1).Info("ADC browser OAuth flow completed successfully",
+		"email", claims.Email,
+		"expiresIn", tokenResp.ExpiresIn,
+	)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// mintToken creates a new access token using the stored refresh token.
+func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("minting access token", "scope", scope)
+
+	refreshToken, err := h.loadRefreshToken(ctx)
+	if err != nil {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	metadata, err := h.loadMetadata(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+
+	// For ADC flow, use the stored client ID
+	clientID := h.config.ClientID
+	if metadata.ClientID != "" {
+		clientID = metadata.ClientID
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("client_id", clientID)
+	if h.config.ClientSecret != "" {
+		data.Set("client_secret", h.config.ClientSecret)
+	}
+	data.Set("refresh_token", refreshToken)
+
+	resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+
+		if errResp.Error == "invalid_grant" {
+			_ = h.Logout(ctx)
+			return nil, fmt.Errorf("%s: %w", errResp.ErrorDescription, auth.ErrTokenExpired)
+		}
+		return nil, fmt.Errorf("token refresh failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	// Handle refresh token rotation
+	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
+		lgr.V(1).Info("refresh token rotated, storing new token")
+		if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, metadata.Scopes); err != nil {
+			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
+		}
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	return &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       scope,
+	}, nil
+}
+
+// revokeRefreshToken revokes the stored refresh token with Google.
+func (h *Handler) revokeRefreshToken(ctx context.Context) error {
+	refreshToken, err := h.loadRefreshToken(ctx)
+	if err != nil {
+		return nil // No refresh token to revoke
+	}
+
+	data := url.Values{}
+	data.Set("token", refreshToken)
+
+	resp, err := h.httpClient.PostForm(ctx, revokeEndpoint, data)
+	if err != nil {
+		return fmt.Errorf("token revocation failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Google returns 200 on success, but we don't fail on revocation errors
+	// because the token might already be revoked
+	return nil
+}
+
+// generateCodeVerifier generates a PKCE code verifier (43-128 character random string).
+func generateCodeVerifier() (string, error) {
+	buf := make([]byte, 32) // 32 bytes → 43 base64url chars
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generating random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// generateCodeChallenge creates a PKCE code challenge from a code verifier.
+func generateCodeChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// openBrowser opens a URL in the default system browser.
+func openBrowser(ctx context.Context, url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	case "linux":
+		cmd = "xdg-open"
+		args = []string{url}
+	case "windows":
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	return exec.CommandContext(ctx, cmd, args...).Start() //nolint:gosec // URL is from trusted internal config
+}

--- a/pkg/auth/gcp/cache.go
+++ b/pkg/auth/gcp/cache.go
@@ -1,0 +1,148 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+)
+
+// TokenCache provides disk-based caching for access tokens via pkg/secrets.
+type TokenCache struct {
+	secretStore secrets.Store
+}
+
+// CachedToken is the structure stored on disk for each cached token.
+type CachedToken struct {
+	AccessToken string    `json:"accessToken"` //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
+	TokenType   string    `json:"tokenType"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	Scope       string    `json:"scope"`
+	CachedAt    time.Time `json:"cachedAt"`
+}
+
+// NewTokenCache creates a new disk-based token cache.
+func NewTokenCache(secretStore secrets.Store) *TokenCache {
+	return &TokenCache{
+		secretStore: secretStore,
+	}
+}
+
+// Get retrieves a token for the given scope from disk cache.
+func (c *TokenCache) Get(ctx context.Context, scope string) (*auth.Token, error) {
+	key := c.scopeToKey(scope)
+
+	data, err := c.secretStore.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, secrets.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cached token: %w", err)
+	}
+
+	var cached CachedToken
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cached token: %w", err)
+	}
+
+	return &auth.Token{
+		AccessToken: cached.AccessToken,
+		TokenType:   cached.TokenType,
+		ExpiresAt:   cached.ExpiresAt,
+		Scope:       cached.Scope,
+	}, nil
+}
+
+// Set stores a token for the given scope to disk cache.
+func (c *TokenCache) Set(ctx context.Context, scope string, token *auth.Token) error {
+	key := c.scopeToKey(scope)
+
+	cached := CachedToken{
+		AccessToken: token.AccessToken,
+		TokenType:   token.TokenType,
+		ExpiresAt:   token.ExpiresAt,
+		Scope:       scope,
+		CachedAt:    time.Now(),
+	}
+
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token for cache: %w", err)
+	}
+
+	if err := c.secretStore.Set(ctx, key, data); err != nil {
+		return fmt.Errorf("failed to write cached token: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a cached token for the given scope.
+func (c *TokenCache) Delete(ctx context.Context, scope string) error {
+	key := c.scopeToKey(scope)
+	return c.secretStore.Delete(ctx, key)
+}
+
+// Clear removes all cached GCP tokens.
+func (c *TokenCache) Clear(ctx context.Context) error {
+	names, err := c.secretStore.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	var lastErr error
+	for _, name := range names {
+		if strings.HasPrefix(name, SecretKeyTokenPrefix) {
+			if err := c.secretStore.Delete(ctx, name); err != nil {
+				lastErr = err
+			}
+		}
+	}
+
+	return lastErr
+}
+
+// ListCachedScopes returns a list of scopes that have cached tokens.
+func (c *TokenCache) ListCachedScopes(ctx context.Context) ([]string, error) {
+	names, err := c.secretStore.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	scopes := make([]string, 0)
+	for _, name := range names {
+		if scope := c.keyToScope(name); scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+
+	return scopes, nil
+}
+
+// scopeToKey converts a scope to a secret key.
+func (c *TokenCache) scopeToKey(scope string) string {
+	encoded := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(scope))
+	return SecretKeyTokenPrefix + encoded
+}
+
+// keyToScope converts a secret key back to a scope.
+func (c *TokenCache) keyToScope(key string) string {
+	if !strings.HasPrefix(key, SecretKeyTokenPrefix) {
+		return ""
+	}
+	encoded := strings.TrimPrefix(key, SecretKeyTokenPrefix)
+	decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(encoded)
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
+}

--- a/pkg/auth/gcp/cache_test.go
+++ b/pkg/auth/gcp/cache_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCache_SetAndGet(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	token := &auth.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       scope,
+	}
+
+	err := cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, scope)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "test-access-token", got.AccessToken)
+	assert.Equal(t, "Bearer", got.TokenType)
+	assert.Equal(t, scope, got.Scope)
+}
+
+func TestTokenCache_Get_NotFound(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	got, err := cache.Get(ctx, "nonexistent-scope")
+	require.NoError(t, err) // returns nil, nil for not found
+	assert.Nil(t, got)
+}
+
+func TestTokenCache_Delete(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	token := &auth.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       scope,
+	}
+
+	err := cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	err = cache.Delete(ctx, scope)
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, scope)
+	require.NoError(t, err) // returns nil, nil for deleted key
+	assert.Nil(t, got)
+}
+
+func TestTokenCache_Clear(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	// Add multiple tokens
+	scopes := []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/bigquery",
+	}
+	for _, scope := range scopes {
+		token := &auth.Token{
+			AccessToken: "token-for-" + scope,
+			TokenType:   "Bearer",
+			ExpiresAt:   time.Now().Add(1 * time.Hour),
+			Scope:       scope,
+		}
+		err := cache.Set(ctx, scope, token)
+		require.NoError(t, err)
+	}
+
+	err := cache.Clear(ctx)
+	require.NoError(t, err)
+
+	// All tokens should be gone
+	for _, scope := range scopes {
+		got, err := cache.Get(ctx, scope)
+		require.NoError(t, err) // returns nil, nil for deleted keys
+		assert.Nil(t, got)
+	}
+}
+
+func TestTokenCache_ScopeToKey(t *testing.T) {
+	cache := NewTokenCache(nil)
+
+	key1 := cache.scopeToKey("https://www.googleapis.com/auth/cloud-platform")
+	key2 := cache.scopeToKey("https://www.googleapis.com/auth/bigquery")
+
+	// Keys should be different for different scopes
+	assert.NotEqual(t, key1, key2)
+
+	// Keys should have the correct prefix
+	assert.Contains(t, key1, SecretKeyTokenPrefix)
+	assert.Contains(t, key2, SecretKeyTokenPrefix)
+}
+
+func TestTokenCache_ListCachedScopes(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+
+	// Add a token
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+	token := &auth.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       scope,
+	}
+	err := cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	scopes, err := cache.ListCachedScopes(ctx)
+	require.NoError(t, err)
+	assert.Len(t, scopes, 1)
+	assert.Contains(t, scopes, scope)
+}
+
+func TestTokenCache_ExpiredToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	cache := NewTokenCache(store)
+	ctx := context.Background()
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	// Cache an expired token
+	token := &auth.Token{
+		AccessToken: "expired-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(-1 * time.Hour),
+		Scope:       scope,
+	}
+	err := cache.Set(ctx, scope, token)
+	require.NoError(t, err)
+
+	// Should still return the expired token (caller decides validity)
+	got, err := cache.Get(ctx, scope)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "expired-token", got.AccessToken)
+	assert.False(t, got.IsValidFor(1*time.Minute))
+}

--- a/pkg/auth/gcp/config.go
+++ b/pkg/auth/gcp/config.go
@@ -1,0 +1,50 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+package gcp
+
+import "fmt"
+
+// Config holds GCP-specific configuration.
+type Config struct {
+	// ClientID is the OAuth 2.0 client ID for the ADC browser flow.
+	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+
+	// ClientSecret is the OAuth 2.0 client secret (not confidential for desktop apps).
+	ClientSecret string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"` //nolint:gosec // G117: not a hardcoded credential, it's a config field
+
+	// DefaultScopes are the default OAuth scopes requested during login.
+	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty"`
+
+	// ImpersonateServiceAccount is the target service account email for impersonation.
+	// When set, all token requests will impersonate this service account.
+	ImpersonateServiceAccount string `json:"impersonateServiceAccount,omitempty" yaml:"impersonateServiceAccount,omitempty"`
+
+	// Project is the default GCP project (informational, not used for auth).
+	Project string `json:"project,omitempty" yaml:"project,omitempty"`
+}
+
+// DefaultConfig returns the default GCP configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		ClientID:     "",
+		ClientSecret: "",
+		DefaultScopes: []string{
+			"openid",
+			"email",
+			"profile",
+			"https://www.googleapis.com/auth/cloud-platform",
+		},
+	}
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.ImpersonateServiceAccount != "" {
+		if len(c.ImpersonateServiceAccount) < 6 {
+			return fmt.Errorf("impersonateServiceAccount must be a valid service account email")
+		}
+	}
+	return nil
+}

--- a/pkg/auth/gcp/config_test.go
+++ b/pkg/auth/gcp/config_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.ClientID)
+	assert.Empty(t, cfg.ClientSecret)
+	assert.Empty(t, cfg.ImpersonateServiceAccount)
+	assert.Empty(t, cfg.Project)
+	assert.Contains(t, cfg.DefaultScopes, "openid")
+	assert.Contains(t, cfg.DefaultScopes, "email")
+	assert.Contains(t, cfg.DefaultScopes, "profile")
+	assert.Contains(t, cfg.DefaultScopes, "https://www.googleapis.com/auth/cloud-platform")
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name:    "empty config is valid",
+			config:  Config{},
+			wantErr: false,
+		},
+		{
+			name: "valid impersonation email",
+			config: Config{
+				ImpersonateServiceAccount: "my-sa@project.iam.gserviceaccount.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "short impersonation email",
+			config: Config{
+				ImpersonateServiceAccount: "ab",
+			},
+			wantErr: true,
+		},
+		{
+			name: "full config is valid",
+			config: Config{
+				ClientID:                  "test-client-id",
+				ClientSecret:              "test-secret",
+				DefaultScopes:             []string{"openid"},
+				ImpersonateServiceAccount: "my-sa@project.iam.gserviceaccount.com",
+				Project:                   "my-project",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/auth/gcp/gcloud_adc.go
+++ b/pkg/auth/gcp/gcloud_adc.go
@@ -1,0 +1,237 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements the gcloud ADC (Application Default Credentials) fallback
+// for users who have already run `gcloud auth application-default login`.
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// EnvCloudSDKConfig is the environment variable for custom gcloud config directory.
+	EnvCloudSDKConfig = "CLOUDSDK_CONFIG"
+)
+
+// GcloudADCCredentials represents the structure of the gcloud ADC JSON file.
+type GcloudADCCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec // This is a field name, not a credential
+	RefreshToken string `json:"refresh_token"` //nolint:gosec // This is a field name, not a credential
+	Type         string `json:"type"`
+}
+
+// getGcloudADCPath returns the path to the gcloud ADC credentials file.
+func getGcloudADCPath() string {
+	// Check CLOUDSDK_CONFIG first
+	if dir := os.Getenv(EnvCloudSDKConfig); dir != "" {
+		return filepath.Join(dir, "application_default_credentials.json")
+	}
+
+	// Platform-specific defaults
+	switch runtime.GOOS {
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "gcloud", "application_default_credentials.json")
+		}
+	default:
+		// Linux and macOS
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+		}
+	}
+
+	return ""
+}
+
+// LoadGcloudADCCredentials loads gcloud ADC credentials from the well-known location.
+func LoadGcloudADCCredentials() (*GcloudADCCredentials, error) {
+	path := getGcloudADCPath()
+	if path == "" {
+		return nil, nil //nolint:nilnil // nil,nil means no credentials found
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // file doesn't exist, no credentials
+		}
+		return nil, fmt.Errorf("reading gcloud ADC file: %w", err)
+	}
+
+	var creds GcloudADCCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parsing gcloud ADC file: %w", err)
+	}
+
+	if creds.Type != "authorized_user" {
+		return nil, nil //nolint:nilnil // not user credentials (could be service account)
+	}
+
+	if creds.RefreshToken == "" {
+		return nil, nil //nolint:nilnil // no refresh token
+	}
+
+	return &creds, nil
+}
+
+// HasGcloudADCCredentials checks if gcloud ADC credentials exist.
+func HasGcloudADCCredentials() bool {
+	creds, err := LoadGcloudADCCredentials()
+	return err == nil && creds != nil
+}
+
+// gcloudADCLogin uses existing gcloud ADC credentials to authenticate.
+func (h *Handler) gcloudADCLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("attempting gcloud ADC fallback login")
+
+	creds, err := LoadGcloudADCCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("loading gcloud ADC credentials: %w", err)
+	}
+	if creds == nil {
+		return nil, fmt.Errorf("no gcloud ADC credentials found; run 'gcloud auth application-default login' or configure a client ID for scafctl")
+	}
+
+	// Use gcloud's refresh token to get an access token
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("client_id", creds.ClientID)
+	data.Set("client_secret", creds.ClientSecret)
+	data.Set("refresh_token", creds.RefreshToken)
+
+	resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("gcloud ADC token refresh failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("gcloud ADC token refresh failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	// Extract claims from ID token or userinfo
+	var claims *auth.Claims
+	claims, err = extractClaims(&tokenResp)
+	if err != nil || claims.Email == "" {
+		// Try userinfo endpoint
+		if tokenResp.AccessToken != "" {
+			claims, err = h.fetchUserinfoClaims(ctx, tokenResp.AccessToken)
+			if err != nil {
+				claims = &auth.Claims{Issuer: "https://accounts.google.com"}
+			}
+		}
+	}
+
+	// Store metadata (but NOT the refresh token — we leave that in gcloud's file)
+	if err := h.storeMetadataOnly(ctx, claims, auth.FlowInteractive, opts.Scopes); err != nil {
+		lgr.V(1).Info("warning: failed to store metadata", "error", err)
+	}
+
+	// Cache the access token
+	scopeStr := tokenResp.Scope
+	if scopeStr == "" {
+		scopeStr = "https://www.googleapis.com/auth/cloud-platform"
+	}
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	_ = h.tokenCache.Set(ctx, scopeStr, &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       scopeStr,
+	})
+
+	lgr.V(1).Info("gcloud ADC fallback login successful", "email", claims.Email)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// getGcloudADCToken refreshes a token using gcloud ADC credentials, with caching.
+func (h *Handler) getGcloudADCToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	if opts.Scope == "" {
+		return nil, auth.ErrInvalidScope
+	}
+
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
+	// Check cache first
+	if !opts.ForceRefresh {
+		cached, err := h.tokenCache.Get(ctx, opts.Scope)
+		if err == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached gcloud ADC token", "scope", opts.Scope)
+			return cached, nil
+		}
+	}
+
+	creds, err := LoadGcloudADCCredentials()
+	if err != nil || creds == nil {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	// Refresh token using gcloud's credentials
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("client_id", creds.ClientID)
+	data.Set("client_secret", creds.ClientSecret)
+	data.Set("refresh_token", creds.RefreshToken)
+
+	resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("gcloud ADC token refresh failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("gcloud ADC token refresh failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	token := &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       opts.Scope,
+	}
+
+	// Cache the token
+	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+		lgr.V(1).Info("failed to cache gcloud ADC token", "error", err)
+	}
+
+	return token, nil
+}

--- a/pkg/auth/gcp/gcloud_adc_test.go
+++ b/pkg/auth/gcp/gcloud_adc_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGcloudADCPath_CustomDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	path := getGcloudADCPath()
+	assert.Equal(t, filepath.Join(tmpDir, "application_default_credentials.json"), path)
+}
+
+func TestGetGcloudADCPath_Default(t *testing.T) {
+	t.Setenv(EnvCloudSDKConfig, "")
+	path := getGcloudADCPath()
+	// Should return a non-empty path on any platform
+	assert.NotEmpty(t, path)
+	assert.Contains(t, path, "application_default_credentials.json")
+}
+
+func TestLoadGcloudADCCredentials_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	creds, err := LoadGcloudADCCredentials()
+	require.NoError(t, err)
+	assert.Nil(t, creds) // No file, no error
+}
+
+func TestLoadGcloudADCCredentials_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	path := filepath.Join(tmpDir, "application_default_credentials.json")
+	err := os.WriteFile(path, []byte("not-json"), 0o600)
+	require.NoError(t, err)
+
+	creds, err := LoadGcloudADCCredentials()
+	require.Error(t, err)
+	assert.Nil(t, creds)
+}
+
+func TestLoadGcloudADCCredentials_WrongType(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	path := filepath.Join(tmpDir, "application_default_credentials.json")
+	data, _ := json.Marshal(map[string]string{
+		"type":          "service_account",
+		"client_id":     "test",
+		"client_secret": "test",
+	})
+	err := os.WriteFile(path, data, 0o600)
+	require.NoError(t, err)
+
+	creds, err := LoadGcloudADCCredentials()
+	require.NoError(t, err)
+	assert.Nil(t, creds) // not authorized_user type
+}
+
+func TestLoadGcloudADCCredentials_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	path := filepath.Join(tmpDir, "application_default_credentials.json")
+	adcCreds := GcloudADCCredentials{
+		ClientID:     "test-client-id.apps.googleusercontent.com",
+		ClientSecret: "test-client-secret",
+		RefreshToken: "test-refresh-token",
+		Type:         "authorized_user",
+	}
+	data, err := json.Marshal(adcCreds)
+	require.NoError(t, err)
+	err = os.WriteFile(path, data, 0o600)
+	require.NoError(t, err)
+
+	creds, err := LoadGcloudADCCredentials()
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "authorized_user", creds.Type)
+	assert.Equal(t, "test-client-id.apps.googleusercontent.com", creds.ClientID)
+	assert.Equal(t, "test-refresh-token", creds.RefreshToken)
+}
+
+func TestHasGcloudADCCredentials_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	assert.False(t, HasGcloudADCCredentials())
+}
+
+func TestHasGcloudADCCredentials_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvCloudSDKConfig, tmpDir)
+
+	path := filepath.Join(tmpDir, "application_default_credentials.json")
+	data, _ := json.Marshal(GcloudADCCredentials{
+		ClientID:     "test",
+		ClientSecret: "test",
+		RefreshToken: "test",
+		Type:         "authorized_user",
+	})
+	_ = os.WriteFile(path, data, 0o600)
+
+	assert.True(t, HasGcloudADCCredentials())
+}

--- a/pkg/auth/gcp/handler.go
+++ b/pkg/auth/gcp/handler.go
@@ -1,0 +1,451 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+)
+
+const (
+	// HandlerName is the unique identifier for the GCP auth handler.
+	HandlerName = "gcp"
+
+	// HandlerDisplayName is the human-readable name.
+	HandlerDisplayName = "Google Cloud Platform"
+
+	// SecretKeyRefreshToken is the secret name for storing the refresh token.
+	SecretKeyRefreshToken = "scafctl.auth.gcp.refresh_token" //nolint:gosec // This is a key name, not a credential
+
+	// SecretKeyMetadata is the secret name for storing token metadata.
+	SecretKeyMetadata = "scafctl.auth.gcp.metadata" //nolint:gosec // This is a key name, not a credential
+
+	// SecretKeyTokenPrefix is the prefix for cached access tokens.
+	SecretKeyTokenPrefix = "scafctl.auth.gcp.token." //nolint:gosec // This is a key prefix, not a credential
+
+	// DefaultTimeout is the default timeout for browser OAuth flow.
+	DefaultTimeout = 5 * time.Minute
+)
+
+// Handler implements auth.Handler for Google Cloud Platform.
+type Handler struct {
+	config      *Config
+	secretStore secrets.Store
+	secretErr   error // deferred error from secrets initialization
+	httpClient  HTTPClient
+	tokenCache  *TokenCache
+}
+
+// Option configures the Handler.
+type Option func(*Handler)
+
+// WithConfig sets the GCP configuration.
+func WithConfig(cfg *Config) Option {
+	return func(h *Handler) {
+		if cfg != nil {
+			if cfg.ClientID != "" {
+				h.config.ClientID = cfg.ClientID
+			}
+			if cfg.ClientSecret != "" {
+				h.config.ClientSecret = cfg.ClientSecret
+			}
+			if len(cfg.DefaultScopes) > 0 {
+				h.config.DefaultScopes = cfg.DefaultScopes
+			}
+			if cfg.ImpersonateServiceAccount != "" {
+				h.config.ImpersonateServiceAccount = cfg.ImpersonateServiceAccount
+			}
+			if cfg.Project != "" {
+				h.config.Project = cfg.Project
+			}
+		}
+	}
+}
+
+// WithSecretStore sets a custom secrets store.
+func WithSecretStore(store secrets.Store) Option {
+	return func(h *Handler) {
+		h.secretStore = store
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for token requests.
+func WithHTTPClient(client HTTPClient) Option {
+	return func(h *Handler) {
+		h.httpClient = client
+	}
+}
+
+// New creates a new GCP auth handler.
+// Secret store initialization is deferred — if it fails, the handler is still
+// created so that metadata operations (Name, SupportedFlows, etc.) work.
+// Operations requiring secrets (Login, Logout, Status, GetToken) will return
+// the deferred error.
+func New(opts ...Option) (*Handler, error) {
+	h := &Handler{
+		config: DefaultConfig(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	// Initialize secret store if not provided
+	if h.secretStore == nil {
+		store, err := secrets.New()
+		if err != nil {
+			h.secretErr = fmt.Errorf("failed to initialize secrets store: %w", err)
+		} else {
+			h.secretStore = store
+		}
+	}
+
+	// Initialize HTTP client if not provided
+	if h.httpClient == nil {
+		h.httpClient = NewDefaultHTTPClient()
+	}
+
+	// Initialize token cache with secret store
+	if h.secretStore != nil {
+		h.tokenCache = NewTokenCache(h.secretStore)
+	}
+
+	return h, nil
+}
+
+// ensureSecrets returns an error if the secret store is not available.
+func (h *Handler) ensureSecrets() error {
+	if h.secretStore == nil {
+		if h.secretErr != nil {
+			return h.secretErr
+		}
+		return fmt.Errorf("secrets store not initialized")
+	}
+	return nil
+}
+
+// Name returns the handler identifier.
+func (h *Handler) Name() string {
+	return HandlerName
+}
+
+// DisplayName returns the human-readable name.
+func (h *Handler) DisplayName() string {
+	return HandlerDisplayName
+}
+
+// SupportedFlows returns the authentication flows this handler supports.
+func (h *Handler) SupportedFlows() []auth.Flow {
+	return []auth.Flow{
+		auth.FlowInteractive,
+		auth.FlowServicePrincipal,
+		auth.FlowWorkloadIdentity,
+		auth.FlowMetadata,
+	}
+}
+
+// Capabilities returns the set of capabilities this handler supports.
+func (h *Handler) Capabilities() []auth.Capability {
+	return []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapFederatedToken,
+	}
+}
+
+// Login initiates the authentication flow.
+func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	// Check if workload identity flow is requested or detected (highest priority)
+	if opts.Flow == auth.FlowWorkloadIdentity || (opts.Flow == "" && HasWorkloadIdentityCredentials()) {
+		return h.workloadIdentityLogin(ctx, opts)
+	}
+
+	// Check if metadata server flow is requested or detected
+	if opts.Flow == auth.FlowMetadata || (opts.Flow == "" && IsMetadataServerAvailable(ctx, h.httpClient)) {
+		return h.metadataLogin(ctx, opts)
+	}
+
+	// Check if service account flow is requested or detected
+	if opts.Flow == auth.FlowServicePrincipal || (opts.Flow == "" && HasServiceAccountCredentials()) {
+		return h.serviceAccountLogin(ctx, opts)
+	}
+
+	// Default to ADC (browser OAuth or gcloud fallback)
+	return h.adcLogin(ctx, opts)
+}
+
+// Logout clears stored credentials and cached tokens.
+func (h *Handler) Logout(ctx context.Context) error {
+	if err := h.ensureSecrets(); err != nil {
+		return err
+	}
+
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("logging out", "handler", HandlerName)
+
+	// Revoke refresh token with Google (ADC flow only)
+	if err := h.revokeRefreshToken(ctx); err != nil {
+		lgr.V(1).Info("failed to revoke refresh token (may not exist)", "error", err)
+	}
+
+	// Clear all cached tokens
+	if err := h.tokenCache.Clear(ctx); err != nil {
+		lgr.V(1).Info("failed to clear token cache (may be empty)", "error", err)
+	}
+
+	// Delete refresh token
+	if err := h.secretStore.Delete(ctx, SecretKeyRefreshToken); err != nil {
+		lgr.V(1).Info("failed to delete refresh token (may not exist)", "error", err)
+	}
+
+	// Delete metadata
+	if err := h.secretStore.Delete(ctx, SecretKeyMetadata); err != nil {
+		lgr.V(1).Info("failed to delete metadata (may not exist)", "error", err)
+	}
+
+	return nil
+}
+
+// Status returns the current authentication status.
+func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	// Check for workload identity credentials first (highest priority)
+	if HasWorkloadIdentityCredentials() {
+		return h.workloadIdentityStatus(ctx)
+	}
+
+	// Check for metadata server
+	// Note: We don't auto-probe metadata server for status to avoid network calls
+	// on every status check. Users who logged in with metadata flow will have stored metadata.
+
+	// Check for service account credentials
+	if HasServiceAccountCredentials() {
+		return h.serviceAccountStatus(ctx)
+	}
+
+	// Check for stored credentials (ADC flow)
+	exists, err := h.secretStore.Exists(ctx, SecretKeyMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check credentials: %w", err)
+	}
+
+	if !exists {
+		// Check for gcloud ADC credentials as fallback
+		if HasGcloudADCCredentials() {
+			return &auth.Status{
+				Authenticated: true,
+				Claims: &auth.Claims{
+					Issuer: "https://accounts.google.com",
+					Name:   "gcloud ADC (application default credentials)",
+				},
+				IdentityType: auth.IdentityTypeUser,
+			}, nil
+		}
+		return &auth.Status{Authenticated: false}, nil
+	}
+
+	// Load metadata
+	metadata, err := h.loadMetadata(ctx)
+	if err != nil {
+		return &auth.Status{Authenticated: false}, nil //nolint:nilerr // treat corrupted metadata as not authenticated
+	}
+
+	status := &auth.Status{
+		Authenticated: true,
+		Claims:        metadata.Claims,
+		IdentityType:  auth.IdentityTypeUser,
+		Scopes:        metadata.Scopes,
+	}
+
+	switch metadata.Flow { //nolint:exhaustive // only SA and WI need override; all others use default IdentityTypeUser
+	case auth.FlowServicePrincipal:
+		status.IdentityType = auth.IdentityTypeServicePrincipal
+	case auth.FlowWorkloadIdentity:
+		status.IdentityType = auth.IdentityTypeWorkloadIdentity
+	}
+
+	if !metadata.RefreshTokenExpiresAt.IsZero() {
+		status.ExpiresAt = metadata.RefreshTokenExpiresAt
+	}
+
+	if metadata.ImpersonateServiceAccount != "" {
+		status.ClientID = metadata.ImpersonateServiceAccount
+	}
+
+	return status, nil
+}
+
+// GetToken returns a valid access token for the specified options.
+func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	// Determine source token function based on priority
+	sourceTokenFunc := h.resolveSourceTokenFunc(ctx)
+
+	// If impersonation is configured, wrap with impersonation
+	if h.config.ImpersonateServiceAccount != "" {
+		return h.getImpersonatedToken(ctx, opts, sourceTokenFunc)
+	}
+
+	return sourceTokenFunc(ctx, opts)
+}
+
+// resolveSourceTokenFunc returns the appropriate token acquisition function
+// based on available credentials, following the auto-detection priority:
+// WI > Metadata > SA Key > ADC (stored) > gcloud ADC.
+func (h *Handler) resolveSourceTokenFunc(_ context.Context) func(context.Context, auth.TokenOptions) (*auth.Token, error) {
+	// Workload identity (highest priority)
+	if HasWorkloadIdentityCredentials() {
+		return h.getWorkloadIdentityToken
+	}
+
+	// Metadata server — check stored metadata to see if we logged in via metadata
+	// (don't probe the network on every token request)
+	metadata, err := h.loadMetadata(context.Background())
+	if err == nil && metadata != nil && metadata.Flow == auth.FlowMetadata {
+		return h.getMetadataToken
+	}
+
+	// Service account key
+	if HasServiceAccountCredentials() {
+		return h.getServiceAccountToken
+	}
+
+	// Check for stored refresh token (ADC browser flow)
+	exists, _ := h.secretStore.Exists(context.Background(), SecretKeyRefreshToken)
+	if exists {
+		return h.getStoredRefreshToken
+	}
+
+	// Fallback to gcloud ADC
+	if HasGcloudADCCredentials() {
+		return h.getGcloudADCToken
+	}
+
+	// No credentials available
+	return func(_ context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+		return nil, auth.ErrNotAuthenticated
+	}
+}
+
+// getStoredRefreshToken gets a token using the stored refresh token, with caching.
+func (h *Handler) getStoredRefreshToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	if opts.Scope == "" {
+		return nil, auth.ErrInvalidScope
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
+	// Check cache first
+	if !opts.ForceRefresh {
+		cached, err := h.tokenCache.Get(ctx, opts.Scope)
+		if err == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached token", "scope", opts.Scope)
+			return cached, nil
+		}
+	}
+
+	// Mint new token via refresh
+	token, err := h.mintToken(ctx, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token
+	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+		lgr.V(1).Info("failed to cache token", "error", err)
+	}
+
+	return token, nil
+}
+
+// InjectAuth adds authentication to an HTTP request.
+func (h *Handler) InjectAuth(ctx context.Context, req *http.Request, opts auth.TokenOptions) error {
+	token, err := h.GetToken(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("%s %s", token.TokenType, token.AccessToken))
+	return nil
+}
+
+// tokenAcquireFunc is a function that acquires a token given credentials and scope.
+type tokenAcquireFunc[T any] func(ctx context.Context, creds T, scope string) (*auth.Token, error)
+
+// getCachedOrAcquireToken is a generic helper that handles the common pattern of:
+// 1. Checking if credentials exist
+// 2. Checking the cache (unless ForceRefresh)
+// 3. Acquiring a new token if needed
+// 4. Caching the new token
+func getCachedOrAcquireToken[T any](
+	ctx context.Context,
+	h *Handler,
+	opts auth.TokenOptions,
+	getCreds func() (T, error),
+	isCredsNil func(T, error) bool,
+	acquireToken tokenAcquireFunc[T],
+	logPrefix string,
+) (*auth.Token, error) {
+	if opts.Scope == "" {
+		opts.Scope = "https://www.googleapis.com/auth/cloud-platform"
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	creds, err := getCreds()
+	if isCredsNil(creds, err) {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
+	// Check cache first (unless ForceRefresh)
+	if !opts.ForceRefresh {
+		cached, cacheErr := h.tokenCache.Get(ctx, opts.Scope)
+		if cacheErr == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached "+logPrefix+" token", "scope", opts.Scope)
+			return cached, nil
+		}
+	}
+
+	// Acquire new token
+	token, err := acquireToken(ctx, creds, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token
+	if cacheErr := h.tokenCache.Set(ctx, opts.Scope, token); cacheErr != nil {
+		lgr.V(1).Info("failed to cache "+logPrefix+" token", "error", cacheErr)
+	}
+
+	return token, nil
+}
+
+// Compile-time check that Handler implements auth.Handler.
+var _ auth.Handler = (*Handler)(nil)

--- a/pkg/auth/gcp/handler_test.go
+++ b/pkg/auth/gcp/handler_test.go
@@ -1,0 +1,420 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_DefaultConfig(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	assert.Equal(t, HandlerName, handler.Name())
+	assert.Equal(t, HandlerDisplayName, handler.DisplayName())
+}
+
+func TestNew_WithConfig(t *testing.T) {
+	store := secrets.NewMockStore()
+	cfg := &Config{
+		ClientID:                  "custom-client-id",
+		ClientSecret:              "custom-secret",
+		ImpersonateServiceAccount: "sa@test.iam.gserviceaccount.com",
+		Project:                   "my-project",
+		DefaultScopes:             []string{"custom-scope"},
+	}
+
+	handler, err := New(WithSecretStore(store), WithConfig(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	assert.Equal(t, "custom-client-id", handler.config.ClientID)
+	assert.Equal(t, "custom-secret", handler.config.ClientSecret)
+	assert.Equal(t, "sa@test.iam.gserviceaccount.com", handler.config.ImpersonateServiceAccount)
+	assert.Equal(t, "my-project", handler.config.Project)
+	assert.Equal(t, []string{"custom-scope"}, handler.config.DefaultScopes)
+}
+
+func TestNew_NilConfig(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store), WithConfig(nil))
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	// Should keep default config
+	assert.Equal(t, DefaultConfig().DefaultScopes, handler.config.DefaultScopes)
+}
+
+func TestNew_WithHTTPClient(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	assert.Equal(t, mockHTTP, handler.httpClient)
+}
+
+func TestNew_DeferredSecretError(t *testing.T) {
+	// When no store is provided and default store creation fails,
+	// the handler should still be created with a deferred error
+	handler, err := New()
+	require.NoError(t, err) // New always succeeds
+	require.NotNil(t, handler)
+
+	// Metadata operations should work
+	assert.Equal(t, HandlerName, handler.Name())
+	assert.Equal(t, HandlerDisplayName, handler.DisplayName())
+}
+
+func TestHandler_Name(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	assert.Equal(t, "gcp", handler.Name())
+}
+
+func TestHandler_DisplayName(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Google Cloud Platform", handler.DisplayName())
+}
+
+func TestHandler_SupportedFlows(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	flows := handler.SupportedFlows()
+	assert.Contains(t, flows, auth.FlowInteractive)
+	assert.Contains(t, flows, auth.FlowServicePrincipal)
+	assert.Contains(t, flows, auth.FlowWorkloadIdentity)
+	assert.Contains(t, flows, auth.FlowMetadata)
+	assert.Len(t, flows, 4)
+}
+
+func TestHandler_Capabilities(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	caps := handler.Capabilities()
+	assert.Contains(t, caps, auth.CapScopesOnLogin)
+	assert.Contains(t, caps, auth.CapScopesOnTokenRequest)
+	assert.Contains(t, caps, auth.CapFederatedToken)
+}
+
+func TestHandler_Status_NotAuthenticated(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Clear any environment-based credentials that could interfere
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+	// Point gcloud ADC to a nonexistent directory to prevent local fallback
+	t.Setenv("CLOUDSDK_CONFIG", t.TempDir())
+
+	status, err := handler.Status(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.False(t, status.Authenticated)
+}
+
+func TestHandler_Status_WithStoredMetadata(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Clear any environment-based credentials
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+
+	// Store metadata
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Email:   "user@example.com",
+			Name:    "Test User",
+			Subject: "12345",
+			Issuer:  "https://accounts.google.com",
+		},
+		Flow:   auth.FlowInteractive,
+		Scopes: []string{"openid", "email"},
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	status, err := handler.Status(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, "user@example.com", status.Claims.Email)
+	assert.Equal(t, "Test User", status.Claims.Name)
+	assert.Equal(t, auth.IdentityTypeUser, status.IdentityType)
+}
+
+func TestHandler_Status_ServicePrincipalMetadata(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Email:   "sa@project.iam.gserviceaccount.com",
+			Subject: "sa-id",
+			Issuer:  "https://accounts.google.com",
+		},
+		Flow:                auth.FlowServicePrincipal,
+		ServiceAccountEmail: "sa@project.iam.gserviceaccount.com",
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	status, err := handler.Status(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, auth.IdentityTypeServicePrincipal, status.IdentityType)
+}
+
+func TestHandler_Logout(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Populate store with credentials
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("refresh-token"))
+	require.NoError(t, err)
+
+	metadataBytes, _ := json.Marshal(&TokenMetadata{
+		Claims: &auth.Claims{Email: "user@example.com"},
+	})
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	// Mock revoke endpoint response
+	mockHTTP.AddResponse(200, map[string]string{"status": "ok"})
+
+	err = handler.Logout(ctx)
+	require.NoError(t, err)
+
+	// Verify credentials are removed
+	exists, _ := store.Exists(ctx, SecretKeyRefreshToken)
+	assert.False(t, exists)
+	exists, _ = store.Exists(ctx, SecretKeyMetadata)
+	assert.False(t, exists)
+}
+
+func TestHandler_Logout_NoCredentials(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Logout should succeed even with no stored credentials
+	err = handler.Logout(ctx)
+	require.NoError(t, err)
+}
+
+func TestHandler_GetToken_NotAuthenticated(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+	// Point gcloud ADC to a nonexistent directory to prevent local fallback
+	t.Setenv("CLOUDSDK_CONFIG", t.TempDir())
+
+	_, err = handler.GetToken(ctx, auth.TokenOptions{
+		Scope: "https://www.googleapis.com/auth/cloud-platform",
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, auth.ErrNotAuthenticated)
+}
+
+func TestHandler_GetToken_FromCache(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+
+	// Store a refresh token so resolveSourceTokenFunc returns getStoredRefreshToken
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
+	require.NoError(t, err)
+
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	// Pre-cache a valid token
+	cachedToken := &auth.Token{
+		AccessToken: "cached-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(30 * time.Minute),
+		Scope:       scope,
+	}
+	err = handler.tokenCache.Set(ctx, scope, cachedToken)
+	require.NoError(t, err)
+
+	// GetToken should return the cached token without any HTTP calls
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope: scope,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "cached-access-token", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+
+	// Verify no HTTP calls were made
+	assert.Empty(t, mockHTTP.Requests)
+}
+
+func TestHandler_GetToken_ForceRefresh(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+	// Point gcloud ADC to a nonexistent directory to prevent local fallback
+	t.Setenv("CLOUDSDK_CONFIG", t.TempDir())
+
+	// Store a refresh token
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
+	require.NoError(t, err)
+
+	// Store metadata (required by mintToken)
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Email: "user@example.com",
+		},
+		Flow:     auth.FlowInteractive,
+		ClientID: "test-client-id",
+		Scopes:   []string{"openid"},
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	// Pre-cache a valid token
+	cachedToken := &auth.Token{
+		AccessToken: "cached-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(30 * time.Minute),
+		Scope:       scope,
+	}
+	err = handler.tokenCache.Set(ctx, scope, cachedToken)
+	require.NoError(t, err)
+
+	// Mock token endpoint response for refresh
+	mockHTTP.AddResponse(200, map[string]any{
+		"access_token": "refreshed-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"scope":        scope,
+	})
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope:        scope,
+		ForceRefresh: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+
+	// Verify an HTTP call was made (force refresh bypasses cache)
+	assert.Len(t, mockHTTP.Requests, 1)
+}
+
+func TestHandler_GetToken_NoScope(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+
+	// Store a refresh token
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
+	require.NoError(t, err)
+
+	// GetToken with no scope should return ErrInvalidScope
+	_, err = handler.GetToken(ctx, auth.TokenOptions{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, auth.ErrInvalidScope)
+}
+
+func TestHandler_InjectAuth(t *testing.T) {
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_EXTERNAL_ACCOUNT", "")
+
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+
+	// Store a refresh token
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("test-refresh-token"))
+	require.NoError(t, err)
+
+	// Cache a valid token
+	cachedToken := &auth.Token{
+		AccessToken: "inject-test-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(30 * time.Minute),
+		Scope:       scope,
+	}
+	err = handler.tokenCache.Set(ctx, scope, cachedToken)
+	require.NoError(t, err)
+
+	// Create a request and inject auth
+	req, _ := newTestRequest(t)
+	err = handler.InjectAuth(ctx, req, auth.TokenOptions{Scope: scope})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer inject-test-token", req.Header.Get("Authorization"))
+}
+
+// Compile-time check for interface implementation.
+var _ auth.Handler = (*Handler)(nil)

--- a/pkg/auth/gcp/helpers_test.go
+++ b/pkg/auth/gcp/helpers_test.go
@@ -1,0 +1,16 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// newTestRequest creates a test HTTP request.
+func newTestRequest(t *testing.T) (*http.Request, error) {
+	t.Helper()
+	return http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/api", nil)
+}

--- a/pkg/auth/gcp/http.go
+++ b/pkg/auth/gcp/http.go
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// HTTPClient abstracts HTTP calls for testability.
+type HTTPClient interface {
+	// PostForm sends a POST request with form-encoded body and returns the response.
+	PostForm(ctx context.Context, url string, data url.Values) (*http.Response, error)
+
+	// Get sends a GET request with the given headers and returns the response.
+	Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error)
+
+	// Do sends an arbitrary HTTP request.
+	Do(ctx context.Context, req *http.Request) (*http.Response, error)
+}
+
+// DefaultHTTPClient is the standard HTTP client implementation.
+type DefaultHTTPClient struct {
+	client *http.Client
+}
+
+// NewDefaultHTTPClient creates a new DefaultHTTPClient.
+func NewDefaultHTTPClient() *DefaultHTTPClient {
+	return &DefaultHTTPClient{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// PostForm sends a POST request with form-encoded body.
+func (c *DefaultHTTPClient) PostForm(ctx context.Context, endpoint string, data url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating POST request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}
+
+// Get sends a GET request with custom headers.
+func (c *DefaultHTTPClient) Get(ctx context.Context, reqURL string, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GET request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}
+
+// Do sends an arbitrary HTTP request.
+func (c *DefaultHTTPClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}
+
+// PostJSON sends a POST request with JSON body.
+func (c *DefaultHTTPClient) PostJSON(ctx context.Context, endpoint string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating POST JSON request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input
+}

--- a/pkg/auth/gcp/http_test.go
+++ b/pkg/auth/gcp/http_test.go
@@ -1,0 +1,160 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockHTTPClient_PostForm(t *testing.T) {
+	mock := NewMockHTTPClient()
+
+	expected := map[string]string{"access_token": "test-token"}
+	mock.AddResponse(200, expected)
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://oauth2.googleapis.com/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {"test-code"},
+		"redirect_uri":  {"http://localhost:8080/callback"},
+		"client_id":     {"test-client-id"},
+		"code_verifier": {"test-verifier"},
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "test-token", result["access_token"])
+
+	// Verify request was recorded
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, "https://oauth2.googleapis.com/token", mock.Requests[0].Endpoint)
+	assert.Equal(t, "POST", mock.Requests[0].Method)
+}
+
+func TestMockHTTPClient_Get(t *testing.T) {
+	mock := NewMockHTTPClient()
+
+	expected := map[string]string{"email": "user@example.com"}
+	mock.AddResponse(200, expected)
+
+	ctx := context.Background()
+	headers := map[string]string{
+		"Authorization": "Bearer test-token",
+	}
+	resp, err := mock.Get(ctx, "https://www.googleapis.com/oauth2/v3/userinfo", headers)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", result["email"])
+
+	// Verify request was recorded
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, "GET", mock.Requests[0].Method)
+	assert.Equal(t, "Bearer test-token", mock.Requests[0].Headers["Authorization"])
+}
+
+func TestMockHTTPClient_Error(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddError(fmt.Errorf("network error"))
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://example.com", nil) //nolint:bodyclose // resp is nil on error
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "network error")
+}
+
+func TestMockHTTPClient_NoResponses(t *testing.T) {
+	mock := NewMockHTTPClient()
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://example.com", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should return 500 when no responses configured
+	assert.Equal(t, 500, resp.StatusCode)
+}
+
+func TestMockHTTPClient_Reset(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(200, "ok")
+
+	ctx := context.Background()
+	resp, err := mock.PostForm(ctx, "https://example.com", nil)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Len(t, mock.Requests, 1)
+
+	// Clear requests manually (no Reset method)
+	mock.Requests = nil
+	assert.Empty(t, mock.Requests)
+}
+
+func TestDefaultHTTPClient(t *testing.T) {
+	client := NewDefaultHTTPClient()
+	require.NotNil(t, client)
+}
+
+func TestMockHTTPClient_Do(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(200, map[string]string{"status": "ok"})
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com/api", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := mock.Do(ctx, req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result["status"])
+
+	// Verify request was recorded
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, "POST", mock.Requests[0].Method)
+}
+
+func TestMockHTTPClient_MultipleResponses(t *testing.T) {
+	mock := NewMockHTTPClient()
+	mock.AddResponse(200, map[string]string{"call": "first"})
+	mock.AddResponse(201, map[string]string{"call": "second"})
+
+	ctx := context.Background()
+
+	resp1, err := mock.PostForm(ctx, "https://example.com/1", nil)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	assert.Equal(t, 200, resp1.StatusCode)
+
+	resp2, err := mock.PostForm(ctx, "https://example.com/2", nil)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, 201, resp2.StatusCode)
+}

--- a/pkg/auth/gcp/impersonation.go
+++ b/pkg/auth/gcp/impersonation.go
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements service account impersonation via the IAM Credentials API.
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// iamCredentialsEndpoint is the base URL for the IAM Credentials API.
+	iamCredentialsEndpoint = "https://iamcredentials.googleapis.com/v1" //nolint:gosec // G101: not a hardcoded credential
+)
+
+// ImpersonationRequest is the request body for generateAccessToken.
+type ImpersonationRequest struct {
+	Scope    []string `json:"scope"`
+	Lifetime string   `json:"lifetime"`
+}
+
+// ImpersonationResponse is the response from generateAccessToken.
+type ImpersonationResponse struct {
+	AccessToken string `json:"accessToken"` //nolint:gosec // G117: not a hardcoded credential
+	ExpireTime  string `json:"expireTime"`
+}
+
+// impersonateServiceAccount acquires an access token by impersonating a service account.
+func (h *Handler) impersonateServiceAccount(ctx context.Context, sourceToken, targetSA string, scopes []string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("impersonating service account",
+		"targetServiceAccount", targetSA,
+		"scopes", scopes,
+	)
+
+	endpoint := fmt.Sprintf("%s/projects/-/serviceAccounts/%s:generateAccessToken",
+		iamCredentialsEndpoint, targetSA)
+
+	reqBody := ImpersonationRequest{
+		Scope:    scopes,
+		Lifetime: "3600s",
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("encoding impersonation request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("creating impersonation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+sourceToken)
+
+	resp, err := h.httpClient.Do(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("impersonation request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("impersonation denied: ensure source identity has roles/iam.serviceAccountTokenCreator on %s", targetSA)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&errBody)
+		return nil, fmt.Errorf("impersonation failed (status %d): %v", resp.StatusCode, errBody)
+	}
+
+	var impResp ImpersonationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&impResp); err != nil {
+		return nil, fmt.Errorf("parsing impersonation response: %w", err)
+	}
+
+	// Parse the expiry time
+	expireTime, err := time.Parse(time.RFC3339, impResp.ExpireTime)
+	if err != nil {
+		// Fallback: assume 1 hour
+		expireTime = time.Now().Add(time.Hour)
+	}
+
+	lgr.V(1).Info("impersonation successful",
+		"targetServiceAccount", targetSA,
+		"expiresAt", expireTime,
+	)
+
+	return &auth.Token{
+		AccessToken: impResp.AccessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   expireTime,
+		Scope:       joinScopes(scopes),
+	}, nil
+}
+
+// getImpersonatedToken acquires a token for the impersonated service account.
+// It first acquires a source token using the configured flow, then impersonates.
+func (h *Handler) getImpersonatedToken(ctx context.Context, opts auth.TokenOptions, sourceTokenFunc func(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error)) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Get the source token
+	sourceToken, err := sourceTokenFunc(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring source token for impersonation: %w", err)
+	}
+
+	targetSA := h.config.ImpersonateServiceAccount
+
+	// Determine scopes
+	scopes := []string{opts.Scope}
+	if opts.Scope == "" {
+		scopes = h.config.DefaultScopes
+	}
+
+	// Check cache for impersonated token
+	cacheKey := fmt.Sprintf("impersonate.%s.%s", targetSA, opts.Scope)
+	if !opts.ForceRefresh {
+		minValidFor := opts.MinValidFor
+		if minValidFor == 0 {
+			minValidFor = auth.DefaultMinValidFor
+		}
+		cached, cacheErr := h.tokenCache.Get(ctx, cacheKey)
+		if cacheErr == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached impersonated token",
+				"targetServiceAccount", targetSA,
+				"scope", opts.Scope,
+			)
+			return cached, nil
+		}
+	}
+
+	// Impersonate
+	token, err := h.impersonateServiceAccount(ctx, sourceToken.AccessToken, targetSA, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the impersonated token
+	if err := h.tokenCache.Set(ctx, cacheKey, token); err != nil {
+		lgr.V(1).Info("failed to cache impersonated token", "error", err)
+	}
+
+	return token, nil
+}

--- a/pkg/auth/gcp/metadata.go
+++ b/pkg/auth/gcp/metadata.go
@@ -1,0 +1,208 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements the GCE metadata server token acquisition flow.
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// EnvGCEMetadataHost allows overriding the metadata server host for testing.
+	EnvGCEMetadataHost = "GCE_METADATA_HOST"
+
+	// defaultMetadataHost is the default GCE metadata server host.
+	defaultMetadataHost = "metadata.google.internal"
+
+	// metadataFlavorHeader is the required header for metadata server requests.
+	metadataFlavorHeader = "Metadata-Flavor"
+
+	// metadataFlavorValue is the required value for the Metadata-Flavor header.
+	metadataFlavorValue = "Google"
+)
+
+// MetadataTokenResponse represents the token response from the metadata server.
+type MetadataTokenResponse struct {
+	AccessToken string `json:"access_token"` //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// getMetadataHost returns the metadata server host, respecting env var override.
+func getMetadataHost() string {
+	if host := os.Getenv(EnvGCEMetadataHost); host != "" {
+		return host
+	}
+	return defaultMetadataHost
+}
+
+// getMetadataTokenURL returns the full URL for the metadata server token endpoint.
+func getMetadataTokenURL() string {
+	return fmt.Sprintf("http://%s/computeMetadata/v1/instance/service-accounts/default/token", getMetadataHost())
+}
+
+// getMetadataEmailURL returns the full URL for the metadata server email endpoint.
+func getMetadataEmailURL() string {
+	return fmt.Sprintf("http://%s/computeMetadata/v1/instance/service-accounts/default/email", getMetadataHost())
+}
+
+// IsMetadataServerAvailable checks if the GCE metadata server is reachable.
+// Uses a short timeout for probing.
+func IsMetadataServerAvailable(ctx context.Context, httpClient HTTPClient) bool {
+	// Try to reach the metadata server with a short timeout
+	headers := map[string]string{
+		metadataFlavorHeader: metadataFlavorValue,
+	}
+	resp, err := httpClient.Get(ctx, getMetadataTokenURL(), headers)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
+}
+
+// metadataLogin validates metadata server access by acquiring a token.
+func (h *Handler) metadataLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting metadata server login", "handler", HandlerName)
+
+	// Acquire a token to validate access
+	token, err := h.acquireMetadataToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("metadata server authentication failed: %w", err)
+	}
+
+	// Try to get the service account email
+	claims := &auth.Claims{
+		Issuer: "https://accounts.google.com",
+	}
+
+	email, emailErr := h.fetchMetadataEmail(ctx)
+	if emailErr == nil && email != "" {
+		claims.Subject = email
+		claims.Email = email
+	}
+
+	// Store metadata
+	if err := h.storeMetadataOnly(ctx, claims, auth.FlowMetadata, opts.Scopes); err != nil {
+		lgr.V(1).Info("warning: failed to store metadata", "error", err)
+	}
+
+	lgr.V(1).Info("metadata server authentication successful", "email", email)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: token.ExpiresAt,
+	}, nil
+}
+
+// acquireMetadataToken acquires a token from the GCE metadata server.
+func (h *Handler) acquireMetadataToken(ctx context.Context) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	tokenURL := getMetadataTokenURL()
+	headers := map[string]string{
+		metadataFlavorHeader: metadataFlavorValue,
+	}
+
+	lgr.V(1).Info("requesting token from metadata server", "url", tokenURL)
+
+	resp, err := h.httpClient.Get(ctx, tokenURL, headers)
+	if err != nil {
+		return nil, fmt.Errorf("metadata server request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("metadata server not available: not running on Google Cloud? (status %d)", resp.StatusCode)
+	}
+
+	var tokenResp MetadataTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse metadata token response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	lgr.V(1).Info("acquired metadata server token",
+		"expiresIn", tokenResp.ExpiresIn,
+	)
+
+	return &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       "https://www.googleapis.com/auth/cloud-platform",
+	}, nil
+}
+
+// fetchMetadataEmail fetches the service account email from the metadata server.
+func (h *Handler) fetchMetadataEmail(ctx context.Context) (string, error) {
+	emailURL := getMetadataEmailURL()
+	headers := map[string]string{
+		metadataFlavorHeader: metadataFlavorValue,
+	}
+
+	resp, err := h.httpClient.Get(ctx, emailURL, headers)
+	if err != nil {
+		return "", fmt.Errorf("metadata email request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("metadata email request failed with status %d", resp.StatusCode)
+	}
+
+	var email []byte
+	buf := make([]byte, 256)
+	n, _ := resp.Body.Read(buf)
+	email = buf[:n]
+
+	return string(email), nil
+}
+
+// getMetadataToken gets a token from metadata server, with caching.
+func (h *Handler) getMetadataToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	// Metadata server doesn't take credentials, so use a simpler approach
+	if opts.Scope == "" {
+		opts.Scope = "https://www.googleapis.com/auth/cloud-platform"
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	minValidFor := opts.MinValidFor
+	if minValidFor == 0 {
+		minValidFor = auth.DefaultMinValidFor
+	}
+
+	// Check cache first
+	if !opts.ForceRefresh {
+		cached, err := h.tokenCache.Get(ctx, opts.Scope)
+		if err == nil && cached != nil && cached.IsValidFor(minValidFor) {
+			lgr.V(1).Info("using cached metadata token", "scope", opts.Scope)
+			return cached, nil
+		}
+	}
+
+	// Acquire new token
+	token, err := h.acquireMetadataToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token
+	if err := h.tokenCache.Set(ctx, opts.Scope, token); err != nil {
+		lgr.V(1).Info("failed to cache metadata token", "error", err)
+	}
+
+	return token, nil
+}

--- a/pkg/auth/gcp/mock.go
+++ b/pkg/auth/gcp/mock.go
@@ -1,0 +1,134 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+// MockHTTPClient is a configurable mock of HTTPClient for unit tests.
+type MockHTTPClient struct {
+	mu        sync.Mutex
+	Requests  []*MockRequest
+	Responses []*MockResponse
+	callIndex int
+}
+
+// MockRequest records a request made via the mock client.
+type MockRequest struct {
+	Method   string
+	Endpoint string
+	Data     url.Values
+	Headers  map[string]string
+	Body     []byte
+}
+
+// MockResponse defines a canned response.
+type MockResponse struct {
+	StatusCode int
+	Body       any // Will be JSON-encoded
+	Err        error
+}
+
+// NewMockHTTPClient creates a new mock HTTP client.
+func NewMockHTTPClient() *MockHTTPClient {
+	return &MockHTTPClient{
+		Requests:  make([]*MockRequest, 0),
+		Responses: make([]*MockResponse, 0),
+	}
+}
+
+// AddResponse adds a response to the queue.
+func (m *MockHTTPClient) AddResponse(statusCode int, body any) *MockHTTPClient {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Responses = append(m.Responses, &MockResponse{
+		StatusCode: statusCode,
+		Body:       body,
+	})
+	return m
+}
+
+// AddError adds an error response to the queue.
+func (m *MockHTTPClient) AddError(err error) *MockHTTPClient {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Responses = append(m.Responses, &MockResponse{
+		Err: err,
+	})
+	return m
+}
+
+// nextResponse records the request and returns the next canned response.
+func (m *MockHTTPClient) nextResponse(method, endpoint string, data url.Values, headers map[string]string, body []byte) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.Requests = append(m.Requests, &MockRequest{
+		Method:   method,
+		Endpoint: endpoint,
+		Data:     data,
+		Headers:  headers,
+		Body:     body,
+	})
+
+	if m.callIndex >= len(m.Responses) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error": "no mock response configured"}`)),
+		}, nil
+	}
+
+	resp := m.Responses[m.callIndex]
+	m.callIndex++
+
+	if resp.Err != nil {
+		return nil, resp.Err
+	}
+
+	var bodyBytes []byte
+	if resp.Body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &http.Response{
+		StatusCode: resp.StatusCode,
+		Body:       io.NopCloser(bytes.NewBuffer(bodyBytes)),
+	}, nil
+}
+
+// PostForm implements HTTPClient.PostForm.
+func (m *MockHTTPClient) PostForm(_ context.Context, endpoint string, data url.Values) (*http.Response, error) {
+	return m.nextResponse(http.MethodPost, endpoint, data, nil, nil)
+}
+
+// Get implements HTTPClient.Get.
+func (m *MockHTTPClient) Get(_ context.Context, endpoint string, headers map[string]string) (*http.Response, error) {
+	return m.nextResponse(http.MethodGet, endpoint, nil, headers, nil)
+}
+
+// Do implements HTTPClient.Do.
+func (m *MockHTTPClient) Do(_ context.Context, req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		body, _ = io.ReadAll(req.Body)
+	}
+	headers := make(map[string]string)
+	for k, v := range req.Header {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+	return m.nextResponse(req.Method, req.URL.String(), nil, headers, body)
+}

--- a/pkg/auth/gcp/service_account.go
+++ b/pkg/auth/gcp/service_account.go
@@ -1,0 +1,282 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements the service account key JWT assertion flow.
+package gcp
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// EnvGoogleApplicationCredentials is the environment variable for service account key file path.
+	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS" //nolint:gosec // G101: not a hardcoded credential
+
+	// tokenEndpoint is the Google OAuth 2.0 token endpoint.
+	tokenEndpoint = "https://oauth2.googleapis.com/token" //nolint:gosec // G117: not a credential, it's an endpoint URL
+)
+
+// ServiceAccountKey represents the JSON structure of a GCP service account key file.
+type ServiceAccountKey struct {
+	Type                    string `json:"type"`
+	ProjectID               string `json:"project_id"`
+	PrivateKeyID            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"` //nolint:gosec // G117: not a hardcoded credential, it's a config field
+	ClientEmail             string `json:"client_email"`
+	ClientID                string `json:"client_id"`
+	AuthURI                 string `json:"auth_uri"`
+	TokenURI                string `json:"token_uri"`
+	AuthProviderX509CertURL string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertURL       string `json:"client_x509_cert_url"`
+}
+
+// GetServiceAccountKey reads and parses a service account key from the
+// GOOGLE_APPLICATION_CREDENTIALS environment variable.
+func GetServiceAccountKey() (*ServiceAccountKey, error) {
+	path := os.Getenv(EnvGoogleApplicationCredentials)
+	if path == "" {
+		return nil, nil //nolint:nilnil // nil,nil means no credentials configured
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G703: path from env var is expected
+	if err != nil {
+		return nil, fmt.Errorf("reading service account key file: %w", err)
+	}
+
+	var key ServiceAccountKey
+	if err := json.Unmarshal(data, &key); err != nil {
+		return nil, fmt.Errorf("parsing service account key file: %w", err)
+	}
+
+	if key.Type != "service_account" {
+		return nil, nil //nolint:nilnil // not a service account key
+	}
+
+	return &key, nil
+}
+
+// HasServiceAccountCredentials checks if service account credentials are configured.
+func HasServiceAccountCredentials() bool {
+	key, err := GetServiceAccountKey()
+	return err == nil && key != nil
+}
+
+// serviceAccountLogin validates SA credentials by acquiring a token.
+func (h *Handler) serviceAccountLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting service account key login", "handler", HandlerName)
+
+	key, err := GetServiceAccountKey()
+	if err != nil {
+		return nil, fmt.Errorf("service account credentials error: %w", err)
+	}
+	if key == nil {
+		return nil, fmt.Errorf("service account credentials not configured: set %s environment variable",
+			EnvGoogleApplicationCredentials)
+	}
+
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+	if len(opts.Scopes) > 0 {
+		scope = joinScopes(opts.Scopes)
+	}
+
+	// Acquire a token to validate credentials
+	token, err := h.acquireServiceAccountToken(ctx, key, scope)
+	if err != nil {
+		return nil, fmt.Errorf("service account authentication failed: %w", err)
+	}
+
+	claims := &auth.Claims{
+		Issuer:   "https://accounts.google.com",
+		Subject:  key.ClientEmail,
+		Email:    key.ClientEmail,
+		ClientID: key.ClientID,
+		ObjectID: key.ClientID,
+	}
+
+	// Store metadata
+	if err := h.storeMetadataOnly(ctx, claims, auth.FlowServicePrincipal, opts.Scopes); err != nil {
+		lgr.V(1).Info("warning: failed to store metadata", "error", err)
+	}
+
+	lgr.V(1).Info("service account authentication successful",
+		"clientEmail", key.ClientEmail,
+		"projectId", key.ProjectID,
+	)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: token.ExpiresAt,
+	}, nil
+}
+
+// acquireServiceAccountToken acquires a token using JWT assertion flow.
+func (h *Handler) acquireServiceAccountToken(ctx context.Context, key *ServiceAccountKey, scope string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Create the JWT assertion
+	now := time.Now()
+	jwtHeader := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": key.PrivateKeyID,
+	}
+	jwtPayload := map[string]any{
+		"iss":   key.ClientEmail,
+		"sub":   key.ClientEmail,
+		"aud":   tokenEndpoint,
+		"iat":   now.Unix(),
+		"exp":   now.Add(time.Hour).Unix(),
+		"scope": scope,
+	}
+
+	headerJSON, err := json.Marshal(jwtHeader)
+	if err != nil {
+		return nil, fmt.Errorf("encoding JWT header: %w", err)
+	}
+	payloadJSON, err := json.Marshal(jwtPayload)
+	if err != nil {
+		return nil, fmt.Errorf("encoding JWT payload: %w", err)
+	}
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerB64 + "." + payloadB64
+
+	// Parse the private key
+	block, _ := pem.Decode([]byte(key.PrivateKey))
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block from private key")
+	}
+
+	rsaKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+
+	privateKey, ok := rsaKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not RSA")
+	}
+
+	// Sign the JWT
+	hash := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(nil, privateKey, 0, hash[:])
+	if err != nil {
+		// Use stdlib big.Int for signing to avoid crypto/rand dependency
+		// Actually rsa.SignPKCS1v15 with nil rand works for deterministic signing
+		// But let's use the proper approach
+		return nil, fmt.Errorf("signing JWT: %w", err)
+	}
+	_ = big.NewInt(0) // keep import for potential future use
+
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+	assertion := signingInput + "." + signatureB64
+
+	// Exchange JWT assertion for access token
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	data.Set("assertion", assertion)
+
+	lgr.V(1).Info("requesting token via JWT assertion",
+		"clientEmail", key.ClientEmail,
+		"scope", scope,
+	)
+
+	resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("token request failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	lgr.V(1).Info("acquired service account token",
+		"expiresIn", tokenResp.ExpiresIn,
+		"scope", scope,
+	)
+
+	return &auth.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       scope,
+	}, nil
+}
+
+// getServiceAccountToken gets a token using service account key, with caching.
+func (h *Handler) getServiceAccountToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	return getCachedOrAcquireToken(
+		ctx,
+		h,
+		opts,
+		func() (*ServiceAccountKey, error) { return GetServiceAccountKey() },
+		func(key *ServiceAccountKey, err error) bool { return key == nil || err != nil },
+		func(ctx context.Context, key *ServiceAccountKey, scope string) (*auth.Token, error) {
+			return h.acquireServiceAccountToken(ctx, key, scope)
+		},
+		"SA",
+	)
+}
+
+// serviceAccountStatus returns the status for SA authentication.
+func (h *Handler) serviceAccountStatus(_ context.Context) (*auth.Status, error) {
+	key, err := GetServiceAccountKey()
+	if err != nil || key == nil {
+		return &auth.Status{ //nolint:nilerr // intentional: credential read errors mean not authenticated
+			Authenticated: false,
+		}, nil
+	}
+
+	return &auth.Status{
+		Authenticated: true,
+		Claims: &auth.Claims{
+			Issuer:   "https://accounts.google.com",
+			Subject:  key.ClientEmail,
+			Email:    key.ClientEmail,
+			ClientID: key.ClientID,
+			ObjectID: key.ClientID,
+			Name:     fmt.Sprintf("Service Account (%s)", key.ClientEmail),
+		},
+		IdentityType: auth.IdentityTypeServicePrincipal,
+		ClientID:     key.ClientID,
+	}, nil
+}
+
+// joinScopes joins scopes into a space-separated string.
+func joinScopes(scopes []string) string {
+	result := ""
+	for i, s := range scopes {
+		if i > 0 {
+			result += " "
+		}
+		result += s
+	}
+	return result
+}

--- a/pkg/auth/gcp/service_account_test.go
+++ b/pkg/auth/gcp/service_account_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServiceAccountKey_NoEnv(t *testing.T) {
+	t.Setenv(EnvGoogleApplicationCredentials, "")
+
+	key, err := GetServiceAccountKey()
+	require.NoError(t, err)
+	assert.Nil(t, key)
+}
+
+func TestGetServiceAccountKey_FileNotFound(t *testing.T) {
+	t.Setenv(EnvGoogleApplicationCredentials, "/nonexistent/path/key.json")
+
+	key, err := GetServiceAccountKey()
+	require.Error(t, err)
+	assert.Nil(t, key)
+}
+
+func TestGetServiceAccountKey_InvalidJSON(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "key.json")
+	err := os.WriteFile(tmpFile, []byte("not-valid-json"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleApplicationCredentials, tmpFile)
+
+	key, err := GetServiceAccountKey()
+	require.Error(t, err)
+	assert.Nil(t, key)
+}
+
+func TestGetServiceAccountKey_WrongType(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "key.json")
+	keyData := map[string]string{
+		"type":         "authorized_user",
+		"client_email": "user@example.com",
+	}
+	data, err := json.Marshal(keyData)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpFile, data, 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleApplicationCredentials, tmpFile)
+
+	key, err := GetServiceAccountKey()
+	require.NoError(t, err)
+	assert.Nil(t, key) // not a service_account type
+}
+
+func TestGetServiceAccountKey_Valid(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "key.json")
+	keyData := ServiceAccountKey{
+		Type:         "service_account",
+		ProjectID:    "my-project",
+		PrivateKeyID: "key-id",
+		ClientEmail:  "sa@my-project.iam.gserviceaccount.com",
+		ClientID:     "12345",
+		TokenURI:     "https://oauth2.googleapis.com/token",
+		PrivateKey:   "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n",
+	}
+	data, err := json.Marshal(keyData)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpFile, data, 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleApplicationCredentials, tmpFile)
+
+	key, err := GetServiceAccountKey()
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, "service_account", key.Type)
+	assert.Equal(t, "my-project", key.ProjectID)
+	assert.Equal(t, "sa@my-project.iam.gserviceaccount.com", key.ClientEmail)
+}
+
+func TestHasServiceAccountCredentials(t *testing.T) {
+	t.Run("no credentials", func(t *testing.T) {
+		t.Setenv(EnvGoogleApplicationCredentials, "")
+		assert.False(t, HasServiceAccountCredentials())
+	})
+
+	t.Run("valid service account", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "key.json")
+		keyData := ServiceAccountKey{
+			Type:        "service_account",
+			ClientEmail: "sa@project.iam.gserviceaccount.com",
+			PrivateKey:  "fake-key",
+		}
+		data, _ := json.Marshal(keyData)
+		_ = os.WriteFile(tmpFile, data, 0o600)
+
+		t.Setenv(EnvGoogleApplicationCredentials, tmpFile)
+		assert.True(t, HasServiceAccountCredentials())
+	})
+}

--- a/pkg/auth/gcp/token.go
+++ b/pkg/auth/gcp/token.go
@@ -1,0 +1,256 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// TokenMetadata stores information about the stored GCP credentials.
+type TokenMetadata struct {
+	Claims                    *auth.Claims `json:"claims"`
+	RefreshTokenExpiresAt     time.Time    `json:"refreshTokenExpiresAt,omitempty"`
+	Flow                      auth.Flow    `json:"flow"`
+	ClientID                  string       `json:"clientId,omitempty"`
+	Project                   string       `json:"project,omitempty"`
+	ImpersonateServiceAccount string       `json:"impersonateServiceAccount,omitempty"`
+	Scopes                    []string     `json:"scopes,omitempty"`
+	ServiceAccountEmail       string       `json:"serviceAccountEmail,omitempty"`
+}
+
+// TokenResponse represents the response from GCP token endpoints.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`  //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
+	RefreshToken string `json:"refresh_token"` //nolint:gosec // G117: not a hardcoded credential, stores runtime token data
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+// TokenErrorResponse represents an error from GCP token endpoint.
+type TokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// storeCredentials securely stores the refresh token and metadata.
+func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, flow auth.Flow, scopes []string) error {
+	// Store refresh token if present (ADC browser flow)
+	if tokenResp.RefreshToken != "" {
+		if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
+			return fmt.Errorf("failed to store refresh token: %w", err)
+		}
+	}
+
+	// Extract claims
+	claims, err := extractClaims(tokenResp)
+	if err != nil {
+		claims = &auth.Claims{
+			Issuer: "https://accounts.google.com",
+		}
+	}
+
+	metadata := &TokenMetadata{
+		Claims:                    claims,
+		Flow:                      flow,
+		ClientID:                  h.config.ClientID,
+		Project:                   h.config.Project,
+		ImpersonateServiceAccount: h.config.ImpersonateServiceAccount,
+		Scopes:                    scopes,
+	}
+
+	if tokenResp.RefreshToken != "" {
+		// Refresh tokens don't have a fixed expiry from Google, but
+		// they can be revoked. We set a long expiry for display purposes.
+		metadata.RefreshTokenExpiresAt = time.Now().Add(180 * 24 * time.Hour)
+	}
+
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := h.secretStore.Set(ctx, SecretKeyMetadata, metadataBytes); err != nil {
+		return fmt.Errorf("failed to store metadata: %w", err)
+	}
+
+	return nil
+}
+
+// storeMetadataOnly stores metadata without a refresh token (for SA/WI/metadata flows).
+func (h *Handler) storeMetadataOnly(ctx context.Context, claims *auth.Claims, flow auth.Flow, scopes []string) error {
+	metadata := &TokenMetadata{
+		Claims:                    claims,
+		Flow:                      flow,
+		Project:                   h.config.Project,
+		ImpersonateServiceAccount: h.config.ImpersonateServiceAccount,
+		Scopes:                    scopes,
+	}
+
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := h.secretStore.Set(ctx, SecretKeyMetadata, metadataBytes); err != nil {
+		return fmt.Errorf("failed to store metadata: %w", err)
+	}
+
+	return nil
+}
+
+// loadRefreshToken loads the stored refresh token.
+func (h *Handler) loadRefreshToken(ctx context.Context) (string, error) {
+	data, err := h.secretStore.Get(ctx, SecretKeyRefreshToken)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// loadMetadata loads the stored token metadata.
+func (h *Handler) loadMetadata(ctx context.Context) (*TokenMetadata, error) {
+	data, err := h.secretStore.Get(ctx, SecretKeyMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata TokenMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+
+	return &metadata, nil
+}
+
+// extractClaims extracts normalized claims from a GCP token response.
+// Uses the ID token (JWT) if available.
+func extractClaims(tokenResp *TokenResponse) (*auth.Claims, error) {
+	if tokenResp.IDToken == "" {
+		return &auth.Claims{
+			Issuer: "https://accounts.google.com",
+		}, nil
+	}
+
+	return extractClaimsFromIDToken(tokenResp.IDToken)
+}
+
+// extractClaimsFromIDToken extracts claims from a GCP ID token JWT.
+func extractClaimsFromIDToken(idToken string) (*auth.Claims, error) {
+	parts := splitJWT(idToken)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid ID token format")
+	}
+
+	payload, err := base64URLDecode(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ID token payload: %w", err)
+	}
+
+	var idTokenClaims struct {
+		Issuer    string `json:"iss"`
+		Subject   string `json:"sub"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		IssuedAt  int64  `json:"iat"`
+		ExpiresAt int64  `json:"exp"`
+	}
+
+	if err := json.Unmarshal(payload, &idTokenClaims); err != nil {
+		return nil, fmt.Errorf("failed to parse ID token claims: %w", err)
+	}
+
+	username := ""
+	if idTokenClaims.Email != "" {
+		if idx := strings.Index(idTokenClaims.Email, "@"); idx > 0 {
+			username = idTokenClaims.Email[:idx]
+		}
+	}
+
+	return &auth.Claims{
+		Issuer:   idTokenClaims.Issuer,
+		Subject:  idTokenClaims.Subject,
+		Email:    idTokenClaims.Email,
+		Name:     idTokenClaims.Name,
+		Username: username,
+		IssuedAt: time.Unix(idTokenClaims.IssuedAt, 0),
+	}, nil
+}
+
+// fetchUserinfoClaims fetches user info from the Google userinfo endpoint.
+func (h *Handler) fetchUserinfoClaims(ctx context.Context, accessToken string) (*auth.Claims, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("fetching user info from Google userinfo endpoint")
+
+	resp, err := h.httpClient.Get(ctx, "https://openidconnect.googleapis.com/v1/userinfo", map[string]string{
+		"Authorization": "Bearer " + accessToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("userinfo request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("userinfo request failed with status %d", resp.StatusCode)
+	}
+
+	var userinfo struct {
+		Sub   string `json:"sub"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&userinfo); err != nil {
+		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
+	}
+
+	username := ""
+	if userinfo.Email != "" {
+		if idx := strings.Index(userinfo.Email, "@"); idx > 0 {
+			username = userinfo.Email[:idx]
+		}
+	}
+
+	return &auth.Claims{
+		Issuer:   "https://accounts.google.com",
+		Subject:  userinfo.Sub,
+		Email:    userinfo.Email,
+		Name:     userinfo.Name,
+		Username: username,
+	}, nil
+}
+
+// splitJWT splits a JWT into its parts.
+func splitJWT(token string) []string {
+	parts := make([]string, 0, 3)
+	start := 0
+	for i := 0; i < len(token); i++ {
+		if token[i] == '.' {
+			parts = append(parts, token[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, token[start:])
+	return parts
+}
+
+// base64URLDecode decodes a base64url encoded string.
+func base64URLDecode(s string) ([]byte, error) {
+	switch len(s) % 4 {
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	}
+	return base64.URLEncoding.DecodeString(s)
+}

--- a/pkg/auth/gcp/token_test.go
+++ b/pkg/auth/gcp/token_test.go
@@ -1,0 +1,202 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreAndLoadMetadata(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	metadata := &TokenMetadata{
+		Claims: &auth.Claims{
+			Email:   "user@example.com",
+			Name:    "Test User",
+			Subject: "12345",
+			Issuer:  "https://accounts.google.com",
+		},
+		Flow:                      auth.FlowInteractive,
+		ClientID:                  "test-client-id",
+		Project:                   "my-project",
+		ImpersonateServiceAccount: "",
+		Scopes:                    []string{"openid", "email"},
+		RefreshTokenExpiresAt:     time.Now().Add(7 * 24 * time.Hour).Truncate(time.Millisecond),
+	}
+
+	// Store metadata
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	err = store.Set(ctx, SecretKeyMetadata, metadataBytes)
+	require.NoError(t, err)
+
+	// Load metadata
+	loaded, err := handler.loadMetadata(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "user@example.com", loaded.Claims.Email)
+	assert.Equal(t, "Test User", loaded.Claims.Name)
+	assert.Equal(t, auth.FlowInteractive, loaded.Flow)
+	assert.Equal(t, "test-client-id", loaded.ClientID)
+	assert.Equal(t, []string{"openid", "email"}, loaded.Scopes)
+}
+
+func TestLoadMetadata_NotFound(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = handler.loadMetadata(ctx)
+	require.Error(t, err)
+}
+
+func TestLoadMetadata_CorruptedData(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Store corrupted data
+	err = store.Set(ctx, SecretKeyMetadata, []byte("not-valid-json"))
+	require.NoError(t, err)
+
+	_, err = handler.loadMetadata(ctx)
+	require.Error(t, err)
+}
+
+func TestStoreAndLoadRefreshToken(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Store refresh token
+	err = store.Set(ctx, SecretKeyRefreshToken, []byte("my-refresh-token"))
+	require.NoError(t, err)
+
+	// Load refresh token
+	token, err := handler.loadRefreshToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "my-refresh-token", token)
+}
+
+func TestLoadRefreshToken_NotFound(t *testing.T) {
+	store := secrets.NewMockStore()
+	handler, err := New(WithSecretStore(store))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = handler.loadRefreshToken(ctx)
+	require.Error(t, err)
+}
+
+func TestExtractClaimsFromIDToken(t *testing.T) {
+	// The extractClaimsFromIDToken function is tested indirectly via roundtrip.
+	// This verifies the JWT parsing utility.
+	tests := []struct {
+		name    string
+		parts   int
+		wantErr bool
+	}{
+		{
+			name:    "empty token",
+			parts:   0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := extractClaimsFromIDToken("")
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSplitJWT(t *testing.T) {
+	tests := []struct {
+		name    string
+		jwt     string
+		wantLen int
+	}{
+		{
+			name:    "valid JWT with 3 parts",
+			jwt:     "header.payload.signature",
+			wantLen: 3,
+		},
+		{
+			name:    "invalid JWT with 2 parts",
+			jwt:     "header.payload",
+			wantLen: 2,
+		},
+		{
+			name:    "empty string",
+			jwt:     "",
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := splitJWT(tt.jwt)
+			assert.Len(t, parts, tt.wantLen)
+		})
+	}
+}
+
+func TestBase64URLDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "standard base64url",
+			input: "SGVsbG8gV29ybGQ",
+			want:  "Hello World",
+		},
+		{
+			name:  "padded base64url",
+			input: "SGVsbG8gV29ybGQ=",
+			want:  "Hello World",
+		},
+		{
+			name:    "invalid base64",
+			input:   "!!!invalid!!!",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := base64URLDecode(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, string(got))
+			}
+		})
+	}
+}

--- a/pkg/auth/gcp/workload_identity.go
+++ b/pkg/auth/gcp/workload_identity.go
@@ -1,0 +1,270 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp provides Google Cloud Platform authentication for scafctl.
+// This file implements the Workload Identity Federation STS token exchange flow.
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// EnvGoogleExternalAccount is the environment variable for external account configuration.
+	EnvGoogleExternalAccount = "GOOGLE_EXTERNAL_ACCOUNT"
+
+	// stsEndpoint is the Google STS token exchange endpoint.
+	stsEndpoint = "https://sts.googleapis.com/v1/token"
+)
+
+// ExternalAccountConfig represents the external account credential configuration JSON.
+type ExternalAccountConfig struct {
+	Type                           string           `json:"type"`
+	Audience                       string           `json:"audience"`
+	SubjectTokenType               string           `json:"subject_token_type"`
+	TokenURL                       string           `json:"token_url"`
+	ServiceAccountImpersonationURL string           `json:"service_account_impersonation_url,omitempty"`
+	CredentialSource               CredentialSource `json:"credential_source"`
+}
+
+// CredentialSource defines where to read the subject token from.
+type CredentialSource struct {
+	File             string                  `json:"file,omitempty"`
+	URL              string                  `json:"url,omitempty"`
+	Headers          map[string]string       `json:"headers,omitempty"`
+	EnvironmentID    string                  `json:"environment_id,omitempty"`
+	Format           *CredentialSourceFormat `json:"format,omitempty"`
+	RegionURL        string                  `json:"region_url,omitempty"`
+	IMDSv2SessionURL string                  `json:"imdsv2_session_token_url,omitempty"`
+}
+
+// CredentialSourceFormat defines the format of the credential source.
+type CredentialSourceFormat struct {
+	Type                  string `json:"type,omitempty"`
+	SubjectTokenFieldName string `json:"subject_token_field_name,omitempty"`
+}
+
+// STSTokenResponse represents the response from the STS token exchange.
+type STSTokenResponse struct {
+	AccessToken     string `json:"access_token"` //nolint:gosec // G117: not a hardcoded credential
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+// GetExternalAccountConfig reads and parses the external account configuration
+// from the GOOGLE_EXTERNAL_ACCOUNT environment variable.
+func GetExternalAccountConfig() (*ExternalAccountConfig, error) {
+	path := os.Getenv(EnvGoogleExternalAccount)
+	if path == "" {
+		return nil, nil //nolint:nilnil // nil,nil means not configured
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G703: path from env var is expected
+	if err != nil {
+		return nil, fmt.Errorf("reading external account config: %w", err)
+	}
+
+	var cfg ExternalAccountConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing external account config: %w", err)
+	}
+
+	if cfg.Type != "external_account" {
+		return nil, nil //nolint:nilnil // not an external account config
+	}
+
+	return &cfg, nil
+}
+
+// HasWorkloadIdentityCredentials checks if workload identity credentials are configured.
+func HasWorkloadIdentityCredentials() bool {
+	cfg, err := GetExternalAccountConfig()
+	return err == nil && cfg != nil
+}
+
+// readSubjectToken reads the subject token from the credential source.
+func readSubjectToken(cfg *ExternalAccountConfig) (string, error) {
+	if cfg.CredentialSource.File != "" {
+		data, err := os.ReadFile(cfg.CredentialSource.File)
+		if err != nil {
+			return "", fmt.Errorf("reading subject token file: %w", err)
+		}
+
+		// Handle structured token formats
+		if cfg.CredentialSource.Format != nil && cfg.CredentialSource.Format.Type == "json" {
+			var tokenDoc map[string]any
+			if err := json.Unmarshal(data, &tokenDoc); err != nil {
+				return "", fmt.Errorf("parsing subject token JSON: %w", err)
+			}
+			fieldName := cfg.CredentialSource.Format.SubjectTokenFieldName
+			if fieldName == "" {
+				fieldName = "token"
+			}
+			tokenVal, ok := tokenDoc[fieldName]
+			if !ok {
+				return "", fmt.Errorf("subject token field %q not found in JSON", fieldName)
+			}
+			tokenStr, ok := tokenVal.(string)
+			if !ok {
+				return "", fmt.Errorf("subject token field %q is not a string", fieldName)
+			}
+			return tokenStr, nil
+		}
+
+		return string(data), nil
+	}
+
+	return "", fmt.Errorf("unsupported credential source: no file or URL configured")
+}
+
+// workloadIdentityLogin validates workload identity credentials by acquiring a token.
+func (h *Handler) workloadIdentityLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting workload identity federation login", "handler", HandlerName)
+
+	cfg, err := GetExternalAccountConfig()
+	if err != nil {
+		return nil, fmt.Errorf("workload identity credentials error: %w", err)
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("workload identity credentials not configured: set %s environment variable",
+			EnvGoogleExternalAccount)
+	}
+
+	scope := "https://www.googleapis.com/auth/cloud-platform"
+	if len(opts.Scopes) > 0 {
+		scope = joinScopes(opts.Scopes)
+	}
+
+	// Acquire a token to validate credentials
+	token, err := h.acquireWorkloadIdentityToken(ctx, cfg, scope)
+	if err != nil {
+		return nil, fmt.Errorf("workload identity authentication failed: %w", err)
+	}
+
+	claims := &auth.Claims{
+		Issuer:  "https://accounts.google.com",
+		Subject: cfg.Audience,
+	}
+
+	// Store metadata
+	if err := h.storeMetadataOnly(ctx, claims, auth.FlowWorkloadIdentity, opts.Scopes); err != nil {
+		lgr.V(1).Info("warning: failed to store metadata", "error", err)
+	}
+
+	lgr.V(1).Info("workload identity authentication successful",
+		"audience", cfg.Audience,
+	)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: token.ExpiresAt,
+	}, nil
+}
+
+// acquireWorkloadIdentityToken acquires a token via STS token exchange.
+func (h *Handler) acquireWorkloadIdentityToken(ctx context.Context, cfg *ExternalAccountConfig, scope string) (*auth.Token, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Read the subject token
+	subjectToken, err := readSubjectToken(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("reading subject token: %w", err)
+	}
+
+	// Exchange via STS
+	endpoint := cfg.TokenURL
+	if endpoint == "" {
+		endpoint = stsEndpoint
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	data.Set("audience", cfg.Audience)
+	data.Set("scope", scope)
+	data.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	data.Set("subject_token_type", cfg.SubjectTokenType)
+	data.Set("subject_token", subjectToken)
+
+	lgr.V(1).Info("requesting token via STS exchange",
+		"endpoint", endpoint,
+		"audience", cfg.Audience,
+	)
+
+	resp, err := h.httpClient.PostForm(ctx, endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("STS token exchange failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("STS token exchange failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var stsResp STSTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse STS response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(stsResp.ExpiresIn) * time.Second)
+
+	lgr.V(1).Info("acquired workload identity token",
+		"expiresIn", stsResp.ExpiresIn,
+	)
+
+	return &auth.Token{
+		AccessToken: stsResp.AccessToken,
+		TokenType:   stsResp.TokenType,
+		ExpiresAt:   expiresAt,
+		Scope:       scope,
+	}, nil
+}
+
+// getWorkloadIdentityToken gets a token using workload identity, with caching.
+func (h *Handler) getWorkloadIdentityToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	return getCachedOrAcquireToken(
+		ctx,
+		h,
+		opts,
+		func() (*ExternalAccountConfig, error) { return GetExternalAccountConfig() },
+		func(cfg *ExternalAccountConfig, err error) bool { return cfg == nil || err != nil },
+		func(ctx context.Context, cfg *ExternalAccountConfig, scope string) (*auth.Token, error) {
+			return h.acquireWorkloadIdentityToken(ctx, cfg, scope)
+		},
+		"WI",
+	)
+}
+
+// workloadIdentityStatus returns the status for workload identity authentication.
+func (h *Handler) workloadIdentityStatus(_ context.Context) (*auth.Status, error) {
+	cfg, err := GetExternalAccountConfig()
+	if err != nil || cfg == nil {
+		return &auth.Status{ //nolint:nilerr // intentional: credential read errors mean not authenticated
+			Authenticated: false,
+		}, nil
+	}
+
+	tokenFile := cfg.CredentialSource.File
+
+	return &auth.Status{
+		Authenticated: true,
+		Claims: &auth.Claims{
+			Issuer:  "https://accounts.google.com",
+			Subject: cfg.Audience,
+			Name:    "Workload Identity Federation",
+		},
+		IdentityType: auth.IdentityTypeWorkloadIdentity,
+		TokenFile:    tokenFile,
+	}, nil
+}

--- a/pkg/auth/gcp/workload_identity_test.go
+++ b/pkg/auth/gcp/workload_identity_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExternalAccountConfig_NoEnv(t *testing.T) {
+	t.Setenv(EnvGoogleExternalAccount, "")
+
+	cfg, err := GetExternalAccountConfig()
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestGetExternalAccountConfig_FileNotFound(t *testing.T) {
+	t.Setenv(EnvGoogleExternalAccount, "/nonexistent/path/config.json")
+
+	cfg, err := GetExternalAccountConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestGetExternalAccountConfig_InvalidJSON(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "config.json")
+	err := os.WriteFile(tmpFile, []byte("not-valid-json"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleExternalAccount, tmpFile)
+
+	cfg, err := GetExternalAccountConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestGetExternalAccountConfig_WrongType(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "config.json")
+	configData := map[string]string{
+		"type": "service_account",
+	}
+	data, err := json.Marshal(configData)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpFile, data, 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleExternalAccount, tmpFile)
+
+	cfg, err := GetExternalAccountConfig()
+	require.NoError(t, err)
+	assert.Nil(t, cfg) // not an external_account type
+}
+
+func TestGetExternalAccountConfig_Valid(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "config.json")
+	configData := ExternalAccountConfig{
+		Type:             "external_account",
+		Audience:         "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+		TokenURL:         "https://sts.googleapis.com/v1/token",
+		CredentialSource: CredentialSource{
+			File: "/var/run/secrets/token",
+		},
+	}
+	data, err := json.Marshal(configData)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpFile, data, 0o600)
+	require.NoError(t, err)
+
+	t.Setenv(EnvGoogleExternalAccount, tmpFile)
+
+	cfg, err := GetExternalAccountConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "external_account", cfg.Type)
+	assert.Contains(t, cfg.Audience, "workloadIdentityPools")
+	assert.Equal(t, "/var/run/secrets/token", cfg.CredentialSource.File)
+}
+
+func TestHasWorkloadIdentityCredentials(t *testing.T) {
+	t.Run("no credentials", func(t *testing.T) {
+		t.Setenv(EnvGoogleExternalAccount, "")
+		assert.False(t, HasWorkloadIdentityCredentials())
+	})
+
+	t.Run("valid external account", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "config.json")
+		configData := ExternalAccountConfig{
+			Type:     "external_account",
+			Audience: "test-audience",
+		}
+		data, _ := json.Marshal(configData)
+		_ = os.WriteFile(tmpFile, data, 0o600)
+
+		t.Setenv(EnvGoogleExternalAccount, tmpFile)
+		assert.True(t, HasWorkloadIdentityCredentials())
+	})
+}
+
+func TestReadSubjectToken_FromFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	err := os.WriteFile(tokenFile, []byte("my-subject-token"), 0o600)
+	require.NoError(t, err)
+
+	cfg := &ExternalAccountConfig{
+		CredentialSource: CredentialSource{
+			File: tokenFile,
+		},
+	}
+
+	token, err := readSubjectToken(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "my-subject-token", token)
+}
+
+func TestReadSubjectToken_FromJSONFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token.json")
+	tokenData := map[string]string{
+		"access_token": "my-json-token",
+	}
+	data, err := json.Marshal(tokenData)
+	require.NoError(t, err)
+	err = os.WriteFile(tokenFile, data, 0o600)
+	require.NoError(t, err)
+
+	cfg := &ExternalAccountConfig{
+		CredentialSource: CredentialSource{
+			File: tokenFile,
+			Format: &CredentialSourceFormat{
+				Type:                  "json",
+				SubjectTokenFieldName: "access_token",
+			},
+		},
+	}
+
+	token, err := readSubjectToken(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "my-json-token", token)
+}
+
+func TestReadSubjectToken_FileNotFound(t *testing.T) {
+	cfg := &ExternalAccountConfig{
+		CredentialSource: CredentialSource{
+			File: "/nonexistent/token",
+		},
+	}
+
+	_, err := readSubjectToken(cfg)
+	require.Error(t, err)
+}
+
+func TestReadSubjectToken_NoSource(t *testing.T) {
+	cfg := &ExternalAccountConfig{
+		CredentialSource: CredentialSource{},
+	}
+
+	_, err := readSubjectToken(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported credential source")
+}

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -73,6 +73,9 @@ const (
 
 	// FlowPAT is authentication using a personal access token from environment variables.
 	FlowPAT Flow = "pat"
+
+	// FlowMetadata is authentication using cloud metadata server (e.g., GCE, Cloud Run).
+	FlowMetadata Flow = "metadata"
 )
 
 // DefaultMinValidFor is the default minimum validity duration for tokens.

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 )
@@ -145,6 +146,34 @@ func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, client
 	}
 
 	return ghauth.New(opts...)
+}
+
+// getGCPHandlerWithOverrides creates a GCP handler with optional client ID and impersonation overrides.
+// The flags take precedence over config.
+func getGCPHandlerWithOverrides(ctx context.Context, clientIDOverride, impersonateOverride string) (auth.Handler, error) {
+	// Check for test-injected handler
+	if h := handlerFromContext(ctx); h != nil {
+		return h, nil
+	}
+
+	gcpCfg := &gcpauth.Config{}
+	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GCP != nil {
+		gcpCfg.ClientID = cfg.Auth.GCP.ClientID
+		gcpCfg.ClientSecret = cfg.Auth.GCP.ClientSecret
+		gcpCfg.DefaultScopes = cfg.Auth.GCP.DefaultScopes
+		gcpCfg.ImpersonateServiceAccount = cfg.Auth.GCP.ImpersonateServiceAccount
+		gcpCfg.Project = cfg.Auth.GCP.Project
+	}
+
+	applyOverride(&gcpCfg.ClientID, clientIDOverride)
+	applyOverride(&gcpCfg.ImpersonateServiceAccount, impersonateOverride)
+
+	var opts []gcpauth.Option
+	if gcpCfg.ClientID != "" || gcpCfg.ImpersonateServiceAccount != "" || len(gcpCfg.DefaultScopes) > 0 {
+		opts = append(opts, gcpauth.WithConfig(gcpCfg))
+	}
+
+	return gcpauth.New(opts...)
 }
 
 // applyOverride sets the target to the override value if it is non-empty.

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -25,13 +26,14 @@ import (
 // CommandLogin creates the 'auth login' command.
 func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
 	var (
-		tenantID       string
-		clientID       string
-		hostname       string
-		timeout        time.Duration
-		flowStr        string
-		federatedToken string
-		scopes         []string
+		tenantID                  string
+		clientID                  string
+		hostname                  string
+		timeout                   time.Duration
+		flowStr                   string
+		federatedToken            string
+		scopes                    []string
+		impersonateServiceAccount string
 	)
 
 	cmd := &cobra.Command{
@@ -48,6 +50,12 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			For the 'github' handler, this supports:
 			- device-code: Interactive authentication via browser (default)
 			- pat: Personal access token from environment variables (GITHUB_TOKEN or GH_TOKEN)
+
+			For the 'gcp' handler, this supports:
+			- interactive: Browser-based OAuth (default for workstations)
+			- service-principal: Service account key (GOOGLE_APPLICATION_CREDENTIALS)
+			- workload-identity: Workload Identity Federation (GOOGLE_EXTERNAL_ACCOUNT)
+			- metadata: GCE metadata server (auto-detected on GCE/GKE/Cloud Run)
 
 			For Entra service principal flow, set these environment variables:
 			- AZURE_CLIENT_ID: Application (client) ID
@@ -70,6 +78,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			Supported handlers:
 			- entra: Microsoft Entra ID
 			- github: GitHub
+			- gcp: Google Cloud Platform
 
 			Examples:
 			  # Login with Entra ID using device code flow (default)
@@ -102,6 +111,24 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			  # Login with specific scopes
 			  scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 			  scafctl auth login github --scope repo --scope read:org
+
+			  # Login with GCP using browser OAuth (default)
+			  scafctl auth login gcp
+
+			  # Login with GCP service account key
+			  scafctl auth login gcp --flow service-principal
+
+			  # Login with GCP workload identity federation
+			  scafctl auth login gcp --flow workload-identity
+
+			  # Login with GCE metadata server
+			  scafctl auth login gcp --flow metadata
+
+			  # Login with GCP service account impersonation
+			  scafctl auth login gcp --impersonate-service-account my-sa@project.iam.gserviceaccount.com
+
+			  # Login with GCP and specific scopes
+			  scafctl auth login gcp --scope https://www.googleapis.com/auth/bigquery
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -155,10 +182,19 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
+			// Validate impersonation flag
+			if impersonateServiceAccount != "" && handlerName != "gcp" {
+				err := fmt.Errorf("--impersonate-service-account is only supported by the 'gcp' auth handler")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
 			// Route to handler-specific login logic
 			switch handlerName {
 			case "github":
 				return loginGitHub(ctx, w, flow, hostname, clientID, timeout, scopes)
+			case "gcp":
+				return loginGCP(ctx, w, flow, clientID, impersonateServiceAccount, timeout, scopes)
 			default:
 				return loginEntra(ctx, w, flow, tenantID, clientID, timeout, federatedToken, flowStr, scopes)
 			}
@@ -172,6 +208,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow (handler-specific)")
 	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for workload identity (requires federated_token capability)")
 	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scopes to request during login (requires scopes_on_login capability)")
+	cmd.Flags().StringVar(&impersonateServiceAccount, "impersonate-service-account", "", "GCP service account email to impersonate (gcp handler only)")
 
 	return cmd
 }
@@ -212,6 +249,50 @@ func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname
 			identity := status.Claims.DisplayIdentity()
 			w.Infof("Already authenticated as %s", identity)
 			w.Info("Use 'scafctl auth logout github' to sign out first, or continue to re-authenticate.")
+			w.Info("")
+		}
+	}
+
+	return executeLogin(ctx, w, handler, flow, "", timeout, scopes)
+}
+
+// loginGCP handles the login flow for the GCP auth handler.
+func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, impersonateServiceAccount string, timeout time.Duration, scopes []string) error {
+	// Auto-detect flow based on available credentials (highest priority first)
+	if flow == "" && gcpauth.HasWorkloadIdentityCredentials() {
+		flow = auth.FlowWorkloadIdentity
+		w.Info("Detected workload identity credentials in environment")
+	} else if flow == "" && gcpauth.HasServiceAccountCredentials() {
+		flow = auth.FlowServicePrincipal
+		w.Info("Detected service account key in environment")
+	}
+
+	// Default to interactive (browser OAuth)
+	if flow == "" {
+		flow = auth.FlowInteractive
+	}
+
+	// Get or create handler with overrides
+	handler, err := getGCPHandlerWithOverrides(ctx, clientID, impersonateServiceAccount)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize auth handler: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Check if already authenticated (skip for non-interactive flows)
+	if flow == auth.FlowInteractive {
+		status, err := handler.Status(ctx)
+		if err != nil {
+			err = fmt.Errorf("failed to check auth status: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+
+		if status.Authenticated {
+			identity := status.Claims.DisplayIdentity()
+			w.Infof("Already authenticated as %s", identity)
+			w.Info("Use 'scafctl auth logout gcp' to sign out first, or continue to re-authenticate.")
 			w.Info("")
 		}
 	}
@@ -349,6 +430,12 @@ func executeLogin(ctx context.Context, w *writer.Writer, handler auth.Handler, f
 	if flow == auth.FlowPAT {
 		w.Info("  Flow:     Personal Access Token")
 	}
+	if flow == auth.FlowMetadata {
+		w.Info("  Flow:     Metadata Server")
+	}
+	if flow == auth.FlowInteractive {
+		w.Info("  Flow:     Interactive (Browser OAuth)")
+	}
 
 	return nil
 }
@@ -361,16 +448,24 @@ func parseFlow(flowStr, handlerName string) (auth.Flow, error) {
 	switch strings.ToLower(flowStr) {
 	case "device-code", "devicecode":
 		return auth.FlowDeviceCode, nil
+	case "interactive":
+		return auth.FlowInteractive, nil
 	case "service-principal", "serviceprincipal", "sp":
 		return auth.FlowServicePrincipal, nil
 	case "workload-identity", "workloadidentity", "wi":
 		return auth.FlowWorkloadIdentity, nil
 	case "pat":
 		return auth.FlowPAT, nil
+	case "metadata":
+		return auth.FlowMetadata, nil
 	default:
-		if handlerName == "github" {
+		switch handlerName {
+		case "github":
 			return "", fmt.Errorf("unknown flow: %s (valid for github: device-code, pat)", flowStr)
+		case "gcp":
+			return "", fmt.Errorf("unknown flow: %s (valid for gcp: interactive, service-principal, workload-identity, metadata)", flowStr)
+		default:
+			return "", fmt.Errorf("unknown flow: %s (valid for entra: device-code, service-principal, workload-identity)", flowStr)
 		}
-		return "", fmt.Errorf("unknown flow: %s (valid for entra: device-code, service-principal, workload-identity)", flowStr)
 	}
 }

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -31,6 +31,9 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 
 			  # Logout from GitHub
 			  scafctl auth logout github
+
+			  # Logout from GCP
+			  scafctl auth logout gcp
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -39,6 +39,9 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			  # Show GitHub auth status
 			  scafctl auth status github
 
+			  # Show GCP auth status
+			  scafctl auth status gcp
+
 			  # Output as JSON
 			  scafctl auth status -o json
 		`),

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -66,6 +66,12 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Output as JSON (includes full token)
 			  scafctl auth token entra --scope "https://management.azure.com/.default" -o json
+
+			  # Get a GCP token for cloud-platform scope
+			  scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform"
+
+			  # Get a GCP token for BigQuery
+			  scafctl auth token gcp --scope "https://www.googleapis.com/auth/bigquery"
 		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	authcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/build"
@@ -238,6 +239,27 @@ func Root(opts *RootOptions) *cobra.Command {
 					lgr.V(1).Info("warning: failed to register GitHub auth handler", "error", regErr)
 				}
 			}
+
+			// Initialize GCP auth handler
+			var gcpOpts []gcpauth.Option
+			if cfg.Auth.GCP != nil {
+				gcpOpts = append(gcpOpts, gcpauth.WithConfig(&gcpauth.Config{
+					ClientID:                  cfg.Auth.GCP.ClientID,
+					ClientSecret:              cfg.Auth.GCP.ClientSecret,
+					DefaultScopes:             cfg.Auth.GCP.DefaultScopes,
+					ImpersonateServiceAccount: cfg.Auth.GCP.ImpersonateServiceAccount,
+					Project:                   cfg.Auth.GCP.Project,
+				}))
+			}
+			gcpHandler, err := gcpauth.New(gcpOpts...)
+			if err != nil {
+				lgr.V(1).Info("warning: failed to initialize GCP auth handler", "error", err)
+			} else {
+				if regErr := authRegistry.Register(gcpHandler); regErr != nil {
+					lgr.V(1).Info("warning: failed to register GCP auth handler", "error", regErr)
+				}
+			}
+
 			ctx = auth.WithRegistry(ctx, authRegistry)
 
 			cCmd.SetContext(ctx)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -247,6 +247,9 @@ type GlobalAuthConfig struct {
 
 	// GitHub contains GitHub authentication configuration.
 	GitHub *GitHubAuthConfig `json:"github,omitempty" yaml:"github,omitempty" mapstructure:"github" doc:"GitHub authentication configuration"`
+
+	// GCP contains Google Cloud Platform authentication configuration.
+	GCP *GCPAuthConfig `json:"gcp,omitempty" yaml:"gcp,omitempty" mapstructure:"gcp" doc:"Google Cloud Platform authentication configuration"`
 }
 
 // EntraAuthConfig contains Entra-specific configuration.
@@ -276,6 +279,24 @@ type GitHubAuthConfig struct {
 
 	// DefaultScopes are requested during login if not specified on command line.
 	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" mapstructure:"defaultScopes" doc:"Default OAuth scopes" maxItems:"20"`
+}
+
+// GCPAuthConfig contains GCP-specific configuration.
+type GCPAuthConfig struct {
+	// ClientID overrides the default OAuth 2.0 client ID.
+	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty" mapstructure:"clientId" doc:"OAuth 2.0 client ID for interactive authentication" maxLength:"255"`
+
+	// ClientSecret overrides the default OAuth 2.0 client secret.
+	ClientSecret string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty" mapstructure:"clientSecret" doc:"OAuth 2.0 client secret (not confidential for desktop apps)" maxLength:"255"` //nolint:gosec // G117: not a hardcoded credential, it's a config field
+
+	// DefaultScopes are requested during login if not specified on command line.
+	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" mapstructure:"defaultScopes" doc:"Default OAuth scopes for GCP authentication" maxItems:"20"`
+
+	// ImpersonateServiceAccount is the service account email to impersonate.
+	ImpersonateServiceAccount string `json:"impersonateServiceAccount,omitempty" yaml:"impersonateServiceAccount,omitempty" mapstructure:"impersonateServiceAccount" doc:"Service account email to impersonate" example:"deploy@my-project.iam.gserviceaccount.com" maxLength:"255"`
+
+	// Project is the default GCP project ID.
+	Project string `json:"project,omitempty" yaml:"project,omitempty" mapstructure:"project" doc:"Default GCP project ID" example:"my-project-123" maxLength:"64"`
 }
 
 // BuildConfig holds build command configuration.

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1184,6 +1184,7 @@ func TestIntegration_AuthList(t *testing.T) {
 	// Should show the built-in handlers
 	assert.Contains(t, stdout, "entra")
 	assert.Contains(t, stdout, "github")
+	assert.Contains(t, stdout, "gcp")
 }
 
 func TestIntegration_AuthListJSON(t *testing.T) {
@@ -1204,6 +1205,46 @@ func TestIntegration_AuthTokenHelp(t *testing.T) {
 	assert.Contains(t, stdout, "--scope")
 	assert.Contains(t, stdout, "--min-valid-for")
 	assert.Contains(t, stdout, "--force-refresh")
+}
+
+func TestIntegration_AuthLoginGCPHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "login", "gcp", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "gcp")
+	assert.Contains(t, stdout, "--flow")
+	assert.Contains(t, stdout, "--impersonate-service-account")
+}
+
+func TestIntegration_AuthLoginGCPInvalidFlow(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "auth", "login", "gcp", "--flow", "invalid-flow")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "unknown flow")
+	assert.Contains(t, stderr, "gcp")
+}
+
+func TestIntegration_AuthStatusGCP(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "auth", "status", "gcp")
+
+	// Should succeed even if not authenticated (shows "not authenticated")
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestIntegration_AuthLogoutGCP(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "logout", "gcp")
+
+	// Should succeed regardless of authentication state
+	assert.Equal(t, 0, exitCode)
+	// May show "Not currently authenticated" or "Successfully logged out" depending on environment
+	assert.True(t,
+		strings.Contains(stdout, "Not currently authenticated") || strings.Contains(stdout, "Successfully logged out"),
+		"expected logout message, got: %s", stdout,
+	)
 }
 
 // ============================================================================


### PR DESCRIPTION
Implement Google Cloud Platform authentication with support for:
- Interactive browser OAuth flow (authorization code + PKCE)
- Service account key JWT assertion flow
- Workload Identity Federation (STS token exchange)
- GCE metadata server authentication
- Service account impersonation via IAM Credentials API
- gcloud ADC fallback for existing credentials
- Disk-based token caching via secrets store

Add CLI integration with login, logout, status, and token commands. Include comprehensive unit tests (48 tests) and integration tests (5 tests). Update documentation with GCP authentication tutorials.
