### PR TITLE
feat: prepare codebase for MCP server integration

### DIFF
--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -1,0 +1,597 @@
+---
+title: MCP Server for scafctl Solutions
+weight: 100
+---
+
+# MCP Server for scafctl Solutions
+
+## Overview
+
+This document evaluates building a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for scafctl solutions. An MCP server exposes **tools**, **resources**, and **prompts** over JSON-RPC 2.0 (typically via stdio or SSE) so that AI agents (Claude, Copilot, etc.) can discover and invoke them programmatically.
+
+## How an MCP Server Works Internally
+
+### The Big Picture
+
+An MCP server is a **long-running process** that sits between an AI agent (e.g., Claude, Copilot) and your application. It speaks a specific protocol (JSON-RPC 2.0) so the AI knows what capabilities are available and how to call them.
+
+Think of it like a REST API, but purpose-built for AI agents instead of web browsers.
+
+### Lifecycle
+
+1. **Startup**: The AI client launches the MCP server process (e.g., `scafctl mcp serve`). This starts a persistent process that listens for JSON-RPC messages over **stdio** (stdin/stdout pipes) or **SSE** (HTTP server-sent events).
+
+2. **Capability Discovery**: The AI client sends an `initialize` request. The server responds with a manifest of everything it can do — its list of tools (with input schemas), resources (with URI templates), and prompts. This is how the AI learns *"I can call `lint_solution` with a `file` parameter"*.
+
+3. **Tool Invocation**: When the AI decides to use a tool, it sends a JSON-RPC `tools/call` request with the tool name and arguments. The server executes the operation and returns the result as a JSON-RPC response.
+
+4. **Shutdown**: When the AI client disconnects, the server process exits.
+
+### What Happens When an AI Calls a Tool
+
+Here is the flow when an AI agent calls, for example, `lint_solution`:
+
+```
+AI Agent                    MCP Server (scafctl)              scafctl Libraries
+   │                              │                                  │
+   │  {"method": "tools/call",    │                                  │
+   │   "params": {                │                                  │
+   │     "name": "lint_solution", │                                  │
+   │     "arguments": {           │                                  │
+   │       "file": "solution.yaml"│                                  │
+   │     }                        │                                  │
+   │   }}                         │                                  │
+   │ ──────────────────────────►  │                                  │
+   │                              │  solution.LoadFromBytes(bytes)   │
+   │                              │ ──────────────────────────────►  │
+   │                              │                                  │
+   │                              │  solution.Validate()             │
+   │                              │ ──────────────────────────────►  │
+   │                              │                                  │
+   │                              │  ◄── []LintFinding              │
+   │                              │                                  │
+   │  {"result": {                │                                  │
+   │    "content": [{             │                                  │
+   │      "type": "text",         │                                  │
+   │      "text": "2 warnings..." │                                  │
+   │    }]                        │                                  │
+   │  }}                          │                                  │
+   │ ◄────────────────────────── │                                  │
+```
+
+### It Is NOT Shelling Out to the CLI
+
+The MCP server would **not** run `scafctl lint solution.yaml` as a subprocess. Instead, it imports and calls the same Go library functions that the CLI commands use internally. This is the key architectural difference:
+
+| Approach | How It Works | Pros | Cons |
+|----------|-------------|------|------|
+| **Library calls** (recommended) | MCP handler calls `solution.LoadFromBytes()`, `resolver.Execute()`, etc. directly as Go function calls | Fast, type-safe, structured output, proper error handling | Requires the MCP server to be part of the scafctl binary |
+| **Subprocess/CLI wrapping** | MCP handler runs `scafctl lint ...` as a child process and parses stdout | Simpler to implement, decoupled | Slow (process spawn per call), fragile text parsing, loses structured data |
+
+Since scafctl already has clean library packages (`pkg/solution/`, `pkg/resolver/`, `pkg/provider/`, etc.) that are separate from the Cobra CLI layer, the library-call approach is straightforward. The MCP tool handlers would be very similar to what the CLI commands already do — just returning JSON instead of writing to a terminal.
+
+### Concrete Example: What a Tool Handler Looks Like
+
+A simplified example of what the `lint_solution` MCP tool handler would look like in Go:
+
+```go
+func handleLintSolution(ctx context.Context, args map[string]any) (*mcp.CallToolResult, error) {
+    filePath := args["file"].(string)
+
+    // Read the solution file (same as CLI does)
+    data, err := os.ReadFile(filePath)
+    if err != nil {
+        return mcp.NewToolResultError("file not found: " + err.Error()), nil
+    }
+
+    // Use the existing library to load + validate (same code path as `scafctl lint`)
+    sol := &solution.Solution{}
+    if err := sol.LoadFromBytes(data); err != nil {
+        return mcp.NewToolResultError("invalid solution: " + err.Error()), nil
+    }
+
+    // Run linting (same code path as `scafctl lint`)
+    findings := linter.Lint(ctx, sol)
+
+    // Return structured result to the AI
+    result, _ := json.Marshal(findings)
+    return mcp.NewToolResultText(string(result)), nil
+}
+```
+
+This is essentially the same logic as the CLI command, minus the Cobra flag parsing and terminal formatting.
+
+### What the AI Agent Sees
+
+From the AI's perspective, it sees a list of tools with schemas, like:
+
+```json
+{
+  "name": "lint_solution",
+  "description": "Validate a scafctl solution file and return lint findings",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "description": "Path to the solution YAML file"
+      }
+    },
+    "required": ["file"]
+  }
+}
+```
+
+The AI decides *when* to call tools based on the user's request. For example, if a user says "check if my solution is valid", the AI would call `lint_solution` and then interpret the results in natural language.
+
+### Where the Server Runs
+
+The MCP server runs **locally on the user's machine**, in the same security context as the user. It has the same filesystem access, network access, and credentials as the user running it. This is important for:
+
+- **Auth**: The server inherits the user's auth tokens (Entra, GitHub, GCP) from the scafctl config
+- **Filesystem**: It can read solution files from the user's projects
+- **Catalog**: It can access local and remote catalogs using the user's configuration
+
+The AI client (VS Code, Claude Desktop, etc.) connects to this local server process — it does not expose anything to the network (when using stdio transport).
+
+## What Is Required
+
+### 1. New Go Dependency
+
+There is no MCP library in `go.mod` today. We would add one:
+
+- **[`mark3labs/mcp-go`](https://github.com/mark3labs/mcp-go)** — the most popular Go MCP SDK, supports stdio + SSE transports
+- Alternatively, hand-roll the JSON-RPC 2.0 protocol (not recommended — ~500 LoC of boilerplate)
+
+### 2. New Package + Command
+
+- **`pkg/mcp/`** — Server implementation, tool/resource registration
+- **`pkg/cmd/scafctl/mcp/`** — New `scafctl mcp serve` CLI command (starts the MCP server on stdio or SSE)
+
+### 3. MCP Tools to Expose
+
+| Tool | Maps To | Description |
+|------|---------|-------------|
+| `list_solutions` | `scafctl get solution` | List available solutions from local catalog |
+| `inspect_solution` | `scafctl get solution <name>` | Get solution metadata, resolvers, actions |
+| `run_solution` | `scafctl run solution` | Execute a solution with parameters |
+| `run_resolver` | `scafctl run resolver` | Run resolvers only (no actions) |
+| `lint_solution` | `scafctl lint` | Validate a solution file |
+| `render_solution` | `scafctl render solution` | Render without executing |
+| `list_providers` | `scafctl get provider` | List available providers |
+| `run_provider` | `scafctl run provider` | Execute a single provider |
+| `catalog_list` | `scafctl catalog list` | List catalog entries |
+| `catalog_pull` | `scafctl catalog pull` | Pull a solution from registry |
+| `test_solution` | `scafctl test functional` | Run functional tests |
+| `explain_solution` | `scafctl explain` | Explain a configuration |
+
+### 4. MCP Resources to Expose
+
+| Resource | Description |
+|----------|-------------|
+| `solution://{name}` | Solution YAML content |
+| `solution://{name}/schema` | JSON Schema for solution inputs |
+| `solution://{name}/graph` | Dependency graph (resolver + action) |
+| `catalog://` | Catalog index |
+
+### 5. Wiring / Integration Points
+
+The existing code is well-factored for this. The key integration points:
+
+- **`pkg/solution/get.Getter`** already handles loading from catalog/file/URL/auto-discovery
+- **`pkg/resolver/executor.go`** has a clean `Execute()` entry point
+- **`pkg/action/executor.go`** is similarly encapsulated
+- **`pkg/provider/registry.go`** gives us provider discovery
+- **`pkg/solution/solution.go`** `LoadFromBytes()` handles parse + validate
+
+We would essentially be creating thin adapters from MCP tool handlers → existing library functions.
+
+## How Hard Would It Be
+
+**Estimated effort: Medium — roughly 1-2 weeks of focused work**
+
+> **Note:** The preparatory refactoring (extracting command logic, creating the MCP context helper, adding the `cel-functions` command, etc.) has already been completed. The remaining effort is the MCP server implementation itself.
+
+| Component | Effort | Rationale |
+|-----------|--------|-----------|
+| MCP server scaffold + stdio transport | ~1 day | Straightforward with `mcp-go` SDK |
+| Core tools (list, inspect, lint, render) | ~2-3 days | Thin wrappers around existing packages — read-only, low risk |
+| `run_solution` / `run_resolver` tools | ~2-3 days | Needs careful handling of: input parameter passing, streaming output, timeout/cancellation, error reporting |
+| MCP resources (solution content, schemas) | ~1 day | Straightforward reads from catalog/filesystem |
+| Testing | ~2-3 days | Unit tests for each tool handler + integration test for the MCP server end-to-end |
+| Docs + tutorials + examples | ~1 day | Per project conventions |
+
+### What Makes It Easier Than Expected
+
+- The codebase has **clean separation** between CLI commands and library logic — we are not fighting Cobra coupling
+- **Preparatory refactoring is complete** — `prepare.Solution()`, `ValidateSolution()`, `ExecuteResolvers()`, `BuildSolutionExplanation()`, `LookupProvider()`, and `mcp.NewContext()` are all ready to be called from MCP tool handlers
+- Providers, resolvers, and solutions all have well-defined interfaces
+- `context.Context` is used throughout, so cancellation propagates naturally
+- The KVX output system already supports JSON, making tool responses trivial
+- The `scafctl get cel-functions` command proves the `ext.All()` API works end-to-end for the `list_cel_functions` MCP tool
+
+### What Makes It Harder
+
+- **Streaming/progress**: Solutions can be long-running. MCP tools are request/response, not streaming. We would need to either: (a) block until complete and return the full result, (b) implement MCP's progress notifications, or (c) return a "job ID" resource for polling
+- **Interactive resolvers**: The `parameter` provider prompts for user input — in MCP context, we would need to either require all params upfront or use MCP's `sampling` capability to ask the AI to provide them
+- **Auth context**: Solutions may need auth tokens (Entra, GitHub, GCP). The MCP server would need to either inherit the CLI's auth config or accept credentials as tool inputs
+- **Side effects**: `run_solution` modifies the world (creates files, calls APIs). AI agents calling this need guardrails — we would want a confirmation/dry-run pattern
+
+## What Would Be the Benefit
+
+**High value — this is where the industry is heading.** Concrete benefits:
+
+### 1. AI-Assisted Solution Authoring
+
+An AI agent could inspect existing solutions, understand provider schemas, and help write new solutions — with real validation feedback by calling `lint_solution` in a loop.
+
+### 2. Natural Language Solution Execution
+
+Instead of learning CLI flags, users say *"Deploy the GCP infrastructure solution with project=my-project and region=us-east1"* — the AI translates to a `run_solution` tool call with the right parameters.
+
+### 3. IDE Integration
+
+VS Code (via Copilot), Cursor, Windsurf, and other AI-enabled editors support MCP. Users editing solution YAML could get real-time validation, auto-completion suggestions, and execution without leaving the editor.
+
+### 4. Catalog Discovery
+
+AI can browse the catalog, compare solutions, and recommend the right one — much more accessible than `scafctl catalog list | grep ...`.
+
+### 5. Debugging Workflows
+
+When a solution fails, an AI agent could automatically inspect the resolver graph, re-run individual resolvers, check provider outputs, and diagnose the issue.
+
+### 6. Composability
+
+Other MCP-aware tools could chain scafctl operations. For example: a CI/CD agent could pull a solution, run its tests, and deploy — all through MCP tool calls.
+
+### 7. Reduced Onboarding Friction
+
+New users don't need to learn the CLI — they describe what they want, and the AI figures out which scafctl commands to run.
+
+## Codebase Readiness Assessment
+
+An analysis of the codebase revealed that ~70% of the operations an MCP server needs were already callable as clean Go library functions. The preparatory refactoring described below has been **completed** — the codebase is now ready for MCP server implementation.
+
+### Already MCP-Ready (No Changes Needed)
+
+These core packages can be called directly from an MCP handler today:
+
+| Package | API | Notes |
+|---|---|---|
+| `pkg/celexp/` | `EvaluateExpression(ctx, expr, data, vars)` | Fully self-contained, thread-safe |
+| `pkg/provider/registry.go` | `Get()`, `List()`, `ListByCapability()` | Thread-safe, no CLI dependencies |
+| `pkg/solution/get/` | `NewGetter().Get(ctx, path)` | Clean dependency injection, no CLI deps |
+| `pkg/resolver/` | `NewExecutor(registry).Execute(ctx, resolvers, params)` | Clean library API |
+| `pkg/action/` | `BuildGraph()`, `NewExecutor().Execute()` | Clean library API |
+| `pkg/config/` | `NewManager("").Load()` | Reads from filesystem and env vars only |
+| `pkg/schema/` | `IntrospectType()`, `GetKind()`, `GenerateConfigSchema()` | Returns structured data |
+| `pkg/settings/` | `NewCliParams()` | Stateless, supports `FromAPI: true` for non-CLI usage |
+| Lint logic | `lintSolution(sol, path, registry)` | Already a pure function in the lint command |
+
+### Completed Preparatory Refactoring
+
+The following changes were implemented to make MCP integration cleaner and improve the codebase independently (better testability, cleaner separation of concerns). All items are **complete** — tests pass and linter is clean.
+
+#### 1. Extract Command Logic from Cobra `RunE` Closures ✅
+
+**Problem:** Command logic lived inside `SolutionOptions.Run(ctx)` methods on Options structs that bundled CLI concerns (`IOStreams`, `KvxOutputFlags`, `CliParams`) with execution config (`ResolverTimeout`, `PhaseTimeout`). An MCP handler could not call these without constructing fake CLI scaffolding.
+
+**Implementation:** Created `pkg/cmd/scafctl/run/execute.go` with standalone functions callable from both CLI and MCP:
+
+```go
+// pkg/cmd/scafctl/run/execute.go
+func ValidateSolution(ctx context.Context, sol *solution.Solution, reg *provider.Registry) *SolutionValidationResult
+func ExecuteResolvers(ctx context.Context, sol *solution.Solution, params map[string]any, reg *provider.Registry, cfg ResolverExecutionConfig) (*ResolverExecutionResult, error)
+func ResolverExecutionConfigFromContext(ctx context.Context) ResolverExecutionConfig
+```
+
+Structured result types (`SolutionValidationResult`, `ResolverExecutionResult`, `ResolverExecutionConfig`) provide type-safe outputs for MCP tool handlers. 5 unit tests in `execute_test.go`.
+
+**Files:** `pkg/cmd/scafctl/run/execute.go`, `pkg/cmd/scafctl/run/execute_test.go`
+
+#### 2. Extract `prepareSolutionForExecution` as a Standalone Function ✅
+
+**Problem:** This helper bundled solution loading + registry setup + bundle extraction + provider registration, but it was a method on the CLI-specific `SolutionOptions` struct.
+
+**Implementation:** Created `pkg/solution/prepare/prepare.go` with a standalone function using the functional options pattern:
+
+```go
+// pkg/solution/prepare/prepare.go
+func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
+
+// Functional options
+func WithGetter(g get.Interface) Option
+func WithRegistry(r *provider.Registry) Option
+func WithStdin(reader io.Reader) Option
+func WithMetrics(errOut io.Writer) Option
+```
+
+Returns `Result{Solution, Registry, Cleanup}`. The CLI's `prepareSolutionForExecution` now delegates to this function. Removed 3 dead methods (`getOrCreateGetter`, `loadSolutionWithBundle`, `getRegistry`) and their unused imports from `common.go`. 9 unit tests in `prepare_test.go`.
+
+**Files:** `pkg/solution/prepare/prepare.go`, `pkg/solution/prepare/prepare_test.go`, `pkg/cmd/scafctl/run/common.go` (refactored)
+
+#### 3. Make `explain` Commands Return Structured Data ✅
+
+**Problem:** The `explain` commands (`solution`, `provider`, `schema`) wrote formatted text imperatively via `Writer` rather than building a struct first. An MCP handler needs structured data, not terminal text.
+
+**Implementation:** Created `pkg/cmd/scafctl/explain/results.go` with structured types and exported helper functions:
+
+```go
+// pkg/cmd/scafctl/explain/results.go
+type SolutionExplanation struct { ... }  // Full solution metadata
+type CatalogInfo struct { ... }          // Catalog metadata
+type ResolverInfo struct { ... }         // Resolver details
+type ActionInfo struct { ... }           // Action details
+
+func LoadSolution(ctx context.Context, path string) (*solution.Solution, error)
+func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation
+func LookupProvider(ctx context.Context, name string, reg *provider.Registry) (*provider.Descriptor, error)
+```
+
+All types have JSON/YAML tags. The CLI `explain solution` and `explain provider` commands now call these functions and format the results. MCP tools can call the same functions and return the structs as JSON.
+
+**Files:** `pkg/cmd/scafctl/explain/results.go`, `pkg/cmd/scafctl/explain/solution.go` (refactored), `pkg/cmd/scafctl/explain/provider.go` (refactored), `pkg/cmd/scafctl/explain/solution_test.go` (updated), `pkg/cmd/scafctl/explain/provider_test.go` (updated)
+
+#### 4. Fix Stray `os.Exit` Call ✅
+
+**Problem:** `pkg/cmd/scafctl/secrets/exists.go` called `os.Exit(1)` directly instead of returning an error. This would crash an MCP server process.
+
+**Implementation:** Replaced with `exitcode.WithCode(fmt.Errorf("secret %q does not exist", name), exitcode.GeneralError)` and removed the unused `"os"` import.
+
+**Files:** `pkg/cmd/scafctl/secrets/exists.go`
+
+#### 5. Create an MCP Context Helper ✅
+
+**Problem:** Several libraries silently pull values from `context.Context` (logger, config, auth registry, writer). An MCP handler needs to know exactly which values to inject.
+
+**Implementation:** Created `pkg/mcp/context.go` with a functional options pattern:
+
+```go
+// pkg/mcp/context.go
+func NewContext(opts ...ContextOption) context.Context
+
+func WithConfig(cfg *config.Config) ContextOption
+func WithLogger(lgr logr.Logger) ContextOption
+func WithAuthRegistry(reg *auth.Registry) ContextOption
+func WithSettings(params *settings.CliParams) ContextOption
+func WithIOStreams(streams *terminal.IOStreams) ContextOption
+```
+
+Provides sensible defaults: discard logger, empty auth registry, quiet/no-color settings, discard IO streams + no-op writer. 7 unit tests in `context_test.go`.
+
+**Files:** `pkg/mcp/context.go`, `pkg/mcp/context_test.go`
+
+#### 6. Add `scafctl get cel-functions` CLI Command ✅
+
+**Problem:** scafctl extends CEL with ~25 custom functions (`map.merge`, `json.unmarshal`, `filepath.join`, `guid.new`, `time.now`, etc.) plus standard CEL extensions (~50+ functions). The data was available programmatically via `ext.All()` in `pkg/celexp/ext/ext.go`, but there was no CLI command for users to discover available CEL functions.
+
+**Implementation:** Created `pkg/cmd/scafctl/get/celfunction/celfunction.go` with the `scafctl get cel-functions` command:
+
+- **Aliases:** `cel-funcs`, `cel`, `cf`
+- **Modes:** List all functions (table view) or get detail on a specific function
+- **Filters:** `--custom` (scafctl-only) and `--built-in` (standard CEL) flags
+- **Output:** Full KVX integration (`-o json/yaml/table/quiet`)
+- **Testable:** Function injection pattern for unit testing without CEL dependencies
+
+12 unit tests in `celfunction_test.go`, 7 integration tests added to `tests/integration/cli_test.go`.
+
+**Files:** `pkg/cmd/scafctl/get/celfunction/celfunction.go`, `pkg/cmd/scafctl/get/celfunction/celfunction_test.go`, `pkg/cmd/scafctl/get/get.go` (wired up), `tests/integration/cli_test.go` (integration tests)
+
+#### 7. Initialize CEL Factories at Server Startup ✅
+
+**Problem:** `celexp.SetEnvFactory()` and `SetCacheFactory()` use `sync.Once` — they can only be called once per process. The MCP server needs to call these during initialization.
+
+**Resolution:** No code change needed. The factory setters are already called during the CLI's `PersistentPreRun` initialization. Since the MCP server runs as a subcommand (`scafctl mcp serve`), it inherits this initialization. The MCP server startup path will call these factory setters as part of its initialization sequence.
+
+### Preparatory Refactoring Summary
+
+| Change | Status | Key Files |
+|---|---|---|
+| Extract `ValidateSolution` / `ExecuteResolvers` from Options | ✅ Complete | `pkg/cmd/scafctl/run/execute.go` |
+| Extract `prepare.Solution` standalone function | ✅ Complete | `pkg/solution/prepare/prepare.go` |
+| Make `explain` commands return structs | ✅ Complete | `pkg/cmd/scafctl/explain/results.go` |
+| Fix `secrets/exists.go` `os.Exit` | ✅ Complete | `pkg/cmd/scafctl/secrets/exists.go` |
+| Create `mcp.NewContext` helper | ✅ Complete | `pkg/mcp/context.go` |
+| Add `scafctl get cel-functions` CLI command | ✅ Complete | `pkg/cmd/scafctl/get/celfunction/celfunction.go` |
+| CEL factory initialization at startup | ✅ No change needed | Inherited from `PersistentPreRun` |
+
+**All preparatory refactoring is complete.** The codebase is ready for MCP server implementation.
+
+### What Does NOT Need to Change
+
+- **Provider registry, CEL evaluation, solution getter, resolver/action executors, config, settings, schema introspection** — all ready as-is
+- **The `RootOptions` pattern** with injectable `IOStreams` and `ExitFunc` already supports in-process execution (integration tests use this today)
+- **JSON/YAML serialization** works everywhere since all structs have proper tags
+- **The `Writer` system** — MCP handlers bypass it entirely and work with structured return values. For library code that pulls Writer from context, a no-op or buffer-backed Writer works fine (`terminal.NewTestIOStreams()` already exists for this)
+
+## Recommended Approach
+
+An incremental rollout is recommended. Step 1 (preparatory refactoring) is already complete.
+
+1. ~~**Preparatory refactoring** (~3-4 days)~~ — **✅ Complete.** Extracted command logic from Cobra closures, fixed `os.Exit`, created MCP context helper, added `cel-functions` command. See [Completed Preparatory Refactoring](#completed-preparatory-refactoring) for details.
+2. **Start with read-only tools** (`list_solutions`, `inspect_solution`, `lint_solution`, `list_providers`) — low risk, immediate value for AI-assisted authoring
+3. **Add `render_solution`** — still safe (no side effects), enables the AI to validate action graphs
+4. **Add `run_solution` with `--dry-run` default** — preview execution without side effects
+5. **Add full `run_solution`** behind explicit confirmation — the AI must surface the plan before executing
+6. **Register as a `scafctl mcp serve` command** using stdio transport (simplest, works with all MCP clients)
+
+This incremental approach lets us ship value at each step while managing the risk of AI-triggered side effects.
+
+## Decisions
+
+### Subcommand vs Separate Binary
+
+**Decision: Subcommand (`scafctl mcp serve`)**
+
+The MCP server will be a subcommand of the existing `scafctl` binary, not a separate binary. This is the industry-standard pattern used by Terraform (`terraform mcp serve`), GitHub CLI (`gh mcp serve`), kubectl, Docker, and others.
+
+Rationale:
+
+- **Single binary distribution** — Users already have `scafctl` installed. No separate install step, no version synchronization between two binaries.
+- **Shared initialization** — The MCP server needs the same config loading, auth setup, CEL factory initialization, provider registry, and plugin discovery that the CLI already does in `PersistentPreRun`. As a subcommand, it gets all of this for free.
+- **Library call approach requires it** — Since we are calling Go library functions directly (not shelling out), the MCP server must be compiled into the same binary to access `pkg/solution/`, `pkg/provider/`, etc.
+- **Versioning is automatic** — The MCP server version always matches the CLI version. No compatibility matrix.
+- **Standard MCP client configuration** — AI clients expect a single command:
+  ```json
+  {
+    "mcpServers": {
+      "scafctl": {
+        "command": "scafctl",
+        "args": ["mcp", "serve"]
+      }
+    }
+  }
+  ```
+
+A separate binary would only make sense if the MCP server had significantly different dependencies that would bloat the CLI (not the case — `mcp-go` is small), needed to run as a shared remote service (not our use case), or was owned by a different team.
+
+### Transport: stdio First, SSE Later
+
+**Decision: Ship with stdio as the default transport. Add SSE support later behind a `--transport` flag.**
+
+The primary use case for the MCP server is through VS Code. stdio is VS Code's preferred and default transport for local MCP servers.
+
+#### How stdio Works in VS Code
+
+VS Code reads MCP server definitions from `.vscode/mcp.json` or workspace settings. A stdio configuration looks like:
+
+```json
+// .vscode/mcp.json
+{
+  "servers": {
+    "scafctl": {
+      "type": "stdio",
+      "command": "scafctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Or equivalently in workspace settings:
+
+```json
+// .vscode/settings.json
+{
+  "mcp": {
+    "servers": {
+      "scafctl": {
+        "type": "stdio",
+        "command": "scafctl",
+        "args": ["mcp", "serve"]
+      }
+    }
+  }
+}
+```
+
+When Copilot (or any MCP-aware extension) activates, VS Code:
+1. Spawns `scafctl mcp serve` as a child process
+2. Sends `initialize` over stdin, reads response from stdout
+3. Discovers tools and their schemas
+4. Sends `tools/call` over stdin when the AI decides to invoke a tool, reads result from stdout
+5. On window close or config change, sends shutdown and kills the process
+
+This is the same pattern VS Code uses for language servers (LSP), which also default to stdio transport.
+
+#### Why stdio First
+
+- **Zero configuration** — No port to pick, no port conflicts, no "address already in use" errors, no macOS firewall popups. It just works.
+- **Security by default** — stdio is inherently local. No network socket to accidentally expose. SSE requires binding to a port, which could theoretically be accessed by other processes.
+- **One server per client** — Each VS Code window spawns its own `scafctl mcp serve` process. Clean lifecycle — client disconnects, process exits. No orphan servers.
+- **Industry standard** — Terraform, GitHub CLI, Docker, kubectl all use stdio for their local MCP servers. Every example in the VS Code MCP documentation uses stdio for local tools.
+- **Simpler implementation** — With `mcp-go`, stdio transport is ~5 lines of setup versus SSE which needs HTTP server configuration, CORS, port selection, graceful shutdown, and health checks.
+
+#### SSE for the Future
+
+SSE will be added later to support:
+- **Remote/shared servers** — A team running one MCP server that multiple developers connect to (e.g., a shared catalog browser)
+- **Web-based AI clients** — Browser-based tools that cannot spawn local processes
+- **Long-lived servers** — MCP servers that need to stay running independently of any single AI client session
+
+The `--transport` flag ensures SSE can be added without a breaking change:
+
+```
+scafctl mcp serve                              # stdio (default)
+scafctl mcp serve --transport sse --port 8080  # future
+```
+
+The transport layer is independent of tool handler code in `mcp-go`, so no tool implementations need to change when SSE is added.
+
+### Authentication Passthrough
+
+**Decision: Inherit the user's existing auth context. No special auth mechanism needed.**
+
+Since the MCP server runs as a local subprocess (`scafctl mcp serve`), it inherits the same security context as any other scafctl command — same environment variables, same filesystem, same keychain access. Authentication works identically to the CLI with no additional configuration.
+
+#### How It Works
+
+1. The user authenticates before starting the MCP server by running `scafctl auth login <provider>` (same as they would before running solutions from the CLI).
+2. The MCP server's `PersistentPreRun` initializes the auth registry from cached tokens, environment variables, and system credential stores — the same code path as every other scafctl command.
+3. VS Code spawns the process in the user's shell environment, so all env vars (`GITHUB_TOKEN`, `GOOGLE_APPLICATION_CREDENTIALS`, Azure env vars, etc.) are present.
+4. Solutions that need cloud credentials access them through the auth registry in context, exactly as they do today.
+
+**In other words: if `scafctl run solution` can authenticate today, `scafctl mcp serve` will authenticate the same way with zero additional work.**
+
+#### Edge Cases
+
+**Token expiry during long sessions:** The CLI is short-lived, but the MCP server may run for hours. If an OAuth token expires mid-session, the auth handlers should refresh tokens automatically (most already do). If they cannot, the tool call returns a clear error and the AI instructs the user to run `scafctl auth login` again.
+
+**Interactive auth flows:** The MCP server communicates over stdio and cannot open a browser for OAuth. Auth must be set up before starting the server. This is the same model as other CLI-based MCP servers.
+
+**Per-solution credential requirements:** Different solutions may need different cloud credentials. The MCP server handles this the same way the CLI does — solutions fail at runtime with a clear error if a required token is missing. The AI can then relay this to the user.
+
+#### Enhancements
+
+- **`auth_status` tool** — Expose a tool that reports which auth providers are configured and whether tokens are valid. The AI can check auth status proactively before attempting execution and tell the user exactly what to set up.
+- **`inspect_solution` auth metadata** — If solutions declare which auth providers they require in metadata, the inspect tool could surface this so the AI can verify auth before running.
+
+### Read-Only Tools Initially
+
+**Decision: Limit to read-only tools for the initial release. Execution tools (`run_solution`, `run_resolver`, `run_provider`) will be added later.**
+
+The primary use case is AI-assisted solution authoring — helping users create solutions, understand schemas, generate CEL expressions, and validate configurations. All of this is read-only. Execution tools introduce complexity (side effects, guardrails, confirmation flows, streaming) that is not needed for the initial value proposition.
+
+#### Initial Tool Set
+
+| Tool | Purpose | Read-Only? |
+|------|---------|------------|
+| `list_solutions` | List available solutions from catalog | Yes |
+| `inspect_solution` | Get solution metadata, resolvers, actions | Yes |
+| `lint_solution` | Validate a solution file | Yes |
+| `list_providers` | List available providers and their schemas | Yes |
+| `get_provider_schema` | Get JSON Schema for a provider's inputs | Yes |
+| `render_solution` | Render action graph without executing | Yes |
+| `list_cel_functions` | List all available CEL functions (built-in + scafctl custom) | Yes |
+| `evaluate_cel` | Test a CEL expression against sample data | Yes |
+| `explain_solution` | Explain a solution's configuration | Yes |
+| `explain_provider` | Explain a provider's capabilities and inputs | Yes |
+| `auth_status` | Report which auth providers are configured | Yes |
+| `catalog_list` | List catalog entries | Yes |
+
+#### Deferred to Future Release
+
+| Tool | Reason to Defer |
+|------|-----------------|
+| `run_solution` | Side effects, needs confirmation/dry-run patterns |
+| `run_resolver` | May trigger external calls depending on providers |
+| `run_provider` | Side effects for action-capable providers |
+| `catalog_pull` | Modifies local catalog state |
+| `test_solution` | Executes resolvers and actions in test mode |
+
+#### Why Read-Only First
+
+- **Lower risk** — No accidental file creation, API calls, or infrastructure changes triggered by AI
+- **No guardrail complexity** — No need to implement confirmation prompts, dry-run defaults, or rate limiting yet
+- **Faster to ship** — Read-only tools are thin wrappers around existing library functions with no streaming or progress concerns
+- **Covers the primary use case** — Solution authoring, schema help, CEL generation, and validation are all read-only operations
+- **Resolves the "destructive operations" open question** — By deferring execution tools, rate limiting and confirmation prompts are also deferred
+
+### Preparatory Refactoring as a Standalone PR
+
+**Decision: Yes, the preparatory refactoring was done as a standalone PR before MCP work begins.**
+
+The refactoring (extracting command logic from Cobra closures, fixing the stray `os.Exit`, creating the MCP context helper, adding the `cel-functions` command, etc.) was submitted as its own PR. This keeps the MCP implementation PR focused on new functionality rather than mixing refactoring with feature work, and the refactoring improvements (better testability, cleaner separation of concerns) benefit the codebase regardless of MCP.
+
+See [Completed Preparatory Refactoring](#completed-preparatory-refactoring) for the full list of changes and file references.

--- a/pkg/cmd/scafctl/explain/provider.go
+++ b/pkg/cmd/scafctl/explain/provider.go
@@ -11,9 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
-	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -77,15 +75,12 @@ func (o *ProviderOptions) Run(ctx context.Context, name string) error {
 	w := writer.New(o.IOStreams, o.CliParams)
 	ctx = writer.WithWriter(ctx, w)
 
-	reg := o.getRegistry(ctx)
-	p, ok := reg.Get(name)
-	if !ok {
-		err := fmt.Errorf("provider %q not found", name)
+	desc, err := LookupProvider(ctx, name, o.registry)
+	if err != nil {
 		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.FileNotFound)
+		return err
 	}
 
-	desc := p.Descriptor()
 	o.printProviderExplanation(w, desc)
 	return nil
 }
@@ -263,17 +258,4 @@ func (o *ProviderOptions) printSchemaProperties(w *writer.Writer, schema *jsonsc
 			w.Plainlnf("%s      Example: %v", indent, prop.Examples[0])
 		}
 	}
-}
-
-// getRegistry returns the provider registry
-func (o *ProviderOptions) getRegistry(ctx context.Context) *provider.Registry {
-	if o.registry != nil {
-		return o.registry
-	}
-
-	reg, err := builtin.DefaultRegistry(ctx)
-	if err != nil {
-		return provider.GetGlobalRegistry()
-	}
-	return reg
 }

--- a/pkg/cmd/scafctl/explain/provider_test.go
+++ b/pkg/cmd/scafctl/explain/provider_test.go
@@ -259,22 +259,44 @@ func TestProviderOptions_Run(t *testing.T) {
 	})
 }
 
-func TestProviderOptions_getRegistry(t *testing.T) {
-	t.Run("returns injected registry when set", func(t *testing.T) {
+func TestLookupProvider(t *testing.T) {
+	t.Run("returns descriptor from injected registry", func(t *testing.T) {
 		customReg := provider.NewRegistry()
+		err := customReg.Register(&mockProvider{
+			descriptor: &provider.Descriptor{
+				Name:         "test-prov",
+				DisplayName:  "Test Provider",
+				Description:  "A test provider",
+				APIVersion:   "scafctl.io/v1",
+				Version:      semver.MustParse("1.0.0"),
+				Capabilities: []provider.Capability{provider.CapabilityFrom},
+				MockBehavior: "Returns test data",
+				Schema:       &jsonschema.Schema{Type: "object"},
+				OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+					provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+						"data": schemahelper.AnyProp(""),
+					}),
+				},
+			},
+		})
+		require.NoError(t, err)
 
-		options := &ProviderOptions{
-			registry: customReg,
-		}
-
-		result := options.getRegistry(context.Background())
-		assert.Equal(t, customReg, result)
+		desc, err := LookupProvider(context.Background(), "test-prov", customReg)
+		require.NoError(t, err)
+		assert.Equal(t, "test-prov", desc.Name)
 	})
 
-	t.Run("returns default registry when not set", func(t *testing.T) {
-		options := &ProviderOptions{}
+	t.Run("returns error for unknown provider", func(t *testing.T) {
+		customReg := provider.NewRegistry()
 
-		result := options.getRegistry(context.Background())
-		assert.NotNil(t, result)
+		_, err := LookupProvider(context.Background(), "nonexistent", customReg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("uses default registry when nil", func(t *testing.T) {
+		// Should not panic even when nil is passed
+		_, err := LookupProvider(context.Background(), "nonexistent-provider-xyz", nil)
+		assert.Error(t, err)
 	})
 }

--- a/pkg/cmd/scafctl/explain/results.go
+++ b/pkg/cmd/scafctl/explain/results.go
@@ -1,0 +1,311 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package explain
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+)
+
+// SolutionExplanation holds structured explanation data for a solution.
+// This can be serialized to JSON/YAML or formatted for terminal output.
+type SolutionExplanation struct {
+	Name        string `json:"name" yaml:"name" doc:"Solution name"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"Human-readable display name"`
+	Version     string `json:"version" yaml:"version" doc:"Solution version"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Solution description"`
+	Category    string `json:"category,omitempty" yaml:"category,omitempty" doc:"Solution category"`
+	Path        string `json:"path,omitempty" yaml:"path,omitempty" doc:"Source file path"`
+
+	Catalog *CatalogInfo `json:"catalog,omitempty" yaml:"catalog,omitempty" doc:"Catalog visibility info"`
+
+	Resolvers []ResolverInfo `json:"resolvers,omitempty" yaml:"resolvers,omitempty" doc:"Resolver configurations"`
+	Actions   []ActionInfo   `json:"actions,omitempty" yaml:"actions,omitempty" doc:"Action configurations"`
+	Finally   []ActionInfo   `json:"finally,omitempty" yaml:"finally,omitempty" doc:"Finally/cleanup actions"`
+
+	Tags        []string         `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Solution tags"`
+	Links       []LinkInfo       `json:"links,omitempty" yaml:"links,omitempty" doc:"Related links"`
+	Maintainers []MaintainerInfo `json:"maintainers,omitempty" yaml:"maintainers,omitempty" doc:"Solution maintainers"`
+}
+
+// CatalogInfo holds catalog metadata.
+type CatalogInfo struct {
+	Visibility string `json:"visibility,omitempty" yaml:"visibility,omitempty" doc:"Catalog visibility level"`
+	Beta       bool   `json:"beta,omitempty" yaml:"beta,omitempty" doc:"Whether the solution is in beta"`
+	Disabled   bool   `json:"disabled,omitempty" yaml:"disabled,omitempty" doc:"Whether the solution is disabled"`
+}
+
+// ResolverInfo holds structured information about a resolver.
+type ResolverInfo struct {
+	Name        string   `json:"name" yaml:"name" doc:"Resolver name"`
+	Providers   []string `json:"providers,omitempty" yaml:"providers,omitempty" doc:"Provider names used"`
+	DependsOn   []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Resolver dependencies"`
+	Conditional bool     `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether resolver has a when condition"`
+	Phases      []string `json:"phases,omitempty" yaml:"phases,omitempty" doc:"Configured phases (resolve, transform, validate)"`
+}
+
+// ActionInfo holds structured information about an action.
+type ActionInfo struct {
+	Name        string   `json:"name" yaml:"name" doc:"Action name"`
+	Provider    string   `json:"provider" yaml:"provider" doc:"Provider used by this action"`
+	DependsOn   []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Action dependencies"`
+	Conditional bool     `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether action has a when condition"`
+	HasRetry    bool     `json:"hasRetry,omitempty" yaml:"hasRetry,omitempty" doc:"Whether retry is configured"`
+	HasForEach  bool     `json:"hasForEach,omitempty" yaml:"hasForEach,omitempty" doc:"Whether forEach is configured"`
+}
+
+// LinkInfo holds a named link.
+type LinkInfo struct {
+	Name string `json:"name" yaml:"name" doc:"Link display name"`
+	URL  string `json:"url" yaml:"url" doc:"Link URL"`
+}
+
+// MaintainerInfo holds maintainer contact info.
+type MaintainerInfo struct {
+	Name  string `json:"name" yaml:"name" doc:"Maintainer name"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty" doc:"Maintainer email"`
+}
+
+// LoadSolution loads a solution from a path using the standard loader with
+// catalog resolution. This function is reusable by both CLI and MCP.
+func LoadSolution(ctx context.Context, path string) (*solution.Solution, error) {
+	lgr := logger.FromContext(ctx)
+
+	var getterOpts []get.Option
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err == nil {
+		catResolver := catalog.NewSolutionResolver(localCatalog, *lgr)
+		getterOpts = append(getterOpts, get.WithCatalogResolver(catResolver))
+	} else {
+		lgr.V(1).Info("catalog not available for solution resolution", "error", err)
+	}
+
+	getter := get.NewGetter(getterOpts...)
+	sol, err := getter.Get(ctx, path)
+	if err != nil {
+		return nil, exitcode.WithCode(
+			fmt.Errorf("failed to load solution: %w", err),
+			exitcode.FileNotFound,
+		)
+	}
+
+	return sol, nil
+}
+
+// BuildSolutionExplanation builds a structured explanation from a loaded solution.
+// This returns data that can be serialized (JSON/YAML) or formatted for display.
+func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation {
+	exp := &SolutionExplanation{
+		Name: sol.Metadata.Name,
+		Path: sol.GetPath(),
+	}
+
+	if sol.Metadata.DisplayName != "" {
+		exp.DisplayName = sol.Metadata.DisplayName
+	}
+	if sol.Metadata.Version != nil {
+		exp.Version = sol.Metadata.Version.String()
+	} else {
+		exp.Version = "unknown"
+	}
+	if sol.Metadata.Description != "" {
+		exp.Description = sol.Metadata.Description
+	}
+	if sol.Metadata.Category != "" {
+		exp.Category = sol.Metadata.Category
+	}
+
+	// Catalog info
+	if sol.Catalog.Visibility != "" || sol.Catalog.Beta || sol.Catalog.Disabled {
+		exp.Catalog = &CatalogInfo{
+			Visibility: string(sol.Catalog.Visibility),
+			Beta:       sol.Catalog.Beta,
+			Disabled:   sol.Catalog.Disabled,
+		}
+	}
+
+	// Resolvers
+	if sol.Spec.HasResolvers() {
+		exp.Resolvers = buildResolverInfos(sol)
+	}
+
+	// Actions
+	if sol.Spec.HasActions() && sol.Spec.Workflow != nil {
+		exp.Actions = buildActionInfos(sol.Spec.Workflow.Actions)
+		exp.Finally = buildActionInfos(sol.Spec.Workflow.Finally)
+	}
+
+	// Tags
+	if len(sol.Metadata.Tags) > 0 {
+		exp.Tags = sol.Metadata.Tags
+	}
+
+	// Links
+	for _, link := range sol.Metadata.Links {
+		exp.Links = append(exp.Links, LinkInfo{
+			Name: link.Name,
+			URL:  link.URL,
+		})
+	}
+
+	// Maintainers
+	for _, m := range sol.Metadata.Maintainers {
+		exp.Maintainers = append(exp.Maintainers, MaintainerInfo{
+			Name:  m.Name,
+			Email: m.Email,
+		})
+	}
+
+	return exp
+}
+
+// LookupProvider looks up a provider by name and returns its descriptor.
+// This is a standalone function reusable by both CLI and MCP.
+func LookupProvider(ctx context.Context, name string, reg *provider.Registry) (*provider.Descriptor, error) {
+	if reg == nil {
+		var err error
+		reg, err = builtin.DefaultRegistry(ctx)
+		if err != nil {
+			reg = provider.GetGlobalRegistry()
+		}
+	}
+
+	p, ok := reg.Get(name)
+	if !ok {
+		return nil, exitcode.WithCode(
+			fmt.Errorf("provider %q not found", name),
+			exitcode.FileNotFound,
+		)
+	}
+
+	return p.Descriptor(), nil
+}
+
+// buildResolverInfos extracts structured resolver information from a solution.
+func buildResolverInfos(sol *solution.Solution) []ResolverInfo {
+	names := make([]string, 0, len(sol.Spec.Resolvers))
+	for name := range sol.Spec.Resolvers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	infos := make([]ResolverInfo, 0, len(names))
+	for _, name := range names {
+		r := sol.Spec.Resolvers[name]
+		if r == nil {
+			continue
+		}
+
+		info := ResolverInfo{
+			Name:        name,
+			Providers:   extractProviderNames(r),
+			DependsOn:   r.DependsOn,
+			Conditional: r.When != nil,
+			Phases:      extractPhases(r),
+		}
+		infos = append(infos, info)
+	}
+
+	return infos
+}
+
+// buildActionInfos extracts structured action information.
+func buildActionInfos(actions map[string]*action.Action) []ActionInfo {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(actions))
+	for name := range actions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	infos := make([]ActionInfo, 0, len(names))
+	for _, name := range names {
+		act := actions[name]
+		if act == nil {
+			continue
+		}
+
+		prov := act.Provider
+		if prov == "" {
+			prov = "unknown"
+		}
+
+		info := ActionInfo{
+			Name:        name,
+			Provider:    prov,
+			DependsOn:   act.DependsOn,
+			Conditional: act.When != nil,
+			HasRetry:    act.Retry != nil,
+			HasForEach:  act.ForEach != nil,
+		}
+		infos = append(infos, info)
+	}
+
+	return infos
+}
+
+// extractProviderNames returns sorted unique provider names from a resolver.
+func extractProviderNames(r *resolver.Resolver) []string {
+	providers := make(map[string]bool)
+
+	if r.Resolve != nil {
+		for _, source := range r.Resolve.With {
+			if source.Provider != "" {
+				providers[source.Provider] = true
+			}
+		}
+	}
+
+	if r.Transform != nil {
+		for _, transform := range r.Transform.With {
+			if transform.Provider != "" {
+				providers[transform.Provider] = true
+			}
+		}
+	}
+
+	if r.Validate != nil {
+		for _, validation := range r.Validate.With {
+			if validation.Provider != "" {
+				providers[validation.Provider] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(providers))
+	for p := range providers {
+		result = append(result, p)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// extractPhases returns which phases are configured on a resolver.
+func extractPhases(r *resolver.Resolver) []string {
+	var phases []string
+	if r.Resolve != nil && len(r.Resolve.With) > 0 {
+		phases = append(phases, "resolve")
+	}
+	if r.Transform != nil && len(r.Transform.With) > 0 {
+		phases = append(phases, "transform")
+	}
+	if r.Validate != nil && len(r.Validate.With) > 0 {
+		phases = append(phases, "validate")
+	}
+	return phases
+}

--- a/pkg/cmd/scafctl/explain/solution.go
+++ b/pkg/cmd/scafctl/explain/solution.go
@@ -5,19 +5,10 @@ package explain
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 
-	"github.com/oakwood-commons/scafctl/pkg/action"
-	"github.com/oakwood-commons/scafctl/pkg/catalog"
-	"github.com/oakwood-commons/scafctl/pkg/exitcode"
-	"github.com/oakwood-commons/scafctl/pkg/logger"
-	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
-	"github.com/oakwood-commons/scafctl/pkg/solution"
-	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -81,113 +72,116 @@ Examples:
 // Run executes the explain solution command
 func (o *SolutionOptions) Run(ctx context.Context) error {
 	w := writer.New(o.IOStreams, o.CliParams)
-	lgr := logger.FromContext(ctx)
 
-	// Set up getter with catalog resolver for bare name resolution
-	var getterOpts []get.Option
-	localCatalog, err := catalog.NewLocalCatalog(*lgr)
-	if err == nil {
-		resolver := catalog.NewSolutionResolver(localCatalog, *lgr)
-		getterOpts = append(getterOpts, get.WithCatalogResolver(resolver))
-	} else {
-		lgr.V(1).Info("catalog not available for solution resolution", "error", err)
-	}
-
-	// Load the solution
-	getter := get.NewGetter(getterOpts...)
-	sol, err := getter.Get(ctx, o.Path)
+	sol, err := LoadSolution(ctx, o.Path)
 	if err != nil {
-		err = fmt.Errorf("failed to load solution: %w", err)
 		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.FileNotFound)
+		return err
 	}
 
-	o.printSolutionExplanation(w, sol)
+	exp := BuildSolutionExplanation(sol)
+	o.printSolutionExplanation(w, exp)
 	return nil
 }
 
 // printSolutionExplanation prints a human-readable explanation of a solution
-func (o *SolutionOptions) printSolutionExplanation(w *writer.Writer, sol *solution.Solution) {
+func (o *SolutionOptions) printSolutionExplanation(w *writer.Writer, exp *SolutionExplanation) {
 	// Header
-	displayName := sol.Metadata.DisplayName
+	displayName := exp.DisplayName
 	if displayName == "" {
-		displayName = sol.Metadata.Name
+		displayName = exp.Name
 	}
-	versionStr := "unknown"
-	if sol.Metadata.Version != nil {
-		versionStr = sol.Metadata.Version.String()
-	}
-	w.Infof("%s (%s@%s)", displayName, sol.Metadata.Name, versionStr)
+	w.Infof("%s (%s@%s)", displayName, exp.Name, exp.Version)
 	w.Plainln("")
 
 	// Description
-	if sol.Metadata.Description != "" {
-		w.Plainln(sol.Metadata.Description)
+	if exp.Description != "" {
+		w.Plainln(exp.Description)
 		w.Plainln("")
 	}
 
 	// Basic metadata
 	w.Infof("Metadata")
-	w.Plainlnf("  Name:       %s", sol.Metadata.Name)
-	w.Plainlnf("  Version:    %s", versionStr)
-	if sol.Metadata.Category != "" {
-		w.Plainlnf("  Category:   %s", sol.Metadata.Category)
+	w.Plainlnf("  Name:       %s", exp.Name)
+	w.Plainlnf("  Version:    %s", exp.Version)
+	if exp.Category != "" {
+		w.Plainlnf("  Category:   %s", exp.Category)
 	}
 	w.Plainln("")
 
 	// Catalog info
-	if sol.Catalog.Visibility != "" || sol.Catalog.Beta || sol.Catalog.Disabled {
+	if exp.Catalog != nil {
 		w.Infof("Catalog")
-		if sol.Catalog.Visibility != "" {
-			w.Plainlnf("  Visibility: %s", sol.Catalog.Visibility)
+		if exp.Catalog.Visibility != "" {
+			w.Plainlnf("  Visibility: %s", exp.Catalog.Visibility)
 		}
-		if sol.Catalog.Beta {
+		if exp.Catalog.Beta {
 			w.Plainln("  Status:     Beta")
 		}
-		if sol.Catalog.Disabled {
+		if exp.Catalog.Disabled {
 			w.Warningf("⚠️  This solution is DISABLED")
 		}
 		w.Plainln("")
 	}
 
 	// Resolvers
-	if sol.Spec.HasResolvers() {
-		w.Infof("Resolvers (%d)", len(sol.Spec.Resolvers))
-		o.printResolvers(w, sol)
+	if len(exp.Resolvers) > 0 {
+		w.Infof("Resolvers (%d)", len(exp.Resolvers))
+		for _, r := range exp.Resolvers {
+			if len(r.Providers) > 0 {
+				w.Plainlnf("  %s (%s)", r.Name, strings.Join(r.Providers, ", "))
+			} else {
+				w.Plainlnf("  %s", r.Name)
+			}
+			if len(r.DependsOn) > 0 {
+				w.Plainlnf("      depends on: %s", strings.Join(r.DependsOn, ", "))
+			}
+			if r.Conditional {
+				w.Plainln("      conditional: yes")
+			}
+			if len(r.Phases) > 0 {
+				w.Plainlnf("      phases: %s", strings.Join(r.Phases, " → "))
+			}
+		}
 		w.Plainln("")
 	}
 
 	// Actions
-	if sol.Spec.HasActions() {
-		actionCount := 0
-		if sol.Spec.Workflow != nil {
-			actionCount = len(sol.Spec.Workflow.Actions) + len(sol.Spec.Workflow.Finally)
-		}
+	actionCount := len(exp.Actions) + len(exp.Finally)
+	if actionCount > 0 {
 		w.Infof("Actions (%d)", actionCount)
-		o.printActions(w, sol)
+		for _, act := range exp.Actions {
+			o.printActionInfo(w, &act, "  ")
+		}
+		if len(exp.Finally) > 0 {
+			w.Plainln("  finally:")
+			for _, act := range exp.Finally {
+				o.printActionInfo(w, &act, "    ")
+			}
+		}
 		w.Plainln("")
 	}
 
 	// Tags
-	if len(sol.Metadata.Tags) > 0 {
+	if len(exp.Tags) > 0 {
 		w.Infof("Tags")
-		w.Plainln(strings.Join(sol.Metadata.Tags, ", "))
+		w.Plainln(strings.Join(exp.Tags, ", "))
 		w.Plainln("")
 	}
 
 	// Links
-	if len(sol.Metadata.Links) > 0 {
+	if len(exp.Links) > 0 {
 		w.Infof("Links")
-		for _, link := range sol.Metadata.Links {
+		for _, link := range exp.Links {
 			w.Plainlnf("  • %s: %s", link.Name, link.URL)
 		}
 		w.Plainln("")
 	}
 
 	// Maintainers
-	if len(sol.Metadata.Maintainers) > 0 {
+	if len(exp.Maintainers) > 0 {
 		w.Infof("Maintainers")
-		for _, m := range sol.Metadata.Maintainers {
+		for _, m := range exp.Maintainers {
 			if m.Email != "" {
 				w.Plainlnf("  • %s <%s>", m.Name, m.Email)
 			} else {
@@ -198,176 +192,26 @@ func (o *SolutionOptions) printSolutionExplanation(w *writer.Writer, sol *soluti
 	}
 
 	// Source path
-	if sol.GetPath() != "" {
+	if exp.Path != "" {
 		w.Infof("Source")
-		w.Plainln(sol.GetPath())
+		w.Plainln(exp.Path)
 	}
 }
 
-// printResolvers prints information about the solution's resolvers
-func (o *SolutionOptions) printResolvers(w *writer.Writer, sol *solution.Solution) {
-	// Sort resolver names for consistent output
-	names := make([]string, 0, len(sol.Spec.Resolvers))
-	for name := range sol.Spec.Resolvers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+// printActionInfo prints a summary of a single action from structured data
+func (o *SolutionOptions) printActionInfo(w *writer.Writer, act *ActionInfo, indent string) {
+	w.Plainlnf("%s%s (%s)", indent, act.Name, act.Provider)
 
-	for _, name := range names {
-		r := sol.Spec.Resolvers[name]
-		if r == nil {
-			continue
-		}
-
-		// Build resolver info - get providers from phases
-		providers := o.getResolverProviders(r)
-		if len(providers) > 0 {
-			w.Plainlnf("  %s (%s)", name, strings.Join(providers, ", "))
-		} else {
-			w.Plainlnf("  %s", name)
-		}
-
-		// Show dependencies if any
-		if len(r.DependsOn) > 0 {
-			w.Plainlnf("      depends on: %s", strings.Join(r.DependsOn, ", "))
-		}
-
-		// Show condition if set
-		if r.When != nil {
-			w.Plainln("      conditional: yes")
-		}
-
-		// Show phases summary
-		phases := o.getResolverPhases(r)
-		if len(phases) > 0 {
-			w.Plainlnf("      phases: %s", strings.Join(phases, " → "))
-		}
-	}
-}
-
-// getResolverProviders extracts all provider names from resolver phases
-func (o *SolutionOptions) getResolverProviders(r *resolver.Resolver) []string {
-	providers := make(map[string]bool)
-
-	if r.Resolve != nil {
-		for _, source := range r.Resolve.With {
-			if source.Provider != "" {
-				providers[source.Provider] = true
-			}
-		}
-	}
-
-	if r.Transform != nil {
-		for _, transform := range r.Transform.With {
-			if transform.Provider != "" {
-				providers[transform.Provider] = true
-			}
-		}
-	}
-
-	if r.Validate != nil {
-		for _, validation := range r.Validate.With {
-			if validation.Provider != "" {
-				providers[validation.Provider] = true
-			}
-		}
-	}
-
-	// Convert to sorted slice
-	result := make([]string, 0, len(providers))
-	for p := range providers {
-		result = append(result, p)
-	}
-	sort.Strings(result)
-	return result
-}
-
-// getResolverPhases returns which phases are configured
-func (o *SolutionOptions) getResolverPhases(r *resolver.Resolver) []string {
-	var phases []string
-	if r.Resolve != nil && len(r.Resolve.With) > 0 {
-		phases = append(phases, "resolve")
-	}
-	if r.Transform != nil && len(r.Transform.With) > 0 {
-		phases = append(phases, "transform")
-	}
-	if r.Validate != nil && len(r.Validate.With) > 0 {
-		phases = append(phases, "validate")
-	}
-	return phases
-}
-
-// printActions prints information about the solution's actions
-func (o *SolutionOptions) printActions(w *writer.Writer, sol *solution.Solution) {
-	if sol.Spec.Workflow == nil {
-		return
-	}
-
-	// Print regular actions
-	if len(sol.Spec.Workflow.Actions) > 0 {
-		// Sort action names for consistent output
-		names := make([]string, 0, len(sol.Spec.Workflow.Actions))
-		for name := range sol.Spec.Workflow.Actions {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-
-		for _, name := range names {
-			act := sol.Spec.Workflow.Actions[name]
-			act.Name = name // Ensure name is set from map key
-			o.printActionSummary(w, act, "  ")
-		}
-	}
-
-	// Print finally actions
-	if len(sol.Spec.Workflow.Finally) > 0 {
-		w.Plainln("  finally:")
-
-		// Sort finally action names for consistent output
-		names := make([]string, 0, len(sol.Spec.Workflow.Finally))
-		for name := range sol.Spec.Workflow.Finally {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-
-		for _, name := range names {
-			act := sol.Spec.Workflow.Finally[name]
-			act.Name = name // Ensure name is set from map key
-			o.printActionSummary(w, act, "    ")
-		}
-	}
-}
-
-// printActionSummary prints a summary of a single action
-func (o *SolutionOptions) printActionSummary(w *writer.Writer, act *action.Action, indent string) {
-	if act == nil {
-		return
-	}
-
-	provider := act.Provider
-	if provider == "" {
-		provider = "unknown"
-	}
-
-	w.Plainlnf("%s%s (%s)", indent, act.Name, provider)
-
-	// Show dependencies if any
 	if len(act.DependsOn) > 0 {
 		w.Plainlnf("%s    depends on: %s", indent, strings.Join(act.DependsOn, ", "))
 	}
-
-	// Show condition if set
-	if act.When != nil {
+	if act.Conditional {
 		w.Plainlnf("%s    conditional: yes", indent)
 	}
-
-	// Show retry if configured
-	if act.Retry != nil {
+	if act.HasRetry {
 		w.Plainlnf("%s    retry: enabled", indent)
 	}
-
-	// Show forEach if configured
-	if act.ForEach != nil {
+	if act.HasForEach {
 		w.Plainlnf("%s    forEach: enabled", indent)
 	}
 }

--- a/pkg/cmd/scafctl/explain/solution_test.go
+++ b/pkg/cmd/scafctl/explain/solution_test.go
@@ -154,7 +154,8 @@ func TestSolutionOptions_printSolutionExplanation(t *testing.T) {
 		sol.SetPath("/path/to/solution.yaml")
 
 		w := writer.New(ioStreams, options.CliParams)
-		options.printSolutionExplanation(w, sol)
+		exp := BuildSolutionExplanation(sol)
+		options.printSolutionExplanation(w, exp)
 
 		output := outBuf.String()
 
@@ -230,7 +231,8 @@ func TestSolutionOptions_printSolutionExplanation(t *testing.T) {
 		}
 
 		w := writer.New(ioStreams, options.CliParams)
-		options.printSolutionExplanation(w, sol)
+		exp := BuildSolutionExplanation(sol)
+		options.printSolutionExplanation(w, exp)
 
 		output := outBuf.String()
 		assert.Contains(t, output, "minimal-solution")
@@ -262,16 +264,15 @@ func TestSolutionOptions_printSolutionExplanation(t *testing.T) {
 		}
 
 		w := writer.New(ioStreams, options.CliParams)
-		options.printSolutionExplanation(w, sol)
+		exp := BuildSolutionExplanation(sol)
+		options.printSolutionExplanation(w, exp)
 
 		output := outBuf.String()
 		assert.Contains(t, output, "DISABLED")
 	})
 }
 
-func TestSolutionOptions_getResolverProviders(t *testing.T) {
-	options := &SolutionOptions{}
-
+func TestExtractProviderNames(t *testing.T) {
 	t.Run("extracts providers from all phases", func(t *testing.T) {
 		r := &resolver.Resolver{
 			Resolve: &resolver.ResolvePhase{
@@ -292,7 +293,7 @@ func TestSolutionOptions_getResolverProviders(t *testing.T) {
 			},
 		}
 
-		providers := options.getResolverProviders(r)
+		providers := extractProviderNames(r)
 
 		assert.Len(t, providers, 4)
 		assert.Contains(t, providers, "http")
@@ -311,7 +312,7 @@ func TestSolutionOptions_getResolverProviders(t *testing.T) {
 			},
 		}
 
-		providers := options.getResolverProviders(r)
+		providers := extractProviderNames(r)
 		assert.Len(t, providers, 1)
 		assert.Equal(t, "http", providers[0])
 	})
@@ -319,14 +320,12 @@ func TestSolutionOptions_getResolverProviders(t *testing.T) {
 	t.Run("returns empty slice for empty resolver", func(t *testing.T) {
 		r := &resolver.Resolver{}
 
-		providers := options.getResolverProviders(r)
+		providers := extractProviderNames(r)
 		assert.Empty(t, providers)
 	})
 }
 
-func TestSolutionOptions_getResolverPhases(t *testing.T) {
-	options := &SolutionOptions{}
-
+func TestExtractPhases(t *testing.T) {
 	t.Run("identifies all phases", func(t *testing.T) {
 		r := &resolver.Resolver{
 			Resolve: &resolver.ResolvePhase{
@@ -340,7 +339,7 @@ func TestSolutionOptions_getResolverPhases(t *testing.T) {
 			},
 		}
 
-		phases := options.getResolverPhases(r)
+		phases := extractPhases(r)
 		assert.Len(t, phases, 3)
 		assert.Equal(t, []string{"resolve", "transform", "validate"}, phases)
 	})
@@ -352,14 +351,14 @@ func TestSolutionOptions_getResolverPhases(t *testing.T) {
 			},
 		}
 
-		phases := options.getResolverPhases(r)
+		phases := extractPhases(r)
 		assert.Equal(t, []string{"resolve"}, phases)
 	})
 
 	t.Run("returns empty slice for empty resolver", func(t *testing.T) {
 		r := &resolver.Resolver{}
 
-		phases := options.getResolverPhases(r)
+		phases := extractPhases(r)
 		assert.Empty(t, phases)
 	})
 }
@@ -395,7 +394,8 @@ func TestSolutionOptions_Run_WithMock(t *testing.T) {
 		// Note: We can't easily inject the getter into Run() without refactoring,
 		// so we'll test the explanation printing directly
 		w := writer.New(ioStreams, options.CliParams)
-		options.printSolutionExplanation(w, sol)
+		exp := BuildSolutionExplanation(sol)
+		options.printSolutionExplanation(w, exp)
 
 		output := outBuf.String()
 		assert.Contains(t, output, "mocked-solution")

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -1,0 +1,399 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package celfunction
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/ext"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// Options holds configuration for the get cel-functions command
+type Options struct {
+	IOStreams *terminal.IOStreams
+	CliParams *settings.Run
+
+	// kvx output integration
+	flags.KvxOutputFlags
+
+	// Filter options
+	Custom  bool // Show only custom (scafctl-specific) functions
+	BuiltIn bool // Show only built-in (cel-go) functions
+
+	// For dependency injection in tests
+	allFn     func() celexp.ExtFunctionList
+	customFn  func() celexp.ExtFunctionList
+	builtInFn func() celexp.ExtFunctionList
+}
+
+// CommandCelFunction creates the 'get cel-functions' subcommand
+func CommandCelFunction(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	options := &Options{}
+
+	cCmd := &cobra.Command{
+		Use:     "cel-functions",
+		Aliases: []string{"cel-funcs", "cel", "cf"},
+		Short:   "List available CEL extension functions",
+		Long: `List all available CEL extension functions, including built-in cel-go
+extensions and custom scafctl-specific functions.
+
+By default, lists all functions. Use --custom or --builtin to filter.
+
+OUTPUT FORMATS:
+  table     Table view with key information (default)
+  json      Full function information as JSON
+  yaml      Full function information as YAML
+  quiet     Function names only (one per line)
+
+Examples:
+  # List all CEL functions
+  scafctl get cel-functions
+
+  # List only custom scafctl functions
+  scafctl get cel-functions --custom
+
+  # List only built-in cel-go functions
+  scafctl get cel-functions --builtin
+
+  # Output as JSON
+  scafctl get cel-functions -o json
+
+  # Get details about a specific function
+  scafctl get cel-functions map.merge
+
+  # Browse interactively
+  scafctl get cel-functions -i`,
+		RunE: func(cCmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			options.IOStreams = ioStreams
+			options.CliParams = cliParams
+
+			if len(args) > 0 {
+				return options.RunGetFunction(ctx, args[0])
+			}
+			return options.RunListFunctions(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	// Add output flags
+	validFormats := []string{"table", "json", "yaml", "quiet"}
+	cCmd.Flags().StringVarP(&options.Output, "output", "o", "",
+		fmt.Sprintf("Output format: %s", strings.Join(validFormats, ", ")))
+	cCmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", false,
+		"Launch interactive TUI for browsing functions")
+	cCmd.Flags().StringVarP(&options.Expression, "expression", "e", "",
+		"CEL expression to filter/transform output data")
+
+	// Filter flags
+	cCmd.Flags().BoolVar(&options.Custom, "custom", false, "Show only custom scafctl functions")
+	cCmd.Flags().BoolVar(&options.BuiltIn, "builtin", false, "Show only built-in cel-go functions")
+
+	return cCmd
+}
+
+// getFunctions returns the appropriate function list based on flags
+func (o *Options) getFunctions() celexp.ExtFunctionList {
+	allFn := ext.All
+	customFn := ext.Custom
+	builtInFn := ext.BuiltIn
+
+	// Allow test injection
+	if o.allFn != nil {
+		allFn = o.allFn
+	}
+	if o.customFn != nil {
+		customFn = o.customFn
+	}
+	if o.builtInFn != nil {
+		builtInFn = o.builtInFn
+	}
+
+	switch {
+	case o.Custom:
+		return customFn()
+	case o.BuiltIn:
+		return builtInFn()
+	default:
+		return allFn()
+	}
+}
+
+// RunListFunctions lists all CEL extension functions
+func (o *Options) RunListFunctions(ctx context.Context) error {
+	funcs := o.getFunctions()
+
+	// Populate function names via CEL env introspection
+	if err := ext.SetFunctionNames(funcs); err != nil {
+		if w := writer.FromContext(ctx); w != nil {
+			w.Warningf("could not resolve function names: %v", err)
+		}
+	}
+
+	// Interactive mode
+	if o.Interactive {
+		if !kvx.IsTerminal(o.IOStreams.Out) {
+			err := fmt.Errorf("interactive mode requires a terminal")
+			if w := writer.FromContext(ctx); w != nil {
+				w.Errorf("%v", err)
+			}
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	}
+
+	// Default (no -o flag): simple list
+	if o.Output == "" && !o.Interactive {
+		return o.printSimpleList(funcs)
+	}
+
+	// Build output data
+	output := buildFunctionListOutput(funcs)
+
+	return o.writeOutput(ctx, output)
+}
+
+// RunGetFunction gets details about a specific function
+func (o *Options) RunGetFunction(ctx context.Context, name string) error {
+	funcs := o.getFunctions()
+
+	// Populate function names
+	if err := ext.SetFunctionNames(funcs); err != nil {
+		if w := writer.FromContext(ctx); w != nil {
+			w.Warningf("could not resolve function names: %v", err)
+		}
+	}
+
+	// Find the function by name (case-insensitive)
+	var found *celexp.ExtFunction
+	for i := range funcs {
+		if strings.EqualFold(funcs[i].Name, name) {
+			found = &funcs[i]
+			break
+		}
+	}
+
+	if found == nil {
+		err := fmt.Errorf("CEL function %q not found", name)
+		if w := writer.FromContext(ctx); w != nil {
+			w.Errorf("%v", err)
+		}
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	// Default: custom formatted view
+	if o.Output == "" && !o.Interactive {
+		return o.printFunctionDetail(found)
+	}
+
+	output := buildFunctionDetailOutput(found)
+	return o.writeOutput(ctx, output)
+}
+
+// printSimpleList prints a simple list of function names and descriptions
+func (o *Options) printSimpleList(funcs celexp.ExtFunctionList) error {
+	out := o.IOStreams.Out
+	noColor := o.CliParams.NoColor
+
+	for _, fn := range funcs {
+		name := fn.Name
+		if !noColor {
+			if fn.Custom {
+				name = "\033[1;32m" + name + "\033[0m" // Bold green for custom
+			} else {
+				name = "\033[1;94m" + name + "\033[0m" // Bold blue for built-in
+			}
+		}
+
+		desc := fn.Description
+		if len(desc) > 80 {
+			desc = desc[:77] + "..."
+		}
+		fmt.Fprintf(out, "  %s\n", name)
+		if desc != "" {
+			dimDesc := desc
+			if !noColor {
+				dimDesc = "\033[2m" + desc + "\033[0m"
+			}
+			fmt.Fprintf(out, "    %s\n", dimDesc)
+		}
+	}
+	return nil
+}
+
+// printFunctionDetail prints a nicely formatted function detail view
+func (o *Options) printFunctionDetail(fn *celexp.ExtFunction) error {
+	out := o.IOStreams.Out
+	noColor := o.CliParams.NoColor
+
+	keyStyle := func(s string) string {
+		if noColor {
+			return s
+		}
+		return "\033[1;94m" + s + "\033[0m"
+	}
+	dimStyle := func(s string) string {
+		if noColor {
+			return s
+		}
+		return "\033[2m" + s + "\033[0m"
+	}
+	tagStyle := func(s string) string {
+		if noColor {
+			return "[" + s + "]"
+		}
+		return "\033[38;5;85;48;5;235m " + s + " \033[0m"
+	}
+
+	// Name and type
+	fmt.Fprintf(out, "%s %s", keyStyle("Name:"), fn.Name)
+	if fn.Custom {
+		fmt.Fprintf(out, " %s", tagStyle("custom"))
+	} else {
+		fmt.Fprintf(out, " %s", tagStyle("built-in"))
+	}
+	fmt.Fprintln(out)
+
+	// Description
+	if fn.Description != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Description:"))
+		fmt.Fprintf(out, "  %s\n", fn.Description)
+	}
+
+	// Function names
+	if len(fn.FunctionNames) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Functions:"))
+		for _, name := range fn.FunctionNames {
+			fmt.Fprintf(out, "  %s\n", name)
+		}
+	}
+
+	// Examples
+	if len(fn.Examples) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Examples:"))
+		for _, ex := range fn.Examples {
+			if ex.Description != "" {
+				fmt.Fprintf(out, "  %s\n", dimStyle(ex.Description))
+			}
+			if ex.Expression != "" {
+				fmt.Fprintf(out, "    %s\n", ex.Expression)
+			}
+		}
+	}
+
+	// Links
+	if len(fn.Links) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Links:"))
+		for _, link := range fn.Links {
+			fmt.Fprintf(out, "  %s\n", link)
+		}
+	}
+
+	return nil
+}
+
+// buildFunctionListOutput builds structured output for the function list
+func buildFunctionListOutput(funcs celexp.ExtFunctionList) []map[string]any {
+	output := make([]map[string]any, 0, len(funcs))
+	for _, fn := range funcs {
+		output = append(output, buildFunctionDetailOutput(&fn))
+	}
+	return output
+}
+
+// buildFunctionDetailOutput builds structured output for a single function
+func buildFunctionDetailOutput(fn *celexp.ExtFunction) map[string]any {
+	m := map[string]any{
+		"name":   fn.Name,
+		"custom": fn.Custom,
+	}
+
+	if fn.Description != "" {
+		m["description"] = fn.Description
+	}
+	if len(fn.FunctionNames) > 0 {
+		m["functionNames"] = fn.FunctionNames
+	}
+	if len(fn.Links) > 0 {
+		m["links"] = fn.Links
+	}
+	if len(fn.Examples) > 0 {
+		examples := make([]map[string]any, 0, len(fn.Examples))
+		for _, ex := range fn.Examples {
+			exMap := map[string]any{}
+			if ex.Description != "" {
+				exMap["description"] = ex.Description
+			}
+			if ex.Expression != "" {
+				exMap["expression"] = ex.Expression
+			}
+			if len(ex.Links) > 0 {
+				exMap["links"] = ex.Links
+			}
+			examples = append(examples, exMap)
+		}
+		m["examples"] = examples
+	}
+
+	return m
+}
+
+// writeOutput writes the output using kvx
+func (o *Options) writeOutput(ctx context.Context, data any) error {
+	if o.Output == "quiet" {
+		return o.writeQuietOutput(data)
+	}
+
+	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
+		o.Output,
+		o.Interactive,
+		o.Expression,
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName("scafctl get cel-functions"),
+		kvx.WithOutputHelp("scafctl get cel-functions", []string{
+			"CEL Extension Functions Viewer",
+			"",
+			"Navigate: ↑↓ arrows | Back: ← | Enter: →",
+			"Search: / or F3 | Expression: F6",
+			"Copy path: F5 | Quit: q or F10",
+		}),
+	)
+	kvxOpts.IOStreams = o.IOStreams
+
+	return kvxOpts.Write(data)
+}
+
+// writeQuietOutput prints just the function names
+func (o *Options) writeQuietOutput(data any) error {
+	switch v := data.(type) {
+	case []map[string]any:
+		for _, item := range v {
+			if name, ok := item["name"].(string); ok {
+				fmt.Fprintln(o.IOStreams.Out, name)
+			}
+		}
+	case map[string]any:
+		if name, ok := v["name"].(string); ok {
+			fmt.Fprintln(o.IOStreams.Out, name)
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
@@ -1,0 +1,244 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package celfunction
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testFuncs() celexp.ExtFunctionList {
+	return celexp.ExtFunctionList{
+		{
+			Name:          "test.custom",
+			Description:   "A test custom function",
+			Custom:        true,
+			FunctionNames: []string{"test_custom"},
+			Examples: []celexp.Example{
+				{Description: "Basic usage", Expression: "test.custom()"},
+			},
+			Links: []string{"https://example.com"},
+		},
+		{
+			Name:          "test.builtin",
+			Description:   "A test built-in function",
+			Custom:        false,
+			FunctionNames: []string{"test_builtin"},
+		},
+	}
+}
+
+func testCustomFuncs() celexp.ExtFunctionList {
+	return celexp.ExtFunctionList{testFuncs()[0]}
+}
+
+func testBuiltInFuncs() celexp.ExtFunctionList {
+	return celexp.ExtFunctionList{testFuncs()[1]}
+}
+
+func mkTestOpts(buf *bytes.Buffer) *Options {
+	return &Options{
+		IOStreams: &terminal.IOStreams{
+			Out:    buf,
+			ErrOut: buf,
+		},
+		CliParams: &settings.Run{
+			NoColor: true,
+		},
+		allFn:     testFuncs,
+		customFn:  testCustomFuncs,
+		builtInFn: testBuiltInFuncs,
+	}
+}
+
+func TestRunListFunctions_SimpleList(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.custom")
+	assert.Contains(t, output, "test.builtin")
+	assert.Contains(t, output, "A test custom function")
+	assert.Contains(t, output, "A test built-in function")
+}
+
+func TestRunListFunctions_CustomFilter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Custom = true
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.custom")
+	assert.NotContains(t, output, "test.builtin")
+}
+
+func TestRunListFunctions_BuiltInFilter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.BuiltIn = true
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.builtin")
+	assert.NotContains(t, output, "test.custom")
+}
+
+func TestRunListFunctions_JSON(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Output = "json"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "\"name\"")
+	assert.Contains(t, output, "\"test.custom\"")
+	assert.Contains(t, output, "\"custom\"")
+}
+
+func TestRunListFunctions_Quiet(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Output = "quiet"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.custom")
+	assert.Contains(t, output, "test.builtin")
+}
+
+func TestRunGetFunction_Found(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunGetFunction(ctx, "test.custom")
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.custom")
+	assert.Contains(t, output, "A test custom function")
+	assert.Contains(t, output, "test_custom")
+	assert.Contains(t, output, "Basic usage")
+	assert.Contains(t, output, "https://example.com")
+}
+
+func TestRunGetFunction_NotFound(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunGetFunction(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRunGetFunction_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunGetFunction(ctx, "TEST.CUSTOM")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "test.custom")
+}
+
+func TestRunGetFunction_JSON(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Output = "json"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+
+	err := opts.RunGetFunction(ctx, "test.custom")
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "\"name\"")
+	assert.Contains(t, output, "\"test.custom\"")
+}
+
+func TestBuildFunctionDetailOutput(t *testing.T) {
+	t.Parallel()
+	fn := &celexp.ExtFunction{
+		Name:          "test",
+		Description:   "test desc",
+		Custom:        true,
+		FunctionNames: []string{"fn1", "fn2"},
+		Links:         []string{"https://example.com"},
+		Examples: []celexp.Example{
+			{Description: "ex1", Expression: "test()"},
+		},
+	}
+
+	result := buildFunctionDetailOutput(fn)
+	assert.Equal(t, "test", result["name"])
+	assert.Equal(t, true, result["custom"])
+	assert.Equal(t, "test desc", result["description"])
+	assert.Equal(t, []string{"fn1", "fn2"}, result["functionNames"])
+	assert.Equal(t, []string{"https://example.com"}, result["links"])
+
+	examples, ok := result["examples"].([]map[string]any)
+	require.True(t, ok)
+	assert.Len(t, examples, 1)
+	assert.Equal(t, "ex1", examples[0]["description"])
+	assert.Equal(t, "test()", examples[0]["expression"])
+}
+
+func TestBuildFunctionListOutput(t *testing.T) {
+	t.Parallel()
+	funcs := testFuncs()
+	result := buildFunctionListOutput(funcs)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "test.custom", result[0]["name"])
+	assert.Equal(t, "test.builtin", result[1]["name"])
+}
+
+func TestCommandCelFunction_Creation(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{}
+	ioStreams := &terminal.IOStreams{}
+	cmd := CommandCelFunction(cliParams, ioStreams, "test/path")
+
+	assert.Equal(t, "cel-functions", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "cel")
+	assert.Contains(t, cmd.Aliases, "cf")
+	assert.NotNil(t, cmd.RunE)
+	assert.NotNil(t, cmd.Flags().Lookup("output"))
+	assert.NotNil(t, cmd.Flags().Lookup("interactive"))
+	assert.NotNil(t, cmd.Flags().Lookup("expression"))
+	assert.NotNil(t, cmd.Flags().Lookup("custom"))
+	assert.NotNil(t, cmd.Flags().Lookup("builtin"))
+}

--- a/pkg/cmd/scafctl/get/get.go
+++ b/pkg/cmd/scafctl/get/get.go
@@ -6,6 +6,7 @@ package get
 import (
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/provider"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/solution"
@@ -24,5 +25,6 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 	cCmd.AddCommand(provider.CommandProvider(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(solution.CommandSolution(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(resolver.CommandResolver(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(celfunction.CommandCelFunction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	return cCmd
 }

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -16,19 +15,16 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
-	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
-	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
-	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
-	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
@@ -184,109 +180,6 @@ func (o *sharedResolverOptions) getEffectiveResolverConfig(ctx context.Context) 
 	result.MaxConcurrency = configValues.MaxConcurrency
 
 	return result
-}
-
-// getOrCreateGetter returns the injected getter or creates a default one, caching the result.
-func (o *sharedResolverOptions) getOrCreateGetter(ctx context.Context) get.Interface {
-	if o.getter != nil {
-		return o.getter
-	}
-
-	lgr := logger.FromContext(ctx)
-
-	getterOpts := []get.Option{
-		get.WithLogger(*lgr),
-	}
-
-	localCatalog, err := catalog.NewLocalCatalog(*lgr)
-	if err == nil {
-		catResolver := catalog.NewSolutionResolver(localCatalog, *lgr)
-		getterOpts = append(getterOpts, get.WithCatalogResolver(catResolver))
-	} else {
-		lgr.V(1).Info("catalog not available for solution resolution", "error", err)
-	}
-
-	o.getter = get.NewGetter(getterOpts...)
-	return o.getter
-}
-
-// loadSolutionWithBundle loads a solution and extracts its bundle if present.
-// Returns the solution, the path to the extracted bundle directory (empty if no bundle),
-// and any error. The caller is responsible for cleaning up the bundle directory.
-func (o *sharedResolverOptions) loadSolutionWithBundle(ctx context.Context) (*solution.Solution, string, error) {
-	lgr := logger.FromContext(ctx)
-	getter := o.getOrCreateGetter(ctx)
-
-	// Handle stdin
-	if o.File == "-" {
-		data, err := io.ReadAll(o.IOStreams.In)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to read from stdin: %w", err)
-		}
-
-		var sol solution.Solution
-		if err := sol.LoadFromBytes(data); err != nil {
-			return nil, "", fmt.Errorf("failed to parse solution from stdin: %w", err)
-		}
-		return &sol, "", nil
-	}
-
-	// Use GetWithBundle for catalog solutions to extract bundle
-	sol, bundleData, err := getter.GetWithBundle(ctx, o.File)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// If there's bundle data, extract it to a temp directory
-	if len(bundleData) > 0 {
-		lgr.V(1).Info("extracting solution bundle", "size", len(bundleData))
-		tmpDir, err := os.MkdirTemp("", "scafctl-bundle-*")
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to create temp directory for bundle: %w", err)
-		}
-
-		// Write the solution YAML to the temp dir so relative paths work
-		solYAML, err := sol.ToYAML()
-		if err != nil {
-			os.RemoveAll(tmpDir)
-			return nil, "", fmt.Errorf("failed to serialize solution: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "solution.yaml"), solYAML, 0o600); err != nil {
-			os.RemoveAll(tmpDir)
-			return nil, "", fmt.Errorf("failed to write solution to temp dir: %w", err)
-		}
-
-		// Extract bundle tar
-		manifest, err := bundler.ExtractBundleTar(bundleData, tmpDir)
-		if err != nil {
-			os.RemoveAll(tmpDir)
-			return nil, "", fmt.Errorf("failed to extract bundle: %w", err)
-		}
-
-		lgr.V(1).Info("extracted bundle",
-			"files", len(manifest.Files),
-			"dir", tmpDir)
-
-		return sol, tmpDir, nil
-	}
-
-	return sol, "", nil
-}
-
-// getRegistry returns the provider registry (creates default if not injected)
-func (o *sharedResolverOptions) getRegistry(ctx context.Context) *provider.Registry {
-	if o.registry != nil {
-		return o.registry
-	}
-
-	reg, err := builtin.DefaultRegistry(ctx)
-	if err != nil {
-		lgr := logger.Get(0)
-		lgr.V(0).Info("warning: failed to register some providers", "error", err)
-		return provider.GetGlobalRegistry()
-	}
-
-	return reg
 }
 
 // exitWithCode prints the error message and returns an ExitError with the appropriate code
@@ -536,78 +429,31 @@ func filterResolversWithDependencies(resolvers []*resolver.Resolver, targetNames
 // prepareSolutionForExecution loads a solution, sets up the provider registry,
 // and registers the solution provider. It handles bundle extraction, plugin merging,
 // and working directory changes. Returns cleanup function that must be deferred.
+//
+// This method delegates to the standalone prepare.PrepareSolution function,
+// passing CLI-specific options (getter, registry, stdin, metrics).
 func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context) (*solution.Solution, *provider.Registry, func(), error) {
-	lgr := logger.FromContext(ctx)
+	var opts []prepare.Option
 
-	// Enable metrics collection if requested
-	if o.ShowMetrics {
-		provider.GlobalMetrics.Enable()
+	if o.getter != nil {
+		opts = append(opts, prepare.WithGetter(o.getter))
+	}
+	if o.registry != nil {
+		opts = append(opts, prepare.WithRegistry(o.registry))
+	}
+	if o.IOStreams != nil && o.IOStreams.In != nil {
+		opts = append(opts, prepare.WithStdin(o.IOStreams.In))
+	}
+	if o.ShowMetrics && o.IOStreams != nil {
+		opts = append(opts, prepare.WithMetrics(o.IOStreams.ErrOut))
 	}
 
-	// Load the solution (with bundle if available)
-	sol, bundleDir, err := o.loadSolutionWithBundle(ctx)
+	result, err := prepare.Solution(ctx, o.File, opts...)
 	if err != nil {
 		return nil, nil, func() {}, err
 	}
 
-	// Build cleanup function
-	cleanup := func() {
-		if o.ShowMetrics {
-			writeMetrics(o.IOStreams.ErrOut)
-		}
-		if bundleDir != "" {
-			os.RemoveAll(bundleDir)
-		}
-	}
-
-	// Change to bundle directory if needed
-	if bundleDir != "" {
-		originalDir, wdErr := os.Getwd()
-		if wdErr != nil {
-			cleanup()
-			return nil, nil, func() {}, fmt.Errorf("failed to get working directory: %w", wdErr)
-		}
-		if chErr := os.Chdir(bundleDir); chErr != nil {
-			cleanup()
-			return nil, nil, func() {}, fmt.Errorf("failed to change to bundle directory: %w", chErr)
-		}
-		origCleanup := cleanup
-		cleanup = func() {
-			_ = os.Chdir(originalDir)
-			origCleanup()
-		}
-		lgr.V(1).Info("using bundle extraction directory as working directory", "dir", bundleDir)
-	}
-
-	lgr.V(1).Info("loaded solution",
-		"name", sol.Metadata.Name,
-		"version", sol.Metadata.Version,
-		"hasResolvers", sol.Spec.HasResolvers(),
-		"hasWorkflow", sol.Spec.HasWorkflow())
-
-	// Merge plugin defaults into provider inputs before DAG construction
-	if len(sol.Bundle.Plugins) > 0 {
-		bundler.MergePluginDefaults(sol)
-		lgr.V(1).Info("merged plugin defaults", "pluginCount", len(sol.Bundle.Plugins))
-	}
-
-	// Set up provider registry
-	reg := o.getRegistry(ctx)
-
-	// Register the solution provider
-	if !reg.Has(solutionprovider.ProviderName) {
-		solGetter := o.getOrCreateGetter(ctx)
-		solProvider := solutionprovider.New(
-			solutionprovider.WithLoader(solGetter),
-			solutionprovider.WithRegistry(reg),
-		)
-		if err := reg.Register(solProvider); err != nil {
-			cleanup()
-			return nil, nil, func() {}, fmt.Errorf("registering solution provider: %w", err)
-		}
-	}
-
-	return sol, reg, cleanup, nil
+	return result.Solution, result.Registry, result.Cleanup, nil
 }
 
 // addSharedResolverFlags adds common resolver flags to a cobra command.

--- a/pkg/cmd/scafctl/run/execute.go
+++ b/pkg/cmd/scafctl/run/execute.go
@@ -1,0 +1,205 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// SolutionValidationResult holds the structured results of validating a solution.
+type SolutionValidationResult struct {
+	// Valid is true when the solution passes all validation checks.
+	Valid bool `json:"valid" yaml:"valid" doc:"Whether the solution is valid"`
+
+	// HasResolvers indicates whether the solution defines resolvers.
+	HasResolvers bool `json:"hasResolvers" yaml:"hasResolvers" doc:"Whether the solution has resolvers"`
+
+	// HasWorkflow indicates whether the solution defines an action workflow.
+	HasWorkflow bool `json:"hasWorkflow" yaml:"hasWorkflow" doc:"Whether the solution has a workflow"`
+
+	// Errors contains any validation errors found.
+	Errors []string `json:"errors,omitempty" yaml:"errors,omitempty" doc:"Validation errors"`
+}
+
+// ValidateSolution validates a loaded solution and its workflow against the
+// given provider registry. This standalone function can be called from both
+// the CLI and the MCP server without requiring CLI-specific types.
+func ValidateSolution(_ context.Context, sol *solution.Solution, reg *provider.Registry) *SolutionValidationResult {
+	result := &SolutionValidationResult{
+		Valid:        true,
+		HasResolvers: sol.Spec.HasResolvers(),
+		HasWorkflow:  sol.Spec.HasWorkflow(),
+	}
+
+	// Validate workflow if present
+	if sol.Spec.HasWorkflow() {
+		adapter := &actionRegistryAdapter{registry: reg}
+		if err := action.ValidateWorkflow(sol.Spec.Workflow, adapter); err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("workflow validation: %s", err))
+		}
+	}
+
+	return result
+}
+
+// ResolverExecutionConfig holds resolver execution parameters decoupled from CLI types.
+// This allows the MCP server to configure resolver execution without constructing
+// fake CLI scaffolding (IOStreams, flag sets, etc.).
+type ResolverExecutionConfig struct {
+	// Timeout is the default timeout per resolver.
+	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Default timeout per resolver"`
+
+	// PhaseTimeout is the timeout for each execution phase.
+	PhaseTimeout time.Duration `json:"phaseTimeout,omitempty" yaml:"phaseTimeout,omitempty" doc:"Timeout for each execution phase"`
+
+	// MaxConcurrency limits concurrent resolver execution (0=unlimited).
+	MaxConcurrency int `json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty" doc:"Maximum concurrent resolvers"`
+
+	// WarnValueSize triggers a warning when resolver values exceed this size in bytes.
+	WarnValueSize int64 `json:"warnValueSize,omitempty" yaml:"warnValueSize,omitempty" doc:"Warn when value exceeds this size"`
+
+	// MaxValueSize rejects resolver values exceeding this size in bytes.
+	MaxValueSize int64 `json:"maxValueSize,omitempty" yaml:"maxValueSize,omitempty" doc:"Reject values exceeding this size"`
+
+	// ValidateAll validates all resolvers even if some fail.
+	ValidateAll bool `json:"validateAll,omitempty" yaml:"validateAll,omitempty" doc:"Validate all resolvers even on failure"`
+
+	// SkipValidation skips resolver validation.
+	SkipValidation bool `json:"skipValidation,omitempty" yaml:"skipValidation,omitempty" doc:"Skip resolver validation"`
+
+	// SkipTransform skips resolver transforms.
+	SkipTransform bool `json:"skipTransform,omitempty" yaml:"skipTransform,omitempty" doc:"Skip resolver transforms"`
+}
+
+// ResolverExecutionResult holds the structured output of resolver execution.
+type ResolverExecutionResult struct {
+	// Data contains the resolved values keyed by resolver name.
+	Data map[string]any `json:"data" yaml:"data" doc:"Resolved values"`
+
+	// Context is the resolver execution context with full metadata.
+	// Only available when execution succeeds.
+	Context *resolver.Context `json:"-" yaml:"-"`
+}
+
+// ExecuteResolvers runs the resolver execution pipeline on the given solution.
+// This standalone function decouples resolver execution from CLI-specific types
+// (IOStreams, progress bars, output formatting). The MCP server uses this to
+// execute resolvers and return structured results.
+func ExecuteResolvers(
+	ctx context.Context,
+	sol *solution.Solution,
+	params map[string]any,
+	reg *provider.Registry,
+	cfg ResolverExecutionConfig,
+) (*ResolverExecutionResult, error) {
+	lgr := logger.FromContext(ctx)
+
+	resolvers := sol.Spec.ResolversToSlice()
+	resolverData := make(map[string]any)
+
+	if len(resolvers) == 0 {
+		if lgr != nil {
+			lgr.V(0).Info("no resolvers to execute")
+		}
+		return &ResolverExecutionResult{
+			Data:    resolverData,
+			Context: resolver.NewContext(),
+		}, nil
+	}
+
+	adapter := &registryAdapter{registry: reg}
+
+	// Build executor options from config
+	executorOpts := []resolver.ExecutorOption{
+		resolver.WithDefaultTimeout(cfg.Timeout),
+		resolver.WithPhaseTimeout(cfg.PhaseTimeout),
+	}
+	if cfg.MaxConcurrency > 0 {
+		executorOpts = append(executorOpts, resolver.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	if cfg.WarnValueSize > 0 {
+		executorOpts = append(executorOpts, resolver.WithWarnValueSize(cfg.WarnValueSize))
+	}
+	if cfg.MaxValueSize > 0 {
+		executorOpts = append(executorOpts, resolver.WithMaxValueSize(cfg.MaxValueSize))
+	}
+	if cfg.ValidateAll {
+		executorOpts = append(executorOpts, resolver.WithValidateAll(true))
+	}
+	if cfg.SkipValidation {
+		executorOpts = append(executorOpts, resolver.WithSkipValidation(true))
+	}
+	if cfg.SkipTransform {
+		executorOpts = append(executorOpts, resolver.WithSkipTransform(true))
+	}
+	executor := resolver.NewExecutor(adapter, executorOpts...)
+
+	// Execute resolvers
+	resultCtx, err := executor.Execute(ctx, resolvers, params)
+	if err != nil {
+		return nil, fmt.Errorf("resolver execution failed: %w", err)
+	}
+
+	// Get resolver context with results
+	resolverCtx, ok := resolver.FromContext(resultCtx)
+	if !ok {
+		return nil, fmt.Errorf("failed to retrieve resolver results")
+	}
+
+	// Build resolver data map
+	for name := range sol.Spec.Resolvers {
+		result, ok := resolverCtx.GetResult(name)
+		if ok && result.Status == resolver.ExecutionStatusSuccess {
+			resolverData[name] = result.Value
+		}
+	}
+
+	if lgr != nil {
+		lgr.V(1).Info("resolver execution complete", "resolvedCount", len(resolverData))
+	}
+
+	return &ResolverExecutionResult{
+		Data:    resolverData,
+		Context: resolverCtx,
+	}, nil
+}
+
+// ResolverExecutionConfigFromContext creates a ResolverExecutionConfig from the
+// application config stored in context, providing sensible defaults.
+func ResolverExecutionConfigFromContext(ctx context.Context) ResolverExecutionConfig {
+	cfg := config.FromContext(ctx)
+	if cfg == nil {
+		return ResolverExecutionConfig{
+			Timeout:      30 * time.Second,
+			PhaseTimeout: 5 * time.Minute,
+		}
+	}
+
+	values, err := cfg.Resolver.ToResolverValues()
+	if err != nil {
+		return ResolverExecutionConfig{
+			Timeout:      30 * time.Second,
+			PhaseTimeout: 5 * time.Minute,
+		}
+	}
+
+	return ResolverExecutionConfig{
+		Timeout:        values.Timeout,
+		PhaseTimeout:   values.PhaseTimeout,
+		MaxConcurrency: values.MaxConcurrency,
+		WarnValueSize:  values.WarnValueSize,
+		MaxValueSize:   values.MaxValueSize,
+		ValidateAll:    values.ValidateAll,
+	}
+}

--- a/pkg/cmd/scafctl/run/execute_test.go
+++ b/pkg/cmd/scafctl/run/execute_test.go
@@ -1,0 +1,68 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSolution(t *testing.T) {
+	t.Run("valid solution with no workflow", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "test"
+		reg := provider.NewRegistry()
+
+		result := ValidateSolution(context.Background(), sol, reg)
+		assert.True(t, result.Valid)
+		assert.False(t, result.HasWorkflow)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("valid solution with empty workflow", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "test"
+		sol.Spec.Workflow = &action.Workflow{
+			Actions: map[string]*action.Action{},
+		}
+		reg := provider.NewRegistry()
+
+		result := ValidateSolution(context.Background(), sol, reg)
+		assert.True(t, result.HasWorkflow)
+		// Empty workflow may or may not be valid depending on validation rules
+	})
+
+	t.Run("reports hasResolvers correctly", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "test"
+		reg := provider.NewRegistry()
+
+		result := ValidateSolution(context.Background(), sol, reg)
+		assert.False(t, result.HasResolvers)
+	})
+}
+
+func TestResolverExecutionConfig(t *testing.T) {
+	t.Run("default config from nil context", func(t *testing.T) {
+		cfg := ResolverExecutionConfigFromContext(context.Background())
+		assert.NotZero(t, cfg.Timeout)
+		assert.NotZero(t, cfg.PhaseTimeout)
+	})
+}
+
+func TestExecuteResolvers(t *testing.T) {
+	t.Run("empty resolvers returns empty data", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "test"
+		reg := provider.NewRegistry()
+
+		result, err := ExecuteResolvers(context.Background(), sol, nil, reg, ResolverExecutionConfig{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Data)
+		assert.NotNil(t, result.Context)
+	})
+}

--- a/pkg/cmd/scafctl/secrets/exists.go
+++ b/pkg/cmd/scafctl/secrets/exists.go
@@ -5,7 +5,6 @@ package secrets
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -56,7 +55,7 @@ func CommandExists(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			// Set exit code
 			if !exists {
-				os.Exit(1)
+				return exitcode.WithCode(fmt.Errorf("secret %q does not exist", name), exitcode.GeneralError)
 			}
 
 			return nil

--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -1,0 +1,128 @@
+package mcp
+
+import (
+	"context"
+	"io"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// ContextOption configures the MCP context setup.
+type ContextOption func(*contextConfig)
+
+type contextConfig struct {
+	config       *config.Config
+	logger       *logr.Logger
+	authRegistry *auth.Registry
+	settings     *settings.Run
+	ioStreams    *terminal.IOStreams
+}
+
+// WithConfig injects application configuration into the MCP context.
+func WithConfig(cfg *config.Config) ContextOption {
+	return func(c *contextConfig) {
+		c.config = cfg
+	}
+}
+
+// WithLogger injects a logger into the MCP context.
+// If not set, a discard logger is used.
+func WithLogger(lgr logr.Logger) ContextOption {
+	return func(c *contextConfig) {
+		c.logger = &lgr
+	}
+}
+
+// WithAuthRegistry injects an auth handler registry into the MCP context.
+// If not set, an empty registry is created.
+func WithAuthRegistry(reg *auth.Registry) ContextOption {
+	return func(c *contextConfig) {
+		c.authRegistry = reg
+	}
+}
+
+// WithSettings injects runtime settings into the MCP context.
+// If not set, quiet/no-color defaults are used.
+func WithSettings(s *settings.Run) ContextOption {
+	return func(c *contextConfig) {
+		c.settings = s
+	}
+}
+
+// WithIOStreams injects custom IO streams into the MCP context.
+// If not set, discard writers are used (MCP output goes through JSON-RPC).
+func WithIOStreams(ios *terminal.IOStreams) ContextOption {
+	return func(c *contextConfig) {
+		c.ioStreams = ios
+	}
+}
+
+// NewContext creates a context.Context pre-populated with all values that
+// scafctl packages pull from context. This ensures MCP tool handlers do not
+// need to figure out which context values each package expects.
+//
+// Injected values:
+//   - logger (logr.Logger) - defaults to discard
+//   - config (*config.Config) - optional
+//   - auth registry (*auth.Registry) - defaults to empty
+//   - writer (*writer.Writer) - defaults to quiet/no-op
+//   - settings (*settings.Run) - defaults to quiet mode
+func NewContext(opts ...ContextOption) context.Context {
+	cfg := &contextConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	ctx := context.Background()
+
+	// Logger
+	if cfg.logger != nil {
+		ctx = logger.WithLogger(ctx, cfg.logger)
+	} else {
+		discardLogger := logr.Discard()
+		ctx = logger.WithLogger(ctx, &discardLogger)
+	}
+
+	// Config
+	if cfg.config != nil {
+		ctx = config.WithConfig(ctx, cfg.config)
+	}
+
+	// Auth registry
+	authReg := cfg.authRegistry
+	if authReg == nil {
+		authReg = auth.NewRegistry()
+	}
+	ctx = auth.WithRegistry(ctx, authReg)
+
+	// Settings
+	s := cfg.settings
+	if s == nil {
+		s = &settings.Run{
+			IsQuiet: true,
+			NoColor: true,
+		}
+	}
+	ctx = settings.IntoContext(ctx, s)
+
+	// IO streams
+	ios := cfg.ioStreams
+	if ios == nil {
+		ios = &terminal.IOStreams{
+			Out:    io.Discard,
+			ErrOut: io.Discard,
+		}
+	}
+
+	// Writer
+	w := writer.New(ios, s)
+	ctx = writer.WithWriter(ctx, w)
+
+	return ctx
+}

--- a/pkg/mcp/context_test.go
+++ b/pkg/mcp/context_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContext(t *testing.T) {
+	t.Run("defaults produce valid context", func(t *testing.T) {
+		ctx := NewContext()
+		lgr := logger.FromContext(ctx)
+		require.NotNil(t, lgr)
+		w := writer.FromContext(ctx)
+		require.NotNil(t, w)
+		authReg := auth.RegistryFromContext(ctx)
+		require.NotNil(t, authReg)
+		s, ok := settings.FromContext(ctx)
+		require.True(t, ok)
+		assert.True(t, s.IsQuiet)
+		assert.True(t, s.NoColor)
+	})
+
+	t.Run("with config", func(t *testing.T) {
+		cfg := &config.Config{Version: 1}
+		ctx := NewContext(WithConfig(cfg))
+		got := config.FromContext(ctx)
+		require.NotNil(t, got)
+		assert.Equal(t, 1, got.Version)
+	})
+
+	t.Run("with logger", func(t *testing.T) {
+		lgr := logr.Discard()
+		ctx := NewContext(WithLogger(lgr))
+		got := logger.FromContext(ctx)
+		require.NotNil(t, got)
+	})
+
+	t.Run("with auth registry", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		ctx := NewContext(WithAuthRegistry(reg))
+		got := auth.RegistryFromContext(ctx)
+		assert.Equal(t, reg, got)
+	})
+
+	t.Run("with settings", func(t *testing.T) {
+		s := &settings.Run{IsQuiet: false, NoColor: false}
+		ctx := NewContext(WithSettings(s))
+		got, ok := settings.FromContext(ctx)
+		require.True(t, ok)
+		assert.False(t, got.IsQuiet)
+	})
+
+	t.Run("config is nil by default", func(t *testing.T) {
+		ctx := NewContext()
+		got := config.FromContext(ctx)
+		assert.Nil(t, got)
+	})
+}

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -1,0 +1,315 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package prepare provides a standalone function for loading and preparing
+// a solution for execution. It decouples solution preparation from CLI-specific
+// types, making it reusable by both CLI commands and the MCP server.
+package prepare
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+)
+
+// Option configures the PrepareSolution function.
+type Option func(*prepareConfig)
+
+type prepareConfig struct {
+	getter      get.Interface
+	registry    *provider.Registry
+	stdin       io.Reader
+	showMetrics bool
+	metricsOut  io.Writer
+}
+
+// WithGetter provides a custom solution getter. If not set, one is created
+// from context (with catalog resolution support).
+func WithGetter(g get.Interface) Option {
+	return func(c *prepareConfig) {
+		c.getter = g
+	}
+}
+
+// WithRegistry provides a custom provider registry. If not set,
+// builtin.DefaultRegistry is used.
+func WithRegistry(r *provider.Registry) Option {
+	return func(c *prepareConfig) {
+		c.registry = r
+	}
+}
+
+// WithStdin provides a reader for stdin-based solution loading (path == "-").
+func WithStdin(r io.Reader) Option {
+	return func(c *prepareConfig) {
+		c.stdin = r
+	}
+}
+
+// WithMetrics enables metrics collection and specifies where to write metrics output.
+func WithMetrics(out io.Writer) Option {
+	return func(c *prepareConfig) {
+		c.showMetrics = true
+		c.metricsOut = out
+	}
+}
+
+// Result holds the output of PrepareSolution.
+type Result struct {
+	// Solution is the loaded and prepared solution.
+	Solution *solution.Solution `json:"solution" yaml:"solution" doc:"The loaded solution"`
+	// Registry is the provider registry with all providers registered,
+	// including the solution provider.
+	Registry *provider.Registry `json:"-" yaml:"-"`
+	// Cleanup must be deferred by the caller. It handles temp directory
+	// removal, working directory restoration, and metrics output.
+	Cleanup func() `json:"-" yaml:"-"`
+}
+
+// Solution loads a solution from the given path, extracts any bundle,
+// merges plugin defaults, sets up the provider registry, and registers the
+// solution provider. The returned Result.Cleanup function must be deferred.
+//
+// This function is the standalone equivalent of the CLI's
+// sharedResolverOptions.prepareSolutionForExecution method, decoupled from
+// CLI-specific types so it can be used by the MCP server and other callers.
+func Solution(ctx context.Context, path string, opts ...Option) (*Result, error) {
+	cfg := &prepareConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	// Enable metrics collection if requested
+	if cfg.showMetrics {
+		provider.GlobalMetrics.Enable()
+	}
+
+	// Get or create the solution getter
+	getter := cfg.getter
+	if getter == nil {
+		getter = newDefaultGetter(ctx)
+	}
+
+	// Load the solution (with bundle if available)
+	sol, bundleDir, err := loadSolutionWithBundle(ctx, getter, path, cfg.stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build cleanup function
+	cleanup := func() {
+		if cfg.showMetrics && cfg.metricsOut != nil {
+			writeMetrics(cfg.metricsOut)
+		}
+		if bundleDir != "" {
+			os.RemoveAll(bundleDir)
+		}
+	}
+
+	// Change to bundle directory if needed
+	if bundleDir != "" {
+		originalDir, wdErr := os.Getwd()
+		if wdErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to get working directory: %w", wdErr)
+		}
+		if chErr := os.Chdir(bundleDir); chErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to change to bundle directory: %w", chErr)
+		}
+		origCleanup := cleanup
+		cleanup = func() {
+			_ = os.Chdir(originalDir)
+			origCleanup()
+		}
+		if lgr != nil {
+			lgr.V(1).Info("using bundle extraction directory as working directory", "dir", bundleDir)
+		}
+	}
+
+	if lgr != nil {
+		lgr.V(1).Info("loaded solution",
+			"name", sol.Metadata.Name,
+			"version", sol.Metadata.Version,
+			"hasResolvers", sol.Spec.HasResolvers(),
+			"hasWorkflow", sol.Spec.HasWorkflow())
+	}
+
+	// Merge plugin defaults into provider inputs before DAG construction
+	if len(sol.Bundle.Plugins) > 0 {
+		bundler.MergePluginDefaults(sol)
+		if lgr != nil {
+			lgr.V(1).Info("merged plugin defaults", "pluginCount", len(sol.Bundle.Plugins))
+		}
+	}
+
+	// Set up provider registry
+	reg := cfg.registry
+	if reg == nil {
+		var regErr error
+		reg, regErr = builtin.DefaultRegistry(ctx)
+		if regErr != nil {
+			if lgr != nil {
+				lgr.V(0).Info("warning: failed to register some providers", "error", regErr)
+			}
+			reg = provider.GetGlobalRegistry()
+		}
+	}
+
+	// Register the solution provider
+	if !reg.Has(solutionprovider.ProviderName) {
+		solProvider := solutionprovider.New(
+			solutionprovider.WithLoader(getter),
+			solutionprovider.WithRegistry(reg),
+		)
+		if err := reg.Register(solProvider); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("registering solution provider: %w", err)
+		}
+	}
+
+	return &Result{
+		Solution: sol,
+		Registry: reg,
+		Cleanup:  cleanup,
+	}, nil
+}
+
+// newDefaultGetter creates a default solution getter with catalog resolution support.
+func newDefaultGetter(ctx context.Context) get.Interface {
+	lgr := logger.FromContext(ctx)
+
+	var getterOpts []get.Option
+	if lgr != nil {
+		getterOpts = append(getterOpts, get.WithLogger(*lgr))
+
+		localCatalog, err := catalog.NewLocalCatalog(*lgr)
+		if err == nil {
+			catResolver := catalog.NewSolutionResolver(localCatalog, *lgr)
+			getterOpts = append(getterOpts, get.WithCatalogResolver(catResolver))
+		} else {
+			lgr.V(1).Info("catalog not available for solution resolution", "error", err)
+		}
+	}
+
+	return get.NewGetter(getterOpts...)
+}
+
+// loadSolutionWithBundle loads a solution and extracts its bundle if present.
+func loadSolutionWithBundle(ctx context.Context, getter get.Interface, path string, stdin io.Reader) (*solution.Solution, string, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Handle stdin
+	if path == "-" {
+		if stdin == nil {
+			return nil, "", fmt.Errorf("stdin requested but no reader provided")
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read from stdin: %w", err)
+		}
+
+		var sol solution.Solution
+		if err := sol.LoadFromBytes(data); err != nil {
+			return nil, "", fmt.Errorf("failed to parse solution from stdin: %w", err)
+		}
+		return &sol, "", nil
+	}
+
+	// Use GetWithBundle for catalog solutions to extract bundle
+	sol, bundleData, err := getter.GetWithBundle(ctx, path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// If there's bundle data, extract it to a temp directory
+	if len(bundleData) > 0 {
+		if lgr != nil {
+			lgr.V(1).Info("extracting solution bundle", "size", len(bundleData))
+		}
+		tmpDir, err := os.MkdirTemp("", "scafctl-bundle-*")
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create temp directory for bundle: %w", err)
+		}
+
+		// Write the solution YAML to the temp dir so relative paths work
+		solYAML, err := sol.ToYAML()
+		if err != nil {
+			os.RemoveAll(tmpDir)
+			return nil, "", fmt.Errorf("failed to serialize solution: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "solution.yaml"), solYAML, 0o600); err != nil {
+			os.RemoveAll(tmpDir)
+			return nil, "", fmt.Errorf("failed to write solution to temp dir: %w", err)
+		}
+
+		// Extract bundle tar
+		manifest, err := bundler.ExtractBundleTar(bundleData, tmpDir)
+		if err != nil {
+			os.RemoveAll(tmpDir)
+			return nil, "", fmt.Errorf("failed to extract bundle: %w", err)
+		}
+
+		if lgr != nil {
+			lgr.V(1).Info("extracted bundle",
+				"files", len(manifest.Files),
+				"dir", tmpDir)
+		}
+
+		return sol, tmpDir, nil
+	}
+
+	return sol, "", nil
+}
+
+// writeMetrics writes provider execution metrics to the given writer.
+func writeMetrics(out io.Writer) {
+	allMetrics := provider.GlobalMetrics.GetAllMetrics()
+	if len(allMetrics) == 0 {
+		return
+	}
+
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Provider Execution Metrics:")
+	fmt.Fprintln(out, strings.Repeat("-", 80))
+	fmt.Fprintf(out, "%-25s %8s %8s %8s %12s %12s\n",
+		"Provider", "Total", "Success", "Failure", "Avg Duration", "Success %")
+	fmt.Fprintln(out, strings.Repeat("-", 80))
+
+	// Sort provider names for consistent output
+	names := make([]string, 0, len(allMetrics))
+	for name := range allMetrics {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		m := allMetrics[name]
+		avgDuration := m.AverageDuration()
+		successRate := m.SuccessRate()
+		fmt.Fprintf(out, "%-25s %8d %8d %8d %12s %11.1f%%\n",
+			name,
+			m.ExecutionCount,
+			m.SuccessCount,
+			m.FailureCount,
+			avgDuration.Round(time.Millisecond),
+			successRate)
+	}
+	fmt.Fprintln(out, strings.Repeat("-", 80))
+}

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1,0 +1,170 @@
+package prepare
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockGetter implements get.Interface for testing
+type mockGetter struct {
+	sol      *solution.Solution
+	bundle   []byte
+	err      error
+	findPath string
+}
+
+func (m *mockGetter) FromLocalFileSystem(_ context.Context, _ string) (*solution.Solution, error) {
+	return m.sol, m.err
+}
+
+func (m *mockGetter) FromURL(_ context.Context, _ string) (*solution.Solution, error) {
+	return m.sol, m.err
+}
+
+func (m *mockGetter) Get(_ context.Context, _ string) (*solution.Solution, error) {
+	return m.sol, m.err
+}
+
+func (m *mockGetter) GetWithBundle(_ context.Context, _ string) (*solution.Solution, []byte, error) {
+	return m.sol, m.bundle, m.err
+}
+
+func (m *mockGetter) FindSolution() string {
+	return m.findPath
+}
+
+var _ get.Interface = (*mockGetter)(nil)
+
+func minimalSolution() *solution.Solution {
+	sol := &solution.Solution{}
+	sol.Metadata.Name = "test-solution"
+	sol.Metadata.Version = semver.MustParse("1.0.0")
+	return sol
+}
+
+func TestSolution(t *testing.T) {
+	t.Run("loads solution from mock getter", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "test-solution", result.Solution.Metadata.Name)
+		assert.NotNil(t, result.Registry)
+		assert.NotNil(t, result.Cleanup)
+
+		result.Cleanup()
+	})
+
+	t.Run("returns error when getter fails", func(t *testing.T) {
+		getter := &mockGetter{err: assert.AnError}
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+		)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("loads from stdin when path is dash", func(t *testing.T) {
+		yamlContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: stdin-solution
+  version: "1.0.0"
+`
+		stdinReader := strings.NewReader(yamlContent)
+
+		result, err := Solution(context.Background(), "-",
+			WithStdin(stdinReader),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "stdin-solution", result.Solution.Metadata.Name)
+		result.Cleanup()
+	})
+
+	t.Run("returns error when stdin requested but nil", func(t *testing.T) {
+		result, err := Solution(context.Background(), "-",
+			WithGetter(&mockGetter{}),
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "stdin requested but no reader provided")
+		assert.Nil(t, result)
+	})
+
+	t.Run("cleanup function is always callable", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+		)
+		require.NoError(t, err)
+
+		result.Cleanup()
+		result.Cleanup()
+	})
+
+	t.Run("with custom registry", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, result.Registry)
+		result.Cleanup()
+	})
+}
+
+func TestWithMetrics(t *testing.T) {
+	t.Run("metrics output is written on cleanup", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+		metricsOut := &bytes.Buffer{}
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+			WithMetrics(metricsOut),
+		)
+		require.NoError(t, err)
+		result.Cleanup()
+	})
+}
+
+func TestOptions(t *testing.T) {
+	t.Run("WithGetter sets getter", func(t *testing.T) {
+		cfg := &prepareConfig{}
+		g := &mockGetter{}
+		WithGetter(g)(cfg)
+		assert.Equal(t, g, cfg.getter)
+	})
+
+	t.Run("WithStdin sets stdin", func(t *testing.T) {
+		cfg := &prepareConfig{}
+		r := strings.NewReader("test")
+		WithStdin(r)(cfg)
+		assert.Equal(t, r, cfg.stdin)
+	})
+
+	t.Run("WithMetrics enables metrics", func(t *testing.T) {
+		cfg := &prepareConfig{}
+		out := &bytes.Buffer{}
+		WithMetrics(out)(cfg)
+		assert.True(t, cfg.showMetrics)
+		assert.Equal(t, out, cfg.metricsOut)
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -165,6 +165,62 @@ func TestIntegration_GetProviderJSON(t *testing.T) {
 }
 
 // ============================================================================
+// Get CEL Functions Tests
+// ============================================================================
+
+func TestIntegration_GetCelFunctions(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions")
+
+	assert.Equal(t, 0, exitCode)
+	// Should list both built-in and custom functions
+	assert.Contains(t, stdout, "strings")
+	assert.Contains(t, stdout, "map.merge")
+}
+
+func TestIntegration_GetCelFunctionsCustom(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions", "--custom")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "map.merge")
+	assert.Contains(t, stdout, "guid.new")
+}
+
+func TestIntegration_GetCelFunctionsBuiltin(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions", "--builtin")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "strings")
+}
+
+func TestIntegration_GetCelFunctionsJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"name\"")
+	assert.Contains(t, stdout, "\"custom\"")
+}
+
+func TestIntegration_GetCelFunctionsQuiet(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions", "-o", "quiet")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "map.merge")
+}
+
+func TestIntegration_GetCelFunctionDetail(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel-functions", "map.merge")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "map.merge")
+}
+
+// ============================================================================
 // Explain Schema Tests
 // ============================================================================
 


### PR DESCRIPTION
Add preparatory refactoring to enable MCP server implementation:

- Add 'scafctl get cel-functions' command with --custom/--builtin filters and full KVX output support (12 unit tests, 7 integration tests)
- Extract solution preparation logic into pkg/solution/prepare/prepare.go with functional options pattern (9 unit tests)
- Extract ValidateSolution, ExecuteResolvers into pkg/cmd/scafctl/run/execute.go for MCP-callable APIs (5 unit tests)
- Refactor explain commands to return structured types (SolutionExplanation, ResolverInfo, ActionInfo) via pkg/cmd/scafctl/explain/results.go
- Create pkg/mcp/context.go with NewContext() helper using functional options for injecting logger, config, auth, settings, IOStreams (7 unit tests)
- Fix os.Exit(1) in secrets/exists.go, use exitcode.WithCode() instead
- Remove dead code from run/common.go (getOrCreateGetter, loadSolutionWithBundle, getRegistry) and unused imports
- Add MCP server design doc with completed refactoring status
