### PR TITLE
feat!: consolidate test schema under \spec.testing\ and add mock HTTP…

### DIFF
--- a/docs/design/functional-testing.md
+++ b/docs/design/functional-testing.md
@@ -34,7 +34,7 @@ This is the primary mechanism for validating solutions in CI and during developm
 | Compose support for tests | ✅ Done | `mergeTests()` and `mergeTestConfig()` in compose |
 | Parallel test execution | ✅ Done | Semaphore-based concurrency control |
 | CEL assertion diagnostics | ✅ Done | `pkg/solution/soltesting/diagnostics.go` |
-| Suite-level setup | ✅ Done | `testConfig.setup` with base sandbox copy |
+| Suite-level setup | ✅ Done | `testing.config.setup` with base sandbox copy |
 | Test tags and filtering | ✅ Done | `--tag` flag, `tags` field on test cases |
 | Per-test environment variables | ✅ Done | `env` field on test cases |
 | Cleanup steps | ✅ Done | `cleanup` field, runs even on failure |
@@ -48,19 +48,19 @@ This is the primary mechanism for validating solutions in CI and during developm
 | Concurrency control | ✅ Done | `-j` flag, `--sequential` as sugar for `-j 1` |
 | Conditional skip (`skipExpression`) | ✅ Done | CEL-based runtime skip evaluation |
 | Test retries | ✅ Done | `retries` field for flaky test resilience |
-| Suite-level cleanup | ✅ Done | `testConfig.cleanup` for teardown after all tests |
+| Suite-level cleanup | ✅ Done | `testing.config.cleanup` for teardown after all tests |
 | File size guard | ✅ Done | Cap `files[].content` at 10MB to prevent OOM |
 | In-process execution safety | ✅ Done | `Root()` accepts `*RootOptions`, no package-level state |
 | Unused template lint warning | ✅ Done | `unused-template` lint rule |
 | Solution filtering (`--solution`) | ✅ Done | Glob-based solution name filtering |
 | `--filter` solution/test format | ✅ Done | `--filter "solution/test-name"` glob support |
 | `--dry-run` flag | ✅ Done | Validate test definitions without executing |
-| Suite-level `env` | ✅ Done | `testConfig.env` shared across all tests |
+| Suite-level `env` | ✅ Done | `testing.config.env` shared across all tests |
 | Binary file content guard | ✅ Done | Non-UTF-8 files get `content` set to `"<binary file>"` |
 | Test execution ordering | ✅ Done | Alphabetical by name; builtins first |
 | Field max limits | ✅ Done | `assertions: 100`, `files: 50`, `tags: 20`, extends depth: 10 |
 | Glob zero-match error | ✅ Done | Test `files` globs matching zero files produce `error` |
-| Environment precedence chain | ✅ Done | process → `testConfig.env` → `TestCase.env` → `InitStep.env` |
+| Environment precedence chain | ✅ Done | process → `testing.config.env` → `TestCase.env` → `InitStep.env` |
 | `TestCase.Validate()` | ✅ Done | Comprehensive test case validation method |
 | Extends non-existent error | ✅ Done | `extends` referencing non-existent test names is a parse-time error |
 | Tests per solution limit | ✅ Done | Max 500 tests per solution |
@@ -73,7 +73,7 @@ This is the primary mechanism for validating solutions in CI and during developm
 
 ### Location
 
-Tests are defined under `spec.tests` in the solution YAML. Like resolvers, tests support the `compose` mechanism for splitting into separate files.
+Tests are defined under `spec.testing.cases` in the solution YAML. Like resolvers, tests support the `compose` mechanism for splitting into separate files.
 
 ---
 
@@ -110,85 +110,86 @@ spec:
           template:
             tmpl: "main.tf.tmpl"
           output: "{{environment}}/main.tf"
-  tests:
-    _base-render:
-      description: "Base render test template"
-      command: [render, solution]
-      assertions:
-        - expression: 'size(__output.actions) >= 1'
+  testing:
+    cases:
+      _base-render:
+        description: "Base render test template"
+        command: [render, solution]
+        assertions:
+          - expression: 'size(__output.actions) >= 1'
 
-    renders-dev-defaults:
-      description: "Default environment renders dev configuration"
-      extends: [_base-render]
-      tags: [smoke, render]
-      assertions:
-        - expression: 'size(__output.actions) == 1'
-          message: "Should produce exactly one action"
-        - contains: "dev/main.tf"
+      renders-dev-defaults:
+        description: "Default environment renders dev configuration"
+        extends: [_base-render]
+        tags: [smoke, render]
+        assertions:
+          - expression: 'size(__output.actions) == 1'
+            message: "Should produce exactly one action"
+          - contains: "dev/main.tf"
 
-    renders-prod-with-resolver-run:
-      description: "Run resolver with prod override"
-      command: [run, resolver]
-      args: ["-r", "env=prod"]
-      tags: [resolver]
-      assertions:
-        - expression: '__output.environment == "prod"'
-        - regex: '"environment":\s*"prod"'
+      renders-prod-with-resolver-run:
+        description: "Run resolver with prod override"
+        command: [run, resolver]
+        args: ["-r", "env=prod"]
+        tags: [resolver]
+        assertions:
+          - expression: '__output.environment == "prod"'
+          - regex: '"environment":\s*"prod"'
 
-    render-prod-override:
-      description: "Render with prod override produces correct paths"
-      extends: [_base-render]
-      args: ["-r", "env=prod"]
-      tags: [render]
-      assertions:
-        - expression: '__output.actions["render-main"].inputs.output == "prod/main.tf"'
+      render-prod-override:
+        description: "Render with prod override produces correct paths"
+        extends: [_base-render]
+        args: ["-r", "env=prod"]
+        tags: [render]
+        assertions:
+          - expression: '__output.actions["render-main"].inputs.output == "prod/main.tf"'
 
-    rejects-invalid-env:
-      description: "Invalid environment fails validation"
-      command: [run, resolver]
-      args: ["-r", "env=invalid"]
-      expectFailure: true
-      tags: [validation]
-      assertions:
-        - contains: "Invalid environment"
-        - notContains: "panic"
-        - contains: "validation"
-          target: stderr
+      rejects-invalid-env:
+        description: "Invalid environment fails validation"
+        command: [run, resolver]
+        args: ["-r", "env=invalid"]
+        expectFailure: true
+        tags: [validation]
+        assertions:
+          - contains: "Invalid environment"
+          - notContains: "panic"
+          - contains: "validation"
+            target: stderr
 
-    passes-lint:
-      description: "Solution passes lint with no errors"
-      command: [lint]
-      tags: [lint]
-      assertions:
-        - expression: '__output.errorCount == 0'
+      passes-lint:
+        description: "Solution passes lint with no errors"
+        command: [lint]
+        tags: [lint]
+        assertions:
+          - expression: '__output.errorCount == 0'
 
-    snapshot-action-graph:
-      description: "Action graph matches golden file"
-      command: [render, solution]
-      args: ["-r", "env=dev"]
-      tags: [snapshot]
-      snapshot: "testdata/expected-render.json"
+      snapshot-action-graph:
+        description: "Action graph matches golden file"
+        command: [render, solution]
+        args: ["-r", "env=dev"]
+        tags: [snapshot]
+        snapshot: "testdata/expected-render.json"
 
-    renders-with-setup:
-      description: "Render with custom setup and cleanup"
-      command: [render, solution]
-      env:
-        CUSTOM_VAR: "test-value"
-      init:
-        - command: "mkdir -p templates"
-      cleanup:
-        - command: "echo 'cleanup complete'"
-      assertions:
-        - expression: 'size(__output.actions) >= 1'
-        - expression: '__output.files["dev/main.tf"].exists'
+      renders-with-setup:
+        description: "Render with custom setup and cleanup"
+        command: [render, solution]
+        env:
+          CUSTOM_VAR: "test-value"
+        init:
+          - command: "mkdir -p templates"
+        cleanup:
+          - command: "echo 'cleanup complete'"
+        assertions:
+          - expression: 'size(__output.actions) >= 1'
+          - expression: '__output.files["dev/main.tf"].exists'
 
-    temporarily-disabled:
-      description: "This test is skipped during development"
-      skip: true
-      skipReason: "Waiting on upstream provider fix"
-      command: [render, solution]
-      assertions:
-        - expression: 'size(__output.actions) == 1'
+      temporarily-disabled:
+        description: "This test is skipped during development"
+        skip: true
+        skipReason: "Waiting on upstream provider fix"
+        command: [render, solution]
+        assertions:
+          - expression: 'size(__output.actions) == 1'
 ~~~
 
 ---
@@ -219,45 +220,47 @@ spec:
 ~~~yaml
 # tests/rendering.yaml
 spec:
-  tests:
-    renders-dev-defaults:
-      description: "Default environment renders dev configuration"
-      command: [render, solution]
-      tags: [smoke, render]
-      assertions:
-        - expression: 'size(__output.actions) == 1'
+  testing:
+    cases:
+      renders-dev-defaults:
+        description: "Default environment renders dev configuration"
+        command: [render, solution]
+        tags: [smoke, render]
+        assertions:
+          - expression: 'size(__output.actions) == 1'
 
-    renders-prod-override:
-      description: "Render with prod override produces correct paths"
-      command: [render, solution]
-      args: ["-r", "env=prod"]
-      tags: [render]
-      assertions:
-        - expression: '__output.actions["render-main"].inputs.output == "prod/main.tf"'
+      renders-prod-override:
+        description: "Render with prod override produces correct paths"
+        command: [render, solution]
+        args: ["-r", "env=prod"]
+        tags: [render]
+        assertions:
+          - expression: '__output.actions["render-main"].inputs.output == "prod/main.tf"'
 ~~~
 
 ~~~yaml
 # tests/validation.yaml
 spec:
-  tests:
-    rejects-invalid-env:
-      description: "Invalid environment fails validation"
-      command: [run, resolver]
-      args: ["-r", "env=invalid"]
-      expectFailure: true
-      tags: [validation]
-      assertions:
-        - contains: "Invalid environment"
+  testing:
+    cases:
+      rejects-invalid-env:
+        description: "Invalid environment fails validation"
+        command: [run, resolver]
+        args: ["-r", "env=invalid"]
+        expectFailure: true
+        tags: [validation]
+        assertions:
+          - contains: "Invalid environment"
 ~~~
 
 ---
 
 ## Test Case Spec
 
-Each test case is a named entry under `spec.tests`. Test names must match `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` (letters, numbers, hyphens, underscores; must start with a letter or number). Names starting with `_` are test templates — they are not executed directly but can be inherited via `extends`.
+Each test case is a named entry under `spec.testing.cases`. Test names must match `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` (letters, numbers, hyphens, underscores; must start with a letter or number). Names starting with `_` are test templates — they are not executed directly but can be inherited via `extends`.
 
 ~~~yaml
-tests:
+cases:
   <test-name>:
     description: <string>
     command: <list[string]>
@@ -280,7 +283,7 @@ tests:
     retries: <int>
 ~~~
 
-Each test case is a named entry under `spec.tests`. The maximum number of tests per solution is **500**.
+Each test case is a named entry under `spec.testing.cases`. The maximum number of tests per solution is **500**.
 
 ### Field Details
 
@@ -310,30 +313,31 @@ Each test case is a named entry under `spec.tests`. The maximum number of tests 
 
 ## Test Configuration
 
-Solution-level test configuration is defined under `spec.testConfig`:
+Solution-level test configuration is defined under `spec.testing.config`:
 
 ~~~yaml
 spec:
-  testConfig:
-    skipBuiltins: true
-    env:
-      SCAFCTL_CONFIG_DIR: "$SCAFCTL_SANDBOX_DIR"
-    setup:
-      - command: "scafctl config set defaults.environment staging"
-      - command: "mkdir -p templates"
-    cleanup:
-      - command: "echo 'suite teardown complete'"
+  testing:
+    config:
+      skipBuiltins: true
+      env:
+        SCAFCTL_CONFIG_DIR: "$SCAFCTL_SANDBOX_DIR"
+      setup:
+        - command: "scafctl config set defaults.environment staging"
+        - command: "mkdir -p templates"
+      cleanup:
+        - command: "echo 'suite teardown complete'"
 ~~~
 
 `skipBuiltins` accepts either a boolean or a list of builtin test names for selective skipping:
 
 ~~~yaml
 # Skip all builtins
-testConfig:
+config:
   skipBuiltins: true
 
 # Skip only specific builtins
-testConfig:
+config:
   skipBuiltins:
     - resolve-defaults
     - render-defaults
@@ -348,7 +352,7 @@ testConfig:
 
 ### Suite-Level Setup
 
-When `testConfig.setup` is defined:
+When `testing.config.setup` is defined:
 
 1. Create a base sandbox and copy the solution + bundle files
 2. Run `setup` steps sequentially in the base sandbox
@@ -359,7 +363,7 @@ This avoids duplicating the same init steps across every test. If any setup step
 
 ### Compose Merge Semantics
 
-When `testConfig` appears in multiple compose files:
+When `testing.config` appears in multiple compose files:
 
 | Field | Merge Behavior |
 | ----- | -------------- |
@@ -369,11 +373,11 @@ When `testConfig` appears in multiple compose files:
 | `cleanup` | Appended in compose-file order (first file's steps run first) |
 | `env` | Merged map; last compose file wins on key conflict |
 
-Compose-file order affects `testConfig.setup`, `testConfig.cleanup`, and `testConfig.env` merge ordering but does **not** affect test execution order. Tests from all compose files are merged into a single map and executed alphabetically (see [Test Execution Ordering](#test-execution-ordering)).
+Compose-file order affects `testing.config.setup`, `testing.config.cleanup`, and `testing.config.env` merge ordering but does **not** affect test execution order. Tests from all compose files are merged into a single map and executed alphabetically (see [Test Execution Ordering](#test-execution-ordering)).
 
-`spec.tests` entries are merged by name using the **reject-duplicates** strategy (same as resolvers and actions). If two compose files define a test with the same name, the compose merge fails with an error.
+`spec.testing.cases` entries are merged by name using the **reject-duplicates** strategy (same as resolvers and actions). If two compose files define a test with the same name, the compose merge fails with an error.
 
-> **`composePart` struct**: The `composePart` struct in `pkg/solution/bundler/compose.go` must be extended with `Tests map[string]*testing.TestCase` and `TestConfig *testing.TestConfig` fields to parse test-related sections from compose files.
+> **`composePart` struct**: The `composePart` struct in `pkg/solution/bundler/compose.go` has a `Testing *soltesting.TestSuite` field to parse test-related sections from compose files.
 
 > **Note**: `SkipBuiltinsValue` requires both `UnmarshalYAML` and `MarshalYAML` implementations to survive the `deepCopySolution` YAML round-trip used in compose.
 
@@ -384,7 +388,7 @@ Compose-file order affects `testConfig.setup`, `testConfig.cleanup`, and `testCo
 Tests can define setup steps that run before the test command. Init steps execute sequentially in the sandbox directory. Init uses the exec provider's input schema, giving access to all execution options.
 
 ~~~yaml
-tests:
+cases:
   renders-with-custom-config:
     description: "Renders with custom configuration"
     init:
@@ -431,7 +435,7 @@ Environment variables are resolved in the following precedence order (highest wi
 | Priority | Source | Description |
 | -------- | ------ | ----------- |
 | 1 (lowest) | Process environment | Inherited from the parent process |
-| 2 | `testConfig.env` | Suite-level env applied to all tests |
+| 2 | `testing.config.env` | Suite-level env applied to all tests |
 | 3 | `TestCase.env` | Per-test env overrides suite-level on key conflict |
 | 4 (highest) | `InitStep.env` | Per-step env overrides all others on key conflict |
 
@@ -445,15 +449,16 @@ Tests can declare additional files required for execution. These files are copie
 
 ~~~yaml
 spec:
-  tests:
-    renders-with-custom-template:
-      description: "Renders with a test-specific template"
-      files:
-        - testdata/custom-main.tf.tmpl
-        - testdata/variables.json
-      command: [render, solution]
-      assertions:
-        - expression: 'size(__output.actions) >= 1'
+  testing:
+    cases:
+      renders-with-custom-template:
+        description: "Renders with a test-specific template"
+        files:
+          - testdata/custom-main.tf.tmpl
+          - testdata/variables.json
+        command: [render, solution]
+        assertions:
+          - expression: 'size(__output.actions) >= 1'
 
 bundle:
   include:
@@ -465,7 +470,7 @@ bundle:
 | Phase | Behavior |
 | ----- | -------- |
 | **Development** | `files` paths are resolved relative to the solution directory. The runner copies them into the sandbox before init/command execution |
-| **Build** | `scafctl build` auto-discovers files referenced in `spec.tests[*].files` and includes them in the bundle artifact as a `TestInclude` discovery source |
+| **Build** | `scafctl build` auto-discovers files referenced in `spec.testing.cases[*].files` and includes them in the bundle artifact as a `TestInclude` discovery source |
 | **Lint** | `scafctl lint` produces an **error** if test files are not covered by `bundle.include` patterns. Tests must work from remote catalog artifacts |
 | **Bundle extraction** | Test files are extracted alongside solution files when a bundled solution is unpacked |
 
@@ -475,7 +480,7 @@ Files are copied into the sandbox maintaining their relative directory structure
 
 Globs in the `files` field (e.g., `testdata/**/*.json`) are resolved at **sandbox setup time** — after suite-level setup completes but before per-test init steps run. This means:
 
-- Globs are expanded against the solution source directory (or the suite-level base sandbox if `testConfig.setup` is defined)
+- Globs are expanded against the solution source directory (or the suite-level base sandbox if `testing.config.setup` is defined)
 - **Zero-match globs produce a test `error`**, not a silent no-op. This catches typos and missing test data early
 - Glob patterns are validated at lint time — `scafctl lint` warns on syntactically invalid glob patterns
 - Resolved paths are logged in verbose output for debugging
@@ -526,7 +531,7 @@ Test names starting with `_` are **templates** — they are not executed directl
 ### Example
 
 ~~~yaml
-tests:
+cases:
   _base-render:
     description: "Base render test"
     command: [render, solution]
@@ -560,7 +565,7 @@ The resolved `render-prod` test inherits:
 Tests can define cleanup steps that run after the test command, **even if the command or assertions fail**. Cleanup uses the same `InitStep` schema as `init`.
 
 ~~~yaml
-tests:
+cases:
   renders-with-temp-state:
     description: "Render with temporary state file"
     command: [render, solution]
@@ -585,7 +590,7 @@ Cleanup steps:
 Tests can be tagged for categorization and selective execution.
 
 ~~~yaml
-tests:
+cases:
   renders-dev:
     description: "Render dev config"
     command: [render, solution]
@@ -632,7 +637,7 @@ Invalid names are rejected during YAML parsing and surfaced as lint errors.
 
 ## Builtin Tests
 
-Every solution automatically receives builtin tests unless `testConfig.skipBuiltins` is set. Builtins validate baseline correctness without requiring explicit test definitions.
+Every solution automatically receives builtin tests unless `testing.config.skipBuiltins` is set. Builtins validate baseline correctness without requiring explicit test definitions.
 
 | Builtin Test | Command | Passes When |
 | ------------ | ------- | ----------- |
@@ -643,7 +648,7 @@ Every solution automatically receives builtin tests unless `testConfig.skipBuilt
 
 Builtins run before user-defined tests. By default, if a builtin fails, user-defined tests still run (they are independent). Use `--fail-fast` to stop remaining tests for that solution on first failure.
 
-Selective skipping is supported via `testConfig.skipBuiltins` — set to `true` to skip all, or provide a list of specific builtin names (without the `builtin:` prefix) to skip only those.
+Selective skipping is supported via `testing.config.skipBuiltins` — set to `true` to skip all, or provide a list of specific builtin names (without the `builtin:` prefix) to skip only those.
 
 ---
 
@@ -886,9 +891,9 @@ This is consistent with how the codebase handles action ordering within executio
 The test runner discovers tests in two ways:
 
 1. **Single solution**: `scafctl test functional -f solution.yaml` — runs tests defined in that solution
-2. **Directory scan**: `scafctl test functional --tests-path path/to/solutions/` — recursively discovers all solution files and runs their `spec.tests`
+2. **Directory scan**: `scafctl test functional --tests-path path/to/solutions/` — recursively discovers all solution files and runs their `spec.testing.cases`
 
-Solutions with no `spec.tests` still run builtin tests (unless `skipBuiltins` is set).
+Solutions with no `spec.testing.cases` still run builtin tests (unless `skipBuiltins` is set).
 
 Test templates (names starting with `_`) are resolved via `extends` but never executed directly.
 
@@ -914,7 +919,7 @@ For each test case:
 16. Run **all** assertions (CEL against parsed output, regex/contains against target stream). All assertions always run regardless of prior failures
 17. Run cleanup steps (even on failure or error)
 18. All checks pass → `pass`; any check fails → `fail`
-19. If `fail` and `retries > 0` → re-run from step 5 up to `retries` times. Each retry creates a **fresh sandbox** (re-copies solution + bundle files from the suite-level base sandbox if `testConfig.setup` is present, otherwise from source). Init steps re-run on each retry. If any retry passes → `pass (retry N/M)`. Retry attempts are shown in verbose output
+19. If `fail` and `retries > 0` → re-run from step 5 up to `retries` times. Each retry creates a **fresh sandbox** (re-copies solution + bundle files from the suite-level base sandbox if `testing.config.setup` is present, otherwise from source). Init steps re-run on each retry. If any retry passes → `pass (retry N/M)`. Retry attempts are shown in verbose output
 
 ### Parallelism
 
@@ -1159,13 +1164,13 @@ Example `<error>` element:
 
 ### Bundler Discovery
 
-`scafctl build` and the bundler's `DiscoverFiles()` must scan `spec.tests[*].files` entries as an additional discovery source. These are tagged as `TestInclude` to distinguish them from `StaticAnalysis` and `ExplicitInclude` sources.
+`scafctl build` and the bundler's `DiscoverFiles()` must scan `spec.testing.cases[*].files` entries as an additional discovery source. These are tagged as `TestInclude` to distinguish them from `StaticAnalysis` and `ExplicitInclude` sources.
 
 This ensures test files are included in the bundle artifact and available when tests run from a remote catalog.
 
 ### Lint Rule
 
-`scafctl lint` produces an **error** when files referenced in `spec.tests[*].files` are not covered by `bundle.include` patterns. Tests must work when the solution is fetched from a remote catalog, so all test files must be bundled.
+`scafctl lint` produces an **error** when files referenced in `spec.testing.cases[*].files` are not covered by `bundle.include` patterns. Tests must work when the solution is fetched from a remote catalog, so all test files must be bundled.
 
 ---
 
@@ -1330,9 +1335,9 @@ const (
 
 ### Additions to Existing Types
 
-- `pkg/solution/spec.go`: Add `Tests map[string]*testing.TestCase` and `TestConfig *testing.TestConfig` fields to `Spec`. Add `HasTests() bool` and `HasTestConfig() bool` helper methods following the existing `Has*()` pattern
-- `pkg/solution/bundler/compose.go`: Extend `composePart` struct with `Tests map[string]*testing.TestCase` and `TestConfig *testing.TestConfig` fields. Extend compose to merge `spec.tests` (by name, reject duplicates) and `spec.testConfig` (`skipBuiltins`: true-wins for bool / union for lists; `env`: merged map, last-file-wins on conflict; `setup`/`cleanup`: appended in compose-file order)
-- `pkg/solution/bundler/discover.go`: Add `TestInclude` discovery source; scan `spec.tests[*].files` entries
+- `pkg/solution/spec.go`: Has `Testing *soltesting.TestSuite` field on `Spec`. `HasTests()` and `HasTestConfig()` delegate to `Testing.HasCases()` and `Testing.HasConfig()`
+- `pkg/solution/bundler/compose.go`: `composePart` has `Testing *soltesting.TestSuite` field. Compose merges `spec.testing.cases` (by name, reject duplicates) and `spec.testing.config` (`skipBuiltins`: true-wins for bool / union for lists; `env`: merged map, last-file-wins on conflict; `setup`/`cleanup`: appended in compose-file order)
+- `pkg/solution/bundler/discover.go`: Add `TestInclude` discovery source; scan `spec.testing.cases[*].files` entries
 
 ---
 
@@ -1362,8 +1367,8 @@ const (
 | Create | `pkg/cmd/scafctl/test/functional.go` | `test functional` command |
 | Create | `pkg/cmd/scafctl/test/list.go` | `test list` command |
 | Modify | `pkg/cmd/scafctl/root.go` | Register `test` command |
-| Modify | `pkg/solution/spec.go` | Add `Tests` and `TestConfig` fields |
-| Modify | `pkg/solution/bundler/compose.go` | Merge `spec.tests` and `spec.testConfig` in compose |
+| Modify | `pkg/solution/spec.go` | Has `Testing *soltesting.TestSuite` field |
+| Modify | `pkg/solution/bundler/compose.go` | Merge `spec.testing.cases` and `spec.testing.config` in compose |
 | Modify | `pkg/solution/bundler/discover.go` | Add `TestInclude` discovery source |
 | Modify | `pkg/cmd/scafctl/lint/` | Add lint rule for unbundled test files (error), invalid test names, and unused templates (warning) |
 | Modify | `pkg/exitcode/exitcode.go` | Add `TestFailed = 11` constant |
@@ -1513,7 +1518,7 @@ The example solution at `examples/solutions/tested-solution/` should include:
 - **In-process execution** over subprocess: the runner invokes the cobra command tree directly using `Root()`. Faster, no built binary dependency, simpler output capture
 - **Auto-inject `-f` by default**: the runner injects `-f <sandbox-solution-path>` unless `injectFile: false`. `-f` must never appear in `args` regardless of `injectFile`. Disabled for catalog solution tests where no local file is needed
 - **Custom `exitFunc`**: uses `writer.WithExitFunc()` to intercept `os.Exit` calls during in-process execution, converting them to `*exitcode.ExitError` values
-- **Tests in `spec.tests`** with compose support: follows existing split-file pattern, keeps tests colocated with the solution
+- **Tests in `spec.testing.cases`** with compose support: follows existing split-file pattern, keeps tests colocated with the solution
 - **Temp directory sandbox**: init scripts can modify files safely without affecting source. Symlinks rejected
 - **Five assertion types** (CEL, regex, contains, notRegex, notContains): CEL for structured assertions; text matching for quick checks; negation for safety
 - **Assertion `target` field**: `stdout` (default), `stderr`, or `combined` for text assertions. Cleaner than separate `stderrContains`/`stderrRegex` fields
@@ -1552,15 +1557,15 @@ The example solution at `examples/solutions/tested-solution/` should include:
 - **File size guard**: 10MB cap on `files[].content` to prevent OOM without blocking tests
 - **Conditional skip via CEL**: `skipExpression` field evaluated at discovery time with `os`, `arch`, `env` context
 - **Test retries**: `retries` field for flaky test resilience, capped at 10 attempts
-- **Suite-level cleanup**: `testConfig.cleanup` runs after all tests, symmetric with `testConfig.setup`
-- **Compose `testConfig` merge**: `setup`/`cleanup` steps appended in compose-file order (new merge strategy); `skipBuiltins` uses `true`-wins for bool, union for lists
+- **Suite-level cleanup**: `testing.config.cleanup` runs after all tests, symmetric with `testing.config.setup`
+- **Compose `testing.config` merge**: `setup`/`cleanup` steps appended in compose-file order (new merge strategy); `skipBuiltins` uses `true`-wins for bool, union for lists
 - **`SkipBuiltinsValue` round-trip**: requires both `UnmarshalYAML` and `MarshalYAML` for compose `deepCopySolution` compatibility
 - **Snapshot normalization pipeline**: fixed set of scrubbers (timestamps, UUIDs, sandbox paths, sorted keys). Custom scrubbers deferred to future enhancement
 - **Alphabetical test ordering** over YAML definition order: consistent with how actions use `sort.Strings` within execution phases. No new infrastructure (ordered maps) needed. Tests should be independent — alphabetical ordering exposes hidden ordering dependencies
 - **`--filter` supports `solution/test-name` format**: when filter contains `/`, match against `solution-name/test-name`. When no `/`, match test name only (backward-compatible). Enables scoping in multi-solution runs
 - **`--solution` flag** for solution-level filtering: glob-based, ANDed with `--filter` and `--tag`. Simpler than always using `solution/test-name` format when you only care about the solution
 - **`--dry-run` flag** over separate `test validate` subcommand: simpler, one less command. Validates definitions and reports discovery without executing
-- **Suite-level `env`** (`testConfig.env`): avoids repeating environment variables on every test case. Precedence: process → `testConfig.env` → `TestCase.env` → `InitStep.env`
+- **Suite-level `env`** (`testing.config.env`): avoids repeating environment variables on every test case. Precedence: process → `testing.config.env` → `TestCase.env` → `InitStep.env`
 - **Fresh sandbox per retry**: each retry creates a new sandbox to ensure side-effect isolation. Init steps re-run on each attempt. Suite-level base sandbox is re-copied, not re-run
 - **Binary file content guard**: non-UTF-8 files get `content` set to `"<binary file>"`, parallel to the size guard. Prevents garbled CEL string comparisons
 - **`output` nil → test `error`** (not `fail`): referencing `output` when the command doesn't support `-o json` is a configuration issue, not an assertion failure
@@ -1573,5 +1578,5 @@ The example solution at `examples/solutions/tested-solution/` should include:
 - **`TestCase.Validate()` method**: comprehensive validation covering name format, field limits, mutual exclusion, and `args` content. Catches errors early at parse time
 - **Assertion count in verbose output**: `PASS (4/4)` / `FAIL (2/4)` gives quick visibility into test thoroughness without requiring `-o json`
 - **Duration as string type**: `"30s"` YAML format with custom marshal/unmarshal. More human-readable than integer seconds and more explicit than Go's default nanosecond marshalling
-- **Environment precedence chain documented**: process → `testConfig.env` → `TestCase.env` → `InitStep.env`. Each level merges with previous; only conflicting keys are overridden
-- **Compose test ordering independent of file order**: tests from all compose files execute alphabetically, not in compose-file order. Only `testConfig.setup`/`cleanup`/`env` follow compose-file ordering
+- **Environment precedence chain documented**: process → `testing.config.env` → `TestCase.env` → `InitStep.env`. Each level merges with previous; only conflicting keys are overridden
+- **Compose test ordering independent of file order**: tests from all compose files execute alphabetically, not in compose-file order. Only `testing.config.setup`/`cleanup`/`env` follow compose-file ordering

--- a/docs/design/testing-consolidation.md
+++ b/docs/design/testing-consolidation.md
@@ -1,0 +1,241 @@
+# Consolidate `Tests` & `TestConfig` into `spec.testing`
+
+## Summary
+
+Move `Spec.Tests` and `Spec.TestConfig` from being sibling fields on the solution `Spec` struct into a single `Spec.Testing *soltesting.TestSuite` field. This groups all test-related configuration under one top-level property.
+
+**This is a breaking change** — all existing solution YAML files must restructure their `spec:` section.
+
+## Before / After
+
+### YAML Structure
+
+**Before:**
+
+```yaml
+spec:
+  resolvers: ...
+  workflow: ...
+  tests:
+    my-test:
+      command: apply
+      args: {}
+  testConfig:
+    skipBuiltins: true
+    env:
+      FOO: bar
+```
+
+**After:**
+
+```yaml
+spec:
+  resolvers: ...
+  workflow: ...
+  testing:
+    config:
+      skipBuiltins: true
+      env:
+        FOO: bar
+    cases:
+      my-test:
+        command: apply
+        args: {}
+```
+
+### Go Types
+
+**Before:**
+
+```go
+type Spec struct {
+    Resolvers  map[string]*resolver.Resolver      `json:"resolvers,omitempty" yaml:"resolvers,omitempty"`
+    Workflow   *action.Workflow                    `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+    Tests      map[string]*soltesting.TestCase     `json:"tests,omitempty" yaml:"tests,omitempty"`
+    TestConfig *soltesting.TestConfig              `json:"testConfig,omitempty" yaml:"testConfig,omitempty"`
+}
+```
+
+**After:**
+
+```go
+type Spec struct {
+    Resolvers map[string]*resolver.Resolver `json:"resolvers,omitempty" yaml:"resolvers,omitempty"`
+    Workflow  *action.Workflow              `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+    Testing   *soltesting.TestSuite         `json:"testing,omitempty" yaml:"testing,omitempty"`
+}
+```
+
+**New `TestSuite` struct** (in `pkg/solution/soltesting`):
+
+```go
+type TestSuite struct {
+    Config *TestConfig             `json:"config,omitempty" yaml:"config,omitempty" doc:"Test configuration"`
+    Cases  map[string]*TestCase    `json:"cases,omitempty" yaml:"cases,omitempty" doc:"Test case definitions keyed by name"`
+}
+```
+
+## Naming Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Wrapper YAML key | `testing` | Intuitive, concise, clearly scopes what's inside |
+| Test map sub-field | `cases` | Avoids redundancy (`testing.tests` reads poorly) |
+| Config sub-field | `config` | Clean — `testing.config` is self-explanatory |
+| Go struct name | `soltesting.TestSuite` | Conventional, clear, aligns with existing patterns |
+
+## Implementation Plan
+
+### Phase 1: Core Type Changes
+
+#### 1. Add `TestSuite` struct to `pkg/solution/soltesting/types.go`
+
+Create the new wrapper struct with `Cases` and `Config` fields, appropriate JSON/YAML tags, and Huma `doc` tags. Add convenience methods:
+
+- `HasCases() bool`
+- `HasConfig() bool`
+
+#### 2. Update `Spec` struct in `pkg/solution/spec.go`
+
+- Remove `Tests` and `TestConfig` fields
+- Add `Testing *soltesting.TestSuite` field (json/yaml: `testing`)
+- Update `HasTests()` to delegate to `s.Testing.HasCases()`
+- Update `HasTestConfig()` to delegate to `s.Testing.HasConfig()`
+- Add `HasTesting()` convenience method
+
+#### 3. Update `pkg/solution/spec_test.go`
+
+Update all `sol.Spec.Tests` → `sol.Spec.Testing.Cases` and `sol.Spec.TestConfig` → `sol.Spec.Testing.Config` references. Update test function names/assertions.
+
+### Phase 2: soltesting Package Internal Updates
+
+#### 4. Update `SolutionTests` in `pkg/solution/soltesting/discovery.go`
+
+- Update `SolutionTests` struct: rename `Tests` → `Cases`, `TestConfig` → `Config` for consistency
+- Update the inline anonymous struct (used for lightweight YAML parsing) to use the new `testing:` nesting
+- Update all `st.Tests` → `st.Cases` and `st.TestConfig` → `st.Config` references (~20 lines)
+
+#### 5. Update `pkg/solution/soltesting/discovery_test.go`
+
+Update struct literal references (~25 lines).
+
+#### 6. Update `pkg/solution/soltesting/runner.go`
+
+Update `st.Tests` → `st.Cases` and `st.TestConfig` → `st.Config` references (~30 lines).
+
+#### 7. Update `pkg/solution/soltesting/runner_test.go`
+
+Update `SolutionTests` struct literals (~12 instances).
+
+#### 8. Update `pkg/solution/soltesting/reporter.go`
+
+Update `st.TestConfig` and `st.Tests` references.
+
+#### 9. Update `ScaffoldResult` in `pkg/solution/soltesting/scaffold.go`
+
+Change `Tests map[string]*TestCase` to output the new nested structure. The scaffold output (for `test init`) should emit YAML matching the new `testing.cases` shape.
+
+#### 10. Update `pkg/solution/soltesting/scaffold_test.go`
+
+Update `result.Tests` references (~20 lines).
+
+#### 11. Update inline structs in `pkg/solution/soltesting/watch.go`
+
+Update inline anonymous struct and `doc.Spec.Tests` references.
+
+#### 12. Update `pkg/solution/soltesting/generate.go`
+
+Update comment references to `spec.tests` and YAML output format.
+
+### Phase 3: Bundler/Compose Changes
+
+#### 13. Update `composePart` in `pkg/solution/bundler/compose.go`
+
+- Update inline struct to use new `Testing` field
+- Refactor `mergeTests()` and `mergeTestConfig()` to operate on `merged.Spec.Testing.Cases` and `merged.Spec.Testing.Config`
+- Ensure nil-safety (initialize `Testing` if nil before merging)
+
+#### 14. Update `pkg/solution/bundler/compose_test.go`
+
+Update `result.Spec.Tests`/`result.Spec.TestConfig` references (~30 lines).
+
+#### 15. Update `pkg/solution/bundler/discover.go`
+
+Update `sol.Spec.Tests` reference and comment.
+
+### Phase 4: CLI Command Updates
+
+#### 16. Update `pkg/cmd/scafctl/lint/lint.go`
+
+Update `sol.Spec.HasTests()`, `sol.Spec.Tests` references to use new paths through `Testing`.
+
+#### 17. Update `pkg/cmd/scafctl/test/functional.go`
+
+Update `solutions[i].TestConfig` references.
+
+#### 18. Update CLI help text in `pkg/cmd/scafctl/test/test.go` and `pkg/cmd/scafctl/test/init.go`
+
+Update doc strings referencing `spec.tests` to `spec.testing.cases`.
+
+#### 19. Update `pkg/mcp/tools_examples.go`
+
+Update description referencing `spec.tests`.
+
+### Phase 5: YAML Files (~43 files)
+
+#### 20. Update example solution
+
+[`examples/solutions/tested-solution/solution.yaml`](../../examples/solutions/tested-solution/solution.yaml): restructure from `spec.tests`/`spec.testConfig` to `spec.testing.cases`/`spec.testing.config`.
+
+#### 21. Update all integration test solution YAML files
+
+All files in [`tests/integration/solutions/`](../../tests/integration/solutions/): same restructuring. Each file's `spec:` section needs `tests:` and `testConfig:` moved under a new `testing:` block, renamed to `cases:` and `config:`.
+
+#### 22. Update compose partial YAML files
+
+- `tests/integration/solutions/composed/tests/rendering.yaml`
+- `tests/integration/solutions/composition/parts/tests.yaml`
+
+### Phase 6: Inline YAML in Go Tests
+
+#### 23. Update inline YAML snippets in `tests/integration/cli_test.go`
+
+~9 embedded YAML strings containing `tests:` and `testConfig:` keys need restructuring to the new nesting.
+
+### Phase 7: Documentation
+
+#### 24. Rewrite `docs/design/functional-testing.md`
+
+~50 references to `spec.tests`, `spec.testConfig`, YAML examples, struct references. All need updating to `spec.testing.cases`/`spec.testing.config`.
+
+#### 25. Rewrite `docs/tutorials/functional-testing.md`
+
+~15 references + YAML examples.
+
+### Phase 8: Verification
+
+#### 26. Build, test, and lint
+
+- `go build ./...` — compiles cleanly
+- `go test ./...` — all unit tests pass
+- `golangci-lint run` — no lint issues
+- Integration tests pass (validates YAML restructuring)
+- Manual review of `test init` scaffold output — confirms new YAML shape
+- Verify JSON schema output in `pkg/schema/solution_schema.go` reflects `testing.cases`/`testing.config`
+
+## Scope Summary
+
+| Category | Count |
+|----------|-------|
+| Go source files | ~21 |
+| YAML solution files | ~43 |
+| Inline YAML in Go tests | ~9 snippets in 1 file |
+| Documentation files | 2 |
+| **Total files affected** | **~67** |
+
+## Notes
+
+- **Backward compatibility**: Not required per project conventions. This is a **breaking change** for all existing solution YAML files.
+- **`SolutionTests`** in `soltesting` already groups `Tests` + `TestConfig` — after this refactor its fields should be aligned to `Cases`/`Config` for consistency.
+- **Schema auto-generation**: The JSON schema in `pkg/schema/solution_schema.go` is auto-generated from struct reflection via Huma tags. It will update automatically when the `Spec` struct changes, but output should be verified.
+- **`ScaffoldResult`**: The `test init` command output format changes to match the new nesting structure.

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -16,7 +16,7 @@ advanced CI integration.
 
 ## Writing Your First Test
 
-Add a `tests` section to your solution's `spec`. Create a file called `solution.yaml`:
+Add a `testing` section to your solution's `spec`. Create a file called `solution.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -33,13 +33,14 @@ spec:
             inputs:
               value: Hello, World!
 
-  tests:
-    render-basic:
-      description: Verify solution renders successfully
-      command: [render, solution]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: greeting
+  testing:
+    cases:
+      render-basic:
+        description: Verify solution renders successfully
+        command: [render, solution]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: greeting
 ```
 
 Run the test:
@@ -63,7 +64,7 @@ Each test specifies a `command` (the scafctl subcommand to run) and one or more
 `assertions` to validate the output. The runner automatically injects
 `-f <sandbox-copy-of-solution>` unless you set `injectFile: false`.
 
-> **Note:** The YAML snippets in the remaining sections of this tutorial show only the `tests:` block or relevant portion. To use them, add them to the `spec.tests` section of your solution file — like the `solution.yaml` example above.
+> **Note:** The YAML snippets in the remaining sections of this tutorial show only the `cases:` block or relevant portion. To use them, add them to the `spec.testing.cases` section of your solution file — like the `solution.yaml` example above.
 
 ---
 
@@ -238,7 +239,7 @@ Define reusable test templates with names starting with `_`. Templates are not e
 directly but can be inherited via `extends`:
 
 ```yaml
-tests:
+cases:
   _render-base:
     description: Base template for rendering tests
     command: [render, solution]
@@ -295,7 +296,7 @@ Circular extends chains and references to non-existent test names are validation
 Snapshots compare command output against a golden file:
 
 ```yaml
-tests:
+cases:
   render-snapshot:
     description: Compare render output to golden file
     command: [render, solution]
@@ -350,10 +351,11 @@ bundle:
     - "testdata/**"
 
 spec:
-  tests:
-    my-test:
-      files: ["testdata/input.txt"]
-      # ...
+  testing:
+    cases:
+      my-test:
+        files: ["testdata/input.txt"]
+        # ...
 ```
 
 The `unbundled-test-file` lint rule will flag test files not covered by `bundle.include`.
@@ -365,7 +367,7 @@ The `unbundled-test-file` lint rule will flag test files not covered by `bundle.
 Tests can define setup commands before and teardown commands after execution:
 
 ```yaml
-tests:
+cases:
   integration-test:
     description: Test with setup/teardown
     init:
@@ -407,7 +409,7 @@ directory) into every init step and test command.
 Set environment variables for a specific test's init, command, and cleanup steps:
 
 ```yaml
-tests:
+cases:
   custom-env-test:
     description: Test with custom environment
     env:
@@ -425,7 +427,7 @@ Variables are resolved in this precedence order (highest wins):
 | Priority | Source | Description |
 |----------|--------|-------------|
 | 1 (lowest) | Process environment | Inherited from the parent process |
-| 2 | `testConfig.env` | Suite-level env applied to all tests |
+| 2 | `testing.config.env` | Suite-level env applied to all tests |
 | 3 | `TestCase.env` | Per-test env overrides suite-level on key conflict |
 | 4 (highest) | `InitStep.env` | Per-step env overrides all others on key conflict |
 
@@ -438,7 +440,7 @@ Variables are resolved in this precedence order (highest wins):
 Copy additional files into the sandbox for test execution:
 
 ```yaml
-tests:
+cases:
   file-test:
     description: Test with additional files
     files:
@@ -460,7 +462,7 @@ files produce a test `error`** to catch typos early.
 Test that a command fails as expected:
 
 ```yaml
-tests:
+cases:
   validation-error:
     description: Invalid input should fail
     command: [render, solution]
@@ -474,7 +476,7 @@ tests:
 For exact exit code matching:
 
 ```yaml
-tests:
+cases:
   specific-exit-code:
     description: Expect specific exit code
     command: [lint]
@@ -493,7 +495,7 @@ tests:
 Set per-test timeouts using Go duration strings:
 
 ```yaml
-tests:
+cases:
   slow-test:
     description: Test that takes longer
     timeout: "2m"
@@ -521,7 +523,7 @@ scafctl test functional -f solution.yaml --timeout 10m
 ### Static Skip
 
 ```yaml
-tests:
+cases:
   temporarily-disabled:
     description: Skipped during development
     skip: true
@@ -536,7 +538,7 @@ tests:
 Skip based on runtime conditions using CEL expressions with `os`, `arch`, and `env` context:
 
 ```yaml
-tests:
+cases:
   linux-only:
     description: Only runs on Linux
     skipExpression: 'os != "linux"'
@@ -559,7 +561,7 @@ tests:
 Retry flaky tests up to 10 times:
 
 ```yaml
-tests:
+cases:
   flaky-test:
     description: Retry on failure
     retries: 3
@@ -582,7 +584,7 @@ By default, the runner auto-injects `-f <sandbox-solution-path>` into every comm
 Disable this for commands that don't accept `-f`:
 
 ```yaml
-tests:
+cases:
   config-check:
     description: Check config (does not use -f)
     injectFile: false
@@ -601,7 +603,7 @@ tests:
 Tag tests for selective execution:
 
 ```yaml
-tests:
+cases:
   renders-dev:
     description: Render dev config
     command: [render, solution]
@@ -631,21 +633,22 @@ Configure settings that apply to all tests in a solution:
 
 ```yaml
 spec:
-  testConfig:
-    skipBuiltins: true
-    env:
-      TEST_MODE: "true"
-      SCAFCTL_CONFIG_DIR: "$SCAFCTL_SANDBOX_DIR"
-    setup:
-      - command: "mkdir -p templates"
-      - command: "scafctl config set defaults.environment staging"
-    cleanup:
-      - command: "echo 'suite teardown complete'"
+  testing:
+    config:
+      skipBuiltins: true
+      env:
+        TEST_MODE: "true"
+        SCAFCTL_CONFIG_DIR: "$SCAFCTL_SANDBOX_DIR"
+      setup:
+        - command: "mkdir -p templates"
+        - command: "scafctl config set defaults.environment staging"
+      cleanup:
+        - command: "echo 'suite teardown complete'"
 ```
 
 ### Suite-Level Setup
 
-When `testConfig.setup` is defined:
+When `testing.config.setup` is defined:
 
 1. A base sandbox is created and solution + bundle files are copied
 2. Setup steps run sequentially in the base sandbox
@@ -661,11 +664,11 @@ for that solution report as `error`.
 
 ```yaml
 # Skip all builtins
-testConfig:
+config:
   skipBuiltins: true
 
 # Skip only specific builtins
-testConfig:
+config:
   skipBuiltins:
     - resolve-defaults
     - render-defaults
@@ -706,13 +709,14 @@ Create a file called `tests/smoke.yaml`:
 ```yaml
 # tests/smoke.yaml
 spec:
-  tests:
-    smoke-render:
-      description: Smoke test for rendering
-      command: [render, solution]
-      tags: [smoke]
-      assertions:
-        - expression: __exitCode == 0
+  testing:
+    cases:
+      smoke-render:
+        description: Smoke test for rendering
+        command: [render, solution]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
 ```
 
 Create a file called `tests/validation.yaml`:
@@ -720,23 +724,24 @@ Create a file called `tests/validation.yaml`:
 ```yaml
 # tests/validation.yaml
 spec:
-  tests:
-    rejects-invalid:
-      description: Invalid input fails
-      command: [run, resolver]
-      args: ["-r", "env=invalid"]
-      expectFailure: true
-      tags: [validation]
-      assertions:
-        - contains: "Invalid"
+  testing:
+    cases:
+      rejects-invalid:
+        description: Invalid input fails
+        command: [run, resolver]
+        args: ["-r", "env=invalid"]
+        expectFailure: true
+        tags: [validation]
+        assertions:
+          - contains: "Invalid"
 ```
 
 Tests from all compose files are merged by name (duplicates are rejected). Execution order
 is alphabetical regardless of compose file order.
 
-### Compose Merge for testConfig
+### Compose Merge for testing.config
 
-When `testConfig` appears in multiple compose files:
+When `testing.config` appears in multiple compose files:
 
 | Field | Merge Behavior |
 |-------|----------------|
@@ -918,14 +923,15 @@ Builtins run before user-defined tests. Skip all builtins:
 scafctl test functional -f solution.yaml --skip-builtins
 ```
 
-Or skip specific ones in your solution's `testConfig`:
+Or skip specific ones in your solution's `testing.config`:
 
 ```yaml
 spec:
-  testConfig:
-    skipBuiltins:
-      - lint
-      - resolve-defaults
+  testing:
+    config:
+      skipBuiltins:
+        - lint
+        - resolve-defaults
 ```
 
 ---
@@ -1136,7 +1142,7 @@ solution's structure. No commands are executed; it performs structural analysis 
 scafctl test init -f solution.yaml
 ```
 
-This outputs YAML to stdout that you can paste into your solution's `spec.tests` section or
+This outputs YAML to stdout that you can paste into your solution's `spec.testing.cases` section or
 redirect to a file:
 
 ```bash
@@ -1205,8 +1211,9 @@ Running `scafctl test init -f solution.yaml` produces:
 # Paste this into your solution's spec section or a compose test file.
 # Customize assertions and parameters to match your expected behavior.
 
-tests:
-    lint:
+testing:
+    cases:
+        lint:
         description: Verify solution has no lint errors
         command:
             - lint
@@ -1311,7 +1318,7 @@ The scaffold is a starting point. After generating, you should:
 1. Executes the command normally and captures the output
 2. Walks the output to derive CEL assertions describing its shape
 3. Writes a normalized snapshot golden file to `testdata/`
-4. Prints the complete test YAML to stdout, ready to paste into `spec.tests`
+4. Prints the complete test YAML to stdout, ready to paste into `spec.testing.cases`
 
 This is the fastest way to lock in known-good behavior. Run the command once to generate the test, curate the assertions, then commit both the test and snapshot.
 
@@ -1450,24 +1457,25 @@ run-solution-env-prod:
 
 ### Step 4 — Paste and Register the Tests
 
-Open `my-app.yaml` and add a `spec.tests` section (or a compose test file — see the [compose test files](#compose-test-files) section). Paste the generated YAML under `tests:`:
+Open `my-app.yaml` and add a `spec.testing.cases` section (or a compose test file — see the [compose test files](#compose-test-files) section). Paste the generated YAML under `cases:`:
 
 ```yaml
 spec:
-  tests:
-    render-solution-env-prod:
-      description: "Auto-generated test for: render solution -r env=prod"
-      command: [render, solution]
-      args: ["-r", "env=prod", "-o", "json"]
-      tags: [generated]
-      assertions:
-        - expression: 'size(__output) == 3'
-          message: __output should have 3 keys
-        - expression: 'size(__output["actions"]) == 2'
-          message: __output["actions"] should have 2 keys
-        - expression: '__output["resolvers"]["environment"] == "prod"'
-        - expression: '__output["resolvers"]["region"] == "us-east-1"'
-      snapshot: "testdata/render-solution-env-prod.json"
+  testing:
+    cases:
+      render-solution-env-prod:
+        description: "Auto-generated test for: render solution -r env=prod"
+        command: [render, solution]
+        args: ["-r", "env=prod", "-o", "json"]
+        tags: [generated]
+        assertions:
+          - expression: 'size(__output) == 3'
+            message: __output should have 3 keys
+          - expression: 'size(__output["actions"]) == 2'
+            message: __output["actions"] should have 2 keys
+          - expression: '__output["resolvers"]["environment"] == "prod"'
+          - expression: '__output["resolvers"]["region"] == "us-east-1"'
+        snapshot: "testdata/render-solution-env-prod.json"
 ```
 
 Then run it:
@@ -1573,7 +1581,7 @@ generate → curate → commit → CI
 ```
 
 1. Run the command with `-o test` for each scenario you want to protect
-2. Paste the output into `spec.tests`
+2. Paste the output into `spec.testing.cases`
 3. Curate — loosen volatile assertions, add missing detail assertions, rename as needed
 4. Commit both the test YAML and the `testdata/*.json` snapshot files
 5. `scafctl test functional` runs in CI on every push

--- a/examples/solutions/tested-solution/solution.yaml
+++ b/examples/solutions/tested-solution/solution.yaml
@@ -55,39 +55,40 @@ spec:
               value: dev
 
   # ---------------------------------------------------------------------------
-  # Test Configuration
+  # Testing
   # ---------------------------------------------------------------------------
-  testConfig:
-    skipBuiltins:
-      - resolve-defaults
-      - render-defaults
-      - lint
-    env:
-      TEST_MODE: "true"
+  testing:
+    config:
+      skipBuiltins:
+        - resolve-defaults
+        - render-defaults
+        - lint
+      env:
+        TEST_MODE: "true"
 
-  # ---------------------------------------------------------------------------
-  # Tests
-  # ---------------------------------------------------------------------------
-  tests:
     # =========================================================================
-    # Templates (not executed directly)
+    # Test Cases
     # =========================================================================
+    cases:
+      # -----------------------------------------------------------------------
+      # Templates (not executed directly)
+      # -----------------------------------------------------------------------
 
-    _render-base:
-      description: Base template for resolver render tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [render]
-      assertions:
-        - expression: __exitCode == 0
+      _render-base:
+        description: Base template for resolver render tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [render]
+        assertions:
+          - expression: __exitCode == 0
 
-    _resolver-base:
-      description: Base template for resolver tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver]
-      assertions:
-        - expression: __exitCode == 0
+      _resolver-base:
+        description: Base template for resolver tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver]
+        assertions:
+          - expression: __exitCode == 0
 
     # =========================================================================
     # Basic Tests
@@ -95,195 +96,195 @@ spec:
 
     # --- Rendering -----------------------------------------------------------
 
-    render-basic:
-      description: Verify solution renders with default parameters
-      extends: [_render-base]
-      tags: [smoke]
-      assertions:
-        - contains: projectName
-        - contains: language
+      render-basic:
+        description: Verify solution renders with default parameters
+        extends: [_render-base]
+        tags: [smoke]
+        assertions:
+          - contains: projectName
+          - contains: language
 
-    render-json:
-      description: Verify JSON output contains all resolvers
-      extends: [_render-base]
-      args: ["-o", "json"]
-      assertions:
-        - expression: '"projectName" in __output'
-        - expression: '"language" in __output'
-        - expression: '"greeting" in __output'
-        - expression: '"environment" in __output'
+      render-json:
+        description: Verify JSON output contains all resolvers
+        extends: [_render-base]
+        args: ["-o", "json"]
+        assertions:
+          - expression: '"projectName" in __output'
+          - expression: '"language" in __output'
+          - expression: '"greeting" in __output'
+          - expression: '"environment" in __output'
 
     # --- Resolvers -----------------------------------------------------------
 
-    resolver-output:
-      description: Verify resolvers produce expected values
-      extends: [_resolver-base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.greeting == "Hello from my-app (go)"
-          message: "Greeting should combine projectName and language"
-        - expression: __output.language == "go"
+      resolver-output:
+        description: Verify resolvers produce expected values
+        extends: [_resolver-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.greeting == "Hello from my-app (go)"
+            message: "Greeting should combine projectName and language"
+          - expression: __output.language == "go"
 
-    resolver-with-params:
-      description: Verify resolver output with custom parameters
-      extends: [_resolver-base]
-      args: ["-r", "projectName=custom-project", "-r", "language=python"]
-      assertions:
-        - expression: __output.greeting == "Hello from custom-project (python)"
-        - expression: __output.projectName == "custom-project"
+      resolver-with-params:
+        description: Verify resolver output with custom parameters
+        extends: [_resolver-base]
+        args: ["-r", "projectName=custom-project", "-r", "language=python"]
+        assertions:
+          - expression: __output.greeting == "Hello from custom-project (python)"
+          - expression: __output.projectName == "custom-project"
 
     # --- Lint ----------------------------------------------------------------
 
-    lint-clean:
-      description: Verify solution has no lint errors
-      command: [lint]
-      tags: [lint, smoke]
-      assertions:
-        - expression: __exitCode == 0
+      lint-clean:
+        description: Verify solution has no lint errors
+        command: [lint]
+        tags: [lint, smoke]
+        assertions:
+          - expression: __exitCode == 0
 
     # =========================================================================
     # Assertion Varieties
     # =========================================================================
 
-    assertion-contains:
-      description: Demonstrate contains assertion
-      extends: [_resolver-base]
-      assertions:
-        - contains: "my-app"
+      assertion-contains:
+        description: Demonstrate contains assertion
+        extends: [_resolver-base]
+        assertions:
+          - contains: "my-app"
 
-    assertion-not-contains:
-      description: Demonstrate notContains assertion
-      extends: [_resolver-base]
-      assertions:
-        - notContains: "ERROR"
-        - notContains: "panic"
+      assertion-not-contains:
+        description: Demonstrate notContains assertion
+        extends: [_resolver-base]
+        assertions:
+          - notContains: "ERROR"
+          - notContains: "panic"
 
-    assertion-regex:
-      description: Demonstrate regex assertion
-      extends: [_resolver-base]
-      assertions:
-        - regex: '"greeting":\s*"Hello from'
+      assertion-regex:
+        description: Demonstrate regex assertion
+        extends: [_resolver-base]
+        assertions:
+          - regex: '"greeting":\s*"Hello from'
 
-    assertion-not-regex:
-      description: Demonstrate notRegex assertion
-      extends: [_resolver-base]
-      assertions:
-        - notRegex: "(?i)\\bpanic\\b|\\bfatal\\b"
+      assertion-not-regex:
+        description: Demonstrate notRegex assertion
+        extends: [_resolver-base]
+        assertions:
+          - notRegex: "(?i)\\bpanic\\b|\\bfatal\\b"
 
-    assertion-target-stderr:
-      description: Demonstrate target field for assertions
-      extends: [_resolver-base]
-      assertions:
-        - notContains: "ERROR"
-          target: stderr
-        - notContains: "panic"
-          target: combined
+      assertion-target-stderr:
+        description: Demonstrate target field for assertions
+        extends: [_resolver-base]
+        assertions:
+          - notContains: "ERROR"
+            target: stderr
+          - notContains: "panic"
+            target: combined
 
-    assertion-message:
-      description: Demonstrate custom failure messages
-      extends: [_resolver-base]
-      assertions:
-        - expression: __output.language == "go"
-          message: "Default language should be 'go'"
-        - contains: "greeting"
-          message: "Output must include the greeting resolver"
+      assertion-message:
+        description: Demonstrate custom failure messages
+        extends: [_resolver-base]
+        assertions:
+          - expression: __output.language == "go"
+            message: "Default language should be 'go'"
+          - contains: "greeting"
+            message: "Output must include the greeting resolver"
 
     # =========================================================================
     # Environment Variables
     # =========================================================================
 
-    env-per-test:
-      description: Demonstrate per-test environment variables
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [env]
-      env:
-        CUSTOM_ENV_VAR: "test-value"
-      assertions:
-        - expression: __exitCode == 0
+      env-per-test:
+        description: Demonstrate per-test environment variables
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [env]
+        env:
+          CUSTOM_ENV_VAR: "test-value"
+        assertions:
+          - expression: __exitCode == 0
 
     # =========================================================================
     # Init and Cleanup
     # =========================================================================
 
-    init-cleanup:
-      description: Demonstrate init and cleanup steps
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [lifecycle]
-      init:
-        - command: "echo 'Setting up test'"
-      cleanup:
-        - command: "echo 'Cleaning up'"
-      assertions:
-        - expression: __exitCode == 0
-        - expression: __output.projectName == "my-app"
+      init-cleanup:
+        description: Demonstrate init and cleanup steps
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [lifecycle]
+        init:
+          - command: "echo 'Setting up test'"
+        cleanup:
+          - command: "echo 'Cleaning up'"
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.projectName == "my-app"
 
     # =========================================================================
     # Expected Failures
     # =========================================================================
 
-    expect-failure:
-      description: Demonstrate expectFailure for a command that fails
-      command: [run, resolver]
-      args: ["--resolver", "nonExistentResolver"]
-      expectFailure: true
-      tags: [negative]
-      assertions:
-        - notContains: "panic"
+      expect-failure:
+        description: Demonstrate expectFailure for a command that fails
+        command: [run, resolver]
+        args: ["--resolver", "nonExistentResolver"]
+        expectFailure: true
+        tags: [negative]
+        assertions:
+          - notContains: "panic"
 
     # =========================================================================
     # Timeouts
     # =========================================================================
 
-    timeout-test:
-      description: Demonstrate per-test timeout
-      extends: [_resolver-base]
-      timeout: "30s"
-      tags: [timeout]
-      assertions:
-        - expression: __output.projectName == "my-app"
+      timeout-test:
+        description: Demonstrate per-test timeout
+        extends: [_resolver-base]
+        timeout: "30s"
+        tags: [timeout]
+        assertions:
+          - expression: __output.projectName == "my-app"
 
     # =========================================================================
     # Skipping Tests
     # =========================================================================
 
-    skip-static:
-      description: Demonstrate static skip
-      skip: true
-      skipReason: "Example of a statically skipped test"
-      command: [render, solution]
-      tags: [skip]
-      assertions:
-        - expression: __exitCode == 0
+      skip-static:
+        description: Demonstrate static skip
+        skip: true
+        skipReason: "Example of a statically skipped test"
+        command: [render, solution]
+        tags: [skip]
+        assertions:
+          - expression: __exitCode == 0
 
-    skip-conditional:
-      description: Demonstrate conditional skip (skips on Windows)
-      skipExpression: 'os == "windows"'
-      extends: [_resolver-base]
-      tags: [skip]
-      assertions:
-        - expression: __output.language == "go"
+      skip-conditional:
+        description: Demonstrate conditional skip (skips on Windows)
+        skipExpression: 'os == "windows"'
+        extends: [_resolver-base]
+        tags: [skip]
+        assertions:
+          - expression: __output.language == "go"
 
     # =========================================================================
     # Retries
     # =========================================================================
 
-    retry-test:
-      description: Demonstrate retries
-      extends: [_resolver-base]
-      retries: 2
-      tags: [retry]
-      assertions:
-        - expression: __output.greeting == "Hello from my-app (go)"
+      retry-test:
+        description: Demonstrate retries
+        extends: [_resolver-base]
+        retries: 2
+        tags: [retry]
+        assertions:
+          - expression: __output.greeting == "Hello from my-app (go)"
 
     # =========================================================================
     # Tags
     # =========================================================================
 
-    tagged-integration:
-      description: Demonstrate tag-based filtering
-      extends: [_resolver-base]
-      tags: [integration, slow]
-      assertions:
-        - expression: __output.projectName == "my-app"
+      tagged-integration:
+        description: Demonstrate tag-based filtering
+        extends: [_resolver-base]
+        tags: [integration, slow]
+        assertions:
+          - expression: __output.projectName == "my-app"

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -600,14 +600,14 @@ func lintTests(sol *solution.Solution, result *Result) {
 
 	// Collect all extends references to detect unused templates.
 	extendsRefs := make(map[string]bool)
-	for _, tc := range sol.Spec.Tests {
+	for _, tc := range sol.Spec.Testing.Cases {
 		for _, ext := range tc.Extends {
 			extendsRefs[ext] = true
 		}
 	}
 
-	for name, tc := range sol.Spec.Tests {
-		location := fmt.Sprintf("tests.%s", name)
+	for name, tc := range sol.Spec.Testing.Cases {
+		location := fmt.Sprintf("testing.cases.%s", name)
 
 		// Rule: invalid-test-name — validate naming pattern.
 		// Use the map key directly rather than tc.Name, which may not be set yet.

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -178,10 +178,10 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 	// Apply skip builtins to each solution's test config
 	if opts.SkipBuiltins {
 		for i := range solutions {
-			if solutions[i].TestConfig == nil {
-				solutions[i].TestConfig = &soltesting.TestConfig{}
+			if solutions[i].Config == nil {
+				solutions[i].Config = &soltesting.TestConfig{}
 			}
-			solutions[i].TestConfig.SkipBuiltins = skipBuiltins
+			solutions[i].Config.SkipBuiltins = skipBuiltins
 		}
 	}
 
@@ -322,7 +322,7 @@ func runWatchMode(ctx context.Context, opts *FunctionalOptions, w *writer.Writer
 	}
 
 	// Unused in watch mode — skip builtins are applied per-run via
-	// the solution's TestConfig, which DiscoverSolutions populates.
+	// the solution's Config, which DiscoverSolutions populates.
 	_ = skipBuiltins
 
 	isTTY := kvx.IsTerminal(opts.IOStreams.ErrOut)

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -39,7 +39,7 @@ based on the resolvers, validation rules, and workflow actions it finds.
 No commands are executed — this is structural analysis only.
 
 The generated YAML is written to stdout and can be pasted into the solution's
-spec.tests section or saved to a separate test file.
+spec.testing.cases section or saved to a separate test file.
 
 Examples:
   # Generate tests from a solution file

--- a/pkg/cmd/scafctl/test/test.go
+++ b/pkg/cmd/scafctl/test/test.go
@@ -26,7 +26,7 @@ SUBCOMMANDS:
 
 Functional tests validate that solutions behave correctly by executing
 scafctl commands against them and checking the output. Tests are defined
-inline in solution YAML under spec.tests or in separate test files
+inline in solution YAML under spec.testing.cases or in separate test files
 under a tests/ directory.`, settings.CliBinaryName),
 		SilenceUsage: true,
 	}

--- a/pkg/mcp/tools_examples.go
+++ b/pkg/mcp/tools_examples.go
@@ -256,7 +256,7 @@ func descriptionFromPath(path string) string {
 		"solutions/composition/parent.yaml":       "Solution composition - parent that composes children",
 		"solutions/composition/child.yaml":        "Solution composition - child partial solution",
 		"solutions/taskfile/solution.yaml":        "Taskfile-based workflow solution",
-		"solutions/tested-solution/solution.yaml": "Solution with functional tests defined in spec.tests",
+		"solutions/tested-solution/solution.yaml": "Solution with functional tests defined in spec.testing.cases",
 
 		// Actions
 		"actions/hello-world.yaml":              "Simple hello world action",

--- a/pkg/solution/bundler/compose.go
+++ b/pkg/solution/bundler/compose.go
@@ -18,13 +18,12 @@ import (
 )
 
 // composePart represents a partial YAML file that contributes resolvers,
-// workflow actions, tests, and/or bundle includes to the parent solution.
+// workflow actions, testing configuration, and/or bundle includes to the parent solution.
 type composePart struct {
 	Spec struct {
-		Resolvers  map[string]*resolver.Resolver   `yaml:"resolvers"`
-		Workflow   *action.Workflow                `yaml:"workflow"`
-		Tests      map[string]*soltesting.TestCase `yaml:"tests"`
-		TestConfig *soltesting.TestConfig          `yaml:"testConfig"`
+		Resolvers map[string]*resolver.Resolver `yaml:"resolvers"`
+		Workflow  *action.Workflow              `yaml:"workflow"`
+		Testing   *soltesting.TestSuite         `yaml:"testing"`
 	} `yaml:"spec"`
 	Bundle struct {
 		Include []string `yaml:"include"`
@@ -58,8 +57,8 @@ func WithReadFileFunc(fn func(string) ([]byte, error)) ComposeOption {
 //   - Resolvers: merged by name. Duplicate resolver names across files are rejected.
 //   - Actions: merged by name. Duplicate action names across files are rejected.
 //   - Finally actions: merged by name. Same duplicate rules apply.
-//   - Tests: merged by name. Duplicate test names across files are rejected.
-//   - TestConfig: skipBuiltins (true-wins for bool, union for lists), env (last wins),
+//   - Testing.Cases: merged by name. Duplicate test names across files are rejected.
+//   - Testing.Config: skipBuiltins (true-wins for bool, union for lists), env (last wins),
 //     setup/cleanup (appended in compose-file order).
 //   - bundle.include: unioned (deduplicated).
 //   - Circular compose references are detected and rejected.
@@ -133,11 +132,13 @@ func Compose(sol *solution.Solution, bundleRoot string, opts ...ComposeOption) (
 				return nil, err
 			}
 
-			if err := mergeTests(merged, part.Spec.Tests, relPath); err != nil {
-				return nil, err
-			}
+			if part.Spec.Testing != nil {
+				if err := mergeTests(merged, part.Spec.Testing.Cases, relPath); err != nil {
+					return nil, err
+				}
 
-			mergeTestConfig(merged, part.Spec.TestConfig)
+				mergeTestConfig(merged, part.Spec.Testing.Config)
+			}
 
 			mergeIncludes(merged, part.Bundle.Include)
 		}
@@ -235,17 +236,20 @@ func mergeTests(merged *solution.Solution, tests map[string]*soltesting.TestCase
 		return nil
 	}
 
-	if merged.Spec.Tests == nil {
-		merged.Spec.Tests = make(map[string]*soltesting.TestCase)
+	if merged.Spec.Testing == nil {
+		merged.Spec.Testing = &soltesting.TestSuite{}
+	}
+	if merged.Spec.Testing.Cases == nil {
+		merged.Spec.Testing.Cases = make(map[string]*soltesting.TestCase)
 	}
 
 	for name, tc := range tests {
-		if _, exists := merged.Spec.Tests[name]; exists {
+		if _, exists := merged.Spec.Testing.Cases[name]; exists {
 			return fmt.Errorf("duplicate test %q: defined in both root solution and composed file %s", name, sourceFile)
 		}
 		// Set the Name field from the map key
 		tc.Name = name
-		merged.Spec.Tests[name] = tc
+		merged.Spec.Testing.Cases[name] = tc
 	}
 	return nil
 }
@@ -261,22 +265,25 @@ func mergeTestConfig(merged *solution.Solution, tc *soltesting.TestConfig) {
 		return
 	}
 
-	if merged.Spec.TestConfig == nil {
-		merged.Spec.TestConfig = &soltesting.TestConfig{}
+	if merged.Spec.Testing == nil {
+		merged.Spec.Testing = &soltesting.TestSuite{}
+	}
+	if merged.Spec.Testing.Config == nil {
+		merged.Spec.Testing.Config = &soltesting.TestConfig{}
 	}
 
 	// SkipBuiltins: true-wins for bool; union for lists
 	if tc.SkipBuiltins.All {
-		merged.Spec.TestConfig.SkipBuiltins.All = true
+		merged.Spec.Testing.Config.SkipBuiltins.All = true
 	}
-	if len(tc.SkipBuiltins.Names) > 0 && !merged.Spec.TestConfig.SkipBuiltins.All {
-		existing := make(map[string]bool, len(merged.Spec.TestConfig.SkipBuiltins.Names))
-		for _, n := range merged.Spec.TestConfig.SkipBuiltins.Names {
+	if len(tc.SkipBuiltins.Names) > 0 && !merged.Spec.Testing.Config.SkipBuiltins.All {
+		existing := make(map[string]bool, len(merged.Spec.Testing.Config.SkipBuiltins.Names))
+		for _, n := range merged.Spec.Testing.Config.SkipBuiltins.Names {
 			existing[n] = true
 		}
 		for _, n := range tc.SkipBuiltins.Names {
 			if !existing[n] {
-				merged.Spec.TestConfig.SkipBuiltins.Names = append(merged.Spec.TestConfig.SkipBuiltins.Names, n)
+				merged.Spec.Testing.Config.SkipBuiltins.Names = append(merged.Spec.Testing.Config.SkipBuiltins.Names, n)
 				existing[n] = true
 			}
 		}
@@ -284,19 +291,19 @@ func mergeTestConfig(merged *solution.Solution, tc *soltesting.TestConfig) {
 
 	// Env: merged map, last file wins on key conflict
 	if len(tc.Env) > 0 {
-		if merged.Spec.TestConfig.Env == nil {
-			merged.Spec.TestConfig.Env = make(map[string]string)
+		if merged.Spec.Testing.Config.Env == nil {
+			merged.Spec.Testing.Config.Env = make(map[string]string)
 		}
 		for k, v := range tc.Env {
-			merged.Spec.TestConfig.Env[k] = v
+			merged.Spec.Testing.Config.Env[k] = v
 		}
 	}
 
 	// Setup: appended in compose-file order
-	merged.Spec.TestConfig.Setup = append(merged.Spec.TestConfig.Setup, tc.Setup...)
+	merged.Spec.Testing.Config.Setup = append(merged.Spec.Testing.Config.Setup, tc.Setup...)
 
 	// Cleanup: appended in compose-file order
-	merged.Spec.TestConfig.Cleanup = append(merged.Spec.TestConfig.Cleanup, tc.Cleanup...)
+	merged.Spec.Testing.Config.Cleanup = append(merged.Spec.Testing.Config.Cleanup, tc.Cleanup...)
 }
 
 // deepCopySolution creates a deep copy of a solution by marshaling to YAML and back.

--- a/pkg/solution/bundler/compose_test.go
+++ b/pkg/solution/bundler/compose_test.go
@@ -283,23 +283,24 @@ func TestCompose_MergesTests(t *testing.T) {
 		if path == "/tmp/bundle/tests.yaml" {
 			return []byte(`
 spec:
-  tests:
-    render-test:
-      description: "Test rendering"
-      command:
-        - render
-        - solution
-      assertions:
-        - contains: "hello"
+  testing:
+    cases:
+      render-test:
+        description: "Test rendering"
+        command:
+          - render
+          - solution
+        assertions:
+          - contains: "hello"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.Contains(t, result.Spec.Tests, "render-test")
-	assert.Equal(t, "Test rendering", result.Spec.Tests["render-test"].Description)
-	assert.Equal(t, "render-test", result.Spec.Tests["render-test"].Name)
+	require.Contains(t, result.Spec.Testing.Cases, "render-test")
+	assert.Equal(t, "Test rendering", result.Spec.Testing.Cases["render-test"].Description)
+	assert.Equal(t, "render-test", result.Spec.Testing.Cases["render-test"].Name)
 }
 
 func TestCompose_MergesTestsFromMultipleFiles(t *testing.T) {
@@ -310,30 +311,32 @@ func TestCompose_MergesTestsFromMultipleFiles(t *testing.T) {
 		case "/tmp/bundle/tests-a.yaml":
 			return []byte(`
 spec:
-  tests:
-    test-a:
-      description: "Test A"
-      command: [render, solution]
-      assertions:
-        - contains: "a"
+  testing:
+    cases:
+      test-a:
+        description: "Test A"
+        command: [render, solution]
+        assertions:
+          - contains: "a"
 `), nil
 		case "/tmp/bundle/tests-b.yaml":
 			return []byte(`
 spec:
-  tests:
-    test-b:
-      description: "Test B"
-      command: [render, solution]
-      assertions:
-        - contains: "b"
+  testing:
+    cases:
+      test-b:
+        description: "Test B"
+        command: [render, solution]
+        assertions:
+          - contains: "b"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	assert.Contains(t, result.Spec.Tests, "test-a")
-	assert.Contains(t, result.Spec.Tests, "test-b")
+	assert.Contains(t, result.Spec.Testing.Cases, "test-a")
+	assert.Contains(t, result.Spec.Testing.Cases, "test-b")
 }
 
 func TestCompose_RejectsDuplicateTests(t *testing.T) {
@@ -344,22 +347,24 @@ func TestCompose_RejectsDuplicateTests(t *testing.T) {
 		case "/tmp/bundle/tests-a.yaml":
 			return []byte(`
 spec:
-  tests:
-    same-test:
-      description: "First"
-      command: [render, solution]
-      assertions:
-        - contains: "a"
+  testing:
+    cases:
+      same-test:
+        description: "First"
+        command: [render, solution]
+        assertions:
+          - contains: "a"
 `), nil
 		case "/tmp/bundle/tests-b.yaml":
 			return []byte(`
 spec:
-  tests:
-    same-test:
-      description: "Second"
-      command: [render, solution]
-      assertions:
-        - contains: "b"
+  testing:
+    cases:
+      same-test:
+        description: "Second"
+        command: [render, solution]
+        assertions:
+          - contains: "b"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
@@ -378,22 +383,25 @@ func TestCompose_MergesTestConfig_SkipBuiltins_TrueWins(t *testing.T) {
 		case "/tmp/bundle/a.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    skipBuiltins: false
+  testing:
+    config:
+      skipBuiltins: false
 `), nil
 		case "/tmp/bundle/b.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.NotNil(t, result.Spec.TestConfig)
-	assert.True(t, result.Spec.TestConfig.SkipBuiltins.All)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	assert.True(t, result.Spec.Testing.Config.SkipBuiltins.All)
 }
 
 func TestCompose_MergesTestConfig_SkipBuiltins_UnionNames(t *testing.T) {
@@ -404,26 +412,29 @@ func TestCompose_MergesTestConfig_SkipBuiltins_UnionNames(t *testing.T) {
 		case "/tmp/bundle/a.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    skipBuiltins:
-      - lint
+  testing:
+    config:
+      skipBuiltins:
+        - lint
 `), nil
 		case "/tmp/bundle/b.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    skipBuiltins:
-      - parse
-      - lint
+  testing:
+    config:
+      skipBuiltins:
+        - parse
+        - lint
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.NotNil(t, result.Spec.TestConfig)
-	assert.False(t, result.Spec.TestConfig.SkipBuiltins.All)
-	assert.ElementsMatch(t, []string{"lint", "parse"}, result.Spec.TestConfig.SkipBuiltins.Names)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	assert.False(t, result.Spec.Testing.Config.SkipBuiltins.All)
+	assert.ElementsMatch(t, []string{"lint", "parse"}, result.Spec.Testing.Config.SkipBuiltins.Names)
 }
 
 func TestCompose_MergesTestConfig_Setup_Appended(t *testing.T) {
@@ -434,26 +445,29 @@ func TestCompose_MergesTestConfig_Setup_Appended(t *testing.T) {
 		case "/tmp/bundle/a.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    setup:
-      - command: "echo first"
+  testing:
+    config:
+      setup:
+        - command: "echo first"
 `), nil
 		case "/tmp/bundle/b.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    setup:
-      - command: "echo second"
+  testing:
+    config:
+      setup:
+        - command: "echo second"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.NotNil(t, result.Spec.TestConfig)
-	require.Len(t, result.Spec.TestConfig.Setup, 2)
-	assert.Equal(t, "echo first", result.Spec.TestConfig.Setup[0].Command)
-	assert.Equal(t, "echo second", result.Spec.TestConfig.Setup[1].Command)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	require.Len(t, result.Spec.Testing.Config.Setup, 2)
+	assert.Equal(t, "echo first", result.Spec.Testing.Config.Setup[0].Command)
+	assert.Equal(t, "echo second", result.Spec.Testing.Config.Setup[1].Command)
 }
 
 func TestCompose_MergesTestConfig_Cleanup_Appended(t *testing.T) {
@@ -464,26 +478,29 @@ func TestCompose_MergesTestConfig_Cleanup_Appended(t *testing.T) {
 		case "/tmp/bundle/a.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    cleanup:
-      - command: "echo cleanup-first"
+  testing:
+    config:
+      cleanup:
+        - command: "echo cleanup-first"
 `), nil
 		case "/tmp/bundle/b.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    cleanup:
-      - command: "echo cleanup-second"
+  testing:
+    config:
+      cleanup:
+        - command: "echo cleanup-second"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.NotNil(t, result.Spec.TestConfig)
-	require.Len(t, result.Spec.TestConfig.Cleanup, 2)
-	assert.Equal(t, "echo cleanup-first", result.Spec.TestConfig.Cleanup[0].Command)
-	assert.Equal(t, "echo cleanup-second", result.Spec.TestConfig.Cleanup[1].Command)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	require.Len(t, result.Spec.Testing.Config.Cleanup, 2)
+	assert.Equal(t, "echo cleanup-first", result.Spec.Testing.Config.Cleanup[0].Command)
+	assert.Equal(t, "echo cleanup-second", result.Spec.Testing.Config.Cleanup[1].Command)
 }
 
 func TestCompose_MergesTestConfig_Env_LastWins(t *testing.T) {
@@ -494,28 +511,31 @@ func TestCompose_MergesTestConfig_Env_LastWins(t *testing.T) {
 		case "/tmp/bundle/a.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    env:
-      KEY1: "from-a"
-      SHARED: "from-a"
+  testing:
+    config:
+      env:
+        KEY1: "from-a"
+        SHARED: "from-a"
 `), nil
 		case "/tmp/bundle/b.yaml":
 			return []byte(`
 spec:
-  testConfig:
-    env:
-      KEY2: "from-b"
-      SHARED: "from-b"
+  testing:
+    config:
+      env:
+        KEY2: "from-b"
+        SHARED: "from-b"
 `), nil
 		}
 		return nil, fmt.Errorf("file not found: %s", path)
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	require.NotNil(t, result.Spec.TestConfig)
-	assert.Equal(t, "from-a", result.Spec.TestConfig.Env["KEY1"])
-	assert.Equal(t, "from-b", result.Spec.TestConfig.Env["KEY2"])
-	assert.Equal(t, "from-b", result.Spec.TestConfig.Env["SHARED"])
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	assert.Equal(t, "from-a", result.Spec.Testing.Config.Env["KEY1"])
+	assert.Equal(t, "from-b", result.Spec.Testing.Config.Env["KEY2"])
+	assert.Equal(t, "from-b", result.Spec.Testing.Config.Env["SHARED"])
 }
 
 func TestCompose_SolutionWithInlineTests_PreservedAfterCompose(t *testing.T) {
@@ -541,8 +561,7 @@ spec:
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
 	// Tests should remain nil since nothing defined them
-	assert.Nil(t, result.Spec.Tests)
-	assert.Nil(t, result.Spec.TestConfig)
+	assert.Nil(t, result.Spec.Testing)
 }
 
 func TestCompose_TestConfigNil_WhenNoTestConfigDefined(t *testing.T) {
@@ -565,5 +584,5 @@ spec:
 	}
 	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
 	require.NoError(t, err)
-	assert.Nil(t, result.Spec.TestConfig)
+	assert.Nil(t, result.Spec.Testing)
 }

--- a/pkg/solution/bundler/discover.go
+++ b/pkg/solution/bundler/discover.go
@@ -24,7 +24,7 @@ const (
 	StaticAnalysis DiscoverySource = iota
 	// ExplicitInclude means the file was declared in bundle.include.
 	ExplicitInclude
-	// TestInclude means the file was referenced in spec.tests[*].files.
+	// TestInclude means the file was referenced in spec.testing.cases[*].files.
 	TestInclude
 )
 
@@ -158,27 +158,29 @@ func DiscoverFiles(sol *solution.Solution, bundleRoot string, opts ...DiscoverOp
 		}
 	}
 
-	// Phase 3: Scan test file references from spec.tests[*].files
-	for _, tc := range sol.Spec.Tests {
-		if tc == nil {
-			continue
-		}
-		for _, fileRef := range tc.Files {
-			// Test file references may be globs — expand them
-			if strings.ContainsAny(fileRef, "*?[{") {
-				expanded, err := expandSingleGlob(bundleRoot, fileRef, cfg)
-				if err != nil {
-					// Log warning but don't fail — globs are validated at test time
-					continue
-				}
-				for _, relPath := range expanded {
-					if err := addFileEntry(result, seen, cfg, bundleRoot, relPath, TestInclude); err != nil {
+	// Phase 3: Scan test file references from spec.testing.cases[*].files
+	if sol.Spec.Testing != nil {
+		for _, tc := range sol.Spec.Testing.Cases {
+			if tc == nil {
+				continue
+			}
+			for _, fileRef := range tc.Files {
+				// Test file references may be globs — expand them
+				if strings.ContainsAny(fileRef, "*?[{") {
+					expanded, err := expandSingleGlob(bundleRoot, fileRef, cfg)
+					if err != nil {
+						// Log warning but don't fail — globs are validated at test time
+						continue
+					}
+					for _, relPath := range expanded {
+						if err := addFileEntry(result, seen, cfg, bundleRoot, relPath, TestInclude); err != nil {
+							continue // skip files that don't exist yet
+						}
+					}
+				} else {
+					if err := addFileEntry(result, seen, cfg, bundleRoot, fileRef, TestInclude); err != nil {
 						continue // skip files that don't exist yet
 					}
-				}
-			} else {
-				if err := addFileEntry(result, seen, cfg, bundleRoot, fileRef, TestInclude); err != nil {
-					continue // skip files that don't exist yet
 				}
 			}
 		}

--- a/pkg/solution/soltesting/discovery.go
+++ b/pkg/solution/soltesting/discovery.go
@@ -18,10 +18,10 @@ import (
 type SolutionTests struct {
 	// SolutionName is the metadata.name from the solution.
 	SolutionName string `json:"solutionName"`
-	// Tests contains the test definitions keyed by test name.
-	Tests map[string]*TestCase `json:"tests"`
-	// TestConfig holds the solution-level test configuration.
-	TestConfig *TestConfig `json:"testConfig,omitempty"`
+	// Cases contains the test definitions keyed by test name.
+	Cases map[string]*TestCase `json:"cases"`
+	// Config holds the solution-level test configuration.
+	Config *TestConfig `json:"config,omitempty"`
 	// FilePath is the absolute path to the solution file.
 	FilePath string `json:"filePath"`
 }
@@ -108,8 +108,7 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 		} `yaml:"metadata"`
 		Compose []string `yaml:"compose"`
 		Spec    struct {
-			Tests      map[string]*TestCase `yaml:"tests"`
-			TestConfig *TestConfig          `yaml:"testConfig"`
+			Testing *TestSuite `yaml:"testing"`
 		} `yaml:"spec"`
 	}
 
@@ -136,41 +135,46 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 				}
 				var composePart struct {
 					Spec struct {
-						Tests      map[string]*TestCase `yaml:"tests"`
-						TestConfig *TestConfig          `yaml:"testConfig"`
+						Testing *TestSuite `yaml:"testing"`
 					} `yaml:"spec"`
 				}
 				if unmarshalErr := yaml.Unmarshal(composeData, &composePart); unmarshalErr != nil {
 					return nil, fmt.Errorf("parsing compose file %q: %w", match, unmarshalErr)
 				}
-				// Merge tests from compose file
-				if doc.Spec.Tests == nil {
-					doc.Spec.Tests = make(map[string]*TestCase)
+				// Initialize doc testing if nil
+				if doc.Spec.Testing == nil {
+					doc.Spec.Testing = &TestSuite{}
 				}
-				for name, tc := range composePart.Spec.Tests {
-					if _, exists := doc.Spec.Tests[name]; exists {
-						return nil, fmt.Errorf("compose file %q: duplicate test name %q", match, name)
+				// Merge cases from compose file
+				if composePart.Spec.Testing != nil {
+					if doc.Spec.Testing.Cases == nil {
+						doc.Spec.Testing.Cases = make(map[string]*TestCase)
 					}
-					doc.Spec.Tests[name] = tc
-				}
-				// Merge testConfig from compose file
-				if composePart.Spec.TestConfig != nil {
-					if doc.Spec.TestConfig == nil {
-						doc.Spec.TestConfig = composePart.Spec.TestConfig
-					} else {
-						mergeTestConfig(doc.Spec.TestConfig, composePart.Spec.TestConfig)
+					for name, tc := range composePart.Spec.Testing.Cases {
+						if _, exists := doc.Spec.Testing.Cases[name]; exists {
+							return nil, fmt.Errorf("compose file %q: duplicate test name %q", match, name)
+						}
+						doc.Spec.Testing.Cases[name] = tc
+					}
+					// Merge config from compose file
+					if composePart.Spec.Testing.Config != nil {
+						if doc.Spec.Testing.Config == nil {
+							doc.Spec.Testing.Config = composePart.Spec.Testing.Config
+						} else {
+							mergeTestConfig(doc.Spec.Testing.Config, composePart.Spec.Testing.Config)
+						}
 					}
 				}
 			}
 		}
 	}
 
-	if len(doc.Spec.Tests) == 0 {
+	if doc.Spec.Testing == nil || len(doc.Spec.Testing.Cases) == 0 {
 		return nil, nil
 	}
 
 	// Set names from map keys
-	for name, tc := range doc.Spec.Tests {
+	for name, tc := range doc.Spec.Testing.Cases {
 		tc.Name = name
 	}
 
@@ -181,8 +185,8 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 
 	return &SolutionTests{
 		SolutionName: doc.Metadata.Name,
-		Tests:        doc.Spec.Tests,
-		TestConfig:   doc.Spec.TestConfig,
+		Cases:        doc.Spec.Testing.Cases,
+		Config:       doc.Spec.Testing.Config,
 		FilePath:     absPath,
 	}, nil
 }
@@ -230,7 +234,7 @@ func FilterTests(solutions []SolutionTests, opts FilterOptions) []SolutionTests 
 		}
 
 		filtered := make(map[string]*TestCase)
-		for name, tc := range st.Tests {
+		for name, tc := range st.Cases {
 			// Exclude templates from execution
 			if tc.IsTemplate() {
 				continue
@@ -250,8 +254,8 @@ func FilterTests(solutions []SolutionTests, opts FilterOptions) []SolutionTests 
 		if len(filtered) > 0 {
 			result = append(result, SolutionTests{
 				SolutionName: st.SolutionName,
-				Tests:        filtered,
-				TestConfig:   st.TestConfig,
+				Cases:        filtered,
+				Config:       st.Config,
 				FilePath:     st.FilePath,
 			})
 		}
@@ -268,8 +272,8 @@ func FilterTests(solutions []SolutionTests, opts FilterOptions) []SolutionTests 
 // SortedTestNames returns the test names from a SolutionTests in sorted order.
 // Builtin tests (prefixed with "builtin:") sort first, then alphabetical.
 func SortedTestNames(st SolutionTests) []string {
-	names := make([]string, 0, len(st.Tests))
-	for name := range st.Tests {
+	names := make([]string, 0, len(st.Cases))
+	for name := range st.Cases {
 		names = append(names, name)
 	}
 

--- a/pkg/solution/soltesting/discovery_test.go
+++ b/pkg/solution/soltesting/discovery_test.go
@@ -17,35 +17,37 @@ const discoverySolutionWithTests = `apiVersion: scafctl.io/v1
 metadata:
   name: my-solution
 spec:
-  tests:
-    smoke-test:
-      command: [render, solution]
-      tags: [smoke, fast]
-      assertions:
-        - contains: "success"
-    integration-test:
-      command: [run, resolver]
-      tags: [integration]
-      assertions:
-        - contains: "resolved"
-    _base-template:
-      command: [lint]
-      tags: [base]
+  testing:
+    cases:
+      smoke-test:
+        command: [render, solution]
+        tags: [smoke, fast]
+        assertions:
+          - contains: "success"
+      integration-test:
+        command: [run, resolver]
+        tags: [integration]
+        assertions:
+          - contains: "resolved"
+      _base-template:
+        command: [lint]
+        tags: [base]
 `
 
 const discoverySolutionWithTestConfig = `apiVersion: scafctl.io/v1
 metadata:
   name: configured-solution
 spec:
-  testConfig:
-    skipBuiltins: true
-    env:
-      FOO: bar
-  tests:
-    basic:
-      command: [render, solution]
-      assertions:
-        - contains: "ok"
+  testing:
+    config:
+      skipBuiltins: true
+      env:
+        FOO: bar
+    cases:
+      basic:
+        command: [render, solution]
+        assertions:
+          - contains: "ok"
 `
 
 const discoverySolutionWithoutTests = `apiVersion: scafctl.io/v1
@@ -81,7 +83,7 @@ func TestDiscoverSolutions_SingleFile(t *testing.T) {
 
 	require.Len(t, results, 1)
 	assert.Equal(t, "my-solution", results[0].SolutionName)
-	assert.Len(t, results[0].Tests, 3)
+	assert.Len(t, results[0].Cases, 3)
 }
 
 func TestDiscoverFromFile(t *testing.T) {
@@ -94,10 +96,10 @@ func TestDiscoverFromFile(t *testing.T) {
 	require.NotNil(t, st)
 
 	assert.Equal(t, "my-solution", st.SolutionName)
-	assert.Contains(t, st.Tests, "smoke-test")
-	assert.Contains(t, st.Tests, "integration-test")
-	assert.Contains(t, st.Tests, "_base-template")
-	assert.Equal(t, "smoke-test", st.Tests["smoke-test"].Name)
+	assert.Contains(t, st.Cases, "smoke-test")
+	assert.Contains(t, st.Cases, "integration-test")
+	assert.Contains(t, st.Cases, "_base-template")
+	assert.Equal(t, "smoke-test", st.Cases["smoke-test"].Name)
 }
 
 func TestDiscoverFromFile_WithTestConfig(t *testing.T) {
@@ -108,8 +110,8 @@ func TestDiscoverFromFile_WithTestConfig(t *testing.T) {
 	st, err := soltesting.DiscoverFromFile(solFile)
 	require.NoError(t, err)
 	require.NotNil(t, st)
-	require.NotNil(t, st.TestConfig)
-	assert.True(t, st.TestConfig.SkipBuiltins.All)
+	require.NotNil(t, st.Config)
+	assert.True(t, st.Config.SkipBuiltins.All)
 }
 
 func TestDiscoverFromFile_NoTests(t *testing.T) {
@@ -126,7 +128,7 @@ func TestFilterTests_NamePattern(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"smoke-test":       {Name: "smoke-test", Command: []string{"render"}},
 				"integration-test": {Name: "integration-test", Command: []string{"run"}},
 				"_template":        {Name: "_template", Command: []string{"x"}},
@@ -139,16 +141,16 @@ func TestFilterTests_NamePattern(t *testing.T) {
 	})
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].Tests, "smoke-test")
-	assert.NotContains(t, result[0].Tests, "integration-test")
-	assert.NotContains(t, result[0].Tests, "_template")
+	assert.Contains(t, result[0].Cases, "smoke-test")
+	assert.NotContains(t, result[0].Cases, "integration-test")
+	assert.NotContains(t, result[0].Cases, "_template")
 }
 
 func TestFilterTests_SolutionTestPattern(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"smoke-test": {Name: "smoke-test", Command: []string{"render"}},
 				"other-test": {Name: "other-test", Command: []string{"run"}},
 			},
@@ -160,15 +162,15 @@ func TestFilterTests_SolutionTestPattern(t *testing.T) {
 	})
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].Tests, "smoke-test")
-	assert.NotContains(t, result[0].Tests, "other-test")
+	assert.Contains(t, result[0].Cases, "smoke-test")
+	assert.NotContains(t, result[0].Cases, "other-test")
 }
 
 func TestFilterTests_TagFilter(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"smoke-test":       {Name: "smoke-test", Tags: []string{"smoke", "fast"}, Command: []string{"x"}},
 				"integration-test": {Name: "integration-test", Tags: []string{"integration"}, Command: []string{"y"}},
 			},
@@ -180,21 +182,21 @@ func TestFilterTests_TagFilter(t *testing.T) {
 	})
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].Tests, "smoke-test")
-	assert.NotContains(t, result[0].Tests, "integration-test")
+	assert.Contains(t, result[0].Cases, "smoke-test")
+	assert.NotContains(t, result[0].Cases, "integration-test")
 }
 
 func TestFilterTests_SolutionFilter(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "alpha",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"test1": {Name: "test1", Command: []string{"x"}},
 			},
 		},
 		{
 			SolutionName: "beta",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"test2": {Name: "test2", Command: []string{"y"}},
 			},
 		},
@@ -212,7 +214,7 @@ func TestFilterTests_CombinedAND(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"smoke-fast": {Name: "smoke-fast", Tags: []string{"smoke"}, Command: []string{"x"}},
 				"smoke-slow": {Name: "smoke-slow", Tags: []string{"integration"}, Command: []string{"y"}},
 				"other":      {Name: "other", Tags: []string{"smoke"}, Command: []string{"z"}},
@@ -226,16 +228,16 @@ func TestFilterTests_CombinedAND(t *testing.T) {
 	})
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].Tests, "smoke-fast")
-	assert.NotContains(t, result[0].Tests, "smoke-slow")
-	assert.NotContains(t, result[0].Tests, "other")
+	assert.Contains(t, result[0].Cases, "smoke-fast")
+	assert.NotContains(t, result[0].Cases, "smoke-slow")
+	assert.NotContains(t, result[0].Cases, "other")
 }
 
 func TestFilterTests_TemplateExclusion(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"test1":     {Name: "test1", Command: []string{"x"}},
 				"_template": {Name: "_template", Command: []string{"y"}},
 			},
@@ -245,15 +247,15 @@ func TestFilterTests_TemplateExclusion(t *testing.T) {
 	result := soltesting.FilterTests(solutions, soltesting.FilterOptions{})
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].Tests, "test1")
-	assert.NotContains(t, result[0].Tests, "_template")
+	assert.Contains(t, result[0].Cases, "test1")
+	assert.NotContains(t, result[0].Cases, "_template")
 }
 
 func TestFilterTests_NoFilters(t *testing.T) {
 	solutions := []soltesting.SolutionTests{
 		{
 			SolutionName: "my-solution",
-			Tests: map[string]*soltesting.TestCase{
+			Cases: map[string]*soltesting.TestCase{
 				"test1": {Name: "test1", Command: []string{"x"}},
 				"test2": {Name: "test2", Command: []string{"y"}},
 			},
@@ -263,12 +265,12 @@ func TestFilterTests_NoFilters(t *testing.T) {
 	result := soltesting.FilterTests(solutions, soltesting.FilterOptions{})
 
 	require.Len(t, result, 1)
-	assert.Len(t, result[0].Tests, 2)
+	assert.Len(t, result[0].Cases, 2)
 }
 
 func TestSortedTestNames(t *testing.T) {
 	st := soltesting.SolutionTests{
-		Tests: map[string]*soltesting.TestCase{
+		Cases: map[string]*soltesting.TestCase{
 			"z-test":        {Name: "z-test"},
 			"a-test":        {Name: "a-test"},
 			"builtin:lint":  {Name: "builtin:lint"},

--- a/pkg/solution/soltesting/generate.go
+++ b/pkg/solution/soltesting/generate.go
@@ -58,7 +58,7 @@ type GenerateResult struct {
 	// TestName is the (possibly derived) name of the test.
 	TestName string `json:"testName" yaml:"testName"`
 
-	// TestCase is the generated test case, ready to paste into spec.tests.
+	// TestCase is the generated test case, ready to paste into spec.testing.cases.
 	TestCase *TestCase `json:"testCase" yaml:"testCase"`
 
 	// SnapshotPath is the relative (or absolute) path where the snapshot file was
@@ -195,7 +195,7 @@ func DeriveTestName(command, args []string) string {
 }
 
 // GenerateToYAML marshals a GenerateResult to YAML ready for pasting into the
-// spec.tests section of a solution file. The outer key is the test name.
+// spec.testing.cases section of a solution file. The outer key is the test name.
 func GenerateToYAML(result *GenerateResult) ([]byte, error) {
 	wrapper := map[string]*TestCase{
 		result.TestName: result.TestCase,

--- a/pkg/solution/soltesting/mockserver/mockserver.go
+++ b/pkg/solution/soltesting/mockserver/mockserver.go
@@ -1,0 +1,281 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mockserver provides a configurable HTTP mock server for functional testing.
+// It is designed to run as a test service, started by the test runner before
+// test execution and stopped afterward. Routes are defined declaratively in
+// solution YAML via the TestConfig.Services field.
+package mockserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Route defines a single mock HTTP endpoint.
+type Route struct {
+	// Path is the URL path to match (exact match).
+	Path string `json:"path" yaml:"path" doc:"URL path to match (exact)" maxLength:"500"`
+
+	// Method is the HTTP method to match. Empty matches all methods.
+	Method string `json:"method,omitempty" yaml:"method,omitempty" doc:"HTTP method to match (empty = all)" maxLength:"10"`
+
+	// Status is the HTTP status code to return (default: 200).
+	Status int `json:"status,omitempty" yaml:"status,omitempty" doc:"HTTP status code to return" maximum:"599"`
+
+	// Body is the response body string.
+	Body string `json:"body,omitempty" yaml:"body,omitempty" doc:"Response body" maxLength:"100000"`
+
+	// Headers are response headers to set.
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty" doc:"Response headers"`
+
+	// Delay is the simulated response delay as a Go duration string (e.g., "100ms").
+	Delay string `json:"delay,omitempty" yaml:"delay,omitempty" doc:"Simulated response delay" maxLength:"20"`
+
+	// Echo when true returns the request details as JSON instead of Body.
+	Echo bool `json:"echo,omitempty" yaml:"echo,omitempty" doc:"Return request details as JSON"`
+}
+
+// EchoResponse is the JSON body returned when Echo is true.
+type EchoResponse struct {
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Headers map[string]string `json:"headers"`
+	Body    string            `json:"body"`
+	Query   map[string]string `json:"query"`
+}
+
+// Request records a received HTTP request for later inspection.
+type Request struct {
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Headers map[string]string `json:"headers"`
+	Body    string            `json:"body"`
+	Time    time.Time         `json:"time"`
+}
+
+// Server is a configurable HTTP mock server for testing.
+type Server struct {
+	routes   []Route
+	server   *http.Server
+	listener net.Listener
+	port     int
+	requests []Request
+	mu       sync.Mutex
+}
+
+// New creates a new mock server with the given routes.
+func New(routes []Route) *Server {
+	return &Server{
+		routes: routes,
+	}
+}
+
+// Start begins listening on a random available port.
+// The assigned port can be retrieved via Port().
+func (s *Server) Start() error {
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listening: %w", err)
+	}
+
+	s.listener = listener
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("unexpected listener address type: %T", listener.Addr())
+	}
+	s.port = tcpAddr.Port
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handler)
+
+	s.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		_ = s.server.Serve(listener)
+	}()
+
+	return s.waitReady()
+}
+
+// waitReady polls the server until it responds.
+func (s *Server) waitReady() error {
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/__health", s.port), nil)
+		if err != nil {
+			return fmt.Errorf("creating health request: %w", err)
+		}
+		resp, err := client.Do(req) //nolint:gosec // health-check URL is constructed from a known local port, not user input
+		if err == nil {
+			resp.Body.Close()
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return fmt.Errorf("server not ready after 5s")
+}
+
+// Stop shuts down the server gracefully.
+func (s *Server) Stop() error {
+	if s.server == nil {
+		return nil
+	}
+	return s.server.Close()
+}
+
+// Port returns the port the server is listening on.
+func (s *Server) Port() int {
+	return s.port
+}
+
+// BaseURL returns the base URL for the server (e.g., "http://127.0.0.1:12345").
+func (s *Server) BaseURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", s.port)
+}
+
+// Requests returns a copy of all recorded requests.
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]Request, len(s.requests))
+	copy(cp, s.requests)
+	return cp
+}
+
+// handler routes incoming requests to configured routes.
+func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/__health" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	s.recordRequest(r)
+
+	route := s.matchRoute(r)
+	if route == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":  "no route matched",
+			"path":   r.URL.Path,
+			"method": r.Method,
+		})
+		return
+	}
+
+	if route.Delay != "" {
+		d, err := time.ParseDuration(route.Delay)
+		if err == nil {
+			time.Sleep(d)
+		}
+	}
+
+	for k, v := range route.Headers {
+		w.Header().Set(k, v)
+	}
+
+	status := route.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+
+	if route.Echo {
+		s.handleEcho(w, r, status)
+		return
+	}
+
+	if w.Header().Get("Content-Type") == "" && route.Body != "" {
+		trimmed := strings.TrimSpace(route.Body)
+		if (strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}")) ||
+			(strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]")) {
+			w.Header().Set("Content-Type", "application/json")
+		} else {
+			w.Header().Set("Content-Type", "text/plain")
+		}
+	}
+
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, route.Body) //nolint:gosec // route body is test-defined, not user-tainted input
+}
+
+// handleEcho returns request details as JSON.
+func (s *Server) handleEcho(w http.ResponseWriter, r *http.Request, status int) {
+	body, _ := io.ReadAll(r.Body)
+
+	headers := make(map[string]string)
+	for k, v := range r.Header {
+		headers[k] = strings.Join(v, ", ")
+	}
+
+	query := make(map[string]string)
+	for k, v := range r.URL.Query() {
+		query[k] = strings.Join(v, ", ")
+	}
+
+	echo := EchoResponse{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: headers,
+		Body:    string(body),
+		Query:   query,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(echo) //nolint:errcheck
+}
+
+// recordRequest saves request details for later inspection.
+func (s *Server) recordRequest(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(strings.NewReader(string(body)))
+
+	headers := make(map[string]string)
+	for k, v := range r.Header {
+		headers[k] = strings.Join(v, ", ")
+	}
+
+	s.mu.Lock()
+	s.requests = append(s.requests, Request{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: headers,
+		Body:    string(body),
+		Time:    time.Now(),
+	})
+	s.mu.Unlock()
+}
+
+// matchRoute finds the first route that matches the request.
+func (s *Server) matchRoute(r *http.Request) *Route {
+	for i := range s.routes {
+		route := &s.routes[i]
+
+		if route.Path != r.URL.Path {
+			continue
+		}
+
+		if route.Method != "" && !strings.EqualFold(route.Method, r.Method) {
+			continue
+		}
+
+		return route
+	}
+	return nil
+}

--- a/pkg/solution/soltesting/mockserver/mockserver_test.go
+++ b/pkg/solution/soltesting/mockserver/mockserver_test.go
@@ -1,0 +1,244 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mockserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpGet is a test helper that performs a GET request with a background context.
+func httpGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// httpPost is a test helper that performs a POST request with a background context.
+func httpPost(t *testing.T, url, contentType string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
+	require.NoError(t, err)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestNew(t *testing.T) {
+	routes := []Route{
+		{Path: "/test", Status: 200, Body: "ok"},
+	}
+	s := New(routes)
+	assert.NotNil(t, s)
+	assert.Len(t, s.routes, 1)
+}
+
+func TestStartStop(t *testing.T) {
+	s := New(nil)
+	require.NoError(t, s.Start())
+	assert.Greater(t, s.Port(), 0)
+	assert.Contains(t, s.BaseURL(), fmt.Sprintf(":%d", s.Port()))
+	require.NoError(t, s.Stop())
+}
+
+func TestStopIdempotent(t *testing.T) {
+	s := New(nil)
+	assert.NoError(t, s.Stop())
+}
+
+func TestStaticRoute(t *testing.T) {
+	s := New([]Route{
+		{
+			Path:   "/api/data",
+			Method: "GET",
+			Status: 200,
+			Body:   "{\"key\":\"value\"}",
+			Headers: map[string]string{
+				"X-Custom": "test-header",
+			},
+		},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/api/data", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "test-header", resp.Header.Get("X-Custom"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "{\"key\":\"value\"}", string(body))
+}
+
+func TestStaticRoutePlainText(t *testing.T) {
+	s := New([]Route{
+		{Path: "/hello", Body: "hello world"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/hello", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "text/plain", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(body))
+}
+
+func TestErrorStatus(t *testing.T) {
+	s := New([]Route{
+		{Path: "/error", Status: 500, Body: "{\"error\":\"internal\"}"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/error", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 500, resp.StatusCode)
+}
+
+func TestMethodMatching(t *testing.T) {
+	s := New([]Route{
+		{Path: "/api", Method: "POST", Status: 201, Body: "{\"created\":true}"},
+		{Path: "/api", Method: "GET", Status: 200, Body: "{\"list\":true}"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/api", s.BaseURL()))
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	resp2 := httpPost(t, fmt.Sprintf("%s/api", s.BaseURL()), "application/json")
+	defer resp2.Body.Close()
+	assert.Equal(t, 201, resp2.StatusCode)
+}
+
+func TestNoRouteMatch(t *testing.T) {
+	s := New([]Route{
+		{Path: "/exists", Status: 200},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/not-found", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestEchoRoute(t *testing.T) {
+	s := New([]Route{
+		{Path: "/echo", Echo: true},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpPost(t, fmt.Sprintf("%s/echo?key=val", s.BaseURL()), "text/plain")
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var echo EchoResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&echo))
+	assert.Equal(t, "POST", echo.Method)
+	assert.Equal(t, "/echo", echo.Path)
+	assert.Equal(t, "val", echo.Query["key"])
+}
+
+func TestDelay(t *testing.T) {
+	s := New([]Route{
+		{Path: "/slow", Delay: "100ms", Body: "delayed"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	start := time.Now()
+	resp := httpGet(t, fmt.Sprintf("%s/slow", s.BaseURL()))
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond)
+}
+
+func TestRequestRecording(t *testing.T) {
+	s := New([]Route{
+		{Path: "/record", Echo: true},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp1 := httpGet(t, fmt.Sprintf("%s/record", s.BaseURL()))
+	resp1.Body.Close()
+
+	resp2 := httpPost(t, fmt.Sprintf("%s/record", s.BaseURL()), "")
+	resp2.Body.Close()
+
+	reqs := s.Requests()
+	assert.Len(t, reqs, 2)
+	assert.Equal(t, "GET", reqs[0].Method)
+	assert.Equal(t, "POST", reqs[1].Method)
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	s := New(nil)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/__health", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestWildcardMethod(t *testing.T) {
+	s := New([]Route{
+		{Path: "/any", Body: "any-method"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/any", s.BaseURL()))
+	resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	resp2 := httpPost(t, fmt.Sprintf("%s/any", s.BaseURL()), "")
+	resp2.Body.Close()
+	assert.Equal(t, 200, resp2.StatusCode)
+}
+
+func TestDefaultStatusIs200(t *testing.T) {
+	s := New([]Route{
+		{Path: "/default", Body: "ok"},
+	})
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	resp := httpGet(t, fmt.Sprintf("%s/default", s.BaseURL()))
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+}

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -211,7 +211,7 @@ func ReportList(solutions []SolutionTests, opts *kvx.OutputOptions, includeBuilt
 	var entries []listEntry
 	for _, st := range solutions {
 		if includeBuiltins {
-			builtins := BuiltinTests(st.TestConfig)
+			builtins := BuiltinTests(st.Config)
 			for _, b := range builtins {
 				entries = append(entries, listEntry{
 					Solution: st.SolutionName,
@@ -224,7 +224,7 @@ func ReportList(solutions []SolutionTests, opts *kvx.OutputOptions, includeBuilt
 
 		names := SortedTestNames(st)
 		for _, name := range names {
-			tc := st.Tests[name]
+			tc := st.Cases[name]
 			if tc.IsTemplate() {
 				continue
 			}

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/shellexec"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockserver"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
 )
@@ -93,15 +94,15 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 		st := &solutions[i]
 
 		// Generate builtins
-		builtins := BuiltinTests(st.TestConfig)
+		builtins := BuiltinTests(st.Config)
 		for _, b := range builtins {
-			st.Tests[b.Name] = b
+			st.Cases[b.Name] = b
 		}
 
 		// Resolve extends
-		if err := ResolveExtends(st.Tests); err != nil {
+		if err := ResolveExtends(st.Cases); err != nil {
 			// All tests in this solution get error status
-			for name := range st.Tests {
+			for name := range st.Cases {
 				result := TestResult{
 					Solution: st.SolutionName,
 					Test:     name,
@@ -115,7 +116,7 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 		}
 
 		// Validate all tests (skip builtins — they are generated internally)
-		for name, tc := range st.Tests {
+		for name, tc := range st.Cases {
 			if IsBuiltin(name) {
 				continue
 			}
@@ -128,7 +129,7 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 				}
 				r.emitTestComplete(result)
 				allResults = append(allResults, result)
-				delete(st.Tests, name)
+				delete(st.Cases, name)
 			}
 		}
 
@@ -144,7 +145,7 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 
 		if r.DryRun {
 			for _, name := range testNames {
-				tc := st.Tests[name]
+				tc := st.Cases[name]
 				if tc.IsTemplate() {
 					continue
 				}
@@ -175,8 +176,8 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 	solutionDir := filepath.Dir(st.FilePath)
 
 	// Run suite-level setup if configured
-	if st.TestConfig != nil && len(st.TestConfig.Setup) > 0 {
-		if err := r.runInitSteps(ctx, st.TestConfig.Setup, solutionDir, nil); err != nil {
+	if st.Config != nil && len(st.Config.Setup) > 0 {
+		if err := r.runInitSteps(ctx, st.Config.Setup, solutionDir, nil); err != nil {
 			// All tests become error status
 			results := make([]TestResult, 0, len(testNames))
 			for _, name := range testNames {
@@ -195,10 +196,73 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 
 	// Ensure suite-level cleanup runs after all tests
 	defer func() {
-		if st.TestConfig != nil && len(st.TestConfig.Cleanup) > 0 {
-			_ = r.runInitSteps(context.Background(), st.TestConfig.Cleanup, solutionDir, nil)
+		if st.Config != nil && len(st.Config.Cleanup) > 0 {
+			_ = r.runInitSteps(context.Background(), st.Config.Cleanup, solutionDir, nil)
 		}
 	}()
+
+	// Start background services (e.g., mock HTTP servers)
+	var serviceEnv map[string]string
+	if st.Config != nil && len(st.Config.Services) > 0 {
+		var servers []*mockserver.Server
+		serviceEnv = make(map[string]string)
+
+		// Ensure servers are stopped after all tests
+		defer func() {
+			for _, srv := range servers {
+				_ = srv.Stop()
+			}
+		}()
+
+		for _, svc := range st.Config.Services {
+			if svc.Type != "http" {
+				results := make([]TestResult, 0, len(testNames))
+				for _, name := range testNames {
+					result := TestResult{
+						Solution: st.SolutionName,
+						Test:     name,
+						Status:   StatusError,
+						Message:  fmt.Sprintf("unsupported service type: %s", svc.Type),
+					}
+					r.emitTestComplete(result)
+					results = append(results, result)
+				}
+				return results, nil
+			}
+
+			srv := mockserver.New(svc.Routes)
+			if err := srv.Start(); err != nil {
+				results := make([]TestResult, 0, len(testNames))
+				for _, name := range testNames {
+					result := TestResult{
+						Solution: st.SolutionName,
+						Test:     name,
+						Status:   StatusError,
+						Message:  fmt.Sprintf("service %q start failed: %s", svc.Name, err),
+					}
+					r.emitTestComplete(result)
+					results = append(results, result)
+				}
+				return results, nil
+			}
+			servers = append(servers, srv)
+
+			if svc.PortEnv != "" {
+				serviceEnv[svc.PortEnv] = fmt.Sprintf("%d", srv.Port())
+			}
+			if svc.BaseURLEnv != "" {
+				serviceEnv[svc.BaseURLEnv] = srv.BaseURL()
+			}
+		}
+
+		// Inject service env vars into testConfig.Env so buildEnvMap picks them up automatically.
+		if st.Config.Env == nil {
+			st.Config.Env = make(map[string]string)
+		}
+		for k, v := range serviceEnv {
+			st.Config.Env[k] = v
+		}
+	}
 
 	concurrency := r.Concurrency
 	if concurrency <= 1 {
@@ -309,7 +373,7 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 
 // runTestWithRetries runs a test, retrying on failure up to tc.Retries times.
 func (r *Runner) runTestWithRetries(ctx context.Context, st *SolutionTests, name, solutionDir string) TestResult {
-	tc := st.Tests[name]
+	tc := st.Cases[name]
 	if tc == nil {
 		return TestResult{
 			Solution: st.SolutionName,
@@ -409,7 +473,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 
 	// Run test init steps
 	if len(tc.Init) > 0 {
-		envMap := r.buildEnvMap(tc, st.TestConfig, sandbox.Path())
+		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
 		if err := r.runInitSteps(ctx, tc.Init, sandbox.Path(), envMap); err != nil {
 			result.Status = StatusError
 			result.Message = fmt.Sprintf("init step failed: %s", err)
@@ -504,7 +568,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 
 	// Run test cleanup steps
 	if len(tc.Cleanup) > 0 {
-		envMap := r.buildEnvMap(tc, st.TestConfig, sandbox.Path())
+		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
 		// Cleanup errors are not test failures, just log them
 		_ = r.runInitSteps(ctx, tc.Cleanup, sandbox.Path(), envMap)
 	}
@@ -561,7 +625,7 @@ func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st 
 
 	// Build isolated environment: inherit parent env + overlay test env vars.
 	// Each subprocess gets its own copy, so no races.
-	envMap := r.buildEnvMap(tc, st.TestConfig, sandbox.Path())
+	envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
 	cmd.Env = os.Environ()
 	for k, v := range envMap {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -89,11 +89,12 @@ func createTestSolution(t *testing.T, dir, name string) string {
 	content := `metadata:
   name: ` + name + `
 spec:
-  tests:
-    basic-test:
-      command: ["run"]
-      assertions:
-        - expression: "__exitCode == 0"
+  testing:
+    cases:
+      basic-test:
+        command: ["run"]
+        assertions:
+          - expression: "__exitCode == 0"
 `
 	path := filepath.Join(dir, "solution.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
@@ -113,8 +114,8 @@ func TestRunnerDryRun(t *testing.T) {
 		{
 			SolutionName: "test-solution",
 			FilePath:     "/tmp/solution.yaml",
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"my-test": {
 					Name:     "my-test",
 					Command:  []string{"run"},
@@ -147,8 +148,8 @@ func TestRunnerSkipTest(t *testing.T) {
 		{
 			SolutionName: "test-solution",
 			FilePath:     "/tmp/solution.yaml",
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"skipped-test": {
 					Name:       "skipped-test",
 					Command:    []string{"run"},
@@ -183,8 +184,8 @@ func TestRunnerPassingTest(t *testing.T) {
 		{
 			SolutionName: "passing-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"pass-test": {
 					Name:    "pass-test",
 					Command: []string{"run"},
@@ -217,8 +218,8 @@ func TestRunnerFailingTest(t *testing.T) {
 		{
 			SolutionName: "failing-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"fail-test": {
 					Name:     "fail-test",
 					Command:  []string{"run"},
@@ -251,8 +252,8 @@ func TestRunnerExpectFailure(t *testing.T) {
 		{
 			SolutionName: "expect-fail-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"expect-fail": {
 					Name:          "expect-fail",
 					Command:       []string{"run"},
@@ -305,8 +306,8 @@ func TestRunnerRetry(t *testing.T) {
 		{
 			SolutionName: "retry-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"retry-test": {
 					Name:     "retry-test",
 					Command:  []string{"run"},
@@ -343,8 +344,8 @@ func TestRunnerFailFast(t *testing.T) {
 		{
 			SolutionName: "failfast-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"aaa-first": {
 					Name:     "aaa-first",
 					Command:  []string{"run"},
@@ -404,8 +405,8 @@ func TestRunnerConcurrency(t *testing.T) {
 		{
 			SolutionName: "concurrent-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests:        tests,
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases:        tests,
 		},
 	}
 
@@ -432,8 +433,8 @@ func TestRunnerNoCommand(t *testing.T) {
 		{
 			SolutionName: "nocmd-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"no-command": {
 					Name: "no-command",
 					// No Command field — fails validation
@@ -463,8 +464,8 @@ func TestRunnerBuiltinParse(t *testing.T) {
 		{
 			SolutionName: "parse-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{Names: []string{"lint", "resolve-defaults", "render-defaults"}}},
-			Tests:        map[string]*TestCase{},
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{Names: []string{"lint", "resolve-defaults", "render-defaults"}}},
+			Cases:        map[string]*TestCase{},
 		},
 	}
 
@@ -498,8 +499,8 @@ func TestRunnerKeepSandbox(t *testing.T) {
 		{
 			SolutionName: "sandbox-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"keep-test": {
 					Name:     "keep-test",
 					Command:  []string{"run"},
@@ -921,8 +922,8 @@ func TestRunnerGlobalTimeout(t *testing.T) {
 		{
 			SolutionName: "timeout-sol",
 			FilePath:     solutionPath,
-			TestConfig:   &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
-			Tests: map[string]*TestCase{
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{All: true}},
+			Cases: map[string]*TestCase{
 				"slow-test": {
 					Name:     "slow-test",
 					Command:  []string{"run"},

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -15,8 +15,8 @@ import (
 
 // ScaffoldResult holds the generated test scaffold for a solution.
 type ScaffoldResult struct {
-	// Tests is a map of generated test cases keyed by name.
-	Tests map[string]*TestCase `json:"tests" yaml:"tests"`
+	// Cases is a map of generated test cases keyed by name.
+	Cases map[string]*TestCase `json:"cases" yaml:"cases"`
 }
 
 // ScaffoldInput provides the solution data needed for scaffold generation,
@@ -33,7 +33,7 @@ type ScaffoldInput struct {
 // It performs structural analysis only — no commands are executed.
 func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 	result := &ScaffoldResult{
-		Tests: make(map[string]*TestCase),
+		Cases: make(map[string]*TestCase),
 	}
 
 	// Always generate builtin-style tests
@@ -57,7 +57,7 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 // addResolveDefaultsTest adds a test that verifies all resolvers resolve with defaults.
 func addResolveDefaultsTest(result *ScaffoldResult) {
 	exitCodeZero := 0
-	result.Tests["resolve-defaults"] = &TestCase{
+	result.Cases["resolve-defaults"] = &TestCase{
 		Description: "Verify all resolvers resolve with default values",
 		Command:     []string{"run", "resolver"},
 		Args:        []string{"-o", "json"},
@@ -69,7 +69,7 @@ func addResolveDefaultsTest(result *ScaffoldResult) {
 // addRenderDefaultsTest adds a test that verifies the solution renders with defaults.
 func addRenderDefaultsTest(result *ScaffoldResult) {
 	exitCodeZero := 0
-	result.Tests["render-defaults"] = &TestCase{
+	result.Cases["render-defaults"] = &TestCase{
 		Description: "Verify solution renders with default values",
 		Command:     []string{"render", "solution"},
 		Tags:        []string{"smoke", "render"},
@@ -80,7 +80,7 @@ func addRenderDefaultsTest(result *ScaffoldResult) {
 // addLintTest adds a lint test.
 func addLintTest(result *ScaffoldResult) {
 	exitCodeZero := 0
-	result.Tests["lint"] = &TestCase{
+	result.Cases["lint"] = &TestCase{
 		Description: "Verify solution has no lint errors",
 		Command:     []string{"lint"},
 		Tags:        []string{"smoke", "lint"},
@@ -106,7 +106,7 @@ func addResolverTests(result *ScaffoldResult, resolvers map[string]*resolver.Res
 		// Generate a basic resolver output test
 		exitCodeZero := 0
 		testName := fmt.Sprintf("resolver-%s", name)
-		result.Tests[testName] = &TestCase{
+		result.Cases[testName] = &TestCase{
 			Description: fmt.Sprintf("Verify resolver %q produces expected output", name),
 			Command:     []string{"run", "resolver"},
 			Args:        []string{"--resolver", name, "-o", "json"},
@@ -145,7 +145,7 @@ func addResolverTests(result *ScaffoldResult, resolvers map[string]*resolver.Res
 
 			// Add parameter override with obviously invalid value
 			tc.Args = append(tc.Args, "--param", fmt.Sprintf("%s=___invalid___", name))
-			result.Tests[failTestName] = tc
+			result.Cases[failTestName] = tc
 		}
 	}
 }
@@ -185,16 +185,18 @@ func addActionTests(result *ScaffoldResult, wf *action.Workflow) {
 
 		exitCodeZero := 0
 		tc.ExitCode = &exitCodeZero
-		result.Tests[testName] = tc
+		result.Cases[testName] = tc
 	}
 }
 
 // ScaffoldToYAML marshals the scaffold result to YAML suitable for embedding
-// in a solution's spec.tests section.
+// in a solution's spec.testing.cases section.
 func ScaffoldToYAML(result *ScaffoldResult) ([]byte, error) {
-	// Build a wrapper that produces spec-level YAML: tests: { ... }
+	// Build a wrapper that produces spec-level YAML: testing: { cases: { ... } }
 	wrapper := map[string]any{
-		"tests": result.Tests,
+		"testing": map[string]any{
+			"cases": result.Cases,
+		},
 	}
 	return yaml.Marshal(wrapper)
 }

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -18,10 +18,10 @@ func TestScaffold_EmptyInput(t *testing.T) {
 	result := Scaffold(&ScaffoldInput{})
 
 	require.NotNil(t, result)
-	assert.Len(t, result.Tests, 3, "should contain resolve-defaults, render-defaults, and lint")
-	assert.Contains(t, result.Tests, "resolve-defaults")
-	assert.Contains(t, result.Tests, "render-defaults")
-	assert.Contains(t, result.Tests, "lint")
+	assert.Len(t, result.Cases, 3, "should contain resolve-defaults, render-defaults, and lint")
+	assert.Contains(t, result.Cases, "resolve-defaults")
+	assert.Contains(t, result.Cases, "render-defaults")
+	assert.Contains(t, result.Cases, "lint")
 }
 
 func TestScaffold_WithResolvers(t *testing.T) {
@@ -62,21 +62,21 @@ func TestScaffold_WithResolvers(t *testing.T) {
 	require.NotNil(t, result)
 
 	// 3 base tests + 2 resolver tests + 1 validation failure test = 6
-	assert.Len(t, result.Tests, 6)
+	assert.Len(t, result.Cases, 6)
 
 	// Base tests
-	assert.Contains(t, result.Tests, "resolve-defaults")
-	assert.Contains(t, result.Tests, "render-defaults")
-	assert.Contains(t, result.Tests, "lint")
+	assert.Contains(t, result.Cases, "resolve-defaults")
+	assert.Contains(t, result.Cases, "render-defaults")
+	assert.Contains(t, result.Cases, "lint")
 
 	// Resolver tests
-	assert.Contains(t, result.Tests, "resolver-repo")
-	assert.Contains(t, result.Tests, "resolver-version")
+	assert.Contains(t, result.Cases, "resolver-repo")
+	assert.Contains(t, result.Cases, "resolver-version")
 
 	// Validation failure test for version
-	assert.Contains(t, result.Tests, "resolver-version-invalid")
-	assert.True(t, result.Tests["resolver-version-invalid"].ExpectFailure)
-	assert.Contains(t, result.Tests["resolver-version-invalid"].Tags, "negative")
+	assert.Contains(t, result.Cases, "resolver-version-invalid")
+	assert.True(t, result.Cases["resolver-version-invalid"].ExpectFailure)
+	assert.Contains(t, result.Cases["resolver-version-invalid"].Tags, "negative")
 }
 
 func TestScaffold_WithActions(t *testing.T) {
@@ -100,13 +100,13 @@ func TestScaffold_WithActions(t *testing.T) {
 	require.NotNil(t, result)
 
 	// 3 base tests + 2 action tests = 5
-	assert.Len(t, result.Tests, 5)
-	assert.Contains(t, result.Tests, "action-build")
-	assert.Contains(t, result.Tests, "action-test")
+	assert.Len(t, result.Cases, 5)
+	assert.Contains(t, result.Cases, "action-build")
+	assert.Contains(t, result.Cases, "action-test")
 
 	// Action tests should include provider tag
-	assert.Contains(t, result.Tests["action-build"].Tags, "exec")
-	assert.Contains(t, result.Tests["action-build"].Tags, "actions")
+	assert.Contains(t, result.Cases["action-build"].Tags, "exec")
+	assert.Contains(t, result.Cases["action-build"].Tags, "actions")
 }
 
 func TestScaffold_ConditionalAction(t *testing.T) {
@@ -127,8 +127,8 @@ func TestScaffold_ConditionalAction(t *testing.T) {
 	result := Scaffold(input)
 
 	require.NotNil(t, result)
-	assert.Contains(t, result.Tests, "action-release")
-	assert.Contains(t, result.Tests["action-release"].Tags, "conditional")
+	assert.Contains(t, result.Cases, "action-release")
+	assert.Contains(t, result.Cases["action-release"].Tags, "conditional")
 }
 
 func TestScaffold_ResolverWithValidationExpression(t *testing.T) {
@@ -157,8 +157,8 @@ func TestScaffold_ResolverWithValidationExpression(t *testing.T) {
 
 	result := Scaffold(input)
 
-	assert.Contains(t, result.Tests, "resolver-goos-invalid")
-	tc := result.Tests["resolver-goos-invalid"]
+	assert.Contains(t, result.Cases, "resolver-goos-invalid")
+	tc := result.Cases["resolver-goos-invalid"]
 	assert.True(t, tc.ExpectFailure)
 	assert.Contains(t, tc.Description, "expression")
 }
@@ -200,7 +200,8 @@ func TestScaffoldToYAML_ContainsExpectedContent(t *testing.T) {
 	out, err := ScaffoldToYAML(result)
 
 	require.NoError(t, err)
-	assert.Contains(t, string(out), "tests:")
+	assert.Contains(t, string(out), "testing:")
+	assert.Contains(t, string(out), "cases:")
 	assert.Contains(t, string(out), "resolve-defaults")
 	assert.Contains(t, string(out), "resolver-repo")
 }

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -5,7 +5,7 @@
 // It defines the test case specification, assertion types, and result structures
 // used by the `scafctl test functional` and `scafctl test list` commands.
 //
-// Test definitions live under `spec.tests` in solution YAML and support
+// Test definitions live under `spec.testing` in solution YAML and support
 // compose-based splitting into separate files.
 package soltesting
 
@@ -18,6 +18,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockserver"
 	"gopkg.in/yaml.v3"
 )
 
@@ -157,6 +158,27 @@ func (s SkipBuiltinsValue) IsSkipped() bool {
 	return s.All || len(s.Names) > 0
 }
 
+// TestSuite groups all test-related configuration under a single top-level property.
+type TestSuite struct {
+	// Config holds solution-level test configuration.
+	Config *TestConfig `json:"config,omitempty" yaml:"config,omitempty" doc:"Test configuration"`
+
+	// Cases is a map of functional test definitions keyed by test name.
+	// Test names must be unique and must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$.
+	// Names starting with _ are templates that are not executed directly.
+	Cases map[string]*TestCase `json:"cases,omitempty" yaml:"cases,omitempty" doc:"Test case definitions keyed by name"`
+}
+
+// HasCases returns true if the suite contains any test case definitions.
+func (ts *TestSuite) HasCases() bool {
+	return ts != nil && len(ts.Cases) > 0
+}
+
+// HasConfig returns true if the suite has test configuration.
+func (ts *TestSuite) HasConfig() bool {
+	return ts != nil && ts.Config != nil
+}
+
 // TestConfig holds solution-level test configuration.
 type TestConfig struct {
 	// SkipBuiltins disables builtin tests. true for all, or list of specific names.
@@ -170,6 +192,30 @@ type TestConfig struct {
 
 	// Cleanup contains suite-level teardown steps run once after all tests complete, even on failure.
 	Cleanup []InitStep `json:"cleanup,omitempty" yaml:"cleanup,omitempty" doc:"Suite-level teardown steps. Run once after all tests complete, even on failure" maxItems:"50"`
+
+	// Services defines background services started before tests and stopped after.
+	// Currently supports "http" type which starts a mock HTTP server.
+	Services []ServiceConfig `json:"services,omitempty" yaml:"services,omitempty" doc:"Background services started before tests" maxItems:"10"`
+}
+
+// ServiceConfig defines a background service for test infrastructure.
+type ServiceConfig struct {
+	// Name is a unique identifier for the service within this solution's tests.
+	Name string `json:"name" yaml:"name" doc:"Unique service identifier" maxLength:"100" pattern:"^[a-zA-Z0-9][a-zA-Z0-9_-]*$"`
+
+	// Type is the service type. Currently only "http" is supported.
+	Type string `json:"type" yaml:"type" doc:"Service type" pattern:"^http$" patternDescription:"Must be: http"`
+
+	// PortEnv is the environment variable name where the assigned port is exposed.
+	// Tests can reference this via testConfig.env or in resolver inputs (e.g., $MOCK_HTTP_PORT).
+	PortEnv string `json:"portEnv" yaml:"portEnv" doc:"Env var name for assigned port" maxLength:"100" pattern:"^[A-Z][A-Z0-9_]*$"`
+
+	// BaseURLEnv is the environment variable name where the base URL is exposed (e.g., http://127.0.0.1:PORT).
+	// Optional — if empty, only PortEnv is set.
+	BaseURLEnv string `json:"baseUrlEnv,omitempty" yaml:"baseUrlEnv,omitempty" doc:"Env var name for base URL" maxLength:"100"`
+
+	// Routes defines the mock HTTP routes (only used when Type is "http").
+	Routes []mockserver.Route `json:"routes,omitempty" yaml:"routes,omitempty" doc:"Mock HTTP routes" maxItems:"100"`
 }
 
 // InitStep is a setup/cleanup command.

--- a/pkg/solution/soltesting/watch.go
+++ b/pkg/solution/soltesting/watch.go
@@ -321,7 +321,9 @@ func discoverSolutionFiles(filePath string) (*SolutionInfo, error) {
 		Kind       string   `yaml:"kind"`
 		Compose    []string `yaml:"compose"`
 		Spec       struct {
-			Tests map[string]any `yaml:"tests"`
+			Testing *struct {
+				Cases map[string]any `yaml:"cases"`
+			} `yaml:"testing"`
 		} `yaml:"spec"`
 	}
 
@@ -330,7 +332,7 @@ func discoverSolutionFiles(filePath string) (*SolutionInfo, error) {
 	}
 
 	// Only watch solution files (must be a Solution kind or have tests).
-	if doc.Kind != "Solution" && len(doc.Spec.Tests) == 0 {
+	if doc.Kind != "Solution" && (doc.Spec.Testing == nil || len(doc.Spec.Testing.Cases) == 0) {
 		return nil, nil
 	}
 

--- a/pkg/solution/spec.go
+++ b/pkg/solution/spec.go
@@ -22,13 +22,8 @@ type Spec struct {
 	// All resolvers are evaluated before any action execution begins.
 	Workflow *action.Workflow `json:"workflow,omitempty" yaml:"workflow,omitempty" doc:"Action workflow specification"`
 
-	// Tests is a map of functional test definitions keyed by test name.
-	// Test names must be unique and must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$.
-	// Names starting with _ are templates that are not executed directly.
-	Tests map[string]*soltesting.TestCase `json:"tests,omitempty" yaml:"tests,omitempty" doc:"Functional test definitions keyed by name"`
-
-	// TestConfig holds solution-level test configuration.
-	TestConfig *soltesting.TestConfig `json:"testConfig,omitempty" yaml:"testConfig,omitempty" doc:"Solution-level test configuration"`
+	// Testing groups all test-related configuration (test cases and config) under one property.
+	Testing *soltesting.TestSuite `json:"testing,omitempty" yaml:"testing,omitempty" doc:"Test suite configuration"`
 }
 
 // ResolversToSlice converts the Resolvers map to a slice for execution.
@@ -68,12 +63,17 @@ func (s *Spec) HasActions() bool {
 	return len(s.Workflow.Actions) > 0 || len(s.Workflow.Finally) > 0
 }
 
+// HasTesting returns true if the spec has a testing suite defined.
+func (s *Spec) HasTesting() bool {
+	return s != nil && s.Testing != nil
+}
+
 // HasTests returns true if the spec contains any test definitions.
 func (s *Spec) HasTests() bool {
-	return s != nil && len(s.Tests) > 0
+	return s != nil && s.Testing.HasCases()
 }
 
 // HasTestConfig returns true if the spec has test configuration.
 func (s *Spec) HasTestConfig() bool {
-	return s != nil && s.TestConfig != nil
+	return s != nil && s.Testing.HasConfig()
 }

--- a/pkg/solution/spec_test.go
+++ b/pkg/solution/spec_test.go
@@ -515,11 +515,12 @@ func TestSpec_HasTests(t *testing.T) {
 	}{
 		{"nil spec", nil, false},
 		{"empty spec", &Spec{}, false},
-		{"nil tests", &Spec{Tests: nil}, false},
-		{"empty tests map", &Spec{Tests: map[string]*soltesting.TestCase{}}, false},
-		{"has tests", &Spec{Tests: map[string]*soltesting.TestCase{
+		{"nil testing", &Spec{Testing: nil}, false},
+		{"nil cases", &Spec{Testing: &soltesting.TestSuite{Cases: nil}}, false},
+		{"empty cases map", &Spec{Testing: &soltesting.TestSuite{Cases: map[string]*soltesting.TestCase{}}}, false},
+		{"has cases", &Spec{Testing: &soltesting.TestSuite{Cases: map[string]*soltesting.TestCase{
 			"test1": {Name: "test1"},
-		}}, true},
+		}}}, true},
 	}
 
 	for _, tt := range tests {
@@ -537,8 +538,9 @@ func TestSpec_HasTestConfig(t *testing.T) {
 	}{
 		{"nil spec", nil, false},
 		{"empty spec", &Spec{}, false},
-		{"nil testConfig", &Spec{TestConfig: nil}, false},
-		{"has testConfig", &Spec{TestConfig: &soltesting.TestConfig{}}, true},
+		{"nil testing", &Spec{Testing: nil}, false},
+		{"nil config", &Spec{Testing: &soltesting.TestSuite{Config: nil}}, false},
+		{"has config", &Spec{Testing: &soltesting.TestSuite{Config: &soltesting.TestConfig{}}}, true},
 	}
 
 	for _, tt := range tests {
@@ -563,27 +565,28 @@ spec:
           - provider: parameter
             inputs:
               key: "env"
-  tests:
-    render-test:
-      description: "Test rendering"
-      command:
-        - render
-        - solution
-      assertions:
-        - contains: "hello"
-      tags:
-        - smoke
-    _base-template:
-      description: "Base template"
-      command:
-        - render
-        - solution
-  testConfig:
-    skipBuiltins: false
-    env:
-      MY_VAR: "value"
-    setup:
-      - command: "echo setup"
+  testing:
+    cases:
+      render-test:
+        description: "Test rendering"
+        command:
+          - render
+          - solution
+        assertions:
+          - contains: "hello"
+        tags:
+          - smoke
+      _base-template:
+        description: "Base template"
+        command:
+          - render
+          - solution
+    config:
+      skipBuiltins: false
+      env:
+        MY_VAR: "value"
+      setup:
+        - command: "echo setup"
 `
 	var sol Solution
 	err := sol.UnmarshalFromBytes([]byte(yamlContent))
@@ -591,9 +594,10 @@ spec:
 
 	assert.True(t, sol.Spec.HasTests())
 	assert.True(t, sol.Spec.HasTestConfig())
-	require.Len(t, sol.Spec.Tests, 2)
+	require.NotNil(t, sol.Spec.Testing)
+	require.Len(t, sol.Spec.Testing.Cases, 2)
 
-	renderTest := sol.Spec.Tests["render-test"]
+	renderTest := sol.Spec.Testing.Cases["render-test"]
 	require.NotNil(t, renderTest)
 	assert.Equal(t, "Test rendering", renderTest.Description)
 	assert.Equal(t, []string{"render", "solution"}, renderTest.Command)
@@ -601,15 +605,15 @@ spec:
 	assert.Equal(t, "hello", renderTest.Assertions[0].Contains)
 	assert.Equal(t, []string{"smoke"}, renderTest.Tags)
 
-	baseTemplate := sol.Spec.Tests["_base-template"]
+	baseTemplate := sol.Spec.Testing.Cases["_base-template"]
 	require.NotNil(t, baseTemplate)
 	assert.Equal(t, "Base template", baseTemplate.Description)
 
-	require.NotNil(t, sol.Spec.TestConfig)
-	assert.False(t, sol.Spec.TestConfig.SkipBuiltins.All)
-	assert.Equal(t, "value", sol.Spec.TestConfig.Env["MY_VAR"])
-	require.Len(t, sol.Spec.TestConfig.Setup, 1)
-	assert.Equal(t, "echo setup", sol.Spec.TestConfig.Setup[0].Command)
+	require.NotNil(t, sol.Spec.Testing.Config)
+	assert.False(t, sol.Spec.Testing.Config.SkipBuiltins.All)
+	assert.Equal(t, "value", sol.Spec.Testing.Config.Env["MY_VAR"])
+	require.Len(t, sol.Spec.Testing.Config.Setup, 1)
+	assert.Equal(t, "echo setup", sol.Spec.Testing.Config.Setup[0].Command)
 }
 
 func TestSolution_RoundTrip_WithTests(t *testing.T) {
@@ -627,16 +631,17 @@ spec:
           - provider: parameter
             inputs:
               key: "env"
-  tests:
-    my-test:
-      description: "A test"
-      command:
-        - render
-        - solution
-      assertions:
-        - contains: "output"
-  testConfig:
-    skipBuiltins: true
+  testing:
+    cases:
+      my-test:
+        description: "A test"
+        command:
+          - render
+          - solution
+        assertions:
+          - contains: "output"
+    config:
+      skipBuiltins: true
 `
 	var sol Solution
 	err := sol.UnmarshalFromBytes([]byte(yamlContent))
@@ -653,12 +658,12 @@ spec:
 
 	// Verify tests survived round-trip
 	assert.True(t, sol2.Spec.HasTests())
-	require.Contains(t, sol2.Spec.Tests, "my-test")
-	assert.Equal(t, "A test", sol2.Spec.Tests["my-test"].Description)
+	require.Contains(t, sol2.Spec.Testing.Cases, "my-test")
+	assert.Equal(t, "A test", sol2.Spec.Testing.Cases["my-test"].Description)
 
 	// Verify testConfig survived round-trip (including SkipBuiltinsValue)
 	assert.True(t, sol2.Spec.HasTestConfig())
-	assert.True(t, sol2.Spec.TestConfig.SkipBuiltins.All)
+	assert.True(t, sol2.Spec.Testing.Config.SkipBuiltins.All)
 }
 
 func TestSolution_BackwardCompat_NoTests(t *testing.T) {
@@ -684,6 +689,5 @@ spec:
 
 	assert.False(t, sol.Spec.HasTests())
 	assert.False(t, sol.Spec.HasTestConfig())
-	assert.Nil(t, sol.Spec.Tests)
-	assert.Nil(t, sol.Spec.TestConfig)
+	assert.Nil(t, sol.Spec.Testing)
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3292,14 +3292,15 @@ spec:
           - provider: static
             inputs:
               value: hello
-  tests:
-    basic-render:
-      description: Verify render works
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: greeting
+  testing:
+    cases:
+      basic-render:
+        description: Verify render works
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: greeting
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3335,13 +3336,14 @@ spec:
           - provider: static
             inputs:
               value: hello
-  tests:
-    fail-on-purpose:
-      description: This test should fail
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - contains: this-string-definitely-does-not-exist-in-output
+  testing:
+    cases:
+      fail-on-purpose:
+        description: This test should fail
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - contains: this-string-definitely-does-not-exist-in-output
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3375,19 +3377,20 @@ spec:
           - provider: static
             inputs:
               value: hi
-  tests:
-    smoke-test:
-      description: Smoke test
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [smoke]
-      assertions:
-        - expression: __exitCode == 0
-    another-test:
-      description: Another test
-      command: [lint]
-      assertions:
-        - expression: __exitCode == 0
+  testing:
+    cases:
+      smoke-test:
+        description: Smoke test
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
+      another-test:
+        description: Another test
+        command: [lint]
+        assertions:
+          - expression: __exitCode == 0
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3424,13 +3427,14 @@ spec:
           - provider: static
             inputs:
               value: data
-  tests:
-    json-test:
-      description: Test with JSON output
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
+  testing:
+    cases:
+      json-test:
+        description: Test with JSON output
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3470,13 +3474,14 @@ spec:
           - provider: static
             inputs:
               value: data
-  tests:
-    junit-test:
-      description: Test for JUnit report
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
+  testing:
+    cases:
+      junit-test:
+        description: Test for JUnit report
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3522,13 +3527,14 @@ spec:
           - provider: static
             inputs:
               value: data
-  tests:
-    dry-test:
-      description: Dry run test
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - contains: impossible-string-that-would-fail
+  testing:
+    cases:
+      dry-test:
+        description: Dry run test
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - contains: impossible-string-that-would-fail
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3566,19 +3572,20 @@ spec:
           - provider: static
             inputs:
               value: data
-  tests:
-    render-pass:
-      description: This test should run and pass
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
-    skipped-test:
-      description: This test should not run due to filter
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - contains: impossible-string-that-would-fail
+  testing:
+    cases:
+      render-pass:
+        description: This test should run and pass
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+      skipped-test:
+        description: This test should not run due to filter
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - contains: impossible-string-that-would-fail
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
@@ -3620,21 +3627,23 @@ spec:
           - provider: static
             inputs:
               value: composed-output
-  tests:
-    _base:
-      description: Base template
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
+  testing:
+    cases:
+      _base:
+        description: Base template
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
 `
 	testFileContent := `spec:
-  tests:
-    composed-test:
-      description: Test from composed file
-      extends: [_base]
-      assertions:
-        - expression: '"msg" in __output'
+  testing:
+    cases:
+      composed-test:
+        description: Test from composed file
+        extends: [_base]
+        assertions:
+          - expression: '"msg" in __output'
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(testsDir, "smoke.yaml"), []byte(testFileContent), 0o644))
@@ -3697,7 +3706,7 @@ spec:
 	t.Logf("stderr: %s", stderr)
 
 	assert.Equal(t, 0, exitCode, "expected exit code 0")
-	assert.Contains(t, stdout, "tests:")
+	assert.Contains(t, stdout, "cases:")
 	assert.Contains(t, stdout, "resolve-defaults")
 	assert.Contains(t, stdout, "render-defaults")
 	assert.Contains(t, stdout, "lint")

--- a/tests/integration/solutions/README.md
+++ b/tests/integration/solutions/README.md
@@ -38,7 +38,12 @@ tests/integration/solutions/
 │   ├── directory/            # Directory list/mkdir
 │   ├── go-template/          # Go template rendering
 │   ├── validation/           # Match/notMatch/expression validation
-│   └── sleep/                # Sleep/timing
+│   ├── sleep/                # Sleep/timing
+│   ├── http/                 # HTTP requests (via mock server)
+│   ├── git/                  # Git operations (via local bare repo)
+│   ├── debug/                # Debug output formatting
+│   ├── parameter/            # CLI parameter passing (-r flag)
+│   └── solution/             # Sub-solution composition
 ├── resolvers/                # Resolver feature tests
 │   ├── dag/                  # Dependency graph ordering
 │   ├── until/                # Fallback chains, until conditions
@@ -46,13 +51,28 @@ tests/integration/solutions/
 │   ├── transform-chain/      # Multi-step transform pipelines
 │   ├── conditional/          # When conditions
 │   ├── timeout/              # Per-resolver timeout
+│   ├── foreach-filter/       # ForEach filter tests
 │   └── sensitive/            # Sensitive value masking
+├── actions/                  # Workflow action tests
+│   ├── exclusive/            # Mutual exclusion (exclusive field)
+│   ├── sequential/           # Sequential dependsOn chains
+│   ├── conditional/          # When conditions on actions
+│   ├── parallel/             # Parallel execution with dependencies
+│   ├── error-handling/       # onError continue/fail behavior
+│   ├── retry/                # Retry with fixed/exponential/linear backoff
+│   ├── conditional-retry/    # retryIf conditional retry
+│   ├── finally/              # Finally cleanup section
+│   ├── foreach/              # ForEach iteration over arrays
+│   ├── timeout/              # Per-action timeout
+│   └── result-schema/        # Result schema validation
 ├── rendering/                # Template rendering tests
 ├── composition/              # Multi-file compose tests
 │   └── parts/                # Composed YAML fragments
+├── test-generation/          # Test generation tests
 └── edge-cases/               # Negative/error tests
     ├── validation-failures/  # Intentional validation errors
     ├── invalid-provider/     # Unknown provider handling
+    ├── invalid-exclusive/    # Invalid exclusive references
     └── timeout-enforcement/  # Timeout violation behavior
 ```
 
@@ -63,6 +83,15 @@ tests/integration/solutions/
 | `smoke` | Quick verification tests, good for CI gates |
 | `provider` | Provider-specific tests |
 | `static`, `env`, `cel`, `exec`, `file`, `directory`, `go-template`, `validation`, `sleep` | Individual provider tests |
+| `http` | HTTP provider tests (uses mock server) |
+| `git` | Git provider tests (uses local bare repo) |
+| `debug` | Debug provider tests |
+| `parameter` | Parameter provider tests |
+| `solution-provider` | Solution provider composition tests |
+| `action` | Workflow action tests |
+| `sequential`, `conditional`, `parallel`, `exclusive` | Action ordering/condition tests |
+| `error-handling`, `retry`, `conditional-retry` | Action error/retry tests |
+| `finally`, `foreach`, `timeout`, `result-schema` | Action feature tests |
 | `resolver` | Resolver feature tests |
 | `dag`, `until`, `type-coercion`, `transform`, `conditional`, `timeout`, `sensitive` | Individual resolver feature tests |
 | `rendering` | Template rendering tests |
@@ -88,12 +117,35 @@ tests/integration/solutions/
 5. Run `scafctl test functional -f <your-solution.yaml>` to verify
 6. The `task integration` step will automatically discover it
 
+## Mock Services
+
+The test framework supports `testConfig.services` for starting background mock servers.
+This eliminates external dependencies for providers like HTTP.
+
+```yaml
+testConfig:
+  services:
+    - name: mock-api
+      type: http                    # Only "http" is currently supported
+      portEnv: MOCK_HTTP_PORT       # Env var set to the server's random port
+      baseUrlEnv: MOCK_BASE_URL     # Env var set to http://127.0.0.1:<port>
+      routes:
+        - path: /api/users
+          method: GET               # Empty = match all methods
+          status: 200               # Default 200
+          body: '{"users": []}'     # Response body
+          headers:                  # Response headers
+            Content-Type: application/json
+          delay: "100ms"            # Simulated latency
+          echo: true                # Return request details as JSON
+```
+
+All mock servers expose a `/__health` endpoint for readiness checks.
+
 ## Excluded Providers
 
 These providers are excluded from functional tests due to external dependencies:
-- **`http`** — requires a network endpoint
-- **`git`** — requires a git repository with specific state
 - **`secret`** — requires keyring/credential store
 - **`identity`** — requires authentication handlers
 
-They can be added later with mocked endpoints or conditional `skipExpression` guards.
+They can be added later with conditional `skipExpression` guards.

--- a/tests/integration/solutions/actions/conditional-retry/solution.yaml
+++ b/tests/integration/solutions/actions/conditional-retry/solution.yaml
@@ -1,0 +1,92 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-conditional-retry
+  version: 1.0.0
+  description: |
+    Functional tests for conditional retry (retryIf).
+    Verifies that retryIf expressions are parsed and rendered
+    correctly in the action graph.
+
+spec:
+  resolvers:
+    apiUrl:
+      description: API URL
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://api.example.com"
+
+  workflow:
+    actions:
+      retryOnExitCode:
+        description: Retry only on specific exit codes
+        provider: exec
+        retry:
+          maxAttempts: 3
+          backoff: fixed
+          initialDelay: 100ms
+          retryIf: "__error.exitCode == 1 || __error.exitCode == 2"
+        inputs:
+          command: "echo conditional retry pass"
+
+      retryOnType:
+        description: Retry only on timeout errors
+        provider: exec
+        retry:
+          maxAttempts: 2
+          backoff: exponential
+          initialDelay: 200ms
+          retryIf: "__error.type == 'timeout'"
+        inputs:
+          command: "echo type-based retry pass"
+
+      noConditionalRetry:
+        description: Plain retry without condition
+        provider: exec
+        retry:
+          maxAttempts: 2
+          backoff: fixed
+          initialDelay: 100ms
+        inputs:
+          command: "echo plain retry pass"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for conditional retry tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, conditional-retry]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, conditional-retry, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-succeed:
+        description: Verify all actions succeed (no failures to trigger retry)
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["retryOnExitCode"].status == "succeeded"
+          - expression: __output.actions["retryOnType"].status == "succeeded"
+          - expression: __output.actions["noConditionalRetry"].status == "succeeded"
+
+      render-retryif:
+        description: Verify retryIf expressions appear in rendered graph
+        extends: [_render-base]
+        assertions:
+          - expression: __output.actions["retryOnExitCode"].retry.maxAttempts == 3
+          - expression: __output.actions["retryOnType"].retry.maxAttempts == 2

--- a/tests/integration/solutions/actions/conditional/solution.yaml
+++ b/tests/integration/solutions/actions/conditional/solution.yaml
@@ -1,0 +1,125 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-conditional
+  version: 1.0.0
+  description: |
+    Functional tests for conditional action execution.
+    Verifies when conditions, skip reasons, and that
+    downstream dependents of skipped actions are also skipped.
+
+spec:
+  resolvers:
+    environment:
+      description: Target environment
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "staging"
+
+    enableNotification:
+      description: Whether to send notifications
+      type: bool
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: false
+
+  workflow:
+    actions:
+      setup:
+        description: Always-run setup
+        provider: exec
+        inputs:
+          command: "echo Setup complete"
+
+      prodDeploy:
+        description: Only runs in production
+        provider: exec
+        dependsOn: [setup]
+        when:
+          expr: "_.environment == 'prod'"
+        inputs:
+          command: "echo Deploying to production"
+
+      stagingDeploy:
+        description: Only runs in staging
+        provider: exec
+        dependsOn: [setup]
+        when:
+          expr: "_.environment == 'staging'"
+        inputs:
+          command: "echo Deploying to staging"
+
+      notify:
+        description: Only runs when notifications enabled
+        provider: exec
+        dependsOn: [setup]
+        when:
+          expr: "_.enableNotification == true"
+        inputs:
+          command: "echo Sending notification"
+
+      alwaysRun:
+        description: Runs regardless of conditions
+        provider: exec
+        dependsOn: [setup]
+        inputs:
+          command: "echo Always running"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for conditional action tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, conditional]
+        assertions:
+          - expression: __exitCode == 0
+
+      staging-deploy-runs:
+        description: Verify staging deploy runs when environment is staging
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["stagingDeploy"].status == "succeeded"
+            message: "Staging deploy should run in staging environment"
+
+      prod-deploy-skipped:
+        description: Verify prod deploy is skipped when environment is staging
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["prodDeploy"].status == "skipped"
+            message: "Prod deploy should be skipped in staging"
+          - expression: __output.actions["prodDeploy"].skipReason == "condition"
+            message: "Skip reason should be condition"
+
+      notification-skipped:
+        description: Verify notification is skipped when disabled
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["notify"].status == "skipped"
+            message: "Notify should be skipped when enableNotification is false"
+
+      always-runs:
+        description: Verify unconditional action always runs
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["alwaysRun"].status == "succeeded"
+            message: "Unconditional action should always succeed"
+
+      skipped-in-list:
+        description: Verify skipped actions appear in skippedActions list
+        extends: [_run-base]
+        assertions:
+          - expression: __output.skippedActions.exists(a, a == "prodDeploy")
+            message: "prodDeploy should be in skippedActions"
+          - expression: __output.skippedActions.exists(a, a == "notify")
+            message: "notify should be in skippedActions"

--- a/tests/integration/solutions/actions/error-handling/solution.yaml
+++ b/tests/integration/solutions/actions/error-handling/solution.yaml
@@ -1,0 +1,95 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-error-handling
+  version: 1.0.0
+  description: |
+    Functional tests for action error handling.
+    Verifies onError continue/fail behavior, non-zero exit code capture,
+    and dependency-failed skip propagation.
+
+spec:
+  resolvers:
+    target:
+      description: Deployment target
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "test-env"
+
+  workflow:
+    actions:
+      successAction:
+        description: Action that succeeds
+        provider: exec
+        inputs:
+          command: "echo success"
+
+      nonZeroExit:
+        description: Action with non-zero exit code (exec provider still succeeds)
+        provider: exec
+        onError: continue
+        inputs:
+          command: "sh -c 'exit 1'"
+
+      afterNonZero:
+        description: Runs after the non-zero exit action
+        provider: exec
+        dependsOn: [nonZeroExit]
+        inputs:
+          command: "echo after-nonzero"
+
+      dependsOnSuccess:
+        description: Depends on the successful action
+        provider: exec
+        dependsOn: [successAction]
+        inputs:
+          command: "echo after-success"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for error handling tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, error-handling]
+        assertions:
+          - expression: __exitCode == 0
+
+      nonzero-exit-captured:
+        description: Verify non-zero exit code is captured in results
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.actions["nonZeroExit"].results.exitCode == 1
+            message: "Exit code should be 1"
+          - expression: __output.actions["nonZeroExit"].results.success == false
+            message: "success should be false for non-zero exit"
+
+      dependent-still-runs:
+        description: Verify dependent action still runs with onError=continue
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["afterNonZero"].status == "succeeded"
+            message: "Dependent action should run after onError=continue"
+          - expression: __output.actions["afterNonZero"].results.stdout.contains("after-nonzero")
+            message: "Dependent should produce correct output"
+
+      success-unaffected:
+        description: Verify unrelated success path is unaffected
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["dependsOnSuccess"].status == "succeeded"
+            message: "Independent success path should work"
+
+      overall-status:
+        description: Verify overall solution status
+        extends: [_run-base]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Overall status should be succeeded when onError=continue"

--- a/tests/integration/solutions/actions/exclusive/solution.yaml
+++ b/tests/integration/solutions/actions/exclusive/solution.yaml
@@ -65,103 +65,104 @@ spec:
           command:
             expr: "'echo Deployment to ' + _.environment + ' complete'"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
+    cases:
     # =========================================================================
     # Base templates
     # =========================================================================
 
-    _render-base:
-      description: Base template for render tests
-      command: [render, solution]
-      args: ["-o", "json"]
-      tags: [exclusive, render]
-      assertions:
-        - expression: __exitCode == 0
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [exclusive, render]
+        assertions:
+          - expression: __exitCode == 0
 
-    _run-base:
-      description: Base template for run tests
-      command: [run, solution]
-      args: ["-o", "json"]
-      tags: [exclusive, run]
-      assertions:
-        - expression: __exitCode == 0
+      _run-base:
+        description: Base template for run tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [exclusive, run]
+        assertions:
+          - expression: __exitCode == 0
 
     # =========================================================================
     # Runtime success
     # =========================================================================
 
-    exclusive-solution-runs:
-      description: Verify exclusive solution executes successfully
-      command: [run, solution]
-      tags: [exclusive, smoke]
-      assertions:
-        - expression: __exitCode == 0
-          message: "Solution with exclusive actions should succeed"
+      exclusive-solution-runs:
+        description: Verify exclusive solution executes successfully
+        command: [run, solution]
+        tags: [exclusive, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Solution with exclusive actions should succeed"
 
-    all-actions-succeed:
-      description: Verify all actions complete with succeeded status
-      extends: [_run-base]
-      tags: [exclusive, smoke]
-      assertions:
-        - expression: __output.status == "succeeded"
-          message: "Overall solution status should be succeeded"
-        - expression: __output.actions["updateDatabase"].status == "succeeded"
-          message: "updateDatabase should succeed"
-        - expression: __output.actions["migrateDatabase"].status == "succeeded"
-          message: "migrateDatabase should succeed"
-        - expression: __output.actions["sendNotification"].status == "succeeded"
-          message: "sendNotification should succeed"
+      all-actions-succeed:
+        description: Verify all actions complete with succeeded status
+        extends: [_run-base]
+        tags: [exclusive, smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Overall solution status should be succeeded"
+          - expression: __output.actions["updateDatabase"].status == "succeeded"
+            message: "updateDatabase should succeed"
+          - expression: __output.actions["migrateDatabase"].status == "succeeded"
+            message: "migrateDatabase should succeed"
+          - expression: __output.actions["sendNotification"].status == "succeeded"
+            message: "sendNotification should succeed"
 
     # =========================================================================
     # Phase-split verification (via render)
     # =========================================================================
 
-    phase-split-verification:
-      description: Verify exclusive actions land in separate execution phases
-      extends: [_render-base]
-      tags: [exclusive, smoke]
-      assertions:
-        - expression: size(__output.executionOrder) == 3
-          message: "Three phases expected: migrateDatabase, updateDatabase, sendNotification"
-        - expression: >
-            !__output.executionOrder.exists(phase,
-              phase.exists(a, a == "migrateDatabase") &&
-              phase.exists(a, a == "updateDatabase"))
-          message: "migrateDatabase and updateDatabase must not share a phase"
+      phase-split-verification:
+        description: Verify exclusive actions land in separate execution phases
+        extends: [_render-base]
+        tags: [exclusive, smoke]
+        assertions:
+          - expression: size(__output.executionOrder) == 3
+            message: "Three phases expected: migrateDatabase, updateDatabase, sendNotification"
+          - expression: >
+              !__output.executionOrder.exists(phase,
+                phase.exists(a, a == "migrateDatabase") &&
+                phase.exists(a, a == "updateDatabase"))
+            message: "migrateDatabase and updateDatabase must not share a phase"
 
-    phases-are-singletons:
-      description: Verify each exclusive action is alone in its phase
-      extends: [_render-base]
-      assertions:
-        - expression: >
-            __output.executionOrder.exists(phase,
-              size(phase) == 1 && phase[0] == "migrateDatabase")
-          message: "migrateDatabase should occupy its own phase"
-        - expression: >
-            __output.executionOrder.exists(phase,
-              size(phase) == 1 && phase[0] == "updateDatabase")
-          message: "updateDatabase should occupy its own phase"
+      phases-are-singletons:
+        description: Verify each exclusive action is alone in its phase
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder.exists(phase,
+                size(phase) == 1 && phase[0] == "migrateDatabase")
+            message: "migrateDatabase should occupy its own phase"
+          - expression: >
+              __output.executionOrder.exists(phase,
+                size(phase) == 1 && phase[0] == "updateDatabase")
+            message: "updateDatabase should occupy its own phase"
 
-    send-notification-last:
-      description: Verify sendNotification is scheduled after the exclusive pair
-      extends: [_render-base]
-      assertions:
-        - expression: >
-            __output.executionOrder[size(__output.executionOrder) - 1].exists(
-              a, a == "sendNotification")
-          message: "sendNotification should be in the last phase"
+      send-notification-last:
+        description: Verify sendNotification is scheduled after the exclusive pair
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder[size(__output.executionOrder) - 1].exists(
+                a, a == "sendNotification")
+            message: "sendNotification should be in the last phase"
 
     # =========================================================================
     # Lint
     # =========================================================================
 
-    lint-passes:
-      description: Verify valid exclusive declarations pass lint without errors
-      command: [lint]
-      tags: [exclusive, lint, smoke]
-      assertions:
-        - expression: __exitCode == 0
-          message: "Valid exclusive references should pass lint"
+      lint-passes:
+        description: Verify valid exclusive declarations pass lint without errors
+        command: [lint]
+        tags: [exclusive, lint, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Valid exclusive references should pass lint"

--- a/tests/integration/solutions/actions/finally/solution.yaml
+++ b/tests/integration/solutions/actions/finally/solution.yaml
@@ -1,0 +1,100 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-finally
+  version: 1.0.0
+  description: |
+    Functional tests for the finally section.
+    Verifies that finally actions always run, even when
+    main actions fail.
+
+spec:
+  resolvers:
+    dbName:
+      description: Test database name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "test_db"
+
+  workflow:
+    actions:
+      setupDb:
+        description: Create test database
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Creating database ' + _.dbName"
+
+      runTests:
+        description: Run test suite
+        provider: exec
+        dependsOn: [setupDb]
+        inputs:
+          command: "echo Running tests"
+
+    finally:
+      cleanupDb:
+        description: Always clean up database
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Dropping database ' + _.dbName"
+
+      notifyComplete:
+        description: Always send completion notification
+        provider: exec
+        inputs:
+          command: "echo Sending completion notification"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for finally tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, finally]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, finally, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      finally-always-runs:
+        description: Verify finally actions run after main actions
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["setupDb"].status == "succeeded"
+          - expression: __output.actions["runTests"].status == "succeeded"
+          - expression: __output.actions["cleanupDb"].status == "succeeded"
+            message: "Finally cleanup should run"
+          - expression: __output.actions["notifyComplete"].status == "succeeded"
+            message: "Finally notification should run"
+
+      render-has-finally:
+        description: Verify render shows finally section
+        extends: [_render-base]
+        assertions:
+          - expression: __output.metadata.hasFinally == true
+            message: "Rendered graph should indicate hasFinally"
+          - expression: size(__output.finallyOrder) > 0
+            message: "finallyOrder should not be empty"
+
+      finally-output-content:
+        description: Verify finally action output content
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["cleanupDb"].results.stdout.contains("Dropping database test_db")
+            message: "Cleanup should reference the database name"

--- a/tests/integration/solutions/actions/foreach/solution.yaml
+++ b/tests/integration/solutions/actions/foreach/solution.yaml
@@ -1,0 +1,105 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-foreach
+  version: 1.0.0
+  description: |
+    Functional tests for the forEach action field.
+    Verifies iteration over arrays, expanded action naming,
+    concurrency configuration, and item/index access.
+
+spec:
+  resolvers:
+    servers:
+      description: List of servers to deploy to
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - web-01
+                - web-02
+                - web-03
+
+    version:
+      description: Deployment version
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "3.0.0"
+
+  workflow:
+    actions:
+      deploy:
+        description: Deploy to each server
+        provider: exec
+        forEach:
+          in:
+            expr: "_.servers"
+          concurrency: 2
+          onError: continue
+        inputs:
+          command:
+            expr: "'echo Deploying v' + _.version + ' to ' + __item"
+
+      healthCheck:
+        description: Health check each server
+        provider: exec
+        dependsOn: [deploy]
+        forEach:
+          in:
+            expr: "_.servers"
+          item: server
+        inputs:
+          command:
+            expr: "'echo Checking health of ' + server"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for forEach tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, foreach]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, foreach, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-iterations-succeed:
+        description: Verify all forEach iterations complete successfully
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Overall status should be succeeded"
+
+      expanded-actions-exist:
+        description: Verify forEach expands into individual actions
+        extends: [_render-base]
+        assertions:
+          - expression: __output.metadata.forEachExpansions.deploy.exists(a, a.contains("deploy"))
+            message: "deploy should have forEach expansions"
+          - expression: size(__output.metadata.forEachExpansions.deploy) == 3
+            message: "deploy should expand into 3 iterations"
+
+      render-concurrency:
+        description: Verify forEach concurrency is reflected in render
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.actions.exists(k,
+                __output.actions[k].forEach.concurrency == 2 &&
+                __output.actions[k].forEach.expandedFrom == "deploy")
+            message: "Expanded deploy actions should show concurrency=2"

--- a/tests/integration/solutions/actions/parallel/solution.yaml
+++ b/tests/integration/solutions/actions/parallel/solution.yaml
@@ -1,0 +1,120 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-parallel
+  version: 1.0.0
+  description: |
+    Functional tests for parallel action execution with dependencies.
+    Verifies that independent actions run in the same phase and
+    dependent actions wait for their prerequisites.
+
+spec:
+  resolvers:
+    appName:
+      description: Application name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "web-service"
+
+  workflow:
+    actions:
+      # Phase 1: These two have no dependencies, should run in parallel
+      buildFrontend:
+        description: Build frontend assets
+        provider: exec
+        inputs:
+          command: "echo Building frontend"
+
+      buildBackend:
+        description: Build backend service
+        provider: exec
+        inputs:
+          command: "echo Building backend"
+
+      # Phase 1 as well: independent
+      runLint:
+        description: Run linter
+        provider: exec
+        inputs:
+          command: "echo Running lint"
+
+      # Phase 2: depends on both builds
+      integrationTests:
+        description: Run integration tests after both builds
+        provider: exec
+        dependsOn: [buildFrontend, buildBackend]
+        inputs:
+          command:
+            expr: "'echo Testing ' + _.appName"
+
+      # Phase 3: depends on tests
+      publish:
+        description: Publish artifacts
+        provider: exec
+        dependsOn: [integrationTests, runLint]
+        inputs:
+          command:
+            expr: "'echo Publishing ' + _.appName"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for parallel tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, parallel]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, parallel, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-succeed:
+        description: Verify all parallel and sequential actions succeed
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["buildFrontend"].status == "succeeded"
+          - expression: __output.actions["buildBackend"].status == "succeeded"
+          - expression: __output.actions["runLint"].status == "succeeded"
+          - expression: __output.actions["integrationTests"].status == "succeeded"
+          - expression: __output.actions["publish"].status == "succeeded"
+
+      parallel-phase-verification:
+        description: Verify independent actions share a phase
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder.exists(phase,
+                phase.exists(a, a == "buildFrontend") &&
+                phase.exists(a, a == "buildBackend") &&
+                phase.exists(a, a == "runLint"))
+            message: "buildFrontend, buildBackend, and runLint should share a phase"
+
+      dependency-ordering:
+        description: Verify publish comes after integrationTests
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder[size(__output.executionOrder) - 1].exists(
+                a, a == "publish")
+            message: "publish should be in the last phase"
+
+      three-phases:
+        description: Verify three execution phases
+        extends: [_render-base]
+        assertions:
+          - expression: size(__output.executionOrder) == 3
+            message: "Should have 3 phases: parallel builds, tests, publish"

--- a/tests/integration/solutions/actions/result-schema/solution.yaml
+++ b/tests/integration/solutions/actions/result-schema/solution.yaml
@@ -1,0 +1,111 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-result-schema
+  version: 1.0.0
+  description: |
+    Functional tests for action result schema validation.
+    Verifies that resultSchema validates action output
+    and that valid output passes schema checks.
+
+spec:
+  resolvers:
+    userId:
+      description: User ID for lookup
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+
+  workflow:
+    actions:
+      fetchUser:
+        description: Action with valid result matching schema
+        provider: cel
+        resultSchema:
+          type: object
+          required: [id, name]
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+              minLength: 1
+            email:
+              type: string
+        inputs:
+          expression: |
+            {"id": 42, "name": "Alice", "email": "alice@example.com"}
+
+      fetchConfig:
+        description: Action returning config with schema
+        provider: cel
+        resultSchema:
+          type: object
+          required: [version, features]
+          properties:
+            version:
+              type: string
+            features:
+              type: array
+              items:
+                type: string
+        inputs:
+          expression: |
+            {"version": "2.0", "features": ["auth", "cache", "logging"]}
+
+      noSchema:
+        description: Action without result schema
+        provider: exec
+        inputs:
+          command: "echo no schema validation"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for result schema tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, result-schema]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, result-schema, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      valid-schema-passes:
+        description: Verify actions with valid results pass schema validation
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["fetchUser"].status == "succeeded"
+            message: "fetchUser with valid schema should succeed"
+          - expression: __output.actions["fetchConfig"].status == "succeeded"
+            message: "fetchConfig with valid schema should succeed"
+
+      no-schema-still-works:
+        description: Verify action without schema also succeeds
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["noSchema"].status == "succeeded"
+
+      render-shows-schema:
+        description: Verify rendered graph includes result schema
+        extends: [_render-base]
+        assertions:
+          - expression: __output.actions.exists_one(k, k == "fetchUser")
+            message: "fetchUser should be in rendered graph"
+          - expression: __output.actions.exists_one(k, k == "fetchConfig")
+            message: "fetchConfig should be in rendered graph"

--- a/tests/integration/solutions/actions/retry/solution.yaml
+++ b/tests/integration/solutions/actions/retry/solution.yaml
@@ -1,0 +1,106 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-retry
+  version: 1.0.0
+  description: |
+    Functional tests for action retry with backoff.
+    Verifies retry configuration parsing and rendering.
+    Uses a command that always succeeds so the action passes
+    on the first attempt, confirming retry config doesn't break execution.
+
+spec:
+  resolvers:
+    endpoint:
+      description: API endpoint
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://api.example.com"
+
+  workflow:
+    actions:
+      fixedRetry:
+        description: Action with fixed backoff retry
+        provider: exec
+        retry:
+          maxAttempts: 3
+          backoff: fixed
+          initialDelay: 100ms
+        inputs:
+          command: "echo fixed retry success"
+
+      exponentialRetry:
+        description: Action with exponential backoff retry
+        provider: exec
+        retry:
+          maxAttempts: 5
+          backoff: exponential
+          initialDelay: 100ms
+          maxDelay: 2s
+        inputs:
+          command: "echo exponential retry success"
+
+      linearRetry:
+        description: Action with linear backoff retry
+        provider: exec
+        retry:
+          maxAttempts: 3
+          backoff: linear
+          initialDelay: 100ms
+          maxDelay: 1s
+        inputs:
+          command: "echo linear retry success"
+
+      noRetry:
+        description: Action with no retry config
+        provider: exec
+        inputs:
+          command: "echo no retry"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for retry tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, retry]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, retry, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-succeed-first-attempt:
+        description: Verify all retry-configured actions succeed on first attempt
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["fixedRetry"].status == "succeeded"
+          - expression: __output.actions["exponentialRetry"].status == "succeeded"
+          - expression: __output.actions["linearRetry"].status == "succeeded"
+          - expression: __output.actions["noRetry"].status == "succeeded"
+
+      render-retry-config:
+        description: Verify retry configuration appears in rendered graph
+        extends: [_render-base]
+        assertions:
+          - expression: __output.actions["fixedRetry"].retry.maxAttempts == 3
+            message: "Fixed retry should have 3 max attempts"
+          - expression: __output.actions["fixedRetry"].retry.backoff == "fixed"
+            message: "Fixed retry should have fixed backoff"
+          - expression: __output.actions["exponentialRetry"].retry.maxAttempts == 5
+            message: "Exponential retry should have 5 max attempts"
+          - expression: __output.actions["exponentialRetry"].retry.backoff == "exponential"
+            message: "Exponential retry should have exponential backoff"

--- a/tests/integration/solutions/actions/sequential/solution.yaml
+++ b/tests/integration/solutions/actions/sequential/solution.yaml
@@ -1,0 +1,118 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-sequential
+  version: 1.0.0
+  description: |
+    Functional tests for sequential action chains.
+    Verifies dependsOn ordering, result propagation,
+    and multi-step workflows.
+
+spec:
+  resolvers:
+    project:
+      description: Project name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-app"
+
+    version:
+      description: Build version
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "2.1.0"
+
+  workflow:
+    actions:
+      checkout:
+        description: Checkout source code
+        displayName: Checkout
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Checking out ' + _.project"
+
+      build:
+        description: Build the project
+        displayName: Build
+        provider: exec
+        dependsOn: [checkout]
+        inputs:
+          command:
+            expr: "'echo Building ' + _.project + ' v' + _.version"
+
+      test:
+        description: Run test suite
+        displayName: Test
+        provider: exec
+        dependsOn: [build]
+        inputs:
+          command:
+            expr: "'echo Testing ' + _.project"
+
+      deploy:
+        description: Deploy the build
+        displayName: Deploy
+        provider: exec
+        dependsOn: [test]
+        inputs:
+          command:
+            expr: "'echo Deploying ' + _.project + ' v' + _.version"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for run tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, sequential]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, sequential, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-succeed:
+        description: Verify all actions in chain succeed
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Overall status should be succeeded"
+          - expression: __output.actions["checkout"].status == "succeeded"
+          - expression: __output.actions["build"].status == "succeeded"
+          - expression: __output.actions["test"].status == "succeeded"
+          - expression: __output.actions["deploy"].status == "succeeded"
+
+      execution-order:
+        description: Verify sequential execution ordering via render
+        extends: [_render-base]
+        assertions:
+          - expression: size(__output.executionOrder) == 4
+            message: "Should have 4 phases for 4 sequential actions"
+          - expression: __output.executionOrder[0].exists(a, a == "checkout")
+            message: "checkout should be first"
+          - expression: __output.executionOrder[3].exists(a, a == "deploy")
+            message: "deploy should be last"
+
+      results-contain-output:
+        description: Verify action results contain exec output
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["build"].results.stdout.contains("Building my-app v2.1.0")
+            message: "Build output should contain project and version"
+          - expression: __output.actions["deploy"].results.stdout.contains("Deploying my-app v2.1.0")
+            message: "Deploy output should contain project and version"

--- a/tests/integration/solutions/actions/timeout/solution.yaml
+++ b/tests/integration/solutions/actions/timeout/solution.yaml
@@ -1,0 +1,84 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-timeout
+  version: 1.0.0
+  description: |
+    Functional tests for per-action timeout.
+    Verifies that timeout configuration is rendered correctly
+    and that actions within timeout complete successfully.
+
+spec:
+  resolvers:
+    target:
+      description: Target system
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "prod-cluster"
+
+  workflow:
+    actions:
+      quickAction:
+        description: Fast action with generous timeout
+        provider: exec
+        timeout: 30s
+        inputs:
+          command: "echo fast action done"
+
+      mediumAction:
+        description: Medium action with timeout
+        provider: exec
+        timeout: 1m
+        dependsOn: [quickAction]
+        inputs:
+          command: "echo medium action done"
+
+      noTimeoutAction:
+        description: Action without timeout
+        provider: exec
+        dependsOn: [quickAction]
+        inputs:
+          command: "echo no timeout action done"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _run-base:
+        description: Base template for timeout tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, timeout]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, timeout, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-within-timeout:
+        description: Verify all actions complete within their timeout
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+          - expression: __output.actions["quickAction"].status == "succeeded"
+          - expression: __output.actions["mediumAction"].status == "succeeded"
+          - expression: __output.actions["noTimeoutAction"].status == "succeeded"
+
+      render-timeout-config:
+        description: Verify timeout values appear in rendered graph
+        extends: [_render-base]
+        assertions:
+          - expression: __output.actions["quickAction"].timeout == "30s"
+            message: "quickAction should show 30s timeout"
+          - expression: __output.actions["mediumAction"].timeout == "1m0s"
+            message: "mediumAction should show 1m timeout"

--- a/tests/integration/solutions/composed/solution.yaml
+++ b/tests/integration/solutions/composed/solution.yaml
@@ -19,19 +19,20 @@ spec:
             inputs:
               value: composed-test-output
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for rendering tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for rendering tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
 
-    render-check:
-      description: Verify rendering works via compose
-      extends: [_base]
-      assertions:
-        - contains: message
+      render-check:
+        description: Verify rendering works via compose
+        extends: [_base]
+        assertions:
+          - contains: message

--- a/tests/integration/solutions/composition/solution.yaml
+++ b/tests/integration/solutions/composition/solution.yaml
@@ -11,45 +11,46 @@ compose:
   - parts/resolvers.yaml
 
 spec:
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for composition tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [composition]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for composition tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [composition]
+        assertions:
+          - expression: __exitCode == 0
 
-    base-resolver:
-      description: Verify base resolver from main file
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: '__output.baseMessage == "from-main"'
-          message: "Main file resolver should be available"
+      base-resolver:
+        description: Verify base resolver from main file
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '__output.baseMessage == "from-main"'
+            message: "Main file resolver should be available"
 
-    composed-resolver:
-      description: Verify resolver from composed file
-      extends: [_base]
-      assertions:
-        - expression: '__output.composedResolver == "from-composed-file"'
-          message: "Composed file resolver should be available"
+      composed-resolver:
+        description: Verify resolver from composed file
+        extends: [_base]
+        assertions:
+          - expression: '__output.composedResolver == "from-composed-file"'
+            message: "Composed file resolver should be available"
 
-    cross-file-dependency:
-      description: Verify composed resolver can reference main resolver
-      extends: [_base]
-      assertions:
-        - expression: '__output.derivedFromBase == "from-main-and-composed"'
-          message: "Composed resolver should access main file resolver"
+      cross-file-dependency:
+        description: Verify composed resolver can reference main resolver
+        extends: [_base]
+        assertions:
+          - expression: '__output.derivedFromBase == "from-main-and-composed"'
+            message: "Composed resolver should access main file resolver"
 
-    all-resolvers-merged:
-      description: Verify all resolvers from all files are present
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: '"baseMessage" in __output'
-        - expression: '"composedResolver" in __output'
-        - expression: '"derivedFromBase" in __output'
+      all-resolvers-merged:
+        description: Verify all resolvers from all files are present
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '"baseMessage" in __output'
+          - expression: '"composedResolver" in __output'
+          - expression: '"derivedFromBase" in __output'

--- a/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
@@ -31,52 +31,53 @@ spec:
         inputs:
           command: "echo missing-ref"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    lint-rejects-self-reference:
-      description: Verify lint catches a self-referencing exclusive declaration
-      command: [lint]
-      tags: [exclusive, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Lint should fail when exclusive contains a self-reference"
-        - contains: "cannot exclude itself"
-          message: "Error message should describe the self-reference problem"
+    cases:
+      lint-rejects-self-reference:
+        description: Verify lint catches a self-referencing exclusive declaration
+        command: [lint]
+        tags: [exclusive, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Lint should fail when exclusive contains a self-reference"
+          - contains: "cannot exclude itself"
+            message: "Error message should describe the self-reference problem"
 
-    lint-rejects-missing-ref:
-      description: Verify lint catches an exclusive reference to a nonexistent action
-      command: [lint]
-      tags: [exclusive, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Lint should fail when exclusive references a nonexistent action"
-        - contains: "not found in actions section"
-          message: "Error message should indicate the missing action reference"
+      lint-rejects-missing-ref:
+        description: Verify lint catches an exclusive reference to a nonexistent action
+        command: [lint]
+        tags: [exclusive, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Lint should fail when exclusive references a nonexistent action"
+          - contains: "not found in actions section"
+            message: "Error message should indicate the missing action reference"
 
-    lint-detects-both-errors:
-      description: Verify lint reports multiple exclusive validation errors
-      command: [lint]
-      args: ["-o", "json"]
-      tags: [exclusive, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Lint should fail with multiple validation errors"
-        - expression: __output.errorCount >= 2
-          message: "Both self-reference and missing-ref errors should be reported"
+      lint-detects-both-errors:
+        description: Verify lint reports multiple exclusive validation errors
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [exclusive, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Lint should fail with multiple validation errors"
+          - expression: __output.errorCount >= 2
+            message: "Both self-reference and missing-ref errors should be reported"
 
-    run-fails-on-invalid-exclusive:
-      description: Verify run solution rejects an invalid exclusive configuration
-      command: [run, solution]
-      tags: [exclusive, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Run should fail when exclusive declarations are invalid"
-        - contains: "workflow validation failed"
-          target: stderr
-          message: "Error should indicate workflow validation failure"
+      run-fails-on-invalid-exclusive:
+        description: Verify run solution rejects an invalid exclusive configuration
+        command: [run, solution]
+        tags: [exclusive, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Run should fail when exclusive declarations are invalid"
+          - contains: "workflow validation failed"
+            target: stderr
+            message: "Error should indicate workflow validation failure"

--- a/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
@@ -18,16 +18,17 @@ spec:
             inputs:
               value: "anything"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    unknown-provider:
-      description: Verify unknown provider produces meaningful error
-      command: [run, resolver]
-      tags: [edge-case, negative]
-      expectFailure: true
-      assertions:
-        - notContains: "panic"
-          target: combined
-          message: "Should not panic on unknown provider"
+    cases:
+      unknown-provider:
+        description: Verify unknown provider produces meaningful error
+        command: [run, resolver]
+        tags: [edge-case, negative]
+        expectFailure: true
+        assertions:
+          - notContains: "panic"
+            target: combined
+            message: "Should not panic on unknown provider"

--- a/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
+++ b/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
@@ -21,17 +21,18 @@ spec:
             inputs:
               duration: "5s"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    timeout-exceeded:
-      description: Verify resolver timeout is enforced
-      command: [run, resolver]
-      args: ["--resolver", "slowResolver"]
-      tags: [edge-case, timeout, negative]
-      timeout: "15s"
-      expectFailure: true
-      assertions:
-        - notContains: "panic"
-          target: combined
+    cases:
+      timeout-exceeded:
+        description: Verify resolver timeout is enforced
+        command: [run, resolver]
+        args: ["--resolver", "slowResolver"]
+        tags: [edge-case, timeout, negative]
+        timeout: "15s"
+        expectFailure: true
+        assertions:
+          - notContains: "panic"
+            target: combined

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -65,45 +65,46 @@ spec:
               notMatch: "\\s"
             message: "Value must not contain spaces"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    valid-passes:
-      description: Verify valid value passes validation
-      command: [run, resolver]
-      args: ["validValue", "-o", "json"]
-      tags: [edge-case, validation, smoke]
-      assertions:
-        - expression: __exitCode == 0
-        - expression: '__output.validValue == "good"'
+    cases:
+      valid-passes:
+        description: Verify valid value passes validation
+        command: [run, resolver]
+        args: ["validValue", "-o", "json"]
+        tags: [edge-case, validation, smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.validValue == "good"'
 
-    regex-failure:
-      description: Verify regex validation failure
-      command: [run, resolver]
-      args: ["invalidRegex"]
-      tags: [edge-case, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Should fail validation"
+      regex-failure:
+        description: Verify regex validation failure
+        command: [run, resolver]
+        args: ["invalidRegex"]
+        tags: [edge-case, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Should fail validation"
 
-    expression-failure:
-      description: Verify CEL expression validation failure
-      command: [run, resolver]
-      args: ["invalidExpression"]
-      tags: [edge-case, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Should fail validation"
+      expression-failure:
+        description: Verify CEL expression validation failure
+        command: [run, resolver]
+        args: ["invalidExpression"]
+        tags: [edge-case, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Should fail validation"
 
-    not-match-failure:
-      description: Verify notMatch validation failure
-      command: [run, resolver]
-      args: ["invalidNotMatch"]
-      tags: [edge-case, validation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Should fail validation"
+      not-match-failure:
+        description: Verify notMatch validation failure
+        command: [run, resolver]
+        args: ["invalidNotMatch"]
+        tags: [edge-case, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Should fail validation"

--- a/tests/integration/solutions/hello-world/solution.yaml
+++ b/tests/integration/solutions/hello-world/solution.yaml
@@ -16,28 +16,29 @@ spec:
             inputs:
               value: Hello, World!
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    render-basic:
-      description: Verify solution renders successfully
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: greeting
+    cases:
+      render-basic:
+        description: Verify solution renders successfully
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: greeting
 
-    resolver-output:
-      description: Verify resolver produces expected value
-      command: [run, resolver]
-      args: ["-o", "json"]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "Hello, World!"
+      resolver-output:
+        description: Verify resolver produces expected value
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "Hello, World!"
 
-    expect-lint-clean:
-      description: Verify solution passes lint
-      command: [lint]
-      assertions:
-        - expression: __exitCode == 0
+      expect-lint-clean:
+        description: Verify solution passes lint
+        command: [lint]
+        assertions:
+          - expression: __exitCode == 0

--- a/tests/integration/solutions/providers/cel/solution.yaml
+++ b/tests/integration/solutions/providers/cel/solution.yaml
@@ -144,85 +144,86 @@ spec:
             inputs:
               expression: '__self.replace(" ", "-")'
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for CEL provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, cel]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for CEL provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, cel]
+        assertions:
+          - expression: __exitCode == 0
 
-    upper-ascii:
-      description: Verify upperAscii string function
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.upperName == "HELLO WORLD"
+      upper-ascii:
+        description: Verify upperAscii string function
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.upperName == "HELLO WORLD"
 
-    lower-ascii:
-      description: Verify lowerAscii string function
-      extends: [_base]
-      assertions:
-        - expression: __output.lowerName == "hello world"
+      lower-ascii:
+        description: Verify lowerAscii string function
+        extends: [_base]
+        assertions:
+          - expression: __output.lowerName == "hello world"
 
-    concatenation:
-      description: Verify string concatenation
-      extends: [_base]
-      assertions:
-        - expression: __output.concatenated == "prefix-Hello World-suffix"
+      concatenation:
+        description: Verify string concatenation
+        extends: [_base]
+        assertions:
+          - expression: __output.concatenated == "prefix-Hello World-suffix"
 
-    list-size:
-      description: Verify size() function on lists
-      extends: [_base]
-      assertions:
-        - expression: __output.listSize == 3
+      list-size:
+        description: Verify size() function on lists
+        extends: [_base]
+        assertions:
+          - expression: __output.listSize == 3
 
-    list-filter:
-      description: Verify filter() on lists
-      extends: [_base]
-      assertions:
-        - expression: size(__output.filteredList) == 2
-        - expression: '"banana" in __output.filteredList'
-        - expression: '"cherry" in __output.filteredList'
+      list-filter:
+        description: Verify filter() on lists
+        extends: [_base]
+        assertions:
+          - expression: size(__output.filteredList) == 2
+          - expression: '"banana" in __output.filteredList'
+          - expression: '"cherry" in __output.filteredList'
 
-    list-map:
-      description: Verify map() on lists
-      extends: [_base]
-      assertions:
-        - expression: __output.mappedList[0] == "APPLE"
-        - expression: __output.mappedList[1] == "BANANA"
+      list-map:
+        description: Verify map() on lists
+        extends: [_base]
+        assertions:
+          - expression: __output.mappedList[0] == "APPLE"
+          - expression: __output.mappedList[1] == "BANANA"
 
-    math-operations:
-      description: Verify arithmetic in CEL
-      extends: [_base]
-      assertions:
-        - expression: __output.mathResult == 35
+      math-operations:
+        description: Verify arithmetic in CEL
+        extends: [_base]
+        assertions:
+          - expression: __output.mathResult == 35
 
-    ternary-conditional:
-      description: Verify ternary operator
-      extends: [_base]
-      assertions:
-        - expression: __output.conditional == "large"
+      ternary-conditional:
+        description: Verify ternary operator
+        extends: [_base]
+        assertions:
+          - expression: __output.conditional == "large"
 
-    contains-check:
-      description: Verify 'in' operator on lists
-      extends: [_base]
-      assertions:
-        - expression: __output.containsCheck == true
+      contains-check:
+        description: Verify 'in' operator on lists
+        extends: [_base]
+        assertions:
+          - expression: __output.containsCheck == true
 
-    string-replace:
-      description: Verify replace() string function
-      extends: [_base]
-      assertions:
-        - expression: __output.stringReplace == "Hello_World"
+      string-replace:
+        description: Verify replace() string function
+        extends: [_base]
+        assertions:
+          - expression: __output.stringReplace == "Hello_World"
 
-    transform-chain:
-      description: Verify multi-step CEL transform pipeline
-      extends: [_base]
-      assertions:
-        - expression: __output.transformed == "mixed-case-input"
-          message: "Chained transforms should trim, lowercase, and replace spaces"
+      transform-chain:
+        description: Verify multi-step CEL transform pipeline
+        extends: [_base]
+        assertions:
+          - expression: __output.transformed == "mixed-case-input"
+            message: "Chained transforms should trim, lowercase, and replace spaces"

--- a/tests/integration/solutions/providers/debug/solution.yaml
+++ b/tests/integration/solutions/providers/debug/solution.yaml
@@ -1,0 +1,144 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-debug-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the debug provider.
+    Uses stderr and file destinations to avoid corrupting JSON output.
+    The debug provider is side-effect free and needs no mocking.
+
+spec:
+  resolvers:
+    sourceData:
+      description: Source data for debug inspection
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: test-item
+                count: 42
+                tags: [alpha, bravo]
+
+    debugStderr:
+      description: Debug output to stderr (does not corrupt stdout JSON)
+      dependsOn: [sourceData]
+      resolve:
+        with:
+          - provider: debug
+            inputs:
+              expression: "_.sourceData"
+              destination: stderr
+              label: "Stderr Debug"
+              format: json
+
+    debugCelFilter:
+      description: Debug with CEL expression filtering to stderr
+      dependsOn: [sourceData]
+      resolve:
+        with:
+          - provider: debug
+            inputs:
+              expression: "_.sourceData.name"
+              destination: stderr
+              label: "Filtered Name"
+
+    debugToFile:
+      description: Debug output to file
+      dependsOn: [sourceData]
+      resolve:
+        with:
+          - provider: debug
+            inputs:
+              expression: "_.sourceData"
+              destination: file
+              file:
+                expr: "_.sandboxDir + '/debug-output.json'"
+              format: json
+              label: "File Debug"
+
+    sandboxDir:
+      description: Sandbox directory path
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: SCAFCTL_SANDBOX_DIR
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+    debugAsTransform:
+      description: Debug provider used in transform pipeline
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "transform-input"
+      transform:
+        with:
+          - provider: debug
+            inputs:
+              label: "Transform Debug"
+              destination: stderr
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _base:
+        description: Base template for debug provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, debug]
+        assertions:
+          - expression: __exitCode == 0
+
+      debug-stderr-destination:
+        description: Verify debug outputs to stderr
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.debugStderr.success == true
+            message: "Debug should succeed"
+          - expression: __output.debugStderr.destination == "stderr"
+            message: "Destination should be stderr"
+
+      debug-cel-filter:
+        description: Verify CEL expression filters data
+        extends: [_base]
+        assertions:
+          - expression: __output.debugCelFilter.success == true
+          - expression: __output.debugCelFilter.result == "test-item"
+            message: "Filtered result should be just the name field"
+
+      debug-file-destination:
+        description: Verify debug can write to file
+        extends: [_base]
+        assertions:
+          - expression: __output.debugToFile.success == true
+          - expression: __output.debugToFile.destination.contains("debug-output.json")
+            message: "Destination should be the file path"
+
+      debug-as-transform:
+        description: Verify debug transform returns debug result
+        extends: [_base]
+        assertions:
+          - expression: __output.debugAsTransform.success == true
+            message: "Debug transform should succeed"
+          - expression: __output.debugAsTransform.result["__self"] == "transform-input"
+            message: "Debug result should contain the original input"
+
+      debug-stderr-contains-output:
+        description: Verify debug stderr contains expected content
+        extends: [_base]
+        assertions:
+          - regex: "test-item"
+            target: stderr
+            message: "Stderr should contain debug output"

--- a/tests/integration/solutions/providers/directory/solution.yaml
+++ b/tests/integration/solutions/providers/directory/solution.yaml
@@ -27,37 +27,38 @@ spec:
               path: .
               recursive: true
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for directory provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, directory]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for directory provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, directory]
+        assertions:
+          - expression: __exitCode == 0
 
-    list-current-dir:
-      description: Verify listing current directory
-      extends: [_base]
-      tags: [smoke]
-      init:
-        - command: "touch file-a.txt file-b.txt file-c.log"
-      cleanup:
-        - command: "rm -f file-a.txt file-b.txt file-c.log"
-      assertions:
-        - contains: "file-a.txt"
-        - contains: "file-b.txt"
+      list-current-dir:
+        description: Verify listing current directory
+        extends: [_base]
+        tags: [smoke]
+        init:
+          - command: "touch file-a.txt file-b.txt file-c.log"
+        cleanup:
+          - command: "rm -f file-a.txt file-b.txt file-c.log"
+        assertions:
+          - contains: "file-a.txt"
+          - contains: "file-b.txt"
 
-    list-recursive:
-      description: Verify recursive listing
-      extends: [_base]
-      init:
-        - command: "mkdir -p subdir && touch subdir/nested.txt top.txt"
-      cleanup:
-        - command: "rm -rf subdir top.txt"
-      assertions:
-        - contains: "nested.txt"
-        - contains: "top.txt"
+      list-recursive:
+        description: Verify recursive listing
+        extends: [_base]
+        init:
+          - command: "mkdir -p subdir && touch subdir/nested.txt top.txt"
+        cleanup:
+          - command: "rm -rf subdir top.txt"
+        assertions:
+          - contains: "nested.txt"
+          - contains: "top.txt"

--- a/tests/integration/solutions/providers/env/solution.yaml
+++ b/tests/integration/solutions/providers/env/solution.yaml
@@ -36,49 +36,50 @@ spec:
               operation: get
               name: SCAFCTL_FUNC_TEST_VAR
 
-  testConfig:
-    skipBuiltins: true
-    env:
-      SCAFCTL_FUNC_TEST_VAR: "global-test-value"
-
-  tests:
-    _base:
-      description: Base template for env provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, env]
-      assertions:
-        - expression: __exitCode == 0
-
-    home-dir:
-      description: Verify HOME variable is readable
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.homeDir.exists == true
-          message: "HOME should exist"
-        - expression: '__output.homeDir.value != ""'
-          message: "HOME should be non-empty"
-
-    default-value:
-      description: Verify default is returned for unset variable
-      extends: [_base]
-      assertions:
-        - expression: '__output.withDefault.value == "fallback-value"'
-          message: "Unset variable should return the default value"
-
-    global-env-injection:
-      description: Verify testConfig env vars are available
-      extends: [_base]
-      assertions:
-        - expression: '__output.testInjected.value == "global-test-value"'
-          message: "testConfig env var should be accessible"
-
-    per-test-env-override:
-      description: Verify per-test env overrides global testConfig env
-      extends: [_base]
+  testing:
+    config:
+      skipBuiltins: true
       env:
-        SCAFCTL_FUNC_TEST_VAR: "overridden-value"
-      assertions:
-        - expression: '__output.testInjected.value == "overridden-value"'
-          message: "Per-test env should override testConfig env"
+        SCAFCTL_FUNC_TEST_VAR: "global-test-value"
+
+    cases:
+      _base:
+        description: Base template for env provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, env]
+        assertions:
+          - expression: __exitCode == 0
+
+      home-dir:
+        description: Verify HOME variable is readable
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.homeDir.exists == true
+            message: "HOME should exist"
+          - expression: '__output.homeDir.value != ""'
+            message: "HOME should be non-empty"
+
+      default-value:
+        description: Verify default is returned for unset variable
+        extends: [_base]
+        assertions:
+          - expression: '__output.withDefault.value == "fallback-value"'
+            message: "Unset variable should return the default value"
+
+      global-env-injection:
+        description: Verify testConfig env vars are available
+        extends: [_base]
+        assertions:
+          - expression: '__output.testInjected.value == "global-test-value"'
+            message: "testConfig env var should be accessible"
+
+      per-test-env-override:
+        description: Verify per-test env overrides global testConfig env
+        extends: [_base]
+        env:
+          SCAFCTL_FUNC_TEST_VAR: "overridden-value"
+        assertions:
+          - expression: '__output.testInjected.value == "overridden-value"'
+            message: "Per-test env should override testConfig env"

--- a/tests/integration/solutions/providers/exec/solution.yaml
+++ b/tests/integration/solutions/providers/exec/solution.yaml
@@ -106,59 +106,60 @@ spec:
             inputs:
               expression: "has(__self.exitCode) ? __self.exitCode : 0"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for exec provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, exec]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for exec provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, exec]
+        assertions:
+          - expression: __exitCode == 0
 
-    simple-echo:
-      description: Verify simple echo command
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.echoSimple == "hello-from-exec"
+      simple-echo:
+        description: Verify simple echo command
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.echoSimple == "hello-from-exec"
 
-    echo-with-args:
-      description: Verify echo with args
-      extends: [_base]
-      assertions:
-        - expression: __output.echoWithArgs == "no-newline"
+      echo-with-args:
+        description: Verify echo with args
+        extends: [_base]
+        assertions:
+          - expression: __output.echoWithArgs == "no-newline"
 
-    piped-command:
-      description: Verify piped command execution
-      extends: [_base]
-      assertions:
-        - expression: __output.pipedCommand == "alpha"
-          message: "Sorted first word should be alpha"
+      piped-command:
+        description: Verify piped command execution
+        extends: [_base]
+        assertions:
+          - expression: __output.pipedCommand == "alpha"
+            message: "Sorted first word should be alpha"
 
-    env-passthrough:
-      description: Verify environment variable passthrough to exec
-      extends: [_base]
-      assertions:
-        - expression: __output.envPassthrough == "exec-env-value"
+      env-passthrough:
+        description: Verify environment variable passthrough to exec
+        extends: [_base]
+        assertions:
+          - expression: __output.envPassthrough == "exec-env-value"
 
-    multiline-output:
-      description: Verify multi-line output capture
-      extends: [_base]
-      assertions:
-        - expression: __output.multilineOutput.contains("line1")
-        - expression: __output.multilineOutput.contains("line3")
+      multiline-output:
+        description: Verify multi-line output capture
+        extends: [_base]
+        assertions:
+          - expression: __output.multilineOutput.contains("line1")
+          - expression: __output.multilineOutput.contains("line3")
 
-    stdin-input:
-      description: Verify stdin is passed to command
-      extends: [_base]
-      assertions:
-        - expression: __output.stdinInput == "stdin-content"
+      stdin-input:
+        description: Verify stdin is passed to command
+        extends: [_base]
+        assertions:
+          - expression: __output.stdinInput == "stdin-content"
 
-    exit-code-capture:
-      description: Verify exit code is captured
-      extends: [_base]
-      assertions:
-        - expression: __output.exitCodeCapture == 0
+      exit-code-capture:
+        description: Verify exit code is captured
+        extends: [_base]
+        assertions:
+          - expression: __output.exitCodeCapture == 0

--- a/tests/integration/solutions/providers/file/solution.yaml
+++ b/tests/integration/solutions/providers/file/solution.yaml
@@ -44,63 +44,64 @@ spec:
               operation: read
               path: ./test-data.json
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for file provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, file]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for file provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, file]
+        assertions:
+          - expression: __exitCode == 0
 
-    read-fixture:
-      description: Verify reading a file
-      extends: [_base]
-      tags: [smoke]
-      init:
-        - command: "echo -n 'fixture-content' > test-fixture.txt"
-        - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
-      cleanup:
-        - command: "rm -f test-fixture.txt test-data.json"
-      assertions:
-        - expression: '__output.readFixture.content == "fixture-content"'
-          message: "Should read the fixture file content"
+      read-fixture:
+        description: Verify reading a file
+        extends: [_base]
+        tags: [smoke]
+        init:
+          - command: "echo -n 'fixture-content' > test-fixture.txt"
+          - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: '__output.readFixture.content == "fixture-content"'
+            message: "Should read the fixture file content"
 
-    file-exists:
-      description: Verify file exists check returns true
-      extends: [_base]
-      init:
-        - command: "echo -n 'exists' > test-fixture.txt"
-        - command: "echo -n '{}' > test-data.json"
-      cleanup:
-        - command: "rm -f test-fixture.txt test-data.json"
-      assertions:
-        - expression: __output.fileExists.exists == true
-          message: "Existing file should return true"
+      file-exists:
+        description: Verify file exists check returns true
+        extends: [_base]
+        init:
+          - command: "echo -n 'exists' > test-fixture.txt"
+          - command: "echo -n '{}' > test-data.json"
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: __output.fileExists.exists == true
+            message: "Existing file should return true"
 
-    file-not-exists:
-      description: Verify file exists check returns false
-      extends: [_base]
-      init:
-        - command: "echo -n 'needed' > test-fixture.txt"
-        - command: "echo -n '{}' > test-data.json"
-      cleanup:
-        - command: "rm -f test-fixture.txt test-data.json"
-      assertions:
-        - expression: __output.fileNotExists.exists == false
-          message: "Non-existent file should return false"
+      file-not-exists:
+        description: Verify file exists check returns false
+        extends: [_base]
+        init:
+          - command: "echo -n 'needed' > test-fixture.txt"
+          - command: "echo -n '{}' > test-data.json"
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: __output.fileNotExists.exists == false
+            message: "Non-existent file should return false"
 
-    read-json-content:
-      description: Verify reading JSON file content
-      extends: [_base]
-      init:
-        - command: "echo -n 'dummy' > test-fixture.txt"
-        - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
-      cleanup:
-        - command: "rm -f test-fixture.txt test-data.json"
-      assertions:
-        - expression: '__output.readJson.content.contains("key")'
-        - expression: '__output.readJson.content.contains("value")'
+      read-json-content:
+        description: Verify reading JSON file content
+        extends: [_base]
+        init:
+          - command: "echo -n 'dummy' > test-fixture.txt"
+          - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: '__output.readJson.content.contains("key")'
+          - expression: '__output.readJson.content.contains("value")'

--- a/tests/integration/solutions/providers/git/solution.yaml
+++ b/tests/integration/solutions/providers/git/solution.yaml
@@ -1,0 +1,120 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-git-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the git provider.
+    Uses per-test init steps to create a local bare repo and seeded
+    work tree so no network access is required.
+
+spec:
+  resolvers:
+    cloneRepo:
+      description: Clone the local bare repo
+      dependsOn: [sandboxDir]
+      resolve:
+        with:
+          - provider: git
+            inputs:
+              operation: clone
+              repository:
+                expr: "_.sandboxDir + '/bare-repo.git'"
+              path:
+                expr: "_.sandboxDir + '/clone-target'"
+
+    repoStatus:
+      description: Check status of the cloned repo
+      dependsOn: [cloneRepo]
+      resolve:
+        with:
+          - provider: git
+            inputs:
+              operation: status
+              path:
+                expr: "_.sandboxDir + '/clone-target'"
+
+    repoLog:
+      description: Get log of the cloned repo
+      dependsOn: [cloneRepo]
+      resolve:
+        with:
+          - provider: git
+            inputs:
+              operation: log
+              path:
+                expr: "_.sandboxDir + '/clone-target'"
+
+    sandboxDir:
+      description: Sandbox directory
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: SCAFCTL_SANDBOX_DIR
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _base:
+        description: Base template for git provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, git]
+        assertions:
+          - expression: __exitCode == 0
+
+      _git-init:
+        description: Template providing git repo initialization
+        init:
+          - command: |
+              set -e
+              BARE="$SCAFCTL_SANDBOX_DIR/bare-repo.git"
+              git init --bare "$BARE"
+              WORK="$SCAFCTL_SANDBOX_DIR/seed-work"
+              git clone "$BARE" "$WORK"
+              cd "$WORK"
+              git config user.email "test@scafctl.io"
+              git config user.name "Test"
+              echo "hello" > README.md
+              git add README.md
+              git commit -m "Initial commit"
+              git push origin main 2>/dev/null || git push origin master 2>/dev/null || true
+            timeout: 30
+
+      clone-local-repo:
+        description: Verify clone from local bare repo succeeds
+        extends: [_base, _git-init]
+        tags: [smoke]
+        assertions:
+          - expression: __output.cloneRepo.success == true
+            message: "Clone should succeed"
+          - expression: __output.cloneRepo.operation == "clone"
+            message: "Operation should be clone"
+
+      repo-status-clean:
+        description: Verify freshly cloned repo has clean status
+        extends: [_base, _git-init]
+        assertions:
+          - expression: __output.repoStatus.success == true
+            message: "Status should succeed"
+          - expression: __output.repoStatus.operation == "status"
+            message: "Operation should be status"
+
+      repo-log:
+        description: Verify log contains initial commit
+        extends: [_base, _git-init]
+        assertions:
+          - expression: __output.repoLog.success == true
+            message: "Log should succeed"
+          - expression: __output.repoLog.output.contains("Initial commit")
+            message: "Log should contain initial commit message"

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -97,43 +97,44 @@ spec:
                 version: {{.version}}
                 featureCount: {{len .features}}
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for go-template provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, go-template]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for go-template provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, go-template]
+        assertions:
+          - expression: __exitCode == 0
 
-    simple-substitution:
-      description: Verify simple variable substitution
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.simpleTemplate == "App: my-service, Version: 2.1.0"
+      simple-substitution:
+        description: Verify simple variable substitution
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.simpleTemplate == "App: my-service, Version: 2.1.0"
 
-    conditional-true:
-      description: Verify conditional template (true branch)
-      extends: [_base]
-      assertions:
-        - expression: __output.conditionalTemplate == "production-ready"
+      conditional-true:
+        description: Verify conditional template (true branch)
+        extends: [_base]
+        assertions:
+          - expression: __output.conditionalTemplate == "production-ready"
 
-    loop-rendering:
-      description: Verify range loop template
-      extends: [_base]
-      assertions:
-        - expression: __output.loopTemplate.contains("[logging]")
-        - expression: __output.loopTemplate.contains("[metrics]")
-        - expression: __output.loopTemplate.contains("[tracing]")
+      loop-rendering:
+        description: Verify range loop template
+        extends: [_base]
+        assertions:
+          - expression: __output.loopTemplate.contains("[logging]")
+          - expression: __output.loopTemplate.contains("[metrics]")
+          - expression: __output.loopTemplate.contains("[tracing]")
 
-    multiline-rendering:
-      description: Verify multiline template
-      extends: [_base]
-      assertions:
-        - expression: __output.multilineTemplate.contains("name: my-service")
-        - expression: __output.multilineTemplate.contains("version: 2.1.0")
-        - expression: __output.multilineTemplate.contains("featureCount: 3")
+      multiline-rendering:
+        description: Verify multiline template
+        extends: [_base]
+        assertions:
+          - expression: __output.multilineTemplate.contains("name: my-service")
+          - expression: __output.multilineTemplate.contains("version: 2.1.0")
+          - expression: __output.multilineTemplate.contains("featureCount: 3")

--- a/tests/integration/solutions/providers/http/solution.yaml
+++ b/tests/integration/solutions/providers/http/solution.yaml
@@ -1,0 +1,171 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-http-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the HTTP provider.
+    Uses a mock HTTP server started via testConfig.services to verify
+    GET, POST, custom headers, error status codes, and response parsing.
+
+spec:
+  resolvers:
+    getUsers:
+      description: GET request returning JSON
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/users'"
+              method: GET
+              headers:
+                Accept: application/json
+
+    postData:
+      description: POST request with echo to verify request body
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/echo'"
+              method: POST
+              body: '{"action":"create","name":"test-item"}'
+              headers:
+                Content-Type: application/json
+
+    notFoundEndpoint:
+      description: GET request to non-existent endpoint
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/missing'"
+              method: GET
+
+    customHeaders:
+      description: GET request with custom response headers
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/custom-headers'"
+              method: GET
+
+    healthCheck:
+      description: GET request to the built-in health endpoint
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/__health'"
+              method: GET
+
+    mockBaseUrl:
+      description: Base URL of mock server from env
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+  testing:
+    config:
+      skipBuiltins: true
+      services:
+        - name: mock-api
+          type: http
+          portEnv: MOCK_HTTP_PORT
+          baseUrlEnv: MOCK_BASE_URL
+          routes:
+            - path: /api/users
+              method: GET
+              status: 200
+              body: '{"users":[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]}'
+              headers:
+                Content-Type: application/json
+            - path: /api/echo
+              method: POST
+              status: 201
+              echo: true
+            - path: /api/missing
+              method: GET
+              status: 404
+              body: '{"error":"not found"}'
+              headers:
+                Content-Type: application/json
+            - path: /api/custom-headers
+              method: GET
+              status: 200
+              body: ok
+              headers:
+                Content-Type: text/plain
+                X-Custom-Header: custom-value
+                X-Request-Id: req-12345
+
+    cases:
+      _base:
+        description: Base template for HTTP provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, http]
+        assertions:
+          - expression: __exitCode == 0
+
+      get-json-response:
+        description: Verify GET request returns parsed JSON body
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.getUsers.body.contains("alice")
+            message: "GET /api/users should contain alice"
+          - expression: __output.getUsers.statusCode == 200
+            message: "Status code should be 200"
+
+      post-echo-body:
+        description: Verify POST request echoes back the request body and method
+        extends: [_base]
+        assertions:
+          - expression: __output.postData.statusCode == 201
+            message: "POST /api/echo should return 201"
+          - expression: __output.postData.body.contains("create")
+            message: "Echo response should contain the posted body content"
+          - expression: __output.postData.body.contains("POST")
+            message: "Echo response should contain the HTTP method"
+
+      not-found-response:
+        description: Verify 404 response from missing endpoint
+        extends: [_base]
+        assertions:
+          - expression: __output.notFoundEndpoint.statusCode == 404
+            message: "Missing endpoint should return 404"
+          - expression: __output.notFoundEndpoint.body.contains("not found")
+            message: "404 body should contain error message"
+
+      custom-response-headers:
+        description: Verify custom response headers are returned
+        extends: [_base]
+        assertions:
+          - expression: __output.customHeaders.statusCode == 200
+          - expression: __output.customHeaders.headers["X-Custom-Header"] == "custom-value"
+            message: "Custom header should be present"
+          - expression: __output.customHeaders.headers["X-Request-Id"] == "req-12345"
+            message: "Request ID header should be present"
+
+      health-endpoint:
+        description: Verify mock server health endpoint
+        extends: [_base]
+        assertions:
+          - expression: __output.healthCheck.statusCode == 200
+            message: "Health endpoint should return 200"

--- a/tests/integration/solutions/providers/parameter/solution.yaml
+++ b/tests/integration/solutions/providers/parameter/solution.yaml
@@ -1,0 +1,132 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-parameter-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the parameter provider.
+    Verifies CLI parameter passing via -r flag, type coercion,
+    fallback chains, and various value formats.
+
+spec:
+  resolvers:
+    stringParam:
+      description: String parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
+
+    intParam:
+      description: Integer parameter
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: count
+
+    boolParam:
+      description: Boolean parameter
+      type: bool
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: enabled
+
+    jsonParam:
+      description: JSON object parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: config
+
+    csvParam:
+      description: CSV list parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: tags
+
+    paramWithDefault:
+      description: Parameter with static fallback
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: optional
+          - provider: static
+            inputs:
+              value: default-value
+
+    missingParam:
+      description: Missing parameter triggers fallback
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: does-not-exist
+          - provider: static
+            inputs:
+              value: fallback-used
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _base:
+        description: Base template for parameter provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, parameter]
+        assertions:
+          - expression: __exitCode == 0
+
+      string-parameter:
+        description: Verify string parameter passed via -r flag
+        extends: [_base]
+        tags: [smoke]
+        args: ["-o", "json", "-r", "name=hello-world", "-r", "count=10", "-r", "enabled=true", "-r", "config={\"key\":\"val\"}", "-r", "tags=a,b,c"]
+        assertions:
+          - expression: __output.stringParam == "hello-world"
+            message: "String parameter should resolve correctly"
+
+      integer-parameter:
+        description: Verify integer parameter with type coercion
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=42", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          - expression: __output.intParam == 42
+            message: "Integer parameter should be coerced to int"
+
+      boolean-parameter:
+        description: Verify boolean parameter with type coercion
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=true", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          - expression: __output.boolParam == true
+            message: "Boolean parameter should be coerced to bool"
+
+      param-with-default:
+        description: Verify missing parameter falls through to static default
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          - expression: __output.paramWithDefault == "default-value"
+            message: "Missing optional parameter should use fallback"
+
+      missing-param-fallback:
+        description: Verify completely missing parameter uses fallback
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          - expression: __output.missingParam == "fallback-used"
+            message: "Non-existent parameter should trigger fallback chain"

--- a/tests/integration/solutions/providers/sleep/solution.yaml
+++ b/tests/integration/solutions/providers/sleep/solution.yaml
@@ -18,23 +18,24 @@ spec:
             inputs:
               duration: "100ms"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for sleep provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, sleep]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for sleep provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, sleep]
+        assertions:
+          - expression: __exitCode == 0
 
-    short-sleep:
-      description: Verify sleep provider completes successfully
-      extends: [_base]
-      tags: [smoke]
-      timeout: "10s"
-      assertions:
-        - contains: shortSleep
-          message: "Sleep resolver should appear in output"
+      short-sleep:
+        description: Verify sleep provider completes successfully
+        extends: [_base]
+        tags: [smoke]
+        timeout: "10s"
+        assertions:
+          - contains: shortSleep
+            message: "Sleep resolver should appear in output"

--- a/tests/integration/solutions/providers/solution/child.yaml
+++ b/tests/integration/solutions/providers/solution/child.yaml
@@ -1,0 +1,36 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: child-for-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      description: Static greeting from child
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello from child"
+    echoParam:
+      type: string
+      description: Echoes the message parameter from parent
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: message
+    computedValue:
+      type: int
+      description: Computed value from parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: number
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "int(__self) * 2"

--- a/tests/integration/solutions/providers/solution/solution.yaml
+++ b/tests/integration/solutions/providers/solution/solution.yaml
@@ -1,0 +1,107 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-solution-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the solution provider.
+    Exercises sub-solution composition, parameter passing, and
+    selective resolver execution via child.yaml in the same directory.
+
+spec:
+  resolvers:
+    childAll:
+      description: Run all resolvers in child solution
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./child.yaml"
+              inputs:
+                message: "from-parent"
+                number: "5"
+
+    childSelectResolver:
+      description: Run only the greeting resolver in child
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./child.yaml"
+              resolvers:
+                - greeting
+
+    childWithInputs:
+      description: Pass inputs and verify child echoes them
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./child.yaml"
+              inputs:
+                message: "custom-message"
+                number: "3"
+              resolvers:
+                - echoParam
+
+    childComputed:
+      description: Verify child computes transformed value
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./child.yaml"
+              inputs:
+                message: "x"
+                number: "7"
+              resolvers:
+                - computedValue
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _base:
+        description: Base template for solution provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, solution-provider]
+        files: ["child.yaml"]
+        assertions:
+          - expression: __exitCode == 0
+
+      run-all-child-resolvers:
+        description: Verify all child resolvers run and return results
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.childAll.status == "success"
+            message: "Child solution should succeed"
+          - expression: __output.childAll.resolvers.greeting == "hello from child"
+            message: "Child greeting resolver should resolve"
+          - expression: __output.childAll.resolvers.echoParam == "from-parent"
+            message: "Child echoParam should echo the parent input"
+
+      select-resolver:
+        description: Verify selective resolver execution
+        extends: [_base]
+        assertions:
+          - expression: __output.childSelectResolver.status == "success"
+          - expression: __output.childSelectResolver.resolvers.greeting == "hello from child"
+            message: "Selected resolver should be available"
+
+      pass-inputs:
+        description: Verify inputs are passed to child parameters
+        extends: [_base]
+        assertions:
+          - expression: __output.childWithInputs.resolvers.echoParam == "custom-message"
+            message: "Child should receive and echo the custom message"
+
+      computed-value:
+        description: Verify child transforms input value
+        extends: [_base]
+        assertions:
+          - expression: __output.childComputed.resolvers.computedValue == 14
+            message: "Child should compute 7 * 2 = 14"

--- a/tests/integration/solutions/providers/static/solution.yaml
+++ b/tests/integration/solutions/providers/static/solution.yaml
@@ -126,94 +126,95 @@ spec:
                 line two
                 line three
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for static provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, static]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for static provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, static]
+        assertions:
+          - expression: __exitCode == 0
 
-    string-value:
-      description: Verify static string resolution
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.stringValue == "hello world"
+      string-value:
+        description: Verify static string resolution
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.stringValue == "hello world"
 
-    int-value:
-      description: Verify static integer resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.intValue == 42
+      int-value:
+        description: Verify static integer resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.intValue == 42
 
-    bool-true:
-      description: Verify static boolean true resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.boolTrue == true
+      bool-true:
+        description: Verify static boolean true resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.boolTrue == true
 
-    bool-false:
-      description: Verify static boolean false resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.boolFalse == false
+      bool-false:
+        description: Verify static boolean false resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.boolFalse == false
 
-    float-value:
-      description: Verify static float resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.floatValue == 3.14
+      float-value:
+        description: Verify static float resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.floatValue == 3.14
 
-    list-value:
-      description: Verify static list resolution
-      extends: [_base]
-      assertions:
-        - expression: size(__output.listValue) == 3
-        - expression: __output.listValue[0] == "alpha"
-        - expression: __output.listValue[2] == "charlie"
+      list-value:
+        description: Verify static list resolution
+        extends: [_base]
+        assertions:
+          - expression: size(__output.listValue) == 3
+          - expression: __output.listValue[0] == "alpha"
+          - expression: __output.listValue[2] == "charlie"
 
-    map-value:
-      description: Verify static map resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.mapValue.host == "localhost"
-        - expression: __output.mapValue.port == 8080
-        - expression: __output.mapValue.enabled == true
+      map-value:
+        description: Verify static map resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.mapValue.host == "localhost"
+          - expression: __output.mapValue.port == 8080
+          - expression: __output.mapValue.enabled == true
 
-    nested-value:
-      description: Verify static nested structure resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.nestedValue.database.primary.host == "db.example.com"
-        - expression: __output.nestedValue.database.primary.port == 5432
-        - expression: size(__output.nestedValue.database.replicas) == 2
+      nested-value:
+        description: Verify static nested structure resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.nestedValue.database.primary.host == "db.example.com"
+          - expression: __output.nestedValue.database.primary.port == 5432
+          - expression: size(__output.nestedValue.database.replicas) == 2
 
-    empty-string:
-      description: Verify static empty string resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.emptyString == ""
+      empty-string:
+        description: Verify static empty string resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.emptyString == ""
 
-    empty-list:
-      description: Verify static empty list resolution
-      extends: [_base]
-      assertions:
-        - expression: size(__output.emptyList) == 0
+      empty-list:
+        description: Verify static empty list resolution
+        extends: [_base]
+        assertions:
+          - expression: size(__output.emptyList) == 0
 
-    empty-map:
-      description: Verify static empty map resolution
-      extends: [_base]
-      assertions:
-        - expression: size(__output.emptyMap) == 0
+      empty-map:
+        description: Verify static empty map resolution
+        extends: [_base]
+        assertions:
+          - expression: size(__output.emptyMap) == 0
 
-    multiline-string:
-      description: Verify static multiline string resolution
-      extends: [_base]
-      assertions:
-        - expression: __output.multilineString.contains("line one")
-        - expression: __output.multilineString.contains("line three")
+      multiline-string:
+        description: Verify static multiline string resolution
+        extends: [_base]
+        assertions:
+          - expression: __output.multilineString.contains("line one")
+          - expression: __output.multilineString.contains("line three")

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -83,45 +83,46 @@ spec:
               expression: "size(__self) >= 3 && size(__self) <= 20"
             message: "Must be between 3 and 20 characters"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for validation provider tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [provider, validation]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for validation provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, validation]
+        assertions:
+          - expression: __exitCode == 0
 
-    valid-name:
-      description: Verify match validation passes
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: '__output.validName == "my-valid-app"'
+      valid-name:
+        description: Verify match validation passes
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '__output.validName == "my-valid-app"'
 
-    valid-email:
-      description: Verify email pattern validation passes
-      extends: [_base]
-      assertions:
-        - expression: '__output.validEmail == "user@example.com"'
+      valid-email:
+        description: Verify email pattern validation passes
+        extends: [_base]
+        assertions:
+          - expression: '__output.validEmail == "user@example.com"'
 
-    not-match-passes:
-      description: Verify notMatch validation passes
-      extends: [_base]
-      assertions:
-        - expression: '__output.noSpaces == "no-spaces-here"'
+      not-match-passes:
+        description: Verify notMatch validation passes
+        extends: [_base]
+        assertions:
+          - expression: '__output.noSpaces == "no-spaces-here"'
 
-    cel-expression-passes:
-      description: Verify CEL expression validation passes
-      extends: [_base]
-      assertions:
-        - expression: __output.celValidation == 42
+      cel-expression-passes:
+        description: Verify CEL expression validation passes
+        extends: [_base]
+        assertions:
+          - expression: __output.celValidation == 42
 
-    multiple-validations:
-      description: Verify multiple validation rules all pass
-      extends: [_base]
-      assertions:
-        - expression: '__output.multiValidation == "hello"'
+      multiple-validations:
+        description: Verify multiple validation rules all pass
+        extends: [_base]
+        assertions:
+          - expression: '__output.multiValidation == "hello"'

--- a/tests/integration/solutions/rendering/solution.yaml
+++ b/tests/integration/solutions/rendering/solution.yaml
@@ -57,39 +57,40 @@ spec:
             inputs:
               expression: '_.projectName + "-" + _.language + "-" + _.version'
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base for resolver tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [rendering]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base for resolver tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [rendering]
+        assertions:
+          - expression: __exitCode == 0
 
-    resolver-data-available:
-      description: Verify all resolver data is available
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: '__output.projectName == "test-project"'
-        - expression: '__output.language == "go"'
-        - expression: '__output.version == "1.0.0"'
-        - expression: size(__output.features) == 3
-        - expression: '__output.computed == "test-project-go-1.0.0"'
+      resolver-data-available:
+        description: Verify all resolver data is available
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '__output.projectName == "test-project"'
+          - expression: '__output.language == "go"'
+          - expression: '__output.version == "1.0.0"'
+          - expression: size(__output.features) == 3
+          - expression: '__output.computed == "test-project-go-1.0.0"'
 
-    render-json-output:
-      description: Verify JSON output contains all resolvers
-      extends: [_base]
-      assertions:
-        - expression: '"projectName" in __output'
-        - expression: '"features" in __output'
+      render-json-output:
+        description: Verify JSON output contains all resolvers
+        extends: [_base]
+        assertions:
+          - expression: '"projectName" in __output'
+          - expression: '"features" in __output'
 
-    render-with-params:
-      description: Verify custom parameter overrides default
-      extends: [_base]
-      args: ["-o", "json", "-r", "projectName=custom-app"]
-      assertions:
-        - expression: '__output.projectName == "custom-app"'
+      render-with-params:
+        description: Verify custom parameter overrides default
+        extends: [_base]
+        args: ["-o", "json", "-r", "projectName=custom-app"]
+        assertions:
+          - expression: '__output.projectName == "custom-app"'

--- a/tests/integration/solutions/resolvers/conditional/solution.yaml
+++ b/tests/integration/solutions/resolvers/conditional/solution.yaml
@@ -76,64 +76,65 @@ spec:
             inputs:
               value: "always-here"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for conditional resolver tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, conditional]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for conditional resolver tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, conditional]
+        assertions:
+          - expression: __exitCode == 0
 
-    dev-default:
-      description: Verify dev config resolves by default
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.devConfig == "development-settings"
-          message: "devConfig should resolve when env=dev"
-        - expression: __output.alwaysPresent == "always-here"
+      dev-default:
+        description: Verify dev config resolves by default
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.devConfig == "development-settings"
+            message: "devConfig should resolve when env=dev"
+          - expression: __output.alwaysPresent == "always-here"
 
-    dev-no-prod:
-      description: Verify prod config is skipped in dev
-      extends: [_base]
-      assertions:
-        - expression: '!("prodConfig" in __output) || __output.prodConfig == null'
-          message: "prodConfig should not resolve when env=dev"
+      dev-no-prod:
+        description: Verify prod config is skipped in dev
+        extends: [_base]
+        assertions:
+          - expression: '!("prodConfig" in __output) || __output.prodConfig == null'
+            message: "prodConfig should not resolve when env=dev"
 
-    prod-config:
-      description: Verify prod config resolves when env=prod
-      extends: [_base]
-      args: ["-r", "env=prod"]
-      assertions:
-        - expression: __output.prodConfig == "production-settings"
+      prod-config:
+        description: Verify prod config resolves when env=prod
+        extends: [_base]
+        args: ["-r", "env=prod"]
+        assertions:
+          - expression: __output.prodConfig == "production-settings"
 
-    prod-no-dev:
-      description: Verify dev config is skipped in prod
-      extends: [_base]
-      args: ["-r", "env=prod"]
-      assertions:
-        - expression: '!("devConfig" in __output) || __output.devConfig == null'
-          message: "devConfig should not resolve when env=prod"
+      prod-no-dev:
+        description: Verify dev config is skipped in prod
+        extends: [_base]
+        args: ["-r", "env=prod"]
+        assertions:
+          - expression: '!("devConfig" in __output) || __output.devConfig == null'
+            message: "devConfig should not resolve when env=prod"
 
-    debug-disabled:
-      description: Verify debug info skipped when debug=false
-      extends: [_base]
-      assertions:
-        - expression: '!("debugInfo" in __output) || __output.debugInfo == null'
+      debug-disabled:
+        description: Verify debug info skipped when debug=false
+        extends: [_base]
+        assertions:
+          - expression: '!("debugInfo" in __output) || __output.debugInfo == null'
 
-    debug-enabled:
-      description: Verify debug info resolves when debug=true
-      extends: [_base]
-      args: ["-r", "debug=true"]
-      assertions:
-        - expression: __output.debugInfo == "debug-enabled"
+      debug-enabled:
+        description: Verify debug info resolves when debug=true
+        extends: [_base]
+        args: ["-r", "debug=true"]
+        assertions:
+          - expression: __output.debugInfo == "debug-enabled"
 
-    always-present:
-      description: Verify unconditional resolver always resolves
-      extends: [_base]
-      assertions:
-        - expression: __output.alwaysPresent == "always-here"
+      always-present:
+        description: Verify unconditional resolver always resolves
+        extends: [_base]
+        assertions:
+          - expression: __output.alwaysPresent == "always-here"

--- a/tests/integration/solutions/resolvers/dag/solution.yaml
+++ b/tests/integration/solutions/resolvers/dag/solution.yaml
@@ -98,59 +98,60 @@ spec:
             inputs:
               expression: '_.chainC + "D"'
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for DAG tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, dag]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for DAG tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, dag]
+        assertions:
+          - expression: __exitCode == 0
 
-    implicit-deps:
-      description: Verify implicit dependencies via _.ref are resolved
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.fullName == "John Doe"
-          message: "fullName should combine firstName and lastName"
+      implicit-deps:
+        description: Verify implicit dependencies via _.ref are resolved
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.fullName == "John Doe"
+            message: "fullName should combine firstName and lastName"
 
-    explicit-depends-on:
-      description: Verify explicit dependsOn is honored
-      extends: [_base]
-      assertions:
-        - expression: __output.greeting == "Hello, John!"
+      explicit-depends-on:
+        description: Verify explicit dependsOn is honored
+        extends: [_base]
+        assertions:
+          - expression: __output.greeting == "Hello, John!"
 
-    multi-level-chain:
-      description: Verify multi-level dependency chain
-      extends: [_base]
-      assertions:
-        - expression: __output.formalGreeting == "Dear John Doe,"
+      multi-level-chain:
+        description: Verify multi-level dependency chain
+        extends: [_base]
+        assertions:
+          - expression: __output.formalGreeting == "Dear John Doe,"
 
-    diamond-dependency:
-      description: Verify diamond dependency pattern
-      extends: [_base]
-      assertions:
-        - expression: __output.summary == 'Hello, John! Your full name is John Doe.'
+      diamond-dependency:
+        description: Verify diamond dependency pattern
+        extends: [_base]
+        assertions:
+          - expression: __output.summary == 'Hello, John! Your full name is John Doe.'
 
-    deep-chain:
-      description: Verify 4-level deep dependency chain
-      extends: [_base]
-      assertions:
-        - expression: __output.chainD == "ABCD"
-          message: "Each level should append its letter"
+      deep-chain:
+        description: Verify 4-level deep dependency chain
+        extends: [_base]
+        assertions:
+          - expression: __output.chainD == "ABCD"
+            message: "Each level should append its letter"
 
-    all-resolvers-present:
-      description: Verify all resolvers are in output
-      extends: [_base]
-      assertions:
-        - expression: '"firstName" in __output'
-        - expression: '"lastName" in __output'
-        - expression: '"fullName" in __output'
-        - expression: '"greeting" in __output'
-        - expression: '"formalGreeting" in __output'
-        - expression: '"summary" in __output'
-        - expression: '"chainD" in __output'
+      all-resolvers-present:
+        description: Verify all resolvers are in output
+        extends: [_base]
+        assertions:
+          - expression: '"firstName" in __output'
+          - expression: '"lastName" in __output'
+          - expression: '"fullName" in __output'
+          - expression: '"greeting" in __output'
+          - expression: '"formalGreeting" in __output'
+          - expression: '"summary" in __output'
+          - expression: '"chainD" in __output'

--- a/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
+++ b/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
@@ -109,121 +109,122 @@ spec:
             inputs:
               expression: "user"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
+    cases:
     # =========================================================================
     # Base template
     # =========================================================================
 
-    _base:
-      description: Base template for forEach filter tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, foreach-filter]
-      assertions:
-        - expression: __exitCode == 0
+      _base:
+        description: Base template for forEach filter tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, foreach-filter]
+        assertions:
+          - expression: __exitCode == 0
 
     # =========================================================================
     # Default filter behavior (keepSkipped: false)
     # =========================================================================
 
-    filter-default-removes-nils:
-      description: Verify default behavior removes nil entries from forEach output
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: size(__output.evenNumbers) == 3
-          message: "Default filter should retain only the 3 even numbers"
-        - expression: __output.evenNumbers[0] == 2
-          message: "First element should be 2"
-        - expression: __output.evenNumbers[1] == 4
-          message: "Second element should be 4"
-        - expression: __output.evenNumbers[2] == 6
-          message: "Third element should be 6"
+      filter-default-removes-nils:
+        description: Verify default behavior removes nil entries from forEach output
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: size(__output.evenNumbers) == 3
+            message: "Default filter should retain only the 3 even numbers"
+          - expression: __output.evenNumbers[0] == 2
+            message: "First element should be 2"
+          - expression: __output.evenNumbers[1] == 4
+            message: "Second element should be 4"
+          - expression: __output.evenNumbers[2] == 6
+            message: "Third element should be 6"
 
-    filter-no-nulls-in-output:
-      description: Verify no null entries exist in default-filtered output
-      extends: [_base]
-      assertions:
-        - expression: >
-            !__output.evenNumbers.exists(v, v == null)
-          message: "Default filter should contain no null entries"
+      filter-no-nulls-in-output:
+        description: Verify no null entries exist in default-filtered output
+        extends: [_base]
+        assertions:
+          - expression: >
+              !__output.evenNumbers.exists(v, v == null)
+            message: "Default filter should contain no null entries"
 
     # =========================================================================
     # keepSkipped: true — index alignment
     # =========================================================================
 
-    keep-skipped-preserves-nils:
-      description: Verify keepSkipped=true preserves nil entries for index alignment
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: size(__output.evenNumbersAligned) == 6
-          message: "keepSkipped should retain all 6 positions including nils"
-        - expression: __output.evenNumbersAligned[0] == null
-          message: "Position 0 (value 1, odd) should be null"
-        - expression: __output.evenNumbersAligned[1] == 2
-          message: "Position 1 (value 2, even) should be 2"
-        - expression: __output.evenNumbersAligned[2] == null
-          message: "Position 2 (value 3, odd) should be null"
-        - expression: __output.evenNumbersAligned[3] == 4
-          message: "Position 3 (value 4, even) should be 4"
-        - expression: __output.evenNumbersAligned[4] == null
-          message: "Position 4 (value 5, odd) should be null"
-        - expression: __output.evenNumbersAligned[5] == 6
-          message: "Position 5 (value 6, even) should be 6"
+      keep-skipped-preserves-nils:
+        description: Verify keepSkipped=true preserves nil entries for index alignment
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: size(__output.evenNumbersAligned) == 6
+            message: "keepSkipped should retain all 6 positions including nils"
+          - expression: __output.evenNumbersAligned[0] == null
+            message: "Position 0 (value 1, odd) should be null"
+          - expression: __output.evenNumbersAligned[1] == 2
+            message: "Position 1 (value 2, even) should be 2"
+          - expression: __output.evenNumbersAligned[2] == null
+            message: "Position 2 (value 3, odd) should be null"
+          - expression: __output.evenNumbersAligned[3] == 4
+            message: "Position 3 (value 4, even) should be 4"
+          - expression: __output.evenNumbersAligned[4] == null
+            message: "Position 4 (value 5, odd) should be null"
+          - expression: __output.evenNumbersAligned[5] == 6
+            message: "Position 5 (value 6, even) should be 6"
 
     # =========================================================================
     # Comparison: filtered vs index-aligned
     # =========================================================================
 
-    filter-vs-keep-count:
-      description: Verify filtered result is smaller than index-aligned result
-      extends: [_base]
-      assertions:
-        - expression: size(__output.evenNumbers) < size(__output.evenNumbersAligned)
-          message: "Filtered result should have fewer elements than index-aligned result"
-        - expression: size(__output.evenNumbers) == 3
-        - expression: size(__output.evenNumbersAligned) == 6
+      filter-vs-keep-count:
+        description: Verify filtered result is smaller than index-aligned result
+        extends: [_base]
+        assertions:
+          - expression: size(__output.evenNumbers) < size(__output.evenNumbersAligned)
+            message: "Filtered result should have fewer elements than index-aligned result"
+          - expression: size(__output.evenNumbers) == 3
+          - expression: size(__output.evenNumbersAligned) == 6
 
     # =========================================================================
     # No when condition — all items pass through
     # =========================================================================
 
-    no-condition-all-pass:
-      description: Verify forEach without when condition passes all items through
-      extends: [_base]
-      assertions:
-        - expression: size(__output.allNumbers) == 3
-          message: "Without when condition all 3 items should pass through"
-        - expression: __output.allNumbers[0] == 10
-        - expression: __output.allNumbers[1] == 20
-        - expression: __output.allNumbers[2] == 30
+      no-condition-all-pass:
+        description: Verify forEach without when condition passes all items through
+        extends: [_base]
+        assertions:
+          - expression: size(__output.allNumbers) == 3
+            message: "Without when condition all 3 items should pass through"
+          - expression: __output.allNumbers[0] == 10
+          - expression: __output.allNumbers[1] == 20
+          - expression: __output.allNumbers[2] == 30
 
     # =========================================================================
     # Object filtering
     # =========================================================================
 
-    active-users-filtered:
-      description: Verify active users are correctly filtered from a mixed list
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: size(__output.activeUsers) == 3
-          message: "3 of 5 users are active and should appear in the output"
-        - expression: __output.activeUsers[0].name == "alice"
-          message: "First active user should be alice"
-        - expression: __output.activeUsers[1].name == "carol"
-          message: "Second active user should be carol"
-        - expression: __output.activeUsers[2].name == "eve"
-          message: "Third active user should be eve"
+      active-users-filtered:
+        description: Verify active users are correctly filtered from a mixed list
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: size(__output.activeUsers) == 3
+            message: "3 of 5 users are active and should appear in the output"
+          - expression: __output.activeUsers[0].name == "alice"
+            message: "First active user should be alice"
+          - expression: __output.activeUsers[1].name == "carol"
+            message: "Second active user should be carol"
+          - expression: __output.activeUsers[2].name == "eve"
+            message: "Third active user should be eve"
 
-    active-users-all-active:
-      description: Verify all returned users have active=true
-      extends: [_base]
-      assertions:
-        - expression: >
-            __output.activeUsers.all(u, u.active == true)
-          message: "All returned users should have active=true"
+      active-users-all-active:
+        description: Verify all returned users have active=true
+        extends: [_base]
+        assertions:
+          - expression: >
+              __output.activeUsers.all(u, u.active == true)
+            message: "All returned users should have active=true"

--- a/tests/integration/solutions/resolvers/sensitive/solution.yaml
+++ b/tests/integration/solutions/resolvers/sensitive/solution.yaml
@@ -28,26 +28,27 @@ spec:
             inputs:
               value: "visible-value"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    sensitive-in-json:
-      description: Verify sensitive value is accessible in JSON output
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, sensitive, smoke]
-      assertions:
-        - expression: __exitCode == 0
-        - expression: __output.normalValue == "visible-value"
+    cases:
+      sensitive-in-json:
+        description: Verify sensitive value is accessible in JSON output
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, sensitive, smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.normalValue == "visible-value"
 
-    sensitive-masked-table:
-      description: Verify sensitive value is masked in table output
-      command: [run, resolver]
-      tags: [resolver, sensitive]
-      assertions:
-        - expression: __exitCode == 0
-        - notContains: "super-secret-password"
-          message: "Sensitive value should be masked in table output"
-        - contains: "visible-value"
-          message: "Non-sensitive value should be visible"
+      sensitive-masked-table:
+        description: Verify sensitive value is masked in table output
+        command: [run, resolver]
+        tags: [resolver, sensitive]
+        assertions:
+          - expression: __exitCode == 0
+          - notContains: "super-secret-password"
+            message: "Sensitive value should be masked in table output"
+          - contains: "visible-value"
+            message: "Non-sensitive value should be visible"

--- a/tests/integration/solutions/resolvers/timeout/solution.yaml
+++ b/tests/integration/solutions/resolvers/timeout/solution.yaml
@@ -34,28 +34,29 @@ spec:
             inputs:
               value: "sleep-completed"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for timeout tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, timeout]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for timeout tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, timeout]
+        assertions:
+          - expression: __exitCode == 0
 
-    fast-within-timeout:
-      description: Verify fast resolver completes within timeout
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.fastResolver == "fast-result"
+      fast-within-timeout:
+        description: Verify fast resolver completes within timeout
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.fastResolver == "fast-result"
 
-    sleep-within-timeout:
-      description: Verify sleep completes within timeout
-      extends: [_base]
-      timeout: "15s"
-      assertions:
-        - expression: __output.timedSleep == "sleep-completed"
+      sleep-within-timeout:
+        description: Verify sleep completes within timeout
+        extends: [_base]
+        timeout: "15s"
+        assertions:
+          - expression: __output.timedSleep == "sleep-completed"

--- a/tests/integration/solutions/resolvers/transform-chain/solution.yaml
+++ b/tests/integration/solutions/resolvers/transform-chain/solution.yaml
@@ -98,48 +98,49 @@ spec:
               name: config
               template: "app={{ .cleanedInput }}"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for transform chain tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, transform]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for transform chain tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, transform]
+        assertions:
+          - expression: __exitCode == 0
 
-    multi-step-clean:
-      description: Verify multi-step string cleaning
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.cleanedInput == "hello-world"
-          message: "Should trim, lowercase, remove punctuation, and hyphenate"
+      multi-step-clean:
+        description: Verify multi-step string cleaning
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.cleanedInput == "hello-world"
+            message: "Should trim, lowercase, remove punctuation, and hyphenate"
 
-    csv-to-filtered-list:
-      description: Verify CSV to filtered uppercase list
-      extends: [_base]
-      assertions:
-        - expression: size(__output.csvToList) == 4
-        - expression: __output.csvToList[0] == "APPLE"
-        - expression: __output.csvToList[3] == "DATE"
+      csv-to-filtered-list:
+        description: Verify CSV to filtered uppercase list
+        extends: [_base]
+        assertions:
+          - expression: size(__output.csvToList) == 4
+          - expression: __output.csvToList[0] == "APPLE"
+          - expression: __output.csvToList[3] == "DATE"
 
-    exec-output-transform:
-      description: Verify exec output is transformed through chain
-      extends: [_base]
-      assertions:
-        - expression: __output.execTransform == "test-value"
+      exec-output-transform:
+        description: Verify exec output is transformed through chain
+        extends: [_base]
+        assertions:
+          - expression: __output.execTransform == "test-value"
 
-    passthrough-no-transform:
-      description: Verify value passes through without transforms
-      extends: [_base]
-      assertions:
-        - expression: __output.passthrough == "unchanged"
+      passthrough-no-transform:
+        description: Verify value passes through without transforms
+        extends: [_base]
+        assertions:
+          - expression: __output.passthrough == "unchanged"
 
-    template-transform:
-      description: Verify go-template transform step
-      extends: [_base]
-      assertions:
-        - expression: __output.templateTransform == "app=hello-world"
+      template-transform:
+        description: Verify go-template transform step
+        extends: [_base]
+        assertions:
+          - expression: __output.templateTransform == "app=hello-world"

--- a/tests/integration/solutions/resolvers/type-coercion/solution.yaml
+++ b/tests/integration/solutions/resolvers/type-coercion/solution.yaml
@@ -71,57 +71,58 @@ spec:
             inputs:
               value: "native"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for type coercion tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, type-coercion]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for type coercion tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, type-coercion]
+        assertions:
+          - expression: __exitCode == 0
 
-    string-to-int:
-      description: Verify string to int coercion
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: __output.stringToInt == 42
+      string-to-int:
+        description: Verify string to int coercion
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.stringToInt == 42
 
-    string-to-bool:
-      description: Verify string to bool coercion
-      extends: [_base]
-      assertions:
-        - expression: __output.stringToBool == true
+      string-to-bool:
+        description: Verify string to bool coercion
+        extends: [_base]
+        assertions:
+          - expression: __output.stringToBool == true
 
-    int-to-string:
-      description: Verify int to string coercion
-      extends: [_base]
-      assertions:
-        - expression: '__output.intToString == "123"'
+      int-to-string:
+        description: Verify int to string coercion
+        extends: [_base]
+        assertions:
+          - expression: '__output.intToString == "123"'
 
-    bool-to-string:
-      description: Verify bool to string coercion
-      extends: [_base]
-      assertions:
-        - expression: '__output.boolToString == "true"'
+      bool-to-string:
+        description: Verify bool to string coercion
+        extends: [_base]
+        assertions:
+          - expression: '__output.boolToString == "true"'
 
-    float-to-int:
-      description: Verify whole float to int coercion
-      extends: [_base]
-      assertions:
-        - expression: __output.wholeFloatToInt == 3
+      float-to-int:
+        description: Verify whole float to int coercion
+        extends: [_base]
+        assertions:
+          - expression: __output.wholeFloatToInt == 3
 
-    native-int:
-      description: Verify native int needs no coercion
-      extends: [_base]
-      assertions:
-        - expression: __output.nativeInt == 99
+      native-int:
+        description: Verify native int needs no coercion
+        extends: [_base]
+        assertions:
+          - expression: __output.nativeInt == 99
 
-    native-string:
-      description: Verify native string needs no coercion
-      extends: [_base]
-      assertions:
-        - expression: '__output.nativeString == "native"'
+      native-string:
+        description: Verify native string needs no coercion
+        extends: [_base]
+        assertions:
+          - expression: '__output.nativeString == "native"'

--- a/tests/integration/solutions/resolvers/until/solution.yaml
+++ b/tests/integration/solutions/resolvers/until/solution.yaml
@@ -46,41 +46,42 @@ spec:
             inputs:
               value: "fallback-after-error"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
-    _base:
-      description: Base template for until/fallback tests
-      command: [run, resolver]
-      args: ["-o", "json"]
-      tags: [resolver, until]
-      assertions:
-        - expression: __exitCode == 0
+    cases:
+      _base:
+        description: Base template for until/fallback tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, until]
+        assertions:
+          - expression: __exitCode == 0
 
-    default-fallback:
-      description: Verify default fallback to last non-null source
-      extends: [_base]
-      tags: [smoke]
-      assertions:
-        - expression: '__output.defaultFallback == "third-source-wins"'
+      default-fallback:
+        description: Verify default fallback to last non-null source
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '__output.defaultFallback == "third-source-wins"'
 
-    param-override:
-      description: Verify parameter overrides static when provided
-      extends: [_base]
-      args: ["-o", "json", "-r", "overrideKey=param-value"]
-      assertions:
-        - expression: '__output.paramOverride == "param-value"'
+      param-override:
+        description: Verify parameter overrides static when provided
+        extends: [_base]
+        args: ["-o", "json", "-r", "overrideKey=param-value"]
+        assertions:
+          - expression: '__output.paramOverride == "param-value"'
 
-    param-fallback:
-      description: Verify static fallback when parameter not provided
-      extends: [_base]
-      assertions:
-        - expression: '__output.paramOverride == "static-fallback"'
+      param-fallback:
+        description: Verify static fallback when parameter not provided
+        extends: [_base]
+        assertions:
+          - expression: '__output.paramOverride == "static-fallback"'
 
-    error-continue:
-      description: Verify onError continue skips failed source
-      extends: [_base]
-      assertions:
-        - expression: '__output.errorContinue == "fallback-after-error"'
-          message: "Should fall through to static after file read fails"
+      error-continue:
+        description: Verify onError continue skips failed source
+        extends: [_base]
+        assertions:
+          - expression: '__output.errorContinue == "fallback-after-error"'
+            message: "Should fall through to static after file read fails"

--- a/tests/integration/solutions/test-generation/solution.yaml
+++ b/tests/integration/solutions/test-generation/solution.yaml
@@ -50,166 +50,167 @@ spec:
           command:
             expr: "'echo Hello from ' + _.environment"
 
-  testConfig:
-    skipBuiltins: true
+  testing:
+    config:
+      skipBuiltins: true
 
-  tests:
+    cases:
     # =========================================================================
     # run resolver -o test
     # =========================================================================
 
-    run-resolver-test-output:
-      description: Verify run resolver -o test emits a valid test YAML block
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation, smoke]
-      assertions:
-        - expression: __exitCode == 0
-          message: "run resolver -o test should succeed"
-        - contains: "command:"
-          message: "Output should include the command field"
-        - contains: "assertions:"
-          message: "Output should include the assertions field"
-        - contains: "Auto-generated test for: run resolver"
-          message: "Output should contain the auto-generated description"
+      run-resolver-test-output:
+        description: Verify run resolver -o test emits a valid test YAML block
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "run resolver -o test should succeed"
+          - contains: "command:"
+            message: "Output should include the command field"
+          - contains: "assertions:"
+            message: "Output should include the assertions field"
+          - contains: "Auto-generated test for: run resolver"
+            message: "Output should contain the auto-generated description"
 
-    run-resolver-test-has-snapshot:
-      description: Verify run resolver -o test includes a snapshot reference
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "snapshot:"
-          message: "Generated test should reference a snapshot file"
+      run-resolver-test-has-snapshot:
+        description: Verify run resolver -o test includes a snapshot reference
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "snapshot:"
+            message: "Generated test should reference a snapshot file"
 
-    run-resolver-test-has-generated-tag:
-      description: Verify the generated test includes the 'generated' tag
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "generated"
-          message: "Generated test should be tagged with 'generated'"
+      run-resolver-test-has-generated-tag:
+        description: Verify the generated test includes the 'generated' tag
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "generated"
+            message: "Generated test should be tagged with 'generated'"
 
-    run-resolver-test-has-args:
-      description: Verify run resolver -o test includes the args field
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "args:"
-          message: "Generated test should include args field"
+      run-resolver-test-has-args:
+        description: Verify run resolver -o test includes the args field
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "args:"
+            message: "Generated test should include args field"
 
-    run-resolver-custom-test-name:
-      description: Verify --test-name overrides the auto-derived test name
-      command: [run, resolver]
-      args: ["-o", "test", "--test-name", "my-custom-resolver-test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "my-custom-resolver-test"
-          message: "Custom test name should appear as the YAML key"
+      run-resolver-custom-test-name:
+        description: Verify --test-name overrides the auto-derived test name
+        command: [run, resolver]
+        args: ["-o", "test", "--test-name", "my-custom-resolver-test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "my-custom-resolver-test"
+            message: "Custom test name should appear as the YAML key"
 
     # =========================================================================
     # render solution -o test
     # =========================================================================
 
-    render-solution-test-output:
-      description: Verify render solution -o test emits a valid test YAML block
-      command: [render, solution]
-      args: ["-o", "test"]
-      tags: [test-generation, smoke]
-      assertions:
-        - expression: __exitCode == 0
-          message: "render solution -o test should succeed"
-        - contains: "command:"
-        - contains: "assertions:"
-        - contains: "Auto-generated test for: render solution"
+      render-solution-test-output:
+        description: Verify render solution -o test emits a valid test YAML block
+        command: [render, solution]
+        args: ["-o", "test"]
+        tags: [test-generation, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "render solution -o test should succeed"
+          - contains: "command:"
+          - contains: "assertions:"
+          - contains: "Auto-generated test for: render solution"
 
-    render-solution-test-has-snapshot:
-      description: Verify render solution -o test includes a snapshot reference
-      command: [render, solution]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "snapshot:"
+      render-solution-test-has-snapshot:
+        description: Verify render solution -o test includes a snapshot reference
+        command: [render, solution]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "snapshot:"
 
-    render-solution-custom-test-name:
-      description: Verify --test-name overrides the auto-derived name for render solution
-      command: [render, solution]
-      args: ["-o", "test", "--test-name", "my-custom-render-test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "my-custom-render-test"
-          message: "Custom test name should appear as the YAML key"
+      render-solution-custom-test-name:
+        description: Verify --test-name overrides the auto-derived name for render solution
+        command: [render, solution]
+        args: ["-o", "test", "--test-name", "my-custom-render-test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "my-custom-render-test"
+            message: "Custom test name should appear as the YAML key"
 
     # =========================================================================
     # run solution -o test
     # =========================================================================
 
-    run-solution-test-output:
-      description: Verify run solution -o test emits a valid test YAML block
-      command: [run, solution]
-      args: ["-o", "test"]
-      tags: [test-generation, smoke]
-      assertions:
-        - expression: __exitCode == 0
-          message: "run solution -o test should succeed"
-        - contains: "command:"
-        - contains: "assertions:"
-        - contains: "Auto-generated test for: run solution"
+      run-solution-test-output:
+        description: Verify run solution -o test emits a valid test YAML block
+        command: [run, solution]
+        args: ["-o", "test"]
+        tags: [test-generation, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "run solution -o test should succeed"
+          - contains: "command:"
+          - contains: "assertions:"
+          - contains: "Auto-generated test for: run solution"
 
-    run-solution-test-has-snapshot:
-      description: Verify run solution -o test includes a snapshot reference
-      command: [run, solution]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "snapshot:"
+      run-solution-test-has-snapshot:
+        description: Verify run solution -o test includes a snapshot reference
+        command: [run, solution]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "snapshot:"
 
     # =========================================================================
     # Unsupported commands
     # =========================================================================
 
-    unsupported-command-error:
-      description: Verify commands that do not support -o test emit a helpful error
-      command: [lint]
-      args: ["-o", "test"]
-      tags: [test-generation, negative]
-      expectFailure: true
-      assertions:
-        - expression: __exitCode != 0
-          message: "Unsupported command should fail"
-        - contains: "is not supported"
-          target: stderr
-          message: "Error should explain that -o test is not supported by this command"
+      unsupported-command-error:
+        description: Verify commands that do not support -o test emit a helpful error
+        command: [lint]
+        args: ["-o", "test"]
+        tags: [test-generation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Unsupported command should fail"
+          - contains: "is not supported"
+            target: stderr
+            message: "Error should explain that -o test is not supported by this command"
 
     # =========================================================================
     # Generated assertions verify actual output shape
     # =========================================================================
 
-    run-resolver-assertions-reference-output:
-      description: Verify generated assertions reference __output
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - contains: "__output"
-          message: "Generated assertions should reference __output"
+      run-resolver-assertions-reference-output:
+        description: Verify generated assertions reference __output
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "__output"
+            message: "Generated assertions should reference __output"
 
-    run-resolver-assertions-check-keys:
-      description: Verify generated assertions check the top-level key count
-      command: [run, resolver]
-      args: ["-o", "test"]
-      tags: [test-generation]
-      assertions:
-        - expression: __exitCode == 0
-        - regex: 'size\(__output\) =='
-          message: "Generated assertions should include a size(__output) check"
+      run-resolver-assertions-check-keys:
+        description: Verify generated assertions check the top-level key count
+        command: [run, resolver]
+        args: ["-o", "test"]
+        tags: [test-generation]
+        assertions:
+          - expression: __exitCode == 0
+          - regex: 'size\(__output\) =='
+            message: "Generated assertions should include a size(__output) check"


### PR DESCRIPTION
… server

BREAKING CHANGE: \spec.tests\ and \spec.testConfig\ are replaced by a unified \spec.testing\ (TestSuite) that groups test cases and config under a single top-level property. All solution YAML files using the old schema must be updated.

Key changes:
- Introduce \TestSuite\ struct with \cases\ and \config\ fields, replacing the flat \	ests\/\	estConfig\ fields on \Spec\
- Add \pkg/solution/soltesting/mockserver\ package: a configurable HTTP mock server for functional testing, defined declaratively via \spec.testing.config.services\; supports routes, echo mode, response delay, and per-request recording
- Add \ServiceConfig\ type to \TestConfig\ enabling background services (currently \	ype: http\) to be started/stopped around test runs, with port and base URL injected as env vars for resolver inputs
- Update bundler (compose, discover) and test runner/scaffold to use the new \Testing\ field throughout
- Migrate all integration test solution YAML files to the new schema
- Add new integration test solutions covering actions (conditional, conditional-retry, error-handling, exclusive, finally, foreach, parallel, result-schema, retry, sequential, timeout) and providers (debug, git, http, parameter, solution)
- Add docs/design/testing-consolidation.md design doc and update functional-testing docs and tutorials