### PR TITLE
feat: add auto and list output formats to kvx

### DIFF
--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -15,8 +15,8 @@ import (
 // KvxOutputFlags holds the flag values for kvx-enabled output.
 // This struct is typically embedded in command options structs.
 type KvxOutputFlags struct {
-	// Output specifies the output format (table, json, yaml, quiet)
-	Output string `json:"output,omitempty" yaml:"output,omitempty" doc:"Output format" example:"table" maxLength:"10"`
+	// Output specifies the output format (auto, table, list, json, yaml, quiet)
+	Output string `json:"output,omitempty" yaml:"output,omitempty" doc:"Output format" example:"auto" maxLength:"10"`
 
 	// Interactive enables the kvx TUI for data exploration
 	Interactive bool `json:"interactive,omitempty" yaml:"interactive,omitempty" doc:"Launch interactive TUI mode"`
@@ -36,7 +36,7 @@ type KvxOutputFlags struct {
 func AddKvxOutputFlags(cmd *cobra.Command, outputFormat *string, interactive *bool, expression *string) {
 	validFormats := kvx.BaseOutputFormats()
 
-	cmd.Flags().StringVarP(outputFormat, "output", "o", "table",
+	cmd.Flags().StringVarP(outputFormat, "output", "o", "auto",
 		fmt.Sprintf("Output format: %s", strings.Join(validFormats, ", ")))
 
 	cmd.Flags().BoolVarP(interactive, "interactive", "i", false,
@@ -82,7 +82,7 @@ func ToKvxOutputOptions(flags *KvxOutputFlags, opts ...kvx.OutputOption) *kvx.Ou
 	if f, ok := kvx.ParseOutputFormat(flags.Output); ok {
 		kvxOpts.Format = f
 	} else {
-		kvxOpts.Format = kvx.OutputFormatTable
+		kvxOpts.Format = kvx.OutputFormatAuto
 	}
 
 	// Apply additional options

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -24,7 +24,7 @@ func TestAddKvxOutputFlags(t *testing.T) {
 	outputFlag := cmd.Flags().Lookup("output")
 	require.NotNil(t, outputFlag)
 	assert.Equal(t, "o", outputFlag.Shorthand)
-	assert.Equal(t, "table", outputFlag.DefValue)
+	assert.Equal(t, "auto", outputFlag.DefValue)
 
 	interactiveFlag := cmd.Flags().Lookup("interactive")
 	require.NotNil(t, interactiveFlag)
@@ -57,8 +57,10 @@ func TestValidateKvxOutputFormat(t *testing.T) {
 		format  string
 		wantErr bool
 	}{
-		{"", false},        // Empty defaults to table
+		{"", false},        // Empty defaults to auto
+		{"auto", false},    //
 		{"table", false},   //
+		{"list", false},    //
 		{"json", false},    //
 		{"yaml", false},    //
 		{"quiet", false},   //
@@ -121,8 +123,8 @@ func TestToKvxOutputOptions_InvalidFormat(t *testing.T) {
 
 	opts := ToKvxOutputOptions(flags)
 
-	// Invalid formats should default to table
-	assert.Equal(t, kvx.OutputFormatTable, opts.Format)
+	// Invalid formats should default to auto
+	assert.Equal(t, kvx.OutputFormatAuto, opts.Format)
 }
 
 func TestNewKvxOutputOptionsFromFlags(t *testing.T) {
@@ -147,11 +149,13 @@ func TestNewKvxOutputOptionsFromFlags_AllFormats(t *testing.T) {
 		format   string
 		expected kvx.OutputFormat
 	}{
+		{"auto", kvx.OutputFormatAuto},
 		{"table", kvx.OutputFormatTable},
+		{"list", kvx.OutputFormatList},
 		{"json", kvx.OutputFormatJSON},
 		{"yaml", kvx.OutputFormatYAML},
 		{"quiet", kvx.OutputFormatQuiet},
-		{"", kvx.OutputFormatTable}, // Empty defaults to table
+		{"", kvx.OutputFormatAuto}, // Empty defaults to auto
 	}
 
 	for _, tt := range tests {
@@ -169,7 +173,7 @@ func TestKvxOutputFlags_Zero_Value(t *testing.T) {
 	assert.False(t, flags.Interactive)
 	assert.Empty(t, flags.Expression)
 
-	// Converting zero value flags should result in table format
+	// Converting zero value flags should result in auto format
 	opts := ToKvxOutputOptions(&flags)
-	assert.Equal(t, kvx.OutputFormatTable, opts.Format)
+	assert.Equal(t, kvx.OutputFormatAuto, opts.Format)
 }

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -72,7 +72,7 @@ func TestCommandResolver_FlagDefaults(t *testing.T) {
 
 	output, err := ff.GetString("output")
 	require.NoError(t, err)
-	assert.Equal(t, "table", output)
+	assert.Equal(t, "auto", output)
 
 	skipTransform, err := ff.GetBool("skip-transform")
 	require.NoError(t, err)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -389,7 +389,7 @@ func (o *SolutionOptions) writeActionOutput(_ context.Context, result *action.Ex
 	}
 
 	switch o.Output {
-	case "table", "":
+	case "auto", "table", "list", "":
 		return o.writeActionOutputDefault(result)
 	case "json":
 		return o.writeActionOutputStructured(result, executionData, "json")

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -72,7 +72,7 @@ func TestCommandSolution_FlagDefaults(t *testing.T) {
 
 	output, err := flags.GetString("output")
 	require.NoError(t, err)
-	assert.Equal(t, "table", output) // Changed from "json" to "table" for kvx integration
+	assert.Equal(t, "auto", output) // Changed from "json" to "auto" for kvx integration
 
 	interactive, err := flags.GetBool("interactive")
 	require.NoError(t, err)

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -214,10 +214,10 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 	}
 
 	// Set up progress reporting unless explicitly disabled or output format
-	// is non-table (json/yaml/quiet — progress would corrupt structured output).
+	// is non-visual (json/yaml/quiet — progress would corrupt structured output).
 	if !opts.NoProgress && !opts.DryRun {
 		format, _ := kvx.ParseOutputFormat(opts.Output)
-		if kvx.IsTableFormat(format) || opts.Output == "" {
+		if kvx.IsKvxFormat(format) {
 			if kvx.IsTerminal(opts.IOStreams.ErrOut) {
 				runner.Progress = NewMPBTestProgress(opts.IOStreams.ErrOut)
 			} else {
@@ -335,7 +335,7 @@ func runWatchMode(ctx context.Context, opts *FunctionalOptions, w *writer.Writer
 				// Set up progress for each run (mpb instances are single-use).
 				if !opts.NoProgress && !opts.DryRun {
 					format, _ := kvx.ParseOutputFormat(opts.Output)
-					if kvx.IsTableFormat(format) || opts.Output == "" {
+					if kvx.IsKvxFormat(format) {
 						if isTTY {
 							runner.Progress = NewMPBTestProgress(opts.IOStreams.ErrOut)
 						} else {

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -63,7 +63,7 @@ func ReportResults(results []TestResult, opts *kvx.OutputOptions, verbose bool, 
 	switch {
 	case kvx.IsQuietFormat(opts.Format):
 		return nil
-	case kvx.IsTableFormat(opts.Format):
+	case kvx.IsKvxFormat(opts.Format):
 		return reportTable(results, opts.IOStreams.Out, verbose, elapsed)
 	default:
 		// JSON / YAML
@@ -253,7 +253,7 @@ func ReportList(solutions []SolutionTests, opts *kvx.OutputOptions, includeBuilt
 	switch {
 	case kvx.IsQuietFormat(opts.Format):
 		return nil
-	case kvx.IsTableFormat(opts.Format):
+	case kvx.IsKvxFormat(opts.Format):
 		return reportListTable(entries, opts.IOStreams.Out)
 	default:
 		return opts.Write(entries)

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -17,8 +17,15 @@ import (
 type OutputFormat string
 
 const (
-	// OutputFormatTable uses kvx table view (default for terminal output)
+	// OutputFormatAuto lets kvx choose the best visual format (table or list)
+	// based on the data shape. This is the default.
+	OutputFormatAuto OutputFormat = "auto"
+
+	// OutputFormatTable uses kvx bordered table view
 	OutputFormatTable OutputFormat = "table"
+
+	// OutputFormatList uses kvx list view for key-value display
+	OutputFormatList OutputFormat = "list"
 
 	// OutputFormatJSON outputs as JSON (for piping/scripting)
 	OutputFormatJSON OutputFormat = "json"
@@ -44,7 +51,9 @@ func (f OutputFormat) String() string {
 // This list is used for flag validation and help text generation.
 func BaseOutputFormats() []string {
 	return []string{
+		string(OutputFormatAuto),
 		string(OutputFormatTable),
+		string(OutputFormatList),
 		string(OutputFormatJSON),
 		string(OutputFormatYAML),
 		string(OutputFormatQuiet),
@@ -58,9 +67,20 @@ func IsStructuredFormat(format OutputFormat) bool {
 	return format == OutputFormatJSON || format == OutputFormatYAML
 }
 
-// IsTableFormat returns true if the format uses kvx table output.
-func IsTableFormat(format OutputFormat) bool {
-	return format == OutputFormatTable || format == ""
+// IsKvxFormat returns true if the format uses kvx visual output (auto, table, or list).
+// These formats render human-readable output to the terminal.
+func IsKvxFormat(format OutputFormat) bool {
+	return format == OutputFormatAuto || format == OutputFormatTable || format == OutputFormatList || format == ""
+}
+
+// IsAutoFormat returns true if the format uses automatic layout selection.
+func IsAutoFormat(format OutputFormat) bool {
+	return format == OutputFormatAuto || format == ""
+}
+
+// IsListFormat returns true if the format uses kvx list output.
+func IsListFormat(format OutputFormat) bool {
+	return format == OutputFormatList
 }
 
 // IsQuietFormat returns true if the format suppresses output.
@@ -72,8 +92,12 @@ func IsQuietFormat(format OutputFormat) bool {
 // It returns the format and whether it was recognized.
 func ParseOutputFormat(s string) (OutputFormat, bool) {
 	switch s {
-	case "table", "":
+	case "auto", "":
+		return OutputFormatAuto, true
+	case "table":
 		return OutputFormatTable, true
+	case "list":
+		return OutputFormatList, true
 	case "json":
 		return OutputFormatJSON, true
 	case "yaml":
@@ -131,7 +155,7 @@ type OutputOptions struct {
 func NewOutputOptions(ioStreams *terminal.IOStreams) *OutputOptions {
 	return &OutputOptions{
 		IOStreams:   ioStreams,
-		Format:      OutputFormatTable,
+		Format:      OutputFormatAuto,
 		PrettyPrint: true,
 	}
 }
@@ -214,11 +238,11 @@ func (o *OutputOptions) Write(data any) error {
 	// Test generation is handled at the command level before reaching kvx.
 	// If it reaches here, the command does not implement test output support.
 	if o.Format == OutputFormatTest {
-		return fmt.Errorf("output format %q is not supported by this command; supported formats: table, json, yaml, quiet", OutputFormatTest)
+		return fmt.Errorf("output format %q is not supported by this command; supported formats: auto, table, list, json, yaml, quiet", OutputFormatTest)
 	}
 
-	// Determine if we should use kvx table/interactive output
-	useKvx := IsTableFormat(o.Format) || o.Interactive
+	// Determine if we should use kvx visual output
+	useKvx := IsKvxFormat(o.Format) || o.Interactive
 
 	if useKvx {
 		return o.writeKvx(data)
@@ -258,6 +282,18 @@ func (o *OutputOptions) writeKvx(data any) error {
 		WithNoColor(o.NoColor),
 		WithIO(o.IOStreams.In, o.IOStreams.Out),
 		WithInteractive(o.Interactive),
+	}
+
+	// Pass layout based on output format
+	switch o.Format {
+	case OutputFormatList:
+		kvxOpts = append(kvxOpts, WithLayout("list"))
+	case OutputFormatTable:
+		kvxOpts = append(kvxOpts, WithLayout("table"))
+	case OutputFormatAuto, OutputFormatJSON, OutputFormatYAML, OutputFormatQuiet, OutputFormatTest:
+		// Auto and empty use default layout (auto).
+		// JSON/YAML/Quiet/Test are handled upstream and should not reach here,
+		// but are listed for exhaustiveness.
 	}
 
 	// Pass context for CEL expression evaluation (enables debug.out, etc.)
@@ -303,7 +339,7 @@ func (o *OutputOptions) writeStructured(data any) error {
 		return o.writeJSON(outputData)
 	case OutputFormatYAML:
 		return o.writeYAML(outputData)
-	case OutputFormatTable, OutputFormatQuiet, OutputFormatTest:
+	case OutputFormatTable, OutputFormatAuto, OutputFormatList, OutputFormatQuiet, OutputFormatTest:
 		// These formats are handled upstream (writeKvx or command-level test generation),
 		// and should not reach writeStructured.
 		return fmt.Errorf("unexpected output format in writeStructured: %s", o.Format)

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -18,7 +18,9 @@ func TestOutputFormat_String(t *testing.T) {
 		format   OutputFormat
 		expected string
 	}{
+		{OutputFormatAuto, "auto"},
 		{OutputFormatTable, "table"},
+		{OutputFormatList, "list"},
 		{OutputFormatJSON, "json"},
 		{OutputFormatYAML, "yaml"},
 		{OutputFormatQuiet, "quiet"},
@@ -34,12 +36,14 @@ func TestOutputFormat_String(t *testing.T) {
 func TestBaseOutputFormats(t *testing.T) {
 	formats := BaseOutputFormats()
 
+	assert.Contains(t, formats, "auto")
 	assert.Contains(t, formats, "table")
+	assert.Contains(t, formats, "list")
 	assert.Contains(t, formats, "json")
 	assert.Contains(t, formats, "yaml")
 	assert.Contains(t, formats, "quiet")
 	assert.Contains(t, formats, "test")
-	assert.Len(t, formats, 5)
+	assert.Len(t, formats, 7)
 }
 
 func TestIsStructuredFormat(t *testing.T) {
@@ -47,7 +51,9 @@ func TestIsStructuredFormat(t *testing.T) {
 		format   OutputFormat
 		expected bool
 	}{
+		{OutputFormatAuto, false},
 		{OutputFormatTable, false},
+		{OutputFormatList, false},
 		{OutputFormatJSON, true},
 		{OutputFormatYAML, true},
 		{OutputFormatQuiet, false},
@@ -60,12 +66,14 @@ func TestIsStructuredFormat(t *testing.T) {
 	}
 }
 
-func TestIsTableFormat(t *testing.T) {
+func TestIsKvxFormat(t *testing.T) {
 	tests := []struct {
 		format   OutputFormat
 		expected bool
 	}{
+		{OutputFormatAuto, true},
 		{OutputFormatTable, true},
+		{OutputFormatList, true},
 		{"", true},
 		{OutputFormatJSON, false},
 		{OutputFormatYAML, false},
@@ -74,7 +82,7 @@ func TestIsTableFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.format), func(t *testing.T) {
-			assert.Equal(t, tt.expected, IsTableFormat(tt.format))
+			assert.Equal(t, tt.expected, IsKvxFormat(tt.format))
 		})
 	}
 }
@@ -85,7 +93,9 @@ func TestIsQuietFormat(t *testing.T) {
 		expected bool
 	}{
 		{OutputFormatQuiet, true},
+		{OutputFormatAuto, false},
 		{OutputFormatTable, false},
+		{OutputFormatList, false},
 		{OutputFormatJSON, false},
 		{OutputFormatYAML, false},
 	}
@@ -103,8 +113,10 @@ func TestParseOutputFormat(t *testing.T) {
 		expected OutputFormat
 		ok       bool
 	}{
+		{"auto", OutputFormatAuto, true},
 		{"table", OutputFormatTable, true},
-		{"", OutputFormatTable, true},
+		{"list", OutputFormatList, true},
+		{"", OutputFormatAuto, true},
 		{"json", OutputFormatJSON, true},
 		{"yaml", OutputFormatYAML, true},
 		{"quiet", OutputFormatQuiet, true},
@@ -269,9 +281,11 @@ func TestOutputOptions_WithOutputFormatString(t *testing.T) {
 	}{
 		{"json", OutputFormatJSON},
 		{"yaml", OutputFormatYAML},
+		{"auto", OutputFormatAuto},
 		{"table", OutputFormatTable},
+		{"list", OutputFormatList},
 		{"quiet", OutputFormatQuiet},
-		{"invalid", OutputFormatTable},
+		{"invalid", OutputFormatAuto},
 	}
 
 	for _, tt := range tests {
@@ -289,7 +303,7 @@ func TestNewOutputOptions_Defaults(t *testing.T) {
 
 	opts := NewOutputOptions(ioStreams)
 
-	assert.Equal(t, OutputFormatTable, opts.Format)
+	assert.Equal(t, OutputFormatAuto, opts.Format)
 	assert.True(t, opts.PrettyPrint)
 	assert.False(t, opts.Interactive)
 	assert.Empty(t, opts.Expression)
@@ -301,7 +315,7 @@ func TestOutputOptions_Write_TableFallbackToJSONWhenNotTTY(t *testing.T) {
 	ioStreams := &terminal.IOStreams{Out: out}
 
 	opts := NewOutputOptions(ioStreams)
-	opts.Format = OutputFormatTable
+	opts.Format = OutputFormatAuto
 
 	data := map[string]any{"name": "test"}
 	err := opts.Write(data)
@@ -315,7 +329,7 @@ func TestOutputOptions_Write_InteractiveErrorWhenNotTTY(t *testing.T) {
 	ioStreams := &terminal.IOStreams{Out: out}
 
 	opts := NewOutputOptions(ioStreams)
-	opts.Format = OutputFormatTable
+	opts.Format = OutputFormatAuto
 	opts.Interactive = true
 
 	data := map[string]any{"name": "test"}

--- a/pkg/terminal/kvx/viewer.go
+++ b/pkg/terminal/kvx/viewer.go
@@ -61,6 +61,10 @@ type ViewerOptions struct {
 	// Theme is the color theme for interactive mode (dark, warm, cool, midnight)
 	Theme string `json:"theme,omitempty" yaml:"theme,omitempty" doc:"Color theme for TUI" example:"dark" maxLength:"20"`
 
+	// Layout controls the non-interactive rendering layout.
+	// Valid values: "auto" (default - kvx decides), "table" (force bordered table), "list" (force list view).
+	Layout string `json:"layout,omitempty" yaml:"layout,omitempty" doc:"Rendering layout for non-interactive display" example:"auto" maxLength:"10"`
+
 	// InitialExpr is an initial expression to evaluate when launching TUI
 	InitialExpr string `json:"initialExpr,omitempty" yaml:"initialExpr,omitempty" doc:"Initial CEL expression to evaluate in TUI" maxLength:"4096"`
 }
@@ -126,6 +130,12 @@ func WithTheme(theme string) Option {
 	return func(o *ViewerOptions) { o.Theme = theme }
 }
 
+// WithLayout sets the rendering layout for non-interactive display.
+// Valid values: "auto" (default), "table", "list".
+func WithLayout(layout string) Option {
+	return func(o *ViewerOptions) { o.Layout = layout }
+}
+
 // WithInitialExpr sets an initial expression for TUI
 func WithInitialExpr(expr string) Option {
 	return func(o *ViewerOptions) { o.InitialExpr = expr }
@@ -173,8 +183,16 @@ func View(data any, opts ...Option) error {
 		return runInteractive(root, options)
 	}
 
-	// Non-interactive: render table
-	return renderTable(root, options)
+	// Non-interactive: render based on layout
+	switch options.Layout {
+	case "list":
+		return renderList(root, options)
+	default:
+		// "auto", "table", and empty all use table rendering.
+		// The upstream tui.RenderTable with ColumnarMode "auto" (default)
+		// already handles smart layout detection for arrays vs objects.
+		return renderTable(root, options)
+	}
 }
 
 // renderTable outputs data as a bordered table (non-interactive).
@@ -186,6 +204,13 @@ func renderTable(root any, options *ViewerOptions) error {
 		Width:    options.Width,
 		NoColor:  options.NoColor,
 	})
+	fmt.Fprint(options.Out, output)
+	return nil
+}
+
+// renderList outputs data as a key-value list (non-interactive).
+func renderList(root any, options *ViewerOptions) error {
+	output := tui.RenderList(root, options.NoColor)
 	fmt.Fprint(options.Out, output)
 	return nil
 }
@@ -248,4 +273,15 @@ func RenderTable(data any, opts tui.TableOptions) (string, error) {
 	}
 
 	return tui.RenderTable(root, opts), nil
+}
+
+// RenderList renders data as a non-interactive list string.
+// This is useful when you need the list output as a string rather than writing to a stream.
+func RenderList(data any, noColor bool) (string, error) {
+	root, err := core.LoadObject(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to load data: %w", err)
+	}
+
+	return tui.RenderList(root, noColor), nil
 }

--- a/pkg/terminal/output/formats.go
+++ b/pkg/terminal/output/formats.go
@@ -14,8 +14,15 @@ package output
 type OutputFormat string
 
 const (
-	// OutputFormatTable uses kvx table view (default for terminal output)
+	// OutputFormatAuto lets kvx choose the best visual format (table or list)
+	// based on the data shape. This is the default.
+	OutputFormatAuto OutputFormat = "auto"
+
+	// OutputFormatTable uses kvx bordered table view
 	OutputFormatTable OutputFormat = "table"
+
+	// OutputFormatList uses kvx list view for key-value display
+	OutputFormatList OutputFormat = "list"
 
 	// OutputFormatJSON outputs as JSON (for piping/scripting)
 	OutputFormatJSON OutputFormat = "json"
@@ -36,7 +43,9 @@ func (f OutputFormat) String() string {
 // This list is used for flag validation and help text generation.
 func BaseOutputFormats() []string {
 	return []string{
+		string(OutputFormatAuto),
 		string(OutputFormatTable),
+		string(OutputFormatList),
 		string(OutputFormatJSON),
 		string(OutputFormatYAML),
 		string(OutputFormatQuiet),
@@ -49,9 +58,9 @@ func IsStructuredFormat(format OutputFormat) bool {
 	return format == OutputFormatJSON || format == OutputFormatYAML
 }
 
-// IsTableFormat returns true if the format uses kvx table output.
-func IsTableFormat(format OutputFormat) bool {
-	return format == OutputFormatTable || format == ""
+// IsKvxFormat returns true if the format uses kvx visual output (auto, table, or list).
+func IsKvxFormat(format OutputFormat) bool {
+	return format == OutputFormatAuto || format == OutputFormatTable || format == OutputFormatList || format == ""
 }
 
 // IsQuietFormat returns true if the format suppresses output.
@@ -63,8 +72,12 @@ func IsQuietFormat(format OutputFormat) bool {
 // It returns the format and whether it was recognized.
 func ParseOutputFormat(s string) (OutputFormat, bool) {
 	switch s {
-	case "table", "":
+	case "auto", "":
+		return OutputFormatAuto, true
+	case "table":
 		return OutputFormatTable, true
+	case "list":
+		return OutputFormatList, true
 	case "json":
 		return OutputFormatJSON, true
 	case "yaml":


### PR DESCRIPTION
Add two new output formats to the kvx output system:

- \uto\ (new default): delegates layout selection to the upstream kvx library, which uses ColumnarMode=auto to intelligently choose between table and list rendering based on data shape.
- \list\: forces kvx list (key-value) rendering via tui.RenderList.

Change the default output format from \	able\ to \uto\ everywhere: flag defaults, NewOutputOptions, and ToKvxOutputOptions fallback.

Rename IsTableFormat to IsKvxFormat (now covers auto, table, list, and empty string) and add IsAutoFormat/IsListFormat helpers. Update ParseOutputFormat so that empty string maps to auto instead of table.

Add WithLayout option to ViewerOptions/View() to pass the layout hint through to renderTable/renderList dispatch. Add renderList() and an exported RenderList() to the kvx viewer.

Update writeActionOutput in solution.go to treat auto and list as visual (default) formats, preventing the unsupported format error introduced by the new default.

Update all affected tests and format validation in reporter.go, functional.go, and the legacy output/formats.go package.
