### PR TITLE
feat(mcp): add solution developer experience tools (Phase 5)

### DIFF
--- a/docs/design/mcp-server-implementation-guide.md
+++ b/docs/design/mcp-server-implementation-guide.md
@@ -1572,9 +1572,12 @@ The `scafctl mcp serve` command's `Long` description (in `pkg/cmd/scafctl/mcp/se
 | 5 | `get_provider_schema` | `tools_provider.go` | Get JSON Schema for a provider's inputs | No | Phase 2 |
 | 6 | `list_cel_functions` | `tools_cel.go` | List available CEL functions | No | Phase 2 |
 | 7 | `evaluate_cel` | `tools_cel.go` | Evaluate a CEL expression with data | No | Phase 3 |
-| 8 | `render_solution` | `tools_solution.go` | Render action/resolver graph | Yes | Phase 3 |
+| 8 | `render_solution` | `tools_solution.go` | Render action/resolver graph (now embeds resolver data) | Yes | Phase 3 |
 | 9 | `auth_status` | `tools_auth.go` | Check auth provider status | Yes | Phase 3 |
 | 10 | `catalog_list` | `tools_catalog.go` | List catalog entries | No | Phase 3 |
+| 11 | `preview_resolvers` | `tools_solution.go` | Execute resolver chain and return per-resolver values | Yes | Phase 5 |
+| 12 | `run_solution_tests` | `tools_solution.go` | Execute functional tests and return structured results | Yes | Phase 5 |
+| 13 | `get_run_command` | `tools_solution.go` | Get exact CLI command to run a solution | Yes | Phase 5 |
 
 ### Complete File Map
 
@@ -1584,7 +1587,7 @@ pkg/mcp/
   context_test.go         # ✅ EXISTS
   server.go               # ✅ EXISTS — Server struct, construction, Serve(), Info()
   server_test.go          # ✅ EXISTS — Server construction tests
-  tools_solution.go       # ✅ EXISTS — list_solutions, inspect_solution, lint_solution, render_solution
+  tools_solution.go       # ✅ EXISTS — list_solutions, inspect_solution, lint_solution, render_solution, preview_resolvers, run_solution_tests, get_run_command
   tools_solution_test.go  # ✅ EXISTS
   tools_provider.go       # ✅ EXISTS — list_providers, get_provider_schema
   tools_provider_test.go  # ✅ EXISTS

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -418,8 +418,9 @@ An incremental rollout was used. All read-only phases are now **complete**.
 5. ~~**Schema, Examples & Prompts**~~ — **✅ Complete.** Added `get_solution_schema` and `explain_kind` tools (Huma-based JSON Schema generation), `list_examples` and `get_example` tools, and 4 MCP prompts (`create_solution`, `debug_solution`, `add_resolver`, `add_action`).
 6. ~~**Testing**~~ — **✅ Complete.** Unit tests for all tool handlers, resources, server, and context. Integration tests for CLI commands and MCP protocol.
 7. ~~**Documentation, Tutorials & Examples**~~ — **✅ Complete.** Tutorial at `docs/tutorials/mcp-server-tutorial.md`, example configs at `examples/mcp/`.
-8. **Add `run_solution` with `--dry-run` default** — preview execution without side effects (deferred to future release)
-9. **Add full `run_solution`** behind explicit confirmation — the AI must surface the plan before executing (deferred to future release)
+8. ~~**Solution Developer Experience Enhancements**~~ — **✅ Complete.** Added 6 new tools (`evaluate_go_template`, `validate_expression`, `explain_lint_rule`, `scaffold_solution`, `preview_action`, `diff_solution`), 1 new resource (`solution://{name}/graph`), 1 new prompt (`compose_solution`), plus `resolver` filter on `preview_resolvers` and `verbose` mode on `run_solution_tests`.
+9. **Add `run_solution` with `--dry-run` default** — preview execution without side effects (deferred to future release)
+10. **Add full `run_solution`** behind explicit confirmation — the AI must surface the plan before executing (deferred to future release)
 
 This incremental approach lets us ship value at each step while managing the risk of AI-triggered side effects.
 

--- a/docs/design/otel-telemetry-migration.md
+++ b/docs/design/otel-telemetry-migration.md
@@ -1,0 +1,877 @@
+# OpenTelemetry Telemetry Migration
+
+**Status:** Proposed  
+**Date:** 2026-02-20  
+**Scope:** `pkg/logger`, `pkg/metrics`, `pkg/telemetry` (new), `pkg/cmd/scafctl/root.go`, trace instrumentation across all subsystems
+
+---
+
+## Overview
+
+This document describes the migration of scafctl's telemetry stack from its current bespoke combination of zap/zapr/Prometheus to a unified OpenTelemetry foundation covering all three observability signals: **logs**, **traces**, and **metrics**.
+
+### Goals
+
+- Remove `go.uber.org/zap`, `go.uber.org/zap/zapcore`, and `github.com/go-logr/zapr`
+- Keep `github.com/go-logr/logr` as the **sole logging interface** — zero changes in 80+ consumer files
+- Route all three signals through the OTel SDK, exported via OTLP when configured and written locally by default
+- Preserve the existing Prometheus `/metrics` scrape endpoint
+- Accept the otel log SDK's Beta stability — spec is stable, breaking API changes are manageable given not being in production
+
+### Non-Goals
+
+- Changing any log call sites (`logger.FromContext`, `lgr.Info(...)`, `lgr.V(1).Info(...)`, etc.)
+- Adding a slog API surface to the codebase
+- Replacing the `pkg/terminal/writer` package — it is terminal UX, not structured logging
+
+---
+
+## Current State
+
+### Logging
+
+`pkg/logger/logger.go` initializes a `*zap.Logger` via `zapcore` and wraps it with `zapr.NewLogger()` to produce a `logr.Logger`. The `sync.Once`-guarded `GetWithOptions()` function sets a package-level `globalLogrLogger`. All 80+ packages retrieve the logger via `logger.FromContext(ctx)` or `logger.WithLogger(ctx, lgr)`.
+
+`pkg/cmd/scafctl/root.go` calls `logger.ParseLogLevel()` (returns `zapcore.Level`) then `logger.GetWithOptions(logger.Options{Level: zapcore.Level(...)})` in `PersistentPreRun`.
+
+`root.go` also directly imports `go.uber.org/zap` to use `zap.Field`-style structured fields on the logr instance.
+
+### Metrics
+
+`pkg/metrics/metrics.go` directly uses `github.com/prometheus/client_golang` types (`prometheus.CounterVec`, `prometheus.HistogramVec`, `prometheus.GaugeVec`). `RegisterMetrics()` calls `prometheus.MustRegister()` on all 15 metrics and wires `promhttp.Handler()` to `/metrics`. There is no OTel involvement.
+
+### Traces
+
+No trace instrumentation exists anywhere in the codebase.
+
+### OpenTelemetry
+
+There are no `go.opentelemetry.io/*` imports in the main module. OTel is only present as transitive indirect dependencies in the separate `scripts/go.mod` sub-module.
+
+---
+
+## Architecture After Migration
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         Application Code                             │
+│           lgr.Info(...)   lgr.V(1).Info(...)   lgr.Error(...)        │
+│           tracer.Start(ctx, "span")                                  │
+│           meter.Float64Counter("metric")                             │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │ logr interface (unchanged)
+              ┌──────────▼──────────┐
+              │  pkg/logger         │  MultiSink
+              │  ─────────────────  │  ├─ slog text/json handler → stderr / file
+              │  logr.New(sink)     │  └─ otellogr.LogSink → OTel LoggerProvider
+              └─────────────────────┘
+                                           │
+┌──────────────────────────────────────────▼──────────────────────────┐
+│                        pkg/telemetry                                 │
+│                                                                      │
+│  LoggerProvider  ─────────────────────────────────────┐             │
+│  TracerProvider  ──────────────────────────┐          │             │
+│  MeterProvider   ─────────────┐            │          │             │
+│                               │            │          │             │
+│            ┌──────────────────▼──┐  ┌──────▼──┐  ┌───▼──────┐     │
+│            │  Prometheus         │  │  OTLP   │  │  OTLP    │     │
+│            │  exporter           │  │  trace  │  │  log     │     │
+│            │  /metrics (HTTP)    │  │  grpc   │  │  grpc    │     │
+│            └─────────────────────┘  └─────────┘  └──────────┘     │
+│                 (always on)          (when OTEL_EXPORTER_OTLP_ENDPOINT set)
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Signal Summary
+
+| Signal  | Local output                     | OTLP output (when endpoint set)          | SDK stability |
+|---------|----------------------------------|------------------------------------------|---------------|
+| Logs    | slog text/json handler → stderr  | `otlploggrpc` BatchProcessor             | Beta (v0.x)   |
+| Traces  | `stdouttrace` → stderr           | `otlptracegrpc`                          | Stable        |
+| Metrics | Prometheus `/metrics` (always)   | `otlpmetricgrpc` (optional addition)     | Stable        |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Replace zap/zapr with otellogr + slog MultiSink
+
+**Affected files:**
+- `pkg/logger/logger.go` — full rewrite
+- `pkg/logger/multisink.go` — new file
+- `pkg/cmd/scafctl/root.go` — remove `go.uber.org/zap` import, update `ParseLogLevel` call
+- `go.mod` / `go.sum` — remove three deps, add one
+
+#### 1.1 `pkg/logger/multisink.go` (new)
+
+A `logr.LogSink` that fans out to multiple sinks simultaneously. `Enabled` returns true if any child sink reports enabled (so the most verbose sink wins). All other methods delegate to every sink in order.
+
+```go
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package logger
+
+import (
+    "github.com/go-logr/logr"
+)
+
+// multiSink fans structured log records out to multiple logr.LogSink
+// implementations simultaneously. Enabled returns true when any child
+// sink is enabled so the most-verbose configured sink wins.
+type multiSink struct {
+    sinks []logr.LogSink
+}
+
+func newMultiSink(sinks ...logr.LogSink) *multiSink {
+    return &multiSink{sinks: sinks}
+}
+
+func (m *multiSink) Init(info logr.RuntimeInfo) {
+    for _, s := range m.sinks {
+        s.Init(info)
+    }
+}
+
+func (m *multiSink) Enabled(level int) bool {
+    for _, s := range m.sinks {
+        if s.Enabled(level) {
+            return true
+        }
+    }
+    return false
+}
+
+func (m *multiSink) Info(level int, msg string, keysAndValues ...any) {
+    for _, s := range m.sinks {
+        if s.Enabled(level) {
+            s.Info(level, msg, keysAndValues...)
+        }
+    }
+}
+
+func (m *multiSink) Error(err error, msg string, keysAndValues ...any) {
+    for _, s := range m.sinks {
+        s.Error(err, msg, keysAndValues...)
+    }
+}
+
+func (m *multiSink) WithValues(keysAndValues ...any) logr.LogSink {
+    next := make([]logr.LogSink, len(m.sinks))
+    for i, s := range m.sinks {
+        next[i] = s.WithValues(keysAndValues...)
+    }
+    return &multiSink{sinks: next}
+}
+
+func (m *multiSink) WithName(name string) logr.LogSink {
+    next := make([]logr.LogSink, len(m.sinks))
+    for i, s := range m.sinks {
+        next[i] = s.WithName(name)
+    }
+    return &multiSink{sinks: next}
+}
+```
+
+#### 1.2 `pkg/logger/logger.go` — key changes
+
+**Type changes (breaking — acceptable):**
+
+| Before | After |
+|--------|-------|
+| `Options.Level zapcore.Level` | `Options.Level slog.Level` |
+| `LogLevelNone = zapcore.FatalLevel + 1` | `LogLevelNone = slog.Level(math.MaxInt32)` |
+| `ParseLogLevel() (zapcore.Level, error)` | `ParseLogLevel() (slog.Level, error)` |
+| `IsDebugLevel()` checks `<= zapcore.Level(-1)` | checks `<= slog.Level(-1)` |
+| `globalZapLogger *zap.Logger` | removed |
+| `Sync()` flushes zap buffer | removed (no-op; telemetry.Shutdown handles OTel flush) |
+
+**Level mapping in `ParseLogLevel`:**
+
+The logr/slog bridge (`logr.FromSlogHandler`) maps logr V-levels to slog levels as `slog.Level(-v)`. We set the handler's minimum level to match:
+
+| Named level | `slog.Level` returned | logr V-levels enabled |
+|-------------|----------------------|-----------------------|
+| `none` / `""` | `math.MaxInt32` | none |
+| `error` | `slog.LevelError` (8) | errors only |
+| `warn` | `slog.LevelWarn` (4) | warn + error |
+| `info` | `slog.LevelInfo` (0) | V(0) info and above |
+| `debug` | `slog.Level(-1)` | V(1) and above |
+| `trace` | `slog.Level(-2)` | V(2) and above |
+| `"n"` (numeric) | `slog.Level(-n)` | V(n) and above |
+
+Note: the `-4*n` spacing used by slog's own named levels (Debug=-4, Info=0, Warn=4, Error=8) is **not** used here. The bridge maps V-level `n` → `slog.Level(-n)`, so the handler threshold must also be `-n`.
+
+**`GetWithOptions` rewrite — replacing zap with slog + otellogr:**
+
+```go
+func GetWithOptions(opts Options) *logr.Logger {
+    once.Do(func() {
+        if opts.Level >= LogLevelNone {
+            gl := logr.Discard()
+            globalLogrLogger = &gl
+            return
+        }
+
+        buildInfo, _ := debug.ReadBuildInfo()
+
+        // ── Sink 1: slog handler for local console/file output ──────────────
+        slogLevel := &slog.LevelVar{}
+        slogLevel.Set(opts.Level)
+
+        var slogWriter io.Writer = os.Stderr
+        // (handle opts.FilePath / opts.AlsoStderr — same logic as current zap code
+        // but writing to an io.Writer instead of zapcore.WriteSyncer)
+
+        var slogHandler slog.Handler
+        handlerOpts := &slog.HandlerOptions{
+            Level:     slogLevel,
+            AddSource: true,
+            ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+                if a.Key == slog.TimeKey && !opts.Timestamps {
+                    return slog.Attr{} // drop timestamp
+                }
+                if a.Key == slog.TimeKey {
+                    a.Key = TimeStampKey
+                }
+                if a.Key == slog.MessageKey {
+                    a.Key = MessageKey
+                }
+                return a
+            },
+        }
+        if opts.Format == FormatJSON {
+            slogHandler = slog.NewJSONHandler(slogWriter, handlerOpts)
+        } else {
+            slogHandler = slog.NewTextHandler(slogWriter, handlerOpts)
+        }
+
+        // Add static fields (commit, version, build time, go version)
+        slogHandler = slogHandler.WithAttrs([]slog.Attr{
+            slog.String(CommitKey, settings.VersionInformation.Commit),
+            slog.String(VersionKey, settings.VersionInformation.BuildVersion),
+            slog.String(BuildTimeKey, settings.VersionInformation.BuildTime),
+            slog.String(GoVersionKey, buildInfo.GoVersion),
+        })
+
+        consoleSink := logr.FromSlogHandler(slogHandler).GetSink()
+
+        // ── Sink 2: otellogr forwarding to global OTel LoggerProvider ────────
+        // Uses log/global.GetLoggerProvider() which returns the provider set by
+        // telemetry.Setup(). If Setup has not been called, this is the noop provider
+        // and nothing is exported — safe for unit tests.
+        otelSink := otellogr.NewLogSink(settings.CliBinaryName,
+            otellogr.WithLoggerProvider(logGlobal.GetLoggerProvider()),
+        )
+
+        gl := logr.New(newMultiSink(consoleSink, otelSink))
+        globalLogrLogger = &gl
+    })
+    if globalLogrLogger == nil {
+        return &defaultNoopLogger
+    }
+    return globalLogrLogger
+}
+```
+
+**Imports after rewrite:**
+
+```go
+import (
+    "context"
+    "fmt"
+    "io"
+    "log/slog"
+    "math"
+    "os"
+    "runtime/debug"
+    "strconv"
+    "strings"
+    "sync"
+
+    "github.com/go-logr/logr"
+    "github.com/oakwood-commons/scafctl/pkg/settings"
+    "go.opentelemetry.io/contrib/bridges/otellogr"
+    logGlobal "go.opentelemetry.io/otel/log/global"
+)
+```
+
+#### 1.3 `pkg/cmd/scafctl/root.go` — changes
+
+- Remove `"go.uber.org/zap"` import
+- Update variable name: `zapLevel` → `logLevel` (type `slog.Level`)
+- Remove `//nolint:gosec` comment that was needed for the `int8` zap cast
+- The `logger.Options{Level: logLevel, ...}` call is otherwise identical
+
+Before:
+```go
+zapLevel, parseErr := logger.ParseLogLevel(resolvedLogLevel)
+// ...
+logOpts := logger.Options{
+    Level: zapLevel,
+    // ...
+}
+```
+
+After:
+```go
+logLevel, parseErr := logger.ParseLogLevel(resolvedLogLevel)
+// ...
+logOpts := logger.Options{
+    Level: logLevel,
+    // ...
+}
+```
+
+Any `zap.Field`-style calls (e.g., `zap.String("key", value)`) become standard logr key-value pairs:
+```go
+// Before
+lgr.Error(err, "failed", zap.String("path", p))
+// After
+lgr.Error(err, "failed", "path", p)
+```
+
+#### 1.4 `go.mod` changes
+
+Remove:
+```
+github.com/go-logr/zapr v1.3.0
+go.uber.org/zap v1.27.1
+go.uber.org/multierr v1.11.0  // will be pruned by go mod tidy
+```
+
+Add:
+```
+go.opentelemetry.io/contrib/bridges/otellogr v0.15.0
+```
+
+The `otel/log` and `otel/log/global` APIs are pulled in transitively via the bridge. They are also added explicitly in Phase 2.
+
+**Verification:**
+```bash
+go build ./...
+grep -r "go.uber.org/zap" .    # must be empty
+go test ./pkg/logger/...
+```
+
+---
+
+### Phase 2 — OTel SDK initialization (`pkg/telemetry`)
+
+**New package:** `pkg/telemetry/`  
+**Affected files:** `pkg/cmd/scafctl/root.go`
+
+This package owns all OTel provider construction and is the single place that imports `otel/sdk/*`. Application packages import only the API packages (`otel/trace`, `otel/metric`, `otel/log`) or use the global accessors via `otel.Tracer()`, `otel.Meter()`.
+
+#### 2.1 `pkg/telemetry/telemetry.go`
+
+```go
+package telemetry
+
+import (
+    "context"
+    "os"
+
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+    "go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
+    "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+    logGlobal "go.opentelemetry.io/otel/log/global"
+    sdklog "go.opentelemetry.io/otel/sdk/log"
+    sdkresource "go.opentelemetry.io/otel/sdk/resource"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+    semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+    // metrics provider added in Phase 3
+)
+
+// Options configures the OTel SDK setup.
+type Options struct {
+    // ServiceName is the OTel resource service.name attribute.
+    // Defaults to settings.CliBinaryName.
+    ServiceName string
+    // ServiceVersion is the OTel resource service.version attribute.
+    // Defaults to settings.VersionInformation.BuildVersion.
+    ServiceVersion string
+    // ExporterEndpoint overrides the OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
+    // When empty, the env var is used. When both are empty no OTLP export occurs.
+    ExporterEndpoint string
+    // ExporterInsecure disables TLS for the OTLP gRPC connection. Useful for local
+    // development against an OTel collector without TLS configured.
+    ExporterInsecure bool
+}
+
+// Setup initializes the OTel TracerProvider, MeterProvider (Phase 3), and
+// LoggerProvider and registers them globally. It must be called before
+// logger.GetWithOptions so the otellogr bridge picks up the real provider.
+//
+// The returned shutdown function must be called before process exit to flush
+// buffered telemetry. Typical usage:
+//
+//   shutdown, err := telemetry.Setup(ctx, opts)
+//   if err != nil { /* handle */ }
+//   defer func() { _ = shutdown(ctx) }()
+func Setup(ctx context.Context, opts Options) (shutdown func(context.Context) error, err error) {
+    // ...
+}
+```
+
+**Resource construction** — shared across all providers:
+
+```go
+res, err := sdkresource.New(ctx,
+    sdkresource.WithAttributes(
+        semconv.ServiceName(opts.ServiceName),
+        semconv.ServiceVersion(opts.ServiceVersion),
+        attribute.String(logger.CommitKey, settings.VersionInformation.Commit),
+        attribute.String(logger.BuildTimeKey, settings.VersionInformation.BuildTime),
+    ),
+    sdkresource.WithOS(),
+    sdkresource.WithHost(),
+)
+```
+
+**Trace provider:**
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` or `opts.ExporterEndpoint` is set:
+```go
+traceExporter, err := otlptracegrpc.New(ctx,
+    otlptracegrpc.WithEndpoint(endpoint),
+    // otlptracegrpc.WithInsecure() when opts.ExporterInsecure
+)
+```
+
+Otherwise, write JSON to stderr for local visibility:
+```go
+traceExporter, err := stdouttrace.New(
+    stdouttrace.WithWriter(os.Stderr),
+    stdouttrace.WithPrettyPrint(),
+)
+```
+
+```go
+tp := sdktrace.NewTracerProvider(
+    sdktrace.WithBatcher(traceExporter),
+    sdktrace.WithResource(res),
+    sdktrace.WithSampler(sdktrace.AlwaysSample()), // configurable later
+)
+otel.SetTracerProvider(tp)
+```
+
+**Log provider:**
+
+```go
+var processors []sdklog.Processor
+
+// Always: stdout/stderr for local visibility
+stdoutLogExp, _ := stdoutlog.New(stdoutlog.WithWriter(os.Stderr))
+processors = append(processors, sdklog.NewSimpleProcessor(stdoutLogExp))
+
+// When OTLP endpoint is configured:
+if endpoint != "" {
+    otlpLogExp, err := otlploggrpc.New(ctx,
+        otlploggrpc.WithEndpoint(endpoint),
+        // otlploggrpc.WithInsecure() when opts.ExporterInsecure
+    )
+    processors = append(processors, sdklog.NewBatchProcessor(otlpLogExp))
+}
+
+lp := sdklog.NewLoggerProvider(
+    sdklog.WithResource(res),
+    // add all processors
+)
+for _, p := range processors { /* lp constructed with each */ }
+logGlobal.SetLoggerProvider(lp)
+```
+
+**Shutdown function:**
+
+```go
+return func(ctx context.Context) error {
+    var errs []error
+    if err := lp.Shutdown(ctx); err != nil { errs = append(errs, err) }
+    if err := tp.Shutdown(ctx); err != nil { errs = append(errs, err) }
+    // mp.Shutdown added in Phase 3
+    return errors.Join(errs...)
+}, nil
+```
+
+#### 2.2 `pkg/telemetry/tracer.go`
+
+```go
+package telemetry
+
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/trace"
+)
+
+const (
+    TracerProvider    = "github.com/oakwood-commons/scafctl"
+    TracerHTTPClient  = TracerProvider + "/httpc"
+    TracerProvider_   = TracerProvider + "/provider"
+    TracerResolver    = TracerProvider + "/resolver"
+    TracerSolution    = TracerProvider + "/solution"
+    TracerAction      = TracerProvider + "/action"
+    TracerMCP         = TracerProvider + "/mcp"
+)
+
+// Tracer returns a named tracer from the global TracerProvider.
+func Tracer(name string) trace.Tracer {
+    return otel.Tracer(name)
+}
+```
+
+#### 2.3 `pkg/cmd/scafctl/root.go` — `PersistentPreRun` update
+
+**Order of operations is critical:** `telemetry.Setup` must run before `logger.GetWithOptions` so that when the `otellogr` sink calls `logGlobal.GetLoggerProvider()` it gets the real SDK provider, not the noop default.
+
+```go
+PersistentPreRun: func(cCmd *cobra.Command, args []string) {
+    // 1. Load config
+    mgr := config.NewManager(configPath)
+    cfg, _ := mgr.Load()
+
+    // 2. Resolve OTLP endpoint (flag > env)
+    otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if cCmd.Flags().Changed("otel-endpoint") {
+        otelEndpoint, _ = cCmd.Flags().GetString("otel-endpoint")
+    }
+
+    // 3. Setup OTel providers (MUST be before logger init)
+    telShutdown, err := telemetry.Setup(context.Background(), telemetry.Options{
+        ServiceName:      settings.CliBinaryName,
+        ServiceVersion:   settings.VersionInformation.BuildVersion,
+        ExporterEndpoint: otelEndpoint,
+        ExporterInsecure: otelInsecureFlag,
+    })
+    if err != nil {
+        _, _ = ioStreams.ErrOut.Write([]byte("Warning: failed to initialize telemetry: " + err.Error() + "\n"))
+    }
+
+    // 4. Initialize logger (otellogr sink now picks up real LoggerProvider)
+    logLevel, parseErr := logger.ParseLogLevel(resolvedLogLevel)
+    lgr := logger.GetWithOptions(logger.Options{Level: logLevel, ...})
+
+    // 5. Defer telemetry shutdown (after cobra command tree completes)
+    cCmd.PostRun = func(_ *cobra.Command, _ []string) {
+        if telShutdown != nil {
+            ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+            defer cancel()
+            _ = telShutdown(ctx)
+        }
+    }
+
+    // ... rest unchanged
+},
+```
+
+New flags added to the root command:
+```go
+cCmd.PersistentFlags().String("otel-endpoint", "", "OpenTelemetry OTLP exporter endpoint (e.g. localhost:4317). Overrides OTEL_EXPORTER_OTLP_ENDPOINT")
+cCmd.PersistentFlags().Bool("otel-insecure", false, "Disable TLS for OTLP gRPC connection (development only)")
+```
+
+#### 2.4 `go.mod` additions (Phase 2)
+
+```
+go.opentelemetry.io/otel v1.40.0
+go.opentelemetry.io/otel/sdk v1.40.0
+go.opentelemetry.io/otel/trace v1.40.0
+go.opentelemetry.io/otel/log v0.16.0
+go.opentelemetry.io/otel/log/global v0.16.0
+go.opentelemetry.io/otel/sdk/log v0.16.0
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0
+go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.16.0
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
+go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
+go.opentelemetry.io/otel/semconv/v1.27.0 v1.40.0
+```
+
+**Verification:**
+```bash
+go build ./...
+go test ./pkg/telemetry/...
+# Start a local OTel collector or use the stdout exporter:
+go run ./cmd/scafctl/... version  # should emit a trace span to stderr
+```
+
+---
+
+### Phase 3 — Migrate metrics to otel SDK + Prometheus exporter
+
+**Affected files:** `pkg/metrics/metrics.go`, `pkg/telemetry/telemetry.go`
+
+#### 3.1 `pkg/metrics/metrics.go` — full rewrite
+
+Replace `prometheus.CounterVec` etc. with `metric.Float64Counter` etc. The `RegisterMetrics()` function becomes `InitMetrics()` and uses `otel.GetMeterProvider().Meter(settings.CliBinaryName)`.
+
+**Instrument mapping:**
+
+| Current Prometheus instrument | OTel instrument | OTel method |
+|-------------------------------|-----------------|-------------|
+| `prometheus.CounterVec` | `metric.Float64Counter` | `.Add(ctx, 1, metric.WithAttributes(...))` |
+| `prometheus.HistogramVec` | `metric.Float64Histogram` | `.Record(ctx, val, metric.WithAttributes(...))` |
+| `prometheus.GaugeVec` | `metric.Float64UpDownCounter` | `.Add(ctx, delta, ...)` |
+| `prometheus.Gauge` | `metric.Float64ObservableGauge` (or `Float64UpDownCounter`) | `.Record(ctx, val)` |
+
+Example — `ProviderExecutionTotal` before:
+```go
+ProviderExecutionTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+    Name: fmt.Sprintf("%s_provider_execution_total", settings.CliBinaryName),
+    Help: "Total number of provider executions",
+}, []string{providerNameLabel, statusLabel})
+```
+
+After:
+```go
+var ProviderExecutionTotal metric.Float64Counter
+
+func InitMetrics() {
+    m := otel.GetMeterProvider().Meter(settings.CliBinaryName)
+    var err error
+    ProviderExecutionTotal, err = m.Float64Counter(
+        fmt.Sprintf("%s_provider_execution_total", settings.CliBinaryName),
+        metric.WithDescription("Total number of provider executions"),
+    )
+    if err != nil { /* log warning */ }
+    // ... all other instruments
+}
+```
+
+`RecordProviderExecution` after:
+```go
+func RecordProviderExecution(providerName string, duration float64, success bool) {
+    status := "success"
+    if !success {
+        status = "failure"
+    }
+    attrs := metric.WithAttributes(
+        attribute.String(providerNameLabel, providerName),
+        attribute.String(statusLabel, status),
+    )
+    ProviderExecutionDuration.Record(context.Background(), duration, attrs)
+    ProviderExecutionTotal.Add(context.Background(), 1, attrs)
+}
+```
+
+`Handler()` returns the Prometheus registry HTTP handler provided by the OTel Prometheus exporter (the exporter is created in `telemetry.Setup` and the registry is stored for this use).
+
+`PrometheusMiddleware` continues to record HTTP metrics using the new OTel counter.
+
+#### 3.2 `pkg/telemetry/telemetry.go` — add MeterProvider
+
+```go
+import (
+    prometheusexporter "go.opentelemetry.io/otel/exporters/prometheus"
+    sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// In Setup():
+promExporter, err := prometheusexporter.New()
+mp := sdkmetric.NewMeterProvider(
+    sdkmetric.WithReader(promExporter),
+    sdkmetric.WithResource(res),
+)
+otel.SetMeterProvider(mp)
+```
+
+The `prometheusexporter` uses the default Prometheus registry by default, so `promhttp.Handler()` in `metrics.Handler()` continues to serve all OTel metrics at `/metrics` with no additional configuration.
+
+#### 3.3 `go.mod` additions (Phase 3)
+
+```
+go.opentelemetry.io/otel/metric v1.40.0
+go.opentelemetry.io/otel/sdk/metric v1.40.0
+go.opentelemetry.io/otel/exporters/prometheus v0.62.0
+```
+
+`github.com/prometheus/client_golang` remains in `go.mod` as an indirect dependency of the OTel Prometheus exporter. It is no longer imported directly by `pkg/metrics`.
+
+**Verification:**
+```bash
+go build ./...
+curl http://localhost:<mcp-port>/metrics   # or start the MCP server and scrape
+grep "scafctl_provider_execution_total" <output>
+```
+
+---
+
+### Phase 4 — Trace instrumentation
+
+Add spans at key execution boundaries. All instrumentation follows the same pattern:
+
+```go
+ctx, span := telemetry.Tracer(telemetry.TracerProvider_).Start(ctx, "provider.Execute",
+    trace.WithAttributes(
+        attribute.String("provider.name", name),
+        attribute.String("provider.type", providerType),
+    ),
+)
+defer span.End()
+
+// On error:
+span.RecordError(err)
+span.SetStatus(codes.Error, err.Error())
+```
+
+#### Instrumentation points
+
+| Package | Tracer constant | Span name | Key attributes |
+|---------|-----------------|-----------|----------------|
+| `pkg/httpc` | `TracerHTTPClient` | auto via `otelhttp.NewTransport` | `http.method`, `http.url`, `http.status_code` |
+| `pkg/provider` | `TracerProvider_` | `provider.Execute` | `provider.name`, `provider.type` |
+| `pkg/resolver` | `TracerResolver` | `resolver.Evaluate` | `resolver.name`, `resolver.type` |
+| `pkg/solution` | `TracerSolution` | `solution.Run` | `solution.path` |
+| `pkg/action` | `TracerAction` | `action.Execute` | `action.name`, `action.step` |
+| `pkg/mcp` | `TracerMCP` | `mcp.Handle` | `mcp.tool`, `mcp.method` |
+
+#### HTTP client auto-instrumentation
+
+In `pkg/httpc`, wrap the `http.Transport` or `http.Client`:
+
+```go
+import "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+transport := otelhttp.NewTransport(http.DefaultTransport)
+client := &http.Client{Transport: transport}
+```
+
+This adds W3C Trace Context propagation headers to outgoing requests and creates a span per request automatically.
+
+#### `go.mod` additions (Phase 4)
+
+```
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.0
+go.opentelemetry.io/otel/codes v1.40.0
+go.opentelemetry.io/otel/propagation v1.40.0
+```
+
+---
+
+### Phase 5 — Documentation, examples, and integration tests
+
+#### Documentation
+
+- Update [docs/tutorials/logging-tutorial.md](../tutorials/logging-tutorial.md): document the new log level flags, the slog text format, and how trace/span IDs appear in log records when a trace is active
+- Create `docs/tutorials/telemetry-tutorial.md`: covers all three signals, configuring `--otel-endpoint`, running a local OTel collector with Jaeger, viewing traces, interpreting stdout trace output
+- Update [docs/design/providers.md](providers.md) with trace span naming conventions
+- Update [docs/design/resolvers.md](resolvers.md) with resolver span attributes
+
+#### Examples
+
+Create `examples/telemetry/`:
+- `collector-config.yaml` — minimal OTel Collector config (receivers: OTLP; exporters: Jaeger, Prometheus; pipelines for all three signals)
+- `docker-compose.yaml` — Jaeger all-in-one + OTel Collector for local development
+- `README.md` — how to run locally and issue a traced scafctl command
+
+#### Integration tests
+
+In [tests/integration/cli_test.go](../../tests/integration/cli_test.go):
+- Verify `--log-level debug` flag still produces debug output after the slog migration
+- Verify `--log-level 3` numeric V-level still works
+- Verify `--otel-endpoint` flag is registered on the root command
+- Verify `--otel-insecure` flag is registered on the root command
+
+In `tests/integration/solutions/telemetry/`:
+- Solution that triggers provider execution and verifies `scafctl_provider_execution_total` increments
+
+---
+
+## Dependency Changes Summary
+
+### Removed
+
+| Module | Reason |
+|--------|--------|
+| `github.com/go-logr/zapr v1.3.0` | Replaced by otellogr bridge |
+| `go.uber.org/zap v1.27.1` | Replaced by slog + OTel |
+| `go.uber.org/multierr v1.11.0` | Transitive dep of zap — removed with it |
+
+### Added
+
+| Module | Version | Phase | Use |
+|--------|---------|-------|-----|
+| `go.opentelemetry.io/contrib/bridges/otellogr` | v0.15.0 | 1 | logr→OTel log bridge |
+| `go.opentelemetry.io/otel` | v1.40.0 | 2 | Root API, global setters |
+| `go.opentelemetry.io/otel/sdk` | v1.40.0 | 2 | SDK base |
+| `go.opentelemetry.io/otel/trace` | v1.40.0 | 2 | Trace API |
+| `go.opentelemetry.io/otel/log` | v0.16.0 | 2 | Log API (Beta) |
+| `go.opentelemetry.io/otel/log/global` | v0.16.0 | 2 | Global log provider |
+| `go.opentelemetry.io/otel/sdk/log` | v0.16.0 | 2 | Log SDK (Beta) |
+| `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` | v1.40.0 | 2 | Local trace output |
+| `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` | v0.16.0 | 2 | Local log output |
+| `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc` | v1.40.0 | 2 | OTLP trace export |
+| `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc` | v0.16.0 | 2 | OTLP log export |
+| `go.opentelemetry.io/otel/semconv/v1.27.0` | v1.40.0 | 2 | Resource semantic conventions |
+| `go.opentelemetry.io/otel/metric` | v1.40.0 | 3 | Metric API |
+| `go.opentelemetry.io/otel/sdk/metric` | v1.40.0 | 3 | Metric SDK |
+| `go.opentelemetry.io/otel/exporters/prometheus` | v0.62.0 | 3 | Prometheus metric export |
+| `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` | v0.15.0 | 4 | HTTP auto-instrumentation |
+| `go.opentelemetry.io/otel/codes` | v1.40.0 | 4 | Span status codes |
+| `go.opentelemetry.io/otel/propagation` | v1.40.0 | 4 | W3C trace context propagation |
+
+---
+
+## Breaking Changes
+
+| Change | Impact | Migration |
+|--------|--------|-----------|
+| `logger.Options.Level` type: `zapcore.Level` → `slog.Level` | Any code constructing `logger.Options` directly | Change type; numeric values shift but `ParseLogLevel()` handles it |
+| `logger.ParseLogLevel()` return type: `zapcore.Level` → `slog.Level` | `root.go` and any direct callers | Update variable type; remove `zap` import |
+| `logger.LogLevelNone` type: `zapcore.Level` → `slog.Level` | Direct comparisons against `LogLevelNone` | Update comparisons |
+| `logger.Sync()` removed | `defer logger.Sync()` calls | Remove; use `defer telemetry.Shutdown()` instead |
+| `logger.Get(logLevel int8)` parameter semantics | Any caller using raw `int8` values | Use named levels via `ParseLogLevel()` or `slog.Level` constants |
+| `pkg/metrics` exported vars change type | Any code calling `.With(prometheus.Labels{...})` | Update to `metric.WithAttributes(attribute.String(...))` |
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| otel/log SDK API breaking change (Beta) | Medium | Low | Isolated to `pkg/logger` and `pkg/telemetry`; fix is contained |
+| otellogr bridge behavior change (v0.x) | Low | Low | Unit tests on `pkg/logger` catch regressions |
+| Performance regression (OTel overhead vs zap) | Low | Low | zap was unnecessary for a CLI; slog is fast enough; BatchProcessor is async |
+| Prometheus metric names change | None | None | OTel Prometheus exporter preserves metric names using the instrument name directly |
+| Init ordering bug (logger before telemetry) | Medium | High | Enforced by calling `telemetry.Setup` before `logger.GetWithOptions` in `PersistentPreRun`; unit tests for noop fallback |
+
+---
+
+## Testing Strategy
+
+### Unit tests
+
+- `pkg/logger/logger_test.go`: test `ParseLogLevel` with all named and numeric levels; test `GetWithOptions` with noop OTel provider (default when `telemetry.Setup` not called)
+- `pkg/logger/multisink_test.go`: test fan-out, Enabled logic, WithValues/WithName propagation
+- `pkg/telemetry/telemetry_test.go`: test `Setup` returns without error; test `shutdown` flushes cleanly; test with and without OTLP endpoint
+
+### Integration tests
+
+- `tests/integration/cli_test.go`: all existing log level tests must pass unchanged
+- New: `--otel-endpoint` and `--otel-insecure` flags are registered
+
+### Manual verification
+
+```bash
+# Phase 1 — confirm zap is removed
+go build ./...
+grep -r "go.uber.org/zap" $(go list -f '{{.Dir}}' ./...) # must find nothing
+
+# Phase 2 — stdout trace output (no collector required)
+unset OTEL_EXPORTER_OTLP_ENDPOINT
+go run ./cmd/scafctl/... --log-level debug version 2>&1 | grep -A5 '"Name":"scafctl'
+
+# Phase 2 — OTLP export
+docker run -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one:latest
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 go run ./cmd/scafctl/... version
+# Open http://localhost:16686 — service "scafctl" should appear
+
+# Phase 3 — Prometheus metrics
+# Run a command that triggers provider execution, then:
+curl http://localhost:<port>/metrics | grep scafctl_provider_execution_total
+
+# Phase 4 — trace spans with HTTP calls
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 go run ./cmd/scafctl/... run -f examples/...
+# Verify nested spans in Jaeger UI
+```

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -16,7 +16,7 @@ This tutorial walks you through setting up scafctl's Model Context Protocol (MCP
 
 The MCP server is a **local process** that translates between the AI agent's JSON-RPC protocol and scafctl's Go library functions. When an AI agent decides to use a tool (e.g., "lint this solution"), it sends a structured request to the MCP server, which calls the same code that the CLI commands use and returns structured JSON results.
 
-All tools exposed by the MCP server are **read-only** — they inspect, validate, evaluate, and list, but never create files, deploy resources, or modify state.
+Most tools exposed by the MCP server are **read-only** — they inspect, validate, evaluate, and list. A few tools (`preview_resolvers`, `run_solution_tests`, `render_solution`) execute solution code which may have side effects depending on the providers used (e.g., exec, http).
 
 ```
 AI Agent (Copilot, Claude, etc.)
@@ -590,18 +590,27 @@ The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"`
 |------|-------------|
 | `auth_status` | Check auth handler status (configured, token validity, expiry). Auth handlers manage authentication identity — they are not solution providers |
 | `catalog_list` | List catalog entries filtered by kind (`solution`, `provider`, `auth-handler`) and name |
+| `diff_solution` | Compare two solution files structurally — shows added, removed, and changed resolvers, actions, metadata, and tests |
 | `evaluate_cel` | Evaluate a CEL expression with inline data, variables, or file-based context |
+| `evaluate_go_template` | Evaluate a Go template against provided data, returning rendered output and referenced fields |
 | `explain_kind` | Explain any registered kind (solution, resolver, action, etc.) — shows all fields, types, descriptions, and validation tags |
+| `explain_lint_rule` | Get a detailed explanation of a lint rule — description, severity, category, why it matters, how to fix it, and examples |
 | `get_example` | Read the contents of a scafctl example file. Use `list_examples` first to find available examples |
 | `get_provider_schema` | Get comprehensive provider info: input schema (with per-property required), output schemas, examples, CLI usage |
 | `get_solution_schema` | Get the full JSON Schema for the solution YAML file format. Optionally drill into a specific field (e.g., `metadata`, `spec`) |
+| `get_run_command` | Get the exact CLI command to run a solution (determines run solution vs run resolver) |
 | `inspect_solution` | Full solution metadata — resolvers, actions, tags, links, maintainers |
 | `lint_solution` | Validate a solution YAML file and return structured findings |
 | `list_cel_functions` | List CEL functions — custom scafctl functions, built-in, or by name |
 | `list_examples` | List available scafctl example files with category filtering (solutions, resolvers, actions, providers, etc.) |
 | `list_providers` | List all providers with capability and category filtering |
 | `list_solutions` | List solutions from the local catalog with name filtering |
+| `preview_action` | Preview what each action in a workflow would do WITHOUT executing — shows materialized inputs, deferred values, phases, and dependencies |
+| `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value. Use `resolver` param to focus on a single resolver and its dependencies |
 | `render_solution` | Render action, resolver, or action-deps graphs as structured JSON |
+| `run_solution_tests` | Execute functional tests defined in a solution and return structured results. Use `verbose=true` for full assertion details |
+| `scaffold_solution` | Generate a complete skeleton solution YAML from parameters — name, description, features, and providers |
+| `validate_expression` | Syntax-check a CEL expression or Go template without executing it — returns validity, errors, and referenced fields |
 
 ## 8. Available Resources
 
@@ -611,6 +620,7 @@ MCP resources are read-only data endpoints that AI agents can fetch on demand:
 |-------------|-------------|
 | `solution://{name}` | Raw YAML content of a solution |
 | `solution://{name}/schema` | JSON Schema for a solution's input parameters |
+| `solution://{name}/graph` | Resolver dependency graph with execution tiers, ASCII diagram, and Mermaid diagram |
 | `provider://{name}` | Detailed provider info: input schema (with required/optional per property), output schemas, examples, CLI usage |
 | `provider://reference` | Compact reference of all providers with required/optional inputs, capabilities, and descriptions |
 
@@ -624,6 +634,9 @@ MCP prompts are predefined templates that guide AI agents through common workflo
 | `debug_solution` | Systematic debugging workflow that inspects, lints, checks schema, and renders dependency graphs. | `path` |
 | `add_resolver` | Guide for adding a resolver using a specific provider. Fetches provider schema and resolver examples. | `provider` |
 | `add_action` | Guide for adding an action to a solution's workflow. Shows all action features (retry, forEach, when, etc.). | `provider` |
+| `update_solution` | Guide for modifying an existing solution. Follows inspect → edit → lint → preview → test workflow. | `path`, `change` |
+| `add_tests` | Guide for writing functional tests for a solution. Covers test schema, assertions, and test patterns. | `path` |
+| `compose_solution` | Guide for designing a multi-file composed solution with partial YAML files that get merged at build time. | `path`, `goal` |
 
 ### Using Prompts
 

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -76,6 +76,53 @@ func (s *Server) registerPrompts() {
 		),
 		s.handleAddActionPrompt,
 	)
+
+	// update_solution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("update_solution",
+			mcp.WithPromptDescription("Guide for modifying an existing scafctl solution. Inspects the current state, makes targeted changes, then validates with lint and preview."),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the existing solution file to modify"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("change",
+				mcp.ArgumentDescription("Description of what to change (e.g., 'add a retry to the deploy action', 'add an HTTP resolver for the API endpoint')"),
+				mcp.RequiredArgument(),
+			),
+		),
+		s.handleUpdateSolutionPrompt,
+	)
+
+	// add_tests prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("add_tests",
+			mcp.WithPromptDescription("Guide for writing functional tests for a scafctl solution. Walks through test schema, assertions, snapshots, and test patterns."),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the solution file to add tests to"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("scope",
+				mcp.ArgumentDescription("What to test: 'resolvers' (test resolver outputs), 'actions' (test workflow execution), 'all' (comprehensive test suite). Default: all"),
+			),
+		),
+		s.handleAddTestsPrompt,
+	)
+
+	// compose_solution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("compose_solution",
+			mcp.WithPromptDescription("Guide for designing a multi-file composed solution using scafctl's composition system. Breaks a solution into reusable partial YAML files that get merged at build time."),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the root solution file (or directory for a new composed solution)"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("goal",
+				mcp.ArgumentDescription("Description of what the composed solution should accomplish (e.g., 'modular deploy pipeline with separate resolver and action bundles')"),
+				mcp.RequiredArgument(),
+			),
+		),
+		s.handleComposeSolutionPrompt,
+	)
 }
 
 // handleCreateSolutionPrompt returns a prompt guiding the AI to create a solution.
@@ -126,7 +173,13 @@ IMPORTANT: Choose the correct run command based on whether the solution has a wo
     'scafctl run solution' will FAIL if there is no workflow defined.
 Parameters are passed with -r/--resolver (NOT -p). Example:
   scafctl run resolver -f ./%s.yaml -r param1=value1 -r param2=value2
-  scafctl run solution -f ./%s.yaml -r param1=value1 -r param2=value2`, name, description, featureList, name, name)
+  scafctl run solution -f ./%s.yaml -r param1=value1 -r param2=value2
+
+After creating the solution file:
+1. Call lint_solution to validate the YAML structure
+2. Call preview_resolvers to verify the resolver chain produces expected values
+3. Call get_run_command to show the user the exact command to run it
+4. If the solution has tests, call run_solution_tests to verify they pass`, name, description, featureList, name, name)
 
 	return &mcp.GetPromptResult{
 		Description: fmt.Sprintf("Create a new scafctl solution: %s", name),
@@ -172,7 +225,11 @@ Check for common issues:
 - Circular dependencies in resolvers or actions
 - Invalid CEL expressions in when/expr fields
 - Type mismatches (resolver type vs actual value)
-- Missing dependsOn when referencing other resolvers/actions`, path, problemDesc, path, path)
+- Missing dependsOn when referencing other resolvers/actions
+
+7. Call preview_resolvers with path %q to check if resolvers execute successfully and produce expected values
+8. If the solution has tests, call run_solution_tests with path %q to verify test results
+9. Call get_run_command with path %q to verify the correct run command`, path, problemDesc, path, path, path, path, path)
 
 	return &mcp.GetPromptResult{
 		Description: fmt.Sprintf("Debug solution: %s", path),
@@ -318,4 +375,253 @@ Cleanup actions go under spec.workflow.finally.<name> (same structure, always ru
 			},
 		},
 	}, nil
+}
+
+// handleUpdateSolutionPrompt returns a prompt for modifying an existing solution.
+func (s *Server) handleUpdateSolutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	change := request.Params.Arguments["change"]
+
+	prompt := fmt.Sprintf(`Modify the existing scafctl solution at %q.
+
+Requested change: %s
+
+Follow this workflow to make a safe, validated change:
+
+STEP 1 — UNDERSTAND the current solution:
+1. Call inspect_solution with path %q to see the full structure (resolvers, actions, metadata)
+2. Read the solution file to understand the current YAML
+
+STEP 2 — PLAN the change:
+3. Call get_solution_schema to verify what fields are available
+4. If adding/modifying providers, call get_provider_schema for each provider used
+5. Call list_providers if you need to find the right provider for the change
+
+STEP 3 — IMPLEMENT the change:
+6. Make targeted edits to the solution file — change ONLY what was requested
+7. Preserve existing structure, formatting, and comments where possible
+8. Use correct ValueRef format for inputs (literal, rslvr:, expr:, tmpl:)
+
+STEP 4 — VALIDATE the change:
+9. Call lint_solution with file %q to check for errors
+10. Call preview_resolvers with path %q to verify resolvers still produce expected values
+11. If the solution has tests, call run_solution_tests with path %q to ensure nothing broke
+12. Call get_run_command with path %q to remind the user how to run it
+
+IMPORTANT:
+- Do NOT restructure the entire solution — make the minimal change needed
+- If lint_solution reports errors after your change, fix them before finishing
+- If preview_resolvers shows unexpected values, investigate and fix
+- Always verify provider field names with get_provider_schema before writing inputs`, path, change, path, path, path, path, path)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Update solution: %s", path),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// handleAddTestsPrompt returns a prompt for writing functional tests.
+func (s *Server) handleAddTestsPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	scope := request.Params.Arguments["scope"]
+
+	if scope == "" {
+		scope = "all"
+	}
+
+	prompt := fmt.Sprintf(`Add functional tests to the scafctl solution at %q.
+
+Test scope: %s
+
+Follow these steps:
+
+STEP 1 — UNDERSTAND the solution:
+1. Call inspect_solution with path %q to see resolvers, actions, and structure
+2. Identify what needs testing based on the scope
+
+STEP 2 — LEARN the test format:
+3. Call explain_kind with kind "solution" and field "testing" to see test schema
+4. Call get_example with path "solutions/tested-solution/solution.yaml" for a practical reference
+5. Review the test case structure
+
+STEP 3 — WRITE the tests:
+
+Tests go under spec.testing in the solution YAML:
+
+  testing:
+    config:                          # optional global config
+      timeout: 30s
+      tags: [smoke]
+    cases:
+      <test-name>:                   # lowercase with hyphens
+        description: "what this tests"
+        command: [render, solution]   # or [run, resolver], [run, solution], [lint]
+        args: ["-o", "json"]         # extra CLI args (do NOT include -f)
+        resolvers:                   # input parameters for test
+          param-name: "test-value"
+        env:                         # environment variables
+          MY_VAR: "value"
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "expected substring"
+          - regex: "pattern.*match"
+          - notContains: "unexpected"
+          - notRegex: "error.*pattern"
+        tags: [smoke, validation]
+
+Available commands for testing:
+- [render, solution]  — render the solution (outputs resolver data), most common
+- [run, resolver]     — execute resolvers only
+- [run, solution]     — execute full workflow (resolvers + actions)
+- [lint]              — lint validation check
+
+Assertion variables available in expressions:
+- __exitCode: CLI exit code (0 = success)
+- __stdout: standard output as string
+- __stderr: standard error as string
+- __output: parsed JSON output (when -o json is used)
+- __sandbox: sandbox directory path
+
+%s
+
+STEP 4 — VALIDATE the tests:
+6. Call lint_solution with file %q to verify the solution with tests is valid YAML
+7. Call run_solution_tests with path %q to execute the tests and verify they pass
+
+IMPORTANT:
+- Test names must be lowercase with hyphens (no spaces, underscores, or uppercase)
+- Built-in tests (lint, parse) run automatically unless skipped
+- Use tags to organize tests (smoke, validation, integration, etc.)
+- The -f flag is auto-injected; do NOT include it in args
+- Use 'render solution' with '-o json' for most resolver output testing`, path, scope, path, scopeHints(scope), path, path)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Add tests to solution: %s", path),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// handleComposeSolutionPrompt returns a prompt for designing a multi-file composed solution.
+func (s *Server) handleComposeSolutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	goal := request.Params.Arguments["goal"]
+
+	prompt := fmt.Sprintf(`Design a multi-file composed scafctl solution.
+
+Root path: %s
+Goal: %s
+
+Composition allows splitting a large solution into multiple partial YAML files that get merged at build time. This promotes reusability and maintainability.
+
+STEP 1 — UNDERSTAND composition:
+1. Call get_solution_schema and look at the "compose" field in the spec
+2. Call get_example with path "solutions/composed/solution.yaml" or similar composition examples from list_examples (category: "solutions")
+
+Composition works by declaring partial YAML files in the root solution:
+
+  spec:
+    compose:
+      - path: resolvers/common.yaml       # relative to root solution
+      - path: resolvers/api.yaml
+      - path: actions/deploy.yaml
+      - path: tests/smoke.yaml
+
+Each partial file is a YAML document containing fragments that get deep-merged into the root solution.
+
+Partial file example (resolvers/common.yaml):
+  spec:
+    resolvers:
+      environment:
+        description: "Deployment environment"
+        type: string
+        resolve:
+          with:
+            - provider: parameter
+              inputs:
+                name: environment
+
+STEP 2 — PLAN the file structure:
+3. Identify natural groupings:
+   - Common resolvers (parameters, shared config) → resolvers/common.yaml
+   - Feature-specific resolvers → resolvers/<feature>.yaml
+   - Action groups → actions/<phase>.yaml (e.g., actions/build.yaml, actions/deploy.yaml)
+   - Tests → tests/<scope>.yaml
+4. Keep the root solution minimal — metadata, compose list, and maybe global config
+
+STEP 3 — CREATE the files:
+5. Create the root solution.yaml with metadata and compose references
+6. Create each partial file with its slice of the solution
+7. Ensure resolver/action names are unique across all files
+8. Handle cross-file dependencies via dependsOn (dependencies can reference names from other files)
+
+STEP 4 — VALIDATE:
+9. Call lint_solution with the root solution file path — linting resolves composition automatically
+10. Call preview_resolvers with the root path to verify resolver chain works
+11. Call render_solution with the root path to see the fully merged structure
+
+IMPORTANT RULES:
+- Partial files contain ONLY the fields they contribute (spec.resolvers, spec.workflow, etc.)
+- The root solution MUST have apiVersion, kind, and metadata
+- Partial files do NOT need apiVersion/kind/metadata
+- Names must be globally unique — two files cannot define the same resolver or action name
+- Use relative paths in the compose list (relative to the root solution file)
+- Deep merge means maps are merged recursively; arrays are replaced, not appended
+- Order matters: later compose entries override earlier ones for conflicting keys`, path, goal)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Compose solution: %s", path),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// scopeHints returns scope-specific testing guidance.
+func scopeHints(scope string) string {
+	switch scope {
+	case "resolvers":
+		return `RESOLVER TESTING TIPS:
+- Use command [render, solution] with args ["-o", "json"] to test resolver outputs
+- Access resolver values via __output.resolvers.<name> in expressions
+- Test each resolver independently with focused assertions
+- Test edge cases: missing params, invalid inputs, type coercion
+- Test conditional resolvers (when clauses) by varying inputs`
+	case "actions":
+		return `ACTION TESTING TIPS:
+- Use command [run, solution] to test the full workflow
+- Test success cases and expected error cases separately
+- Use 'expectFailure: true' for tests that should exit non-zero
+- Test conditional actions (when clauses) by providing different resolver inputs
+- Check file creation/modification in the sandbox directory
+- Use forEach scenarios if actions iterate over collections`
+	default:
+		return `COMPREHENSIVE TESTING TIPS:
+- Start with resolver tests (command: [render, solution], args: ["-o", "json"])
+- Then add action/workflow tests (command: [run, solution])
+- Include edge cases: missing params, invalid inputs
+- Tag tests appropriately: smoke (fast, essential), validation, integration
+- Test both success and expected failure paths`
+	}
 }

--- a/pkg/mcp/prompts_test.go
+++ b/pkg/mcp/prompts_test.go
@@ -181,3 +181,118 @@ func TestHandleAddActionPrompt(t *testing.T) {
 		assert.Contains(t, text, "perform an operation") // default purpose
 	})
 }
+
+func TestHandleUpdateSolutionPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with all arguments", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "update_solution"
+		request.Params.Arguments = map[string]string{
+			"path":   "solutions/my-solution/solution.yaml",
+			"change": "add retry logic to the deploy action",
+		}
+
+		result, err := srv.handleUpdateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-solution/solution.yaml")
+		assert.Contains(t, text, "add retry logic to the deploy action")
+		assert.Contains(t, text, "inspect_solution")
+		assert.Contains(t, text, "lint_solution")
+		assert.Contains(t, text, "preview_resolvers")
+		assert.Contains(t, text, "run_solution_tests")
+		assert.Contains(t, text, "get_run_command")
+		assert.Contains(t, text, "STEP 1")
+		assert.Contains(t, text, "STEP 4")
+	})
+}
+
+func TestHandleAddTestsPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with all arguments", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "add_tests"
+		request.Params.Arguments = map[string]string{
+			"path":  "solutions/my-solution/solution.yaml",
+			"scope": "resolvers",
+		}
+
+		result, err := srv.handleAddTestsPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-solution/solution.yaml")
+		assert.Contains(t, text, "resolvers")
+		assert.Contains(t, text, "RESOLVER TESTING TIPS")
+		assert.Contains(t, text, "lint_solution")
+		assert.Contains(t, text, "run_solution_tests")
+		assert.Contains(t, text, "explain_kind")
+	})
+
+	t.Run("with default scope", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "add_tests"
+		request.Params.Arguments = map[string]string{
+			"path": "test.yaml",
+		}
+
+		result, err := srv.handleAddTestsPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "COMPREHENSIVE TESTING TIPS") // default scope
+	})
+
+	t.Run("actions scope", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "add_tests"
+		request.Params.Arguments = map[string]string{
+			"path":  "test.yaml",
+			"scope": "actions",
+		}
+
+		result, err := srv.handleAddTestsPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "ACTION TESTING TIPS")
+	})
+}
+
+func TestHandleComposeSolutionPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with all arguments", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "compose_solution"
+		request.Params.Arguments = map[string]string{
+			"path": "solutions/my-composed",
+			"goal": "modular deploy pipeline with separate resolver and action bundles",
+		}
+
+		result, err := srv.handleComposeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+		assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-composed")
+		assert.Contains(t, text, "modular deploy pipeline")
+		assert.Contains(t, text, "compose")
+		assert.Contains(t, text, "partial")
+		assert.Contains(t, text, "deep-merge")
+	})
+}

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -46,6 +46,15 @@ func (s *Server) registerResourceTemplates() {
 	)
 	s.mcpServer.AddResourceTemplate(providerTemplate, s.handleProviderResource)
 
+	// solution://{name}/graph — resolver dependency graph
+	graphTemplate := mcp.NewResourceTemplate(
+		"solution://{name}/graph",
+		"Solution Dependency Graph",
+		mcp.WithTemplateDescription("Returns the resolver dependency graph for a solution as JSON with execution tiers and an ASCII + Mermaid diagram. Use the solution's local file path, catalog name, or URL as the {name} parameter."),
+		mcp.WithTemplateMIMEType("application/json"),
+	)
+	s.mcpServer.AddResourceTemplate(graphTemplate, s.handleSolutionGraphResource)
+
 	// provider://reference — compact reference of all providers and their key properties
 	s.mcpServer.AddResource(
 		mcp.NewResource(
@@ -108,6 +117,48 @@ func (s *Server) handleSolutionSchemaResource(_ context.Context, request mcp.Rea
 			URI:      request.Params.URI,
 			MIMEType: "application/json",
 			Text:     string(schemaJSON),
+		},
+	}, nil
+}
+
+// handleSolutionGraphResource returns the resolver dependency graph for a solution.
+func (s *Server) handleSolutionGraphResource(_ context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	name := extractNameFromURI(request.Params.URI, "solution://")
+	name = strings.TrimSuffix(name, "/graph")
+	if name == "" {
+		return nil, fmt.Errorf("solution name is required in URI (e.g., solution://path/to/solution.yaml/graph)")
+	}
+
+	sol, err := explain.LoadSolution(s.ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("loading solution %q: %w", name, err)
+	}
+
+	result, err := s.renderResolverGraph(sol, s.registry)
+	if err != nil {
+		return nil, fmt.Errorf("rendering resolver graph: %w", err)
+	}
+
+	// Extract the JSON text from the tool result
+	if result.IsError {
+		tc, ok := result.Content[0].(mcp.TextContent)
+		if !ok {
+			return nil, fmt.Errorf("building graph: unexpected content type")
+		}
+		return nil, fmt.Errorf("building graph: %s", tc.Text)
+	}
+
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content type in graph result")
+	}
+	graphJSON := tc.Text
+
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: "application/json",
+			Text:     graphJSON,
 		},
 	}, nil
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -82,10 +82,43 @@ func WithServerContext(ctx context.Context) ServerOption {
 }
 
 const serverInstructions = `scafctl is a CLI tool for managing infrastructure solutions using CEL expressions, 
-Go templates, and a provider-based architecture. This MCP server exposes read-only tools 
-for inspecting solutions, validating configurations, evaluating CEL expressions, and 
-browsing the solution catalog. All tools are safe to call — they do not modify files, 
-create resources, or trigger side effects.
+Go templates, and a provider-based architecture. This MCP server exposes tools 
+for inspecting solutions, validating configurations, evaluating CEL expressions, 
+browsing the solution catalog, previewing resolver outputs, and running functional tests.
+
+Most tools are read-only and safe to call. The following tools execute solution code 
+and may have side effects depending on the providers used (e.g., exec, http):
+  - preview_resolvers: executes the resolver chain
+  - preview_action: builds action graph from live resolver data (executes resolvers, but NOT actions)
+  - run_solution_tests: runs functional test cases
+  - render_solution: executes resolvers to build graphs
+All other tools only inspect, validate, or list — they never modify files or trigger side effects.
+
+Solution Development Workflow:
+  For the best AI-assisted solution authoring experience, follow this loop:
+  1. Create/edit the solution YAML (or call scaffold_solution to generate a skeleton)
+  2. Call lint_solution to validate structure (call explain_lint_rule for help with findings)
+  3. Call validate_expression to check CEL/Go-template syntax in isolation
+  4. Call evaluate_go_template to test Go templates with sample data
+  5. Call preview_resolvers to verify resolver outputs (use resolver param to focus on one)
+  6. Call preview_action to dry-run the action graph and see materialized inputs
+  7. Call run_solution_tests to run functional tests (use verbose=true for full assertion details)
+  8. Call diff_solution to compare solution versions before committing changes
+  9. Call get_run_command to get the exact CLI command for the user
+
+Scaffolding a New Solution:
+  Call scaffold_solution with a name, description, and optional features/providers to 
+  generate a complete skeleton YAML with examples. This is the fastest way to start.
+
+Expression Debugging:
+  - validate_expression: syntax-check CEL expressions or Go templates without running them
+  - evaluate_go_template: render a Go template with sample data and see referenced fields
+  - evaluate_cel: evaluate a CEL expression with data context
+
+Composition Workflow:
+  For multi-file solutions, use the compose_solution prompt to guide splitting a solution 
+  into reusable partial YAML files. The solution://{name}/graph resource shows the resolver 
+  dependency graph for a composed (or standalone) solution.
 
 Provider Schema Reference:
   When creating or editing solution YAML (actions, resolvers), ALWAYS call 
@@ -242,6 +275,21 @@ func (s *Server) registerTools() {
 
 	// Auth tools (Phase 3)
 	s.registerAuthTools()
+
+	// Template & expression tools
+	s.registerTemplateTools()
+
+	// Lint explanation tools
+	s.registerLintTools()
+
+	// Scaffold tools
+	s.registerScaffoldTools()
+
+	// Action preview tools
+	s.registerActionTools()
+
+	// Diff tools
+	s.registerDiffTools()
 }
 
 // registerResources registers all MCP resources on the server.

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -116,6 +116,17 @@ func TestServerInfo(t *testing.T) {
 		assert.True(t, toolNames["explain_kind"])
 		assert.True(t, toolNames["list_examples"])
 		assert.True(t, toolNames["get_example"])
+		// Template & expression tools
+		assert.True(t, toolNames["evaluate_go_template"])
+		assert.True(t, toolNames["validate_expression"])
+		// Lint tools
+		assert.True(t, toolNames["explain_lint_rule"])
+		// Scaffold tools
+		assert.True(t, toolNames["scaffold_solution"])
+		// Action tools
+		assert.True(t, toolNames["preview_action"])
+		// Diff tools
+		assert.True(t, toolNames["diff_solution"])
 	})
 }
 

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -1,0 +1,226 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+)
+
+// registerActionTools registers action-related MCP tools.
+func (s *Server) registerActionTools() {
+	// preview_action
+	previewActionTool := mcp.NewTool("preview_action",
+		mcp.WithDescription("Preview what each action in a solution's workflow would do WITHOUT executing it. Resolves all inputs (expanding CEL expressions, Go templates, and resolver references) and shows the final computed values each action would receive. This is an 'action dry-run' that shows the full picture before execution."),
+		mcp.WithTitleAnnotation("Preview Actions"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+		mcp.WithObject("params",
+			mcp.Description("Input parameters as key-value pairs for parameter-type resolvers (e.g., {\"env\": \"prod\", \"region\": \"us-east-1\"})"),
+		),
+		mcp.WithString("action",
+			mcp.Description("Preview a specific action by name. If omitted, previews all actions."),
+		),
+	)
+	s.mcpServer.AddTool(previewActionTool, s.handlePreviewAction)
+}
+
+// handlePreviewAction shows what each action would do with fully resolved inputs.
+func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	actionFilter := request.GetString("action", "")
+
+	// Parse params
+	var params map[string]any
+	args := request.GetArguments()
+	if p, ok := args["params"]; ok && p != nil {
+		if pm, ok := p.(map[string]any); ok {
+			params = pm
+		} else {
+			return mcp.NewToolResultError("'params' must be an object (key-value pairs)"), nil
+		}
+	}
+
+	// Load solution
+	prepResult, err := prepare.Solution(s.ctx, path,
+		prepare.WithRegistry(s.registry),
+	)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+	}
+	if prepResult.Cleanup != nil {
+		defer prepResult.Cleanup()
+	}
+
+	sol := prepResult.Solution
+
+	if !sol.Spec.HasWorkflow() {
+		return mcp.NewToolResultError("solution does not define a workflow — use preview_resolvers instead"), nil
+	}
+
+	// Execute resolvers to get data for action inputs
+	resolverData, err := s.executeResolversForRender(sol, params)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+	}
+
+	// Build the action graph (this materializes inputs)
+	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to build action graph: %v", err)), nil
+	}
+
+	// Build structured preview response
+	type forEachPreview struct {
+		ExpandedFrom string `json:"expandedFrom,omitempty"`
+		Item         any    `json:"item,omitempty"`
+		Index        int    `json:"index,omitempty"`
+	}
+	type retryPreview struct {
+		MaxAttempts int    `json:"maxAttempts,omitempty"`
+		Backoff     string `json:"backoff,omitempty"`
+	}
+	type actionPreview struct {
+		Name               string            `json:"name"`
+		Description        string            `json:"description,omitempty"`
+		Provider           string            `json:"provider"`
+		MaterializedInputs map[string]any    `json:"materializedInputs,omitempty"`
+		DeferredInputs     map[string]string `json:"deferredInputs,omitempty"`
+		Dependencies       []string          `json:"dependencies,omitempty"`
+		When               string            `json:"when,omitempty"`
+		Section            string            `json:"section"`
+		Phase              int               `json:"phase"`
+		ForEach            *forEachPreview   `json:"forEach,omitempty"`
+		Retry              *retryPreview     `json:"retry,omitempty"`
+		Timeout            string            `json:"timeout,omitempty"`
+		OnError            string            `json:"onError,omitempty"`
+		Exclusive          []string          `json:"exclusive,omitempty"`
+	}
+
+	previews := make([]actionPreview, 0)
+
+	// Build a phase map for execution ordering
+	phaseMap := make(map[string]int)
+	for i, phase := range graph.ExecutionOrder {
+		for _, name := range phase {
+			phaseMap[name] = i + 1
+		}
+	}
+	for i, phase := range graph.FinallyOrder {
+		for _, name := range phase {
+			phaseMap[name] = i + 1
+		}
+	}
+
+	// Collect and sort action names for deterministic output
+	names := make([]string, 0, len(graph.Actions))
+	for name := range graph.Actions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		ea := graph.Actions[name]
+
+		// Apply filter — match against both expanded name and original action name
+		if actionFilter != "" && name != actionFilter && ea.Name != actionFilter {
+			continue
+		}
+
+		preview := actionPreview{
+			Name:               name,
+			Provider:           ea.Provider,
+			MaterializedInputs: ea.MaterializedInputs,
+			Dependencies:       ea.Dependencies,
+			Section:            ea.Section,
+			Phase:              phaseMap[name],
+		}
+
+		// Use fields from the embedded Action
+		preview.Description = ea.Description
+		if ea.When != nil && ea.When.Expr != nil {
+			preview.When = string(*ea.When.Expr)
+		}
+		if ea.Timeout != nil {
+			preview.Timeout = ea.Timeout.String()
+		}
+		if ea.OnError != "" {
+			preview.OnError = string(ea.OnError)
+		}
+		if ea.Retry != nil {
+			preview.Retry = &retryPreview{
+				MaxAttempts: ea.Retry.MaxAttempts,
+				Backoff:     string(ea.Retry.Backoff),
+			}
+		}
+
+		// Map deferred inputs to their expression strings
+		if len(ea.DeferredInputs) > 0 {
+			preview.DeferredInputs = make(map[string]string, len(ea.DeferredInputs))
+			for k, v := range ea.DeferredInputs {
+				expr := v.OriginalExpr
+				if expr == "" {
+					expr = v.OriginalTmpl
+				}
+				if expr == "" && v.Deferred {
+					expr = "(deferred)"
+				}
+				preview.DeferredInputs[k] = expr
+			}
+		}
+
+		// forEach info
+		if ea.ForEachMetadata != nil {
+			preview.ForEach = &forEachPreview{
+				ExpandedFrom: ea.ForEachMetadata.ExpandedFrom,
+				Item:         ea.ForEachMetadata.Item,
+				Index:        ea.ForEachMetadata.Index,
+			}
+		}
+
+		// Exclusive
+		if len(ea.ExpandedExclusive) > 0 {
+			preview.Exclusive = ea.ExpandedExclusive
+		}
+
+		previews = append(previews, preview)
+	}
+
+	// Verify the filtered action exists
+	if actionFilter != "" && len(previews) == 0 {
+		availableNames := make([]string, 0, len(graph.Actions))
+		for name := range graph.Actions {
+			availableNames = append(availableNames, name)
+		}
+		sort.Strings(availableNames)
+		return mcp.NewToolResultError(fmt.Sprintf("action %q not found. Available actions: %v", actionFilter, availableNames)), nil
+	}
+
+	response := map[string]any{
+		"actions":      previews,
+		"totalActions": len(graph.Actions),
+		"totalPhases":  graph.TotalPhases(),
+		"resolverData": resolverData,
+	}
+	if actionFilter != "" {
+		response["filter"] = actionFilter
+	}
+
+	return mcp.NewToolResultJSON(response)
+}

--- a/pkg/mcp/tools_action_test.go
+++ b/pkg/mcp/tools_action_test.go
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlePreviewAction(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("missing path", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent solution", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/solution.yaml",
+		}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("solution without workflow", func(t *testing.T) {
+		// Create a temp solution with no workflow
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "solution.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-workflow
+  version: "1.0.0"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "workflow")
+	})
+
+	t.Run("solution with workflow", func(t *testing.T) {
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "solution.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: with-workflow
+  version: "1.0.0"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+  workflow:
+    actions:
+      echo:
+        description: "Echo greeting"
+        provider: exec
+        inputs:
+          command:
+            tmpl: "echo {{ .resolvers.greeting }}"
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError, "unexpected error: %v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.NotNil(t, output["actions"])
+		assert.NotNil(t, output["resolverData"])
+	})
+
+	t.Run("filter nonexistent action", func(t *testing.T) {
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "solution.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: filter-test
+  version: "1.0.0"
+spec:
+  resolvers:
+    val:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "x"
+  workflow:
+    actions:
+      step1:
+        provider: exec
+        inputs:
+          command: "echo step1"
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{
+			"path":   solFile,
+			"action": "nonexistent",
+		}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "nonexistent")
+	})
+}

--- a/pkg/mcp/tools_diff.go
+++ b/pkg/mcp/tools_diff.go
@@ -1,0 +1,291 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
+)
+
+// registerDiffTools registers diff/comparison MCP tools.
+func (s *Server) registerDiffTools() {
+	// diff_solution
+	diffSolutionTool := mcp.NewTool("diff_solution",
+		mcp.WithDescription("Compare two solution files and show structural differences. Identifies added, removed, and changed resolvers, actions, metadata, and test cases. Useful for reviewing changes before committing or understanding what was modified."),
+		mcp.WithTitleAnnotation("Diff Solution"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path_a",
+			mcp.Required(),
+			mcp.Description("Path to the first solution file (e.g., the original version)"),
+		),
+		mcp.WithString("path_b",
+			mcp.Required(),
+			mcp.Description("Path to the second solution file (e.g., the modified version)"),
+		),
+	)
+	s.mcpServer.AddTool(diffSolutionTool, s.handleDiffSolution)
+}
+
+// handleDiffSolution compares two solutions structurally.
+func (s *Server) handleDiffSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	pathA, err := request.RequireString("path_a")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	pathB, err := request.RequireString("path_b")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	solA, err := explain.LoadSolution(s.ctx, pathA)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading solution A (%s): %v", pathA, err)), nil
+	}
+	solB, err := explain.LoadSolution(s.ctx, pathB)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading solution B (%s): %v", pathB, err)), nil
+	}
+
+	type change struct {
+		Field    string `json:"field"`
+		Type     string `json:"type"` // "added", "removed", "changed"
+		OldValue any    `json:"oldValue,omitempty"`
+		NewValue any    `json:"newValue,omitempty"`
+	}
+
+	var changes []change
+
+	// Compare metadata
+	if solA.Metadata.Name != solB.Metadata.Name {
+		changes = append(changes, change{Field: "metadata.name", Type: "changed", OldValue: solA.Metadata.Name, NewValue: solB.Metadata.Name})
+	}
+	if solA.Metadata.Description != solB.Metadata.Description {
+		changes = append(changes, change{Field: "metadata.description", Type: "changed", OldValue: solA.Metadata.Description, NewValue: solB.Metadata.Description})
+	}
+	if solA.Metadata.Version != nil && solB.Metadata.Version != nil {
+		if solA.Metadata.Version.String() != solB.Metadata.Version.String() {
+			changes = append(changes, change{Field: "metadata.version", Type: "changed", OldValue: solA.Metadata.Version.String(), NewValue: solB.Metadata.Version.String()})
+		}
+	}
+
+	// Compare resolvers
+	resolversA := make(map[string]bool)
+	resolversB := make(map[string]bool)
+	if solA.Spec.HasResolvers() {
+		for name := range solA.Spec.Resolvers {
+			resolversA[name] = true
+		}
+	}
+	if solB.Spec.HasResolvers() {
+		for name := range solB.Spec.Resolvers {
+			resolversB[name] = true
+		}
+	}
+
+	// Find added/removed resolvers
+	for name := range resolversB {
+		if !resolversA[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "added"})
+		}
+	}
+	for name := range resolversA {
+		if !resolversB[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "removed"})
+		}
+	}
+
+	// Check for changed resolvers (both exist)
+	for name := range resolversA {
+		if resolversB[name] {
+			rA := solA.Spec.Resolvers[name]
+			rB := solB.Spec.Resolvers[name]
+
+			if rA.Type != rB.Type {
+				changes = append(changes, change{
+					Field: fmt.Sprintf("spec.resolvers.%s.type", name), Type: "changed",
+					OldValue: string(rA.Type), NewValue: string(rB.Type),
+				})
+			}
+			if rA.Description != rB.Description {
+				changes = append(changes, change{
+					Field: fmt.Sprintf("spec.resolvers.%s.description", name), Type: "changed",
+					OldValue: rA.Description, NewValue: rB.Description,
+				})
+			}
+
+			// Compare primary provider
+			provA := ""
+			provB := ""
+			if rA.Resolve != nil && len(rA.Resolve.With) > 0 {
+				provA = rA.Resolve.With[0].Provider
+			}
+			if rB.Resolve != nil && len(rB.Resolve.With) > 0 {
+				provB = rB.Resolve.With[0].Provider
+			}
+			if provA != provB {
+				changes = append(changes, change{
+					Field: fmt.Sprintf("spec.resolvers.%s.provider", name), Type: "changed",
+					OldValue: provA, NewValue: provB,
+				})
+			}
+		}
+	}
+
+	// Compare actions
+	actionsA := make(map[string]bool)
+	actionsB := make(map[string]bool)
+	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Actions != nil {
+		for name := range solA.Spec.Workflow.Actions {
+			actionsA[name] = true
+		}
+	}
+	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Actions != nil {
+		for name := range solB.Spec.Workflow.Actions {
+			actionsB[name] = true
+		}
+	}
+
+	for name := range actionsB {
+		if !actionsA[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "added"})
+		}
+	}
+	for name := range actionsA {
+		if !actionsB[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "removed"})
+		}
+	}
+
+	// Check changed actions
+	for name := range actionsA {
+		if actionsB[name] {
+			aA := solA.Spec.Workflow.Actions[name]
+			aB := solB.Spec.Workflow.Actions[name]
+
+			if aA.Provider != aB.Provider {
+				changes = append(changes, change{
+					Field: fmt.Sprintf("spec.workflow.actions.%s.provider", name), Type: "changed",
+					OldValue: aA.Provider, NewValue: aB.Provider,
+				})
+			}
+			if aA.Description != aB.Description {
+				changes = append(changes, change{
+					Field: fmt.Sprintf("spec.workflow.actions.%s.description", name), Type: "changed",
+					OldValue: aA.Description, NewValue: aB.Description,
+				})
+			}
+		}
+	}
+
+	// Compare finally actions
+	finallyA := make(map[string]bool)
+	finallyB := make(map[string]bool)
+	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Finally != nil {
+		for name := range solA.Spec.Workflow.Finally {
+			finallyA[name] = true
+		}
+	}
+	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Finally != nil {
+		for name := range solB.Spec.Workflow.Finally {
+			finallyB[name] = true
+		}
+	}
+
+	for name := range finallyB {
+		if !finallyA[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "added"})
+		}
+	}
+	for name := range finallyA {
+		if !finallyB[name] {
+			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "removed"})
+		}
+	}
+
+	// Compare test cases
+	var testsA, testsB map[string]bool
+	if solA.Spec.Testing != nil && solA.Spec.Testing.Cases != nil {
+		testsA = make(map[string]bool, len(solA.Spec.Testing.Cases))
+		for name := range solA.Spec.Testing.Cases {
+			testsA[name] = true
+		}
+	}
+	if solB.Spec.Testing != nil && solB.Spec.Testing.Cases != nil {
+		testsB = make(map[string]bool, len(solB.Spec.Testing.Cases))
+		for name := range solB.Spec.Testing.Cases {
+			testsB[name] = true
+		}
+	}
+
+	if testsA != nil || testsB != nil {
+		if testsA == nil {
+			testsA = make(map[string]bool)
+		}
+		if testsB == nil {
+			testsB = make(map[string]bool)
+		}
+
+		for name := range testsB {
+			if !testsA[name] {
+				changes = append(changes, change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "added"})
+			}
+		}
+		for name := range testsA {
+			if !testsB[name] {
+				changes = append(changes, change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "removed"})
+			}
+		}
+	}
+
+	// Workflow added/removed
+	if !solA.Spec.HasWorkflow() && solB.Spec.HasWorkflow() {
+		changes = append(changes, change{Field: "spec.workflow", Type: "added"})
+	} else if solA.Spec.HasWorkflow() && !solB.Spec.HasWorkflow() {
+		changes = append(changes, change{Field: "spec.workflow", Type: "removed"})
+	}
+
+	// Testing added/removed
+	if solA.Spec.Testing == nil && solB.Spec.Testing != nil {
+		changes = append(changes, change{Field: "spec.testing", Type: "added"})
+	} else if solA.Spec.Testing != nil && solB.Spec.Testing == nil {
+		changes = append(changes, change{Field: "spec.testing", Type: "removed"})
+	}
+
+	// Sort changes for deterministic output
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Field < changes[j].Field
+	})
+
+	// Count by type
+	added, removed, changed := 0, 0, 0
+	for _, c := range changes {
+		switch c.Type {
+		case "added":
+			added++
+		case "removed":
+			removed++
+		case "changed":
+			changed++
+		}
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"pathA":   pathA,
+		"pathB":   pathB,
+		"changes": changes,
+		"summary": map[string]any{
+			"total":   len(changes),
+			"added":   added,
+			"removed": removed,
+			"changed": changed,
+		},
+	})
+}

--- a/pkg/mcp/tools_diff_test.go
+++ b/pkg/mcp/tools_diff_test.go
@@ -1,0 +1,198 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDiffSolution(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("missing path_a", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_solution"
+		request.Params.Arguments = map[string]any{
+			"path_b": "/some/path.yaml",
+		}
+
+		result, err := srv.handleDiffSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing path_b", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_solution"
+		request.Params.Arguments = map[string]any{
+			"path_a": "/some/path.yaml",
+		}
+
+		result, err := srv.handleDiffSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("identical solutions", func(t *testing.T) {
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "solution.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: identical
+  version: "1.0.0"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_solution"
+		request.Params.Arguments = map[string]any{
+			"path_a": solFile,
+			"path_b": solFile,
+		}
+
+		result, err := srv.handleDiffSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		summary := output["summary"].(map[string]any)
+		assert.Equal(t, float64(0), summary["total"])
+	})
+
+	t.Run("different solutions", func(t *testing.T) {
+		dir := t.TempDir()
+		solA := filepath.Join(dir, "a.yaml")
+		err := os.WriteFile(solA, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: solution-a
+  version: "1.0.0"
+  description: "First version"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+    old-resolver:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "old"
+`), 0o644)
+		require.NoError(t, err)
+
+		solB := filepath.Join(dir, "b.yaml")
+		err = os.WriteFile(solB, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: solution-b
+  version: "2.0.0"
+  description: "Second version"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+    new-resolver:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_solution"
+		request.Params.Arguments = map[string]any{
+			"path_a": solA,
+			"path_b": solB,
+		}
+
+		result, err := srv.handleDiffSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		summary := output["summary"].(map[string]any)
+		assert.Greater(t, summary["total"], float64(0))
+
+		// Should detect: name changed, description changed, version changed,
+		// old-resolver removed, new-resolver added
+		changes := output["changes"].([]any)
+		assert.NotEmpty(t, changes)
+
+		// Verify some changes exist
+		changeFields := make(map[string]string)
+		for _, c := range changes {
+			cm := c.(map[string]any)
+			changeFields[cm["field"].(string)] = cm["type"].(string)
+		}
+
+		assert.Equal(t, "changed", changeFields["metadata.name"])
+		assert.Equal(t, "changed", changeFields["metadata.description"])
+		assert.Equal(t, "added", changeFields["spec.resolvers.new-resolver"])
+		assert.Equal(t, "removed", changeFields["spec.resolvers.old-resolver"])
+	})
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "exists.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: exists
+  version: "1.0.0"
+spec: {}
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_solution"
+		request.Params.Arguments = map[string]any{
+			"path_a": solFile,
+			"path_b": "/nonexistent/path.yaml",
+		}
+
+		result, err := srv.handleDiffSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -1,0 +1,255 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
+)
+
+// registerLintTools registers lint-related MCP tools.
+func (s *Server) registerLintTools() {
+	// explain_lint_rule
+	explainLintRuleTool := mcp.NewTool("explain_lint_rule",
+		mcp.WithDescription("Get a detailed explanation and fix suggestions for a specific lint rule. When lint_solution returns findings with a ruleName, use this tool to understand what the rule checks for, why it matters, and how to fix it."),
+		mcp.WithTitleAnnotation("Explain Lint Rule"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("rule",
+			mcp.Required(),
+			mcp.Description("The lint rule name to explain (e.g., 'unused-resolver', 'invalid-expression', 'missing-provider')"),
+		),
+	)
+	s.mcpServer.AddTool(explainLintRuleTool, s.handleExplainLintRule)
+}
+
+// lintRuleExplanation contains a detailed explanation of a lint rule.
+type lintRuleExplanation struct {
+	Rule        string   `json:"rule"`
+	Severity    string   `json:"severity"`
+	Category    string   `json:"category"`
+	Description string   `json:"description"`
+	Why         string   `json:"why"`
+	Fix         string   `json:"fix"`
+	Examples    []string `json:"examples,omitempty"`
+}
+
+// handleExplainLintRule returns a detailed explanation for a specific lint rule.
+func (s *Server) handleExplainLintRule(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	rule, err := request.RequireString("rule")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	explanation, ok := lintRuleExplanations[rule]
+	if !ok {
+		// List all known rules
+		known := make([]string, 0, len(lintRuleExplanations))
+		for k := range lintRuleExplanations {
+			known = append(known, k)
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("unknown lint rule %q. Known rules: %s", rule, strings.Join(known, ", "))), nil
+	}
+
+	return mcp.NewToolResultJSON(explanation)
+}
+
+// lintRuleExplanations maps rule names to detailed explanations.
+// These match the rules defined in pkg/cmd/scafctl/lint/lint.go.
+var lintRuleExplanations = map[string]lintRuleExplanation{
+	"empty-solution": {
+		Rule:        "empty-solution",
+		Severity:    string(lint.SeverityError),
+		Category:    "structure",
+		Description: "The solution has no resolvers defined under spec.resolvers and no workflow defined under spec.workflow.",
+		Why:         "A solution must have at least resolvers or a workflow to be useful. Without either, there's nothing to execute.",
+		Fix:         "Add at least one resolver under spec.resolvers or define a workflow with actions under spec.workflow.actions.",
+		Examples: []string{
+			"spec:\n  resolvers:\n    greeting:\n      type: string\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: Hello World",
+		},
+	},
+	"reserved-name": {
+		Rule:        "reserved-name",
+		Severity:    string(lint.SeverityError),
+		Category:    "naming",
+		Description: "A resolver uses a reserved name that conflicts with built-in variables.",
+		Why:         "Names like '__actions', '__error', '__item', '__index', and '_' are reserved for internal use in CEL expressions and forEach iterations.",
+		Fix:         "Rename the resolver to avoid reserved names. Use descriptive names like 'user-input' or 'api-response' instead.",
+		Examples:    []string{"Reserved names: __actions, __error, __item, __index, _"},
+	},
+	"unused-resolver": {
+		Rule:        "unused-resolver",
+		Severity:    string(lint.SeverityWarning),
+		Category:    "usage",
+		Description: "A resolver is defined but never referenced by any other resolver, action input, when clause, or expression.",
+		Why:         "Unused resolvers add complexity without benefit. They may indicate a typo in a reference or leftover code from refactoring.",
+		Fix:         "Either remove the unused resolver, reference it in an action input (rslvr: resolver-name), use it in a CEL expression (_.resolver_name), or add it as a dependency (dependsOn).",
+	},
+	"missing-provider": {
+		Rule:        "missing-provider",
+		Severity:    string(lint.SeverityError),
+		Category:    "provider",
+		Description: "A resolver step or action references a provider name that is not registered in the provider registry.",
+		Why:         "The solution cannot execute if it references providers that don't exist. This usually indicates a typo in the provider name.",
+		Fix:         "Use list_providers to see all available provider names. Common providers: static, parameter, env, http, cel, file, exec, directory, go-template, validation.",
+	},
+	"invalid-expression": {
+		Rule:        "invalid-expression",
+		Severity:    string(lint.SeverityError),
+		Category:    "expression",
+		Description: "A CEL expression (in a 'when' clause or 'expr' input) has a syntax error and cannot be parsed.",
+		Why:         "Invalid CEL expressions will cause runtime failures. Common issues include missing quotes around strings, unbalanced parentheses, and using unknown functions.",
+		Fix:         "Use validate_expression with type 'cel' to check the expression syntax. Use list_cel_functions to see available functions. Use evaluate_cel to test the expression with sample data.",
+	},
+	"invalid-template": {
+		Rule:        "invalid-template",
+		Severity:    string(lint.SeverityError),
+		Category:    "template",
+		Description: "A Go template (in a 'tmpl' input) has a syntax error and cannot be parsed.",
+		Why:         "Invalid Go templates will cause runtime failures. Common issues include unclosed actions (missing '}}'), unclosed control blocks (if/range/with without end), and unknown functions.",
+		Fix:         "Use validate_expression with type 'go-template' to check the template syntax. Use evaluate_go_template to test the template with sample data.",
+	},
+	"invalid-dependency": {
+		Rule:        "invalid-dependency",
+		Severity:    string(lint.SeverityError),
+		Category:    "dependency",
+		Description: "An action's dependsOn references an action name that does not exist in the workflow.",
+		Why:         "Actions with invalid dependencies cannot be scheduled for execution. This usually indicates a typo in the action name.",
+		Fix:         "Check the action names in spec.workflow.actions and ensure all dependsOn references match exactly. Names are case-sensitive.",
+	},
+	"empty-workflow": {
+		Rule:        "empty-workflow",
+		Severity:    string(lint.SeverityWarning),
+		Category:    "structure",
+		Description: "A workflow section is defined (spec.workflow) but contains no actions.",
+		Why:         "An empty workflow serves no purpose. If you only need resolvers, remove the workflow section entirely.",
+		Fix:         "Either add actions under spec.workflow.actions or remove spec.workflow entirely if you only need resolvers.",
+	},
+	"finally-with-foreach": {
+		Rule:        "finally-with-foreach",
+		Severity:    string(lint.SeverityError),
+		Category:    "validation",
+		Description: "An action in the spec.workflow.finally section uses forEach, which is not supported.",
+		Why:         "Finally actions are cleanup/teardown steps that must run reliably. forEach adds complexity and potential failure points that could prevent cleanup from completing.",
+		Fix:         "Remove the forEach from the finally action. If you need to iterate during cleanup, move the action to spec.workflow.actions and handle cleanup differently.",
+	},
+	"workflow-validation": {
+		Rule:        "workflow-validation",
+		Severity:    string(lint.SeverityError),
+		Category:    "validation",
+		Description: "The workflow has structural validation errors such as circular dependencies between actions.",
+		Why:         "Circular dependencies create infinite loops that prevent the workflow from completing. The dependency graph must be a DAG (directed acyclic graph).",
+		Fix:         "Use render_solution with graph_type 'action-deps' to visualize the dependency graph. Break cycles by reordering dependencies or removing unnecessary dependsOn references.",
+	},
+	"schema-violation": {
+		Rule:        "schema-violation",
+		Severity:    string(lint.SeverityError),
+		Category:    "schema",
+		Description: "The solution YAML violates the JSON Schema definition. This includes unknown fields, type mismatches, pattern violations, and constraint violations.",
+		Why:         "Schema violations indicate the YAML structure doesn't match what scafctl expects. This will cause parsing errors or unexpected behavior.",
+		Fix:         "Use get_solution_schema to see the expected schema. Common issues: unknown field names (typos), wrong types (string vs int), invalid metadata.name pattern (must be lowercase with hyphens, 3-60 chars).",
+	},
+	"unknown-provider-input": {
+		Rule:        "unknown-provider-input",
+		Severity:    string(lint.SeverityError),
+		Category:    "provider",
+		Description: "An input key passed to a provider is not declared in that provider's input schema.",
+		Why:         "Unknown inputs are silently ignored, which usually indicates a typo. The intended field won't receive its value.",
+		Fix:         "Use get_provider_schema with the provider name to see all valid input field names. For example, the exec provider requires 'command' (not 'cmd').",
+	},
+	"invalid-provider-input-type": {
+		Rule:        "invalid-provider-input-type",
+		Severity:    string(lint.SeverityError),
+		Category:    "provider",
+		Description: "A literal input value doesn't match the type expected by the provider's schema (e.g., passing a string where an integer is required).",
+		Why:         "Type mismatches cause runtime errors. The provider expects a specific type and will fail to process the wrong type.",
+		Fix:         "Use get_provider_schema to check the expected type for each input. Ensure literal values match (e.g., use '42' not 'forty-two' for integer fields).",
+	},
+	"invalid-test-name": {
+		Rule:        "invalid-test-name",
+		Severity:    string(lint.SeverityError),
+		Category:    "naming",
+		Description: "A test case name doesn't match the required naming pattern (lowercase with hyphens).",
+		Why:         "Test names must be lowercase with hyphens (e.g., 'my-test-case') for consistency and to work correctly with filtering.",
+		Fix:         "Rename the test to use only lowercase letters, numbers, and hyphens. Avoid spaces, underscores, and uppercase letters.",
+	},
+	"unbundled-test-file": {
+		Rule:        "unbundled-test-file",
+		Severity:    string(lint.SeverityError),
+		Category:    "bundling",
+		Description: "A test case references a file that is not covered by the solution's bundle.include patterns.",
+		Why:         "When the solution is published to the catalog, unbundled files won't be included, causing test failures.",
+		Fix:         "Add the file path or a glob pattern to bundle.include that covers the test file. Example: bundle:\n  include:\n    - 'tests/**'",
+	},
+	"unused-template": {
+		Rule:        "unused-template",
+		Severity:    string(lint.SeverityWarning),
+		Category:    "usage",
+		Description: "A test template (name starting with '_') is defined but not referenced by any test case via 'extends'.",
+		Why:         "Unused test templates add unnecessary complexity. They may indicate a typo in an extends reference.",
+		Fix:         "Either remove the unused template or reference it from a test case using 'extends: _template-name'.",
+	},
+	"missing-description": {
+		Rule:        "missing-description",
+		Severity:    string(lint.SeverityInfo),
+		Category:    "documentation",
+		Description: "A resolver or action does not have a description field.",
+		Why:         "Descriptions help others understand what each resolver/action does. They appear in inspect_solution output and documentation.",
+		Fix:         "Add a description field: description: \"Brief explanation of what this does\"",
+	},
+	"long-timeout": {
+		Rule:        "long-timeout",
+		Severity:    string(lint.SeverityInfo),
+		Category:    "performance",
+		Description: "An action has a timeout exceeding 10 minutes.",
+		Why:         "Very long timeouts may indicate a misconfiguration or an action that should be broken into smaller steps. They also delay failure detection.",
+		Fix:         "Consider reducing the timeout or breaking the action into smaller steps. If the long timeout is intentional, this is just an informational notice.",
+	},
+	"unused-finally": {
+		Rule:        "unused-finally",
+		Severity:    string(lint.SeverityInfo),
+		Category:    "structure",
+		Description: "A finally section is defined but there are no regular actions in the workflow.",
+		Why:         "Finally actions are cleanup steps that run after regular actions. Without regular actions, there's nothing to clean up after.",
+		Fix:         "Either add regular actions under spec.workflow.actions or remove the spec.workflow.finally section.",
+	},
+	"permissive-result-schema": {
+		Rule:        "permissive-result-schema",
+		Severity:    string(lint.SeverityInfo),
+		Category:    "schema",
+		Description: "An action's resultSchema is defined but doesn't specify a type, making it accept any value.",
+		Why:         "A result schema without a type constraint doesn't provide meaningful validation of action output.",
+		Fix:         "Add a 'type' field to the resultSchema: resultSchema:\n  type: object\n  properties:\n    status:\n      type: string",
+	},
+	"invalid-result-schema": {
+		Rule:        "invalid-result-schema",
+		Severity:    string(lint.SeverityError),
+		Category:    "schema",
+		Description: "An action's resultSchema is not a valid JSON Schema definition.",
+		Why:         "Invalid result schemas cannot be used to validate action outputs, causing runtime errors.",
+		Fix:         "Ensure the resultSchema follows JSON Schema syntax. Use get_solution_schema to see the expected format.",
+	},
+	"undefined-required-property": {
+		Rule:        "undefined-required-property",
+		Severity:    string(lint.SeverityError),
+		Category:    "schema",
+		Description: "A resultSchema lists a property in 'required' that is not defined in 'properties'.",
+		Why:         "Requiring a property that isn't defined means the validation will always fail for that property.",
+		Fix:         "Either add the missing property to 'properties' or remove it from the 'required' list.",
+	},
+	"schema-error": {
+		Rule:        "schema-error",
+		Severity:    string(lint.SeverityWarning),
+		Category:    "schema",
+		Description: "Schema validation could not be performed (schema generation failed).",
+		Why:         "This is an internal issue that prevents full validation. The solution may still work but hasn't been fully checked.",
+		Fix:         "This usually resolves itself. If persistent, check that the solution YAML is well-formed (valid YAML syntax).",
+	},
+}

--- a/pkg/mcp/tools_lint_test.go
+++ b/pkg/mcp/tools_lint_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleExplainLintRule(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("known rule", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "explain_lint_rule"
+		request.Params.Arguments = map[string]any{
+			"rule": "empty-solution",
+		}
+
+		result, err := srv.handleExplainLintRule(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, "empty-solution", output["rule"])
+		assert.NotEmpty(t, output["description"])
+		assert.NotEmpty(t, output["fix"])
+		assert.NotEmpty(t, output["why"])
+	})
+
+	t.Run("unknown rule", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "explain_lint_rule"
+		request.Params.Arguments = map[string]any{
+			"rule": "nonexistent-rule",
+		}
+
+		result, err := srv.handleExplainLintRule(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "nonexistent-rule")
+	})
+
+	t.Run("missing required param", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "explain_lint_rule"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleExplainLintRule(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("all known rules have required fields", func(t *testing.T) {
+		for name, explanation := range lintRuleExplanations {
+			assert.NotEmpty(t, explanation.Rule, "rule %q missing Rule field", name)
+			assert.NotEmpty(t, explanation.Description, "rule %q missing Description", name)
+			assert.NotEmpty(t, explanation.Fix, "rule %q missing Fix", name)
+			assert.NotEmpty(t, explanation.Why, "rule %q missing Why", name)
+			assert.NotEmpty(t, explanation.Category, "rule %q missing Category", name)
+			assert.NotEmpty(t, explanation.Severity, "rule %q missing Severity", name)
+		}
+	})
+}

--- a/pkg/mcp/tools_scaffold.go
+++ b/pkg/mcp/tools_scaffold.go
@@ -1,0 +1,304 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// registerScaffoldTools registers solution scaffolding MCP tools.
+func (s *Server) registerScaffoldTools() {
+	// scaffold_solution
+	scaffoldSolutionTool := mcp.NewTool("scaffold_solution",
+		mcp.WithDescription("Generate a valid skeleton solution YAML from parameters. Produces a guaranteed-valid starting point with the correct structure, including metadata, resolvers, workflow, and tests based on selected features. The generated YAML can be immediately linted and customized."),
+		mcp.WithTitleAnnotation("Scaffold Solution"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("Solution name (lowercase with hyphens, 3-60 chars, e.g., 'my-solution')"),
+		),
+		mcp.WithString("description",
+			mcp.Required(),
+			mcp.Description("Brief description of what the solution does"),
+		),
+		mcp.WithString("version",
+			mcp.Description("Semantic version (default: '1.0.0')"),
+		),
+		mcp.WithArray("features",
+			mcp.Description("Features to include in the scaffold. Options: parameters, resolvers, actions, transforms, validation, tests, composition"),
+		),
+		mcp.WithArray("providers",
+			mcp.Description("Specific providers to include examples for (e.g., ['http', 'exec', 'cel']). Use list_providers to see available providers."),
+		),
+	)
+	s.mcpServer.AddTool(scaffoldSolutionTool, s.handleScaffoldSolution)
+}
+
+// handleScaffoldSolution generates a skeleton solution YAML.
+func (s *Server) handleScaffoldSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := request.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	description, err := request.RequireString("description")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	version := request.GetString("version", "1.0.0")
+
+	// Parse features
+	features := make(map[string]bool)
+	args := request.GetArguments()
+	if featuresRaw, ok := args["features"]; ok && featuresRaw != nil {
+		if featureSlice, ok := featuresRaw.([]any); ok {
+			for _, f := range featureSlice {
+				if fs, ok := f.(string); ok {
+					features[fs] = true
+				}
+			}
+		}
+	}
+
+	// Parse providers
+	var providerNames []string
+	if providersRaw, ok := args["providers"]; ok && providersRaw != nil {
+		if providerSlice, ok := providersRaw.([]any); ok {
+			for _, p := range providerSlice {
+				if ps, ok := p.(string); ok {
+					providerNames = append(providerNames, ps)
+				}
+			}
+		}
+	}
+
+	// Default features if none specified
+	if len(features) == 0 {
+		features["parameters"] = true
+		features["resolvers"] = true
+	}
+
+	yaml := buildScaffoldYAML(name, description, version, features, providerNames)
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"yaml":     yaml,
+		"filename": fmt.Sprintf("%s.yaml", name),
+		"features": featureKeys(features),
+		"nextSteps": []string{
+			"Save the YAML to a file",
+			"Customize the resolver and action values for your use case",
+			"Run lint_solution to validate the structure",
+			"Run preview_resolvers to test resolver outputs",
+			"Run get_run_command to see how to execute it",
+		},
+	})
+}
+
+// buildScaffoldYAML generates solution YAML from scaffold parameters.
+func buildScaffoldYAML(name, description, version string, features map[string]bool, providers []string) string {
+	var b strings.Builder
+
+	// Header
+	b.WriteString("apiVersion: scafctl.io/v1\n")
+	b.WriteString("kind: Solution\n")
+	b.WriteString("metadata:\n")
+	fmt.Fprintf(&b, "  name: %s\n", name)
+	fmt.Fprintf(&b, "  version: \"%s\"\n", version)
+	fmt.Fprintf(&b, "  description: %s\n", description)
+	b.WriteString("  tags:\n")
+	b.WriteString("    - scaffold\n")
+	b.WriteString("\nspec:\n")
+
+	// Resolvers
+	if features["resolvers"] || features["parameters"] || features["transforms"] || features["validation"] {
+		b.WriteString("  resolvers:\n")
+
+		if features["parameters"] {
+			b.WriteString("    # User-provided input parameter\n")
+			b.WriteString("    input-name:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A user-provided input value\"\n")
+			b.WriteString("      example: \"my-value\"\n")
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: parameter\n")
+
+			if features["validation"] {
+				b.WriteString("      validate:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: validation\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              expression: 'size(__self) >= 1 && size(__self) <= 100'\n")
+				b.WriteString("            message: \"Input must be between 1 and 100 characters\"\n")
+			}
+		}
+
+		if features["resolvers"] && !features["parameters"] {
+			b.WriteString("    # Static value resolver\n")
+			b.WriteString("    config-value:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A static configuration value\"\n")
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: static\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              value: \"default-value\"\n")
+		}
+
+		if features["transforms"] {
+			b.WriteString("    # Transformed value\n")
+			b.WriteString("    processed:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A value processed through a transform\"\n")
+			if features["parameters"] {
+				b.WriteString("      dependsOn:\n")
+				b.WriteString("        - input-name\n")
+			}
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: static\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              value: \"raw-data\"\n")
+			b.WriteString("      transform:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: cel\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              expression: '__self.upperAscii()'\n")
+		}
+
+		// Provider-specific resolver examples
+		for _, p := range providers {
+			switch p {
+			case "http":
+				b.WriteString("    # HTTP API call\n")
+				b.WriteString("    api-data:\n")
+				b.WriteString("      type: object\n")
+				b.WriteString("      description: \"Data fetched from an API\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: http\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              url: \"https://api.example.com/data\"\n")
+				b.WriteString("              method: GET\n")
+			case "env":
+				b.WriteString("    # Environment variable\n")
+				b.WriteString("    env-value:\n")
+				b.WriteString("      type: string\n")
+				b.WriteString("      description: \"Value from environment variable\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: env\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              name: MY_ENV_VAR\n")
+			case "file":
+				b.WriteString("    # File content\n")
+				b.WriteString("    file-content:\n")
+				b.WriteString("      type: string\n")
+				b.WriteString("      description: \"Content read from a file\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: file\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              path: \"./config.json\"\n")
+			}
+		}
+	}
+
+	// Workflow / Actions
+	if features["actions"] {
+		b.WriteString("\n  workflow:\n")
+		b.WriteString("    actions:\n")
+
+		hasExec := false
+		for _, p := range providers {
+			switch p {
+			case "exec":
+				hasExec = true
+				b.WriteString("      # Execute a command\n")
+				b.WriteString("      run-command:\n")
+				b.WriteString("        description: \"Execute a shell command\"\n")
+				b.WriteString("        provider: exec\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          command: \"echo 'Hello from scaffold'\"\n")
+			case "directory":
+				b.WriteString("      # Create a directory structure\n")
+				b.WriteString("      create-output:\n")
+				b.WriteString("        description: \"Create output directory\"\n")
+				b.WriteString("        provider: directory\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          operation: create\n")
+				b.WriteString("          path: \"./output\"\n")
+			case "go-template":
+				b.WriteString("      # Render a template\n")
+				b.WriteString("      render-template:\n")
+				b.WriteString("        description: \"Render a Go template\"\n")
+				b.WriteString("        provider: go-template\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          template: \"Hello {{ .Name }}\"\n")
+				b.WriteString("          output: \"./output/greeting.txt\"\n")
+			}
+		}
+
+		// Default action if no provider-specific ones were added
+		if !hasExec && len(providers) == 0 {
+			b.WriteString("      # Example action\n")
+			b.WriteString("      hello:\n")
+			b.WriteString("        description: \"A simple action\"\n")
+			b.WriteString("        provider: exec\n")
+			b.WriteString("        inputs:\n")
+			b.WriteString("          command:\n")
+			b.WriteString("            expr: '\"echo Hello, \" + resolvers.input_name'\n")
+		}
+	}
+
+	// Tests
+	if features["tests"] {
+		b.WriteString("\n  testing:\n")
+		b.WriteString("    cases:\n")
+		b.WriteString("      # Basic lint validation\n")
+		b.WriteString("      basic-render:\n")
+		b.WriteString("        description: \"Verify solution renders successfully\"\n")
+		b.WriteString("        command: [render, solution]\n")
+		b.WriteString("        args: [\"-o\", \"json\"]\n")
+
+		if features["parameters"] {
+			b.WriteString("        resolvers:\n")
+			b.WriteString("          input-name: \"test-value\"\n")
+		}
+
+		b.WriteString("        assertions:\n")
+		b.WriteString("          - expression: __exitCode == 0\n")
+
+		if features["parameters"] {
+			b.WriteString("          - expression: __output.resolvers.input_name == \"test-value\"\n")
+		}
+	}
+
+	// Composition
+	if features["composition"] {
+		b.WriteString("\n# Uncomment to compose with partial solutions:\n")
+		b.WriteString("# compose:\n")
+		b.WriteString("#   - ./common-resolvers.yaml\n")
+		b.WriteString("#   - ./shared-actions.yaml\n")
+	}
+
+	return b.String()
+}
+
+// featureKeys returns sorted keys from a features map.
+func featureKeys(features map[string]bool) []string {
+	keys := make([]string, 0, len(features))
+	for k := range features {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/mcp/tools_scaffold_test.go
+++ b/pkg/mcp/tools_scaffold_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleScaffoldSolution(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("minimal scaffold", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "scaffold_solution"
+		request.Params.Arguments = map[string]any{
+			"name":        "my-test-solution",
+			"description": "A test solution",
+		}
+
+		result, err := srv.handleScaffoldSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		yaml, ok := output["yaml"].(string)
+		require.True(t, ok)
+		assert.Contains(t, yaml, "apiVersion: scafctl.io/v1")
+		assert.Contains(t, yaml, "name: my-test-solution")
+		assert.Contains(t, yaml, "A test solution")
+	})
+
+	t.Run("with features and providers", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "scaffold_solution"
+		request.Params.Arguments = map[string]any{
+			"name":        "full-solution",
+			"description": "Full featured solution",
+			"features":    []any{"parameters", "actions", "transforms", "validation", "tests", "composition"},
+			"providers":   []any{"http", "exec"},
+		}
+
+		result, err := srv.handleScaffoldSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		yaml, ok := output["yaml"].(string)
+		require.True(t, ok)
+		assert.Contains(t, yaml, "apiVersion: scafctl.io/v1")
+		assert.Contains(t, yaml, "parameter")
+		assert.Contains(t, yaml, "actions")
+		assert.Contains(t, yaml, "testing")
+		assert.Contains(t, yaml, "compose")
+	})
+
+	t.Run("custom version", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "scaffold_solution"
+		request.Params.Arguments = map[string]any{
+			"name":        "versioned",
+			"description": "Custom version",
+			"version":     "2.0.0",
+		}
+
+		result, err := srv.handleScaffoldSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		yaml, ok := output["yaml"].(string)
+		require.True(t, ok)
+		assert.Contains(t, yaml, `version: "2.0.0"`)
+	})
+
+	t.Run("missing required name", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "scaffold_solution"
+		request.Params.Arguments = map[string]any{
+			"description": "No name",
+		}
+
+		result, err := srv.handleScaffoldSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing required description", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "scaffold_solution"
+		request.Params.Arguments = map[string]any{
+			"name": "no-description",
+		}
+
+		result, err := srv.handleScaffoldSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -6,7 +6,11 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/action"
@@ -19,6 +23,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
 )
 
 // registerSolutionTools registers all solution-related MCP tools.
@@ -92,6 +98,69 @@ func (s *Server) registerSolutionTools() {
 		),
 	)
 	s.mcpServer.AddTool(renderSolutionTool, s.handleRenderSolution)
+
+	// preview_resolvers
+	previewResolversTool := mcp.NewTool("preview_resolvers",
+		mcp.WithDescription("Execute a solution's resolver chain and return each resolver's resolved value. This is the 'does it actually work?' step between writing YAML and running the full solution. Shows the resolved value, type, and status for every resolver. Accepts optional input parameters for parameter-type resolvers. Use the 'resolver' parameter to debug a single resolver and see its resolve/transform/validate pipeline in detail."),
+		mcp.WithTitleAnnotation("Preview Resolvers"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+		mcp.WithObject("params",
+			mcp.Description("Input parameters as key-value pairs for parameter-type resolvers (e.g., {\"env\": \"prod\", \"region\": \"us-east-1\"})"),
+		),
+		mcp.WithString("resolver",
+			mcp.Description("Debug a single resolver by name. Returns detailed pipeline info (resolve, transform, validate phases) for just this resolver and its dependencies."),
+		),
+	)
+	s.mcpServer.AddTool(previewResolversTool, s.handlePreviewResolvers)
+
+	// run_solution_tests
+	runSolutionTestsTool := mcp.NewTool("run_solution_tests",
+		mcp.WithDescription("Execute functional tests defined in a solution YAML file (spec.testing.cases) or in a tests/ directory. Returns structured test results with pass/fail status, duration, and assertion details. Closes the write → lint → test loop entirely within the AI session."),
+		mcp.WithTitleAnnotation("Run Solution Tests"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution YAML file or directory containing solution files with tests"),
+		),
+		mcp.WithString("filter",
+			mcp.Description("Glob pattern to filter test names (e.g., 'render-*', 'validation-*')"),
+		),
+		mcp.WithString("tag",
+			mcp.Description("Run only tests with this tag (e.g., 'smoke', 'validation')"),
+		),
+		mcp.WithBoolean("skip_builtins",
+			mcp.Description("Skip built-in tests (lint, parse). Default: false"),
+		),
+		mcp.WithBoolean("verbose",
+			mcp.Description("Include assertion details for ALL tests (not just failures). Useful for verifying why tests pass. Default: false"),
+		),
+	)
+	s.mcpServer.AddTool(runSolutionTestsTool, s.handleRunSolutionTests)
+
+	// get_run_command
+	getRunCommandTool := mcp.NewTool("get_run_command",
+		mcp.WithDescription("Get the exact CLI command to run a solution. Analyzes the solution to determine whether to use 'run solution' or 'run resolver', identifies required parameter-type resolvers, and returns the complete command with correct flags. Eliminates guesswork about which command form to use."),
+		mcp.WithTitleAnnotation("Get Run Command"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+	)
+	s.mcpServer.AddTool(getRunCommandTool, s.handleGetRunCommand)
 }
 
 // handleListSolutions lists available solutions from the local catalog.
@@ -272,6 +341,18 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 		return mcp.NewToolResultError(fmt.Sprintf("failed to render action graph: %v", err)), nil
 	}
 
+	// Embed resolver data alongside the graph for a complete picture
+	if len(resolverData) > 0 {
+		type actionGraphWithResolvers struct {
+			Graph        json.RawMessage `json:"graph"`
+			ResolverData map[string]any  `json:"resolverData"`
+		}
+		return mcp.NewToolResultJSON(actionGraphWithResolvers{
+			Graph:        json.RawMessage(rendered),
+			ResolverData: resolverData,
+		})
+	}
+
 	return mcp.NewToolResultText(string(rendered)), nil
 }
 
@@ -342,4 +423,394 @@ func (s *Server) executeResolversForRender(sol *solution.Solution, params map[st
 	}
 
 	return result.Data, nil
+}
+
+// handlePreviewResolvers executes a solution's resolver chain and returns each resolver's value.
+func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Parse params
+	var params map[string]any
+	args := request.GetArguments()
+	if p, ok := args["params"]; ok && p != nil {
+		if pm, ok := p.(map[string]any); ok {
+			params = pm
+		} else {
+			return mcp.NewToolResultError("'params' must be an object (key-value pairs)"), nil
+		}
+	}
+
+	// Load solution
+	prepResult, err := prepare.Solution(s.ctx, path,
+		prepare.WithRegistry(s.registry),
+	)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+	}
+	if prepResult.Cleanup != nil {
+		defer prepResult.Cleanup()
+	}
+
+	sol := prepResult.Solution
+	reg := prepResult.Registry
+
+	if !sol.Spec.HasResolvers() {
+		return mcp.NewToolResultJSON(map[string]any{
+			"resolvers": map[string]any{},
+			"message":   "Solution does not define any resolvers",
+		})
+	}
+
+	if reg == nil {
+		reg, err = builtin.DefaultRegistry(s.ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to create provider registry: %v", err)), nil
+		}
+	}
+
+	cfg := run.ResolverExecutionConfigFromContext(s.ctx)
+	// Check if we're debugging a single resolver
+	resolverFilter := request.GetString("resolver", "")
+
+	result, err := run.ExecuteResolvers(s.ctx, sol, params, reg, cfg)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+	}
+
+	// Build structured response with per-resolver details
+	type resolverPhaseInfo struct {
+		Provider string `json:"provider,omitempty"`
+		Inputs   any    `json:"inputs,omitempty"`
+	}
+
+	type resolverPreview struct {
+		Value       any                 `json:"value"`
+		Type        string              `json:"type,omitempty"`
+		Description string              `json:"description,omitempty"`
+		Status      string              `json:"status"`
+		Provider    string              `json:"provider,omitempty"`
+		DependsOn   []string            `json:"dependsOn,omitempty"`
+		Resolve     []resolverPhaseInfo `json:"resolve,omitempty"`
+		Transform   []resolverPhaseInfo `json:"transform,omitempty"`
+		Validate    []resolverPhaseInfo `json:"validate,omitempty"`
+		When        string              `json:"when,omitempty"`
+	}
+
+	resolvers := make(map[string]resolverPreview, len(sol.Spec.Resolvers))
+	for name, rslvr := range sol.Spec.Resolvers {
+		// If filtering to a single resolver, check if this one or its deps match
+		if resolverFilter != "" && name != resolverFilter {
+			// Include dependencies of the filtered resolver
+			if !isResolverDependency(sol, resolverFilter, name) {
+				continue
+			}
+		}
+
+		preview := resolverPreview{
+			Description: rslvr.Description,
+			Type:        string(rslvr.Type),
+		}
+
+		// Get the primary provider name
+		if rslvr.Resolve != nil && len(rslvr.Resolve.With) > 0 {
+			preview.Provider = rslvr.Resolve.With[0].Provider
+		}
+
+		// Add pipeline details for single-resolver debugging
+		if resolverFilter != "" {
+			preview.DependsOn = rslvr.DependsOn
+			if rslvr.When != nil && rslvr.When.Expr != nil {
+				preview.When = string(*rslvr.When.Expr)
+			}
+			if rslvr.Resolve != nil {
+				for _, step := range rslvr.Resolve.With {
+					preview.Resolve = append(preview.Resolve, resolverPhaseInfo{
+						Provider: step.Provider,
+						Inputs:   step.Inputs,
+					})
+				}
+			}
+			if rslvr.Transform != nil {
+				for _, step := range rslvr.Transform.With {
+					preview.Transform = append(preview.Transform, resolverPhaseInfo{
+						Provider: step.Provider,
+						Inputs:   step.Inputs,
+					})
+				}
+			}
+			if rslvr.Validate != nil {
+				for _, step := range rslvr.Validate.With {
+					preview.Validate = append(preview.Validate, resolverPhaseInfo{
+						Provider: step.Provider,
+						Inputs:   step.Inputs,
+					})
+				}
+			}
+		}
+
+		if val, ok := result.Data[name]; ok {
+			preview.Value = val
+			preview.Status = "resolved"
+		} else {
+			preview.Status = "unresolved"
+		}
+
+		resolvers[name] = preview
+	}
+
+	// Verify the filtered resolver exists
+	if resolverFilter != "" {
+		if _, ok := sol.Spec.Resolvers[resolverFilter]; !ok {
+			availableNames := make([]string, 0, len(sol.Spec.Resolvers))
+			for name := range sol.Spec.Resolvers {
+				availableNames = append(availableNames, name)
+			}
+			sort.Strings(availableNames)
+			return mcp.NewToolResultError(fmt.Sprintf("resolver %q not found. Available resolvers: %v", resolverFilter, availableNames)), nil
+		}
+	}
+
+	response := map[string]any{
+		"resolvers": resolvers,
+		"total":     len(sol.Spec.Resolvers),
+		"resolved":  len(result.Data),
+	}
+	if resolverFilter != "" {
+		response["filter"] = resolverFilter
+		response["total"] = len(resolvers)
+	}
+
+	return mcp.NewToolResultJSON(response)
+}
+
+// handleRunSolutionTests executes functional tests for a solution.
+func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	filter := request.GetString("filter", "")
+	tag := request.GetString("tag", "")
+	skipBuiltins := false
+	if sb, ok := request.GetArguments()["skip_builtins"]; ok {
+		if b, ok := sb.(bool); ok {
+			skipBuiltins = b
+		}
+	}
+
+	// Verify the path exists
+	if _, err := os.Stat(path); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("path not found: %v", err)), nil
+	}
+
+	// Discover solutions with tests
+	solutions, err := soltesting.DiscoverSolutions(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("test discovery failed: %v", err)), nil
+	}
+
+	if len(solutions) == 0 {
+		return mcp.NewToolResultJSON(map[string]any{
+			"results": []any{},
+			"summary": map[string]any{
+				"total":   0,
+				"message": "No solutions with tests found",
+			},
+		})
+	}
+
+	// Apply skip builtins
+	if skipBuiltins {
+		for i := range solutions {
+			if solutions[i].Config == nil {
+				solutions[i].Config = &soltesting.TestConfig{}
+			}
+			solutions[i].Config.SkipBuiltins = soltesting.SkipBuiltinsValue{All: true}
+		}
+	}
+
+	// Resolve binary path for subprocess execution
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to resolve executable path: %v", err)), nil
+	}
+
+	// Build runner
+	runner := &soltesting.Runner{
+		BinaryPath:  binaryPath,
+		Concurrency: 1, // Sequential for MCP to keep output clean
+		FailFast:    false,
+		TestTimeout: 30 * time.Second,
+		IOStreams:   &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+
+	// Apply filters
+	if filter != "" {
+		runner.Filter.NamePatterns = []string{filter}
+	}
+	if tag != "" {
+		runner.Filter.Tags = []string{tag}
+	}
+
+	// Execute tests
+	start := time.Now()
+	results, err := runner.Run(s.ctx, solutions)
+	elapsed := time.Since(start)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("test execution failed: %v", err)), nil
+	}
+
+	// Build structured response
+	summary := soltesting.Summarize(results)
+	summary.WallDuration = elapsed
+
+	type testResultItem struct {
+		Solution   string                       `json:"solution"`
+		Test       string                       `json:"test"`
+		Status     string                       `json:"status"`
+		Duration   string                       `json:"duration"`
+		Message    string                       `json:"message,omitempty"`
+		Assertions []soltesting.AssertionResult `json:"assertions,omitempty"`
+	}
+
+	items := make([]testResultItem, 0, len(results))
+	for _, r := range results {
+		item := testResultItem{
+			Solution: r.Solution,
+			Test:     r.Test,
+			Status:   string(r.Status),
+			Duration: r.Duration.String(),
+			Message:  r.Message,
+		}
+		// Include assertions for failed tests always, or all tests if verbose
+		verbose := request.GetBool("verbose", false)
+		if len(r.Assertions) > 0 && (verbose || r.Status == soltesting.StatusFail) {
+			item.Assertions = r.Assertions
+		}
+		items = append(items, item)
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"results": items,
+		"summary": map[string]any{
+			"total":    summary.Total,
+			"passed":   summary.Passed,
+			"failed":   summary.Failed,
+			"errors":   summary.Errors,
+			"skipped":  summary.Skipped,
+			"duration": summary.ElapsedDuration().String(),
+		},
+	})
+}
+
+// handleGetRunCommand analyzes a solution and returns the exact CLI command to run it.
+func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	sol, err := explain.LoadSolution(s.ctx, path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+	}
+
+	hasResolvers := sol.Spec.HasResolvers()
+	hasWorkflow := sol.Spec.HasWorkflow()
+
+	// Determine command variant
+	var command string
+	var explanation string
+	switch {
+	case hasWorkflow:
+		command = "scafctl run solution"
+		explanation = "Solution has a workflow with actions — use 'run solution'"
+	case hasResolvers:
+		command = "scafctl run resolver"
+		explanation = "Solution has resolvers but no workflow — use 'run resolver'"
+	default:
+		return mcp.NewToolResultJSON(map[string]any{
+			"error":       "Solution has neither resolvers nor a workflow",
+			"explanation": "Nothing to run — the solution needs either resolvers or a workflow section",
+		})
+	}
+
+	// Find parameter-type resolvers (these require -r flags)
+	type paramInfo struct {
+		Name        string `json:"name"`
+		Type        string `json:"type,omitempty"`
+		Description string `json:"description,omitempty"`
+		Example     any    `json:"example,omitempty"`
+	}
+
+	var parameters []paramInfo
+	if hasResolvers {
+		// Collect resolver names sorted for deterministic output
+		names := make([]string, 0, len(sol.Spec.Resolvers))
+		for name := range sol.Spec.Resolvers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			rslvr := sol.Spec.Resolvers[name]
+			if rslvr.Resolve == nil || len(rslvr.Resolve.With) == 0 {
+				continue
+			}
+			// Check if the primary provider is "parameter"
+			if rslvr.Resolve.With[0].Provider == "parameter" {
+				p := paramInfo{
+					Name:        name,
+					Type:        string(rslvr.Type),
+					Description: rslvr.Description,
+					Example:     rslvr.Example,
+				}
+				parameters = append(parameters, p)
+			}
+		}
+	}
+
+	// Build the full command string
+	fullCommand := fmt.Sprintf("%s -f %s", command, path)
+	for _, p := range parameters {
+		exampleVal := "<value>"
+		if p.Example != nil {
+			exampleVal = fmt.Sprintf("%v", p.Example)
+		}
+		fullCommand += fmt.Sprintf(" -r %s=%s", p.Name, exampleVal)
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"command":      fullCommand,
+		"subcommand":   command,
+		"explanation":  explanation,
+		"parameters":   parameters,
+		"hasWorkflow":  hasWorkflow,
+		"hasResolvers": hasResolvers,
+	})
+}
+
+// isResolverDependency checks if candidateName is a direct or transitive dependency
+// of the targetResolver within the solution's resolver graph.
+func isResolverDependency(sol *solution.Solution, targetResolver, candidateName string) bool {
+	target, ok := sol.Spec.Resolvers[targetResolver]
+	if !ok {
+		return false
+	}
+
+	// Check direct dependencies
+	for _, dep := range target.DependsOn {
+		if dep == candidateName {
+			return true
+		}
+		// Recurse into transitive dependencies
+		if isResolverDependency(sol, dep, candidateName) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -398,3 +398,418 @@ spec:
 		assert.Contains(t, text, "params")
 	})
 }
+
+func TestHandlePreviewResolvers(t *testing.T) {
+	t.Run("missing path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/solution.yaml",
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("solution without resolvers returns empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "no-resolvers.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-resolvers
+  version: 1.0.0
+spec:
+  workflow:
+    actions:
+      greet:
+        provider: exec
+        inputs:
+          command: "echo hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Contains(t, parsed, "message")
+	})
+
+	t.Run("previews static resolvers", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "static-resolvers.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: static-resolvers
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello World"
+    count:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, float64(2), parsed["total"])
+		assert.Equal(t, float64(2), parsed["resolved"])
+
+		resolvers := parsed["resolvers"].(map[string]any)
+		greeting := resolvers["greeting"].(map[string]any)
+		assert.Equal(t, "Hello World", greeting["value"])
+		assert.Equal(t, "resolved", greeting["status"])
+		assert.Equal(t, "static", greeting["provider"])
+	})
+
+	t.Run("invalid params type returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "sol.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test
+  version: 1.0.0
+spec:
+  resolvers:
+    x:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "ok"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path":   solFile,
+			"params": "not-an-object",
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleGetRunCommand(t *testing.T) {
+	t.Run("missing path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("solution with workflow returns run solution", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "with-workflow.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: with-workflow
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+  workflow:
+    actions:
+      greet:
+        provider: exec
+        inputs:
+          command: "echo hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, "scafctl run solution", parsed["subcommand"])
+		assert.Equal(t, true, parsed["hasWorkflow"])
+		assert.Equal(t, true, parsed["hasResolvers"])
+		assert.Contains(t, parsed["command"], "run solution")
+	})
+
+	t.Run("solution without workflow returns run resolver", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "resolvers-only.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: resolvers-only
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, "scafctl run resolver", parsed["subcommand"])
+		assert.Equal(t, false, parsed["hasWorkflow"])
+		assert.Contains(t, parsed["command"], "run resolver")
+	})
+
+	t.Run("solution with parameter resolvers includes flags", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "with-params.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: with-params
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      type: string
+      description: "Target environment"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              prompt: "Enter environment"
+    region:
+      type: string
+      description: "AWS region"
+      example: "us-east-1"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              prompt: "Enter region"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		// Check parameters are detected
+		params := parsed["parameters"].([]any)
+		assert.Len(t, params, 2)
+
+		// Check command includes -r flags
+		cmd := parsed["command"].(string)
+		assert.Contains(t, cmd, "-r env=")
+		assert.Contains(t, cmd, "-r region=us-east-1")
+	})
+
+	t.Run("empty solution returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "empty.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: empty
+  version: 1.0.0
+spec: {}
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		// Should return a result with error info (not IsError, but contains 'error' key)
+		assert.False(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "error")
+	})
+}
+
+func TestHandleRunSolutionTests(t *testing.T) {
+	t.Run("missing path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_solution_tests"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleRunSolutionTests(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_solution_tests"
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/path",
+		}
+
+		result, err := srv.handleRunSolutionTests(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("directory with no tests returns empty results", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "no-tests.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-tests
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_solution_tests"
+		request.Params.Arguments = map[string]any{
+			"path":          solFile,
+			"skip_builtins": true,
+		}
+
+		result, err := srv.handleRunSolutionTests(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		summary := parsed["summary"].(map[string]any)
+		assert.Equal(t, float64(0), summary["total"])
+	})
+}

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -1,0 +1,254 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/google/cel-go/cel"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"sigs.k8s.io/yaml"
+)
+
+// registerTemplateTools registers Go template and expression validation tools.
+func (s *Server) registerTemplateTools() {
+	// evaluate_go_template
+	evaluateGoTemplateTool := mcp.NewTool("evaluate_go_template",
+		mcp.WithDescription("Evaluate a Go template against provided data. Go templates use {{ .FieldName }} syntax and support pipelines, conditionals (if/else), ranges, and custom functions. Data is accessible via dot notation (e.g., {{ .Name }}, {{ .Items }}). Use this to test tmpl: fields in solution YAML before committing them."),
+		mcp.WithTitleAnnotation("Evaluate Go Template"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("template",
+			mcp.Required(),
+			mcp.Description("Go template content to evaluate (e.g., 'Hello {{ .Name }}', '{{ range .Items }}{{ . }}{{ end }}')"),
+		),
+		mcp.WithObject("data",
+			mcp.Description("Data object accessible via dot notation in the template (e.g., {\"Name\": \"world\", \"Items\": [\"a\", \"b\"]})"),
+		),
+		mcp.WithString("data_file",
+			mcp.Description("Path to a YAML/JSON file to load as template data (alternative to 'data')"),
+		),
+		mcp.WithString("left_delim",
+			mcp.Description("Left delimiter for the template (default: '{{')"),
+		),
+		mcp.WithString("right_delim",
+			mcp.Description("Right delimiter for the template (default: '}}')"),
+		),
+		mcp.WithString("missing_key",
+			mcp.Description("Behavior when a map key is missing: 'default' (prints '<no value>'), 'zero' (uses zero value), 'error' (returns error). Default: 'default'"),
+			mcp.Enum("default", "zero", "error"),
+		),
+	)
+	s.mcpServer.AddTool(evaluateGoTemplateTool, s.handleEvaluateGoTemplate)
+
+	// validate_expression
+	validateExpressionTool := mcp.NewTool("validate_expression",
+		mcp.WithDescription("Validate a CEL expression or Go template for syntax errors WITHOUT executing it. Returns whether the expression/template is valid and any parse errors found. Use this for quick syntax checking of when clauses, expr fields, and tmpl fields in solution YAML."),
+		mcp.WithTitleAnnotation("Validate Expression"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("expression",
+			mcp.Required(),
+			mcp.Description("The expression or template content to validate"),
+		),
+		mcp.WithString("type",
+			mcp.Required(),
+			mcp.Description("Expression type: 'cel' for CEL expressions, 'go-template' for Go templates"),
+			mcp.Enum("cel", "go-template"),
+		),
+		mcp.WithString("left_delim",
+			mcp.Description("Left delimiter for Go templates (default: '{{')"),
+		),
+		mcp.WithString("right_delim",
+			mcp.Description("Right delimiter for Go templates (default: '}}')"),
+		),
+	)
+	s.mcpServer.AddTool(validateExpressionTool, s.handleValidateExpression)
+}
+
+// handleEvaluateGoTemplate evaluates a Go template against provided data.
+func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	tmplContent, err := request.RequireString("template")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	args := request.GetArguments()
+
+	// Get data from inline or file
+	var data any
+	inlineData, hasInlineData := args["data"]
+	dataFile := request.GetString("data_file", "")
+
+	if hasInlineData && inlineData != nil && dataFile != "" {
+		return mcp.NewToolResultError("cannot specify both 'data' and 'data_file' — use one or the other"), nil
+	}
+
+	if dataFile != "" {
+		fileBytes, err := os.ReadFile(dataFile)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to read data file %q: %v", dataFile, err)), nil
+		}
+		var fileData any
+		if err := yaml.Unmarshal(fileBytes, &fileData); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to parse data file %q: %v", dataFile, err)), nil
+		}
+		data = fileData
+	} else if hasInlineData && inlineData != nil {
+		data = inlineData
+	}
+
+	// Build template options
+	opts := gotmpl.TemplateOptions{
+		Content: tmplContent,
+		Name:    "mcp-evaluate",
+		Data:    data,
+	}
+
+	if leftDelim := request.GetString("left_delim", ""); leftDelim != "" {
+		opts.LeftDelim = leftDelim
+	}
+	if rightDelim := request.GetString("right_delim", ""); rightDelim != "" {
+		opts.RightDelim = rightDelim
+	}
+	if missingKey := request.GetString("missing_key", ""); missingKey != "" {
+		opts.MissingKey = gotmpl.MissingKeyOption(missingKey)
+	}
+
+	// Execute the template
+	svc := gotmpl.NewService(nil)
+	result, err := svc.Execute(s.ctx, opts)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("template execution failed: %v", err)), nil
+	}
+
+	// Also extract references for debugging help
+	refs, _ := svc.GetReferences(s.ctx, opts)
+
+	response := map[string]any{
+		"template": tmplContent,
+		"output":   result.Output,
+	}
+	if len(refs) > 0 {
+		response["referencedFields"] = refs
+	}
+
+	return mcp.NewToolResultJSON(response)
+}
+
+// handleValidateExpression validates a CEL expression or Go template for syntax errors.
+func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	expression, err := request.RequireString("expression")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	exprType, err := request.RequireString("type")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	switch exprType {
+	case "cel":
+		return s.validateCELExpression(expression)
+	case "go-template":
+		leftDelim := request.GetString("left_delim", "")
+		rightDelim := request.GetString("right_delim", "")
+		return s.validateGoTemplate(expression, leftDelim, rightDelim)
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("unknown expression type %q — use 'cel' or 'go-template'", exprType)), nil
+	}
+}
+
+// validateCELExpression checks a CEL expression for syntax errors without executing it.
+func (s *Server) validateCELExpression(expression string) (*mcp.CallToolResult, error) {
+	env, err := cel.NewEnv()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create CEL environment: %v", err)), nil
+	}
+
+	_, issues := env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return mcp.NewToolResultJSON(map[string]any{
+			"valid":      false,
+			"type":       "cel",
+			"expression": expression,
+			"error":      issues.Err().Error(),
+			"suggestion": "Check CEL syntax. Common issues: missing quotes around strings, using == instead of =, unbalanced parentheses. Use list_cel_functions to see available functions.",
+		})
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"valid":      true,
+		"type":       "cel",
+		"expression": expression,
+	})
+}
+
+// validateGoTemplate checks a Go template for parse errors without executing it.
+func (s *Server) validateGoTemplate(content, leftDelim, rightDelim string) (*mcp.CallToolResult, error) {
+	// Use text/template to parse-only (no execution)
+	tmpl := template.New("mcp-validate")
+
+	switch {
+	case leftDelim != "" && rightDelim != "":
+		tmpl = tmpl.Delims(leftDelim, rightDelim)
+	case leftDelim != "":
+		tmpl = tmpl.Delims(leftDelim, "}}")
+	case rightDelim != "":
+		tmpl = tmpl.Delims("{{", rightDelim)
+	}
+
+	_, err := tmpl.Parse(content)
+	if err != nil {
+		errMsg := err.Error()
+		suggestion := "Check Go template syntax. Common issues: missing closing braces '}}', unclosed {{ if }}/{{ range }}/{{ with }} blocks, undefined functions."
+		if strings.Contains(errMsg, "function") {
+			suggestion = "The template references an unknown function. Use standard Go template functions or check available custom functions."
+		}
+
+		return mcp.NewToolResultJSON(map[string]any{
+			"valid":      false,
+			"type":       "go-template",
+			"template":   content,
+			"error":      errMsg,
+			"suggestion": suggestion,
+		})
+	}
+
+	// Also extract field references via gotmpl for extra help
+	opts := gotmpl.TemplateOptions{
+		Content: content,
+		Name:    "mcp-validate",
+	}
+	if leftDelim != "" {
+		opts.LeftDelim = leftDelim
+	}
+	if rightDelim != "" {
+		opts.RightDelim = rightDelim
+	}
+
+	svc := gotmpl.NewService(nil)
+	refs, _ := svc.GetReferences(s.ctx, opts)
+
+	response := map[string]any{
+		"valid":    true,
+		"type":     "go-template",
+		"template": content,
+	}
+	if len(refs) > 0 {
+		response["referencedFields"] = refs
+	}
+
+	return mcp.NewToolResultJSON(response)
+}

--- a/pkg/mcp/tools_template_test.go
+++ b/pkg/mcp/tools_template_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleEvaluateGoTemplate(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("simple template", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "evaluate_go_template"
+		request.Params.Arguments = map[string]any{
+			"template": "Hello {{ .name }}!",
+			"data":     map[string]any{"name": "World"},
+		}
+
+		result, err := srv.handleEvaluateGoTemplate(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, "Hello World!", output["output"])
+	})
+
+	t.Run("template with no data", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "evaluate_go_template"
+		request.Params.Arguments = map[string]any{
+			"template": "Static text only",
+		}
+
+		result, err := srv.handleEvaluateGoTemplate(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, "Static text only", output["output"])
+	})
+
+	t.Run("template missing required param", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "evaluate_go_template"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleEvaluateGoTemplate(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("invalid template syntax", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "evaluate_go_template"
+		request.Params.Arguments = map[string]any{
+			"template": "{{ .name",
+		}
+
+		result, err := srv.handleEvaluateGoTemplate(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleValidateExpression(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("valid CEL expression", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": "1 + 2 == 3",
+			"type":       "cel",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, true, output["valid"])
+		assert.Equal(t, "cel", output["type"])
+	})
+
+	t.Run("invalid CEL expression", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": "1 + + 2",
+			"type":       "cel",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError) // tool returns valid=false, not an error
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, false, output["valid"])
+	})
+
+	t.Run("valid Go template", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": "{{ .name }}",
+			"type":       "go-template",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, true, output["valid"])
+		assert.Equal(t, "go-template", output["type"])
+	})
+
+	t.Run("invalid Go template", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": "{{ .name",
+			"type":       "go-template",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, false, output["valid"])
+	})
+
+	t.Run("missing required params", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": "test",
+			"type":       "javascript",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3817,6 +3817,11 @@ func TestIntegration_MCPServeInfo(t *testing.T) {
 	assert.True(t, toolNames["explain_kind"], "expected explain_kind tool")
 	assert.True(t, toolNames["list_examples"], "expected list_examples tool")
 	assert.True(t, toolNames["get_example"], "expected get_example tool")
+
+	// Phase 5 tools (authoring workflow)
+	assert.True(t, toolNames["preview_resolvers"], "expected preview_resolvers tool")
+	assert.True(t, toolNames["run_solution_tests"], "expected run_solution_tests tool")
+	assert.True(t, toolNames["get_run_command"], "expected get_run_command tool")
 }
 
 func TestIntegration_MCPServeProtocol(t *testing.T) {


### PR DESCRIPTION
Add 6 new MCP tool handlers and supporting resources/prompts to improve the AI-assisted solution development workflow.

New tools:
- evaluate_go_template: render Go templates with provided data
- validate_expression: validate CEL expressions without executing
- explain_lint_rule: human-readable guidance for lint rule IDs
- scaffold_solution: generate starter solution YAML from intent
- preview_action: dry-run a single action step without side effects
- diff_solution: structured diff between two solution YAML files

Enhancements to existing tools:
- preview_resolvers: add optional resolver filter
- run_solution_tests: add verbose flag for per-assertion output
- get_run_command: return exact CLI invocation for a solution
- render_solution: embed resolver data in graph output

New resource: solution://{name}/graph
New prompt: compose_solution

All new handlers include unit tests; CLI integration tests updated.

docs: add proposed OTel telemetry migration design document
docs: update mcp-server.md marking Phase 5 complete
