### PR TITLE
Mcp

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -48,6 +48,17 @@ Runnable examples are located in the [`/examples`](https://github.com/oakwood-co
 
 - [`examples/actions/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/actions) — Action workflow examples
 - [`examples/config/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/config) — Configuration examples
+- [`examples/exec/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/exec) — Shell execution examples
+- [`examples/mcp/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/mcp) — MCP server integration examples
+- [`examples/providers/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/providers) — Provider examples
 - [`examples/resolvers/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/resolvers) — Resolver examples
+- [`examples/snapshots/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/snapshots) — Snapshot examples
 - [`examples/solutions/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/solutions) — Complete solution examples
 - [`examples/plugins/`](https://github.com/oakwood-commons/scafctl/tree/main/examples/plugins) — Plugin examples
+
+Browse examples from the CLI:
+
+```bash
+scafctl examples list
+scafctl examples get resolvers/hello-world.yaml
+```

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -28,7 +28,23 @@ Architecture and design documentation for scafctl.
 - [Catalog Build Bundling](catalog-build-bundling.md) — Solution file bundling
 - [Catalog CLI Design Decision](catalog-cli-design-decision.md) — ADR: push/pull reference patterns
 - [JSON Schema Migration](jsonschema-migration-decision.md) — ADR: provider schema approach
+- [Shared Library Migration](shared-library-migration.md) — Shared library extraction for MCP/CLI parity
 - [Future Enhancements](future-enhancements.md) — Planned features and enhancements
+
+## MCP & AI Integration
+
+- [MCP Server](mcp-server.md) — MCP server architecture and tool design
+- [MCP Server Enhancements](mcp-server-enhancements.md) — Enhanced tools, prompts, resources, and CLI parity
+- [MCP Server Implementation Guide](mcp-server-implementation-guide.md) — Implementation patterns and conventions
+
+## Auth & Infrastructure
+
+- [Entra Auth Implementation](entra-auth-implementation.md) — Microsoft Entra ID authentication
+- [GCP Auth Handler](gcp-auth-handler.md) — Google Cloud Platform authentication
+- [GitHub Auth Handler](github-auth-handler.md) — GitHub authentication
+- [OTel Telemetry Migration](otel-telemetry-migration.md) — OpenTelemetry integration
+- [State](state.md) — State management design
+- [Testing Consolidation](testing-consolidation.md) — Testing strategy consolidation
 
 ## Contributing
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -37,6 +37,14 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 | `build solution` | ✅ Implemented | Catalog feature |
 | `catalog list/inspect/delete/prune` | ✅ Implemented | Catalog management |
 | `catalog save/load` | ✅ Implemented | Offline distribution |
+| `eval cel` | ✅ Implemented | Evaluate CEL expressions from CLI |
+| `eval template` | ✅ Implemented | Evaluate Go templates from CLI |
+| `eval validate` | ✅ Implemented | Validate solution files from CLI |
+| `new solution` | ✅ Implemented | Scaffold a new solution from template |
+| `lint rules` | ✅ Implemented | List all available lint rules |
+| `lint explain` | ✅ Implemented | Explain a specific lint rule |
+| `examples list` | ✅ Implemented | List available example configurations |
+| `examples get` | ✅ Implemented | Get/download an example file |
 | `push solution/plugin` | 📋 Planned | Remote catalog feature |
 | `pull solution/plugin` | 📋 Planned | Remote catalog feature |
 | `tag solution/plugin` | 📋 Planned | Catalog feature |
@@ -818,3 +826,129 @@ The scafctl CLI follows a structured, extensible pattern:
 - Names and versions identify concrete artifacts
 
 This design enables dynamic extension, clear UX, and long-term scalability without breaking existing commands.
+
+---
+
+## Evaluating Expressions
+
+The `eval` command group lets you test CEL expressions, Go templates, and validate solution files without running a full solution.
+
+### Evaluate CEL
+
+~~~bash
+# Simple expression
+scafctl eval cel "1 + 2"
+
+# With JSON data
+scafctl eval cel '_.name == "test"' --data '{"name": "test"}'
+
+# From a data file
+scafctl eval cel '_.items.size() > 0' --data-file data.json
+
+# Output as JSON
+scafctl eval cel '_.items.filter(i, i.active)' --data-file data.json -o json
+~~~
+
+### Evaluate Go Template
+
+~~~bash
+# Simple template
+scafctl eval template '{{.name}}' --data '{"name": "hello"}'
+
+# Template from file
+scafctl eval template --template-file template.txt --data-file data.json
+
+# With output file
+scafctl eval template --template-file template.txt --data-file data.json --output result.txt
+~~~
+
+### Validate Solution
+
+~~~bash
+# Validate a solution YAML file
+scafctl eval validate -f solution.yaml
+
+# Output as JSON
+scafctl eval validate -f solution.yaml -o json
+~~~
+
+---
+
+## Creating New Solutions
+
+Scaffold a new solution from a built-in template:
+
+~~~bash
+# Interactive — prompts for name, description, providers
+scafctl new solution
+
+# With flags
+scafctl new solution --name my-solution --description "My new solution" --output my-solution.yaml
+
+# With specific providers
+scafctl new solution --name my-solution --providers static,exec,cel
+~~~
+
+---
+
+## Exploring Lint Rules
+
+### List Rules
+
+List all available lint rules with severity, category, and descriptions:
+
+~~~bash
+# List all rules
+scafctl lint rules
+
+# Output as JSON
+scafctl lint rules -o json
+~~~
+
+### Explain a Rule
+
+Get a detailed explanation of a specific lint rule:
+
+~~~bash
+# Show rule details, examples, and fix guidance
+scafctl lint explain <rule-id>
+
+# Output as JSON
+scafctl lint explain <rule-id> -o json
+~~~
+
+---
+
+## Browsing Examples
+
+Discover and download built-in example configurations:
+
+### List Examples
+
+~~~bash
+# List all examples
+scafctl examples list
+
+# Filter by category
+scafctl examples list --category solutions
+scafctl examples list --category resolvers
+scafctl examples list --category actions
+
+# Output as JSON
+scafctl examples list -o json
+
+# Output as YAML
+scafctl examples list -o yaml
+~~~
+
+### Get an Example
+
+~~~bash
+# Print example to stdout
+scafctl examples get resolvers/hello-world.yaml
+
+# Save to file
+scafctl examples get resolvers/hello-world.yaml -o output.yaml
+~~~
+
+Aliases: `ls` for list

--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -1,0 +1,1255 @@
+---
+title: MCP Server Enhancements & CLI Parity
+weight: 102
+---
+
+# MCP Server Enhancements & CLI Parity
+
+This document is the implementation plan for the next phase of MCP server improvements and the introduction of CLI parity for MCP-only tools. It builds on the existing [MCP Server design](./mcp-server.md) and [Implementation Guide](./mcp-server-implementation-guide.md).
+
+## Table of Contents
+
+- [Motivation](#motivation)
+- [Part 1: CLI Parity — Exposing MCP Tools as CLI Commands](#part-1-cli-parity--exposing-mcp-tools-as-cli-commands)
+  - [Architecture: Shared Library Pattern](#architecture-shared-library-pattern)
+  - [Phase 1A: `scafctl eval` Command Group](#phase-1a-scafctl-eval-command-group)
+  - [Phase 1B: `scafctl new` Command](#phase-1b-scafctl-new-command)
+  - [Phase 1C: `scafctl lint` Subcommands](#phase-1c-scafctl-lint-subcommands)
+  - [Phase 1E: `scafctl examples` Command Group](#phase-1e-scafctl-examples-command-group)
+  - [Phase 1F: Enhanced `--dry-run` Output](#phase-1f-enhanced---dry-run-output)
+- [Part 2: New MCP Tools](#part-2-new-mcp-tools)
+  - [Phase 2A: `extract_resolver_refs`](#phase-2a-extract_resolver_refs)
+  - [Phase 2B: `generate_test_scaffold`](#phase-2b-generate_test_scaffold)
+  - [Phase 2C: `list_tests`](#phase-2c-list_tests)
+  - [Phase 2D: `show_snapshot`](#phase-2d-show_snapshot)
+  - [Phase 2E: `diff_snapshots`](#phase-2e-diff_snapshots)
+  - [Phase 2F: `catalog_inspect`](#phase-2f-catalog_inspect)
+  - [Phase 2G: `list_auth_handlers`](#phase-2g-list_auth_handlers)
+  - [Phase 2H: `get_config_paths`](#phase-2h-get_config_paths)
+  - [Phase 2I: `validate_expressions` (Batch)](#phase-2i-validate_expressions-batch)
+- [Part 3: New MCP Prompts](#part-3-new-mcp-prompts)
+  - [Phase 3A: `analyze_execution` Prompt](#phase-3a-analyze_execution-prompt)
+  - [Phase 3B: `migrate_solution` Prompt](#phase-3b-migrate_solution-prompt)
+  - [Phase 3C: `optimize_solution` Prompt](#phase-3c-optimize_solution-prompt)
+- [Part 4: New MCP Resources](#part-4-new-mcp-resources)
+  - [Phase 4A: `solution://{name}/tests` Resource](#phase-4a-solutionnametests-resource)
+- [Part 5: Architecture & Quality Improvements](#part-5-architecture--quality-improvements)
+  - [Phase 5A: Extract Shared Libraries from Inline MCP Code](#phase-5a-extract-shared-libraries-from-inline-mcp-code)
+  - [Phase 5B: Structured Error Context](#phase-5b-structured-error-context)
+  - [Phase 5C: Tool Latency Hints](#phase-5c-tool-latency-hints)
+  - [Phase 5D: `get_version` Tool](#phase-5d-get_version-tool)
+- [Implementation Order](#implementation-order)
+- [Testing Strategy](#testing-strategy)
+
+---
+
+## Motivation
+
+The MCP server currently exposes 26 tools, 9 prompts, and 5 resources. After analyzing the full codebase, two categories of improvements have been identified:
+
+1. **MCP-only tools that should also be CLI commands.** Several tools were built exclusively for the MCP server (`evaluate_cel`, `scaffold_solution`, `diff_solution`, etc.) but provide value to developers working without AI/MCP. These should be exposed as first-class CLI commands via a shared library layer.
+
+2. **CLI capabilities not yet exposed via MCP.** Existing CLI commands like `get resolver refs`, `test init`, `test list`, `snapshot show/diff`, `catalog inspect`, `auth list`, and `config paths` provide high-value read-only operations that AI agents currently cannot use.
+
+Additionally, several cross-cutting improvements (batch validation, structured errors, new prompts for post-execution analysis) would improve the overall developer and agent experience.
+
+---
+
+## Part 1: CLI Parity — Exposing MCP Tools as CLI Commands
+
+### Architecture: Shared Library Pattern
+
+**Problem:** Several MCP tools contain logic inline in `pkg/mcp/tools_*.go` that has no shared library counterpart. This means CLI commands cannot reuse the logic, and any fixes/improvements must be duplicated.
+
+**Solution:** Extract shared logic into dedicated library packages. Both the MCP handler and the CLI command become thin wrappers over the same library.
+
+```
+┌─────────────────┐     ┌──────────────────┐
+│  CLI Command     │     │  MCP Tool Handler │
+│  (cobra handler) │     │  (MCP handler)    │
+└────────┬────────┘     └────────┬─────────┘
+         │                       │
+         ▼                       ▼
+┌──────────────────────────────────────────┐
+│         Shared Library Package            │
+│  (pkg/scaffold/, pkg/soldiff/, etc.)      │
+│  - Pure functions, no CLI/MCP deps        │
+│  - Structured input/output types          │
+│  - Full test coverage                     │
+└──────────────────────────────────────────┘
+```
+
+**Packages to extract:**
+
+| Current Location | Extract To | Reason |
+|------------------|-----------|--------|
+| `pkg/mcp/tools_scaffold.go` → `buildScaffoldYAML()` | `pkg/scaffold/` | Solution scaffolding logic (~150 lines inline) |
+| `pkg/mcp/tools_diff.go` → diff logic | `pkg/soldiff/` | Solution structural comparison (~150 lines inline) |
+| `pkg/mcp/tools_examples.go` → `scanExamples()` | `pkg/examples/` | Embedded examples via `go:embed` + scanning/categorization |
+
+Tools that already call shared library code (`evaluate_cel` → `pkg/celexp`, `evaluate_go_template` → `pkg/gotmpl`, `list_lint_rules` → `pkg/cmd/scafctl/lint`) need no extraction — they just need CLI command wrappers.
+
+---
+
+### Phase 1A: `scafctl eval` Command Group
+
+**New commands:** `scafctl eval cel` and `scafctl eval template`
+
+These expose the MCP `evaluate_cel` and `evaluate_go_template` tools as CLI commands. Developers frequently need to test CEL expressions and Go templates in isolation when building solutions.
+
+#### `scafctl eval cel`
+
+```
+scafctl eval cel --expression 'size(name) > 3' --var name=hello
+scafctl eval cel --expression 'items.filter(i, i.active)' --data '{"items": [{"name": "a", "active": true}]}'
+scafctl eval cel --expression 'has(config.timeout)' --file config.json
+```
+
+**File:** `pkg/cmd/scafctl/eval/cel.go`
+
+**Inputs:**
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--expression`, `-e` | string | Yes | CEL expression to evaluate |
+| `--var`, `-v` | string (repeatable) | No | Variables as `key=value` pairs |
+| `--data`, `-d` | string | No | JSON data context (inline) |
+| `--file`, `-f` | string | No | JSON/YAML file for data context |
+| `-o` | string | No | Output format: `json`, `yaml`, `table` (default: `table`) |
+
+**Implementation:**
+- Parse flags → build `map[string]any` data context
+- Call `celexp.EvaluateExpression()` from `pkg/celexp/context.go`
+- Format and write output via `kvx.OutputOptions`
+
+**Shared code:** `pkg/celexp` — already exists, no extraction needed.
+
+#### `scafctl eval template`
+
+```
+scafctl eval template --template '{{ .name | upper }}' --var name=hello
+scafctl eval template --template-file deploy.tmpl --data '{"env": "prod"}'
+scafctl eval template --template '{{ ._.config.host }}' --file resolvers.json
+```
+
+**File:** `pkg/cmd/scafctl/eval/template.go`
+
+**Inputs:**
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--template`, `-t` | string | No* | Go template string (inline) |
+| `--template-file` | string | No* | Go template file path |
+| `--var`, `-v` | string (repeatable) | No | Variables as `key=value` pairs |
+| `--data`, `-d` | string | No | JSON data context (inline) |
+| `--file`, `-f` | string | No | JSON/YAML file for data context |
+| `--show-refs` | bool | No | Also output referenced resolver fields |
+| `-o` | string | No | Output format: `json`, `yaml`, `table` (default: `table`) |
+
+*One of `--template` or `--template-file` is required.
+
+**Implementation:**
+- Parse flags → build data context
+- Call `gotmpl.NewService(nil).Execute()` from `pkg/gotmpl`
+- Optionally call `gotmpl.Service.GetReferences()` for `--show-refs`
+- Format and write output via `kvx.OutputOptions`
+
+**Shared code:** `pkg/gotmpl` — already exists, no extraction needed.
+
+#### `scafctl eval validate`
+
+```
+scafctl eval validate --expression 'size(name) > 3' --type cel
+scafctl eval validate --expression '{{ .name }}' --type go-template
+```
+
+**File:** `pkg/cmd/scafctl/eval/validate.go`
+
+**Inputs:**
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--expression`, `-e` | string | Yes | Expression to validate |
+| `--type` | string | Yes | Expression type: `cel` or `go-template` |
+| `-o` | string | No | Output format |
+
+**Implementation:**
+- CEL: use `cel.NewEnv().Parse()` to syntax-check
+- Go template: use `template.New().Parse()` + `gotmpl.Service.GetReferences()`
+- Report: valid/invalid, error details, referenced variables
+
+---
+
+### Phase 1B: `scafctl new` Command
+
+**New command:** `scafctl new solution`
+
+Exposes the MCP `scaffold_solution` tool as a CLI command. This is the highest-impact missing CLI command — creating new solutions currently requires copying examples or writing YAML from scratch.
+
+```
+scafctl new solution --name my-deploy --description "Deploy to Kubernetes" --features parameters,resolvers,actions --providers exec,http
+scafctl new solution --name simple-transform --description "Text transformer" > solution.yaml
+```
+
+**File:** `pkg/cmd/scafctl/new/solution.go`
+
+**Inputs:**
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name`, `-n` | string | Yes | Solution name (lowercase, hyphens, 3-60 chars) |
+| `--description`, `-d` | string | Yes | Brief description |
+| `--version` | string | No | Semver version (default: `1.0.0`) |
+| `--features` | string (csv) | No | Features: `parameters`, `resolvers`, `actions`, `transforms`, `validation`, `tests`, `composition` |
+| `--providers` | string (csv) | No | Include provider-specific examples |
+| `--output`, `-o` | string | No | Output file path (default: stdout) |
+
+**Prerequisite — Extract shared library:**
+
+Create `pkg/scaffold/scaffold.go` (note: the shared library package remains `pkg/scaffold/` since it describes the operation; only the CLI command is `new`):
+
+```go
+package scaffold
+
+type Options struct {
+    Name        string
+    Description string
+    Version     string
+    Features    map[string]bool
+    Providers   []string
+}
+
+type Result struct {
+    YAML     string
+    Filename string
+    Features []string
+}
+
+func Solution(opts Options) *Result { ... }
+```
+
+Move `buildScaffoldYAML()` and helpers from `pkg/mcp/tools_scaffold.go` into this package. Update the MCP handler to call `scaffold.Solution()`.
+
+---
+
+### Phase 1C: `scafctl lint` Subcommands
+
+**New commands:** `scafctl lint rules` and `scafctl lint explain`
+
+```
+scafctl lint rules                           # list all rules (table)
+scafctl lint rules --severity error          # filter by severity
+scafctl lint rules --category naming         # filter by category
+scafctl lint rules -o json                   # JSON output for tooling
+
+scafctl lint explain missing-description     # explain a specific rule
+scafctl lint explain unknown-provider-input  # detailed fix guidance
+```
+
+**Files:**
+- `pkg/cmd/scafctl/lint/rules_cmd.go` — `scafctl lint rules`
+- `pkg/cmd/scafctl/lint/explain_cmd.go` — `scafctl lint explain`
+
+**Shared code:** `pkg/cmd/scafctl/lint/rules.go` already exports `ListRules()` and `GetRule()` — no extraction needed. CLI commands are thin wrappers.
+
+**`scafctl lint rules` outputs:**
+| Column | Description |
+|--------|-------------|
+| Rule | Rule name (e.g., `missing-description`) |
+| Severity | `error`, `warning`, `info` |
+| Category | `naming`, `structure`, `dependency`, etc. |
+| Description | One-line summary |
+
+**`scafctl lint explain` outputs:**
+| Field | Description |
+|-------|-------------|
+| Rule | Rule name |
+| Severity | `error` / `warning` / `info` |
+| Category | Rule category |
+| Description | Full description |
+| Why It Matters | Impact explanation |
+| How to Fix | Step-by-step fix instructions |
+| Example | Correct YAML example |
+
+---
+
+### Phase 1E: `scafctl examples` Command Group
+
+**New commands:** `scafctl examples list` and `scafctl examples get`
+
+```
+scafctl examples list                        # list all examples
+scafctl examples list --category solutions   # filter by category
+scafctl examples list -o json                # JSON output
+
+scafctl examples get solutions/email-notifier/solution.yaml   # print example
+scafctl examples get providers/http-resolver.yaml > my.yaml   # save to file
+```
+
+**Files:**
+- `pkg/cmd/scafctl/examples/list.go`
+- `pkg/cmd/scafctl/examples/get.go`
+
+**Prerequisite — Extract shared library with `go:embed`:**
+
+The current MCP implementation in `pkg/mcp/tools_examples.go` uses `runtime.Caller(0)` and directory-walking heuristics to locate the `examples/` directory at runtime. This is fragile — it only works when running from a repo checkout or development build. For `scafctl examples` to work as a distributed CLI command (installed binary, containers, CI), the examples must be embedded into the binary.
+
+**Approach:** Use Go's `go:embed` directive, which is already an established pattern in this codebase (see `pkg/cmd/scafctl/config/init.go` for config templates). The `examples/` directory is 520KB / 87 files — trivially small for embedding.
+
+**Why `go:embed` over alternatives:**
+
+| Approach | Verdict | Reason |
+|----------|---------|--------|
+| `go:embed` | **Recommended** | Works offline, version-locked to binary, zero dependencies, established pattern in codebase |
+| Fetch from GitHub API | Rejected | Requires network, rate limits, auth for private repos, version mismatch risk |
+| Bundle as OCI catalog artifact | Rejected | Requires catalog configuration just to see examples — too much friction |
+| Filesystem-only (current) | Rejected | Only works in development; non-starter for distributed binary |
+
+**Implementation:**
+
+Since `go:embed` can only access files in the embedding package's directory or subdirectories, the example YAML files need to be accessible from `pkg/examples/`. Two options:
+
+1. **Copy at build time** (recommended): Add a build step to `taskfile.yaml` that copies `examples/` → `pkg/examples/files/` before `go build`. Add `pkg/examples/files/` to `.gitignore`.
+2. **Symlink**: Create `pkg/examples/files` as a symlink to `../../examples`. NOTE: `go:embed` does **not** follow symlinks, so this only works if the build tool resolves symlinks first.
+
+Create `pkg/examples/examples.go`:
+
+```go
+package examples
+
+import "embed"
+
+//go:embed files/*
+var EmbeddedExamples embed.FS
+
+type Example struct {
+    Path        string `json:"path"`
+    Category    string `json:"category"`
+    Description string `json:"description"`
+    Size        int64  `json:"size"`
+}
+
+// Scan walks the embedded examples filesystem and returns matching examples.
+// If category is empty, returns all examples.
+func Scan(category string) ([]Example, error) { ... }
+
+// Read returns the contents of an embedded example file.
+func Read(path string) (string, error) { ... }
+
+// Categories returns the list of available example categories.
+func Categories() []string { ... }
+```
+
+Key changes from the current MCP implementation:
+- **No `FindExamplesDir()`** — the directory concept is replaced by `embed.FS`
+- **No `runtime.Caller()` hacks** — examples are always available in the binary
+- `Scan()` and `Read()` operate on `EmbeddedExamples` instead of `os.ReadDir`/`os.ReadFile`
+- Examples are version-locked — `scafctl v0.15.0` always shows v0.15.0 examples
+
+Move `scanExamples()` logic and description mapping from `pkg/mcp/tools_examples.go` into this package, adapted to use `fs.WalkDir` on `embed.FS`. Update both MCP handler and CLI command to use it.
+
+**Build integration (`taskfile.yaml`):**
+
+```yaml
+tasks:
+  embed:examples:
+    desc: Copy examples into pkg/examples/files for go:embed
+    cmds:
+      - rm -rf pkg/examples/files
+      - cp -r examples pkg/examples/files
+    sources:
+      - examples/**/*
+    generates:
+      - pkg/examples/files/**/*
+
+  build:
+    deps: [embed:examples]
+    cmds:
+      - go build -ldflags "..." -o dist/scafctl ./cmd/scafctl/scafctl.go
+```
+
+---
+
+### Phase 1F: Enhanced `--dry-run` Output
+
+**Enhancement:** Replace the current lightweight `--dry-run` output on `scafctl run solution` with the full rich report that the MCP `dry_run_solution` / `preview_resolvers` / `preview_action` tools produce.
+
+Currently `--dry-run` shows basic action names, phases, and providers. The MCP tools show much richer data: mock provider behaviors, materialized inputs, deferred inputs, forEach metadata, retry config, and dependency graphs. There is no reason these should be separate — `--dry-run` *is* preview.
+
+**Breaking change:** The `--dry-run` output format changes from a simple summary to a full structured report. This is intentional.
+
+```
+scafctl run solution -f ./solution.yaml --dry-run -r env=prod          # full dry-run report (table)
+scafctl run solution -f ./solution.yaml --dry-run -r env=prod -o json  # machine-readable
+```
+
+**Enhanced `--dry-run` output includes:**
+
+| Section | Current | Enhanced |
+|---------|---------|----------|
+| Actions | Name, phase, provider | + materialized inputs, deferred inputs, mock provider behavior, forEach metadata, retry config |
+| Resolvers | Not shown | Full resolver materialization: values, phases, dependencies, transform chains |
+| Dependencies | Not shown | Dependency graph (resolver + action) |
+| Parameters | Not shown | Resolved parameter values |
+| Validation | Not shown | Expression validation results, missing `dependsOn` warnings |
+
+**Implementation:**
+
+1. Extract the rich dry-run/preview logic from the MCP tools (`preview_resolvers`, `preview_action`, `dry_run_solution`) into a shared library package (e.g., `pkg/dryrun/`)
+2. Define structured output types:
+
+```go
+package dryrun
+
+type Report struct {
+    Solution    string            `json:"solution"`
+    Version     string            `json:"version"`
+    Parameters  map[string]any    `json:"parameters"`
+    Resolvers   []ResolverPreview `json:"resolvers"`
+    Actions     []ActionPreview   `json:"actions"`
+    Graph       GraphInfo         `json:"graph"`
+    Validation  []ValidationIssue `json:"validation,omitempty"`
+}
+
+type ResolverPreview struct {
+    Name         string   `json:"name"`
+    Provider     string   `json:"provider"`
+    Phase        int      `json:"phase"`
+    DependsOn    []string `json:"dependsOn,omitempty"`
+    MaterializedInputs map[string]any `json:"materializedInputs,omitempty"`
+    DeferredInputs     []string       `json:"deferredInputs,omitempty"`
+    Transforms   []string `json:"transforms,omitempty"`
+}
+
+type ActionPreview struct {
+    Name         string         `json:"name"`
+    Phase        int            `json:"phase"`
+    Provider     string         `json:"provider"`
+    MockBehavior string         `json:"mockBehavior"`
+    Inputs       map[string]any `json:"inputs,omitempty"`
+    DeferredInputs []string     `json:"deferredInputs,omitempty"`
+    ForEach      *ForEachMeta   `json:"forEach,omitempty"`
+    Retry        *RetryConfig   `json:"retry,omitempty"`
+    DependsOn    []string       `json:"dependsOn,omitempty"`
+}
+
+func Generate(ctx context.Context, sol *solution.Solution, params map[string]any) (*Report, error) { ... }
+```
+
+3. Update `scafctl run solution --dry-run` to call `dryrun.Generate()` and render via `kvx.OutputOptions`
+4. Update the MCP tools (`preview_resolvers`, `preview_action`, `dry_run_solution`) to call the same shared library
+5. Support `-o table|json|yaml` on the CLI output
+
+**Shared code:** `pkg/dryrun/` — new package extracted from MCP inline logic.
+
+**MCP tool parity:** The three MCP tools remain as separate tools (agents benefit from granularity), but they all call into `pkg/dryrun/` internally. The CLI `--dry-run` produces the equivalent of calling all three.
+
+---
+
+## Part 2: New MCP Tools
+
+### Phase 2A: `extract_resolver_refs`
+
+**Priority: Critical** — Most impactful missing tool for AI-assisted solution authoring.
+
+**Description:** Takes a Go template or CEL expression (inline text or file path) and returns all resolver references (`_.resolverName` patterns) found in it. This is essential for AI agents to correctly populate `dependsOn` fields.
+
+**File:** `pkg/mcp/tools_refs.go`
+
+**Tool Definition:**
+```go
+mcp.NewTool("extract_resolver_refs",
+    mcp.WithDescription("Extract resolver references (_.resolverName patterns) from Go templates or CEL expressions. Returns a list of referenced resolver names, which should be used to populate the 'dependsOn' field. Accepts inline text or a file path."),
+    mcp.WithTitleAnnotation("Extract Resolver References"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+    mcp.WithString("text",
+        mcp.Description("Inline Go template or CEL expression text to analyze"),
+    ),
+    mcp.WithString("file",
+        mcp.Description("Path to a template file to analyze"),
+    ),
+    mcp.WithString("type",
+        mcp.Description("Expression type: 'go-template' (default) or 'cel'"),
+    ),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "source": "inline" | "file",
+  "sourceType": "go-template" | "cel",
+  "references": ["config", "environment", "credentials"],
+  "count": 3,
+  "details": [
+    {"resolver": "config", "fields": ["host", "port"]},
+    {"resolver": "environment", "fields": ["name"]},
+    {"resolver": "credentials", "fields": []}
+  ]
+}
+```
+
+**Shared code:** `gotmpl.GetGoTemplateReferences()` and `celexp.Expression.GetUnderscoreVariables()` already exist. The MCP handler extracts resolver names from full paths (e.g., `_.config.host` → resolver `config`, field `host`).
+
+**CLI counterpart:** Already exists as `scafctl get resolver refs`. No new CLI command needed.
+
+**Update `serverInstructions`:** Add guidance:
+```
+When creating or editing Go templates (tmpl:) or CEL expressions (expr:) that reference resolvers,
+call extract_resolver_refs to determine which resolver names are referenced, then use those
+names in the dependsOn field.
+```
+
+---
+
+### Phase 2B: `generate_test_scaffold`
+
+**Priority: High** — Completes the test authoring workflow.
+
+**Description:** Analyzes a solution's resolvers and workflow, then generates a starter test YAML that covers the basic cases. Pairs with the existing `add_tests` prompt.
+
+**File:** `pkg/mcp/tools_test.go`
+
+**Tool Definition:**
+```go
+mcp.NewTool("generate_test_scaffold",
+    mcp.WithDescription("Analyze a solution and generate a starter functional test scaffold. Examines resolvers (types, parameters, transforms) and workflow actions (providers, dependencies) to produce test cases with appropriate assertions. The generated YAML can be added to the solution's spec.testing section."),
+    mcp.WithTitleAnnotation("Generate Test Scaffold"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(true),
+    mcp.WithString("path",
+        mcp.Required(),
+        mcp.Description("Path to the solution file to generate tests for"),
+    ),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "yaml": "spec:\n  testing:\n    cases:\n      ...",
+  "testCount": 5,
+  "coverage": {
+    "resolversWithTests": ["config", "environment"],
+    "resolversWithoutTests": [],
+    "actionsWithTests": ["deploy"],
+    "actionsWithoutTests": []
+  },
+  "nextSteps": [
+    "Review and customize the test assertions",
+    "Add edge case tests for error conditions",
+    "Run run_solution_tests to verify tests pass"
+  ]
+}
+```
+
+**Shared code:** `soltesting.Scaffold()` and `soltesting.ScaffoldToYAML()` from `pkg/solution/soltesting/scaffold.go`.
+
+**CLI counterpart:** Already exists as `scafctl test init`. No new CLI command needed.
+
+---
+
+### Phase 2C: `list_tests`
+
+**Priority: High** — Enables test discovery before execution.
+
+**Description:** Discovers and lists all functional tests defined in solution files without executing them. Returns test names, tags, commands, and skip status.
+
+**File:** `pkg/mcp/tools_test.go` (same file as `generate_test_scaffold`)
+
+**Tool Definition:**
+```go
+mcp.NewTool("list_tests",
+    mcp.WithDescription("Discover and list functional tests defined in solutions without executing them. Returns test names, tags, commands, expected behavior, and skip status. Use this to understand what tests exist before calling run_solution_tests."),
+    mcp.WithTitleAnnotation("List Tests"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(true),
+    mcp.WithString("path",
+        mcp.Description("Path to a solution file or directory containing solutions with tests"),
+    ),
+    mcp.WithString("filter",
+        mcp.Description("Filter test names by glob pattern (e.g., 'smoke-*')"),
+    ),
+    mcp.WithString("tag",
+        mcp.Description("Filter tests by tag (e.g., 'smoke', 'validation')"),
+    ),
+    mcp.WithBoolean("include_builtins",
+        mcp.Description("Include built-in tests (lint, parse). Default: false"),
+    ),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "solutions": [
+    {
+      "solution": "my-solution",
+      "file": "./my-solution.yaml",
+      "tests": [
+        {
+          "name": "basic-resolve",
+          "description": "Test basic resolver output",
+          "command": ["render", "solution"],
+          "tags": ["smoke"],
+          "skip": false,
+          "assertionCount": 3
+        }
+      ]
+    }
+  ],
+  "totalTests": 5,
+  "totalSolutions": 1
+}
+```
+
+**Shared code:** `soltesting.DiscoverSolutions()` and `soltesting.FilterTests()` from `pkg/solution/soltesting/discovery.go`.
+
+**CLI counterpart:** Already exists as `scafctl test list`. No new CLI command needed.
+
+---
+
+### Phase 2D: `show_snapshot`
+
+**Priority: High** — Enables post-execution analysis.
+
+**Description:** Loads a resolver execution snapshot file and returns structured summary data including solution metadata, timing, status, and per-resolver values/errors.
+
+**File:** `pkg/mcp/tools_snapshot.go`
+
+**Tool Definition:**
+```go
+mcp.NewTool("show_snapshot",
+    mcp.WithDescription("Load and display a resolver execution snapshot. Shows solution metadata, execution timing, status (success/failure), parameter values, and per-resolver results (value, status, duration, provider). Use this to inspect past execution results for debugging."),
+    mcp.WithTitleAnnotation("Show Snapshot"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+    mcp.WithString("path",
+        mcp.Required(),
+        mcp.Description("Path to the snapshot JSON file"),
+    ),
+    mcp.WithString("format",
+        mcp.Description("Output detail level: 'summary' (default), 'resolvers' (include per-resolver data), 'full' (everything including raw values)"),
+    ),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "solution": "my-solution",
+  "version": "1.0.0",
+  "timestamp": "2026-02-20T15:30:00Z",
+  "scafctlVersion": "0.15.0",
+  "duration": "2.3s",
+  "status": "success",
+  "resolverCount": { "total": 10, "success": 9, "failed": 1, "skipped": 0 },
+  "phases": 3,
+  "parameters": { "env": "prod", "region": "us-east1" },
+  "resolvers": [
+    {
+      "name": "config",
+      "status": "success",
+      "value": { "host": "api.example.com" },
+      "duration": "150ms",
+      "provider": "http",
+      "phase": 1
+    }
+  ]
+}
+```
+
+**Shared code:** `resolver.LoadSnapshot()` from `pkg/resolver/snapshot.go`.
+
+**CLI counterpart:** Already exists as `scafctl snapshot show`. No new CLI command needed.
+
+---
+
+### Phase 2E: `diff_snapshots`
+
+**Priority: High** — Enables regression detection.
+
+**Description:** Compares two snapshot files and returns value changes, status changes, additions, and removals between runs.
+
+**File:** `pkg/mcp/tools_snapshot.go` (same file as `show_snapshot`)
+
+**Tool Definition:**
+```go
+mcp.NewTool("diff_snapshots",
+    mcp.WithDescription("Compare two resolver execution snapshots and show differences. Identifies resolvers with changed values, status changes (success→failure), additions, and removals. Useful for detecting regressions between runs or understanding the impact of solution changes."),
+    mcp.WithTitleAnnotation("Diff Snapshots"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+    mcp.WithString("before",
+        mcp.Required(),
+        mcp.Description("Path to the baseline (before) snapshot file"),
+    ),
+    mcp.WithString("after",
+        mcp.Required(),
+        mcp.Description("Path to the comparison (after) snapshot file"),
+    ),
+    mcp.WithBoolean("ignore_unchanged",
+        mcp.Description("Omit unchanged resolvers from the response. Default: true"),
+    ),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "before": { "solution": "my-solution", "timestamp": "...", "status": "success" },
+  "after":  { "solution": "my-solution", "timestamp": "...", "status": "success" },
+  "changes": {
+    "added": [{ "name": "new-resolver", "value": "..." }],
+    "removed": [{ "name": "old-resolver", "value": "..." }],
+    "changed": [
+      {
+        "name": "config",
+        "fields": [
+          { "field": "value.host", "before": "old.example.com", "after": "new.example.com" }
+        ]
+      }
+    ],
+    "statusChanges": [
+      { "name": "api-call", "before": "success", "after": "failed" }
+    ]
+  },
+  "summary": { "added": 1, "removed": 1, "changed": 1, "statusChanges": 1, "unchanged": 7 }
+}
+```
+
+**Shared code:** `resolver.DiffSnapshotsWithOptions()` and formatting functions from `pkg/resolver/diff.go`.
+
+**CLI counterpart:** Already exists as `scafctl snapshot diff`. No new CLI command needed.
+
+---
+
+### Phase 2F: `catalog_inspect`
+
+**Priority: Medium** — Adds drill-down capability to catalog.
+
+**Description:** Returns detailed metadata about a specific catalog artifact (name, version, kind, digest, size, creation time, annotations).
+
+**File:** `pkg/mcp/tools_catalog.go` (add to existing file)
+
+**Tool Definition:**
+```go
+mcp.NewTool("catalog_inspect",
+    mcp.WithDescription("Show detailed metadata about a specific catalog artifact. Returns name, version, kind, digest, size, creation timestamp, catalog source, and annotations. Use catalog_list first to find artifact references."),
+    mcp.WithTitleAnnotation("Catalog Inspect"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+    mcp.WithString("reference",
+        mcp.Required(),
+        mcp.Description("Artifact reference (e.g., 'my-solution:1.0.0' or 'my-solution@sha256:abc123')"),
+    ),
+)
+```
+
+**Shared code:** `catalog.ParseReference()`, `catalog.NewLocalCatalog()`, `localCatalog.Resolve()` from `pkg/catalog/`.
+
+**CLI counterpart:** Already exists as `scafctl catalog inspect`. No new CLI command needed.
+
+---
+
+### Phase 2G: `list_auth_handlers`
+
+**Priority: Medium** — Supplements existing `auth_status`.
+
+**Description:** Lists all registered auth handlers with their supported authentication flows and capabilities. Complements `auth_status` which shows current credential *status* but not what mechanisms are *available*.
+
+**File:** `pkg/mcp/tools_auth.go` (add to existing file)
+
+**Tool Definition:**
+```go
+mcp.NewTool("list_auth_handlers",
+    mcp.WithDescription("List all registered authentication handlers with their supported flows (device-code, client-credentials, etc.) and capabilities. Use this to understand what authentication mechanisms are available when configuring solutions that need specific auth providers. Use auth_status to check the current credential status for a specific handler."),
+    mcp.WithTitleAnnotation("List Auth Handlers"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+)
+```
+
+**Shared code:** Auth registry `ListHandlers()` or iterating handler names via the auth registry from `pkg/auth/`.
+
+**CLI counterpart:** Already exists as `scafctl auth list`. No new CLI command needed.
+
+---
+
+### Phase 2H: `get_config_paths`
+
+**Priority: Medium** — Environment awareness for agents.
+
+**Description:** Returns all XDG-compliant paths used by scafctl (config, data, cache, state, secrets, catalogs, plugins, logs, history).
+
+**File:** `pkg/mcp/tools_config.go` (add to existing file)
+
+**Tool Definition:**
+```go
+mcp.NewTool("get_config_paths",
+    mcp.WithDescription("Return all file system paths used by scafctl, resolved for the current platform. Shows where config, data, cache, catalogs, plugins, secrets, and logs are stored. Useful for locating snapshots, cached artifacts, or diagnosing path-related issues."),
+    mcp.WithTitleAnnotation("Get Config Paths"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+)
+```
+
+**Response Schema:**
+```json
+{
+  "paths": [
+    { "name": "config", "path": "/Users/user/.config/scafctl", "description": "Configuration files", "xdgVariable": "XDG_CONFIG_HOME" },
+    { "name": "data", "path": "/Users/user/.local/share/scafctl", "description": "Application data" },
+    { "name": "cache", "path": "/Users/user/.cache/scafctl", "description": "HTTP and build cache" },
+    { "name": "catalogs", "path": "/Users/user/.local/share/scafctl/catalogs", "description": "Local artifact catalogs" },
+    { "name": "snapshots", "path": "/Users/user/.local/share/scafctl/snapshots", "description": "Resolver execution snapshots" }
+  ]
+}
+```
+
+**Shared code:** Path resolution from `pkg/paths/`.
+
+**CLI counterpart:** Already exists as `scafctl config paths`. No new CLI command needed.
+
+---
+
+### Phase 2I: `validate_expressions` (Batch)
+
+**Priority: Medium** — Reduces round-trips for bulk validation.
+
+**Description:** Validates multiple CEL/Go-template expressions in a single call. A solution file can have dozens of expressions across resolvers and actions — validating them one by one via `validate_expression` is expensive.
+
+**File:** `pkg/mcp/tools_template.go` (add to existing file)
+
+**Tool Definition:**
+```go
+mcp.NewTool("validate_expressions",
+    mcp.WithDescription("Validate multiple CEL expressions and/or Go templates in a single call. Returns per-expression validation results. More efficient than calling validate_expression repeatedly when checking all expressions in a solution."),
+    mcp.WithTitleAnnotation("Validate Expressions (Batch)"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+    mcp.WithArray("expressions",
+        mcp.Required(),
+        mcp.Description("Array of {expression, type} objects. Type is 'cel' or 'go-template'."),
+    ),
+)
+```
+
+**Input:**
+```json
+{
+  "expressions": [
+    { "expression": "size(name) > 3", "type": "cel" },
+    { "expression": "{{ .name | upper }}", "type": "go-template" },
+    { "expression": "items.filter(i, i.active", "type": "cel" }
+  ]
+}
+```
+
+**Response Schema:**
+```json
+{
+  "results": [
+    { "index": 0, "expression": "size(name) > 3", "type": "cel", "valid": true },
+    { "index": 1, "expression": "{{ .name | upper }}", "type": "go-template", "valid": true, "references": ["name"] },
+    { "index": 2, "expression": "items.filter(i, i.active", "type": "cel", "valid": false, "error": "missing closing parenthesis" }
+  ],
+  "summary": { "total": 3, "valid": 2, "invalid": 1 }
+}
+```
+
+**CLI counterpart:** Could be exposed as `scafctl eval validate --batch` or accept multiple `--expression` flags.
+
+---
+
+## Part 3: New MCP Prompts
+
+### Phase 3A: `analyze_execution` Prompt
+
+**Priority: High** — Fills the post-execution analysis gap.
+
+All existing prompts are pre-execution (create, debug, update, prepare). This prompt guides the agent through post-execution analysis when something went wrong.
+
+**Arguments:**
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `snapshot_path` | Yes | Path to the snapshot from the failed/unexpected run |
+| `previous_snapshot` | No | Path to a known-good snapshot for comparison |
+| `problem` | No | Description of what went wrong |
+
+**Prompt content guide:**
+1. Call `show_snapshot` with the provided path to inspect results
+2. Identify failed resolvers (status != success)
+3. If `previous_snapshot` provided, call `diff_snapshots` to find what changed
+4. For failed resolvers, check provider configuration (`get_provider_schema`)
+5. Cross-reference with `auth_status` if HTTP/cloud providers are involved
+6. Suggest specific fixes based on error patterns
+7. If fixes are applied, suggest re-running and comparing with `diff_snapshots`
+
+---
+
+### Phase 3B: `migrate_solution` Prompt
+
+**Priority: Medium** — Guides structural refactoring.
+
+Different from `update_solution` (targeted changes). This prompt handles larger structural refactoring: adding composition, migrating from inline to file-based templates, splitting a monolith solution, upgrading patterns, etc.
+
+**Arguments:**
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `path` | Yes | Path to the solution to migrate |
+| `migration` | Yes | Type: `add-composition`, `extract-templates`, `split-solution`, `add-tests`, `upgrade-patterns` |
+| `target_dir` | No | Target directory for split/extracted files |
+
+**Prompt content guide (varies by migration type):**
+1. Call `inspect_solution` to understand current structure
+2. Call `lint_solution` to establish baseline (zero errors before migration)
+3. Plan the migration based on type:
+   - `add-composition`: identify natural groupings → create partial files → add compose references
+   - `extract-templates`: find inline templates → extract to files → update references
+   - `split-solution`: identify independent sections → create child solutions → parent references
+4. Execute migration changes
+5. Call `lint_solution` to verify no regressions
+6. Call `preview_resolvers` to verify outputs unchanged
+7. Call `diff_solution` on before/after to confirm only structural changes
+8. If tests exist, call `run_solution_tests` to verify
+
+---
+
+### Phase 3C: `optimize_solution` Prompt
+
+**Priority: Medium** — Performance and quality analysis.
+
+**Arguments:**
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `path` | Yes | Path to the solution to optimize |
+| `focus` | No | Focus area: `performance`, `readability`, `testing`, `all` (default: `all`) |
+
+**Prompt content guide:**
+1. Call `inspect_solution` to understand the solution structure
+2. Call `render_solution` with `graph_type=resolver` to analyze the dependency graph
+3. Call `render_solution` with `graph_type=action-deps` to analyze action dependencies
+4. Call `lint_solution` to identify quality issues
+5. Analyze for optimization opportunities:
+   - **Performance:** Find serial chains that could run in parallel (independent resolvers without `dependsOn`), identify unnecessary `dependsOn` constraints, spot duplicate resolver work
+   - **Readability:** Long resolver names, missing descriptions, complex nested expressions, inconsistent naming
+   - **Testing:** Missing test coverage (compare resolvers/actions vs test cases), missing edge case tests
+6. Call `extract_resolver_refs` on complex templates to verify `dependsOn` accuracy
+7. Present prioritized recommendations with specific YAML changes
+8. After applying changes, re-lint and re-preview to verify no regressions
+
+---
+
+## Part 4: New MCP Resources
+
+### Phase 4A: `solution://{name}/tests` Resource
+
+**Priority: Low** — Convenience resource.
+
+Add a resource template that returns structured test case data for a solution.
+
+```go
+testsTemplate := mcp.NewResourceTemplate(
+    "solution://{name}/tests",
+    "Solution Tests",
+    mcp.WithTemplateDescription("Returns the functional test cases defined in a solution as structured JSON. Includes test names, commands, assertions, tags, and configuration."),
+    mcp.WithTemplateMIMEType("application/json"),
+)
+```
+
+**File:** `pkg/mcp/resources.go` (add to existing file)
+
+This complements the `list_tests` tool by providing a resource-oriented access pattern. Some MCP clients prefer reading resources over calling tools for data retrieval.
+
+---
+
+## Part 5: Architecture & Quality Improvements
+
+### Phase 5A: Extract Shared Libraries from Inline MCP Code
+
+**Priority: High** — Prerequisite for CLI parity (Part 1).
+
+| Package | Source | Description |
+|---------|--------|-------------|
+| `pkg/scaffold/` | `pkg/mcp/tools_scaffold.go` | `buildScaffoldYAML()`, `featureKeys()`, provider template generation |
+| `pkg/soldiff/` | `pkg/mcp/tools_diff.go` | Solution structural comparison, change classification |
+| `pkg/examples/` | `pkg/mcp/tools_examples.go` | `scanExamples()`, category/description handling, embedded via `go:embed` |
+
+Each extraction should:
+1. Create the new package with exported types and functions
+2. Add comprehensive unit tests in the new package
+3. Update the MCP handler to call the shared code
+4. Verify MCP tests still pass
+5. Then build the CLI wrapper on top
+
+**Special note for `pkg/examples/`:** This extraction also replaces the fragile `findExamplesDir()` filesystem-walking approach with `go:embed`. The `examples/` directory (520KB, 87 files) is copied into `pkg/examples/files/` at build time and embedded into the binary via `//go:embed files/*`. This follows the existing pattern in `pkg/cmd/scafctl/config/init.go` which embeds config templates. See [Phase 1E](#phase-1e-scafctl-examples-command-group) for full details.
+
+---
+
+### Phase 5B: Structured Error Context
+
+**Priority: Medium** — Improves AI agent error handling.
+
+Currently tool errors are flat strings via `mcp.NewToolResultError(err.Error())`. Add structured error context where applicable:
+
+```go
+type ToolError struct {
+    Code       string   `json:"code"`                 // e.g., "SOLUTION_NOT_FOUND", "INVALID_EXPRESSION"
+    Message    string   `json:"message"`              // Human-readable message
+    Field      string   `json:"field,omitempty"`       // Affected field (if applicable)
+    Suggestion string   `json:"suggestion,omitempty"`  // Suggested fix
+    Related    []string `json:"related,omitempty"`     // Related tool calls that might help
+}
+```
+
+Create a helper:
+```go
+func newStructuredError(code, message string, opts ...ErrorOption) *mcp.CallToolResult {
+    // Build ToolError, marshal to JSON, return as mcp.NewToolResultError()
+}
+```
+
+Apply to high-frequency error paths in:
+- `lint_solution` — include rule name, severity, fix suggestion
+- `preview_resolvers` — include resolver name, provider, error type
+- `dry_run_solution` — include phase, resolver/action name, error details
+- `evaluate_cel` / `evaluate_go_template` — include parse position, expected syntax
+
+---
+
+### Phase 5C: Tool Latency Hints
+
+**Priority: Low** — Helps AI agents optimize tool selection.
+
+Add latency categories to tool descriptions to help AI agents choose efficient tool call sequences:
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| `⚡ instant` | `list_lint_rules`, `explain_lint_rule`, `explain_kind`, `get_solution_schema`, `get_config`, `get_config_paths`, `list_auth_handlers`, `validate_expression` | In-memory lookups, no I/O |
+| `🔄 fast` | `lint_solution`, `inspect_solution`, `list_solutions`, `list_providers`, `get_provider_schema`, `catalog_list`, `catalog_inspect`, `diff_solution`, `list_tests`, `list_examples`, `get_example`, `scaffold_solution`, `extract_resolver_refs`, `generate_test_scaffold` | File I/O, parsing, no network |
+| `🌐 variable` | `preview_resolvers`, `preview_action`, `dry_run_solution`, `run_solution_tests`, `evaluate_cel`, `render_solution` | May involve network calls depending on providers |
+
+Update `serverInstructions` with a section:
+```
+Tool Latency Guide:
+  - Instant (in-memory): list_lint_rules, explain_lint_rule, explain_kind, get_solution_schema, 
+    get_config, get_config_paths, list_auth_handlers, validate_expression(s)
+  - Fast (file I/O): lint_solution, inspect_solution, list_*, catalog_*, diff_solution, 
+    scaffold_solution, extract_resolver_refs, generate_test_scaffold
+  - Variable (may use network): preview_resolvers, preview_action, dry_run_solution, 
+    run_solution_tests, evaluate_cel, render_solution
+  Prefer instant/fast tools for initial analysis; use variable-latency tools for validation.
+```
+
+---
+
+### Phase 5D: `get_version` Tool
+
+**Priority: Low** — Environmental context.
+
+The MCP `initialize` response includes the server version, but agents cannot query it after initialization. A lightweight tool helps agents give version-appropriate guidance.
+
+```go
+mcp.NewTool("get_version",
+    mcp.WithDescription("Return the scafctl version, build time, and commit hash."),
+    mcp.WithTitleAnnotation("Get Version"),
+    mcp.WithReadOnlyHintAnnotation(true),
+    mcp.WithDestructiveHintAnnotation(false),
+    mcp.WithIdempotentHintAnnotation(true),
+    mcp.WithOpenWorldHintAnnotation(false),
+)
+```
+
+**Response:**
+```json
+{
+  "version": "0.15.0",
+  "commit": "abc123def",
+  "buildTime": "2026-02-20T15:30:00Z"
+}
+```
+
+---
+
+## Implementation Order
+
+Recommended execution order balancing impact, dependencies, and effort:
+
+### Sprint 1: Shared Library Extraction (Prerequisite)
+1. **Phase 5A:** Extract `pkg/scaffold/`, `pkg/soldiff/`, `pkg/examples/` from MCP inline code
+2. Update MCP handlers to use extracted packages
+3. Verify all existing MCP tests pass
+
+### Sprint 2: Highest-Impact MCP Tools
+4. **Phase 2A:** `extract_resolver_refs` tool
+5. **Phase 2B:** `generate_test_scaffold` tool
+6. **Phase 2C:** `list_tests` tool
+7. Update `serverInstructions` with new tool guidance
+
+### Sprint 3: CLI Parity — Core Commands
+8. **Phase 1A:** `scafctl eval cel`, `scafctl eval template`, `scafctl eval validate`
+9. **Phase 1B:** `scafctl new solution`
+10. **Phase 1C:** `scafctl lint rules`, `scafctl lint explain`
+
+### Sprint 4: Snapshot & Analysis Tools
+11. **Phase 2D:** `show_snapshot` tool
+12. **Phase 2E:** `diff_snapshots` tool
+13. **Phase 3A:** `analyze_execution` prompt
+
+### Sprint 5: CLI Parity — Additional Commands
+14. **Phase 1E:** `scafctl examples list`, `scafctl examples get`
+15. **Phase 1F:** Enhanced `--dry-run` output (full rich report replaces lightweight summary)
+
+### Sprint 6: Supplementary MCP Enhancements
+16. **Phase 2F:** `catalog_inspect` tool
+17. **Phase 2G:** `list_auth_handlers` tool
+18. **Phase 2H:** `get_config_paths` tool
+19. **Phase 2I:** `validate_expressions` batch tool
+
+### Sprint 7: Prompts, Resources & Polish
+20. **Phase 3B:** `migrate_solution` prompt
+21. **Phase 3C:** `optimize_solution` prompt
+22. **Phase 4A:** `solution://{name}/tests` resource
+23. **Phase 5B:** Structured error context
+24. **Phase 5C:** Tool latency hints in server instructions
+25. **Phase 5D:** `get_version` tool
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Every new tool, prompt, and CLI command must have unit tests following existing patterns:
+
+- **MCP tools:** `pkg/mcp/tools_*_test.go` — test handler functions with mock server context
+- **CLI commands:** `pkg/cmd/scafctl/<cmd>/*_test.go` — test with `testify/assert`, mock IOStreams
+- **Shared libraries:** `pkg/<package>/*_test.go` — pure function tests with table-driven cases
+- **Prompts:** `pkg/mcp/prompts_test.go` — verify prompt arguments and message content
+
+### Integration Tests
+
+- Add new CLI commands to `tests/integration/cli_test.go`
+- Create solution integration tests in `tests/integration/solutions/` for new tool workflows
+- For MCP tools that wrap existing CLI capabilities, verify output parity between CLI and MCP
+
+### Test Coverage Targets
+
+| Component | Minimum Coverage |
+|-----------|-----------------|
+| Shared library packages (`pkg/scaffold/`, `pkg/soldiff/`, `pkg/examples/`) | 90% |
+| MCP tool handlers | 85% |
+| CLI command handlers | 80% |
+| MCP prompts | 70% (content verification) |
+
+---
+
+## Summary
+
+| Category | Count | Details |
+|----------|-------|---------|
+| New MCP Tools | 9 | `extract_resolver_refs`, `generate_test_scaffold`, `list_tests`, `show_snapshot`, `diff_snapshots`, `catalog_inspect`, `list_auth_handlers`, `get_config_paths`, `validate_expressions` |
+| New MCP Prompts | 3 | `analyze_execution`, `migrate_solution`, `optimize_solution` |
+| New MCP Resources | 1 | `solution://{name}/tests` |
+| New CLI Commands | 9 | `eval cel`, `eval template`, `eval validate`, `new solution`, `lint rules`, `lint explain`, `examples list`, `examples get`, enhanced `--dry-run` |
+| Library Extractions | 3 | `pkg/scaffold/`, `pkg/soldiff/`, `pkg/examples/` |
+| Architecture Improvements | 4 | Structured errors, latency hints, `get_version`, shared library pattern |
+| Estimated Sprints | 7 | ~1-2 weeks each depending on team capacity |
+
+---
+
+## Part 6: MCP Protocol Feature Adoption
+
+This section covers enhancements that leverage additional MCP protocol capabilities from the mcp-go SDK v0.44.0. These features improve the user experience, provide richer metadata, and enable more interactive workflows.
+
+### 6A: Progress Notifications for Long-Running Tools
+
+**File**: `pkg/mcp/progress.go`
+
+Tools that take significant time now send real-time progress notifications to the MCP client using `notifications/progress`. Implemented via a `progressReporter` helper that:
+- Extracts the progress token from `request.Params.Meta.ProgressToken`
+- Falls back to logger output if no token is provided
+- Reports progress with step count, total, and human-readable messages
+
+**Tools with progress**: `preview_resolvers`, `run_solution_tests`, `dry_run_solution`
+
+### 6B: Tool Icons
+
+**File**: `pkg/mcp/icons.go`
+
+All 36 tools, 12 prompts, and 6 resources now have SVG icons using data URIs. Icons are categorized by function (solution, provider, CEL, template, etc.) and use distinct colors for visual differentiation. Supported by MCP clients like VS Code, Claude Desktop, and Cursor.
+
+### 6C: Output Schemas
+
+**File**: `pkg/mcp/output_schemas.go`
+
+11 tools now declare their output JSON Schema via `mcp.WithRawOutputSchema()`, enabling MCP clients to validate and render structured output:
+- `list_solutions`, `inspect_solution`, `lint_solution`, `render_solution`, `preview_resolvers`
+- `get_version`, `evaluate_cel`, `auth_status`, `get_config`, `get_config_paths`, `dry_run_solution`
+
+### 6D: ResourceLink in Tool Results
+
+Tools that return structured data about solutions or providers now include `ResourceLink` items pointing to related MCP resources:
+- `inspect_solution` → links to `solution://{path}`, `solution://{path}/schema`, `solution://{path}/graph`
+- `list_providers` → link to `provider://reference`
+- `preview_resolvers` → links to `solution://{path}`, `solution://{path}/graph`
+
+### 6E: Content Annotations (Audience/Priority)
+
+The `get_run_command` tool now annotates its output content with audience hints:
+- Command text → `assistant` audience (high priority) for LLM consumption
+- Explanation text → `user` audience for human display
+
+### 6F: Resource Annotations
+
+All resource templates and resources have audience and priority annotations:
+- Solution YAML content → both `user` and `assistant`, priority 0.7
+- Provider reference → `assistant` only, priority 0.8
+- Schema/graph/tests → `assistant`, priority 0.5-0.6
+
+### 6G: Deferred Tool Loading
+
+Rarely-used tools are marked with `mcp.WithDeferLoading(true)` to reduce initial load time:
+- `show_snapshot`, `diff_snapshots`, `diff_solution`, `extract_resolver_refs`, `explain_lint_rule`
+
+### 6H: Elicitation for Interactive Workflows
+
+**File**: `pkg/mcp/capabilities.go`
+
+The `preview_resolvers` tool now uses MCP elicitation to prompt users for missing parameter values. When a solution has `parameter` provider resolvers without provided values, the tool sends an `ElicitationRequest` with a JSON Schema describing the required fields.
+
+### 6I: Roots Discovery for Workspace Awareness
+
+**File**: `pkg/mcp/capabilities.go`
+
+The `list_solutions` tool uses MCP roots discovery to find solution files in workspace directories when the catalog returns empty results. This enables workspace-aware behavior in MCP clients.
+
+### 6J: Resource Recovery and Task Capabilities
+
+**File**: `pkg/mcp/server.go`
+
+- `server.WithResourceRecovery()` — automatic panic recovery in resource handlers
+- `server.WithTaskCapabilities(true, true, true)` — enables async task listing, cancellation, and tool-call tasks
+
+### 6K: MCP Log Streaming
+
+**File**: `pkg/mcp/progress.go`
+
+A `sendLog()` helper enables real-time log streaming to connected MCP clients via `notifications/message`, supporting log levels (info, warning, error) and named loggers.
+

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -609,3 +609,65 @@ The primary use case is AI-assisted solution authoring — helping users create 
 The refactoring (extracting command logic from Cobra closures, fixing the stray `os.Exit`, creating the MCP context helper, adding the `cel-functions` command, etc.) was submitted as its own PR. This keeps the MCP implementation PR focused on new functionality rather than mixing refactoring with feature work, and the refactoring improvements (better testability, cleaner separation of concerns) benefit the codebase regardless of MCP.
 
 See [Completed Preparatory Refactoring](#completed-preparatory-refactoring) for the full list of changes and file references.
+
+## Advanced Protocol Features
+
+The MCP server leverages several advanced features from the mcp-go SDK (v0.44.0):
+
+### Observability Hooks & Middleware
+
+All MCP requests are instrumented with timing and logging via `server.Hooks`:
+- `BeforeAny` / `OnSuccess` / `OnError` hooks log request lifecycle
+- `BeforeCallTool` / `AfterCallTool` hooks track tool execution duration
+- `OnRegisterSession` / `OnUnregisterSession` track client connections
+- Separate tool and resource timing middleware layers
+
+Implementation: `pkg/mcp/hooks.go`
+
+### Structured Errors
+
+All tool error responses use a consistent structured format (`ToolError`) with:
+- Machine-readable error code (`INVALID_INPUT`, `NOT_FOUND`, `LOAD_FAILED`, etc.)
+- Contextual field name identifying which input caused the error
+- Actionable suggestions for resolution
+- Related tool names that may help
+
+Implementation: `pkg/mcp/errors.go`
+
+### Auto-Completion
+
+The server provides completion suggestions for prompt arguments and resource template URIs:
+- Provider names from the registry
+- Migration types, solution features
+- Solution names from the local catalog
+- Lint rule names, CEL function names, example names
+
+Implementation: `pkg/mcp/completions.go`
+
+### Contextual Tool Filtering
+
+A `ToolFilterFunc` dynamically hides tools whose required capabilities are unavailable:
+- Auth tools hidden when no auth handlers configured
+- Catalog tools hidden when no catalogs configured
+- Provider tools hidden when no registry available
+
+Implementation: `pkg/mcp/filter.go`
+
+### Transport Protocols
+
+The server supports three transports via CLI flags:
+- **stdio** (default): JSON-RPC 2.0 over stdin/stdout
+- **sse**: Server-Sent Events over HTTP (for remote/multi-client)
+- **http**: Streamable HTTP transport
+
+Implementation: `pkg/mcp/server.go` (`Serve`, `ServeSSE`, `ServeHTTP`)
+
+### Additional SDK Capabilities
+
+- **Structured Log Streaming**: `SendLog()` sends log messages to clients respecting their log level
+- **Workspace Roots**: `RequestRoots()` discovers client workspace directories
+- **Sampling**: `RequestSampling()` requests LLM completions from the client
+- **Elicitation**: `RequestElicitation()` requests structured user input
+- **Resource Notifications**: `NotifyResourcesChanged()` and `NotifyToolsChanged()` for change propagation
+- **Pagination**: Configurable via `WithPaginationLimit()`
+- **Tool & Resource Capabilities**: `listChanged` enabled for dynamic registration

--- a/docs/design/shared-library-migration.md
+++ b/docs/design/shared-library-migration.md
@@ -1,0 +1,656 @@
+---
+title: Shared Library Migration Plan
+weight: 103
+---
+
+# Shared Library Migration Plan
+
+This document defines the prioritized plan for extracting business logic from CLI command packages (`pkg/cmd/scafctl/...`) and MCP handler files (`pkg/mcp/tools_*.go`) into proper shared domain packages (`pkg/...`). This is a prerequisite for adding a future API server layer and ensures all entry points (CLI, MCP, API) delegate to the same shared code with minimal duplication.
+
+## Table of Contents
+
+- [Motivation](#motivation)
+- [Architecture Goal](#architecture-goal)
+- [Current State](#current-state)
+- [Migration Phases](#migration-phases)
+  - [Phase 0: Trivial Moves (No Refactoring)](#phase-0-trivial-moves-no-refactoring)
+  - [Phase 1: MCP Inline Extractions](#phase-1-mcp-inline-extractions)
+  - [Phase 2: CLI Moderate Extractions](#phase-2-cli-moderate-extractions)
+  - [Phase 3: CLI Heavy Extractions](#phase-3-cli-heavy-extractions)
+- [Migration Rules](#migration-rules)
+- [Dependency Direction](#dependency-direction)
+- [Testing Strategy](#testing-strategy)
+- [Tracking](#tracking)
+
+---
+
+## Motivation
+
+Today, three concerns prevent the codebase from cleanly supporting CLI + MCP + API entry points:
+
+1. **Shared logic lives in CLI packages.** The MCP server already imports 5 CLI command packages (`pkg/cmd/scafctl/{explain,lint,run,get/provider}`). A future API server would inherit the same anti-pattern dependency direction.
+
+2. **MCP handlers contain ~560 lines of inline business logic** (scaffold YAML generation, solution diffing, example discovery, config sanitization) that cannot be reused by CLI commands or an API.
+
+3. **CLI handlers contain ~6,500 lines of inline business logic** (build pipeline, graph rendering, bundle operations, crypto, auth orchestration) that cannot be reused by MCP tools or an API.
+
+The fix is mechanical: extract shared logic into domain packages under `pkg/`, then make CLI, MCP, and API entry points thin wrappers.
+
+---
+
+## Architecture Goal
+
+Every entry point should follow the same pattern:
+
+```
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│ CLI Command  │  │ MCP Handler  │  │ API Handler  │
+│ (cobra)      │  │ (mcp-go)     │  │ (http/grpc)  │
+└──────┬───────┘  └──────┬───────┘  └──────┬───────┘
+       │                 │                 │
+       │  Parse flags/   │  Parse MCP      │  Parse HTTP
+       │  args into       │  params into    │  request into
+       │  domain types    │  domain types   │  domain types
+       │                 │                 │
+       ▼                 ▼                 ▼
+┌─────────────────────────────────────────────────────┐
+│              Shared Domain Package                   │
+│  pkg/<domain>/                                       │
+│  - Accepts domain types (no CLI/MCP/HTTP types)      │
+│  - Returns domain types                              │
+│  - Pure business logic                               │
+│  - Full test coverage                                │
+└─────────────────────────────────────────────────────┘
+```
+
+**Entry point responsibilities (the minimum):**
+1. Parse input from the transport layer (flags, MCP params, HTTP body) into domain types
+2. Call the shared domain function
+3. Format the result for the transport layer (table/JSON output, MCP response, HTTP response)
+
+**Shared package rules:**
+- No imports from `pkg/cmd/`, `pkg/mcp/`, or any future `pkg/api/`
+- No imports of `cobra`, `mcp-go`, `net/http`, `terminal/writer`, `terminal/kvx`, `settings.Run`
+- Accept and return plain Go types, domain structs, or interfaces defined in domain packages
+- All exported functions must be callable from any entry point
+
+---
+
+## Current State
+
+### What's Already Clean
+
+These shared packages exist and are properly delegated to by both CLI and MCP:
+
+| Shared Package | Used by CLI | Used by MCP |
+|---|---|---|
+| `pkg/celexp` | — | `evaluate_cel`, `list_cel_functions` |
+| `pkg/gotmpl` | — | `evaluate_go_template` |
+| `pkg/catalog` | `catalog *` | `catalog_list`, `list_solutions` |
+| `pkg/solution/soltesting` | `test *` | `run_solution_tests` |
+| `pkg/provider` (registry) | `get provider` | `list_providers` |
+| `pkg/solution/prepare` | `run *` | `lint_solution`, `dry_run_solution`, `preview_*` |
+| `pkg/resolver` | `render solution`, `run resolver` | `render_solution` |
+| `pkg/action` | `run solution` | `preview_action`, `dry_run_solution` |
+| `pkg/auth` | `auth *` | `auth_status` |
+| `pkg/config` | `config *` | `get_config` |
+| `pkg/schema` | `config schema`, `explain schema` | `get_solution_schema`, `explain_kind` |
+
+### What Needs Migration
+
+#### Functions Currently in CLI Packages, Imported by MCP
+
+| Current Location | Exported Functions | CLI Deps in Signature? | MCP Imports It? |
+|---|---|---|---|
+| `pkg/cmd/scafctl/explain/results.go` | `LoadSolution()`, `BuildSolutionExplanation()`, `LookupProvider()` | **No** | Yes |
+| `pkg/cmd/scafctl/lint/lint.go` | `Solution()`, `FilterBySeverity()` | **No** | Yes |
+| `pkg/cmd/scafctl/lint/rules.go` | `KnownRules`, `ListRules()`, `GetRule()` | **No** | Yes |
+| `pkg/cmd/scafctl/run/execute.go` | `ExecuteResolvers()`, `ValidateSolution()`, `ResolverExecutionConfigFromContext()` | **No** | Yes |
+| `pkg/cmd/scafctl/get/provider/provider.go` | `BuildProviderDetail()`, `BuildSchemaOutput()`, `GenerateCLIExamples()`, `SchemaPlaceholder()`, `CapabilitiesToStrings()` | **No** | Yes |
+
+Key insight: the exported *functions* are already CLI-free in their signatures. The migration is primarily about relocating them to the correct package — not rewriting them.
+
+#### Inline Logic in MCP Handlers
+
+| File | Function | Lines | Depends On |
+|---|---|---|---|
+| `tools_scaffold.go` | `buildScaffoldYAML()` | ~170 | `fmt`, `strings` only |
+| `tools_diff.go` | diff logic in `handleDiffSolution()` | ~150 | `explain.LoadSolution()` |
+| `tools_examples.go` | `findExamplesDir()`, `scanExamples()`, `descriptionFromPath()` | ~120 | `os`, `filepath`, `runtime` |
+| `tools_config.go` | `sanitizeConfig()` + 6 struct types | ~120 | `pkg/config` |
+
+#### Inline Logic in CLI Handlers
+
+| File | Lines | Description |
+|---|---|---|
+| `render/solution.go` | ~750 | Graph rendering (ASCII/DOT/Mermaid/JSON), snapshot, test output |
+| `build/solution.go` | ~650 | Build pipeline: discovery, composition, vendoring, OCI |
+| `bundle/diff.go` | ~550 | Solution diff computation, file/vendored/plugin diffs |
+| `run/common.go` | ~400 | Solution loading orchestration, output formatting |
+| `bundle/extract.go` | ~300 | Bundle extraction with filtering |
+| `auth/login.go` | ~280 | Multi-provider login flow routing |
+| `secrets/export.go` + `import.go` | ~320 | AES-256-GCM + PBKDF2 crypto |
+| `vendor/update.go` | ~250 | Dependency re-resolution, lock file management |
+| `snapshot/save.go` | ~150 | Save pipeline: execution, redaction, snapshot capture |
+| `get/resolver/refs.go` | ~150 | Template/CEL reference extraction |
+| `config/paths.go` | ~200 | Per-platform path table generation |
+| `cache/clear.go` | ~200 | Dir walking, size calc, cache clearing |
+| `get/celfunction/celfunction.go` | ~200 | Function listing/detail formatting |
+
+---
+
+## Migration Phases
+
+### Phase 0: Trivial Moves (No Refactoring)
+
+**Effort:** Low — files are already CLI-free. Move files, update imports, add package aliases.  
+**Impact:** High — fixes the dependency direction for the 5 packages MCP already imports.  
+**Risk:** Low — function signatures don't change. Only import paths change.
+
+#### Phase 0A: `pkg/cmd/scafctl/explain/results.go` → `pkg/solution/inspect/`
+
+**Why first:** Most imported shared file (used by MCP `tools_solution.go`, `tools_diff.go`, `tools_provider.go`, `resources.go`).
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/solution/inspect/inspect.go` |
+| Move | `LoadSolution()`, `BuildSolutionExplanation()`, `LookupProvider()` + all 6 exported types |
+| Update imports | `pkg/mcp/tools_solution.go`, `tools_diff.go`, `tools_provider.go`, `resources.go`, `pkg/cmd/scafctl/explain/*.go` |
+| Old package | `pkg/cmd/scafctl/explain/results.go` becomes a thin re-export or is deleted (CLI `explain` commands update to import `pkg/solution/inspect/`) |
+| Tests | Move `results_test.go` if it exists, or create tests in new location |
+
+**New package API:**
+
+```go
+package inspect
+
+import "github.com/oakwood-commons/scafctl/pkg/solution"
+
+type SolutionExplanation struct { ... }  // existing struct
+type ResolverInfo struct { ... }
+type ActionInfo struct { ... }
+// ... other types
+
+func LoadSolution(ctx context.Context, path string) (*solution.Solution, error)
+func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation
+func LookupProvider(ctx context.Context, name string, reg *provider.Registry) (*provider.Descriptor, error)
+```
+
+#### Phase 0B: `pkg/cmd/scafctl/run/execute.go` → `pkg/solution/execute/`
+
+**Why:** Second most critical — `ExecuteResolvers()` is the core resolver execution engine used by MCP `tools_solution.go` and `tools_dryrun.go`.
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/solution/execute/execute.go` |
+| Move | `ValidateSolution()`, `ExecuteResolvers()`, `ResolverExecutionConfigFromContext()` + 3 exported types |
+| Update imports | `pkg/mcp/tools_solution.go`, `tools_dryrun.go`, `pkg/cmd/scafctl/run/*.go` |
+
+**New package API:**
+
+```go
+package execute
+
+type SolutionValidationResult struct { ... }
+type ResolverExecutionConfig struct { ... }
+type ResolverExecutionResult struct { ... }
+
+func ValidateSolution(ctx context.Context, sol *solution.Solution, reg *provider.Registry) *SolutionValidationResult
+func ExecuteResolvers(ctx context.Context, sol *solution.Solution, params map[string]any, reg *provider.Registry, cfg ResolverExecutionConfig) (*ResolverExecutionResult, error)
+func ResolverExecutionConfigFromContext(ctx context.Context) ResolverExecutionConfig
+```
+
+#### Phase 0C: `pkg/cmd/scafctl/lint/{lint.go,rules.go}` → `pkg/lint/`
+
+**Why:** Lint engine and rule registry are used by MCP `tools_lint.go` and `tools_solution.go`.
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/lint/lint.go` — the `Solution()` function, `FilterBySeverity()`, all unexported lint helpers (`lintResolvers`, `lintWorkflow`, `lintAction`, etc.), types (`SeverityLevel`, `Finding`, `Result`) |
+| Create | `pkg/lint/rules.go` — `KnownRules`, `RuleMeta`, `ListRules()`, `GetRule()` |
+| Keep in CLI | `pkg/cmd/scafctl/lint/cmd.go` — only `CommandLint()`, `Options`, `runLint()` (thin wrapper calling `lint.Solution()`) |
+| Update imports | `pkg/mcp/tools_lint.go`, `tools_solution.go` |
+
+**Note:** The `lint.go` file in the CLI package has ~900 lines. The exported functions (`Solution()`, `FilterBySeverity()`) and all the unexported domain functions (`lintResolvers`, `lintWorkflow`, `lintAction`, `lintExpressions`, `validateCELSyntax`, `validateTemplateSyntax`, `collectReferencedResolvers`, `lintResultSchema`, etc.) should all move to `pkg/lint/`. What remains in the CLI package is just the cobra command constructor and output formatting — roughly 100 lines.
+
+#### Phase 0D: `pkg/cmd/scafctl/get/provider/` shared functions → `pkg/provider/detail/`
+
+**Why:** `BuildProviderDetail()` and `BuildSchemaOutput()` are used by MCP `tools_provider.go` and `resources.go`.
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/provider/detail/detail.go` |
+| Move | `BuildProviderDetail()`, `BuildSchemaOutput()`, `GenerateCLIExamples()`, `SchemaPlaceholder()`, `CapabilitiesToStrings()` |
+| Keep in CLI | `pkg/cmd/scafctl/get/provider/` — `CommandProvider()`, `Options`, TUI code (`tui.go`), CLI-specific formatting |
+| Update imports | `pkg/mcp/tools_provider.go`, `resources.go` |
+
+#### Phase 0 Completion Criteria
+
+After Phase 0, the dependency graph becomes:
+
+```
+pkg/mcp         → pkg/solution/inspect, pkg/solution/execute, pkg/lint, pkg/provider/detail
+pkg/cmd/scafctl → pkg/solution/inspect, pkg/solution/execute, pkg/lint, pkg/provider/detail
+pkg/api (future)→ pkg/solution/inspect, pkg/solution/execute, pkg/lint, pkg/provider/detail
+```
+
+No entry point package imports another entry point package. This is the critical fix.
+
+---
+
+### Phase 1: MCP Inline Extractions
+
+**Effort:** Low-Medium — functions are already standalone, just need to be moved and exported.  
+**Impact:** Medium — enables new CLI commands (`scafctl new`, `scafctl examples`) from the MCP enhancements plan.  
+**Risk:** Low — no signature changes to existing consumers.
+
+#### Phase 1A: `pkg/mcp/tools_scaffold.go` → `pkg/scaffold/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/scaffold/scaffold.go` |
+| Move | `buildScaffoldYAML()` → export as `Solution()` |
+| Define | `Options` struct (Name, Description, Version, Features, Providers) |
+| Define | `Result` struct (YAML string, Filename, Features list) |
+| Update | `pkg/mcp/tools_scaffold.go` — call `scaffold.Solution()` |
+| Enables | `scafctl new solution` CLI command (Phase 1B of mcp-server-enhancements.md) |
+
+**New package API:**
+
+```go
+package scaffold
+
+type Options struct {
+    Name        string            `json:"name" yaml:"name"`
+    Description string            `json:"description" yaml:"description"`
+    Version     string            `json:"version" yaml:"version"`
+    Features    map[string]bool   `json:"features" yaml:"features"`
+    Providers   []string          `json:"providers" yaml:"providers"`
+}
+
+type Result struct {
+    YAML     string   `json:"yaml" yaml:"yaml"`
+    Filename string   `json:"filename" yaml:"filename"`
+    Features []string `json:"features" yaml:"features"`
+}
+
+func Solution(opts Options) (*Result, error)
+```
+
+#### Phase 1B: `pkg/mcp/tools_diff.go` → `pkg/soldiff/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/soldiff/diff.go` |
+| Extract | Inline diff logic from `handleDiffSolution()` into `Compare()` |
+| Define | `Change` struct (Field, Type, Old, New, OldValue, NewValue) |
+| Define | `DiffResult` struct (Changes, Summary by type, HasDifferences bool) |
+| Update | `pkg/mcp/tools_diff.go` — call `soldiff.Compare()` |
+| Enables | `scafctl diff solution` CLI command, API endpoint |
+
+**New package API:**
+
+```go
+package soldiff
+
+type Change struct {
+    Field    string `json:"field" yaml:"field"`
+    Type     string `json:"type" yaml:"type"`       // "added", "removed", "changed"
+    Old      string `json:"old,omitempty" yaml:"old,omitempty"`
+    New      string `json:"new,omitempty" yaml:"new,omitempty"`
+    OldValue any    `json:"oldValue,omitempty" yaml:"oldValue,omitempty"`
+    NewValue any    `json:"newValue,omitempty" yaml:"newValue,omitempty"`
+}
+
+type DiffResult struct {
+    Changes        []Change       `json:"changes" yaml:"changes"`
+    Summary        map[string]int `json:"summary" yaml:"summary"`
+    HasDifferences bool           `json:"hasDifferences" yaml:"hasDifferences"`
+}
+
+func Compare(a, b *solution.Solution) *DiffResult
+```
+
+#### Phase 1C: `pkg/mcp/tools_examples.go` → `pkg/examples/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/examples/examples.go` |
+| Move | `findExamplesDir()`, `scanExamples()`, `descriptionFromPath()`, `exampleItem` type |
+| Export | As `FindDir()`, `Scan()`, `DescriptionFromPath()`, `Item` |
+| Consider | Replace `runtime.Caller`/`findExamplesDir` with `go:embed` (as recommended in mcp-server-enhancements.md) |
+| Update | `pkg/mcp/tools_examples.go` — call `examples.Scan()`, `examples.FindDir()` |
+| Enables | `scafctl examples list/get` CLI commands |
+
+#### Phase 1D: `pkg/mcp/tools_config.go` → `pkg/config/sanitize.go`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/config/sanitize.go` (inside existing `pkg/config/` package) |
+| Move | `sanitizeConfig()` → export as `Sanitize()`, all sanitized struct types |
+| Update | `pkg/mcp/tools_config.go` — call `config.Sanitize()` |
+| Enables | API `GET /config` endpoint returning redacted config |
+
+This one goes into the existing `pkg/config/` package since it operates directly on `config.Config`.
+
+---
+
+### Phase 2: CLI Moderate Extractions
+
+**Effort:** Medium — requires untangling domain logic from CLI-specific output formatting.  
+**Impact:** Medium — enables MCP tools for operations currently CLI-only.  
+**Risk:** Medium — must ensure CLI behavior doesn't regress.
+
+#### Phase 2A: `pkg/cmd/scafctl/secrets/{export,import}.go` crypto → `pkg/secrets/crypto/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/secrets/crypto/crypto.go` |
+| Move | `encryptExport()` → `Encrypt()`, `decryptExport()` → `Decrypt()` |
+| Move | Constants: `pbkdf2Iterations`, `pbkdf2KeySize`, `pbkdf2SaltSize` |
+| Move | Types: `ExportFormat`, `ExportedSecret` |
+| Keep in CLI | `CommandExport()`, `CommandImport()` (flag parsing, password prompting, file I/O) |
+
+#### Phase 2B: `pkg/cmd/scafctl/snapshot/save.go` → `pkg/resolver/snapshot/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/resolver/snapshot/save.go` |
+| Extract | Save pipeline: provider setup → resolver execution → redaction → snapshot capture |
+| Define | `SaveOptions` struct, `Save(ctx, opts) (*resolver.Snapshot, error)` |
+| Keep in CLI | `CommandSave()` (flag parsing, file output) |
+| Enables | MCP `save_snapshot` tool, API endpoint |
+
+#### Phase 2C: `pkg/cmd/scafctl/get/resolver/refs.go` → `pkg/resolver/refs/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/resolver/refs/refs.go` |
+| Extract | Template/CEL reference extraction logic |
+| Define | `ExtractRefs(sol *solution.Solution) ([]Ref, error)` |
+| Keep in CLI | Command constructor, output formatting |
+| Enables | MCP `extract_resolver_refs` tool (Phase 2A of mcp-server-enhancements.md) |
+
+#### Phase 2D: `pkg/cmd/scafctl/config/paths.go` logic → `pkg/paths/`
+
+| Action | Detail |
+|---|---|
+| Extract | Per-platform path table generation into `pkg/paths/` (which already exists) |
+| Define | `AllPaths() []PathInfo` that returns structured path data |
+| Keep in CLI | Command constructor, table formatting |
+| Enables | MCP `get_config_paths` tool (Phase 2H of mcp-server-enhancements.md) |
+
+#### Phase 2E: `pkg/cmd/scafctl/get/celfunction/` → `pkg/celexp/detail/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/celexp/detail/detail.go` |
+| Extract | Function listing, detail building, formatting |
+| Keep in CLI | Command constructor, TUI, output formatting |
+
+#### Phase 2F: `pkg/cmd/scafctl/cache/` logic → `pkg/cache/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/cache/cache.go` |
+| Extract | `Info() CacheInfo`, `Clear(opts ClearOptions) error` |
+| Keep in CLI | Command constructor, confirmation prompts, output formatting |
+
+#### Phase 2G: `pkg/cmd/scafctl/run/common.go` shared logic → `pkg/solution/execute/`
+
+| Action | Detail |
+|---|---|
+| Move | `filterResolversWithDependencies()`, `calculateValueSize()` into `pkg/solution/execute/` (created in Phase 0B) |
+| Extract | `prepareSolutionForExecution()` core logic (without CLI types) into a shared function |
+| Keep in CLI | `sharedResolverOptions`, `addSharedResolverFlags`, output writing, progress bars |
+| Note | This package is where `run/execute.go` was moved in Phase 0B. This phase extends it. |
+
+---
+
+### Phase 3: CLI Heavy Extractions
+
+**Effort:** High — large files with deeply interleaved CLI and domain logic.  
+**Impact:** High — unlocks the largest blocks of functionality for MCP/API.  
+**Risk:** Higher — extensive refactoring, more test surface area.
+
+#### Phase 3A: `pkg/cmd/scafctl/lint/lint.go` engine → `pkg/lint/`
+
+This extends Phase 0C. Phase 0C moves the exported functions and types. Phase 3A moves the **unexported lint rule implementations** (~700 lines):
+
+| Functions to Move | Lines |
+|---|---|
+| `lintResolvers()` | ~55 |
+| `lintWorkflow()` | ~65 |
+| `lintAction()` | ~50 |
+| `lintResultSchema()` | ~40 |
+| `lintExpressions()` | ~30 |
+| `validateCELSyntax()` | ~15 |
+| `validateTemplateSyntax()` | ~5 |
+| `collectReferencedResolvers()` | ~50 |
+| `scanInputsForResolverRefs()` | ~50 |
+| `lintProviderInputs()` | ~80 |
+| `registryAdapter` type | ~15 |
+| Additional helpers | ~remaining |
+
+**Note:** Phase 0C and Phase 3A can be combined into a single phase if preferred — the split is only to provide an early checkpoint.
+
+#### Phase 3B: `pkg/cmd/scafctl/build/solution.go` → `pkg/solution/builder/`
+
+Note: `pkg/solution/bundler/` already exists. The build orchestration is distinct from bundling.
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/solution/builder/builder.go` |
+| Extract | Build pipeline: solution discovery → validation → composition → vendoring → dedup → hash → bundle creation |
+| Define | `BuildOptions`, `BuildResult`, `Build(ctx, opts) (*BuildResult, error)` |
+| Keep in CLI | `CommandBuildSolution()` (flag parsing, progress output, OCI push orchestration) |
+| Complexity | High — interleaves file I/O, catalog lookups, and bundler calls |
+
+#### Phase 3C: `pkg/cmd/scafctl/render/solution.go` → `pkg/solution/render/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/solution/render/render.go` |
+| Extract | `RenderResolverGraph()`, `RenderActionGraph()` for multiple formats (ASCII, DOT, Mermaid, JSON) |
+| Extract | Snapshot creation logic, test output generation |
+| Define | `RenderOptions`, `RenderResult` |
+| Keep in CLI | `CommandSolution()` (flag parsing, output formatting) |
+| Note | Some rendering already exists in `pkg/resolver` (`RenderASCII`, `RenderMermaid`) and `pkg/action` (`BuildVisualization`). This phase consolidates the orchestration layer. |
+
+#### Phase 3D: `pkg/cmd/scafctl/bundle/{diff,extract,verify}.go` → `pkg/solution/bundler/`
+
+| Action | Detail |
+|---|---|
+| Extend | `pkg/solution/bundler/` (already exists with core bundling logic) |
+| Move | Diff computation logic → `bundler.Diff()` |
+| Move | Extraction logic → `bundler.Extract()` (may already partially exist) |
+| Move | Verification logic → `bundler.Verify()` |
+| Keep in CLI | Command constructors, output formatting |
+
+#### Phase 3E: `pkg/cmd/scafctl/auth/login.go` → `pkg/auth/`
+
+| Action | Detail |
+|---|---|
+| Extend | `pkg/auth/` (already exists) |
+| Extract | Flow routing, handler construction with config overrides |
+| Define | `LoginOptions`, `Login(ctx, opts) error` |
+| Keep in CLI | `CommandLogin()`, interactive prompts, browser launch |
+| Complexity | Medium-High — multiple auth providers, interactive flows |
+
+#### Phase 3F: `pkg/cmd/scafctl/vendor/update.go` → `pkg/solution/bundler/vendor/`
+
+| Action | Detail |
+|---|---|
+| Create | `pkg/solution/bundler/vendor/vendor.go` |
+| Extract | Dependency re-resolution, vendored file update, lock file management |
+| Define | `UpdateOptions`, `Update(ctx, opts) (*UpdateResult, error)` |
+| Keep in CLI | Command constructor, output formatting |
+
+---
+
+## Migration Rules
+
+These rules apply to every phase:
+
+### 1. One Phase at a Time
+Complete each phase fully (including tests, import updates, and CI passing) before starting the next. Do not partially extract.
+
+### 2. No Behavior Changes
+Extractions must be pure mechanical moves. Do not change logic, add features, or fix bugs during extraction. File issues for anything discovered.
+
+### 3. Re-Export Pattern for Backward Compatibility
+When moving functions out of a CLI package, consider temporarily re-exporting from the old location to avoid a big-bang import update:
+
+```go
+// pkg/cmd/scafctl/explain/results.go (after move)
+package explain
+
+import "github.com/oakwood-commons/scafctl/pkg/solution/inspect"
+
+// Deprecated: Use pkg/solution/inspect.LoadSolution directly.
+var LoadSolution = inspect.LoadSolution
+```
+
+Remove re-exports in a follow-up PR once all callers are updated. Since we allow breaking changes, this is optional — direct import path updates in a single PR are also acceptable.
+
+### 4. Test Migration
+- Move tests alongside the code they test
+- Verify test count doesn't decrease
+- Run full test suite after each phase
+
+### 5. Import Update Verification
+After each phase, verify no `pkg/cmd/scafctl/` imports remain in `pkg/mcp/` for the migrated functionality:
+
+```bash
+grep -r 'pkg/cmd/scafctl/' pkg/mcp/ --include='*.go' | grep -v '_test.go'
+```
+
+The goal is to reduce this list to zero.
+
+---
+
+## Dependency Direction
+
+### Before Migration
+
+```
+pkg/mcp ──→ pkg/cmd/scafctl/explain    ← WRONG (MCP depends on CLI)
+pkg/mcp ──→ pkg/cmd/scafctl/lint       ← WRONG
+pkg/mcp ──→ pkg/cmd/scafctl/run        ← WRONG
+pkg/mcp ──→ pkg/cmd/scafctl/get/provider ← WRONG
+pkg/mcp ──→ pkg/celexp, pkg/gotmpl, pkg/catalog, ...  ← CORRECT
+```
+
+### After Migration (Phase 0 complete)
+
+```
+pkg/mcp ──→ pkg/solution/inspect       ← CORRECT (MCP depends on domain)
+pkg/mcp ──→ pkg/lint                   ← CORRECT
+pkg/mcp ──→ pkg/solution/execute       ← CORRECT
+pkg/mcp ──→ pkg/provider/detail        ← CORRECT
+pkg/mcp ──→ pkg/celexp, pkg/gotmpl, pkg/catalog, ...  ← CORRECT (unchanged)
+
+pkg/cmd/scafctl/explain ──→ pkg/solution/inspect  ← CORRECT (CLI depends on domain)
+pkg/cmd/scafctl/lint    ──→ pkg/lint              ← CORRECT
+pkg/cmd/scafctl/run     ──→ pkg/solution/execute  ← CORRECT
+```
+
+### After Full Migration
+
+```
+pkg/mcp ──────────┐
+pkg/cmd/scafctl ──┼──→ pkg/{domain packages only}
+pkg/api (future) ─┘
+
+No cross-dependencies between entry point packages.
+```
+
+---
+
+## Testing Strategy
+
+### Per-Phase Testing
+
+| Phase | Test Approach |
+|---|---|
+| Phase 0 | Existing tests move with code. Run `go test ./...` — zero failures expected. Run MCP integration tests. |
+| Phase 1 | New unit tests for exported functions in new packages (90% coverage target). MCP handler tests should still pass unchanged. |
+| Phase 2 | New unit tests for extracted functions. CLI command tests should still pass unchanged. |
+| Phase 3 | New unit tests + update CLI tests to test through shared package. Most involved testing phase. |
+
+### Validation Command
+
+After each phase:
+
+```bash
+# Verify no new CLI imports in MCP
+grep -rn 'pkg/cmd/scafctl/' pkg/mcp/ --include='*.go' | grep -v _test.go
+
+# Run all tests
+go test ./... -count=1
+
+# Run linter
+golangci-lint run
+
+# Run integration tests
+go test ./tests/integration/... -count=1
+```
+
+---
+
+## Tracking
+
+### Phase 0: Trivial Moves
+
+| ID | Task | New Package | Status |
+|---|---|---|---|
+| 0A | Move `explain/results.go` exports | `pkg/solution/inspect/` | Not Started |
+| 0B | Move `run/execute.go` exports | `pkg/solution/execute/` | Not Started |
+| 0C | Move `lint/` exports (types + `Solution()` + `FilterBySeverity()` + `KnownRules` + `ListRules()` + `GetRule()`) | `pkg/lint/` | Not Started |
+| 0D | Move `get/provider/` shared functions | `pkg/provider/detail/` | Not Started |
+
+### Phase 1: MCP Inline Extractions
+
+| ID | Task | New Package | Status |
+|---|---|---|---|
+| 1A | Extract scaffold YAML generation | `pkg/scaffold/` | Not Started |
+| 1B | Extract solution diff logic | `pkg/soldiff/` | Not Started |
+| 1C | Extract examples discovery | `pkg/examples/` | Not Started |
+| 1D | Extract config sanitization | `pkg/config/` (extend) | Not Started |
+
+### Phase 2: CLI Moderate Extractions
+
+| ID | Task | New Package | Status |
+|---|---|---|---|
+| 2A | Extract secrets crypto | `pkg/secrets/crypto/` | Not Started |
+| 2B | Extract snapshot save pipeline | `pkg/resolver/snapshot/` | Not Started |
+| 2C | Extract resolver refs extraction | `pkg/resolver/refs/` | Not Started |
+| 2D | Extract config paths logic | `pkg/paths/` (extend) | Not Started |
+| 2E | Extract CEL function detail | `pkg/celexp/detail/` | Not Started |
+| 2F | Extract cache operations | `pkg/cache/` | Not Started |
+| 2G | Extract run/common.go shared logic | `pkg/solution/execute/` (extend) | Not Started |
+
+### Phase 3: CLI Heavy Extractions
+
+| ID | Task | New Package | Status |
+|---|---|---|---|
+| 3A | Move remaining lint rule implementations | `pkg/lint/` (extend) | Not Started |
+| 3B | Extract build pipeline | `pkg/solution/builder/` | Not Started |
+| 3C | Extract render orchestration | `pkg/solution/render/` | Not Started |
+| 3D | Extract bundle diff/extract/verify | `pkg/solution/bundler/` (extend) | Not Started |
+| 3E | Extract auth login orchestration | `pkg/auth/` (extend) | Not Started |
+| 3F | Extract vendor update logic | `pkg/solution/bundler/vendor/` | Not Started |
+
+---
+
+## Summary
+
+| Phase | Tasks | Effort | Impact | Lines Moved |
+|---|---|---|---|---|
+| **Phase 0** | 4 | Low | **Critical** — fixes dependency direction | ~1,200 |
+| **Phase 1** | 4 | Low-Medium | Medium — enables new CLI/API commands | ~560 |
+| **Phase 2** | 7 | Medium | Medium — unlocks moderate CLI logic | ~1,400 |
+| **Phase 3** | 6 | High | High — unlocks largest code blocks | ~3,300 |
+| **Total** | 21 | — | — | ~6,500 |
+
+**Recommended start:** Phase 0 — it has the highest impact-to-effort ratio and is prerequisite for everything else.

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -28,6 +28,12 @@ Step-by-step guides for learning scafctl features.
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
 
+## Developer Tools
+
+- [Solution Scaffolding Tutorial](scaffolding-tutorial.md) — Create new solutions with `scafctl new solution`
+- [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
+- [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
+
 ## Reference
 
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution with embedded and external shells

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -1206,9 +1206,19 @@ rm -rf deploy-app/
 
 ---
 
+## Using the Catalog with the MCP Server
+
+When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server provides catalog tools:
+
+- **`catalog_list`** — List catalog entries filtered by kind and name
+- **`catalog_inspect`** — Get detailed metadata for a specific catalog artifact — version, kind, digest, created timestamp, and dependency list
+
+The AI can inspect catalog artifacts, look up solution versions, and help you manage your catalog.
+
 ## Next Steps
 
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate structured text with Go templates
 - [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
 - [Functional Testing Tutorial](functional-testing.md) — Write and run automated tests
 - [Configuration Tutorial](config-tutorial.md) — Manage application configuration
+- [MCP Server Tutorial](mcp-server-tutorial.md) — AI-assisted catalog management

--- a/docs/tutorials/eval-tutorial.md
+++ b/docs/tutorials/eval-tutorial.md
@@ -1,0 +1,249 @@
+---
+title: "Eval Tutorial"
+weight: 52
+---
+
+# Eval Tutorial
+
+This tutorial covers using the `scafctl eval` command group to test CEL expressions, render Go templates, and validate solution files — all without running a full solution.
+
+## Overview
+
+The `eval` commands are developer tools for quick iteration:
+
+- **`eval cel`** — Evaluate CEL expressions with inline or file-based data
+- **`eval template`** — Render Go templates against JSON/YAML data
+- **`eval validate`** — Validate a solution file against the schema and lint rules
+
+```
+┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+│  Expression  │  ────►  │  scafctl     │  ────►  │   Result     │
+│  or Template │         │    eval      │         │   (stdout)   │
+└──────────────┘         └──────────────┘         └──────────────┘
+```
+
+These commands are especially useful when writing or debugging resolver expressions, action templates, and solution configurations.
+
+## 1. Evaluating CEL Expressions
+
+### Basic Usage
+
+Evaluate a simple expression:
+
+```bash
+scafctl eval cel "1 + 2"
+# 3
+```
+
+String operations:
+
+```bash
+scafctl eval cel '"hello".upperAscii()'
+# HELLO
+```
+
+### Using Inline Data
+
+Pass JSON data to the expression via `--data`:
+
+```bash
+scafctl eval cel '_.name + " is " + string(_.age)' \
+  --data '{"name": "Alice", "age": 30}'
+# Alice is 30
+```
+
+The data is available under `_`, just like in solution resolvers.
+
+### Using Data Files
+
+For larger datasets, use `--data-file`:
+
+```bash
+# Create a data file
+cat > data.json << 'EOF'
+{
+  "items": [
+    {"name": "item-a", "active": true},
+    {"name": "item-b", "active": false},
+    {"name": "item-c", "active": true}
+  ]
+}
+EOF
+
+# Filter active items
+scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file data.json
+# ["item-a", "item-c"]
+```
+
+### Output Formats
+
+Use `-o` to control output format:
+
+```bash
+# JSON output
+scafctl eval cel '{"greeting": "hello", "count": 42}' -o json
+
+# YAML output
+scafctl eval cel '{"greeting": "hello", "count": 42}' -o yaml
+```
+
+### Built-in Functions
+
+Test scafctl's custom CEL extension functions:
+
+```bash
+# String functions
+scafctl eval cel '"hello-world".toCamelCase()'
+# helloWorld
+
+scafctl eval cel '"hello-world".toPascalCase()'
+# HelloWorld
+
+# List the available CEL functions
+scafctl eval cel 'true' --list-functions
+```
+
+> **Tip:** Use `eval cel` to prototype resolver expressions before adding them to a solution. This is much faster than running the entire solution each time.
+
+## 2. Evaluating Go Templates
+
+### Basic Usage
+
+Render a template with inline data:
+
+```bash
+scafctl eval template '{{.name}} has {{.count}} items' \
+  --data '{"name": "project", "count": 5}'
+# project has 5 items
+```
+
+### Template Files
+
+For multi-line templates, use `--template-file`:
+
+```bash
+cat > greeting.tmpl << 'EOF'
+Hello, {{.name}}!
+You have {{len .items}} items:
+{{range .items}}- {{.}}
+{{end}}
+EOF
+
+scafctl eval template --template-file greeting.tmpl \
+  --data '{"name": "Alice", "items": ["task-1", "task-2", "task-3"]}'
+```
+
+### Data Files
+
+Combine template files with data files:
+
+```bash
+scafctl eval template --template-file config.tmpl --data-file values.json
+```
+
+### Writing Output to File
+
+Save rendered output to a file:
+
+```bash
+scafctl eval template --template-file config.tmpl \
+  --data-file values.json \
+  --output generated-config.yaml
+```
+
+> **Tip:** Use `eval template` to preview scaffold/render actions before running the full solution workflow.
+
+## 3. Validating Solution Files
+
+### Basic Validation
+
+Check a solution file for schema errors and lint violations:
+
+```bash
+scafctl eval validate -f solution.yaml
+```
+
+### JSON Output
+
+Get structured validation results:
+
+```bash
+scafctl eval validate -f solution.yaml -o json
+```
+
+This returns:
+
+```json
+{
+  "file": "solution.yaml",
+  "errorCount": 0,
+  "warnCount": 1,
+  "infoCount": 0,
+  "findings": [
+    {
+      "rule": "missing-description",
+      "severity": "warning",
+      "message": "Solution metadata should include a description",
+      "location": "metadata"
+    }
+  ]
+}
+```
+
+### Quick Validation in Scripts
+
+Use quiet mode for CI/CD pipelines:
+
+```bash
+if scafctl eval validate -f solution.yaml -o quiet; then
+  echo "Valid!"
+else
+  echo "Validation failed"
+  exit 1
+fi
+```
+
+## 4. Common Workflows
+
+### Prototyping Resolver Expressions
+
+When building a new resolver, iterate quickly with `eval cel`:
+
+```bash
+# 1. Start with simple expression
+scafctl eval cel '"Hello, " + _.name' --data '{"name": "World"}'
+
+# 2. Add complexity
+scafctl eval cel '_.items.filter(i, i.enabled).map(i, i.name).join(", ")' \
+  --data-file real-data.json
+
+# 3. Once working, copy to solution YAML
+```
+
+### Testing Template Rendering
+
+Preview template output before integrating into actions:
+
+```bash
+# Test with known data
+scafctl eval template --template-file deploy.tmpl --data '{"env": "staging", "replicas": 3}'
+
+# Test with real resolver output (from a snapshot)
+scafctl eval template --template-file deploy.tmpl --data-file snapshot.json
+```
+
+### Pre-commit Validation
+
+Add to your pre-commit hooks or CI pipeline:
+
+```bash
+# Validate all solution files in a directory
+find . -name 'solution.yaml' -exec scafctl eval validate -f {} -o quiet \;
+```
+
+## Next Steps
+
+- [CEL Expressions Tutorial](cel-tutorial.md) — Deep dive into CEL expression syntax and custom functions
+- [Go Templates Tutorial](go-templates-tutorial.md) — Go template syntax and scafctl template functions
+- [Resolver Tutorial](resolver-tutorial.md) — Use expressions in resolvers
+- [Functional Testing Tutorial](functional-testing.md) — Automated solution testing

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -222,12 +222,35 @@ scafctl render solution -f solution.yaml -i
 
 # JSON/YAML output
 scafctl render solution -f solution.yaml -o json
+
+# Scaffold a new solution
+scafctl new solution --name my-app --output my-app.yaml
+
+# Browse and download examples
+scafctl examples list
+scafctl examples get resolvers/hello-world.yaml -o hello.yaml
+
+# Evaluate a CEL expression
+scafctl eval cel '"hello".upperAscii()'
+
+# Validate a solution file
+scafctl eval validate -f solution.yaml
+
+# List lint rules
+scafctl lint rules
+
+# Explain a lint rule
+scafctl lint explain <rule-id>
 ```
 
 ## Next Steps
 
+- [Solution Scaffolding Tutorial](scaffolding-tutorial.md) — Create new solutions quickly
 - [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
 - [Actions Tutorial](actions-tutorial.md) — Learn about workflows
+- [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates
+- [Linting Tutorial](linting-tutorial.md) — Validate solutions and explore lint rules
 - [Catalog Tutorial](catalog-tutorial.md) — Store and run solutions by name
 - [Provider Reference](provider-reference.md) — All providers documented
+- [MCP Server Tutorial](mcp-server-tutorial.md) — AI-assisted development
 - [Examples](https://github.com/oakwood-commons/scafctl/tree/main/examples) — Working examples

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -1,0 +1,254 @@
+---
+title: "Linting Tutorial"
+weight: 45
+---
+
+# Linting Tutorial
+
+This tutorial covers using scafctl's lint commands to validate solution files, explore available lint rules, and understand how to fix issues.
+
+## Overview
+
+scafctl includes a built-in linter that checks solution YAML files for:
+
+- **Schema violations** — Invalid field names, wrong types, missing required fields
+- **Best practices** — Missing descriptions, unused resolvers, naming conventions
+- **Correctness** — Broken resolver references, invalid CEL expressions, circular dependencies
+
+```
+┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+│  Solution    │  ────►  │  scafctl     │  ────►  │  Findings    │
+│  YAML        │         │    lint      │         │  (warnings,  │
+│              │         │              │         │   errors)    │
+└──────────────┘         └──────────────┘         └──────────────┘
+```
+
+## 1. Linting a Solution
+
+### Basic Lint
+
+```bash
+scafctl lint -f solution.yaml
+```
+
+Output shows findings in a table with severity, rule, message, and location.
+
+### JSON Output
+
+Get structured results for CI/CD integration:
+
+```bash
+scafctl lint -f solution.yaml -o json
+```
+
+```json
+{
+  "file": "solution.yaml",
+  "errorCount": 1,
+  "warnCount": 2,
+  "infoCount": 0,
+  "findings": [
+    {
+      "rule": "invalid-resolver-ref",
+      "severity": "error",
+      "message": "Resolver 'config' references undefined resolver 'settings'",
+      "location": "spec.resolvers.config"
+    }
+  ]
+}
+```
+
+### Quiet Mode
+
+For scripts and CI pipelines — exit code only:
+
+```bash
+if scafctl lint -f solution.yaml -o quiet; then
+  echo "Lint passed"
+else
+  echo "Lint failed"
+  exit 1
+fi
+```
+
+## 2. Exploring Lint Rules
+
+### List All Rules
+
+See all available lint rules:
+
+```bash
+scafctl lint rules
+```
+
+This shows:
+
+| ID | Severity | Category | Description |
+|----|----------|----------|-------------|
+| missing-description | warning | best-practice | Solution should have a description |
+| unused-resolver | warning | correctness | Resolver is defined but never referenced |
+| ... | ... | ... | ... |
+
+### Filter by Format
+
+```bash
+# JSON output for tooling
+scafctl lint rules -o json
+
+# YAML output
+scafctl lint rules -o yaml
+```
+
+## 3. Understanding a Rule
+
+Get detailed information about any lint rule:
+
+```bash
+scafctl lint explain <rule-id>
+```
+
+For example:
+
+```bash
+scafctl lint explain missing-description
+```
+
+This shows:
+
+- **Description** — What the rule checks
+- **Severity** — Error, warning, or info
+- **Category** — Which category (e.g., best-practice, correctness, schema)
+- **Why it matters** — Why this rule exists
+- **How to fix** — Step-by-step fix instructions
+- **Examples** — Before/after YAML showing the fix
+
+### JSON Output
+
+```bash
+scafctl lint explain missing-description -o json
+```
+
+## 4. Linting in CI/CD
+
+### GitHub Actions Example
+
+```yaml
+- name: Lint solutions
+  run: |
+    find . -name 'solution.yaml' | while read -r file; do
+      if ! scafctl lint -f "$file" -o quiet; then
+        echo "FAIL: $file"
+        scafctl lint -f "$file"
+        exit 1
+      fi
+    done
+```
+
+### Pre-commit Hook
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+git diff --cached --name-only --diff-filter=ACM | grep 'solution.yaml$' | while read -r file; do
+  scafctl lint -f "$file" -o quiet || exit 1
+done
+```
+
+### Task Runner Integration
+
+The project's `taskfile.yaml` includes a `lint:solutions` task that lints all solution examples and integration test solutions:
+
+```bash
+task lint:solutions
+```
+
+## 5. Common Lint Findings and Fixes
+
+### Missing Description
+
+```yaml
+# Before (triggers warning)
+metadata:
+  name: my-solution
+  version: 1.0.0
+
+# After (fixed)
+metadata:
+  name: my-solution
+  version: 1.0.0
+  description: "Collects configuration from multiple sources"
+```
+
+### Invalid Resolver Reference
+
+```yaml
+# Before (triggers error — 'settings' doesn't exist)
+resolvers:
+  config:
+    type: string
+    resolve:
+      with:
+        - provider: cel
+          inputs:
+            expression: '_.settings.key'
+
+# After (add the missing resolver)
+resolvers:
+  settings:
+    type: object
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value:
+              key: "value"
+  config:
+    type: string
+    resolve:
+      with:
+        - provider: cel
+          inputs:
+            expression: '_.settings.key'
+```
+
+### Unknown Fields
+
+```yaml
+# Before (triggers error — 'deps' is not a valid field)
+resolvers:
+  greeting:
+    type: string
+    deps: [config]  # Wrong! Use 'dependsOn'
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value: "hello"
+
+# After (use correct field name)
+resolvers:
+  greeting:
+    type: string
+    dependsOn: [config]
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value: "hello"
+```
+
+## 6. Using Lint with the MCP Server
+
+When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
+
+- **`lint_solution` tool** — Same as `scafctl lint` but returns structured JSON to the AI
+- **`explain_lint_rule` tool** — Same as `scafctl lint explain`
+- **`validate_expressions` tool** — Validate CEL expressions without running them
+
+The AI agent can lint your solution as part of its workflow — for example, the `debug_solution` and `update_solution` prompts automatically include linting steps.
+
+## Next Steps
+
+- [Eval Tutorial](eval-tutorial.md) — Validate and test expressions
+- [Functional Testing Tutorial](functional-testing.md) — Automated solution testing
+- [MCP Server Tutorial](mcp-server-tutorial.md) — AI-assisted development with linting

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -48,15 +48,27 @@ You should see JSON output listing all available tools:
   "version": "dev",
   "tools": [
     { "name": "auth_status", "description": "Report which auth handlers (e.g. entra, gcp, github) are configured..." },
+    { "name": "catalog_inspect", "description": "Get detailed metadata for a specific catalog artifact..." },
     { "name": "catalog_list", "description": "List entries in the local catalog..." },
+    { "name": "diff_solution", "description": "Compare two solution files structurally..." },
+    { "name": "diff_snapshots", "description": "Diff two resolver snapshots..." },
     { "name": "evaluate_cel", "description": "Evaluate a CEL expression..." },
-    { "name": "get_provider_schema", "description": "Get the full JSON Schema for a provider..." },
+    { "name": "evaluate_go_template", "description": "Evaluate a Go template against provided data..." },
+    { "name": "extract_resolver_refs", "description": "Find all resolver cross-references in a solution..." },
+    { "name": "generate_test_scaffold", "description": "Generate functional test cases for a solution..." },
+    { "name": "get_config_paths", "description": "List all XDG-compliant paths used by scafctl..." },
+    { "name": "get_version", "description": "Return scafctl version, commit, and build time..." },
     { "name": "inspect_solution", "description": "Get full solution metadata..." },
     { "name": "lint_solution", "description": "Validate a solution file..." },
+    { "name": "list_auth_handlers", "description": "List all registered auth handlers..." },
     { "name": "list_cel_functions", "description": "List all available CEL functions..." },
+    { "name": "list_examples", "description": "List available scafctl example files..." },
     { "name": "list_providers", "description": "List all available providers..." },
     { "name": "list_solutions", "description": "List available solutions from the local catalog..." },
-    { "name": "render_solution", "description": "Render a solution's action graph..." }
+    { "name": "list_tests", "description": "List functional tests defined in a solution..." },
+    { "name": "render_solution", "description": "Render a solution's action graph..." },
+    { "name": "show_snapshot", "description": "Show the contents of a resolver snapshot..." },
+    { "name": "validate_expressions", "description": "Validate CEL expressions or Go templates..." }
   ]
 }
 ```
@@ -611,6 +623,16 @@ The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"`
 | `run_solution_tests` | Execute functional tests defined in a solution and return structured results. Use `verbose=true` for full assertion details |
 | `scaffold_solution` | Generate a complete skeleton solution YAML from parameters — name, description, features, and providers |
 | `validate_expression` | Syntax-check a CEL expression or Go template without executing it — returns validity, errors, and referenced fields |
+| `catalog_inspect` | Get detailed metadata for a specific catalog artifact — version, kind, digest, created timestamp, and dependency list |
+| `extract_resolver_refs` | Find all resolver cross-references (`_.resolverName`) in a solution — shows which resolvers reference which others |
+| `generate_test_scaffold` | Generate functional test case scaffolding for a solution — creates test YAML with assertions and tags based on the solution's resolvers and actions |
+| `list_tests` | List functional tests defined in a solution's `spec.testing.cases` — shows test names, descriptions, assertions, and tags |
+| `show_snapshot` | Display the contents of a resolver execution snapshot file — resolver values, timing, status, and errors |
+| `diff_snapshots` | Compare two resolver snapshots and return structured diffs — added, removed, modified, and unchanged resolvers |
+| `list_auth_handlers` | List all registered authentication handlers with their configuration status and token expiry |
+| `get_config_paths` | List all XDG-compliant paths used by scafctl — config, data, cache, state, secrets, plugins, and runtime directories |
+| `validate_expressions` | Batch-validate multiple CEL expressions or Go templates — returns validity, errors, and referenced fields for each |
+| `get_version` | Return scafctl version, commit SHA, and build timestamp |
 
 ## 8. Available Resources
 
@@ -623,6 +645,7 @@ MCP resources are read-only data endpoints that AI agents can fetch on demand:
 | `solution://{name}/graph` | Resolver dependency graph with execution tiers, ASCII diagram, and Mermaid diagram |
 | `provider://{name}` | Detailed provider info: input schema (with required/optional per property), output schemas, examples, CLI usage |
 | `provider://reference` | Compact reference of all providers with required/optional inputs, capabilities, and descriptions |
+| `solution://{name}/tests` | Functional test cases defined in a solution's `spec.testing.cases` — test names, descriptions, assertions, tags, and configuration |
 
 ## 9. Available Prompts
 
@@ -637,6 +660,9 @@ MCP prompts are predefined templates that guide AI agents through common workflo
 | `update_solution` | Guide for modifying an existing solution. Follows inspect → edit → lint → preview → test workflow. | `path`, `change` |
 | `add_tests` | Guide for writing functional tests for a solution. Covers test schema, assertions, and test patterns. | `path` |
 | `compose_solution` | Guide for designing a multi-file composed solution with partial YAML files that get merged at build time. | `path`, `goal` |
+| `analyze_execution` | Analyze solution execution results — diagnose failures, performance bottlenecks, and unexpected values. | `path` |
+| `migrate_solution` | Guide for migrating a solution — add composition, extract templates, split into multiple files, add tests, or upgrade patterns. | `path`, `migration` |
+| `optimize_solution` | Analyze a solution for optimization opportunities — performance, readability, testing coverage, or all areas. | `path` |
 
 ### Using Prompts
 
@@ -789,6 +815,148 @@ If you are behind a corporate proxy, ensure proxy environment variables are avai
   }
 }
 ```
+
+## Advanced Features
+
+### Transport Protocols
+
+The MCP server supports three transport protocols:
+
+```bash
+# Default: stdio (JSON-RPC 2.0 over stdin/stdout)
+scafctl mcp serve
+
+# SSE: Server-Sent Events over HTTP
+scafctl mcp serve --transport sse --addr :8080
+
+# HTTP: Streamable HTTP transport
+scafctl mcp serve --transport http --addr :8080
+```
+
+SSE and HTTP transports are useful for remote or multi-client scenarios where stdio is not available.
+
+### Structured Error Responses
+
+All tool errors return structured JSON with machine-readable context:
+
+```json
+{
+  "code": "INVALID_INPUT",
+  "message": "'path' is required",
+  "field": "path",
+  "suggestion": "Provide the path to a solution file",
+  "related": ["list_solutions", "scaffold_solution"]
+}
+```
+
+Error codes include:
+- `INVALID_INPUT` — Bad or missing input arguments
+- `NOT_FOUND` — Requested resource doesn't exist
+- `VALIDATION_ERROR` — Content failed validation
+- `LOAD_FAILED` — Could not load or parse a file
+- `EXECUTION_FAILED` — Runtime execution error
+- `AUTH_REQUIRED` — Authentication needed
+- `CONFIG_ERROR` — Configuration issue
+
+### Observability Hooks
+
+The server includes built-in observability via hooks and middleware:
+
+- **Request timing**: Every tool and resource call is timed and logged
+- **Session tracking**: Client connections and disconnections are logged
+- **Error tracking**: Failures include timing and context information
+
+Enable detailed logging with:
+
+```bash
+scafctl mcp serve --log-file /tmp/scafctl-mcp.log
+```
+
+### Auto-Completion
+
+MCP clients that support argument completion will receive suggestions for:
+
+- **Provider names**: When a prompt or resource expects a provider name
+- **Migration types**: composition, templates, split, tests, upgrade
+- **Solution features**: resolvers, actions, transforms, validation, etc.
+- **Solution names**: From the local catalog for resource template URIs
+- **Lint rule names**: Available lint rules for the explain_lint_rule tool
+
+### Contextual Tool Filtering
+
+The server dynamically filters tools based on available capabilities:
+
+- **Auth tools** (e.g., `auth_status`) are hidden when no auth handlers are configured
+- **Catalog tools** (e.g., `catalog_list`) are hidden when no catalogs are configured
+- **Provider tools** (e.g., `list_providers`) are hidden when no registry is available
+
+This reduces noise and prevents AI agents from invoking tools that will always fail.
+
+### Log Streaming
+
+The server can stream structured log messages to connected clients in real-time during tool execution. This uses the MCP logging notification protocol, respecting the client's configured log level.
+
+### Workspace Roots
+
+For clients that support the MCP roots capability, the server can discover workspace root directories, enabling workspace-aware file operations.
+
+### Sampling and Elicitation
+
+The server supports two client interaction capabilities:
+
+- **Sampling**: Request the client's LLM to generate text (e.g., for intelligent defaults)
+- **Elicitation**: Request structured input from the user during tool execution
+
+### Stdio Tuning
+
+For high-throughput scenarios, you can tune the stdio transport:
+
+```bash
+scafctl mcp serve --worker-pool-size 4 --queue-size 200
+```
+
+## 10. Protocol Features
+
+The MCP server leverages advanced protocol features from the MCP spec (2025-06-18) for a richer experience.
+
+### Progress Notifications
+
+Long-running tools (`preview_resolvers`, `run_solution_tests`, `dry_run_solution`) send real-time progress notifications. Clients that pass a `progressToken` in the request metadata will receive `notifications/progress` messages with step count, total, and human-readable descriptions.
+
+### Icons
+
+All tools, prompts, and resources include SVG icons via data URIs. MCP clients that support the `icons` field (VS Code, Claude Desktop, Cursor) display these alongside tool names for quick visual identification.
+
+### Output Schemas
+
+Key tools declare their output JSON Schema via `outputSchema`, enabling clients to validate and render structured output. This applies to `list_solutions`, `inspect_solution`, `preview_resolvers`, `get_version`, `evaluate_cel`, `auth_status`, `get_config`, `get_config_paths`, `lint_solution`, `render_solution`, and `dry_run_solution`.
+
+### ResourceLink in Results
+
+Tool results include `ResourceLink` items that point to related MCP resources:
+- `inspect_solution` → links to the solution's YAML, schema, and dependency graph resources
+- `list_providers` → link to the provider quick reference resource
+- `preview_resolvers` → links to the solution and its dependency graph
+
+### Content Annotations
+
+Some tool results annotate content items with audience hints (`user` vs `assistant`) and priority values. For example, `get_run_command` marks the command text for the assistant and the explanation for the user.
+
+### Deferred Loading
+
+Rarely-used tools (`show_snapshot`, `diff_snapshots`, `diff_solution`, `extract_resolver_refs`, `explain_lint_rule`) use deferred loading to reduce initial tool list size. They are still discoverable but load lazily.
+
+### Elicitation
+
+When `preview_resolvers` encounters parameter-type resolvers without provided values, it uses MCP elicitation to prompt the user for input interactively. This works with clients that support the `elicitation` capability.
+
+### Roots Discovery
+
+The `list_solutions` tool uses MCP roots to discover solution files in workspace directories when the catalog returns no results, enabling workspace-aware behavior.
+
+### Resource Recovery
+
+All resource handlers have automatic panic recovery (`WithResourceRecovery`), ensuring a panic in one resource handler doesn't crash the server.
 
 ## Next Steps
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -524,7 +524,7 @@ transform:
 
 ## http
 
-HTTP client for API calls.
+HTTP client for API calls with built-in pagination support for fetching data across multiple pages.
 
 ### Capabilities
 
@@ -542,15 +542,87 @@ HTTP client for API calls.
 | `retry` | object | ❌ | Retry configuration |
 | `auth` | string | ❌ | Auth provider (e.g., `entra`, `github`) |
 | `scope` | string | ❌ | OAuth scope for authentication |
+| `pagination` | object | ❌ | Pagination configuration (see below) |
+
+### Pagination
+
+The `pagination` input enables automatic multi-page fetching. Five strategies are supported to cover different API pagination patterns.
+
+#### Pagination Fields
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `strategy` | string | ✅ | One of: `offset`, `pageNumber`, `cursor`, `linkHeader`, `custom` |
+| `maxPages` | int | ✅ | Safety limit for max pages to fetch (default: 100, max: 10000) |
+| `collectPath` | string | ❌ | CEL expression to extract items from each response (e.g., `body.items`) |
+| `stopWhen` | string | ❌ | CEL expression; if true, stop paginating (e.g., `size(body.items) == 0`) |
+
+**CEL variables available** in `collectPath`, `stopWhen`, and strategy-specific expressions:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `statusCode` | int | HTTP response status code |
+| `body` | any | Parsed JSON response body |
+| `rawBody` | string | Raw response body string |
+| `headers` | object | Response headers |
+| `page` | int | Current page number (1-based) |
+
+#### Strategy: `offset`
+
+Increments an offset query parameter each page.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | int | *(required)* | Page size |
+| `offsetParam` | string | `offset` | Query parameter name for offset |
+| `limitParam` | string | `limit` | Query parameter name for limit |
+
+#### Strategy: `pageNumber`
+
+Increments a page number query parameter each page.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pageSize` | int | *(required)* | Page size |
+| `pageParam` | string | `page` | Query parameter name for page number |
+| `pageSizeParam` | string | `pageSize` | Query parameter name for page size |
+| `startPage` | int | `1` | Starting page number |
+
+#### Strategy: `cursor`
+
+Extracts a cursor token or next URL from the response to fetch subsequent pages.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nextTokenPath` | string | CEL expression to extract cursor from response (e.g., `body.nextCursor`) |
+| `nextTokenParam` | string | Query parameter to set with the cursor value (required with `nextTokenPath`) |
+| `nextURLPath` | string | CEL expression to extract the full next page URL (e.g., `body['@odata.nextLink']`). Alternative to `nextTokenPath`. |
+
+Use `nextTokenPath` + `nextTokenParam` for APIs that return a token. Use `nextURLPath` for APIs that return a full URL (e.g., Microsoft Graph `@odata.nextLink`).
+
+#### Strategy: `linkHeader`
+
+Follows `rel="next"` links in the `Link` response header (RFC 8288). Used by GitHub, GitLab, and other REST APIs. No additional configuration needed.
+
+#### Strategy: `custom`
+
+Full control using CEL expressions.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nextURL` | string | CEL expression returning the full next page URL (empty string = stop) |
+| `nextParams` | string | CEL expression returning a map of query params for the next request (empty map = stop) |
 
 ### Output
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `statusCode` | int | HTTP status code |
-| `body` | string | Response body |
-| `headers` | object | Response headers |
+| `statusCode` | int | HTTP status code (last page when paginating) |
+| `body` | string | Response body. When paginating with `collectPath`, contains JSON array of all collected items |
+| `headers` | object | Response headers (last page when paginating) |
 | `success` | bool | Whether request succeeded (action only) |
+| `pages` | int | Number of pages fetched (only when paginating) |
+| `totalItems` | int | Total items collected across all pages (only when paginating) |
 
 ### Examples
 
@@ -594,6 +666,76 @@ resolve:
           Accept: application/json
         auth: github
         scope: repo
+
+# Cursor pagination (token-based)
+provider: http
+inputs:
+  url: https://api.example.com/items
+  pagination:
+    strategy: cursor
+    maxPages: 10
+    nextTokenPath: "body.nextCursor"
+    nextTokenParam: "cursor"
+    collectPath: "body.items"
+    stopWhen: "body.nextCursor == null"
+
+# Cursor pagination (OData / Microsoft Graph nextLink)
+provider: http
+inputs:
+  url: https://graph.microsoft.com/v1.0/users?$top=100
+  authProvider: entra
+  scope: "https://graph.microsoft.com/.default"
+  pagination:
+    strategy: cursor
+    maxPages: 50
+    nextURLPath: "body['@odata.nextLink']"
+    collectPath: "body.value"
+
+# Link header pagination (GitHub-style)
+provider: http
+inputs:
+  url: https://api.github.com/users/octocat/repos?per_page=30
+  headers:
+    Accept: application/vnd.github+json
+  pagination:
+    strategy: linkHeader
+    maxPages: 5
+    collectPath: "body"
+
+# Offset pagination
+provider: http
+inputs:
+  url: https://api.example.com/records
+  pagination:
+    strategy: offset
+    maxPages: 20
+    limit: 50
+    collectPath: "body.records"
+    stopWhen: "size(body.records) < 50"
+
+# Page number pagination
+provider: http
+inputs:
+  url: https://api.example.com/products
+  pagination:
+    strategy: pageNumber
+    maxPages: 10
+    pageSize: 25
+    pageParam: "page"
+    pageSizeParam: "per_page"
+    collectPath: "body.products"
+    stopWhen: "size(body.products) == 0"
+
+# Custom pagination with CEL expressions
+provider: http
+inputs:
+  url: https://api.example.com/search?q=test
+  pagination:
+    strategy: custom
+    maxPages: 10
+    nextURL: "has(body.links) && has(body.links.next) ? body.links.next : ''"
+    collectPath: "body.results"
+    stopWhen: "!has(body.links) || !has(body.links.next)"
 ```
 
 ---
@@ -876,6 +1018,7 @@ validate:
         match: "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
         expression: "!__self.startsWith('v0.')"
         message: "Version must be semver format and >= v1.0.0"
+
 ```
 
 ## Next Steps

--- a/docs/tutorials/scaffolding-tutorial.md
+++ b/docs/tutorials/scaffolding-tutorial.md
@@ -1,0 +1,160 @@
+---
+title: "Solution Scaffolding Tutorial"
+weight: 15
+---
+
+# Solution Scaffolding Tutorial
+
+This tutorial covers using `scafctl new solution` to quickly scaffold new solution files with the correct structure, providers, and best practices.
+
+## Overview
+
+The `new solution` command generates a complete, valid solution YAML file based on your inputs. Instead of writing YAML from scratch (and getting field names wrong), scaffolding gives you a working starting point.
+
+```
+┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+│  Parameters  │  ────►  │  scafctl     │  ────►  │  Solution    │
+│  (name, etc) │         │  new solution│         │  YAML File   │
+└──────────────┘         └──────────────┘         └──────────────┘
+```
+
+## 1. Quick Start
+
+### Generate a Basic Solution
+
+```bash
+scafctl new solution \
+  --name my-app \
+  --description "My application configuration" \
+  --output my-app.yaml
+```
+
+This generates a valid solution file with:
+- Correct `apiVersion` and `kind`
+- Metadata with name, version, and description
+- A sample resolver using the `static` provider
+- An example workflow action
+
+### Verify the Output
+
+Immediately validate the generated file:
+
+```bash
+scafctl eval validate -f my-app.yaml
+```
+
+Run it:
+
+```bash
+scafctl run solution -f my-app.yaml
+```
+
+## 2. Choosing Providers
+
+Specify which providers to include in the scaffolded solution:
+
+```bash
+# Include specific providers
+scafctl new solution \
+  --name api-collector \
+  --description "Collect data from APIs" \
+  --providers http,cel,exec \
+  --output api-collector.yaml
+```
+
+The generator creates resolver examples using each specified provider with correct input schemas.
+
+### Available Providers
+
+Not sure which providers to use? List them first:
+
+```bash
+scafctl get provider
+```
+
+Or get details on a specific provider:
+
+```bash
+scafctl get provider http
+```
+
+## 3. Starting from Examples
+
+Instead of scaffolding from scratch, you can also start from an existing example:
+
+```bash
+# Browse available solution examples
+scafctl examples list --category solutions
+
+# Download one as a starting point
+scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
+
+# Modify and validate
+scafctl eval validate -f my-solution.yaml
+```
+
+This is useful when you want a more complete starting point with real patterns (parameters, validation, actions, composition).
+
+## 4. Common Scaffolding Patterns
+
+### Resolver-Only Solution
+
+For solutions that just gather and transform data without side-effect actions:
+
+```bash
+scafctl new solution \
+  --name data-collector \
+  --description "Gather configuration from multiple sources" \
+  --providers static,env,http,cel \
+  --output data-collector.yaml
+```
+
+Then run with the resolver command:
+
+```bash
+scafctl run resolver -f data-collector.yaml -o yaml
+```
+
+### Full Workflow Solution
+
+For solutions with actions:
+
+```bash
+scafctl new solution \
+  --name deploy-pipeline \
+  --description "Deployment automation pipeline" \
+  --providers static,exec,cel \
+  --output deploy-pipeline.yaml
+```
+
+### Adding Tests After Scaffolding
+
+Once your solution works, add functional tests:
+
+```bash
+# View the testing section that was scaffolded
+scafctl eval validate -f my-solution.yaml
+
+# Use the MCP server to generate test scaffolding (if using AI tools)
+# Or see the Functional Testing Tutorial for manual test writing
+```
+
+## 5. Workflow
+
+The recommended scaffolding workflow:
+
+1. **Scaffold** — `scafctl new solution --name my-app --output my-app.yaml`
+2. **Validate** — `scafctl eval validate -f my-app.yaml`
+3. **Edit** — Modify resolvers and actions for your needs
+4. **Lint** — `scafctl lint -f my-app.yaml`
+5. **Test** — `scafctl run resolver -f my-app.yaml` to verify resolvers
+6. **Run** — `scafctl run solution -f my-app.yaml` for the full workflow
+
+## Next Steps
+
+- [Getting Started](getting-started.md) — Full getting started guide
+- [Resolver Tutorial](resolver-tutorial.md) — Deep dive into resolvers
+- [Actions Tutorial](actions-tutorial.md) — Build workflow actions
+- [Provider Reference](provider-reference.md) — All available providers
+- [Functional Testing Tutorial](functional-testing.md) — Add automated tests
+- [Eval Tutorial](eval-tutorial.md) — Test expressions before adding to solutions

--- a/docs/tutorials/snapshots-tutorial.md
+++ b/docs/tutorials/snapshots-tutorial.md
@@ -23,6 +23,26 @@ Snapshots capture the state of resolver execution — values, timing, status, er
 └─────────────┘     └──────────────┘     └──────────────┘
 ```
 
+## When to Use Snapshots
+
+Snapshots are **flag-triggered** (`--snapshot`), never automatically created. Here are the real-world scenarios where they provide value:
+
+| Use Case | Scenario | How | Why Not Just Logs? |
+|----------|----------|-----|-------------------|
+| **Debugging a failed run** | A resolver fails or returns an unexpected value | `--snapshot` captures full state even when execution fails — you see which resolvers succeeded, which failed, and the exact error for each | Logs show temporal events; snapshots show the complete picture — every resolver's value, status, and timing in one structured file |
+| **Regression detection** | You changed a solution, provider config, or parameter and need to verify nothing broke | Capture a known-good baseline, then diff after changes | `git diff` shows YAML changes; `snapshot diff` shows what those changes *did to the output* |
+| **Environment comparison** | You need to see exactly which resolver values differ between staging and production | Snapshot with `-r env=staging` vs `-r env=production` and diff | Environment differences are computed at runtime by providers — they can't be seen by inspecting the solution YAML |
+| **Golden-file testing** | Automated CI checks that resolver outputs haven't drifted | The `soltesting` package compares execution output against stored snapshots, normalizing timestamps and UUIDs | Manual inspection doesn't scale; golden files catch regressions automatically |
+| **Audit trail** | Record what values were resolved at a specific point in time (before/after a deployment or config change) | Capture and archive snapshots with timestamps | Logs are ephemeral; snapshots are portable JSON files you can store and revisit |
+| **Safe sharing** | A teammate needs to see your resolver output, but the solution uses secrets or credentials | `--redact` replaces values of `sensitive: true` resolvers with `<redacted>` | Copy-pasting terminal output risks leaking secrets and loses structure |
+
+### Key Properties
+
+- **Captures failures too** — Unlike normal output that stops on error, snapshots record partial state. A snapshot from a failed run shows you exactly which resolvers succeeded before the failure.
+- **Structured data** — Every resolver's value, status, duration, phase, provider calls, and errors in one JSON file. Supports programmatic processing (`-o json`), CI pipeline assertions, and diff operations.
+- **Redaction-safe** — Resolvers marked `sensitive: true` in the solution YAML have their values replaced with `<redacted>` when using `--redact`, making snapshots safe to share or store in version control.
+- **Deterministic diff** — `snapshot diff` with `--ignore-fields duration,providerCalls` strips non-deterministic timing data, leaving only meaningful value and status changes.
+
 ## Creating Snapshots
 
 ### From `render`
@@ -273,9 +293,19 @@ scafctl snapshot save -f solution.yaml --output shareable.json --redact
 | `--redact` | save, render | Redact sensitive resolver values |
 | `-r key=value` | save | Pass resolver parameters |
 
+## Using Snapshots with the MCP Server
+
+When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server provides snapshot tools:
+
+- **`show_snapshot`** — Display snapshot contents with structured output (same as `scafctl snapshot show`)
+- **`diff_snapshots`** — Compare two snapshots and return structured diffs showing added, removed, modified, and unchanged resolvers
+
+The `analyze_execution` prompt automatically suggests using snapshots for debugging.
+
 ## Next Steps
 
 - [Functional Testing Tutorial](functional-testing.md) — Write and run automated tests
 - [Configuration Tutorial](config-tutorial.md) — Manage application configuration
 - [Resolver Tutorial](resolver-tutorial.md) — Learn about resolvers that snapshots capture
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data from HTTP calls
+- [MCP Server Tutorial](mcp-server-tutorial.md) — AI-assisted snapshot analysis

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,26 @@ scafctl run solution -f examples/actions/hello-world.yaml --debug
 scafctl run solution -f examples/actions/hello-world.yaml --log-level info --log-format json
 ```
 
+### Browse Examples from the CLI
+
+You can also discover and download examples using the built-in `examples` command:
+
+```bash
+# List all available examples
+scafctl examples list
+
+# Filter by category
+scafctl examples list --category resolvers
+scafctl examples list --category actions
+scafctl examples list --category solutions
+
+# Download an example
+scafctl examples get resolvers/hello-world.yaml -o hello.yaml
+
+# List in JSON format
+scafctl examples list -o json
+```
+
 ---
 
 ## Directory Structure
@@ -37,6 +57,7 @@ scafctl run solution -f examples/actions/hello-world.yaml --log-level info --log
 | [snapshots/](snapshots/) | Execution snapshot capture and comparison |
 | [catalog/](catalog/) | Catalog bundling and registry examples |
 | [config/](config/) | Configuration file examples |
+| [eval/](eval/) | CEL and Go template evaluation data and templates |
 | [plugins/](plugins/) | go-plugin source code examples (see note below) |
 | [mcp/](mcp/) | MCP server configurations for AI clients |
 
@@ -68,6 +89,18 @@ Action workflows demonstrate executing tasks with dependencies, parallelism, and
 | [template-render.yaml](actions/template-render.yaml) | Render files from templates | `scafctl run solution -f examples/actions/template-render.yaml` |
 | [go-template-inline.yaml](actions/go-template-inline.yaml) | Inline Go templates with loops/conditionals | `scafctl run solution -f examples/actions/go-template-inline.yaml` |
 | [complex-workflow.yaml](actions/complex-workflow.yaml) | Full CI/CD-style workflow | `scafctl run solution -f examples/actions/complex-workflow.yaml` |
+
+---
+
+## Eval Examples
+
+Data files and templates for use with `scafctl eval` commands.
+
+| Example | Description | Run |
+|---------|-------------|-----|
+| [cel-data.json](eval/cel-data.json) | Sample data for CEL expression evaluation | `scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file examples/eval/cel-data.json` |
+| [deployment.tmpl](eval/deployment.tmpl) | Kubernetes deployment template | `scafctl eval template --template-file examples/eval/deployment.tmpl --data-file examples/eval/template-data.json` |
+| [template-data.json](eval/template-data.json) | Data for Go template rendering | Used with `deployment.tmpl` above |
 
 ---
 

--- a/examples/eval/cel-data.json
+++ b/examples/eval/cel-data.json
@@ -1,0 +1,28 @@
+# CEL Evaluation Examples
+# Test CEL expressions from the command line without writing a full solution.
+#
+# Run: scafctl eval cel "1 + 2"
+# Run: scafctl eval cel '_.name + " is " + string(_.age)' --data '{"name": "Alice", "age": 30}'
+# Run: scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file eval/cel-data.json
+
+# This file is example data for use with `scafctl eval cel`:
+#
+#   scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file eval/cel-data.json
+#   scafctl eval cel '_.items.size()' --data-file eval/cel-data.json
+#   scafctl eval cel '_.items.exists(i, i.name == "deploy-service")' --data-file eval/cel-data.json
+
+{
+  "project": "example-app",
+  "environment": "staging",
+  "items": [
+    {"name": "build-image", "active": true, "priority": 1},
+    {"name": "run-tests", "active": true, "priority": 2},
+    {"name": "deploy-service", "active": false, "priority": 3},
+    {"name": "notify-team", "active": true, "priority": 4}
+  ],
+  "config": {
+    "replicas": 3,
+    "region": "us-east-1",
+    "features": ["logging", "metrics", "tracing"]
+  }
+}

--- a/examples/eval/deployment.tmpl
+++ b/examples/eval/deployment.tmpl
@@ -1,0 +1,33 @@
+# Go Template Evaluation Example
+# Render Go templates from the command line.
+#
+# Run: scafctl eval template --template-file eval/deployment.tmpl --data-file eval/template-data.json
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.name}}
+  namespace: {{.namespace}}
+  labels:
+    app: {{.name}}
+    environment: {{.environment}}
+spec:
+  replicas: {{.replicas}}
+  selector:
+    matchLabels:
+      app: {{.name}}
+  template:
+    metadata:
+      labels:
+        app: {{.name}}
+    spec:
+      containers:
+        - name: {{.name}}
+          image: {{.image}}:{{.tag}}
+          ports:
+            - containerPort: {{.port}}
+          env:
+{{- range $key, $value := .env}}
+            - name: {{$key}}
+              value: "{{$value}}"
+{{- end}}

--- a/examples/eval/template-data.json
+++ b/examples/eval/template-data.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-app",
+  "namespace": "production",
+  "environment": "prod",
+  "replicas": 3,
+  "image": "ghcr.io/example/my-app",
+  "tag": "v1.2.3",
+  "port": 8080,
+  "env": {
+    "LOG_LEVEL": "info",
+    "DATABASE_URL": "postgres://db:5432/myapp",
+    "CACHE_TTL": "300"
+  }
+}

--- a/examples/providers/http-pagination-cursor.yaml
+++ b/examples/providers/http-pagination-cursor.yaml
@@ -1,0 +1,14 @@
+# Cursor-based pagination (token extracted from response body)
+# Fetches all items by following the nextCursor token until null
+name: cursor-pagination
+provider: http
+inputs:
+  url: "https://api.example.com/items?limit=50"
+  method: GET
+  pagination:
+    strategy: cursor
+    maxPages: 10
+    nextTokenPath: "body.nextCursor"
+    nextTokenParam: "cursor"
+    collectPath: "body.items"
+    stopWhen: "size(body.items) == 0"

--- a/examples/providers/http-pagination-link-header.yaml
+++ b/examples/providers/http-pagination-link-header.yaml
@@ -1,0 +1,14 @@
+# Link header pagination (RFC 8288)
+# Follows rel="next" links in the Link response header
+# Used by GitHub, GitLab, and many REST APIs
+name: link-header-pagination
+provider: http
+inputs:
+  url: "https://api.github.com/users/octocat/repos?per_page=30"
+  method: GET
+  headers:
+    Accept: "application/vnd.github+json"
+  pagination:
+    strategy: linkHeader
+    maxPages: 5
+    collectPath: "body"

--- a/examples/providers/http-pagination-odata.yaml
+++ b/examples/providers/http-pagination-odata.yaml
@@ -1,0 +1,15 @@
+# OData / Microsoft Graph pagination
+# Follows @odata.nextLink URL from the response body
+# Common pattern for Microsoft Graph, Dynamics 365, and OData APIs
+name: odata-pagination
+provider: http
+inputs:
+  url: "https://graph.microsoft.com/v1.0/users?$top=100"
+  method: GET
+  authProvider: entra
+  scope: "https://graph.microsoft.com/.default"
+  pagination:
+    strategy: cursor
+    maxPages: 50
+    nextURLPath: "body['@odata.nextLink']"
+    collectPath: "body.value"

--- a/examples/providers/http-pagination-offset.yaml
+++ b/examples/providers/http-pagination-offset.yaml
@@ -1,0 +1,15 @@
+# Offset-based pagination
+# Uses offset and limit query parameters to page through results
+name: offset-pagination
+provider: http
+inputs:
+  url: "https://api.example.com/records"
+  method: GET
+  pagination:
+    strategy: offset
+    maxPages: 20
+    limit: 50
+    offsetParam: "offset"
+    limitParam: "limit"
+    collectPath: "body.records"
+    stopWhen: "size(body.records) < 50"

--- a/examples/providers/http-pagination-page-number.yaml
+++ b/examples/providers/http-pagination-page-number.yaml
@@ -1,0 +1,16 @@
+# Page number pagination
+# Increments a page number query parameter each request
+name: page-number-pagination
+provider: http
+inputs:
+  url: "https://api.example.com/products"
+  method: GET
+  pagination:
+    strategy: pageNumber
+    maxPages: 10
+    pageSize: 25
+    pageParam: "page"
+    pageSizeParam: "per_page"
+    startPage: 1
+    collectPath: "body.products"
+    stopWhen: "size(body.products) == 0"

--- a/pkg/cmd/scafctl/eval/cel.go
+++ b/pkg/cmd/scafctl/eval/cel.go
@@ -1,0 +1,222 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// CELOptions holds options for the eval cel command.
+type CELOptions struct {
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
+	Output     string
+	Expression string
+	Vars       []string
+	Data       string
+	File       string
+}
+
+// CELResult holds the result of evaluating a CEL expression.
+type CELResult struct {
+	Expression string `json:"expression" yaml:"expression" doc:"The CEL expression that was evaluated"`
+	Result     any    `json:"result" yaml:"result" doc:"The evaluation result"`
+	Type       string `json:"type" yaml:"type" doc:"The Go type of the result"`
+}
+
+// CommandCEL creates the 'eval cel' command.
+func CommandCEL(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &CELOptions{}
+
+	cCmd := &cobra.Command{
+		Use:     "cel",
+		Aliases: []string{"c"},
+		Short:   "Evaluate a CEL expression",
+		Long: heredoc.Doc(`
+			Evaluate a CEL expression with optional data context.
+
+			Provide variables via --var flags (key=value pairs) or structured
+			data via --data (inline JSON) or --file (JSON/YAML file). File data
+			is available as the root object "_" in the expression.
+
+			Examples:
+			  # Simple variable evaluation
+			  scafctl eval cel --expression 'size(name) > 3' -v name=hello
+
+			  # With inline JSON data
+			  scafctl eval cel --expression 'items.filter(i, i.active)' \
+			    -d '{"items": [{"name": "a", "active": true}]}'
+
+			  # With data from a file
+			  scafctl eval cel --expression 'has(config.timeout)' --file config.json
+
+			  # Output as JSON
+			  scafctl eval cel --expression '1 + 2' -o json
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVar(&opts.Expression, "expression", "", "CEL expression to evaluate (required)")
+	cCmd.Flags().StringArrayVarP(&opts.Vars, "var", "v", nil, "Variable as key=value (repeatable)")
+	cCmd.Flags().StringVar(&opts.Data, "data", "", "Inline JSON data context")
+	cCmd.Flags().StringVar(&opts.File, "file", "", "JSON/YAML file for data context")
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "auto", "Output format: auto, json, yaml")
+
+	_ = cCmd.MarkFlagRequired("expression")
+
+	return cCmd
+}
+
+// Run executes the eval cel command.
+func (o *CELOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	// Build root data from --data or --file
+	rootData, err := buildDataContext(o.Data, o.File)
+	if err != nil {
+		w.Errorf("failed to build data context: %v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Parse --var flags into additional variables
+	vars, err := parseVars(o.Vars)
+	if err != nil {
+		w.Errorf("failed to parse variables: %v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Evaluate the expression
+	result, err := celexp.EvaluateExpression(ctx, o.Expression, rootData, vars)
+	if err != nil {
+		w.Errorf("CEL evaluation failed: %v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	celResult := &CELResult{
+		Expression: o.Expression,
+		Result:     result,
+		Type:       fmt.Sprintf("%T", result),
+	}
+
+	// Handle structured output formats
+	if o.Output == "json" || o.Output == "yaml" {
+		return writeStructured(o.IOStreams, celResult, o.Output)
+	}
+
+	// Table output
+	w.Plainf("%v\n", result)
+
+	return nil
+}
+
+// buildDataContext creates a data context map from --data or --file flags.
+func buildDataContext(data, file string) (any, error) {
+	if data != "" && file != "" {
+		return nil, fmt.Errorf("cannot use both --data and --file")
+	}
+
+	if data == "" && file == "" {
+		return nil, nil
+	}
+
+	var raw []byte
+	if data != "" {
+		raw = []byte(data)
+	} else {
+		var err error
+		raw, err = os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading file %s: %w", file, err)
+		}
+	}
+
+	// Try JSON first, then YAML
+	var result any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		if err2 := yaml.Unmarshal(raw, &result); err2 != nil {
+			return nil, fmt.Errorf("data is not valid JSON or YAML: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// parseVars converts key=value pairs into a map.
+func parseVars(vars []string) (map[string]any, error) {
+	if len(vars) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]any, len(vars))
+	for _, v := range vars {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid variable format %q; expected key=value", v)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := parts[1]
+
+		// Try to parse as JSON for complex values
+		var parsed any
+		if err := json.Unmarshal([]byte(value), &parsed); err == nil {
+			result[key] = parsed
+		} else {
+			result[key] = value
+		}
+	}
+
+	return result, nil
+}
+
+// writeStructured writes data as JSON or YAML to the output stream.
+func writeStructured(ioStreams *terminal.IOStreams, data any, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(ioStreams.Out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case "yaml":
+		enc := yaml.NewEncoder(ioStreams.Out)
+		enc.SetIndent(2)
+		err := enc.Encode(data)
+		_ = enc.Close()
+		return err
+	default:
+		return fmt.Errorf("unsupported output format %q; use json or yaml", format)
+	}
+}

--- a/pkg/cmd/scafctl/eval/eval.go
+++ b/pkg/cmd/scafctl/eval/eval.go
@@ -1,0 +1,33 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package eval provides commands for evaluating and validating CEL expressions and Go templates.
+package eval
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandEval creates the 'eval' command group.
+func CommandEval(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := &cobra.Command{
+		Use:   "eval",
+		Short: "Evaluate CEL expressions and Go templates",
+		Long: `Evaluate and validate CEL expressions and Go templates in isolation.
+
+Useful for testing expressions and templates before using them in solutions.`,
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+
+	cCmd.AddCommand(CommandCEL(cliParams, ioStreams, cmdPath))
+	cCmd.AddCommand(CommandTemplate(cliParams, ioStreams, cmdPath))
+	cCmd.AddCommand(CommandValidate(cliParams, ioStreams, cmdPath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/eval/template.go
+++ b/pkg/cmd/scafctl/eval/template.go
@@ -1,0 +1,214 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// TemplateOptions holds options for the eval template command.
+type TemplateOptions struct {
+	IOStreams    *terminal.IOStreams
+	CliParams    *settings.Run
+	Output       string
+	Template     string
+	TemplateFile string
+	Vars         []string
+	Data         string
+	File         string
+	ShowRefs     bool
+}
+
+// TemplateResult holds the result of evaluating a Go template.
+type TemplateResult struct {
+	Output     string                     `json:"output" yaml:"output" doc:"The rendered template output"`
+	Template   string                     `json:"template" yaml:"template" doc:"The template that was evaluated"`
+	References []gotmpl.TemplateReference `json:"references,omitempty" yaml:"references,omitempty" doc:"Referenced template variables"`
+}
+
+// CommandTemplate creates the 'eval template' command.
+func CommandTemplate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &TemplateOptions{}
+
+	cCmd := &cobra.Command{
+		Use:     "template",
+		Aliases: []string{"tmpl", "t"},
+		Short:   "Evaluate a Go template",
+		Long: heredoc.Doc(`
+			Evaluate a Go template with optional data context.
+
+			Provide a template inline via --template or from a file via --template-file.
+			Data can come from --var flags, inline JSON via --data, or a file via --file.
+
+			Use --show-refs to also list template variable references found in the template.
+
+			Examples:
+			  # Simple variable rendering
+			  scafctl eval template -t '{{ .name | upper }}' -v name=hello
+
+			  # Template from file with data
+			  scafctl eval template --template-file deploy.tmpl -d '{"env": "prod"}'
+
+			  # Show referenced resolver fields
+			  scafctl eval template -t '{{ ._.config.host }}' -f resolvers.json --show-refs
+
+			  # Output as JSON
+			  scafctl eval template -t '{{ .name }}' -v name=world -o json
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Go template string (inline)")
+	cCmd.Flags().StringVar(&opts.TemplateFile, "template-file", "", "Go template file path")
+	cCmd.Flags().StringArrayVarP(&opts.Vars, "var", "v", nil, "Variable as key=value (repeatable)")
+	cCmd.Flags().StringVar(&opts.Data, "data", "", "Inline JSON data context")
+	cCmd.Flags().StringVar(&opts.File, "file", "", "JSON/YAML file for data context")
+	cCmd.Flags().BoolVar(&opts.ShowRefs, "show-refs", false, "Also output referenced template variables")
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "auto", "Output format: auto, json, yaml")
+
+	cCmd.MarkFlagsMutuallyExclusive("template", "template-file")
+
+	return cCmd
+}
+
+// Run executes the eval template command.
+func (o *TemplateOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	// Get template content
+	tmplContent, err := o.getTemplateContent()
+	if err != nil {
+		w.Errorf("failed to get template content: %v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Build data context
+	rootData, err := buildDataContext(o.Data, o.File)
+	if err != nil {
+		w.Errorf("failed to build data context: %v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Parse --var flags
+	vars, err := parseVars(o.Vars)
+	if err != nil {
+		w.Errorf("failed to parse variables: %v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Merge root data and vars into a single data map
+	data := mergeData(rootData, vars)
+
+	// Execute template
+	result, err := gotmpl.Execute(ctx, gotmpl.TemplateOptions{
+		Content: tmplContent,
+		Name:    "eval",
+		Data:    data,
+	})
+	if err != nil {
+		w.Errorf("template execution failed: %v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	tmplResult := &TemplateResult{
+		Output:   result.Output,
+		Template: tmplContent,
+	}
+
+	// Optionally extract references
+	if o.ShowRefs {
+		refs, refErr := gotmpl.GetGoTemplateReferences(tmplContent, "{{", "}}")
+		if refErr == nil {
+			tmplResult.References = refs
+		}
+	}
+
+	// Handle structured output formats
+	if o.Output == "json" || o.Output == "yaml" {
+		return writeStructured(o.IOStreams, tmplResult, o.Output)
+	}
+
+	// Plain output - just the rendered template
+	w.Plainf("%s\n", result.Output)
+
+	if o.ShowRefs && len(tmplResult.References) > 0 {
+		w.Plain("")
+		w.Infof("Referenced variables:")
+		for _, ref := range tmplResult.References {
+			w.Plainf("  %s (at position %s)\n", ref.Path, ref.Position)
+		}
+	}
+
+	return nil
+}
+
+// getTemplateContent returns the template string from flags.
+func (o *TemplateOptions) getTemplateContent() (string, error) {
+	if o.Template == "" && o.TemplateFile == "" {
+		return "", fmt.Errorf("one of --template or --template-file is required")
+	}
+
+	if o.Template != "" {
+		return o.Template, nil
+	}
+
+	data, err := os.ReadFile(o.TemplateFile)
+	if err != nil {
+		return "", fmt.Errorf("reading template file %s: %w", o.TemplateFile, err)
+	}
+
+	return string(data), nil
+}
+
+// mergeData combines root data and vars into a single map suitable for template execution.
+func mergeData(rootData any, vars map[string]any) map[string]any {
+	result := make(map[string]any)
+
+	// If rootData is a map, merge it in
+	if m, ok := rootData.(map[string]any); ok {
+		for k, v := range m {
+			result[k] = v
+		}
+	} else if rootData != nil {
+		result["_"] = rootData
+	}
+
+	// Overlay vars
+	for k, v := range vars {
+		result[k] = v
+	}
+
+	return result
+}

--- a/pkg/cmd/scafctl/eval/validate.go
+++ b/pkg/cmd/scafctl/eval/validate.go
@@ -1,0 +1,184 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/google/cel-go/cel"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// ValidateOptions holds options for the eval validate command.
+type ValidateOptions struct {
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
+	Output     string
+	Expression string
+	Type       string
+}
+
+// ValidateResult holds the result of validating an expression.
+type ValidateResult struct {
+	Expression string   `json:"expression" yaml:"expression" doc:"The expression that was validated" maxLength:"4096"`
+	Type       string   `json:"type" yaml:"type" doc:"The expression type (cel or go-template)" maxLength:"20"`
+	Valid      bool     `json:"valid" yaml:"valid" doc:"Whether the expression is syntactically valid"`
+	Error      string   `json:"error,omitempty" yaml:"error,omitempty" doc:"Error message if invalid" maxLength:"4096"`
+	References []string `json:"references,omitempty" yaml:"references,omitempty" doc:"Referenced variables found in the expression" maxItems:"100"`
+}
+
+// CommandValidate creates the 'eval validate' command.
+func CommandValidate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &ValidateOptions{}
+
+	cCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a CEL expression or Go template for syntax errors",
+		Long: heredoc.Doc(`
+			Validate the syntax of a CEL expression or Go template without evaluating it.
+
+			This is useful for checking expressions before embedding them in solutions
+			or for CI/CD pipelines that validate solution files.
+
+			Examples:
+			  # Validate a CEL expression
+			  scafctl eval validate --expression 'size(name) > 3' --type cel
+
+			  # Validate a Go template
+			  scafctl eval validate --expression '{{ .name }}' --type go-template
+
+			  # Output as JSON
+			  scafctl eval validate --expression '{{ .name' --type go-template -o json
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVar(&opts.Expression, "expression", "", "Expression to validate (required)")
+	cCmd.Flags().StringVar(&opts.Type, "type", "", "Expression type: cel or go-template (required)")
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "auto", "Output format: auto, json, yaml")
+
+	_ = cCmd.MarkFlagRequired("expression")
+	_ = cCmd.MarkFlagRequired("type")
+
+	return cCmd
+}
+
+// Run executes the eval validate command.
+func (o *ValidateOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	var result *ValidateResult
+
+	switch o.Type {
+	case "cel":
+		result = validateCEL(o.Expression)
+	case "go-template", "gotemplate", "template":
+		result = validateGoTemplate(o.Expression)
+	default:
+		err := fmt.Errorf("unsupported type %q; use 'cel' or 'go-template'", o.Type)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Handle structured output formats
+	if o.Output == "json" || o.Output == "yaml" {
+		return writeStructured(o.IOStreams, result, o.Output)
+	}
+
+	// Table output
+	if result.Valid {
+		w.Successf("Expression is valid (%s)\n", result.Type)
+		if len(result.References) > 0 {
+			w.Infof("Referenced variables:")
+			for _, ref := range result.References {
+				w.Plainf("  %s\n", ref)
+			}
+		}
+	} else {
+		w.Errorf("Expression is invalid (%s): %s\n", result.Type, result.Error)
+		return exitcode.WithCode(fmt.Errorf("invalid expression"), exitcode.InvalidInput)
+	}
+
+	return nil
+}
+
+// validateCEL validates a CEL expression for syntax errors.
+func validateCEL(expr string) *ValidateResult {
+	result := &ValidateResult{
+		Expression: expr,
+		Type:       "cel",
+		Valid:      true,
+	}
+
+	env, err := cel.NewEnv()
+	if err != nil {
+		result.Valid = false
+		result.Error = fmt.Sprintf("failed to create CEL environment: %v", err)
+		return result
+	}
+
+	_, issues := env.Parse(expr)
+	if issues != nil && issues.Err() != nil {
+		result.Valid = false
+		result.Error = issues.Err().Error()
+		return result
+	}
+
+	return result
+}
+
+// validateGoTemplate validates a Go template for syntax errors and extracts references.
+func validateGoTemplate(expr string) *ValidateResult {
+	result := &ValidateResult{
+		Expression: expr,
+		Type:       "go-template",
+		Valid:      true,
+	}
+
+	_, err := template.New("validate").Parse(expr)
+	if err != nil {
+		result.Valid = false
+		result.Error = err.Error()
+		return result
+	}
+
+	// Extract references
+	refs, refErr := gotmpl.GetGoTemplateReferences(expr, "{{", "}}")
+	if refErr == nil {
+		for _, ref := range refs {
+			result.References = append(result.References, ref.Path)
+		}
+	}
+
+	return result
+}

--- a/pkg/cmd/scafctl/examples/examples.go
+++ b/pkg/cmd/scafctl/examples/examples.go
@@ -1,0 +1,29 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package examples provides commands for browsing and retrieving embedded scafctl examples.
+package examples
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandExamples creates the 'examples' command group.
+func CommandExamples(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := &cobra.Command{
+		Use:          "examples",
+		Short:        "Browse and retrieve scafctl example configurations",
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+
+	cCmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
+	cCmd.AddCommand(CommandGet(cliParams, ioStreams, cmdPath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/examples/get.go
+++ b/pkg/cmd/scafctl/examples/get.go
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	exampleslib "github.com/oakwood-commons/scafctl/pkg/examples"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// GetOptions holds options for the examples get command.
+type GetOptions struct {
+	IOStreams *terminal.IOStreams
+	CliParams *settings.Run
+	Path      string
+	Output    string // output file path (empty = stdout)
+}
+
+// CommandGet creates the 'examples get' command.
+func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &GetOptions{}
+
+	cCmd := &cobra.Command{
+		Use:   "get <example-path>",
+		Short: "Get the contents of an example",
+		Long: heredoc.Doc(`
+			Retrieve and display the contents of an example configuration file.
+
+			The example-path is the relative path shown by 'scafctl examples list'.
+
+			Examples:
+			  # Display an example
+			  scafctl examples get solutions/email-notifier/solution.yaml
+
+			  # Save an example to a file
+			  scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
+
+			  # View a provider example
+			  scafctl examples get resolvers/cel-basics.yaml
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+			opts.Path = args[0]
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Write example to file instead of stdout")
+
+	return cCmd
+}
+
+// Run executes the examples get command.
+func (o *GetOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	content, err := exampleslib.Read(o.Path)
+	if err != nil {
+		w.Errorf("Example not found: %s", o.Path)
+		return exitcode.WithCode(fmt.Errorf("failed to read example: %w", err), exitcode.FileNotFound)
+	}
+
+	if o.Output != "" {
+		if err := os.WriteFile(o.Output, []byte(content), 0o600); err != nil {
+			return fmt.Errorf("failed to write to %q: %w", o.Output, err)
+		}
+		w.Successf("Example saved to %s", o.Output)
+		return nil
+	}
+
+	// Write to stdout
+	w.Plain(content)
+	return nil
+}

--- a/pkg/cmd/scafctl/examples/list.go
+++ b/pkg/cmd/scafctl/examples/list.go
@@ -1,0 +1,109 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package examples
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	exampleslib "github.com/oakwood-commons/scafctl/pkg/examples"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// ListOptions holds options for the examples list command.
+type ListOptions struct {
+	IOStreams      *terminal.IOStreams
+	CliParams      *settings.Run
+	KvxOutputFlags flags.KvxOutputFlags
+	Category       string
+}
+
+// CommandList creates the 'examples list' command.
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &ListOptions{}
+
+	cCmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List available example configurations",
+		Long: heredoc.Doc(`
+			List all available scafctl example configurations.
+
+			Examples are organized by category: solutions, resolvers, actions, providers, etc.
+			Use --category to filter by a specific category.
+
+			Examples:
+			  # List all examples
+			  scafctl examples list
+
+			  # Filter by category
+			  scafctl examples list --category solutions
+
+			  # Output as JSON
+			  scafctl examples list -o json
+
+			  # List available categories
+			  scafctl examples list --category ""
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cCmd, &opts.KvxOutputFlags)
+	cCmd.Flags().StringVar(&opts.Category, "category", "", "Filter by category (e.g., solutions, resolvers, actions)")
+
+	return cCmd
+}
+
+// Run executes the examples list command.
+func (o *ListOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	items, err := exampleslib.Scan(o.Category)
+	if err != nil {
+		return err
+	}
+
+	if len(items) == 0 {
+		if o.Category != "" {
+			w.Infof("No examples found in category %q.", o.Category)
+			cats := exampleslib.Categories()
+			if len(cats) > 0 {
+				w.Infof("Available categories: %s", strings.Join(cats, ", "))
+			}
+		} else {
+			w.Infof("No examples available.")
+		}
+		return nil
+	}
+
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
+	return outputOpts.Write(items)
+}

--- a/pkg/cmd/scafctl/explain/results.go
+++ b/pkg/cmd/scafctl/explain/results.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 )
 
 // SolutionExplanation holds structured explanation data for a solution.
@@ -49,21 +50,23 @@ type CatalogInfo struct {
 
 // ResolverInfo holds structured information about a resolver.
 type ResolverInfo struct {
-	Name        string   `json:"name" yaml:"name" doc:"Resolver name"`
-	Providers   []string `json:"providers,omitempty" yaml:"providers,omitempty" doc:"Provider names used"`
-	DependsOn   []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Resolver dependencies"`
-	Conditional bool     `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether resolver has a when condition"`
-	Phases      []string `json:"phases,omitempty" yaml:"phases,omitempty" doc:"Configured phases (resolve, transform, validate)"`
+	Name        string              `json:"name" yaml:"name" doc:"Resolver name"`
+	Providers   []string            `json:"providers,omitempty" yaml:"providers,omitempty" doc:"Provider names used"`
+	DependsOn   []string            `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Resolver dependencies"`
+	Conditional bool                `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether resolver has a when condition"`
+	Phases      []string            `json:"phases,omitempty" yaml:"phases,omitempty" doc:"Configured phases (resolve, transform, validate)"`
+	SourcePos   *sourcepos.Position `json:"sourcePos,omitempty" yaml:"sourcePos,omitempty" doc:"Source file location"`
 }
 
 // ActionInfo holds structured information about an action.
 type ActionInfo struct {
-	Name        string   `json:"name" yaml:"name" doc:"Action name"`
-	Provider    string   `json:"provider" yaml:"provider" doc:"Provider used by this action"`
-	DependsOn   []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Action dependencies"`
-	Conditional bool     `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether action has a when condition"`
-	HasRetry    bool     `json:"hasRetry,omitempty" yaml:"hasRetry,omitempty" doc:"Whether retry is configured"`
-	HasForEach  bool     `json:"hasForEach,omitempty" yaml:"hasForEach,omitempty" doc:"Whether forEach is configured"`
+	Name        string              `json:"name" yaml:"name" doc:"Action name"`
+	Provider    string              `json:"provider" yaml:"provider" doc:"Provider used by this action"`
+	DependsOn   []string            `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Action dependencies"`
+	Conditional bool                `json:"conditional,omitempty" yaml:"conditional,omitempty" doc:"Whether action has a when condition"`
+	HasRetry    bool                `json:"hasRetry,omitempty" yaml:"hasRetry,omitempty" doc:"Whether retry is configured"`
+	HasForEach  bool                `json:"hasForEach,omitempty" yaml:"hasForEach,omitempty" doc:"Whether forEach is configured"`
+	SourcePos   *sourcepos.Position `json:"sourcePos,omitempty" yaml:"sourcePos,omitempty" doc:"Source file location"`
 }
 
 // LinkInfo holds a named link.
@@ -137,14 +140,15 @@ func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation {
 	}
 
 	// Resolvers
+	sm := sol.SourceMap()
 	if sol.Spec.HasResolvers() {
-		exp.Resolvers = buildResolverInfos(sol)
+		exp.Resolvers = buildResolverInfos(sol, sm)
 	}
 
 	// Actions
 	if sol.Spec.HasActions() && sol.Spec.Workflow != nil {
-		exp.Actions = buildActionInfos(sol.Spec.Workflow.Actions)
-		exp.Finally = buildActionInfos(sol.Spec.Workflow.Finally)
+		exp.Actions = buildActionInfos(sol.Spec.Workflow.Actions, sm, "spec.workflow.actions")
+		exp.Finally = buildActionInfos(sol.Spec.Workflow.Finally, sm, "spec.workflow.finally")
 	}
 
 	// Tags
@@ -194,7 +198,7 @@ func LookupProvider(ctx context.Context, name string, reg *provider.Registry) (*
 }
 
 // buildResolverInfos extracts structured resolver information from a solution.
-func buildResolverInfos(sol *solution.Solution) []ResolverInfo {
+func buildResolverInfos(sol *solution.Solution, sm *sourcepos.SourceMap) []ResolverInfo {
 	names := make([]string, 0, len(sol.Spec.Resolvers))
 	for name := range sol.Spec.Resolvers {
 		names = append(names, name)
@@ -215,6 +219,14 @@ func buildResolverInfos(sol *solution.Solution) []ResolverInfo {
 			Conditional: r.When != nil,
 			Phases:      extractPhases(r),
 		}
+
+		// Enrich with source position
+		if sm != nil {
+			if pos, ok := sm.Get("spec.resolvers." + name); ok {
+				info.SourcePos = &pos
+			}
+		}
+
 		infos = append(infos, info)
 	}
 
@@ -222,7 +234,7 @@ func buildResolverInfos(sol *solution.Solution) []ResolverInfo {
 }
 
 // buildActionInfos extracts structured action information.
-func buildActionInfos(actions map[string]*action.Action) []ActionInfo {
+func buildActionInfos(actions map[string]*action.Action, sm *sourcepos.SourceMap, basePath string) []ActionInfo {
 	if len(actions) == 0 {
 		return nil
 	}
@@ -253,6 +265,14 @@ func buildActionInfos(actions map[string]*action.Action) []ActionInfo {
 			HasRetry:    act.Retry != nil,
 			HasForEach:  act.ForEach != nil,
 		}
+
+		// Enrich with source position
+		if sm != nil {
+			if pos, ok := sm.Get(basePath + "." + name); ok {
+				info.SourcePos = &pos
+			}
+		}
+
 		infos = append(infos, info)
 	}
 

--- a/pkg/cmd/scafctl/explain/solution_test.go
+++ b/pkg/cmd/scafctl/explain/solution_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -413,5 +414,97 @@ func TestSolutionOptions_Run_WithMock(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, sol)
 		mockGetter.AssertExpectations(t)
+	})
+}
+
+func TestBuildSolutionExplanation_SourcePositions(t *testing.T) {
+	t.Run("includes source positions when source map is set", func(t *testing.T) {
+		ver := semver.MustParse("1.0.0")
+		sol := &solution.Solution{
+			APIVersion: "scafctl.io/v1",
+			Kind:       "Solution",
+			Metadata: solution.Metadata{
+				Name:    "pos-test",
+				Version: ver,
+			},
+			Spec: solution.Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"greeting": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{Provider: "static"},
+							},
+						},
+					},
+				},
+				Workflow: &action.Workflow{
+					Actions: map[string]*action.Action{
+						"deploy": {
+							Name:     "deploy",
+							Provider: "exec",
+						},
+					},
+					Finally: map[string]*action.Action{
+						"cleanup": {
+							Name:     "cleanup",
+							Provider: "exec",
+						},
+					},
+				},
+			},
+		}
+
+		// Set up source map with positions
+		sm := sourcepos.NewSourceMap()
+		sm.Set("spec.resolvers.greeting", sourcepos.Position{Line: 8, Column: 5, File: "solution.yaml"})
+		sm.Set("spec.workflow.actions.deploy", sourcepos.Position{Line: 15, Column: 7, File: "solution.yaml"})
+		sm.Set("spec.workflow.finally.cleanup", sourcepos.Position{Line: 22, Column: 7, File: "solution.yaml"})
+		sol.SetSourceMap(sm)
+
+		exp := BuildSolutionExplanation(sol)
+
+		// Verify resolver source position
+		require.Len(t, exp.Resolvers, 1)
+		require.NotNil(t, exp.Resolvers[0].SourcePos)
+		assert.Equal(t, 8, exp.Resolvers[0].SourcePos.Line)
+		assert.Equal(t, 5, exp.Resolvers[0].SourcePos.Column)
+		assert.Equal(t, "solution.yaml", exp.Resolvers[0].SourcePos.File)
+
+		// Verify action source position
+		require.Len(t, exp.Actions, 1)
+		require.NotNil(t, exp.Actions[0].SourcePos)
+		assert.Equal(t, 15, exp.Actions[0].SourcePos.Line)
+		assert.Equal(t, 7, exp.Actions[0].SourcePos.Column)
+
+		// Verify finally source position
+		require.Len(t, exp.Finally, 1)
+		require.NotNil(t, exp.Finally[0].SourcePos)
+		assert.Equal(t, 22, exp.Finally[0].SourcePos.Line)
+	})
+
+	t.Run("omits source positions when no source map", func(t *testing.T) {
+		sol := &solution.Solution{
+			APIVersion: "scafctl.io/v1",
+			Kind:       "Solution",
+			Metadata: solution.Metadata{
+				Name: "no-pos",
+			},
+			Spec: solution.Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"data": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{Provider: "static"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		exp := BuildSolutionExplanation(sol)
+
+		require.Len(t, exp.Resolvers, 1)
+		assert.Nil(t, exp.Resolvers[0].SourcePos)
 	})
 }

--- a/pkg/cmd/scafctl/lint/explain_cmd.go
+++ b/pkg/cmd/scafctl/lint/explain_cmd.go
@@ -1,0 +1,121 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// ExplainOptions holds options for the lint explain command.
+type ExplainOptions struct {
+	IOStreams      *terminal.IOStreams
+	CliParams      *settings.Run
+	KvxOutputFlags flags.KvxOutputFlags
+}
+
+// CommandExplainRule creates the 'lint explain' command.
+func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &ExplainOptions{}
+
+	cCmd := &cobra.Command{
+		Use:   "explain <rule-name>",
+		Short: "Explain a specific lint rule in detail",
+		Long: heredoc.Doc(`
+			Show detailed information about a specific lint rule, including
+			its severity, category, description, why it matters, how to fix it,
+			and examples that would trigger it.
+
+			Examples:
+			  # Explain a rule
+			  scafctl lint explain missing-description
+
+			  # Explain with JSON output
+			  scafctl lint explain unknown-provider-input -o json
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx, args[0])
+		},
+		SilenceUsage: true,
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cCmd, &opts.KvxOutputFlags)
+
+	return cCmd
+}
+
+// Run executes the lint explain command.
+func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
+	w := writer.MustFromContext(ctx)
+
+	rule, found := GetRule(ruleName)
+	if !found {
+		err := fmt.Errorf("unknown rule %q; run 'scafctl lint rules' to see available rules", ruleName)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Handle structured output formats
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
+	if kvx.IsStructuredFormat(outputOpts.Format) {
+		return outputOpts.Write(rule)
+	}
+
+	// Table output
+	w.Infof("Rule: %s\n", rule.Rule)
+	w.Plain("")
+	w.Plainf("Severity:    %s\n", rule.Severity)
+	w.Plainf("Category:    %s\n", rule.Category)
+	w.Plainf("Description: %s\n", rule.Description)
+	w.Plain("")
+
+	if rule.Why != "" {
+		w.Infof("Why:")
+		w.Plainf("  %s\n", rule.Why)
+		w.Plain("")
+	}
+
+	if rule.Fix != "" {
+		w.Infof("Fix:")
+		w.Plainf("  %s\n", rule.Fix)
+		w.Plain("")
+	}
+
+	if len(rule.Examples) > 0 {
+		w.Infof("Examples that trigger this rule:")
+		for _, ex := range rule.Examples {
+			w.Plainf("  • %s\n", ex)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -21,17 +21,21 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/schema"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/solution/walk"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -57,6 +61,9 @@ type Finding struct {
 	Message    string        `json:"message" yaml:"message"`
 	Suggestion string        `json:"suggestion,omitempty" yaml:"suggestion,omitempty"`
 	RuleName   string        `json:"ruleName" yaml:"ruleName"`
+	Line       int           `json:"line,omitempty" yaml:"line,omitempty"`
+	Column     int           `json:"column,omitempty" yaml:"column,omitempty"`
+	SourceFile string        `json:"sourceFile,omitempty" yaml:"sourceFile,omitempty"`
 }
 
 // Result contains all lint findings for a solution.
@@ -66,6 +73,9 @@ type Result struct {
 	ErrorCount int        `json:"errorCount" yaml:"errorCount"`
 	WarnCount  int        `json:"warnCount" yaml:"warnCount"`
 	InfoCount  int        `json:"infoCount" yaml:"infoCount"`
+
+	// sourceMap is used internally to enrich findings with source positions.
+	sourceMap *sourcepos.SourceMap `json:"-" yaml:"-"`
 }
 
 // Options holds command flags and settings.
@@ -141,16 +151,22 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (required)")
+	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (required for lint)")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
 	cmd.Flags().StringVar(&options.Severity, "severity", "info", "Minimum severity to report: error, warning, info")
 
-	_ = cmd.MarkFlagRequired("file")
+	lintPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandRules(cliParams, ioStreams, lintPath))
+	cmd.AddCommand(CommandExplainRule(cliParams, ioStreams, lintPath))
 
 	return cmd
 }
 
 func runLint(ctx context.Context, opts *Options) error {
+	if opts.File == "" {
+		return fmt.Errorf("required flag \"file\" not set")
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	// Set up getter with catalog resolver for bare name resolution
@@ -240,6 +256,9 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 		Findings: make([]*Finding, 0),
 	}
 
+	// Capture source map for enriching findings with line/column positions.
+	result.sourceMap = sol.SourceMap()
+
 	// Schema validation: validate the raw YAML against the generated JSON Schema.
 	// This catches unknown fields, type mismatches, pattern violations, etc.
 	lintSchema(filePath, result)
@@ -271,14 +290,32 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 }
 
 func (r *Result) addFinding(severity SeverityLevel, category, location, message, suggestion, rule string) {
-	r.Findings = append(r.Findings, &Finding{
+	f := &Finding{
 		Severity:   severity,
 		Category:   category,
 		Location:   location,
 		Message:    message,
 		Suggestion: suggestion,
 		RuleName:   rule,
-	})
+	}
+
+	// Enrich with source position if a source map is available.
+	// Lint paths omit the "spec." prefix (e.g. "resolvers.foo"), while the
+	// source map records full YAML paths (e.g. "spec.resolvers.foo").
+	// Try the raw location first, then the "spec." prefixed variant.
+	if r.sourceMap != nil {
+		if pos, ok := r.sourceMap.Get(location); ok {
+			f.Line = pos.Line
+			f.Column = pos.Column
+			f.SourceFile = pos.File
+		} else if pos, ok := r.sourceMap.Get("spec." + location); ok {
+			f.Line = pos.Line
+			f.Column = pos.Column
+			f.SourceFile = pos.File
+		}
+	}
+
+	r.Findings = append(r.Findings, f)
 }
 
 func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Registry, referencedResolvers map[string]bool) {
@@ -332,6 +369,69 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				}
 
 				lintExpressions(step.Inputs, stepLocation, result)
+			}
+		}
+
+		// Check for self-references in transform/validate phases.
+		// Using _.resolverName in these phases creates a circular dependency;
+		// the correct idiom is __self.
+		lintResolverSelfReferences(name, res, location, result)
+	}
+}
+
+// lintResolverSelfReferences checks whether a resolver's transform or validate
+// expressions reference their own name via _.resolverName instead of __self.
+func lintResolverSelfReferences(name string, res *resolver.Resolver, location string, result *Result) {
+	// Build the pattern to detect: _.resolverName (with optional field access)
+	selfPattern := "_." + name
+
+	checkInputs := func(inputs map[string]*spec.ValueRef, stepLoc string) {
+		for _, val := range inputs {
+			if val == nil {
+				continue
+			}
+			if val.Expr != nil && strings.Contains(string(*val.Expr), selfPattern) {
+				result.addFinding(SeverityError, "expression", stepLoc,
+					fmt.Sprintf("resolver '%s' references itself via _.%s in an expression; use __self instead", name, name),
+					fmt.Sprintf("Replace _.%s with __self in the expression to avoid a circular dependency", name),
+					"resolver-self-reference")
+			}
+			if val.Tmpl != nil && strings.Contains(string(*val.Tmpl), selfPattern) {
+				result.addFinding(SeverityError, "expression", stepLoc,
+					fmt.Sprintf("resolver '%s' references itself via _.%s in a template; use __self instead", name, name),
+					fmt.Sprintf("Replace _.%s with __self in the template to avoid a circular dependency", name),
+					"resolver-self-reference")
+			}
+		}
+	}
+
+	if res.Transform != nil {
+		for i, step := range res.Transform.With {
+			stepLoc := fmt.Sprintf("%s.transform.with[%d]", location, i)
+			checkInputs(step.Inputs, stepLoc)
+		}
+	}
+
+	if res.Validate != nil {
+		for i, step := range res.Validate.With {
+			stepLoc := fmt.Sprintf("%s.validate.with[%d]", location, i)
+			checkInputs(step.Inputs, stepLoc)
+			// Also check the message field which can be a ValueRef
+			if step.Message != nil {
+				if step.Message.Expr != nil && strings.Contains(string(*step.Message.Expr), selfPattern) {
+					msgLoc := fmt.Sprintf("%s.validate.with[%d].message", location, i)
+					result.addFinding(SeverityError, "expression", msgLoc,
+						fmt.Sprintf("resolver '%s' references itself via _.%s in message; use __self instead", name, name),
+						fmt.Sprintf("Replace _.%s with __self in the message expression", name),
+						"resolver-self-reference")
+				}
+				if step.Message.Tmpl != nil && strings.Contains(string(*step.Message.Tmpl), selfPattern) {
+					msgLoc := fmt.Sprintf("%s.validate.with[%d].message", location, i)
+					result.addFinding(SeverityError, "expression", msgLoc,
+						fmt.Sprintf("resolver '%s' references itself via _.%s in message template; use __self instead", name, name),
+						fmt.Sprintf("Replace _.%s with __self in the message template", name),
+						"resolver-self-reference")
+				}
 			}
 		}
 	}
@@ -559,53 +659,29 @@ func collectReferencedResolvers(sol *solution.Solution) map[string]bool {
 
 	resolverRefPattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)|__resolvers\.([a-zA-Z_][a-zA-Z0-9_]*)`)
 
-	for _, res := range sol.Spec.Resolvers {
-		if res.Resolve == nil {
-			continue
-		}
-		for _, step := range res.Resolve.With {
-			scanInputsForResolverRefs(step.Inputs, resolverRefPattern, refs)
-		}
-	}
-
-	if sol.Spec.Workflow != nil {
-		for _, act := range sol.Spec.Workflow.Actions {
-			scanInputsForResolverRefs(act.Inputs, resolverRefPattern, refs)
-			if act.When != nil && act.When.Expr != nil {
-				scanExpressionForResolverRefs(string(*act.When.Expr), resolverRefPattern, refs)
+	_ = walk.Walk(sol, &walk.Visitor{
+		ValueRef: func(_ string, vr *spec.ValueRef) error {
+			if vr.Resolver != nil {
+				refs[*vr.Resolver] = true
 			}
-		}
-		for _, act := range sol.Spec.Workflow.Finally {
-			scanInputsForResolverRefs(act.Inputs, resolverRefPattern, refs)
-			if act.When != nil && act.When.Expr != nil {
-				scanExpressionForResolverRefs(string(*act.When.Expr), resolverRefPattern, refs)
+			if vr.Expr != nil {
+				scanExpressionForResolverRefs(string(*vr.Expr), resolverRefPattern, refs)
 			}
-		}
-	}
+			if vr.Tmpl != nil {
+				scanExpressionForResolverRefs(string(*vr.Tmpl), resolverRefPattern, refs)
+			}
+			if vr.Literal != nil {
+				scanLiteralForResolverRefs(vr.Literal, resolverRefPattern, refs)
+			}
+			return nil
+		},
+		Condition: func(_, _ string, expr *celexp.Expression) error {
+			scanExpressionForResolverRefs(string(*expr), resolverRefPattern, refs)
+			return nil
+		},
+	})
 
 	return refs
-}
-
-func scanInputsForResolverRefs(inputs map[string]*spec.ValueRef, pattern *regexp.Regexp, refs map[string]bool) {
-	for _, val := range inputs {
-		if val == nil {
-			continue
-		}
-		// Direct resolver reference: rslvr: resolverName
-		if val.Resolver != nil {
-			refs[*val.Resolver] = true
-		}
-		if val.Expr != nil {
-			scanExpressionForResolverRefs(string(*val.Expr), pattern, refs)
-		}
-		if val.Tmpl != nil {
-			scanExpressionForResolverRefs(string(*val.Tmpl), pattern, refs)
-		}
-		// Recurse into literal map values to find nested rslvr/expr/tmpl references
-		if val.Literal != nil {
-			scanLiteralForResolverRefs(val.Literal, pattern, refs)
-		}
-	}
 }
 
 // scanLiteralForResolverRefs scans literal values (maps, slices) for nested
@@ -770,39 +846,24 @@ func lintSchema(filePath string, result *Result) {
 // Expression, template, and resolver-reference values are silently skipped
 // because they can only be validated at runtime.
 func lintProviderInputs(sol *solution.Solution, result *Result, registry *provider.Registry) {
-	// Lint resolver inputs
-	for name, res := range sol.Spec.Resolvers {
-		if res.Resolve != nil {
-			for i, step := range res.Resolve.With {
-				location := fmt.Sprintf("resolvers.%s.resolve.with[%d]", name, i)
-				lintProviderInputsForStep(step.Provider, step.Inputs, location, result, registry)
-			}
-		}
-		if res.Transform != nil {
-			for i, step := range res.Transform.With {
-				location := fmt.Sprintf("resolvers.%s.transform.with[%d]", name, i)
-				lintProviderInputsForStep(step.Provider, step.Inputs, location, result, registry)
-			}
-		}
-		if res.Validate != nil {
-			for i, step := range res.Validate.With {
-				location := fmt.Sprintf("resolvers.%s.validate.with[%d]", name, i)
-				lintProviderInputsForStep(step.Provider, step.Inputs, location, result, registry)
-			}
-		}
-	}
-
-	// Lint workflow action inputs
-	if sol.Spec.Workflow != nil {
-		for name, act := range sol.Spec.Workflow.Actions {
-			location := fmt.Sprintf("workflow.actions.%s", name)
-			lintProviderInputsForStep(act.Provider, act.Inputs, location, result, registry)
-		}
-		for name, act := range sol.Spec.Workflow.Finally {
-			location := fmt.Sprintf("workflow.finally.%s", name)
-			lintProviderInputsForStep(act.Provider, act.Inputs, location, result, registry)
-		}
-	}
+	_ = walk.Walk(sol, &walk.Visitor{
+		ProviderSource: func(path string, ps *resolver.ProviderSource) error {
+			lintProviderInputsForStep(ps.Provider, ps.Inputs, strings.TrimPrefix(path, "spec."), result, registry)
+			return nil
+		},
+		ProviderTransform: func(path string, pt *resolver.ProviderTransform) error {
+			lintProviderInputsForStep(pt.Provider, pt.Inputs, strings.TrimPrefix(path, "spec."), result, registry)
+			return nil
+		},
+		ProviderValidation: func(path string, pv *resolver.ProviderValidation) error {
+			lintProviderInputsForStep(pv.Provider, pv.Inputs, strings.TrimPrefix(path, "spec."), result, registry)
+			return nil
+		},
+		Action: func(path, _, _ string, act *action.Action) error {
+			lintProviderInputsForStep(act.Provider, act.Inputs, strings.TrimPrefix(path, "spec."), result, registry)
+			return nil
+		},
+	})
 }
 
 // lintProviderInputsForStep validates inputs for a single provider step.

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -5,7 +5,6 @@ package lint
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -286,74 +285,255 @@ func TestLintProviderInputs_MissingProviderSkipped(t *testing.T) {
 	}
 }
 
-func TestScanInputsForResolverRefs_DirectRslvr(t *testing.T) {
-	refs := make(map[string]bool)
-	pattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-
+func TestCollectReferencedResolvers_DirectRslvr(t *testing.T) {
 	resolverName := "myResolver"
-	inputs := map[string]*spec.ValueRef{
-		"field": {Resolver: &resolverName},
-	}
-
-	scanInputsForResolverRefs(inputs, pattern, refs)
-	assert.True(t, refs["myResolver"], "should detect direct rslvr reference")
-}
-
-func TestScanInputsForResolverRefs_NestedRslvrInLiteral(t *testing.T) {
-	refs := make(map[string]bool)
-	pattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-
-	// Simulates: value: { body: { rslvr: "emailBody" } }
-	inputs := map[string]*spec.ValueRef{
-		"value": {
-			Literal: map[string]any{
-				"body": map[string]any{
-					"rslvr": "emailBody",
-				},
-				"subject": map[string]any{
-					"rslvr": "emailSubject",
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"source": {
+					Name: "source",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"field": {Resolver: &resolverName},
+							},
+						}},
+					},
 				},
 			},
 		},
 	}
 
-	scanInputsForResolverRefs(inputs, pattern, refs)
+	refs := collectReferencedResolvers(sol)
+	assert.True(t, refs["myResolver"], "should detect direct rslvr reference")
+}
+
+func TestCollectReferencedResolvers_NestedRslvrInLiteral(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"source": {
+					Name: "source",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"value": {
+									Literal: map[string]any{
+										"body": map[string]any{
+											"rslvr": "emailBody",
+										},
+										"subject": map[string]any{
+											"rslvr": "emailSubject",
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	refs := collectReferencedResolvers(sol)
 	assert.True(t, refs["emailBody"], "should detect nested rslvr in literal map")
 	assert.True(t, refs["emailSubject"], "should detect nested rslvr in literal map")
 }
 
-func TestScanInputsForResolverRefs_NestedExprInLiteral(t *testing.T) {
-	refs := make(map[string]bool)
-	pattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-
-	// Simulates: value: { ts: { expr: "_.timestamp" } }
-	inputs := map[string]*spec.ValueRef{
-		"value": {
-			Literal: map[string]any{
-				"ts": map[string]any{
-					"expr": "string(_.timestamp)",
+func TestCollectReferencedResolvers_NestedExprInLiteral(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"source": {
+					Name: "source",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"value": {
+									Literal: map[string]any{
+										"ts": map[string]any{
+											"expr": "string(_.timestamp)",
+										},
+									},
+								},
+							},
+						}},
+					},
 				},
 			},
 		},
 	}
 
-	scanInputsForResolverRefs(inputs, pattern, refs)
+	refs := collectReferencedResolvers(sol)
 	assert.True(t, refs["timestamp"], "should detect resolver ref in nested expr")
 }
 
-func TestScanInputsForResolverRefs_NestedInArray(t *testing.T) {
-	refs := make(map[string]bool)
-	pattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-
-	// Simulates: args: [ { rslvr: "env" } ]
-	inputs := map[string]*spec.ValueRef{
-		"args": {
-			Literal: []any{
-				map[string]any{"rslvr": "env"},
+func TestCollectReferencedResolvers_NestedInArray(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"source": {
+					Name: "source",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"args": {
+									Literal: []any{
+										map[string]any{"rslvr": "env"},
+									},
+								},
+							},
+						}},
+					},
+				},
 			},
 		},
 	}
 
-	scanInputsForResolverRefs(inputs, pattern, refs)
+	refs := collectReferencedResolvers(sol)
 	assert.True(t, refs["env"], "should detect rslvr inside array elements")
+}
+
+func TestLintResolverSelfReferences(t *testing.T) {
+	validationProv := newFakeProvider("validation", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	celProv := newFakeProvider("cel", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+
+	reg := provider.NewRegistry()
+	_ = reg.Register(validationProv)
+	_ = reg.Register(celProv)
+	_ = reg.Register(staticProv)
+
+	selfExpr := celexp.Expression("_.publicSiteCheck.statusCode == 200")
+	correctExpr := celexp.Expression("__self.statusCode == 200")
+	otherExpr := celexp.Expression("_.otherResolver.value == 'ok'")
+
+	tests := []struct {
+		name          string
+		resolverName  string
+		resolver      *resolver.Resolver
+		expectFinding bool
+		findingRule   string
+	}{
+		{
+			name:         "validate self-reference via _.name triggers finding",
+			resolverName: "publicSiteCheck",
+			resolver: &resolver.Resolver{
+				Type: "object",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "test"}}}},
+				},
+				Validate: &resolver.ValidatePhase{
+					With: []resolver.ProviderValidation{{
+						Provider: "validation",
+						Inputs:   map[string]*spec.ValueRef{"expression": {Expr: &selfExpr}},
+					}},
+				},
+			},
+			expectFinding: true,
+			findingRule:   "resolver-self-reference",
+		},
+		{
+			name:         "validate using __self is clean",
+			resolverName: "publicSiteCheck",
+			resolver: &resolver.Resolver{
+				Type: "object",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "test"}}}},
+				},
+				Validate: &resolver.ValidatePhase{
+					With: []resolver.ProviderValidation{{
+						Provider: "validation",
+						Inputs:   map[string]*spec.ValueRef{"expression": {Expr: &correctExpr}},
+					}},
+				},
+			},
+			expectFinding: false,
+		},
+		{
+			name:         "validate referencing other resolver is fine",
+			resolverName: "publicSiteCheck",
+			resolver: &resolver.Resolver{
+				Type: "object",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "test"}}}},
+				},
+				Validate: &resolver.ValidatePhase{
+					With: []resolver.ProviderValidation{{
+						Provider: "validation",
+						Inputs:   map[string]*spec.ValueRef{"expression": {Expr: &otherExpr}},
+					}},
+				},
+			},
+			expectFinding: false,
+		},
+		{
+			name:         "transform self-reference via _.name triggers finding",
+			resolverName: "myValue",
+			resolver: &resolver.Resolver{
+				Type: "string",
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "test"}}}},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{{
+						Provider: "cel",
+						Inputs:   map[string]*spec.ValueRef{"expression": {Expr: exprPtr("_.myValue + '-suffix'")}},
+					}},
+				},
+			},
+			expectFinding: true,
+			findingRule:   "resolver-self-reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sol := &solution.Solution{
+				Spec: solution.Spec{
+					Resolvers: map[string]*resolver.Resolver{
+						tt.resolverName: tt.resolver,
+					},
+				},
+			}
+
+			result := Solution(sol, "test.yaml", reg)
+
+			selfRefFindings := filterFindingsByRule(result, tt.findingRule)
+			if tt.expectFinding {
+				require.NotEmpty(t, selfRefFindings, "expected resolver-self-reference finding")
+				assert.Contains(t, selfRefFindings[0].Message, tt.resolverName)
+			} else {
+				assert.Empty(t, selfRefFindings, "expected no resolver-self-reference finding")
+			}
+		})
+	}
+}
+
+func exprPtr(s string) *celexp.Expression {
+	e := celexp.Expression(s)
+	return &e
+}
+
+func filterFindingsByRule(result *Result, rule string) []*Finding {
+	if rule == "" {
+		return nil
+	}
+	var out []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == rule {
+			out = append(out, f)
+		}
+	}
+	return out
 }

--- a/pkg/cmd/scafctl/lint/rules.go
+++ b/pkg/cmd/scafctl/lint/rules.go
@@ -1,0 +1,267 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import "sort"
+
+// RuleMeta describes a single lint rule, including its severity, category,
+// and human-readable guidance.  This is the authoritative source of truth
+// for lint rule metadata — both the linter and the MCP server derive
+// their knowledge from this registry.
+type RuleMeta struct {
+	// Rule is the kebab-case rule identifier used in Finding.RuleName.
+	Rule string `json:"rule"`
+
+	// Severity is one of "error", "warning", or "info".
+	Severity string `json:"severity"`
+
+	// Category groups related rules (e.g. "structure", "naming", "provider").
+	Category string `json:"category"`
+
+	// Description is a short summary of what the rule checks.
+	Description string `json:"description"`
+
+	// Why explains the rationale for the rule.
+	Why string `json:"why"`
+
+	// Fix gives concrete instructions for resolving a finding.
+	Fix string `json:"fix"`
+
+	// Examples optionally provide sample YAML or commands.
+	Examples []string `json:"examples,omitempty"`
+}
+
+// KnownRules is the canonical registry of all lint rules.
+// Every addFinding call in lint.go MUST use a key from this map.
+var KnownRules = map[string]RuleMeta{
+	"empty-solution": {
+		Rule:        "empty-solution",
+		Severity:    string(SeverityError),
+		Category:    "structure",
+		Description: "The solution has no resolvers defined under spec.resolvers and no workflow defined under spec.workflow.",
+		Why:         "A solution must have at least resolvers or a workflow to be useful. Without either, there's nothing to execute.",
+		Fix:         "Add at least one resolver under spec.resolvers or define a workflow with actions under spec.workflow.actions.",
+		Examples: []string{
+			"spec:\n  resolvers:\n    greeting:\n      type: string\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: Hello World",
+		},
+	},
+	"reserved-name": {
+		Rule:        "reserved-name",
+		Severity:    string(SeverityError),
+		Category:    "naming",
+		Description: "A resolver uses a reserved name that conflicts with built-in variables.",
+		Why:         "Names like '__actions', '__error', '__item', '__index', and '_' are reserved for internal use in CEL expressions and forEach iterations.",
+		Fix:         "Rename the resolver to avoid reserved names. Use descriptive names like 'user-input' or 'api-response' instead.",
+		Examples:    []string{"Reserved names: __actions, __error, __item, __index, _"},
+	},
+	"unused-resolver": {
+		Rule:        "unused-resolver",
+		Severity:    string(SeverityWarning),
+		Category:    "usage",
+		Description: "A resolver is defined but never referenced by any other resolver, action input, when clause, or expression.",
+		Why:         "Unused resolvers add complexity without benefit. They may indicate a typo in a reference or leftover code from refactoring.",
+		Fix:         "Either remove the unused resolver, reference it in an action input (rslvr: resolver-name), use it in a CEL expression (_.resolver_name), or add it as a dependency (dependsOn).",
+	},
+	"missing-provider": {
+		Rule:        "missing-provider",
+		Severity:    string(SeverityError),
+		Category:    "provider",
+		Description: "A resolver step or action references a provider name that is not registered in the provider registry.",
+		Why:         "The solution cannot execute if it references providers that don't exist. This usually indicates a typo in the provider name.",
+		Fix:         "Use list_providers to see all available provider names. Common providers: static, parameter, env, http, cel, file, exec, directory, go-template, validation.",
+	},
+	"invalid-expression": {
+		Rule:        "invalid-expression",
+		Severity:    string(SeverityError),
+		Category:    "expression",
+		Description: "A CEL expression (in a 'when' clause or 'expr' input) has a syntax error and cannot be parsed.",
+		Why:         "Invalid CEL expressions will cause runtime failures. Common issues include missing quotes around strings, unbalanced parentheses, and using unknown functions.",
+		Fix:         "Use validate_expression with type 'cel' to check the expression syntax. Use list_cel_functions to see available functions. Use evaluate_cel to test the expression with sample data.",
+	},
+	"invalid-template": {
+		Rule:        "invalid-template",
+		Severity:    string(SeverityError),
+		Category:    "template",
+		Description: "A Go template (in a 'tmpl' input) has a syntax error and cannot be parsed.",
+		Why:         "Invalid Go templates will cause runtime failures. Common issues include unclosed actions (missing '}}'), unclosed control blocks (if/range/with without end), and unknown functions.",
+		Fix:         "Use validate_expression with type 'go-template' to check the template syntax. Use evaluate_go_template to test the template with sample data.",
+	},
+	"invalid-dependency": {
+		Rule:        "invalid-dependency",
+		Severity:    string(SeverityError),
+		Category:    "dependency",
+		Description: "An action's dependsOn references an action name that does not exist in the workflow.",
+		Why:         "Actions with invalid dependencies cannot be scheduled for execution. This usually indicates a typo in the action name.",
+		Fix:         "Check the action names in spec.workflow.actions and ensure all dependsOn references match exactly. Names are case-sensitive.",
+	},
+	"empty-workflow": {
+		Rule:        "empty-workflow",
+		Severity:    string(SeverityWarning),
+		Category:    "structure",
+		Description: "A workflow section is defined (spec.workflow) but contains no actions.",
+		Why:         "An empty workflow serves no purpose. If you only need resolvers, remove the workflow section entirely.",
+		Fix:         "Either add actions under spec.workflow.actions or remove spec.workflow entirely if you only need resolvers.",
+	},
+	"finally-with-foreach": {
+		Rule:        "finally-with-foreach",
+		Severity:    string(SeverityError),
+		Category:    "validation",
+		Description: "An action in the spec.workflow.finally section uses forEach, which is not supported.",
+		Why:         "Finally actions are cleanup/teardown steps that must run reliably. forEach adds complexity and potential failure points that could prevent cleanup from completing.",
+		Fix:         "Remove the forEach from the finally action. If you need to iterate during cleanup, move the action to spec.workflow.actions and handle cleanup differently.",
+	},
+	"workflow-validation": {
+		Rule:        "workflow-validation",
+		Severity:    string(SeverityError),
+		Category:    "validation",
+		Description: "The workflow has structural validation errors such as circular dependencies between actions.",
+		Why:         "Circular dependencies create infinite loops that prevent the workflow from completing. The dependency graph must be a DAG (directed acyclic graph).",
+		Fix:         "Use render_solution with graph_type 'action-deps' to visualize the dependency graph. Break cycles by reordering dependencies or removing unnecessary dependsOn references.",
+	},
+	"schema-violation": {
+		Rule:        "schema-violation",
+		Severity:    string(SeverityError),
+		Category:    "schema",
+		Description: "The solution YAML violates the JSON Schema definition. This includes unknown fields, type mismatches, pattern violations, and constraint violations.",
+		Why:         "Schema violations indicate the YAML structure doesn't match what scafctl expects. This will cause parsing errors or unexpected behavior.",
+		Fix:         "Use get_solution_schema to see the expected schema. Common issues: unknown field names (typos), wrong types (string vs int), invalid metadata.name pattern (must be lowercase with hyphens, 3-60 chars).",
+	},
+	"unknown-provider-input": {
+		Rule:        "unknown-provider-input",
+		Severity:    string(SeverityError),
+		Category:    "provider",
+		Description: "An input key passed to a provider is not declared in that provider's input schema.",
+		Why:         "Unknown inputs are silently ignored, which usually indicates a typo. The intended field won't receive its value.",
+		Fix:         "Use get_provider_schema with the provider name to see all valid input field names. For example, the exec provider requires 'command' (not 'cmd').",
+	},
+	"invalid-provider-input-type": {
+		Rule:        "invalid-provider-input-type",
+		Severity:    string(SeverityError),
+		Category:    "provider",
+		Description: "A literal input value doesn't match the type expected by the provider's schema (e.g., passing a string where an integer is required).",
+		Why:         "Type mismatches cause runtime errors. The provider expects a specific type and will fail to process the wrong type.",
+		Fix:         "Use get_provider_schema to check the expected type for each input. Ensure literal values match (e.g., use '42' not 'forty-two' for integer fields).",
+	},
+	"invalid-test-name": {
+		Rule:        "invalid-test-name",
+		Severity:    string(SeverityError),
+		Category:    "naming",
+		Description: "A test case name doesn't match the required naming pattern (lowercase with hyphens).",
+		Why:         "Test names must be lowercase with hyphens (e.g., 'my-test-case') for consistency and to work correctly with filtering.",
+		Fix:         "Rename the test to use only lowercase letters, numbers, and hyphens. Avoid spaces, underscores, and uppercase letters.",
+	},
+	"unbundled-test-file": {
+		Rule:        "unbundled-test-file",
+		Severity:    string(SeverityError),
+		Category:    "bundling",
+		Description: "A test case references a file that is not covered by the solution's bundle.include patterns.",
+		Why:         "When the solution is published to the catalog, unbundled files won't be included, causing test failures.",
+		Fix:         "Add the file path or a glob pattern to bundle.include that covers the test file. Example: bundle:\n  include:\n    - 'tests/**'",
+	},
+	"unused-template": {
+		Rule:        "unused-template",
+		Severity:    string(SeverityWarning),
+		Category:    "usage",
+		Description: "A test template (name starting with '_') is defined but not referenced by any test case via 'extends'.",
+		Why:         "Unused test templates add unnecessary complexity. They may indicate a typo in an extends reference.",
+		Fix:         "Either remove the unused template or reference it from a test case using 'extends: _template-name'.",
+	},
+	"missing-description": {
+		Rule:        "missing-description",
+		Severity:    string(SeverityInfo),
+		Category:    "documentation",
+		Description: "A resolver or action does not have a description field.",
+		Why:         "Descriptions help others understand what each resolver/action does. They appear in inspect_solution output and documentation.",
+		Fix:         "Add a description field: description: \"Brief explanation of what this does\"",
+	},
+	"long-timeout": {
+		Rule:        "long-timeout",
+		Severity:    string(SeverityInfo),
+		Category:    "performance",
+		Description: "An action has a timeout exceeding 10 minutes.",
+		Why:         "Very long timeouts may indicate a misconfiguration or an action that should be broken into smaller steps. They also delay failure detection.",
+		Fix:         "Consider reducing the timeout or breaking the action into smaller steps. If the long timeout is intentional, this is just an informational notice.",
+	},
+	"unused-finally": {
+		Rule:        "unused-finally",
+		Severity:    string(SeverityInfo),
+		Category:    "structure",
+		Description: "A finally section is defined but there are no regular actions in the workflow.",
+		Why:         "Finally actions are cleanup steps that run after regular actions. Without regular actions, there's nothing to clean up after.",
+		Fix:         "Either add regular actions under spec.workflow.actions or remove the spec.workflow.finally section.",
+	},
+	"permissive-result-schema": {
+		Rule:        "permissive-result-schema",
+		Severity:    string(SeverityInfo),
+		Category:    "schema",
+		Description: "An action's resultSchema is defined but doesn't specify a type, making it accept any value.",
+		Why:         "A result schema without a type constraint doesn't provide meaningful validation of action output.",
+		Fix:         "Add a 'type' field to the resultSchema: resultSchema:\n  type: object\n  properties:\n    status:\n      type: string",
+	},
+	"invalid-result-schema": {
+		Rule:        "invalid-result-schema",
+		Severity:    string(SeverityError),
+		Category:    "schema",
+		Description: "An action's resultSchema is not a valid JSON Schema definition.",
+		Why:         "Invalid result schemas cannot be used to validate action outputs, causing runtime errors.",
+		Fix:         "Ensure the resultSchema follows JSON Schema syntax. Use get_solution_schema to see the expected format.",
+	},
+	"undefined-required-property": {
+		Rule:        "undefined-required-property",
+		Severity:    string(SeverityError),
+		Category:    "schema",
+		Description: "A resultSchema lists a property in 'required' that is not defined in 'properties'.",
+		Why:         "Requiring a property that isn't defined means the validation will always fail for that property.",
+		Fix:         "Either add the missing property to 'properties' or remove it from the 'required' list.",
+	},
+	"schema-error": {
+		Rule:        "schema-error",
+		Severity:    string(SeverityWarning),
+		Category:    "schema",
+		Description: "Schema validation could not be performed (schema generation failed).",
+		Why:         "This is an internal issue that prevents full validation. The solution may still work but hasn't been fully checked.",
+		Fix:         "This usually resolves itself. If persistent, check that the solution YAML is well-formed (valid YAML syntax).",
+	},
+	"resolver-self-reference": {
+		Rule:        "resolver-self-reference",
+		Severity:    string(SeverityError),
+		Category:    "expression",
+		Description: "A resolver's validate or transform phase references its own name via _.resolverName instead of using __self.",
+		Why:         "Using _.resolverName in a transform or validate expression creates a circular dependency, because the dependency graph interprets it as the resolver depending on itself. Use __self to access the resolver's current value in these phases.",
+		Fix:         "Replace _.resolverName with __self in the expression. For example, change '_.myResolver.statusCode == 200' to '__self.statusCode == 200'.",
+		Examples: []string{
+			"# Wrong (causes cycle):\nvalidate:\n  with:\n    - provider: validation\n      inputs:\n        expression: \"_.myResolver.statusCode == 200\"\n\n# Correct:\nvalidate:\n  with:\n    - provider: validation\n      inputs:\n        expression: \"__self.statusCode == 200\"",
+		},
+	},
+}
+
+// ListRules returns all known lint rules sorted by severity (error > warning > info)
+// then alphabetically by rule name.
+func ListRules() []RuleMeta {
+	rules := make([]RuleMeta, 0, len(KnownRules))
+	for _, r := range KnownRules {
+		rules = append(rules, r)
+	}
+
+	severityOrder := map[string]int{
+		string(SeverityError):   0,
+		string(SeverityWarning): 1,
+		string(SeverityInfo):    2,
+	}
+	sort.Slice(rules, func(i, j int) bool {
+		si, sj := severityOrder[rules[i].Severity], severityOrder[rules[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		return rules[i].Rule < rules[j].Rule
+	})
+
+	return rules
+}
+
+// GetRule looks up a rule by name. Returns the RuleMeta and true if found.
+func GetRule(name string) (RuleMeta, bool) {
+	r, ok := KnownRules[name]
+	return r, ok
+}

--- a/pkg/cmd/scafctl/lint/rules_cmd.go
+++ b/pkg/cmd/scafctl/lint/rules_cmd.go
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// RulesOptions holds options for the lint rules command.
+type RulesOptions struct {
+	IOStreams      *terminal.IOStreams
+	CliParams      *settings.Run
+	KvxOutputFlags flags.KvxOutputFlags
+	Severity       string
+	Category       string
+}
+
+// CommandRules creates the 'lint rules' command.
+func CommandRules(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &RulesOptions{}
+
+	cCmd := &cobra.Command{
+		Use:     "rules",
+		Aliases: []string{"r"},
+		Short:   "List all available lint rules",
+		Long: heredoc.Doc(`
+			List all lint rules that scafctl checks for when linting solutions.
+
+			Rules are grouped by severity (error, warning, info) and category.
+			Use --severity and --category to filter the list.
+
+			Examples:
+			  # List all rules
+			  scafctl lint rules
+
+			  # Show only error-level rules
+			  scafctl lint rules --severity error
+
+			  # Filter by category
+			  scafctl lint rules --category naming
+
+			  # Output as JSON for tooling
+			  scafctl lint rules -o json
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cCmd, &opts.KvxOutputFlags)
+	cCmd.Flags().StringVar(&opts.Severity, "severity", "", "Filter by severity: error, warning, info")
+	cCmd.Flags().StringVar(&opts.Category, "category", "", "Filter by category")
+
+	return cCmd
+}
+
+// Run executes the lint rules command.
+func (o *RulesOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	rules := ListRules()
+
+	// Filter by severity
+	if o.Severity != "" {
+		severity := strings.ToLower(o.Severity)
+		filtered := make([]RuleMeta, 0, len(rules))
+		for _, r := range rules {
+			if strings.EqualFold(r.Severity, severity) {
+				filtered = append(filtered, r)
+			}
+		}
+		rules = filtered
+	}
+
+	// Filter by category
+	if o.Category != "" {
+		category := strings.ToLower(o.Category)
+		filtered := make([]RuleMeta, 0, len(rules))
+		for _, r := range rules {
+			if strings.EqualFold(r.Category, category) {
+				filtered = append(filtered, r)
+			}
+		}
+		rules = filtered
+	}
+
+	// Handle structured output formats
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
+	if kvx.IsStructuredFormat(outputOpts.Format) {
+		return outputOpts.Write(rules)
+	}
+
+	// Table output
+	if len(rules) == 0 {
+		w.Infof("No rules match the specified filters.")
+		return nil
+	}
+
+	// Find max lengths for alignment
+	maxRule := 0
+	maxSev := 0
+	maxCat := 0
+	for _, r := range rules {
+		if len(r.Rule) > maxRule {
+			maxRule = len(r.Rule)
+		}
+		if len(r.Severity) > maxSev {
+			maxSev = len(r.Severity)
+		}
+		if len(r.Category) > maxCat {
+			maxCat = len(r.Category)
+		}
+	}
+
+	w.Infof("Lint Rules (%d)\n", len(rules))
+	w.Plain("")
+	w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, "RULE", maxSev, "SEVERITY", maxCat, "CATEGORY", "DESCRIPTION")
+	w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, strings.Repeat("─", maxRule), maxSev, strings.Repeat("─", maxSev), maxCat, strings.Repeat("─", maxCat), strings.Repeat("─", 40))
+
+	for _, r := range rules {
+		w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, r.Rule, maxSev, r.Severity, maxCat, r.Category, r.Description)
+	}
+
+	return nil
+}

--- a/pkg/cmd/scafctl/lint/rules_test.go
+++ b/pkg/cmd/scafctl/lint/rules_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnownRulesHaveRequiredFields(t *testing.T) {
+	for name, rule := range KnownRules {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, name, rule.Rule, "map key must match Rule field")
+			assert.NotEmpty(t, rule.Severity, "Severity required")
+			assert.NotEmpty(t, rule.Category, "Category required")
+			assert.NotEmpty(t, rule.Description, "Description required")
+			assert.NotEmpty(t, rule.Why, "Why required")
+			assert.NotEmpty(t, rule.Fix, "Fix required")
+
+			// Severity must be valid
+			validSeverity := map[string]bool{
+				string(SeverityError):   true,
+				string(SeverityWarning): true,
+				string(SeverityInfo):    true,
+			}
+			assert.True(t, validSeverity[rule.Severity], "invalid severity %q for rule %q", rule.Severity, name)
+		})
+	}
+}
+
+func TestKnownRulesCount(t *testing.T) {
+	// We expect exactly 24 rules — update this when new rules are added
+	assert.Equal(t, 24, len(KnownRules), "expected 24 known lint rules")
+}
+
+func TestListRules(t *testing.T) {
+	rules := ListRules()
+	require.Equal(t, len(KnownRules), len(rules))
+
+	// Verify sorted by severity then name
+	severityOrder := map[string]int{
+		string(SeverityError):   0,
+		string(SeverityWarning): 1,
+		string(SeverityInfo):    2,
+	}
+
+	for i := 1; i < len(rules); i++ {
+		prev := rules[i-1]
+		curr := rules[i]
+		prevOrd := severityOrder[prev.Severity]
+		currOrd := severityOrder[curr.Severity]
+		if prevOrd == currOrd {
+			assert.LessOrEqual(t, prev.Rule, curr.Rule, "rules within same severity should be alphabetical")
+		} else {
+			assert.Less(t, prevOrd, currOrd, "errors before warnings before info")
+		}
+	}
+}
+
+func TestGetRule(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		rule, ok := GetRule("empty-solution")
+		assert.True(t, ok)
+		assert.Equal(t, "empty-solution", rule.Rule)
+		assert.Equal(t, string(SeverityError), rule.Severity)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := GetRule("nonexistent-rule")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -21,11 +22,14 @@ import (
 
 // ServeOptions holds the options for the serve command.
 type ServeOptions struct {
-	Transport string
-	LogFile   string
-	Info      bool
-	CliParams *settings.Run
-	IOStreams *terminal.IOStreams
+	Transport      string
+	Addr           string
+	LogFile        string
+	Info           bool
+	WorkerPoolSize int
+	QueueSize      int
+	CliParams      *settings.Run
+	IOStreams      *terminal.IOStreams
 }
 
 // CommandServe creates the `scafctl mcp serve` command.
@@ -42,7 +46,11 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			Start the Model Context Protocol (MCP) server for AI agent integration.
 
 			The MCP server exposes scafctl capabilities as tools that AI agents can discover
-			and invoke programmatically. It communicates over stdio (JSON-RPC 2.0) by default.
+			and invoke programmatically. It supports multiple transport protocols:
+
+			  - stdio: JSON-RPC 2.0 over stdin/stdout (default)
+			  - sse: Server-Sent Events over HTTP
+			  - http: Streamable HTTP transport
 
 			Example VS Code configuration (.vscode/mcp.json):
 
@@ -64,11 +72,20 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			# Start the MCP server (stdio transport)
 			scafctl mcp serve
 
+			# Start with SSE transport on port 8080
+			scafctl mcp serve --transport sse --addr :8080
+
+			# Start with streamable HTTP transport
+			scafctl mcp serve --transport http --addr :8080
+
 			# Print server capabilities as JSON and exit
 			scafctl mcp serve --info
 
 			# Start with file-based logging for debugging
 			scafctl mcp serve --log-file /tmp/scafctl-mcp.log
+
+			# Tune stdio worker pool and queue
+			scafctl mcp serve --worker-pool-size 4 --queue-size 200
 		`),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -76,9 +93,12 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Transport, "transport", "stdio", "Transport protocol (stdio)")
+	cmd.Flags().StringVar(&opts.Transport, "transport", "stdio", "Transport protocol (stdio, sse, http)")
+	cmd.Flags().StringVar(&opts.Addr, "addr", ":8080", "Listen address for SSE/HTTP transports")
 	cmd.Flags().StringVar(&opts.LogFile, "log-file", "", "Write server logs to file (default: stderr)")
 	cmd.Flags().BoolVar(&opts.Info, "info", false, "Print server capabilities as JSON and exit")
+	cmd.Flags().IntVar(&opts.WorkerPoolSize, "worker-pool-size", 0, "Stdio worker pool size (0 = SDK default)")
+	cmd.Flags().IntVar(&opts.QueueSize, "queue-size", 0, "Stdio message queue size (0 = SDK default)")
 
 	return cmd
 }
@@ -112,6 +132,12 @@ func runServe(ctx context.Context, opts *ServeOptions) error {
 	if authReg != nil {
 		serverOpts = append(serverOpts, mcpserver.WithServerAuthRegistry(authReg))
 	}
+	if opts.WorkerPoolSize > 0 {
+		serverOpts = append(serverOpts, mcpserver.WithWorkerPoolSize(opts.WorkerPoolSize))
+	}
+	if opts.QueueSize > 0 {
+		serverOpts = append(serverOpts, mcpserver.WithQueueSize(opts.QueueSize))
+	}
 
 	// Create server
 	srv, err := mcpserver.NewServer(serverOpts...)
@@ -129,7 +155,25 @@ func runServe(ctx context.Context, opts *ServeOptions) error {
 		return nil
 	}
 
-	// Start serving
+	// Start serving on the requested transport
 	lgr.Info("starting MCP server", "transport", opts.Transport)
-	return srv.Serve()
+
+	switch opts.Transport {
+	case "stdio":
+		var stdioOpts []server.StdioOption
+		if opts.WorkerPoolSize > 0 {
+			stdioOpts = append(stdioOpts, server.WithStdioContextFunc(func(ctx context.Context) context.Context {
+				return ctx
+			}))
+		}
+		return srv.Serve(stdioOpts...)
+	case "sse":
+		lgr.Info("SSE server listening", "addr", opts.Addr)
+		return srv.ServeSSE(opts.Addr)
+	case "http":
+		lgr.Info("HTTP server listening", "addr", opts.Addr)
+		return srv.ServeHTTP(opts.Addr)
+	default:
+		return fmt.Errorf("unsupported transport %q: use stdio, sse, or http", opts.Transport)
+	}
 }

--- a/pkg/cmd/scafctl/new/new.go
+++ b/pkg/cmd/scafctl/new/new.go
@@ -1,0 +1,31 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package newcmd provides commands for creating new scafctl resources.
+package newcmd
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandNew creates the 'new' command group.
+func CommandNew(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := &cobra.Command{
+		Use:   "new",
+		Short: "Create new scafctl resources",
+		Long: `Create new solutions, templates, and other scafctl resources from scratch.
+
+Generates well-structured YAML scaffolds with best practices built in.`,
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+
+	cCmd.AddCommand(CommandSolution(cliParams, ioStreams, cmdPath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/new/solution.go
+++ b/pkg/cmd/scafctl/new/solution.go
@@ -1,0 +1,181 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package newcmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/scaffold"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// SolutionOptions holds options for the new solution command.
+type SolutionOptions struct {
+	IOStreams   *terminal.IOStreams
+	CliParams   *settings.Run
+	Name        string
+	Description string
+	Version     string
+	Features    string
+	Providers   string
+	Output      string
+}
+
+// CommandSolution creates the 'new solution' command.
+func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &SolutionOptions{}
+
+	cCmd := &cobra.Command{
+		Use:     "solution",
+		Aliases: []string{"sol", "s"},
+		Short:   "Create a new solution scaffold",
+		Long: heredoc.Doc(`
+			Generate a new solution YAML scaffold with best practices.
+
+			Creates a well-structured solution file with the specified features
+			and provider examples. Output defaults to stdout so you can pipe
+			it to a file or review before saving.
+
+			Available features:
+			  parameters   - Input parameters with validation
+			  resolvers    - Data resolution from providers
+			  actions      - Workflow actions
+			  transforms   - Data transformation
+			  validation   - Input validation rules
+			  tests        - Test suite scaffold
+			  composition  - Solution composition
+
+			Examples:
+			  # Create a basic solution
+			  scafctl new solution -n my-deploy -d "Deploy to Kubernetes"
+
+			  # Include specific features
+			  scafctl new solution -n my-deploy -d "Deploy to K8s" \
+			    --features parameters,resolvers,actions
+
+			  # Include provider-specific examples
+			  scafctl new solution -n my-deploy -d "Deploy" \
+			    --providers exec,http
+
+			  # Write to a file
+			  scafctl new solution -n my-deploy -d "Deploy" -o my-deploy.yaml
+
+			  # Pipe to file
+			  scafctl new solution -n my-deploy -d "Deploy" > my-deploy.yaml
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Solution name (lowercase, hyphens, 3-60 chars) (required)")
+	cCmd.Flags().StringVar(&opts.Description, "description", "", "Brief description of the solution (required)")
+	cCmd.Flags().StringVar(&opts.Version, "version", "1.0.0", "Semantic version")
+	cCmd.Flags().StringVar(&opts.Features, "features", "", "Comma-separated features: parameters,resolvers,actions,transforms,validation,tests,composition")
+	cCmd.Flags().StringVar(&opts.Providers, "providers", "", "Comma-separated provider examples to include")
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output file path (default: stdout)")
+
+	_ = cCmd.MarkFlagRequired("name")
+	_ = cCmd.MarkFlagRequired("description")
+
+	return cCmd
+}
+
+// Run executes the new solution command.
+func (o *SolutionOptions) Run(ctx context.Context) error {
+	w := writer.MustFromContext(ctx)
+
+	// Build features map
+	features := make(map[string]bool)
+	if o.Features != "" {
+		for _, f := range strings.Split(o.Features, ",") {
+			f = strings.TrimSpace(f)
+			if f != "" {
+				// Validate feature name
+				valid := false
+				for _, vf := range scaffold.ValidFeatures {
+					if f == vf {
+						valid = true
+						break
+					}
+				}
+				if !valid {
+					err := fmt.Errorf("unknown feature %q; valid features: %s", f, strings.Join(scaffold.ValidFeatures, ", "))
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				features[f] = true
+			}
+		}
+	}
+
+	// Parse providers
+	var providers []string
+	if o.Providers != "" {
+		for _, p := range strings.Split(o.Providers, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				providers = append(providers, p)
+			}
+		}
+	}
+
+	// Build scaffold
+	result := scaffold.Solution(scaffold.Options{
+		Name:        o.Name,
+		Description: o.Description,
+		Version:     o.Version,
+		Features:    features,
+		Providers:   providers,
+	})
+
+	// Write output
+	if o.Output != "" {
+		if err := os.WriteFile(o.Output, []byte(result.YAML), 0o600); err != nil {
+			w.Errorf("failed to write file: %v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+		w.Successf("Solution written to %s\n", o.Output)
+		if len(result.NextSteps) > 0 {
+			w.Plain("")
+			w.Infof("Next steps:")
+			for _, step := range result.NextSteps {
+				w.Plainf("  • %s\n", step)
+			}
+		}
+		return nil
+	}
+
+	// Write to stdout
+	fmt.Fprint(o.IOStreams.Out, result.YAML)
+
+	return nil
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -18,10 +18,13 @@ import (
 	cachecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/cache"
 	catalogcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/catalog"
 	configcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/config"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/eval"
+	examplescmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/examples"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
 	mcpcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/mcp"
+	newcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/new"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/render"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
@@ -332,6 +335,9 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.AddCommand(secretscmd.CommandSecrets(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(authcmd.CommandAuth(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(lint.CommandLint(cliParams, ioStreams, settings.CliBinaryName))
+	cCmd.AddCommand(eval.CommandEval(cliParams, ioStreams, settings.CliBinaryName))
+	cCmd.AddCommand(newcmd.CommandNew(cliParams, ioStreams, settings.CliBinaryName))
+	cCmd.AddCommand(examplescmd.CommandExamples(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(build.CommandBuild(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(catalogcmd.CommandCatalog(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(cachecmd.CommandCache(cliParams, ioStreams, settings.CliBinaryName))

--- a/pkg/cmd/scafctl/run/execute.go
+++ b/pkg/cmd/scafctl/run/execute.go
@@ -80,6 +80,10 @@ type ResolverExecutionConfig struct {
 
 	// SkipTransform skips resolver transforms.
 	SkipTransform bool `json:"skipTransform,omitempty" yaml:"skipTransform,omitempty" doc:"Skip resolver transforms"`
+
+	// DryRun enables dry-run mode: providers return mock/no-op outputs
+	// instead of performing real side effects.
+	DryRun bool `json:"dryRun,omitempty" yaml:"dryRun,omitempty" doc:"Enable dry-run mode (providers return mock outputs)"`
 }
 
 // ResolverExecutionResult holds the structured output of resolver execution.
@@ -104,6 +108,11 @@ func ExecuteResolvers(
 	cfg ResolverExecutionConfig,
 ) (*ResolverExecutionResult, error) {
 	lgr := logger.FromContext(ctx)
+
+	// Enable dry-run mode on the context when requested.
+	if cfg.DryRun {
+		ctx = provider.WithDryRun(ctx, true)
+	}
 
 	resolvers := sol.Spec.ResolversToSlice()
 	resolverData := make(map[string]any)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -14,10 +14,12 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/dryrun"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -262,6 +264,11 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	lgr.V(1).Info("parsed parameters", "count", len(params))
 
+	// Dry run — execute resolvers in dry-run mode and show structured report
+	if o.DryRun {
+		return o.executeDryRun(ctx, sol, reg, params)
+	}
+
 	// Execute resolvers if present
 	resolvers := sol.Spec.ResolversToSlice()
 
@@ -285,12 +292,6 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		"totalActions", len(graph.Actions),
 		"mainPhases", len(graph.ExecutionOrder),
 		"finallyPhases", len(graph.FinallyOrder))
-
-	// Dry run - just show what would be executed
-	if o.DryRun {
-		o.showDryRun(graph)
-		return nil
-	}
 
 	// Set up action progress callback if enabled
 	var actionProgressCallback action.ProgressCallback
@@ -325,40 +326,140 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	return o.writeActionOutput(ctx, result, executionData)
 }
 
-// showDryRun displays what would be executed without actually running
-func (o *SolutionOptions) showDryRun(graph *action.Graph) {
-	fmt.Fprintln(o.IOStreams.Out, "=== DRY RUN ===")
-	fmt.Fprintln(o.IOStreams.Out, "")
-	fmt.Fprintf(o.IOStreams.Out, "Total actions: %d\n", len(graph.Actions))
-	fmt.Fprintf(o.IOStreams.Out, "Main phases: %d\n", len(graph.ExecutionOrder))
-	fmt.Fprintf(o.IOStreams.Out, "Finally phases: %d\n", len(graph.FinallyOrder))
-	fmt.Fprintln(o.IOStreams.Out, "")
-
-	fmt.Fprintln(o.IOStreams.Out, "EXECUTION ORDER:")
-	for i, phase := range graph.ExecutionOrder {
-		fmt.Fprintf(o.IOStreams.Out, "  Phase %d: %s\n", i, strings.Join(phase, ", "))
-	}
-
-	if len(graph.FinallyOrder) > 0 {
-		fmt.Fprintln(o.IOStreams.Out, "")
-		fmt.Fprintln(o.IOStreams.Out, "FINALLY ORDER:")
-		for i, phase := range graph.FinallyOrder {
-			fmt.Fprintf(o.IOStreams.Out, "  Phase %d: %s\n", i, strings.Join(phase, ", "))
+// executeDryRun runs resolvers in dry-run mode and produces a structured report
+// showing what a full solution execution would do without side effects.
+func (o *SolutionOptions) executeDryRun(ctx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any) error {
+	// Execute resolvers in dry-run mode to get preview data
+	var resolverData map[string]any
+	if sol.Spec.HasResolvers() {
+		cfg := ResolverExecutionConfigFromContext(ctx)
+		cfg.DryRun = true
+		result, err := ExecuteResolvers(ctx, sol, params, reg, cfg)
+		if err != nil {
+			// Non-fatal — report will include warnings
+			resolverData = make(map[string]any)
+		} else {
+			resolverData = result.Data
 		}
 	}
 
-	fmt.Fprintln(o.IOStreams.Out, "")
-	fmt.Fprintln(o.IOStreams.Out, "ACTIONS:")
-	for name, act := range graph.Actions {
-		fmt.Fprintf(o.IOStreams.Out, "  %s:\n", name)
-		fmt.Fprintf(o.IOStreams.Out, "    provider: %s\n", act.Provider)
-		if len(act.Dependencies) > 0 {
-			fmt.Fprintf(o.IOStreams.Out, "    dependencies: %s\n", strings.Join(act.Dependencies, ", "))
+	report, err := dryrun.Generate(ctx, sol, dryrun.Options{
+		Params:       params,
+		Registry:     reg,
+		ResolverData: resolverData,
+	})
+	if err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("dry-run failed: %w", err), exitcode.GeneralError)
+	}
+
+	return o.writeDryRunOutput(report)
+}
+
+// writeDryRunOutput renders a dry-run report in the requested output format.
+func (o *SolutionOptions) writeDryRunOutput(report *dryrun.Report) error {
+	switch o.Output {
+	case "json":
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal dry-run report: %w", err)
 		}
-		if act.ForEachMetadata != nil {
-			fmt.Fprintf(o.IOStreams.Out, "    forEach: expanded from %s[%d]\n", act.ForEachMetadata.ExpandedFrom, act.ForEachMetadata.Index)
+		fmt.Fprintln(o.IOStreams.Out, string(data))
+		return nil
+	case "yaml":
+		data, err := yaml.Marshal(report)
+		if err != nil {
+			return fmt.Errorf("failed to marshal dry-run report: %w", err)
+		}
+		fmt.Fprint(o.IOStreams.Out, string(data))
+		return nil
+	case "quiet":
+		return nil
+	default:
+		return o.writeDryRunTable(report)
+	}
+}
+
+// writeDryRunTable renders a human-readable dry-run report to the terminal.
+func (o *SolutionOptions) writeDryRunTable(report *dryrun.Report) error {
+	out := o.IOStreams.Out
+
+	fmt.Fprintln(out, "=== DRY RUN ===")
+	fmt.Fprintln(out, "")
+	fmt.Fprintf(out, "Solution:     %s\n", report.Solution)
+	if report.Version != "" {
+		fmt.Fprintf(out, "Version:      %s\n", report.Version)
+	}
+	fmt.Fprintf(out, "Has resolvers: %t\n", report.HasResolvers)
+	fmt.Fprintf(out, "Has workflow:  %t\n", report.HasWorkflow)
+
+	// Parameters
+	if len(report.Parameters) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "PARAMETERS:")
+		for k, v := range report.Parameters {
+			fmt.Fprintf(out, "  %s = %v\n", k, v)
 		}
 	}
+
+	// Resolvers
+	if len(report.Resolvers) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "RESOLVERS:")
+		for name, r := range report.Resolvers {
+			status := r.Status
+			if r.Value != nil {
+				fmt.Fprintf(out, "  %-30s [%s] = %v\n", name, status, r.Value)
+			} else {
+				fmt.Fprintf(out, "  %-30s [%s]\n", name, status)
+			}
+		}
+	}
+
+	// Action plan
+	if len(report.ActionPlan) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintf(out, "ACTION PLAN (%d actions, %d phases):\n", report.TotalActions, report.TotalPhases)
+		currentPhase := -1
+		for _, act := range report.ActionPlan {
+			if act.Phase != currentPhase {
+				currentPhase = act.Phase
+				fmt.Fprintf(out, "\n  Phase %d:\n", currentPhase)
+			}
+			fmt.Fprintf(out, "    %s (%s/%s)\n", act.Name, act.Section, act.Provider)
+			if act.Description != "" {
+				fmt.Fprintf(out, "      desc: %s\n", act.Description)
+			}
+			if len(act.Dependencies) > 0 {
+				fmt.Fprintf(out, "      deps: %s\n", strings.Join(act.Dependencies, ", "))
+			}
+			if act.When != "" {
+				fmt.Fprintf(out, "      when: %s\n", act.When)
+			}
+			if act.MockBehavior != "" {
+				fmt.Fprintf(out, "      mock: %s\n", act.MockBehavior)
+			}
+		}
+	}
+
+	// Mock behaviors
+	if len(report.MockBehaviors) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "PROVIDER MOCK BEHAVIORS:")
+		for _, mb := range report.MockBehaviors {
+			fmt.Fprintf(out, "  %-20s %s\n", mb.Provider+":", mb.MockBehavior)
+		}
+	}
+
+	// Warnings
+	if len(report.Warnings) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "WARNINGS:")
+		for _, w := range report.Warnings {
+			fmt.Fprintf(out, "  - %s\n", w)
+		}
+	}
+
+	return nil
 }
 
 // getActionIOStreams returns the provider IO streams for action execution.

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -1,0 +1,231 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dryrun provides structured dry-run report generation for scafctl solutions.
+//
+// It coordinates resolver preview (dry-run mode) and action graph building to produce
+// a unified report showing what a solution execution would do without side effects.
+package dryrun
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// Report is the full structured dry-run output.
+type Report struct {
+	DryRun        bool                `json:"dryRun" yaml:"dryRun"`
+	Solution      string              `json:"solution" yaml:"solution"`
+	Version       string              `json:"version,omitempty" yaml:"version,omitempty"`
+	HasResolvers  bool                `json:"hasResolvers" yaml:"hasResolvers"`
+	HasWorkflow   bool                `json:"hasWorkflow" yaml:"hasWorkflow"`
+	Parameters    map[string]any      `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Resolvers     map[string]Resolver `json:"resolvers,omitempty" yaml:"resolvers,omitempty"`
+	ActionPlan    []Action            `json:"actionPlan,omitempty" yaml:"actionPlan,omitempty"`
+	TotalActions  int                 `json:"totalActions,omitempty" yaml:"totalActions,omitempty"`
+	TotalPhases   int                 `json:"totalPhases,omitempty" yaml:"totalPhases,omitempty"`
+	MockBehaviors []MockBehavior      `json:"mockBehaviors,omitempty" yaml:"mockBehaviors,omitempty"`
+	Warnings      []string            `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+// Resolver describes a single resolver's dry-run result.
+type Resolver struct {
+	Value  any    `json:"value" yaml:"value"`
+	Status string `json:"status" yaml:"status"`
+	DryRun bool   `json:"dryRun" yaml:"dryRun"`
+}
+
+// Action describes a single action in the dry-run plan.
+type Action struct {
+	Name               string            `json:"name" yaml:"name"`
+	Provider           string            `json:"provider" yaml:"provider"`
+	Description        string            `json:"description,omitempty" yaml:"description,omitempty"`
+	MaterializedInputs map[string]any    `json:"materializedInputs,omitempty" yaml:"materializedInputs,omitempty"`
+	DeferredInputs     map[string]string `json:"deferredInputs,omitempty" yaml:"deferredInputs,omitempty"`
+	Dependencies       []string          `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	When               string            `json:"when,omitempty" yaml:"when,omitempty"`
+	Section            string            `json:"section" yaml:"section"`
+	Phase              int               `json:"phase" yaml:"phase"`
+	MockBehavior       string            `json:"mockBehavior,omitempty" yaml:"mockBehavior,omitempty"`
+}
+
+// MockBehavior describes what a provider does in dry-run mode.
+type MockBehavior struct {
+	Provider     string `json:"provider" yaml:"provider"`
+	MockBehavior string `json:"mockBehavior" yaml:"mockBehavior"`
+}
+
+// Options controls the dry-run generation.
+type Options struct {
+	// Params are the resolver parameters that were (or would be) passed.
+	Params map[string]any
+	// Registry provides provider descriptors for mock behavior lookups.
+	Registry *provider.Registry
+	// ResolverData is the pre-executed resolver data (from dry-run mode execution).
+	// Callers should execute resolvers with dry-run enabled before calling Generate.
+	// If nil, the report will note that resolver data was not provided.
+	ResolverData map[string]any
+}
+
+// Generate builds a structured dry-run report from a solution and pre-executed resolver data.
+// Callers must execute resolvers (with dry-run mode) themselves and pass the data via Options.
+func Generate(ctx context.Context, sol *solution.Solution, opts Options) (*Report, error) {
+	reg := opts.Registry
+	resolverData := opts.ResolverData
+	if resolverData == nil {
+		resolverData = make(map[string]any)
+	}
+
+	report := &Report{
+		DryRun:       true,
+		Solution:     sol.Metadata.Name,
+		Version:      versionString(sol.Metadata.Version),
+		HasResolvers: sol.Spec.HasResolvers(),
+		HasWorkflow:  sol.Spec.HasWorkflow(),
+		Parameters:   opts.Params,
+		Resolvers:    make(map[string]Resolver),
+	}
+
+	// Build resolver entries from pre-executed data
+	if sol.Spec.HasResolvers() {
+		for name, val := range resolverData {
+			report.Resolvers[name] = Resolver{
+				Value:  val,
+				Status: "resolved",
+				DryRun: true,
+			}
+		}
+		// Mark missing resolvers
+		for name := range sol.Spec.Resolvers {
+			if _, ok := report.Resolvers[name]; !ok {
+				report.Resolvers[name] = Resolver{
+					Status: "not-resolved",
+					DryRun: true,
+				}
+				report.Warnings = append(report.Warnings, fmt.Sprintf("resolver %q did not produce a value", name))
+			}
+		}
+	}
+
+	// Phase 2: Build action plan
+	if sol.Spec.HasWorkflow() {
+		graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
+		if err != nil {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("action graph build failed: %v", err))
+		} else {
+			report.TotalActions = len(graph.Actions)
+			report.TotalPhases = graph.TotalPhases()
+
+			// Build phase map
+			phaseMap := make(map[string]int)
+			for i, phase := range graph.ExecutionOrder {
+				for _, name := range phase {
+					phaseMap[name] = i + 1
+				}
+			}
+			for i, phase := range graph.FinallyOrder {
+				for _, name := range phase {
+					phaseMap[name] = i + 1
+				}
+			}
+
+			// Collect sorted action entries
+			names := make([]string, 0, len(graph.Actions))
+			for name := range graph.Actions {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			for _, name := range names {
+				ea := graph.Actions[name]
+				entry := Action{
+					Name:               name,
+					Provider:           ea.Provider,
+					Description:        ea.Description,
+					MaterializedInputs: ea.MaterializedInputs,
+					Dependencies:       ea.Dependencies,
+					Section:            ea.Section,
+					Phase:              phaseMap[name],
+				}
+				if ea.When != nil && ea.When.Expr != nil {
+					entry.When = string(*ea.When.Expr)
+				}
+
+				// Deferred inputs
+				if len(ea.DeferredInputs) > 0 {
+					entry.DeferredInputs = make(map[string]string, len(ea.DeferredInputs))
+					for k, v := range ea.DeferredInputs {
+						expr := v.OriginalExpr
+						if expr == "" {
+							expr = v.OriginalTmpl
+						}
+						if expr == "" && v.Deferred {
+							expr = "(deferred)"
+						}
+						entry.DeferredInputs[k] = expr
+					}
+				}
+
+				// Provider mock behavior
+				if reg != nil {
+					if p, found := reg.Get(ea.Provider); found {
+						entry.MockBehavior = p.Descriptor().MockBehavior
+					}
+				}
+
+				report.ActionPlan = append(report.ActionPlan, entry)
+			}
+		}
+	}
+
+	// Phase 3: Collect provider mock behaviors
+	usedProviders := make(map[string]bool)
+	for _, res := range sol.Spec.Resolvers {
+		if res.Resolve != nil {
+			for _, step := range res.Resolve.With {
+				usedProviders[step.Provider] = true
+			}
+		}
+	}
+	if sol.Spec.HasWorkflow() {
+		for _, act := range sol.Spec.Workflow.Actions {
+			usedProviders[act.Provider] = true
+		}
+		for _, act := range sol.Spec.Workflow.Finally {
+			usedProviders[act.Provider] = true
+		}
+	}
+
+	providerNames := make([]string, 0, len(usedProviders))
+	for name := range usedProviders {
+		if name != "" {
+			providerNames = append(providerNames, name)
+		}
+	}
+	sort.Strings(providerNames)
+
+	if reg != nil {
+		for _, name := range providerNames {
+			if p, found := reg.Get(name); found {
+				report.MockBehaviors = append(report.MockBehaviors, MockBehavior{
+					Provider:     name,
+					MockBehavior: p.Descriptor().MockBehavior,
+				})
+			}
+		}
+	}
+
+	return report, nil
+}
+
+func versionString(v fmt.Stringer) string {
+	if v == nil {
+		return ""
+	}
+	return v.String()
+}

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -1,0 +1,275 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package examples provides access to embedded scafctl example files.
+//
+// Examples are embedded at build time via go:embed, making them available
+// in distributed binaries without filesystem access to the source repo.
+//
+// For development, examples are also looked up from the filesystem as a
+// fallback when the embedded filesystem is empty or when the examples
+// weren't copied at build time.
+package examples
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+//go:embed files/*
+var EmbeddedExamples embed.FS
+
+// Example represents an example file in the listing.
+type Example struct {
+	Path        string `json:"path"`
+	Category    string `json:"category"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// Scan walks the examples filesystem and returns matching examples.
+// If category is empty, returns all examples.
+func Scan(category string) ([]Example, error) {
+	examplesFS, root, err := getExamplesFS()
+	if err != nil {
+		return nil, err
+	}
+
+	var items []Example
+	err = fs.WalkDir(examplesFS, root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		// Only include YAML files
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		// Get the relative path from the root
+		relPath, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		// Determine category from the first directory component
+		parts := strings.SplitN(relPath, "/", 2)
+		cat := ""
+		name := relPath
+		if len(parts) > 1 {
+			cat = parts[0]
+			name = parts[1]
+		}
+
+		// Apply category filter
+		if category != "" && cat != category {
+			return nil
+		}
+
+		// Skip intentionally bad examples
+		if strings.Contains(relPath, "bad-solution") {
+			return nil
+		}
+
+		item := Example{
+			Path:        relPath,
+			Category:    cat,
+			Name:        name,
+			Description: DescriptionFromPath(relPath),
+		}
+		items = append(items, item)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by category then name
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Category != items[j].Category {
+			return items[i].Category < items[j].Category
+		}
+		return items[i].Name < items[j].Name
+	})
+
+	return items, nil
+}
+
+// Read returns the contents of an example file.
+func Read(path string) (string, error) {
+	examplesFS, root, err := getExamplesFS()
+	if err != nil {
+		return "", err
+	}
+
+	// Security: ensure the path doesn't escape
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return "", fmt.Errorf("path must not contain '..'")
+	}
+
+	fullPath := filepath.Join(root, cleanPath)
+	content, err := fs.ReadFile(examplesFS, fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read example %q: %w", path, err)
+	}
+
+	return string(content), nil
+}
+
+// Categories returns the list of available example categories.
+func Categories() []string {
+	items, err := Scan("")
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var cats []string
+	for _, item := range items {
+		if item.Category != "" && !seen[item.Category] {
+			seen[item.Category] = true
+			cats = append(cats, item.Category)
+		}
+	}
+	sort.Strings(cats)
+	return cats
+}
+
+// getExamplesFS returns either the embedded FS or a fallback OS FS.
+func getExamplesFS() (fs.FS, string, error) {
+	// Try embedded examples first — check for actual content (not just .gitkeep)
+	entries, err := fs.ReadDir(EmbeddedExamples, "files")
+	if err == nil {
+		hasContent := false
+		for _, e := range entries {
+			if e.IsDir() || (e.Name() != ".gitkeep" && e.Name() != ".keep") {
+				hasContent = true
+				break
+			}
+		}
+		if hasContent {
+			return EmbeddedExamples, "files", nil
+		}
+	}
+
+	// Fallback: find examples directory on the filesystem (development mode)
+	dir, err := findExamplesDir()
+	if err != nil {
+		return nil, "", fmt.Errorf("examples not available: embedded examples not found and filesystem fallback failed: %w", err)
+	}
+	return os.DirFS(dir), ".", nil
+}
+
+// findExamplesDir locates the examples directory relative to the package source.
+func findExamplesDir() (string, error) {
+	// Strategy 1: Find relative to this source file (works in development/testing)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if ok {
+		// This file is at pkg/examples/examples.go
+		// Project root is ../../ from here
+		pkgDir := filepath.Dir(thisFile)
+		projectRoot := filepath.Join(pkgDir, "..", "..")
+		examplesDir := filepath.Join(projectRoot, "examples")
+		if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
+			return examplesDir, nil
+		}
+	}
+
+	// Strategy 2: Check current working directory
+	cwd, err := os.Getwd()
+	if err == nil {
+		examplesDir := filepath.Join(cwd, "examples")
+		if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
+			return examplesDir, nil
+		}
+	}
+
+	// Strategy 3: Walk up from cwd looking for examples/
+	if err == nil {
+		dir := cwd
+		for i := 0; i < 10; i++ {
+			examplesDir := filepath.Join(dir, "examples")
+			if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
+				return examplesDir, nil
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+
+	return "", fmt.Errorf("could not locate examples directory")
+}
+
+// DescriptionFromPath generates a human-readable description from a file path.
+func DescriptionFromPath(path string) string {
+	descriptions := map[string]string{
+		// Solutions
+		"solutions/comprehensive/solution.yaml":   "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
+		"solutions/email-notifier/solution.yaml":  "Email notification solution with parameters, validation, and action workflow",
+		"solutions/terraform/solution.yaml":       "Terraform infrastructure scaffolding solution",
+		"solutions/k8s-clusters/solution.yaml":    "Kubernetes cluster provisioning solution",
+		"solutions/directory/solution.yaml":       "Directory provider examples (list, read, create, copy)",
+		"solutions/scaffold-demo/solution.yaml":   "Scaffold/template rendering demo solution",
+		"solutions/github-auth/solution.yaml":     "GitHub authentication and API access solution",
+		"solutions/composition/parent.yaml":       "Solution composition - parent that composes children",
+		"solutions/composition/child.yaml":        "Solution composition - child partial solution",
+		"solutions/taskfile/solution.yaml":        "Taskfile-based workflow solution",
+		"solutions/tested-solution/solution.yaml": "Solution with functional tests defined in spec.testing.cases",
+
+		// Actions
+		"actions/hello-world.yaml":              "Simple hello world action",
+		"actions/sequential-chain.yaml":         "Actions executed sequentially using dependsOn",
+		"actions/parallel-with-deps.yaml":       "Parallel actions with dependency ordering",
+		"actions/conditional-execution.yaml":    "Actions with conditional execution (when clauses)",
+		"actions/error-handling.yaml":           "Error handling with onError behavior",
+		"actions/finally-cleanup.yaml":          "Finally block for cleanup actions",
+		"actions/foreach-deploy.yaml":           "ForEach iteration over collections",
+		"actions/retry-backoff.yaml":            "Retry with exponential backoff",
+		"actions/conditional-retry.yaml":        "Retry with conditional retry logic (retryIf)",
+		"actions/complex-workflow.yaml":         "Complex workflow with all action features",
+		"actions/template-render.yaml":          "Template rendering action",
+		"actions/go-template-inline.yaml":       "Inline Go template action",
+		"actions/result-schema-validation.yaml": "Action result schema validation",
+
+		// Resolvers
+		"resolvers/hello-world.yaml":         "Simple static value resolver",
+		"resolvers/parameters.yaml":          "Parameter provider for user input",
+		"resolvers/dependencies.yaml":        "Resolver dependency chain (dependsOn)",
+		"resolvers/env-config.yaml":          "Environment variable resolver",
+		"resolvers/validation.yaml":          "Resolver validation rules",
+		"resolvers/transform-pipeline.yaml":  "Multi-step transform pipeline",
+		"resolvers/cel-basics.yaml":          "CEL expression basics in resolvers",
+		"resolvers/cel-builtins.yaml":        "CEL built-in functions reference",
+		"resolvers/cel-extensions.yaml":      "scafctl custom CEL extensions",
+		"resolvers/cel-transforms.yaml":      "CEL-based transform examples",
+		"resolvers/cel-common-patterns.yaml": "Common CEL patterns and recipes",
+		"resolvers/feature-flags.yaml":       "Feature flag resolver pattern",
+		"resolvers/identity.yaml":            "Identity/auth resolver pattern",
+		"resolvers/secrets.yaml":             "Secrets resolver pattern",
+	}
+
+	if desc, ok := descriptions[path]; ok {
+		return desc
+	}
+
+	// Fallback: generate from filename
+	name := filepath.Base(path)
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+	name = strings.ReplaceAll(name, "-", " ")
+	name = strings.ReplaceAll(name, "_", " ")
+	return strings.Title(name) + " example" //nolint:staticcheck // strings.Title is fine for simple cases
+}

--- a/pkg/examples/files/.gitkeep
+++ b/pkg/examples/files/.gitkeep
@@ -1,0 +1,3 @@
+# This directory is populated at build time by copying the examples/ directory.
+# See taskfile.yaml embed:examples task.
+# Added to .gitignore.

--- a/pkg/mcp/capabilities.go
+++ b/pkg/mcp/capabilities.go
@@ -1,0 +1,137 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/filepath"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	solutionget "github.com/oakwood-commons/scafctl/pkg/solution/get"
+)
+
+// discoverWorkspaceRoots asks the MCP client for its workspace root directories
+// and returns file paths. If the client doesn't support roots or the request fails,
+// it returns nil (callers should fall back to explicit paths).
+func (s *Server) discoverWorkspaceRoots(ctx context.Context) []string {
+	roots, err := s.RequestRoots(ctx)
+	if err != nil {
+		s.logger.V(1).Info("failed to request workspace roots", "error", err)
+		return nil
+	}
+
+	paths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		uri := root.URI
+		// Convert file:// URIs to filesystem paths
+		if strings.HasPrefix(uri, "file://") {
+			paths = append(paths, strings.TrimPrefix(uri, "file://"))
+		}
+	}
+
+	return paths
+}
+
+// discoverSolutionFiles searches for solution files using the same conventions
+// as the CLI (settings.RootSolutionFolders + settings.SolutionFileNames). It also
+// searches MCP workspace roots if provided by the client. Returns all discovered
+// file paths, or nil if none found.
+func (s *Server) discoverSolutionFiles(ctx context.Context) []string {
+	var files []string
+
+	// 1. Use the canonical CLI discovery logic (searches CWD-relative paths)
+	getter := solutionget.NewGetter(solutionget.WithLogger(s.logger))
+	if found := getter.FindSolution(); found != "" {
+		files = append(files, found)
+	}
+
+	// 2. Also search MCP workspace roots using the same file name patterns
+	roots := s.discoverWorkspaceRoots(ctx)
+	for _, root := range roots {
+		for _, folder := range settings.RootSolutionFolders {
+			for _, filename := range settings.SolutionFileNames {
+				fullPath := filepath.Join(root, folder, filename)
+				if filepath.PathExists(fullPath, nil) {
+					// Deduplicate against already-found files
+					if !containsPath(files, fullPath) {
+						files = append(files, fullPath)
+					}
+				}
+			}
+		}
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+	return files
+}
+
+// containsPath checks if a path is already in the slice.
+func containsPath(paths []string, target string) bool {
+	for _, p := range paths {
+		if p == target {
+			return true
+		}
+	}
+	return false
+}
+
+// elicitMissingParams uses the MCP elicitation capability to prompt the user
+// for missing required parameters. Returns a map of parameter names to values
+// provided by the user, or nil if elicitation is not supported/declined.
+func (s *Server) elicitMissingParams(ctx context.Context, paramNames []string, descriptions map[string]string) map[string]string {
+	if len(paramNames) == 0 {
+		return nil
+	}
+
+	// Build the elicitation schema with properties for each missing parameter
+	properties := make(map[string]map[string]string, len(paramNames))
+	for _, name := range paramNames {
+		prop := map[string]string{"type": "string"}
+		if desc, ok := descriptions[name]; ok {
+			prop["description"] = desc
+		} else {
+			prop["description"] = fmt.Sprintf("Value for parameter %q", name)
+		}
+		properties[name] = prop
+	}
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+		"required":   paramNames,
+	}
+
+	req := mcp.ElicitationRequest{}
+	req.Params.Message = "The following parameters are required to run this solution. Please provide values:"
+	req.Params.RequestedSchema = schema
+
+	result, err := s.RequestElicitation(ctx, req)
+	if err != nil {
+		s.logger.V(1).Info("elicitation request failed", "error", err)
+		return nil
+	}
+
+	if result == nil || result.Action != "accept" {
+		return nil
+	}
+
+	// Extract the parameter values from the elicitation result
+	values := make(map[string]string, len(paramNames))
+	if result.Content != nil {
+		if contentMap, ok := result.Content.(map[string]any); ok {
+			for _, name := range paramNames {
+				if val, ok := contentMap[name]; ok {
+					values[name] = fmt.Sprintf("%v", val)
+				}
+			}
+		}
+	}
+
+	return values
+}

--- a/pkg/mcp/completions.go
+++ b/pkg/mcp/completions.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/ext"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
+	"github.com/oakwood-commons/scafctl/pkg/examples"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// promptCompletionProvider provides auto-completion for prompt arguments.
+type promptCompletionProvider struct {
+	registry *provider.Registry
+}
+
+// CompletePromptArgument returns completions for a prompt argument.
+func (p *promptCompletionProvider) CompletePromptArgument(
+	_ context.Context,
+	promptName string,
+	argument mcp.CompleteArgument,
+	_ mcp.CompleteContext,
+) (*mcp.Completion, error) {
+	prefix := strings.ToLower(argument.Value)
+
+	switch {
+	case argument.Name == "provider":
+		return p.completeProviderNames(prefix)
+	case argument.Name == "migration" && promptName == "migrate_solution":
+		return completeMigrationTypes(prefix)
+	case argument.Name == "features":
+		return completeFeatures(prefix)
+	}
+
+	return &mcp.Completion{}, nil
+}
+
+func (p *promptCompletionProvider) completeProviderNames(prefix string) (*mcp.Completion, error) {
+	if p.registry == nil {
+		return &mcp.Completion{}, nil
+	}
+
+	var matches []string
+	for _, name := range p.registry.List() {
+		if prefix == "" || strings.HasPrefix(strings.ToLower(name), prefix) {
+			matches = append(matches, name)
+		}
+	}
+	sort.Strings(matches)
+	if len(matches) > 100 {
+		matches = matches[:100]
+	}
+
+	return &mcp.Completion{
+		Values:  matches,
+		HasMore: false,
+	}, nil
+}
+
+func completeMigrationTypes(prefix string) (*mcp.Completion, error) {
+	types := []string{"composition", "templates", "split", "tests", "upgrade"}
+	var matches []string
+	for _, t := range types {
+		if prefix == "" || strings.HasPrefix(t, prefix) {
+			matches = append(matches, t)
+		}
+	}
+	return &mcp.Completion{
+		Values:  matches,
+		HasMore: false,
+	}, nil
+}
+
+func completeFeatures(prefix string) (*mcp.Completion, error) {
+	features := []string{"resolvers", "actions", "transforms", "validation", "parameters", "composition", "tests"}
+	var matches []string
+	for _, f := range features {
+		if prefix == "" || strings.HasPrefix(f, prefix) {
+			matches = append(matches, f)
+		}
+	}
+	return &mcp.Completion{
+		Values:  matches,
+		HasMore: false,
+	}, nil
+}
+
+// resourceCompletionProvider provides auto-completion for resource template URIs.
+type resourceCompletionProvider struct {
+	registry *provider.Registry
+	logger   logr.Logger
+	ctx      context.Context
+}
+
+// CompleteResourceArgument returns completions for a resource template argument.
+func (r *resourceCompletionProvider) CompleteResourceArgument(
+	_ context.Context,
+	uri string,
+	argument mcp.CompleteArgument,
+	_ mcp.CompleteContext,
+) (*mcp.Completion, error) {
+	prefix := strings.ToLower(argument.Value)
+
+	switch {
+	case strings.HasPrefix(uri, "provider://"):
+		return r.completeProviderNames(prefix)
+	case strings.HasPrefix(uri, "solution://"):
+		return r.completeSolutionNames(prefix)
+	}
+
+	return &mcp.Completion{}, nil
+}
+
+func (r *resourceCompletionProvider) completeProviderNames(prefix string) (*mcp.Completion, error) {
+	if r.registry == nil {
+		return &mcp.Completion{}, nil
+	}
+
+	var matches []string
+	for _, name := range r.registry.List() {
+		if prefix == "" || strings.HasPrefix(strings.ToLower(name), prefix) {
+			matches = append(matches, name)
+		}
+	}
+	sort.Strings(matches)
+	if len(matches) > 100 {
+		matches = matches[:100]
+	}
+
+	return &mcp.Completion{
+		Values:  matches,
+		HasMore: false,
+	}, nil
+}
+
+func (r *resourceCompletionProvider) completeSolutionNames(prefix string) (*mcp.Completion, error) {
+	cat, err := catalog.NewLocalCatalog(r.logger)
+	if err != nil {
+		// Return empty completions when catalog is unavailable — not an error for completions.
+		return &mcp.Completion{}, nil //nolint:nilerr // gracefully degrade
+	}
+
+	entries, err := cat.List(r.ctx, catalog.ArtifactKindSolution, "")
+	if err != nil {
+		// Return empty completions on list failure — not an error for completions.
+		return &mcp.Completion{}, nil //nolint:nilerr // gracefully degrade
+	}
+
+	var matches []string
+	for _, entry := range entries {
+		name := strings.ToLower(entry.Reference.Name)
+		if prefix == "" || strings.HasPrefix(name, prefix) {
+			matches = append(matches, entry.Reference.Name)
+		}
+	}
+	sort.Strings(matches)
+	if len(matches) > 100 {
+		matches = matches[:100]
+	}
+
+	return &mcp.Completion{
+		Values:  matches,
+		HasMore: len(entries) > 100,
+	}, nil
+}
+
+// toolArgCompletions returns common completions used by tool arguments.
+// These are used in tool descriptions to hint at valid values.
+type toolArgCompletions struct {
+	registry *provider.Registry
+}
+
+// ProviderNames returns available provider names.
+func (c *toolArgCompletions) ProviderNames() []string {
+	if c.registry == nil {
+		return nil
+	}
+	names := c.registry.List()
+	sort.Strings(names)
+	return names
+}
+
+// LintRuleNames returns available lint rule names.
+func (c *toolArgCompletions) LintRuleNames() []string {
+	rules := lint.ListRules()
+	names := make([]string, 0, len(rules))
+	for _, r := range rules {
+		names = append(names, r.Rule)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// CELFunctionNames returns available CEL function names.
+func (c *toolArgCompletions) CELFunctionNames() []string {
+	functions := ext.All()
+	names := make([]string, 0, len(functions))
+	for _, f := range functions {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ExampleNames returns available example file names.
+func (c *toolArgCompletions) ExampleNames() []string {
+	files, err := examples.Scan("")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		names = append(names, f.Path)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/mcp/completions_test.go
+++ b/pkg/mcp/completions_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptCompletionProvider(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	p := &promptCompletionProvider{registry: reg}
+
+	t.Run("provider argument returns empty when no providers", func(t *testing.T) {
+		completion, err := p.CompletePromptArgument(context.Background(), "some_prompt", mcp.CompleteArgument{
+			Name:  "provider",
+			Value: "",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.Empty(t, completion.Values)
+	})
+
+	t.Run("migration argument returns types", func(t *testing.T) {
+		completion, err := p.CompletePromptArgument(context.Background(), "migrate_solution", mcp.CompleteArgument{
+			Name:  "migration",
+			Value: "",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, completion.Values)
+		assert.Contains(t, completion.Values, "composition")
+		assert.Contains(t, completion.Values, "templates")
+	})
+
+	t.Run("migration argument filters by prefix", func(t *testing.T) {
+		completion, err := p.CompletePromptArgument(context.Background(), "migrate_solution", mcp.CompleteArgument{
+			Name:  "migration",
+			Value: "comp",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"composition"}, completion.Values)
+	})
+
+	t.Run("features argument returns feature list", func(t *testing.T) {
+		completion, err := p.CompletePromptArgument(context.Background(), "explain_feature", mcp.CompleteArgument{
+			Name:  "features",
+			Value: "",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, completion.Values)
+		assert.Contains(t, completion.Values, "resolvers")
+		assert.Contains(t, completion.Values, "actions")
+	})
+
+	t.Run("unknown argument returns empty", func(t *testing.T) {
+		completion, err := p.CompletePromptArgument(context.Background(), "some_prompt", mcp.CompleteArgument{
+			Name:  "unknown_arg",
+			Value: "",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.Empty(t, completion.Values)
+	})
+
+	t.Run("nil registry is safe", func(t *testing.T) {
+		provider := &promptCompletionProvider{registry: nil}
+		completion, err := provider.CompletePromptArgument(context.Background(), "some_prompt", mcp.CompleteArgument{
+			Name:  "provider",
+			Value: "",
+		}, mcp.CompleteContext{})
+		require.NoError(t, err)
+		assert.Empty(t, completion.Values)
+	})
+}
+
+func TestCompleteMigrationTypes(t *testing.T) {
+	t.Run("empty prefix returns all types", func(t *testing.T) {
+		completion, err := completeMigrationTypes("")
+		require.NoError(t, err)
+		assert.Len(t, completion.Values, 5)
+	})
+
+	t.Run("prefix filters results", func(t *testing.T) {
+		completion, err := completeMigrationTypes("up")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"upgrade"}, completion.Values)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		completion, err := completeMigrationTypes("xyz")
+		require.NoError(t, err)
+		assert.Empty(t, completion.Values)
+	})
+}
+
+func TestCompleteFeatures(t *testing.T) {
+	t.Run("empty prefix returns all features", func(t *testing.T) {
+		completion, err := completeFeatures("")
+		require.NoError(t, err)
+		assert.NotEmpty(t, completion.Values)
+	})
+
+	t.Run("prefix filters results", func(t *testing.T) {
+		completion, err := completeFeatures("res")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"resolvers"}, completion.Values)
+	})
+}
+
+func TestToolArgCompletions(t *testing.T) {
+	t.Run("provider names with nil registry", func(t *testing.T) {
+		c := &toolArgCompletions{registry: nil}
+		names := c.ProviderNames()
+		assert.Nil(t, names)
+	})
+
+	t.Run("provider names with empty registry", func(t *testing.T) {
+		c := &toolArgCompletions{registry: provider.NewRegistry()}
+		names := c.ProviderNames()
+		assert.Empty(t, names)
+	})
+
+	t.Run("lint rule names returns rules", func(t *testing.T) {
+		c := &toolArgCompletions{}
+		names := c.LintRuleNames()
+		// Should return at least some rules from the lint package
+		assert.NotEmpty(t, names)
+	})
+
+	t.Run("CEL function names returns functions", func(t *testing.T) {
+		c := &toolArgCompletions{}
+		names := c.CELFunctionNames()
+		// Should return at least some CEL functions
+		assert.NotEmpty(t, names)
+	})
+
+	t.Run("example names returns examples", func(t *testing.T) {
+		c := &toolArgCompletions{}
+		names := c.ExampleNames()
+		// Should return at least some examples from embedded FS
+		assert.NotEmpty(t, names)
+	})
+}

--- a/pkg/mcp/enhancements_test.go
+++ b/pkg/mcp/enhancements_test.go
@@ -1,0 +1,238 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgressReporter(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("no progress token logs instead", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "test_tool"
+		request.Params.Arguments = map[string]any{}
+
+		reporter := newProgressReporter(srv, request)
+		assert.Nil(t, reporter.token, "should have no progress token")
+
+		// Should not panic when reporting without a token
+		reporter.setTotal(3)
+		reporter.report(srv.ctx, 1, "step 1")
+		reporter.report(srv.ctx, 2, "step 2")
+		reporter.report(srv.ctx, 3, "step 3")
+	})
+
+	t.Run("with progress token", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "test_tool"
+		request.Params.Arguments = map[string]any{}
+		request.Params.Meta = &mcp.Meta{
+			ProgressToken: mcp.ProgressToken("test-token-123"),
+		}
+
+		reporter := newProgressReporter(srv, request)
+		assert.NotNil(t, reporter.token, "should have progress token")
+
+		reporter.setTotal(5)
+		assert.Equal(t, float64(5), reporter.total)
+	})
+}
+
+func TestToolIcons(t *testing.T) {
+	// Verify all expected icon categories exist
+	expectedCategories := []string{
+		"solution", "provider", "cel", "template", "schema",
+		"example", "catalog", "auth", "lint", "scaffold",
+		"action", "diff", "dryrun", "config", "refs",
+		"testing", "snapshot", "version",
+	}
+
+	for _, cat := range expectedCategories {
+		t.Run("tool icon "+cat, func(t *testing.T) {
+			icon, ok := toolIcons[cat]
+			assert.True(t, ok, "icon category %q should exist", cat)
+			assert.NotEmpty(t, icon.Src, "icon %q should have Src", cat)
+			assert.Equal(t, "image/svg+xml", icon.MIMEType, "icon %q should be SVG", cat)
+			assert.Contains(t, icon.Src, "data:image/svg+xml,", "icon %q should be data URI", cat)
+		})
+	}
+}
+
+func TestPromptIcons(t *testing.T) {
+	expectedCategories := []string{"create", "debug", "guide", "analyze"}
+
+	for _, cat := range expectedCategories {
+		t.Run("prompt icon "+cat, func(t *testing.T) {
+			icon, ok := promptIcons[cat]
+			assert.True(t, ok, "prompt icon %q should exist", cat)
+			assert.NotEmpty(t, icon.Src)
+			assert.Equal(t, "image/svg+xml", icon.MIMEType)
+		})
+	}
+}
+
+func TestResourceIcons(t *testing.T) {
+	expectedCategories := []string{"solution", "provider"}
+
+	for _, cat := range expectedCategories {
+		t.Run("resource icon "+cat, func(t *testing.T) {
+			icon, ok := resourceIcons[cat]
+			assert.True(t, ok, "resource icon %q should exist", cat)
+			assert.NotEmpty(t, icon.Src)
+			assert.Equal(t, "image/svg+xml", icon.MIMEType)
+		})
+	}
+}
+
+func TestToolInputSchemas(t *testing.T) {
+	// Verify all registered tool schemas are valid JSON Schema.
+	// In particular, array-typed properties must have an "items" definition
+	// or MCP clients (VS Code, Cursor, etc.) will reject the tool.
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	tools := srv.mcpServer.ListTools()
+	require.NotEmpty(t, tools, "server should have registered tools")
+
+	for name, st := range tools {
+		t.Run(name, func(t *testing.T) {
+			// Marshal the tool to JSON and back so we get the final schema
+			// exactly as the MCP client would see it.
+			raw, err := json.Marshal(st.Tool)
+			require.NoError(t, err, "tool should marshal to JSON")
+
+			var toolJSON map[string]any
+			require.NoError(t, json.Unmarshal(raw, &toolJSON))
+
+			// Check inputSchema
+			if schema, ok := toolJSON["inputSchema"].(map[string]any); ok {
+				assertSchemaArrayItems(t, name, "inputSchema", schema)
+			}
+
+			// Check outputSchema — VS Code Copilot validates these too
+			if schema, ok := toolJSON["outputSchema"].(map[string]any); ok {
+				assertSchemaArrayItems(t, name, "outputSchema", schema)
+			}
+		})
+	}
+}
+
+// assertSchemaArrayItems recursively checks that any "type":"array" node has an "items" key.
+// It walks properties, items, and additionalProperties.
+func assertSchemaArrayItems(t *testing.T, toolName, path string, schema any) {
+	t.Helper()
+	m, ok := schema.(map[string]any)
+	if !ok {
+		return
+	}
+
+	if typ, ok := m["type"].(string); ok && typ == "array" {
+		assert.Contains(t, m, "items",
+			"tool %q at %q is type array but missing required 'items' schema", toolName, path)
+	}
+
+	// Recurse into items
+	if items, ok := m["items"]; ok {
+		assertSchemaArrayItems(t, toolName, path+".items", items)
+	}
+
+	// Recurse into object properties
+	if props, ok := m["properties"].(map[string]any); ok {
+		for name, val := range props {
+			assertSchemaArrayItems(t, toolName, path+"."+name, val)
+		}
+	}
+
+	// Recurse into additionalProperties
+	if addl, ok := m["additionalProperties"].(map[string]any); ok {
+		assertSchemaArrayItems(t, toolName, path+".additionalProperties", addl)
+	}
+}
+
+func TestOutputSchemas(t *testing.T) {
+	// Verify all output schemas are valid JSON
+	schemas := map[string][]byte{
+		"ListSolutions":    outputSchemaListSolutions,
+		"InspectSolution":  outputSchemaInspectSolution,
+		"ListProviders":    outputSchemaListProviders,
+		"Version":          outputSchemaVersion,
+		"LintResult":       outputSchemaLintResult,
+		"EvaluateCEL":      outputSchemaEvaluateCEL,
+		"RenderSolution":   outputSchemaRenderSolution,
+		"AuthStatus":       outputSchemaAuthStatus,
+		"GetConfig":        outputSchemaGetConfig,
+		"GetConfigPaths":   outputSchemaGetConfigPaths,
+		"PreviewResolvers": outputSchemaPreviewResolvers,
+		"DryRun":           outputSchemaDryRun,
+	}
+
+	for name, schema := range schemas {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, len(schema) > 0, "schema should not be empty")
+			// Verify it's valid JSON
+			var parsed map[string]any
+			err := json.Unmarshal(schema, &parsed)
+			assert.NoError(t, err, "schema should be valid JSON")
+			// Verify it has a type
+			assert.Contains(t, parsed, "type", "schema should have a type field")
+		})
+	}
+}
+
+func TestElicitMissingParams(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("empty param names returns nil", func(t *testing.T) {
+		result := srv.elicitMissingParams(srv.ctx, nil, nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("elicitation gracefully degrades without session", func(t *testing.T) {
+		// Without a connected MCP session, elicitation should return nil
+		result := srv.elicitMissingParams(srv.ctx, []string{"name"}, map[string]string{
+			"name": "Your name",
+		})
+		assert.Nil(t, result)
+	})
+}
+
+func TestDiscoverWorkspaceRoots(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("gracefully returns nil without session", func(t *testing.T) {
+		roots := srv.discoverWorkspaceRoots(srv.ctx)
+		assert.Nil(t, roots)
+	})
+
+	t.Run("discoverSolutionFiles returns nil without roots", func(t *testing.T) {
+		files := srv.discoverSolutionFiles(srv.ctx)
+		// May return a file if CWD has a solution, or nil otherwise
+		// Either way it should not panic
+		_ = files
+	})
+}
+
+func TestContainsPath(t *testing.T) {
+	assert.True(t, containsPath([]string{"/a/b", "/c/d"}, "/a/b"))
+	assert.False(t, containsPath([]string{"/a/b", "/c/d"}, "/e/f"))
+	assert.False(t, containsPath(nil, "/a/b"))
+}
+
+func TestSendLog(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	// Should not panic without a session
+	srv.sendLog(srv.ctx, mcp.LoggingLevelInfo, "test-logger", "test message")
+}

--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// ToolError represents a structured error response from an MCP tool.
+// It provides machine-readable error codes, actionable suggestions,
+// and references to related tools that may help resolve the issue.
+type ToolError struct {
+	// Code is a machine-readable error code (e.g., "INVALID_INPUT", "NOT_FOUND").
+	Code string `json:"code"`
+	// Message is a human-readable error description.
+	Message string `json:"message"`
+	// Field is the input field that caused the error (optional).
+	Field string `json:"field,omitempty"`
+	// Suggestion is an actionable hint for fixing the error (optional).
+	Suggestion string `json:"suggestion,omitempty"`
+	// Related lists tool names that may help resolve the issue (optional).
+	Related []string `json:"related,omitempty"`
+}
+
+// ErrorOption configures a ToolError.
+type ErrorOption func(*ToolError)
+
+// WithField sets the field that caused the error.
+func WithField(field string) ErrorOption {
+	return func(e *ToolError) {
+		e.Field = field
+	}
+}
+
+// WithSuggestion sets an actionable fix suggestion.
+func WithSuggestion(suggestion string) ErrorOption {
+	return func(e *ToolError) {
+		e.Suggestion = suggestion
+	}
+}
+
+// WithRelatedTools sets related tools that may help.
+func WithRelatedTools(tools ...string) ErrorOption {
+	return func(e *ToolError) {
+		e.Related = tools
+	}
+}
+
+// newStructuredError creates a structured error result with machine-readable context.
+// Use this instead of mcp.NewToolResultError for errors that benefit from
+// additional context (e.g., field-specific validation, fix suggestions).
+func newStructuredError(code, message string, opts ...ErrorOption) *mcp.CallToolResult {
+	te := &ToolError{
+		Code:    code,
+		Message: message,
+	}
+	for _, opt := range opts {
+		opt(te)
+	}
+
+	data, err := json.Marshal(te)
+	if err != nil {
+		// Fall back to plain text error
+		return mcp.NewToolResultError(message)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: string(data),
+			},
+		},
+		IsError: true,
+	}
+}
+
+// Common error codes for MCP tools.
+const (
+	ErrCodeInvalidInput    = "INVALID_INPUT"
+	ErrCodeNotFound        = "NOT_FOUND"
+	ErrCodeValidationError = "VALIDATION_ERROR"
+	ErrCodeLoadFailed      = "LOAD_FAILED"
+	ErrCodeExecFailed      = "EXECUTION_FAILED"
+	ErrCodeAuthRequired    = "AUTH_REQUIRED"
+	ErrCodeConfigError     = "CONFIG_ERROR"
+)

--- a/pkg/mcp/filter.go
+++ b/pkg/mcp/filter.go
@@ -1,0 +1,56 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// contextualToolFilter dynamically shows/hides tools based on the current
+// server configuration. Tools that require unavailable capabilities are
+// filtered out so AI agents don't call tools that will always fail.
+func contextualToolFilter(s *Server) func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+	return func(_ context.Context, tools []mcp.Tool) []mcp.Tool {
+		// Determine what's available
+		hasAuth := s.authReg != nil && len(s.authReg.List()) > 0
+		hasCatalog := s.config != nil && len(s.config.Catalogs) > 0
+		hasRegistry := s.registry != nil
+
+		// Tools that require specific capabilities
+		authTools := map[string]bool{
+			"auth_status":        true,
+			"list_auth_handlers": true,
+		}
+		catalogTools := map[string]bool{
+			"catalog_list":    true,
+			"catalog_inspect": true,
+			"list_solutions":  true,
+		}
+		registryTools := map[string]bool{
+			"list_providers":      true,
+			"get_provider_schema": true,
+		}
+
+		filtered := make([]mcp.Tool, 0, len(tools))
+		for _, tool := range tools {
+			// Hide auth tools when no auth handlers configured
+			if !hasAuth && authTools[tool.Name] {
+				continue
+			}
+			// Hide catalog tools when no catalogs configured
+			if !hasCatalog && catalogTools[tool.Name] {
+				continue
+			}
+			// Hide provider tools when no registry available
+			if !hasRegistry && registryTools[tool.Name] {
+				continue
+			}
+			filtered = append(filtered, tool)
+		}
+
+		return filtered
+	}
+}

--- a/pkg/mcp/filter_test.go
+++ b/pkg/mcp/filter_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextualToolFilter(t *testing.T) {
+	t.Run("all capabilities available - no filtering", func(t *testing.T) {
+		srv := &Server{
+			authReg:  auth.NewRegistry(),
+			config:   &config.Config{Catalogs: []config.CatalogConfig{{Name: "test"}}},
+			registry: provider.NewRegistry(),
+		}
+
+		filter := contextualToolFilter(srv)
+		tools := []mcp.Tool{
+			{Name: "auth_status"},
+			{Name: "catalog_list"},
+			{Name: "list_providers"},
+			{Name: "lint_solution"},
+		}
+
+		// Even with auth and catalog configured, auth_status/catalog_list are
+		// filtered when no handlers or catalogs are empty. But here we have catalogs.
+		// Auth needs List() > 0, which is empty so auth tools should still be filtered.
+		filtered := filter(context.Background(), tools)
+		// auth tools should be filtered (empty registry has no handlers)
+		assert.Equal(t, 3, len(filtered))
+	})
+
+	t.Run("no auth registry - hides auth tools", func(t *testing.T) {
+		srv := &Server{
+			authReg:  nil,
+			config:   &config.Config{Catalogs: []config.CatalogConfig{{Name: "test"}}},
+			registry: provider.NewRegistry(),
+		}
+
+		filter := contextualToolFilter(srv)
+		tools := []mcp.Tool{
+			{Name: "auth_status"},
+			{Name: "list_auth_handlers"},
+			{Name: "lint_solution"},
+			{Name: "list_providers"},
+		}
+
+		filtered := filter(context.Background(), tools)
+		names := toolNames(filtered)
+		assert.NotContains(t, names, "auth_status")
+		assert.NotContains(t, names, "list_auth_handlers")
+		assert.Contains(t, names, "lint_solution")
+		assert.Contains(t, names, "list_providers")
+	})
+
+	t.Run("no catalogs - hides catalog tools", func(t *testing.T) {
+		srv := &Server{
+			config:   &config.Config{},
+			registry: provider.NewRegistry(),
+		}
+
+		filter := contextualToolFilter(srv)
+		tools := []mcp.Tool{
+			{Name: "catalog_list"},
+			{Name: "catalog_inspect"},
+			{Name: "lint_solution"},
+		}
+
+		filtered := filter(context.Background(), tools)
+		names := toolNames(filtered)
+		assert.NotContains(t, names, "catalog_list")
+		assert.NotContains(t, names, "catalog_inspect")
+		assert.Contains(t, names, "lint_solution")
+	})
+
+	t.Run("no registry - hides provider tools", func(t *testing.T) {
+		srv := &Server{
+			registry: nil,
+		}
+
+		filter := contextualToolFilter(srv)
+		tools := []mcp.Tool{
+			{Name: "list_providers"},
+			{Name: "get_provider_schema"},
+			{Name: "lint_solution"},
+		}
+
+		filtered := filter(context.Background(), tools)
+		names := toolNames(filtered)
+		assert.NotContains(t, names, "list_providers")
+		assert.NotContains(t, names, "get_provider_schema")
+		assert.Contains(t, names, "lint_solution")
+	})
+
+	t.Run("nil config - hides catalog tools", func(t *testing.T) {
+		srv := &Server{
+			config: nil,
+		}
+
+		filter := contextualToolFilter(srv)
+		tools := []mcp.Tool{
+			{Name: "catalog_list"},
+			{Name: "list_solutions"},
+			{Name: "evaluate_cel"},
+		}
+
+		filtered := filter(context.Background(), tools)
+		names := toolNames(filtered)
+		assert.NotContains(t, names, "catalog_list")
+		assert.Contains(t, names, "evaluate_cel")
+	})
+
+	t.Run("empty tools list returns empty", func(t *testing.T) {
+		srv := &Server{}
+		filter := contextualToolFilter(srv)
+		filtered := filter(context.Background(), []mcp.Tool{})
+		assert.Empty(t, filtered)
+	})
+}
+
+func toolNames(tools []mcp.Tool) []string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return names
+}

--- a/pkg/mcp/hooks.go
+++ b/pkg/mcp/hooks.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// newObservabilityHooks creates lifecycle hooks for logging, timing,
+// and error tracking on every MCP request.
+func newObservabilityHooks(lgr logr.Logger) *server.Hooks {
+	hooks := &server.Hooks{}
+
+	// Log every incoming request (method + id)
+	hooks.AddBeforeAny(func(_ context.Context, id any, method mcp.MCPMethod, _ any) {
+		lgr.V(1).Info("mcp request", "method", string(method), "id", id)
+	})
+
+	// Log successes with timing info
+	hooks.AddOnSuccess(func(_ context.Context, id any, method mcp.MCPMethod, _, _ any) {
+		lgr.V(1).Info("mcp request succeeded", "method", string(method), "id", id)
+	})
+
+	// Log errors for debugging
+	hooks.AddOnError(func(_ context.Context, id any, method mcp.MCPMethod, _ any, err error) {
+		lgr.Error(err, "mcp request failed", "method", string(method), "id", id)
+	})
+
+	// Log tool calls specifically for higher visibility
+	hooks.AddBeforeCallTool(func(_ context.Context, id any, message *mcp.CallToolRequest) {
+		lgr.Info("tool call", "tool", message.Params.Name, "id", id)
+	})
+
+	hooks.AddAfterCallTool(func(_ context.Context, id any, message *mcp.CallToolRequest, result any) {
+		isErr := false
+		if r, ok := result.(*mcp.CallToolResult); ok && r != nil {
+			isErr = r.IsError
+		}
+		lgr.Info("tool call completed", "tool", message.Params.Name, "id", id, "isError", isErr)
+	})
+
+	// Log session lifecycle
+	hooks.AddOnRegisterSession(func(_ context.Context, session server.ClientSession) {
+		lgr.Info("session registered", "sessionID", session.SessionID())
+	})
+
+	hooks.AddOnUnregisterSession(func(_ context.Context, session server.ClientSession) {
+		lgr.Info("session unregistered", "sessionID", session.SessionID())
+	})
+
+	return hooks
+}
+
+// toolTimingMiddleware wraps tool handlers with timing instrumentation.
+// It logs the duration of each tool call and adds it to the result metadata.
+func toolTimingMiddleware(lgr logr.Logger) server.ToolHandlerMiddleware {
+	return func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			start := time.Now()
+			result, err := next(ctx, request)
+			duration := time.Since(start)
+
+			toolName := request.Params.Name
+			lgr.V(1).Info("tool execution time",
+				"tool", toolName,
+				"duration", duration.String(),
+				"durationMs", duration.Milliseconds(),
+			)
+
+			return result, err
+		}
+	}
+}
+
+// resourceTimingMiddleware wraps resource handlers with timing instrumentation.
+func resourceTimingMiddleware(lgr logr.Logger) server.ResourceHandlerMiddleware {
+	return func(next server.ResourceHandlerFunc) server.ResourceHandlerFunc {
+		return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			start := time.Now()
+			result, err := next(ctx, request)
+			duration := time.Since(start)
+
+			lgr.V(1).Info("resource read time",
+				"uri", request.Params.URI,
+				"duration", duration.String(),
+				"durationMs", duration.Milliseconds(),
+			)
+
+			return result, err
+		}
+	}
+}

--- a/pkg/mcp/hooks_test.go
+++ b/pkg/mcp/hooks_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewObservabilityHooks(t *testing.T) {
+	t.Run("returns non-nil hooks", func(t *testing.T) {
+		lgr := logr.Discard()
+		hooks := newObservabilityHooks(lgr)
+		require.NotNil(t, hooks)
+	})
+}
+
+func TestToolTimingMiddleware(t *testing.T) {
+	t.Run("returns non-nil middleware", func(t *testing.T) {
+		lgr := logr.Discard()
+		mw := toolTimingMiddleware(lgr)
+		require.NotNil(t, mw)
+	})
+}
+
+func TestResourceTimingMiddleware(t *testing.T) {
+	t.Run("returns non-nil middleware", func(t *testing.T) {
+		lgr := logr.Discard()
+		mw := resourceTimingMiddleware(lgr)
+		require.NotNil(t, mw)
+	})
+}
+
+func TestNewServerWithHooks(t *testing.T) {
+	// Verify that hooks are wired up during server creation (no panics).
+	srv, err := NewServer(WithServerLogger(logr.Discard()))
+	require.NoError(t, err)
+	assert.NotNil(t, srv)
+}

--- a/pkg/mcp/icons.go
+++ b/pkg/mcp/icons.go
@@ -1,0 +1,119 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// Icon constants for MCP tools, resources, and prompts.
+// These use data URIs with inline SVGs for maximum compatibility across
+// MCP clients (VS Code, Claude Desktop, Cursor, etc.). Each icon is a
+// simple, recognizable symbol that communicates the tool's purpose.
+
+// toolIcons maps tool categories to their icons.
+var toolIcons = map[string]mcp.Icon{
+	"solution": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%234A90D9' stroke-width='2'><path d='M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z'/><path d='M14 2v6h6'/><path d='M8 13h8'/><path d='M8 17h8'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"provider": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2350C878' stroke-width='2'><rect x='2' y='3' width='20' height='18' rx='2'/><path d='M7 8h10M7 12h10M7 16h6'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"cel": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23E57373' stroke-width='2'><path d='M7 8l-4 4 4 4M17 8l4 4-4 4'/><line x1='14' y1='4' x2='10' y2='20'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"template": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23FFB74D' stroke-width='2'><path d='M12 2L2 7l10 5 10-5-10-5z'/><path d='M2 17l10 5 10-5'/><path d='M2 12l10 5 10-5'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"schema": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%239575CD' stroke-width='2'><path d='M4 7V4a2 2 0 012-2h8.5L20 7.5V20a2 2 0 01-2 2H6a2 2 0 01-2-2v-3'/><path d='M14 2v6h6'/><path d='M3 15l3-3-3-3'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"example": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2326A69A' stroke-width='2'><path d='M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z'/><path d='M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"catalog": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23AB47BC' stroke-width='2'><path d='M4 19.5A2.5 2.5 0 016.5 17H20'/><path d='M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"auth": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23EF5350' stroke-width='2'><path d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"lint": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23FFA726' stroke-width='2'><path d='M22 11.08V12a10 10 0 11-5.93-9.14'/><path d='M22 4L12 14.01l-3-3'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"scaffold": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2342A5F5' stroke-width='2'><rect x='3' y='3' width='18' height='18' rx='2'/><path d='M3 9h18M9 21V9'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"action": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23FF7043' stroke-width='2'><polygon points='5,3 19,12 5,21 5,3'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"diff": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237E57C2' stroke-width='2'><line x1='18' y1='20' x2='18' y2='10'/><line x1='12' y1='20' x2='12' y2='4'/><line x1='6' y1='20' x2='6' y2='14'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"dryrun": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2366BB6A' stroke-width='2'><circle cx='12' cy='12' r='10'/><path d='M12 6v6l4 2'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"config": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2378909C' stroke-width='2'><circle cx='12' cy='12' r='3'/><path d='M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"refs": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%235C6BC0' stroke-width='2'><path d='M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71'/><path d='M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"testing": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%234CAF50' stroke-width='2'><path d='M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"snapshot": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238D6E63' stroke-width='2'><path d='M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z'/><circle cx='12' cy='13' r='4'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"version": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2390A4AE' stroke-width='2'><circle cx='12' cy='12' r='10'/><line x1='12' y1='16' x2='12' y2='12'/><line x1='12' y1='8' x2='12.01' y2='8'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+}
+
+// promptIcons maps prompt categories to their icons.
+var promptIcons = map[string]mcp.Icon{
+	"create": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%234A90D9' stroke-width='2'><circle cx='12' cy='12' r='10'/><line x1='12' y1='8' x2='12' y2='16'/><line x1='8' y1='12' x2='16' y2='12'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"debug": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23E57373' stroke-width='2'><path d='M12 22c-4.97 0-9-2.69-9-6v-4c0-3.31 4.03-6 9-6s9 2.69 9 6v4c0 3.31-4.03 6-9 6z'/><path d='M12 6V2M6 18H2M22 18h-4M20 10h2M2 10h2M6.3 6.3L4 4M17.7 6.3L20 4'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"guide": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2326A69A' stroke-width='2'><path d='M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z'/><path d='M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"analyze": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237E57C2' stroke-width='2'><circle cx='11' cy='11' r='8'/><line x1='21' y1='21' x2='16.65' y2='16.65'/><line x1='11' y1='8' x2='11' y2='14'/><line x1='8' y1='11' x2='14' y2='11'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+}
+
+// resourceIcons maps resource types to their icons.
+var resourceIcons = map[string]mcp.Icon{
+	"solution": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%234A90D9' stroke-width='2'><path d='M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z'/><path d='M14 2v6h6'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+	"provider": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2350C878' stroke-width='2'><rect x='2' y='3' width='20' height='18' rx='2'/><path d='M7 8h10M7 12h10M7 16h6'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
+}

--- a/pkg/mcp/output_schemas.go
+++ b/pkg/mcp/output_schemas.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import "encoding/json"
+
+// Output schemas for tools that return well-defined JSON structures.
+// These help MCP clients understand and validate tool output shapes.
+
+// outputSchemaListSolutions is the output schema for the list_solutions tool.
+var outputSchemaListSolutions = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"solutions": {
+			"type": "array",
+			"description": "List of discovered solutions",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"version": { "type": "string" },
+					"description": { "type": "string" },
+					"path": { "type": "string" },
+					"source": { "type": "string" },
+					"resolver_count": { "type": "integer" },
+					"action_count": { "type": "integer" },
+					"has_tests": { "type": "boolean" }
+				}
+			}
+		},
+		"total": { "type": "integer", "description": "Total number of solutions found" }
+	}
+}`)
+
+// outputSchemaInspectSolution is the output schema for the inspect_solution tool.
+var outputSchemaInspectSolution = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"metadata": {
+			"type": "object",
+			"properties": {
+				"name": { "type": "string" },
+				"version": { "type": "string" },
+				"description": { "type": "string" }
+			}
+		},
+		"resolvers": {
+			"type": "object",
+			"description": "Map of resolver name to resolver details",
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"provider": { "type": "string" },
+					"depends_on": { "type": "array", "items": { "type": "string" } }
+				}
+			}
+		},
+		"actions": {
+			"type": "object",
+			"description": "Map of action name to action details",
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"provider": { "type": "string" },
+					"depends_on": { "type": "array", "items": { "type": "string" } }
+				}
+			}
+		},
+		"dependency_graph": { "type": "string" }
+	}
+}`)
+
+// outputSchemaListProviders is the output schema for the list_providers tool.
+var outputSchemaListProviders = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"providers": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"description": { "type": "string" },
+					"capabilities": {
+						"type": "array",
+						"items": { "type": "string" }
+					}
+				}
+			}
+		},
+		"total": { "type": "integer" }
+	}
+}`)
+
+// outputSchemaVersion is the output schema for the get_version tool.
+var outputSchemaVersion = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"version": { "type": "string" },
+		"commit": { "type": "string" },
+		"build_time": { "type": "string" },
+		"go_version": { "type": "string" },
+		"os": { "type": "string" },
+		"arch": { "type": "string" }
+	}
+}`)
+
+// outputSchemaLintResult is the output schema for the lint_solution tool.
+var outputSchemaLintResult = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"findings": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"rule": { "type": "string" },
+					"severity": { "type": "string", "enum": ["error", "warning", "info"] },
+					"message": { "type": "string" },
+					"location": { "type": "string" }
+				}
+			}
+		},
+		"summary": {
+			"type": "object",
+			"properties": {
+				"errors": { "type": "integer" },
+				"warnings": { "type": "integer" },
+				"info": { "type": "integer" },
+				"total": { "type": "integer" }
+			}
+		}
+	}
+}`)
+
+// outputSchemaEvaluateCEL is the output schema for the evaluate_cel tool.
+var outputSchemaEvaluateCEL = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"result": { "description": "The evaluation result (any JSON type)" },
+		"type": { "type": "string", "description": "The Go type of the result" }
+	}
+}`)
+
+// outputSchemaRenderSolution is the output schema for the render_solution tool.
+var outputSchemaRenderSolution = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"rendered_yaml": { "type": "string", "description": "The rendered solution YAML" },
+		"resolver_graph": { "type": "string", "description": "ASCII dependency graph" },
+		"mermaid_graph": { "type": "string", "description": "Mermaid diagram syntax" }
+	}
+}`)
+
+// outputSchemaAuthStatus is the output schema for the auth_status tool.
+var outputSchemaAuthStatus = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"authenticated": { "type": "boolean" },
+		"handler": { "type": "string" },
+		"details": { "type": "object" }
+	}
+}`)
+
+// outputSchemaGetConfig is the output schema for the get_config tool.
+var outputSchemaGetConfig = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"config": { "type": "object", "description": "The application configuration" }
+	}
+}`)
+
+// outputSchemaGetConfigPaths is the output schema for the get_config_paths tool.
+var outputSchemaGetConfigPaths = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"config_dir": { "type": "string" },
+		"data_dir": { "type": "string" },
+		"cache_dir": { "type": "string" },
+		"state_dir": { "type": "string" }
+	}
+}`)
+
+// outputSchemaPreviewResolvers is the output schema for the preview_resolvers tool.
+var outputSchemaPreviewResolvers = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"resolvers": {
+			"type": "object",
+			"description": "Map of resolver name to resolved value or error",
+			"additionalProperties": {}
+		},
+		"summary": {
+			"type": "object",
+			"properties": {
+				"total": { "type": "integer" },
+				"resolved": { "type": "integer" },
+				"failed": { "type": "integer" },
+				"skipped": { "type": "integer" }
+			}
+		}
+	}
+}`)
+
+// outputSchemaDryRun is the output schema for the dry_run_solution tool.
+var outputSchemaDryRun = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"resolvers": { "type": "object", "description": "Resolver preview results" },
+		"actions": {
+			"type": "array",
+			"description": "Action execution plan",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"provider": { "type": "string" },
+					"would_execute": { "type": "boolean" },
+					"depends_on": { "type": "array", "items": { "type": "string" } }
+				}
+			}
+		}
+	}
+}`)

--- a/pkg/mcp/progress.go
+++ b/pkg/mcp/progress.go
@@ -1,0 +1,109 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// progressReporter sends progress notifications to connected MCP clients
+// during long-running tool operations. It gracefully handles cases where
+// no session is available (e.g., stdio transport without session context)
+// by logging progress instead.
+type progressReporter struct {
+	mcpServer *server.MCPServer
+	logger    logr.Logger
+	token     mcp.ProgressToken
+	total     float64
+}
+
+// newProgressReporter creates a reporter for a tool invocation. It extracts the
+// progress token from the request's _meta field if the client provided one.
+// If no token is present, the reporter becomes a no-op (progress is only logged).
+func newProgressReporter(s *Server, request mcp.CallToolRequest) *progressReporter {
+	r := &progressReporter{
+		mcpServer: s.mcpServer,
+		logger:    s.logger,
+	}
+
+	// Extract progress token from the request _meta if provided by the client
+	if request.Params.Meta != nil {
+		r.token = request.Params.Meta.ProgressToken
+	}
+
+	return r
+}
+
+// setTotal sets the total number of work items for progress calculation.
+func (r *progressReporter) setTotal(total float64) {
+	r.total = total
+}
+
+// report sends a progress notification to the client.
+// progress is the current step (1-based), message is a human-readable status.
+// If no progress token was provided by the client, it logs instead.
+func (r *progressReporter) report(ctx context.Context, progress float64, message string) {
+	if r.token == nil {
+		r.logger.V(1).Info("progress", "step", progress, "total", r.total, "message", message)
+		return
+	}
+
+	var totalPtr *float64
+	if r.total > 0 {
+		totalPtr = &r.total
+	}
+	var msgPtr *string
+	if message != "" {
+		msgPtr = &message
+	}
+
+	notification := mcp.NewProgressNotification(r.token, progress, totalPtr, msgPtr)
+
+	// Convert typed params to map[string]any for SendNotificationToClient.
+	paramsMap := map[string]any{
+		"progressToken": r.token,
+		"progress":      progress,
+	}
+	if totalPtr != nil {
+		paramsMap["total"] = *totalPtr
+	}
+	if msgPtr != nil {
+		paramsMap["message"] = *msgPtr
+	}
+	_ = notification // ensure the notification type stays validated at compile time
+
+	if err := r.mcpServer.SendNotificationToClient(ctx, "notifications/progress", paramsMap); err != nil {
+		r.logger.V(1).Info("failed to send progress notification",
+			"error", err,
+			"progress", progress,
+			"total", r.total,
+		)
+	}
+}
+
+// sendLog sends a structured log message to the connected MCP client.
+// This uses the MCP logging capability (notifications/message) for
+// real-time log streaming during tool execution.
+func (s *Server) sendLog(ctx context.Context, level mcp.LoggingLevel, loggerName, message string) {
+	notification := mcp.LoggingMessageNotification{
+		Notification: mcp.Notification{
+			Method: "notifications/message",
+		},
+	}
+	notification.Params.Level = level
+	notification.Params.Logger = loggerName
+	notification.Params.Data = message
+
+	if err := s.mcpServer.SendLogMessageToClient(ctx, notification); err != nil {
+		s.logger.V(1).Info("failed to send log to client",
+			"error", err,
+			"level", string(level),
+			"message", message,
+		)
+	}
+}

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -11,12 +11,46 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// resolvePathArg detects whether a prompt argument contains file content
+// (as happens when MCP clients resolve file references to their contents)
+// rather than a file system path. Returns a path reference suitable for
+// embedding in tool call instructions and an optional inline note explaining
+// that the file content was provided instead of a path.
+func resolvePathArg(argValue string) (pathRef, inlineNote string) {
+	trimmed := strings.TrimSpace(argValue)
+	if !strings.Contains(argValue, "\n") &&
+		len(trimmed) < 500 &&
+		!strings.HasPrefix(trimmed, "apiVersion:") &&
+		!strings.HasPrefix(trimmed, "kind:") {
+		// Looks like a normal file path
+		return argValue, ""
+	}
+
+	// The argument contains file content, not a path.
+	// Include the content for context and instruct the LLM to determine the real path.
+	inlineNote = fmt.Sprintf(`
+
+IMPORTANT: The path argument contains the solution's YAML content instead of a file path.
+This happens when MCP clients resolve file references to their contents.
+You MUST determine the actual file system path before calling any tools
+(inspect_solution, lint_solution, run_solution_tests, etc.).
+Ask the user for the file path if it cannot be determined from context.
+
+Solution content provided inline:
+---
+%s
+---
+`, argValue)
+	return "<solution_file_path>", inlineNote
+}
+
 // registerPrompts registers all MCP prompts on the server.
 func (s *Server) registerPrompts() {
 	// create_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("create_solution",
 			mcp.WithPromptDescription("Guide for creating a new scafctl solution YAML file from scratch. Provides the solution schema, examples, and step-by-step instructions."),
+			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("name",
 				mcp.ArgumentDescription("Name for the new solution (lowercase, hyphens allowed, e.g., 'my-solution')"),
 				mcp.RequiredArgument(),
@@ -36,6 +70,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("debug_solution",
 			mcp.WithPromptDescription("Help debug a scafctl solution that isn't working as expected. Inspects the solution, lints it, and suggests fixes."),
+			mcp.WithPromptIcons(promptIcons["debug"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to debug"),
 				mcp.RequiredArgument(),
@@ -51,6 +86,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("add_resolver",
 			mcp.WithPromptDescription("Guide for adding a new resolver to an existing solution. Shows available providers, schema, and patterns."),
+			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("provider",
 				mcp.ArgumentDescription("Provider to use for the resolver (e.g., parameter, static, env, http, cel, file, exec)"),
 				mcp.RequiredArgument(),
@@ -66,6 +102,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("add_action",
 			mcp.WithPromptDescription("Guide for adding a new action to an existing solution's workflow. Shows available action providers, schema, and patterns."),
+			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("provider",
 				mcp.ArgumentDescription("Provider to use for the action (e.g., exec, http, directory, go-template)"),
 				mcp.RequiredArgument(),
@@ -81,6 +118,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("update_solution",
 			mcp.WithPromptDescription("Guide for modifying an existing scafctl solution. Inspects the current state, makes targeted changes, then validates with lint and preview."),
+			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the existing solution file to modify"),
 				mcp.RequiredArgument(),
@@ -97,6 +135,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("add_tests",
 			mcp.WithPromptDescription("Guide for writing functional tests for a scafctl solution. Walks through test schema, assertions, snapshots, and test patterns."),
+			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to add tests to"),
 				mcp.RequiredArgument(),
@@ -112,6 +151,7 @@ func (s *Server) registerPrompts() {
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("compose_solution",
 			mcp.WithPromptDescription("Guide for designing a multi-file composed solution using scafctl's composition system. Breaks a solution into reusable partial YAML files that get merged at build time."),
+			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the root solution file (or directory for a new composed solution)"),
 				mcp.RequiredArgument(),
@@ -122,6 +162,93 @@ func (s *Server) registerPrompts() {
 			),
 		),
 		s.handleComposeSolutionPrompt,
+	)
+
+	// fix_lint prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("fix_lint",
+			mcp.WithPromptDescription("Guide for fixing lint findings in a scafctl solution. Lints the solution, explains each finding, and applies targeted fixes in priority order (errors first, then warnings)."),
+			mcp.WithPromptIcons(promptIcons["debug"]),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the solution file to fix"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("severity",
+				mcp.ArgumentDescription("Minimum severity to fix: 'error' (errors only), 'warning' (errors + warnings), 'info' (all). Default: warning"),
+			),
+		),
+		s.handleFixLintPrompt,
+	)
+
+	// prepare_execution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("prepare_execution",
+			mcp.WithPromptDescription("Prepare a scafctl solution for execution. Validates, previews, and generates the exact CLI command — without actually running it. Use this when you're ready to run a solution but want to verify everything first."),
+			mcp.WithPromptIcons(promptIcons["guide"]),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the solution file to prepare for execution"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("params",
+				mcp.ArgumentDescription("Comma-separated key=value input parameters (e.g., 'env=prod,region=us-east1')"),
+			),
+		),
+		s.handlePrepareExecutionPrompt,
+	)
+
+	// analyze_execution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("analyze_execution",
+			mcp.WithPromptDescription("Analyze a completed scafctl execution by inspecting the snapshot. Identifies failures, regressions, and suggests fixes. Optionally compares against a known-good snapshot."),
+			mcp.WithPromptIcons(promptIcons["analyze"]),
+			mcp.WithArgument("snapshot_path",
+				mcp.ArgumentDescription("Path to the snapshot JSON file from the failed or unexpected run"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("previous_snapshot",
+				mcp.ArgumentDescription("Path to a known-good snapshot for comparison (optional — enables regression detection)"),
+			),
+			mcp.WithArgument("problem",
+				mcp.ArgumentDescription("Description of what went wrong or what was unexpected"),
+			),
+		),
+		s.handleAnalyzeExecutionPrompt,
+	)
+
+	// migrate_solution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("migrate_solution",
+			mcp.WithPromptDescription("Guide for structurally refactoring a scafctl solution. Supports adding composition, extracting templates, splitting into multiple files, adding tests, and upgrading to newer patterns."),
+			mcp.WithPromptIcons(promptIcons["guide"]),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the solution file to migrate"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("migration",
+				mcp.ArgumentDescription("Migration type: 'add-composition' (split into composed files), 'extract-templates' (move inline templates to files), 'split-solution' (break into smaller solutions), 'add-tests' (add comprehensive functional tests), 'upgrade-patterns' (modernize to latest best practices)"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("target_dir",
+				mcp.ArgumentDescription("Target directory for split/extracted files (optional, defaults to solution directory)"),
+			),
+		),
+		s.handleMigrateSolutionPrompt,
+	)
+
+	// optimize_solution prompt
+	s.mcpServer.AddPrompt(
+		mcp.NewPrompt("optimize_solution",
+			mcp.WithPromptDescription("Analyze a scafctl solution for performance, readability, and quality improvements. Identifies parallelization opportunities, unnecessary dependencies, naming issues, and missing test coverage."),
+			mcp.WithPromptIcons(promptIcons["analyze"]),
+			mcp.WithArgument("path",
+				mcp.ArgumentDescription("Path to the solution file to optimize"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("focus",
+				mcp.ArgumentDescription("Optimization focus: 'performance' (parallelization, dependency optimization), 'readability' (naming, structure, documentation), 'testing' (coverage gaps, missing edge cases), 'all' (comprehensive analysis). Default: all"),
+			),
+		),
+		s.handleOptimizeSolutionPrompt,
 	)
 }
 
@@ -154,6 +281,9 @@ Follow these rules when creating the solution:
 - metadata.name must be lowercase with hyphens only (3-60 chars)
 - metadata.version must be a valid semver (e.g., "1.0.0")
 - Resolvers go under spec.resolvers.<name> with resolve/transform/validate phases
+- The resolver "type" field is OPTIONAL. Only set it when the resolved value is a known scalar type.
+  NEVER set type: string on resolvers using providers that return objects (e.g., http returns {statusCode, body, headers}).
+  When in doubt, omit the type field entirely.
 - Actions go under spec.workflow.actions.<name> with provider and inputs
 - Use ValueRef format for inputs: literal (raw value), rslvr (resolver reference), expr (CEL expression), or tmpl (Go template)
 - Always validate user inputs using the validate phase with the validation provider
@@ -165,6 +295,9 @@ NEVER invent fields that don't exist in the schema. Only use fields documented i
 When using any provider in an action, ALWAYS call get_provider_schema first to verify the exact field names and types.
 
 After creating the solution, tell the user how to run it.
+IMPORTANT: When referencing filenames in your response, ALWAYS prefix relative paths
+with "./" (e.g., "./test-solution.yaml", NOT "test-solution.yaml"). Bare filenames
+without "./" get auto-linkified by VS Code Chat into broken content-reference URLs.
 IMPORTANT: Choose the correct run command based on whether the solution has a workflow:
   • If the solution has spec.workflow.actions (i.e. it performs side-effects/actions):
       scafctl run solution -f ./<filename>.yaml -r key=value
@@ -200,13 +333,15 @@ func (s *Server) handleDebugSolutionPrompt(_ context.Context, request mcp.GetPro
 	path := request.Params.Arguments["path"]
 	problem := request.Params.Arguments["problem"]
 
+	pathRef, inlineNote := resolvePathArg(path)
+
 	problemDesc := "The solution is not working as expected."
 	if problem != "" {
 		problemDesc = problem
 	}
 
 	prompt := fmt.Sprintf(`Debug the scafctl solution at %q.
-
+%s
 Problem: %s
 
 Follow this debugging process:
@@ -229,7 +364,7 @@ Check for common issues:
 
 7. Call preview_resolvers with path %q to check if resolvers execute successfully and produce expected values
 8. If the solution has tests, call run_solution_tests with path %q to verify test results
-9. Call get_run_command with path %q to verify the correct run command`, path, problemDesc, path, path, path, path, path)
+9. Call get_run_command with path %q to verify the correct run command`, pathRef, inlineNote, problemDesc, pathRef, pathRef, pathRef, pathRef, pathRef)
 
 	return &mcp.GetPromptResult{
 		Description: fmt.Sprintf("Debug solution: %s", path),
@@ -272,7 +407,7 @@ A resolver has these phases:
 Resolver field structure:
   <resolver-name>:
     description: "what this resolves"
-    type: string|int|float|bool|array|object|time|duration|any
+    type: string|int|float|bool|array|object|time|duration|any  # OPTIONAL — see type rules below
     resolve:
       with:
         - provider: %q
@@ -287,8 +422,25 @@ Resolver field structure:
       with:
         - provider: validation
           inputs:
-            expression: "<CEL validation expression>"
+            expression: "<CEL validation expression using __self>"
           message: "Error message if validation fails"
+
+IMPORTANT rules for resolver phases:
+- Each phase (resolve, transform, validate) MUST use the "with" key containing an array. Never use a bare array.
+- In transform and validate phases, use __self to reference the resolver's own value, NOT _.resolverName.
+  Using _.resolverName creates a circular dependency. __self is the correct way to access the current value.
+  Example: expression: "__self.statusCode == 200"  (correct)
+           expression: "_.myResolver.statusCode == 200"  (WRONG - causes cycle)
+- In resolve phase, _.otherResolver references other resolvers' values (not self).
+
+IMPORTANT rules for the resolver "type" field:
+- The type field is OPTIONAL. When omitted, the value passes through as-is (equivalent to type: any).
+- Only set type when you KNOW the resolved value is a simple scalar (string, int, float, bool).
+- NEVER set type: string on resolvers that use providers returning objects/maps (e.g., http, exec).
+  The http provider returns an object with statusCode, body, headers — setting type: string would
+  cause a coercion error. Omit the type field or use type: object for these providers.
+- When in doubt, OMIT the type field entirely — it is safer than guessing wrong.
+- Call get_provider_schema to check what a provider returns before deciding on a type.
 
 Input values use ValueRef format:
 - Literal: just the raw value
@@ -382,8 +534,10 @@ func (s *Server) handleUpdateSolutionPrompt(_ context.Context, request mcp.GetPr
 	path := request.Params.Arguments["path"]
 	change := request.Params.Arguments["change"]
 
-	prompt := fmt.Sprintf(`Modify the existing scafctl solution at %q.
+	pathRef, inlineNote := resolvePathArg(path)
 
+	prompt := fmt.Sprintf(`Modify the existing scafctl solution at %q.
+%s
 Requested change: %s
 
 Follow this workflow to make a safe, validated change:
@@ -412,7 +566,7 @@ IMPORTANT:
 - Do NOT restructure the entire solution — make the minimal change needed
 - If lint_solution reports errors after your change, fix them before finishing
 - If preview_resolvers shows unexpected values, investigate and fix
-- Always verify provider field names with get_provider_schema before writing inputs`, path, change, path, path, path, path, path)
+- Always verify provider field names with get_provider_schema before writing inputs`, pathRef, inlineNote, change, pathRef, pathRef, pathRef, pathRef, pathRef)
 
 	return &mcp.GetPromptResult{
 		Description: fmt.Sprintf("Update solution: %s", path),
@@ -433,12 +587,14 @@ func (s *Server) handleAddTestsPrompt(_ context.Context, request mcp.GetPromptRe
 	path := request.Params.Arguments["path"]
 	scope := request.Params.Arguments["scope"]
 
+	pathRef, inlineNote := resolvePathArg(path)
+
 	if scope == "" {
 		scope = "all"
 	}
 
 	prompt := fmt.Sprintf(`Add functional tests to the scafctl solution at %q.
-
+%s
 Test scope: %s
 
 Follow these steps:
@@ -448,7 +604,7 @@ STEP 1 — UNDERSTAND the solution:
 2. Identify what needs testing based on the scope
 
 STEP 2 — LEARN the test format:
-3. Call explain_kind with kind "solution" and field "testing" to see test schema
+3. Call explain_kind with kind "solution" and field "spec.testing" to see test schema
 4. Call get_example with path "solutions/tested-solution/solution.yaml" for a practical reference
 5. Review the test case structure
 
@@ -496,15 +652,21 @@ STEP 4 — VALIDATE the tests:
 6. Call lint_solution with file %q to verify the solution with tests is valid YAML
 7. Call run_solution_tests with path %q to execute the tests and verify they pass
 
+After adding tests, tell the user how to run them from the CLI:
+  scafctl test functional -f ./<filename>.yaml
+  scafctl test functional -f ./<filename>.yaml -v   # verbose output
+IMPORTANT: The CLI command is 'scafctl test functional -f <file>', NOT 'scafctl test -f <file>'.
+The 'functional' subcommand is REQUIRED. 'scafctl test -f' will FAIL.
+
 IMPORTANT:
 - Test names must be lowercase with hyphens (no spaces, underscores, or uppercase)
 - Built-in tests (lint, parse) run automatically unless skipped
 - Use tags to organize tests (smoke, validation, integration, etc.)
 - The -f flag is auto-injected; do NOT include it in args
-- Use 'render solution' with '-o json' for most resolver output testing`, path, scope, path, scopeHints(scope), path, path)
+- Use 'render solution' with '-o json' for most resolver output testing`, pathRef, inlineNote, scope, pathRef, scopeHints(scope), pathRef, pathRef)
 
 	return &mcp.GetPromptResult{
-		Description: fmt.Sprintf("Add tests to solution: %s", path),
+		Description: fmt.Sprintf("Add tests to solution: %s", pathRef),
 		Messages: []mcp.PromptMessage{
 			{
 				Role: mcp.RoleUser,
@@ -522,16 +684,19 @@ func (s *Server) handleComposeSolutionPrompt(_ context.Context, request mcp.GetP
 	path := request.Params.Arguments["path"]
 	goal := request.Params.Arguments["goal"]
 
+	pathRef, inlineNote := resolvePathArg(path)
+
 	prompt := fmt.Sprintf(`Design a multi-file composed scafctl solution.
 
 Root path: %s
+%s
 Goal: %s
 
 Composition allows splitting a large solution into multiple partial YAML files that get merged at build time. This promotes reusability and maintainability.
 
 STEP 1 — UNDERSTAND composition:
 1. Call get_solution_schema and look at the "compose" field in the spec
-2. Call get_example with path "solutions/composed/solution.yaml" or similar composition examples from list_examples (category: "solutions")
+2. Call get_example with path "solutions/composition/parent.yaml" or similar composition examples from list_examples (category: "solutions")
 
 Composition works by declaring partial YAML files in the root solution:
 
@@ -582,10 +747,10 @@ IMPORTANT RULES:
 - Names must be globally unique — two files cannot define the same resolver or action name
 - Use relative paths in the compose list (relative to the root solution file)
 - Deep merge means maps are merged recursively; arrays are replaced, not appended
-- Order matters: later compose entries override earlier ones for conflicting keys`, path, goal)
+- Order matters: later compose entries override earlier ones for conflicting keys`, pathRef, inlineNote, goal)
 
 	return &mcp.GetPromptResult{
-		Description: fmt.Sprintf("Compose solution: %s", path),
+		Description: fmt.Sprintf("Compose solution: %s", pathRef),
 		Messages: []mcp.PromptMessage{
 			{
 				Role: mcp.RoleUser,
@@ -623,5 +788,483 @@ func scopeHints(scope string) string {
 - Include edge cases: missing params, invalid inputs
 - Tag tests appropriately: smoke (fast, essential), validation, integration
 - Test both success and expected failure paths`
+	}
+}
+
+// handleFixLintPrompt returns a prompt guiding the AI to fix lint findings.
+func (s *Server) handleFixLintPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	severity := request.Params.Arguments["severity"]
+
+	pathRef, inlineNote := resolvePathArg(path)
+
+	if severity == "" {
+		severity = "warning"
+	}
+
+	prompt := fmt.Sprintf(`Fix lint findings in the scafctl solution at %q.
+%s
+Minimum severity to fix: %s
+
+Follow this exact workflow:
+
+STEP 1 — LINT the solution:
+1. Call lint_solution with file %q and severity %q to get current findings
+2. If there are no findings, report "Solution is clean" and stop
+
+STEP 2 — UNDERSTAND each finding:
+3. For each finding, call explain_lint_rule with the finding's ruleName to get:
+   - What the rule checks for
+   - Why it matters
+   - How to fix it
+   - Examples of correct usage
+
+STEP 3 — FIX findings in priority order:
+Fix errors first, then warnings, then info:
+
+For each finding:
+4. Read the solution file and locate the problem area (the finding's "location" field tells you where)
+5. Apply the fix suggested by explain_lint_rule
+6. If the fix requires verifying a provider's schema (e.g., fixing unknown-provider-input), call get_provider_schema first
+7. If the fix involves CEL expressions, call validate_expression to verify the corrected expression
+8. If the fix involves Go templates, call evaluate_go_template to verify
+
+STEP 4 — VALIDATE the fixes:
+9. Call lint_solution again with the same severity to confirm all findings are resolved
+10. If new findings appeared from the fixes, repeat from STEP 3
+11. Call preview_resolvers with path %q to verify the solution still works correctly
+
+IMPORTANT:
+- Fix ONE finding at a time to avoid cascading errors
+- Always re-lint after each fix to catch regressions
+- Do NOT change anything unrelated to the lint findings
+- If a finding is intentional (e.g., long-timeout for a known long operation), explain and skip it
+- Some findings may be related (e.g., unused-resolver + missing reference) — fix them together`, pathRef, inlineNote, severity, pathRef, severity, pathRef)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Fix lint findings in: %s", pathRef),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// handlePrepareExecutionPrompt returns a prompt that validates and prepares a solution for execution.
+func (s *Server) handlePrepareExecutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	params := request.Params.Arguments["params"]
+
+	pathRef, inlineNote := resolvePathArg(path)
+
+	paramsSection := ""
+	if params != "" {
+		paramsSection = fmt.Sprintf("\nUser-provided parameters: %s\n", params)
+	}
+
+	prompt := fmt.Sprintf(`Prepare the scafctl solution at %q for execution.
+%s%s
+This prompt validates the solution, previews its behavior, and provides the exact CLI 
+command to run it — without actually executing it. The user makes the final decision.
+
+STEP 1 — INSPECT the solution:
+1. Call inspect_solution with path %q to understand its structure
+2. Identify:
+   - Does it have a spec.workflow.actions section? → needs 'run solution'
+   - Does it have only resolvers (no workflow)? → needs 'run resolver'
+   - What resolver parameters does it expect? (look for parameter provider usage)
+
+STEP 2 — VALIDATE the solution:
+3. Call lint_solution with file %q to check for errors
+4. If there are error-severity findings, STOP and tell the user to fix them first
+   (suggest using the fix_lint prompt)
+
+STEP 3 — CHECK authentication:
+5. Call auth_status to see configured auth providers
+6. Cross-reference with the solution's providers — if the solution uses HTTP providers 
+   that need auth, or cloud providers (GCP, Azure, GitHub), warn if auth is not configured
+
+STEP 4 — PREVIEW the solution:
+7. Call preview_resolvers with path %q to see what values the resolvers produce
+   - Verify resolver outputs look correct for the given parameters
+   - Flag any resolvers that returned errors or unexpected values
+8. If the solution has a workflow, call preview_action with path %q to see the action graph
+   - Review which actions would execute and in what order
+   - Check for any actions with conditions (when clauses) that might skip
+
+STEP 5 — GENERATE the run command:
+9. Call get_run_command with path %q to get the exact CLI command
+
+STEP 6 — PRESENT the execution plan:
+Present a clear summary to the user:
+
+**Solution:** <name> (v<version>)
+**Command type:** run solution / run resolver
+**Parameters:** <list of parameters and their values>
+**Resolvers:** <count> resolvers will execute
+**Actions:** <count> actions will execute (if applicable)
+**Auth:** <status of required auth providers>
+**Warnings:** <any issues from preview>
+
+**Command to run:**
+`+"```"+`
+<exact command from get_run_command>
+`+"```"+`
+
+DO NOT run the command yourself. Present it to the user and let them execute it.
+If there are any concerns from the preview (unexpected values, missing auth, lint warnings), 
+highlight them clearly so the user can make an informed decision.`, pathRef, inlineNote, paramsSection, pathRef, pathRef, pathRef, pathRef, pathRef)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Prepare execution: %s", pathRef),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// handleAnalyzeExecutionPrompt returns a prompt guiding post-execution analysis.
+func (s *Server) handleAnalyzeExecutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	snapshotPath := request.Params.Arguments["snapshot_path"]
+	previousSnapshot := request.Params.Arguments["previous_snapshot"]
+	problem := request.Params.Arguments["problem"]
+
+	problemDesc := "The execution did not produce the expected results."
+	if problem != "" {
+		problemDesc = problem
+	}
+
+	var diffSection string
+	if previousSnapshot != "" {
+		diffSection = fmt.Sprintf(`
+STEP 2 — COMPARE with the previous snapshot:
+3. Call diff_snapshots with before %q and after %q
+4. Review the diff output:
+   - Look for status changes (success → failed indicates a regression)
+   - Look for value changes (unexpected output changes)
+   - Look for added/removed resolvers (structural changes)
+5. For any regressions (success → failed), note the resolver name and error message`, previousSnapshot, snapshotPath)
+	} else {
+		diffSection = `
+STEP 2 — No previous snapshot provided:
+- If the user has a known-good snapshot from a prior run, suggest they provide it for comparison
+- Without a baseline, focus on the error messages and resolver statuses in the current snapshot`
+	}
+
+	prompt := fmt.Sprintf(`Analyze the execution results from snapshot at %q.
+
+Problem reported: %s
+
+Follow this analysis process:
+
+STEP 1 — INSPECT the snapshot:
+1. Call show_snapshot with path %q and format "full" to see complete results
+2. Review the snapshot:
+   - Overall status (success/failed)
+   - Duration (was it unusually slow?)
+   - Phase execution order
+   - Failed resolvers (status != "success")
+   - Resolver errors (error messages)
+%s
+
+STEP 3 — DIAGNOSE failed resolvers:
+For each failed resolver:
+6. Note the provider used and the error message
+7. Call get_provider_schema for that provider to verify the configuration is correct
+8. If the provider is an HTTP/cloud provider (http, gcp, azure, github), call auth_status to check authentication
+9. Common failure patterns:
+   - "connection refused" or "timeout" → service endpoint issue, check URL/host configuration
+   - "401 Unauthorized" or "403 Forbidden" → auth issue, verify credentials/tokens
+   - "no such key" or "not found" → configuration key changed or missing
+   - "template execution failed" → Go template syntax error, use eval_template to test
+   - "CEL evaluation failed" → CEL expression error, use eval_cel to test
+   - "dependency failed" → upstream resolver failed, fix that first
+
+STEP 4 — SUGGEST fixes:
+10. For each issue found, provide a specific fix:
+    - If it's a configuration issue: show the exact YAML change needed
+    - If it's an auth issue: show the auth setup command
+    - If it's an expression error: show the corrected expression
+    - If it's a dependency issue: identify the root cause (upstream) resolver
+
+STEP 5 — VERIFY fixes:
+11. After suggesting fixes, recommend verification steps:
+    - Re-run the solution with --snapshot flag to capture new results
+    - Compare new snapshot with the problematic one using diff_snapshots
+    - Run lint_solution to check for any structural issues
+
+Present findings as:
+
+**Execution Summary:**
+- Status: <overall status>
+- Duration: <duration>
+- Resolvers: <success>/<total> succeeded
+
+**Failed Resolvers:**
+For each failure:
+- **<name>** (<provider>): <error summary>
+  - Root cause: <analysis>
+  - Fix: <specific fix>
+
+**Regressions:** (if comparison snapshot provided)
+- <list of resolvers that changed from success to failed>
+
+**Recommended Actions:**
+1. <prioritized list of fixes>`, snapshotPath, problemDesc, snapshotPath, diffSection)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Analyze execution: %s", snapshotPath),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// handleMigrateSolutionPrompt returns a prompt guiding structural migration of a solution.
+func (s *Server) handleMigrateSolutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	migration := request.Params.Arguments["migration"]
+	targetDir := request.Params.Arguments["target_dir"]
+
+	pathRef, inlineNote := resolvePathArg(path)
+
+	targetSection := ""
+	if targetDir != "" {
+		targetSection = fmt.Sprintf("\nTarget directory for extracted/split files: %s\n", targetDir)
+	}
+
+	migrationGuide := migrationTypeGuide(migration)
+
+	prompt := fmt.Sprintf(`Migrate the scafctl solution at %q.
+%s
+Migration type: %s
+%s
+This prompt guides a STRUCTURAL refactoring of the solution. Unlike update_solution (which makes
+targeted functional changes), this migration reorganizes the solution's architecture while
+preserving its behavior.
+
+STEP 1 — ESTABLISH baseline:
+1. Call inspect_solution with path %q to understand the current structure
+2. Call lint_solution with file %q to establish a baseline — note any existing findings
+3. Call preview_resolvers with path %q to capture expected resolver outputs (these MUST NOT change)
+
+STEP 2 — PLAN the migration:
+%s
+
+STEP 3 — EXECUTE the migration:
+4. Apply the planned changes according to the migration type above
+5. Preserve ALL functional behavior — resolver outputs, action execution order, and conditions must remain identical
+
+STEP 4 — VALIDATE the migration:
+6. Call lint_solution with the root solution file — ZERO new findings should appear
+7. Call preview_resolvers with the root path — compare outputs against the baseline from STEP 1
+8. Call diff_solution between the original and migrated solution to confirm only structural changes
+9. If the solution has tests, call run_solution_tests to verify all tests still pass
+
+CRITICAL RULES:
+- Migration MUST be behavior-preserving — same inputs produce same outputs
+- Do NOT add, remove, or modify resolver logic (that's what update_solution is for)
+- Do NOT change action behavior or ordering
+- If any validation step fails, revert the change and investigate before continuing
+- Document what was migrated and why in commit messages`, pathRef, inlineNote, migration, targetSection, pathRef, pathRef, pathRef, migrationGuide)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Migrate solution (%s): %s", migration, pathRef),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// migrationTypeGuide returns migration-specific instructions.
+func migrationTypeGuide(migration string) string {
+	switch migration {
+	case "add-composition":
+		return `Migration: ADD COMPOSITION
+- Identify logical groupings of resolvers and actions
+- Create partial YAML files for each group (e.g., resolvers/params.yaml, actions/deploy.yaml)
+- Move resolver and action definitions into the partials
+- Add spec.compose entries in the root solution pointing to each partial
+- The root solution keeps metadata, compose list, and any shared configuration
+- Verify the merged result matches the original with lint_solution`
+	case "extract-templates":
+		return `Migration: EXTRACT TEMPLATES
+- Find all inline Go templates (tmpl: fields with multi-line content)
+- Create template files in a templates/ directory alongside the solution
+- Replace inline tmpl: values with file references (tmpl: file:templates/<name>.tmpl)
+- For CEL expressions, consider if complex ones should become standalone files
+- Use extract_resolver_refs on each template to verify references are preserved`
+	case "split-solution":
+		return `Migration: SPLIT SOLUTION
+- Identify independent functional units in the solution
+- Create separate solution files for each unit
+- Ensure each sub-solution is self-contained (has its own resolvers)
+- Shared resolvers should be duplicated or extracted into a composition partial
+- Update any documentation or run commands to reference the new files`
+	case "add-tests":
+		return `Migration: ADD TESTS
+- Call generate_test_scaffold to get starter test cases based on the solution
+- Add comprehensive tests for each resolver (use command [render, solution] -o json)
+- Add workflow tests if spec.workflow exists (use command [run, solution])
+- Include edge cases: missing parameters, invalid inputs, boundary values
+- Tag tests appropriately (smoke, validation, integration)
+- Call run_solution_tests to verify all new tests pass`
+	case "upgrade-patterns":
+		return `Migration: UPGRADE PATTERNS
+- Check for deprecated patterns (old-style ValueRef formats, legacy fields)
+- Replace string concatenation in templates with proper expressions
+- Add missing validation phases to resolvers that accept user input
+- Ensure all providers are using their latest input field names (call get_provider_schema)
+- Add display_name and description fields where missing
+- Standardize naming conventions (lowercase-with-hyphens)
+- Add type annotations to resolvers that are missing them`
+	default:
+		return fmt.Sprintf(`Migration: %s
+- Inspect the solution to understand current structure
+- Plan changes that preserve behavior
+- Execute incrementally, validating after each change`, migration)
+	}
+}
+
+// handleOptimizeSolutionPrompt returns a prompt for performance/quality analysis.
+func (s *Server) handleOptimizeSolutionPrompt(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := request.Params.Arguments["path"]
+	focus := request.Params.Arguments["focus"]
+
+	pathRef, inlineNote := resolvePathArg(path)
+
+	if focus == "" {
+		focus = "all"
+	}
+
+	focusGuide := optimizationFocusGuide(focus)
+
+	prompt := fmt.Sprintf(`Optimize the scafctl solution at %q.
+%s
+Optimization focus: %s
+
+STEP 1 — ANALYZE structure:
+1. Call inspect_solution with path %q to see the full structure
+2. Call render_solution with path %q and graph_type "resolver" to see the resolver dependency graph
+3. Call render_solution with path %q and graph_type "action-deps" to see action dependencies
+4. Call lint_solution with file %q to identify quality issues
+
+STEP 2 — IDENTIFY optimization opportunities:
+%s
+
+STEP 3 — PRIORITIZE recommendations:
+Present findings as a prioritized list:
+
+**High Impact:**
+- Changes that improve execution speed or correctness
+- Missing validations that could prevent runtime errors
+
+**Medium Impact:**
+- Readability improvements that help maintainability
+- Test coverage gaps
+
+**Low Impact:**
+- Cosmetic naming/formatting improvements
+- Documentation additions
+
+For each recommendation, provide:
+- What to change (specific YAML snippet)
+- Why it helps
+- Expected impact
+
+STEP 4 — VALIDATE changes (if user applies them):
+5. Call lint_solution to verify no regressions
+6. Call preview_resolvers to confirm resolver outputs are unchanged
+7. Call extract_resolver_refs on any modified templates to verify references
+8. If tests exist, call run_solution_tests to ensure nothing broke
+
+IMPORTANT:
+- Optimizations MUST be behavior-preserving unless explicitly noted
+- Flag any changes that alter execution order or outputs
+- Performance changes (parallelization) should be safe — only parallelize truly independent items`, pathRef, inlineNote, focus, pathRef, pathRef, pathRef, pathRef, focusGuide)
+
+	return &mcp.GetPromptResult{
+		Description: fmt.Sprintf("Optimize solution (%s): %s", focus, pathRef),
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: prompt,
+				},
+			},
+		},
+	}, nil
+}
+
+// optimizationFocusGuide returns focus-specific optimization instructions.
+func optimizationFocusGuide(focus string) string {
+	switch focus {
+	case "performance":
+		return `PERFORMANCE ANALYSIS:
+- Identify resolvers that run serially but could run in parallel (no shared dependencies)
+- Find unnecessary dependsOn chains — remove dependencies that aren't actually needed
+- Look for duplicate resolver work (two resolvers fetching the same data)
+- Check action parallelization opportunities (independent actions in different phases)
+- Look for expensive operations (HTTP calls, exec commands) that could be cached or avoided
+- Check if resolver types are set correctly (wrong types cause unnecessary conversion overhead)`
+	case "readability":
+		return `READABILITY ANALYSIS:
+- Check naming consistency: resolver names, action names, parameter names (should be lowercase-with-hyphens)
+- Look for missing descriptions on resolvers and actions
+- Find overly complex CEL expressions that could be simplified or split
+- Identify undocumented parameters (parameter provider resolvers without descriptions)
+- Check for magic values that should be named resolvers
+- Look for duplicate template logic that could be extracted
+- Verify display_name fields are set for user-facing resolvers`
+	case "testing":
+		return `TESTING ANALYSIS:
+- Call list_tests to see existing test coverage
+- Call generate_test_scaffold to see what tests are recommended
+- Identify untested resolvers (especially those with complex transform/validate phases)
+- Look for missing edge case tests (empty inputs, boundary values, error conditions)
+- Check for untested conditional logic (when clauses)
+- Verify error path testing (expected failures, validation errors)
+- Look for missing integration tests if the solution has external dependencies`
+	default:
+		return `COMPREHENSIVE ANALYSIS (all areas):
+
+PERFORMANCE:
+- Identify serial resolvers that could run in parallel
+- Find unnecessary dependency chains
+- Look for duplicate work and caching opportunities
+
+READABILITY:
+- Check naming consistency and missing descriptions
+- Simplify complex expressions
+- Document undocumented parameters
+
+TESTING:
+- Identify untested resolvers and actions
+- Look for missing edge case coverage
+- Call list_tests and generate_test_scaffold for gap analysis`
 	}
 }

--- a/pkg/mcp/prompts_test.go
+++ b/pkg/mcp/prompts_test.go
@@ -5,9 +5,12 @@ package mcp
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/examples"
+	"github.com/oakwood-commons/scafctl/pkg/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -295,4 +298,426 @@ func TestHandleComposeSolutionPrompt(t *testing.T) {
 		assert.Contains(t, text, "partial")
 		assert.Contains(t, text, "deep-merge")
 	})
+}
+
+func TestHandleFixLintPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with all arguments", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "fix_lint"
+		request.Params.Arguments = map[string]string{
+			"path":     "solutions/my-solution/solution.yaml",
+			"severity": "error",
+		}
+
+		result, err := srv.handleFixLintPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+		assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-solution/solution.yaml")
+		assert.Contains(t, text, "error")
+		assert.Contains(t, text, "lint_solution")
+		assert.Contains(t, text, "explain_lint_rule")
+		assert.Contains(t, text, "STEP 1")
+		assert.Contains(t, text, "STEP 4")
+		assert.Contains(t, text, "preview_resolvers")
+	})
+
+	t.Run("with default severity", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "fix_lint"
+		request.Params.Arguments = map[string]string{
+			"path": "test.yaml",
+		}
+
+		result, err := srv.handleFixLintPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "warning") // default severity
+	})
+}
+
+func TestHandlePrepareExecutionPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with all arguments", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "prepare_execution"
+		request.Params.Arguments = map[string]string{
+			"path":   "solutions/deploy/solution.yaml",
+			"params": "env=prod,region=us-east1",
+		}
+
+		result, err := srv.handlePrepareExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+		assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/deploy/solution.yaml")
+		assert.Contains(t, text, "env=prod,region=us-east1")
+		assert.Contains(t, text, "inspect_solution")
+		assert.Contains(t, text, "lint_solution")
+		assert.Contains(t, text, "auth_status")
+		assert.Contains(t, text, "preview_resolvers")
+		assert.Contains(t, text, "preview_action")
+		assert.Contains(t, text, "get_run_command")
+		assert.Contains(t, text, "DO NOT run the command yourself")
+		assert.Contains(t, text, "STEP 1")
+		assert.Contains(t, text, "STEP 6")
+	})
+
+	t.Run("without params", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "prepare_execution"
+		request.Params.Arguments = map[string]string{
+			"path": "test.yaml",
+		}
+
+		result, err := srv.handlePrepareExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "test.yaml")
+		assert.NotContains(t, text, "User-provided parameters")
+	})
+}
+
+func TestResolvePathArg(t *testing.T) {
+	t.Run("normal file path returns as-is", func(t *testing.T) {
+		pathRef, inlineNote := resolvePathArg("solutions/my-solution/solution.yaml")
+		assert.Equal(t, "solutions/my-solution/solution.yaml", pathRef)
+		assert.Empty(t, inlineNote)
+	})
+
+	t.Run("absolute file path returns as-is", func(t *testing.T) {
+		pathRef, inlineNote := resolvePathArg("/Users/kcloutie/src/test-solution.yaml")
+		assert.Equal(t, "/Users/kcloutie/src/test-solution.yaml", pathRef)
+		assert.Empty(t, inlineNote)
+	})
+
+	t.Run("YAML content with newlines returns placeholder", func(t *testing.T) {
+		content := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: test"
+		pathRef, inlineNote := resolvePathArg(content)
+		assert.Equal(t, "<solution_file_path>", pathRef)
+		assert.Contains(t, inlineNote, "YAML content instead of a file path")
+		assert.Contains(t, inlineNote, "determine the actual file system path")
+		assert.Contains(t, inlineNote, content)
+	})
+
+	t.Run("content starting with apiVersion without newlines", func(t *testing.T) {
+		content := "apiVersion: scafctl.io/v1 kind: Solution"
+		pathRef, inlineNote := resolvePathArg(content)
+		assert.Equal(t, "<solution_file_path>", pathRef)
+		assert.Contains(t, inlineNote, "YAML content instead of a file path")
+	})
+
+	t.Run("content starting with kind", func(t *testing.T) {
+		content := "kind: Solution\napiVersion: scafctl.io/v1"
+		pathRef, inlineNote := resolvePathArg(content)
+		assert.Equal(t, "<solution_file_path>", pathRef)
+		assert.Contains(t, inlineNote, "YAML content instead of a file path")
+	})
+
+	t.Run("very long string treated as content", func(t *testing.T) {
+		longPath := "a/" + string(make([]byte, 600))
+		pathRef, inlineNote := resolvePathArg(longPath)
+		assert.Equal(t, "<solution_file_path>", pathRef)
+		assert.NotEmpty(t, inlineNote)
+	})
+
+	t.Run("short relative path returns as-is", func(t *testing.T) {
+		pathRef, inlineNote := resolvePathArg("test.yaml")
+		assert.Equal(t, "test.yaml", pathRef)
+		assert.Empty(t, inlineNote)
+	})
+}
+
+func TestPromptHandlersWithInlineContent(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	yamlContent := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: test-solution\nspec:\n  resolvers:\n    myInput:\n      type: string"
+
+	t.Run("add_tests with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "add_tests"
+		request.Params.Arguments = map[string]string{
+			"path":  yamlContent,
+			"scope": "resolvers",
+		}
+
+		result, err := srv.handleAddTestsPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>", "should use placeholder instead of inline content for tool calls")
+		assert.Contains(t, text, "YAML content instead of a file path", "should include inline note")
+		assert.Contains(t, text, "apiVersion: scafctl.io/v1", "should include the solution content for context")
+		assert.NotContains(t, text, `path "apiVersion:`, "should NOT embed content in tool call arguments")
+	})
+
+	t.Run("debug_solution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "debug_solution"
+		request.Params.Arguments = map[string]string{
+			"path":    yamlContent,
+			"problem": "test problem",
+		}
+
+		result, err := srv.handleDebugSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("update_solution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "update_solution"
+		request.Params.Arguments = map[string]string{
+			"path":   yamlContent,
+			"change": "add a resolver",
+		}
+
+		result, err := srv.handleUpdateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("fix_lint with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "fix_lint"
+		request.Params.Arguments = map[string]string{
+			"path": yamlContent,
+		}
+
+		result, err := srv.handleFixLintPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("prepare_execution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "prepare_execution"
+		request.Params.Arguments = map[string]string{
+			"path": yamlContent,
+		}
+
+		result, err := srv.handlePrepareExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("migrate_solution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "migrate_solution"
+		request.Params.Arguments = map[string]string{
+			"path":      yamlContent,
+			"migration": "add-tests",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("optimize_solution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "optimize_solution"
+		request.Params.Arguments = map[string]string{
+			"path": yamlContent,
+		}
+
+		result, err := srv.handleOptimizeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+
+	t.Run("compose_solution with inline content", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "compose_solution"
+		request.Params.Arguments = map[string]string{
+			"path": yamlContent,
+			"goal": "split into modules",
+		}
+
+		result, err := srv.handleComposeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "<solution_file_path>")
+		assert.Contains(t, text, "YAML content instead of a file path")
+	})
+}
+
+// TestPromptToolReferencesAreValid runs every prompt handler and validates that
+// all tool names, explain_kind field paths, and get_example paths referenced in
+// the generated prompt text actually exist. This catches bugs like referencing a
+// renamed tool, a wrong field path (e.g. "testing" vs "spec.testing"), or a
+// nonexistent example file.
+func TestPromptToolReferencesAreValid(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	// Collect all registered tool names from the server.
+	registeredTools := make(map[string]bool)
+	for name := range srv.mcpServer.ListTools() {
+		registeredTools[name] = true
+	}
+	require.NotEmpty(t, registeredTools, "server should have registered tools")
+
+	// Define all prompts with their required arguments so we can invoke each handler.
+	promptCalls := []struct {
+		name    string
+		handler func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error)
+		args    map[string]string
+	}{
+		{
+			name:    "create_solution",
+			handler: srv.handleCreateSolutionPrompt,
+			args:    map[string]string{"name": "test-solution", "description": "Test", "features": "resolvers, actions"},
+		},
+		{
+			name:    "debug_solution",
+			handler: srv.handleDebugSolutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "problem": "not working"},
+		},
+		{
+			name:    "add_resolver",
+			handler: srv.handleAddResolverPrompt,
+			args:    map[string]string{"provider": "static", "purpose": "test"},
+		},
+		{
+			name:    "add_action",
+			handler: srv.handleAddActionPrompt,
+			args:    map[string]string{"provider": "exec", "purpose": "test"},
+		},
+		{
+			name:    "update_solution",
+			handler: srv.handleUpdateSolutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "change": "add resolver"},
+		},
+		{
+			name:    "add_tests",
+			handler: srv.handleAddTestsPrompt,
+			args:    map[string]string{"path": "test.yaml", "scope": "all"},
+		},
+		{
+			name:    "compose_solution",
+			handler: srv.handleComposeSolutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "goal": "split"},
+		},
+		{
+			name:    "fix_lint",
+			handler: srv.handleFixLintPrompt,
+			args:    map[string]string{"path": "test.yaml", "severity": "warning"},
+		},
+		{
+			name:    "prepare_execution",
+			handler: srv.handlePrepareExecutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "params": "env=dev"},
+		},
+		{
+			name:    "analyze_execution",
+			handler: srv.handleAnalyzeExecutionPrompt,
+			args:    map[string]string{"snapshot_path": "/tmp/snap.json", "previous_snapshot": "/tmp/prev.json", "problem": "fail"},
+		},
+		{
+			name:    "migrate_solution",
+			handler: srv.handleMigrateSolutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "migration": "add-tests", "target_dir": "./out"},
+		},
+		{
+			name:    "optimize_solution",
+			handler: srv.handleOptimizeSolutionPrompt,
+			args:    map[string]string{"path": "test.yaml", "focus": "all"},
+		},
+	}
+
+	// Regex patterns to extract references from prompt text.
+	toolCallRe := regexp.MustCompile(`Call ([a-z_]+)`)
+	explainKindFieldRe := regexp.MustCompile(`explain_kind with kind "([^"]+)" and field "([^"]+)"`)
+	getExamplePathRe := regexp.MustCompile(`get_example with path "([^"]+)"`)
+
+	for _, pc := range promptCalls {
+		t.Run(pc.name, func(t *testing.T) {
+			request := mcp.GetPromptRequest{}
+			request.Params.Name = pc.name
+			request.Params.Arguments = pc.args
+
+			result, err := pc.handler(context.Background(), request)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotEmpty(t, result.Messages)
+
+			text := result.Messages[0].Content.(mcp.TextContent).Text
+			require.NotEmpty(t, text)
+
+			// Validate every "Call <tool_name>" reference is a registered tool.
+			toolMatches := toolCallRe.FindAllStringSubmatch(text, -1)
+			for _, match := range toolMatches {
+				toolName := match[1]
+				assert.True(t, registeredTools[toolName],
+					"prompt %q references tool %q which is not registered. Available tools: %v",
+					pc.name, toolName, registeredTools)
+			}
+
+			// Validate every explain_kind field reference actually resolves.
+			fieldMatches := explainKindFieldRe.FindAllStringSubmatch(text, -1)
+			for _, match := range fieldMatches {
+				kindName := match[1]
+				fieldPath := match[2]
+
+				kindDef, ok := schema.GetKind(kindName)
+				require.True(t, ok, "prompt %q references kind %q which is not registered", pc.name, kindName)
+
+				fieldInfo, err := schema.IntrospectField(kindDef.TypeInstance, fieldPath)
+				assert.NoError(t, err,
+					"prompt %q references explain_kind(kind=%q, field=%q) but IntrospectField fails: %v",
+					pc.name, kindName, fieldPath, err)
+				if err == nil {
+					assert.NotEmpty(t, fieldInfo.Name,
+						"prompt %q: explain_kind(kind=%q, field=%q) resolved but returned empty field name",
+						pc.name, kindName, fieldPath)
+				}
+			}
+
+			// Validate every get_example path reference points to an existing example.
+			exampleMatches := getExamplePathRe.FindAllStringSubmatch(text, -1)
+			for _, match := range exampleMatches {
+				examplePath := match[1]
+				_, readErr := examples.Read(examplePath)
+				assert.NoError(t, readErr,
+					"prompt %q references get_example path %q which does not exist",
+					pc.name, examplePath)
+			}
+		})
+	}
 }

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -15,27 +15,28 @@ import (
 	getprovider "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 )
 
 // registerResourceTemplates registers MCP resource templates on the server.
 func (s *Server) registerResourceTemplates() {
-	// solution://{name} — raw solution YAML content
+	// solution://{+name} — unified solution resource template using RFC 6570 reserved expansion
+	// so that file paths containing slashes (e.g., solution:///Users/.../file.yaml) match.
+	// Suffix-based routing dispatches to content, schema, graph, or tests handlers.
 	solutionTemplate := mcp.NewResourceTemplate(
-		"solution://{name}",
-		"Solution Content",
-		mcp.WithTemplateDescription("Returns the raw YAML content of a solution. Use the solution's local file path, catalog name, or URL as the {name} parameter."),
+		"solution://{+name}",
+		"Solution Resource",
+		mcp.WithTemplateDescription("Access solution content, schema, dependency graph, or tests. "+
+			"Use the solution's local file path, catalog name, or URL as the name. "+
+			"Append /schema for the input JSON Schema, /graph for the resolver dependency graph, "+
+			"or /tests for the functional test cases. "+
+			"Examples: solution://path/to/solution.yaml, solution://my-solution/schema, "+
+			"solution:///abs/path/solution.yaml/tests"),
 		mcp.WithTemplateMIMEType("application/yaml"),
+		mcp.WithTemplateIcons(resourceIcons["solution"]),
+		mcp.WithTemplateAnnotations([]mcp.Role{mcp.RoleUser, mcp.RoleAssistant}, 0.7, ""),
 	)
-	s.mcpServer.AddResourceTemplate(solutionTemplate, s.handleSolutionResource)
-
-	// solution://{name}/schema — solution input schema
-	schemaTemplate := mcp.NewResourceTemplate(
-		"solution://{name}/schema",
-		"Solution Input Schema",
-		mcp.WithTemplateDescription("Returns a JSON Schema describing the expected input parameters for a solution's resolvers. Use the solution's local file path, catalog name, or URL as the {name} parameter."),
-		mcp.WithTemplateMIMEType("application/json"),
-	)
-	s.mcpServer.AddResourceTemplate(schemaTemplate, s.handleSolutionSchemaResource)
+	s.mcpServer.AddResourceTemplate(solutionTemplate, s.routeSolutionResource)
 
 	// provider://{name} — provider details including schema, examples, capabilities
 	providerTemplate := mcp.NewResourceTemplate(
@@ -43,17 +44,10 @@ func (s *Server) registerResourceTemplates() {
 		"Provider Details",
 		mcp.WithTemplateDescription("Returns detailed information about a provider including its input schema (with required/optional properties, types, defaults, examples), output schemas per capability, YAML usage examples, CLI usage examples, and capabilities. Use the provider name (e.g., exec, http, static, file, cel, directory, parameter) as the {name} parameter."),
 		mcp.WithTemplateMIMEType("application/json"),
+		mcp.WithTemplateIcons(resourceIcons["provider"]),
+		mcp.WithTemplateAnnotations([]mcp.Role{mcp.RoleAssistant}, 0.6, ""),
 	)
 	s.mcpServer.AddResourceTemplate(providerTemplate, s.handleProviderResource)
-
-	// solution://{name}/graph — resolver dependency graph
-	graphTemplate := mcp.NewResourceTemplate(
-		"solution://{name}/graph",
-		"Solution Dependency Graph",
-		mcp.WithTemplateDescription("Returns the resolver dependency graph for a solution as JSON with execution tiers and an ASCII + Mermaid diagram. Use the solution's local file path, catalog name, or URL as the {name} parameter."),
-		mcp.WithTemplateMIMEType("application/json"),
-	)
-	s.mcpServer.AddResourceTemplate(graphTemplate, s.handleSolutionGraphResource)
 
 	// provider://reference — compact reference of all providers and their key properties
 	s.mcpServer.AddResource(
@@ -62,9 +56,29 @@ func (s *Server) registerResourceTemplates() {
 			"Provider Quick Reference",
 			mcp.WithResourceDescription("Returns a compact reference of all registered providers with their required inputs, capabilities, and descriptions. Use this to quickly understand what providers are available and what inputs they need, without calling get_provider_schema for each one individually."),
 			mcp.WithMIMEType("application/json"),
+			mcp.WithResourceIcons(resourceIcons["provider"]),
+			mcp.WithAnnotations([]mcp.Role{mcp.RoleAssistant}, 0.8, ""),
 		),
 		s.handleProviderReferenceResource,
 	)
+}
+
+// routeSolutionResource dispatches solution resource requests based on URI suffix.
+// This unified router avoids map iteration ordering issues when multiple templates
+// with {+name} (reserved expansion) could match the same URI.
+func (s *Server) routeSolutionResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	name := extractNameFromURI(request.Params.URI, "solution://")
+
+	switch {
+	case strings.HasSuffix(name, "/tests"):
+		return s.handleSolutionTestsResource(ctx, request)
+	case strings.HasSuffix(name, "/schema"):
+		return s.handleSolutionSchemaResource(ctx, request)
+	case strings.HasSuffix(name, "/graph"):
+		return s.handleSolutionGraphResource(ctx, request)
+	default:
+		return s.handleSolutionResource(ctx, request)
+	}
 }
 
 // handleSolutionResource returns the raw YAML content of a solution.
@@ -271,6 +285,92 @@ func (s *Server) handleProviderReferenceResource(_ context.Context, request mcp.
 			URI:      request.Params.URI,
 			MIMEType: "application/json",
 			Text:     string(refJSON),
+		},
+	}, nil
+}
+
+// handleSolutionTestsResource returns the functional test cases defined in a solution.
+func (s *Server) handleSolutionTestsResource(_ context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	name := extractNameFromURI(request.Params.URI, "solution://")
+	name = strings.TrimSuffix(name, "/tests")
+	if name == "" {
+		return nil, fmt.Errorf("solution name is required in URI (e.g., solution://path/to/solution.yaml/tests)")
+	}
+
+	st, err := soltesting.DiscoverFromFile(name)
+	if err != nil {
+		return nil, fmt.Errorf("discovering tests in %q: %w", name, err)
+	}
+
+	if len(st.Cases) == 0 {
+		result := map[string]any{
+			"solutionName": st.SolutionName,
+			"filePath":     st.FilePath,
+			"testCount":    0,
+			"cases":        map[string]any{},
+		}
+		resultJSON, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshaling test data: %w", err)
+		}
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(resultJSON),
+			},
+		}, nil
+	}
+
+	// Build structured test data
+	cases := make(map[string]any, len(st.Cases))
+	testNames := soltesting.SortedTestNames(*st)
+	for _, tName := range testNames {
+		tc := st.Cases[tName]
+		caseData := map[string]any{
+			"command": tc.Command,
+		}
+		if tc.Description != "" {
+			caseData["description"] = tc.Description
+		}
+		if len(tc.Args) > 0 {
+			caseData["args"] = tc.Args
+		}
+		if len(tc.Assertions) > 0 {
+			caseData["assertions"] = tc.Assertions
+		}
+		if len(tc.Tags) > 0 {
+			caseData["tags"] = tc.Tags
+		}
+		if tc.Skip {
+			caseData["skip"] = true
+			if tc.SkipReason != "" {
+				caseData["skipReason"] = tc.SkipReason
+			}
+		}
+		cases[tName] = caseData
+	}
+
+	result := map[string]any{
+		"solutionName": st.SolutionName,
+		"filePath":     st.FilePath,
+		"testCount":    len(st.Cases),
+		"cases":        cases,
+	}
+	if st.Config != nil {
+		result["config"] = st.Config
+	}
+
+	resultJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling test data: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(resultJSON),
 		},
 	}, nil
 }

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -388,6 +388,91 @@ func TestExtractNameFromURI(t *testing.T) {
 	}
 }
 
+func TestRouteSolutionResource(t *testing.T) {
+	// Create a test solution file to use across sub-tests
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "test-solution.yaml")
+	solYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+  description: Test solution for routing
+spec:
+  resolvers:
+    greeting:
+      description: A greeting
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello!"
+  testing:
+    cases:
+      basic-test:
+        description: renders successfully
+        command: [render, solution]
+        assertions:
+          - expression: __exitCode == 0
+`
+	require.NoError(t, os.WriteFile(solPath, []byte(solYAML), 0o644))
+
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("routes to content handler for bare path", func(t *testing.T) {
+		request := mcp.ReadResourceRequest{}
+		request.Params.URI = "solution://" + solPath
+
+		contents, err := srv.routeSolutionResource(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, contents, 1)
+		textContent, ok := mcp.AsTextResourceContents(contents[0])
+		require.True(t, ok)
+		assert.Equal(t, "application/yaml", textContent.MIMEType)
+		assert.Contains(t, textContent.Text, "test-solution")
+	})
+
+	t.Run("routes to schema handler for /schema suffix", func(t *testing.T) {
+		request := mcp.ReadResourceRequest{}
+		request.Params.URI = "solution://" + solPath + "/schema"
+
+		contents, err := srv.routeSolutionResource(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, contents, 1)
+		textContent, ok := mcp.AsTextResourceContents(contents[0])
+		require.True(t, ok)
+		assert.Equal(t, "application/json", textContent.MIMEType)
+		assert.Contains(t, textContent.Text, "test-solution Input Parameters")
+	})
+
+	t.Run("routes to tests handler for /tests suffix", func(t *testing.T) {
+		request := mcp.ReadResourceRequest{}
+		request.Params.URI = "solution://" + solPath + "/tests"
+
+		contents, err := srv.routeSolutionResource(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, contents, 1)
+		textContent, ok := mcp.AsTextResourceContents(contents[0])
+		require.True(t, ok)
+		assert.Equal(t, "application/json", textContent.MIMEType)
+		assert.Contains(t, textContent.Text, "basic-test")
+	})
+
+	t.Run("routes to graph handler for /graph suffix", func(t *testing.T) {
+		request := mcp.ReadResourceRequest{}
+		request.Params.URI = "solution://" + solPath + "/graph"
+
+		contents, err := srv.routeSolutionResource(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, contents, 1)
+		textContent, ok := mcp.AsTextResourceContents(contents[0])
+		require.True(t, ok)
+		assert.Equal(t, "application/json", textContent.MIMEType)
+	})
+}
+
 func TestGenerateSolutionInputSchema(t *testing.T) {
 	t.Run("nil solution spec", func(t *testing.T) {
 		sol := &solution.Solution{}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -6,9 +6,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
 	"sort"
 
 	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -25,18 +29,27 @@ type Server struct {
 	authReg   *auth.Registry
 	config    *config.Config
 	version   string
+
+	// sseServer is the SSE transport server (nil for stdio).
+	sseServer *server.SSEServer
+	// httpServer is the Streamable HTTP transport server (nil for stdio).
+	httpServer *server.StreamableHTTPServer
 }
 
 // ServerOption configures the MCP server.
 type ServerOption func(*serverConfig)
 
 type serverConfig struct {
-	logger   *logr.Logger
-	registry *provider.Registry
-	authReg  *auth.Registry
-	config   *config.Config
-	version  string
-	ctx      context.Context
+	logger          *logr.Logger
+	registry        *provider.Registry
+	authReg         *auth.Registry
+	config          *config.Config
+	version         string
+	ctx             context.Context
+	paginationLimit int
+	workerPoolSize  int
+	queueSize       int
+	errorLogger     *log.Logger
 }
 
 // WithServerLogger sets the logger for the MCP server.
@@ -81,6 +94,35 @@ func WithServerContext(ctx context.Context) ServerOption {
 	}
 }
 
+// WithPaginationLimit sets the maximum number of items per page
+// for list operations (tools, resources, prompts).
+func WithPaginationLimit(limit int) ServerOption {
+	return func(c *serverConfig) {
+		c.paginationLimit = limit
+	}
+}
+
+// WithWorkerPoolSize sets the number of workers for the stdio transport.
+func WithWorkerPoolSize(size int) ServerOption {
+	return func(c *serverConfig) {
+		c.workerPoolSize = size
+	}
+}
+
+// WithQueueSize sets the message queue size for the stdio transport.
+func WithQueueSize(size int) ServerOption {
+	return func(c *serverConfig) {
+		c.queueSize = size
+	}
+}
+
+// WithErrorLog sets the error logger for the stdio transport.
+func WithErrorLog(lgr *log.Logger) ServerOption {
+	return func(c *serverConfig) {
+		c.errorLogger = lgr
+	}
+}
+
 const serverInstructions = `scafctl is a CLI tool for managing infrastructure solutions using CEL expressions, 
 Go templates, and a provider-based architecture. This MCP server exposes tools 
 for inspecting solutions, validating configurations, evaluating CEL expressions, 
@@ -90,6 +132,7 @@ Most tools are read-only and safe to call. The following tools execute solution 
 and may have side effects depending on the providers used (e.g., exec, http):
   - preview_resolvers: executes the resolver chain
   - preview_action: builds action graph from live resolver data (executes resolvers, but NOT actions)
+  - dry_run_solution: full dry-run — resolvers execute in mock mode, action graph is built but NOT executed
   - run_solution_tests: runs functional test cases
   - render_solution: executes resolvers to build graphs
 All other tools only inspect, validate, or list — they never modify files or trigger side effects.
@@ -106,6 +149,29 @@ Solution Development Workflow:
   8. Call diff_solution to compare solution versions before committing changes
   9. Call get_run_command to get the exact CLI command for the user
 
+Lint Workflow:
+  When lint_solution returns findings:
+  1. Call list_lint_rules to see all available rules and their severities
+  2. Call explain_lint_rule with each finding's ruleName for detailed fix guidance
+  3. Use the fix_lint prompt for automated step-by-step fix guidance
+
+Execution Preparation:
+  When the user wants to run a solution, use the prepare_execution prompt.
+  This validates, previews, and generates the CLI command WITHOUT executing — 
+  the user makes the final decision to run.
+
+Dry-Run:
+  Call dry_run_solution to perform a full dry-run of a solution. Providers execute
+  in mock mode (no side effects), resolvers return mock/placeholder values, and the
+  action graph is built but NOT executed. The response includes resolver outputs,
+  action plan with materialized inputs, and provider mock behaviors.
+
+Configuration:
+  Call get_config to see the current scafctl configuration (catalogs, settings,
+  logging, HTTP client, CEL, resolver, action, auth, build). Use the optional
+  'section' parameter to retrieve only a specific section.  Sensitive fields are
+  automatically redacted.
+
 Scaffolding a New Solution:
   Call scaffold_solution with a name, description, and optional features/providers to 
   generate a complete skeleton YAML with examples. This is the fastest way to start.
@@ -114,6 +180,23 @@ Expression Debugging:
   - validate_expression: syntax-check CEL expressions or Go templates without running them
   - evaluate_go_template: render a Go template with sample data and see referenced fields
   - evaluate_cel: evaluate a CEL expression with data context
+  - extract_resolver_refs: extract _.resolverName references from Go templates or CEL expressions
+    When creating or editing Go templates (tmpl:) or CEL expressions (expr:) that reference resolvers,
+    call extract_resolver_refs to determine which resolver names are referenced, then use those
+    names in the dependsOn field.
+
+Testing Workflow:
+  - generate_test_scaffold: analyze a solution and generate starter test cases covering resolvers and actions
+  - list_tests: discover all functional tests in a solution without executing them
+  - run_solution_tests: execute the functional tests (use verbose=true for full assertion details)
+  When writing tests, first call generate_test_scaffold for a starter scaffold, then customize.
+
+Post-Execution Analysis:
+  - show_snapshot: load and inspect a resolver execution snapshot (summary, resolvers, or full detail)
+  - diff_snapshots: compare two execution snapshots to detect regressions, value changes, and status changes
+  - Use the analyze_execution prompt for guided post-execution debugging when something went wrong
+  When a user reports execution issues, use analyze_execution with the snapshot path (and optionally
+  a known-good snapshot for comparison) for structured root-cause analysis.
 
 Composition Workflow:
   For multi-file solutions, use the compose_solution prompt to guide splitting a solution 
@@ -131,6 +214,13 @@ CLI Usage Reference (use these exact flags when suggesting commands to users):
   Run resolvers only:   scafctl run resolver -f ./solution.yaml -r key=value
   Lint a solution:      scafctl lint -f ./solution.yaml
   Inspect a solution:   scafctl explain -f ./solution.yaml
+  Run tests:            scafctl test functional -f ./solution.yaml
+  Run tests (verbose):  scafctl test functional -f ./solution.yaml -v
+
+IMPORTANT — test CLI command:
+  • The test command is 'scafctl test functional -f <file>', NOT 'scafctl test -f <file>'.
+  • The 'functional' subcommand is REQUIRED. The -f flag belongs to the 'functional' subcommand.
+  • 'scafctl test -f' will FAIL with 'unknown shorthand flag: f'.
 
 IMPORTANT — choosing between 'run solution' and 'run resolver':
   • 'scafctl run solution' REQUIRES the solution to have a spec.workflow section with actions.
@@ -144,7 +234,33 @@ IMPORTANT: Resolver parameters are passed with -r/--resolver, NOT -p. There is n
 Examples:
   scafctl run solution -f ./my-solution.yaml -r env=prod -r region=us-east1
   scafctl run solution my-catalog-solution -r inputText="Hello World" -r operation=uppercase
-  scafctl run resolver -f ./my-solution.yaml -r name=value`
+  scafctl run resolver -f ./my-solution.yaml -r name=value
+
+IMPORTANT — file path references:
+  When mentioning solution filenames in responses, ALWAYS use a "./" prefix for
+  relative paths (e.g., "./my-solution.yaml", NOT "my-solution.yaml"). Bare filenames
+  without "./" are auto-linkified by VS Code Chat into broken content-reference URLs.
+
+IMPORTANT — resolver type field:
+  The resolver "type" field is OPTIONAL. When omitted, the value passes through as-is.
+  Only set it for known scalar types (string, int, bool, etc.). NEVER set type: string
+  on resolvers using providers that return objects/maps (e.g., http returns
+  {statusCode, body, headers}). Setting the wrong type causes coercion errors.
+  When in doubt, omit the type field entirely.
+
+Tool Latency Guide (helps optimize tool selection):
+  ⚡ Instant (in-memory, no I/O):
+    get_solution_schema, list_providers, get_provider_schema, list_lint_rules,
+    explain_lint_rule, explain_kind, validate_expression, evaluate_cel,
+    get_run_command, list_auth_handlers, get_config_paths, get_version
+  🔄 Fast (local file I/O):
+    inspect_solution, lint_solution, diff_solution, list_catalog, catalog_inspect,
+    list_examples, get_example, scaffold_solution, extract_resolver_refs,
+    generate_test_scaffold, list_tests, show_snapshot, diff_snapshots,
+    get_config, evaluate_go_template, validate_expressions
+  🌐 Variable (may use network or execute code):
+    preview_resolvers, preview_action, dry_run_solution, render_solution,
+    run_solution_tests`
 
 // NewServer creates a new MCP server with all tools and resources registered.
 func NewServer(opts ...ServerOption) (*Server, error) {
@@ -186,16 +302,46 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		s.logger = logr.Discard()
 	}
 
+	// Build server options for mcp-go
+	serverOpts := []server.ServerOption{
+		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
+		server.WithRecovery(),
+		server.WithResourceRecovery(),
+		server.WithInstructions(serverInstructions),
+		// Enable advanced protocol capabilities
+		server.WithLogging(),
+		server.WithRoots(),
+		server.WithElicitation(),
+		server.WithCompletions(),
+		// Task support for async long-running operations
+		server.WithTaskCapabilities(true, true, true),
+		// Observability hooks & middleware
+		server.WithHooks(newObservabilityHooks(s.logger)),
+		server.WithToolHandlerMiddleware(toolTimingMiddleware(s.logger)),
+		server.WithResourceHandlerMiddleware(resourceTimingMiddleware(s.logger)),
+		// Completions providers
+		server.WithPromptCompletionProvider(&promptCompletionProvider{registry: s.registry}),
+		server.WithResourceCompletionProvider(&resourceCompletionProvider{registry: s.registry, logger: s.logger, ctx: s.ctx}),
+		// Dynamic tool filtering
+		server.WithToolFilter(contextualToolFilter(s)),
+	}
+
+	// Optional: pagination
+	if cfg.paginationLimit > 0 {
+		serverOpts = append(serverOpts, server.WithPaginationLimit(cfg.paginationLimit))
+	}
+
 	// Create the mcp-go server
 	s.mcpServer = server.NewMCPServer(
 		"scafctl",
 		cfg.version,
-		server.WithToolCapabilities(false),
-		server.WithResourceCapabilities(true, false),
-		server.WithPromptCapabilities(false),
-		server.WithRecovery(),
-		server.WithInstructions(serverInstructions),
+		serverOpts...,
 	)
+
+	// Enable sampling capability
+	s.mcpServer.EnableSampling()
 
 	// Register all tools
 	s.registerTools()
@@ -210,8 +356,101 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 }
 
 // Serve starts the MCP server on stdio transport (blocking).
-func (s *Server) Serve() error {
-	return server.ServeStdio(s.mcpServer)
+func (s *Server) Serve(opts ...server.StdioOption) error {
+	return server.ServeStdio(s.mcpServer, opts...)
+}
+
+// ServeSSE starts the MCP server on SSE transport at the given address.
+func (s *Server) ServeSSE(addr string) error {
+	s.sseServer = server.NewSSEServer(s.mcpServer)
+	s.logger.Info("starting SSE server", "addr", addr)
+	return s.sseServer.Start(addr)
+}
+
+// ServeHTTP starts the MCP server on Streamable HTTP transport at the given address.
+func (s *Server) ServeHTTP(addr string) error {
+	s.httpServer = server.NewStreamableHTTPServer(s.mcpServer)
+	s.logger.Info("starting Streamable HTTP server", "addr", addr)
+	return s.httpServer.Start(addr)
+}
+
+// Handler returns an http.Handler for the Streamable HTTP transport.
+// This is useful for embedding the MCP server into an existing HTTP server.
+func (s *Server) Handler() http.Handler {
+	if s.httpServer != nil {
+		return s.httpServer
+	}
+	s.httpServer = server.NewStreamableHTTPServer(s.mcpServer)
+	return s.httpServer
+}
+
+// MCPServer returns the underlying mcp-go MCPServer.
+// This is useful for advanced operations like sending notifications.
+func (s *Server) MCPServer() *server.MCPServer {
+	return s.mcpServer
+}
+
+// SendLog sends a structured log message to connected MCP clients.
+// This enables real-time log streaming during tool execution.
+func (s *Server) SendLog(ctx context.Context, level mcp.LoggingLevel, loggerName, message string, data any) error {
+	notification := mcp.LoggingMessageNotification{
+		Notification: mcp.Notification{
+			Method: "notifications/message",
+		},
+	}
+	notification.Params.Level = level
+	notification.Params.Logger = loggerName
+
+	if data != nil {
+		raw, err := json.Marshal(data)
+		if err == nil {
+			notification.Params.Data = raw
+		}
+	}
+
+	// Set the message as data if no structured data provided
+	if data == nil {
+		notification.Params.Data = message
+	}
+
+	return s.mcpServer.SendLogMessageToClient(ctx, notification)
+}
+
+// RequestRoots asks the MCP client for its workspace root directories.
+// This enables workspace-aware file discovery in tools.
+func (s *Server) RequestRoots(ctx context.Context) ([]mcp.Root, error) {
+	result, err := s.mcpServer.RequestRoots(ctx, mcp.ListRootsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("requesting roots: %w", err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.Roots, nil
+}
+
+// RequestSampling asks the MCP client's LLM to generate content.
+// This enables server-side use of the client's AI capabilities.
+func (s *Server) RequestSampling(ctx context.Context, req mcp.CreateMessageRequest) (*mcp.CreateMessageResult, error) {
+	return s.mcpServer.RequestSampling(ctx, req)
+}
+
+// RequestElicitation asks the MCP client to prompt the user for input.
+// This enables interactive parameter collection during tool execution.
+func (s *Server) RequestElicitation(ctx context.Context, req mcp.ElicitationRequest) (*mcp.ElicitationResult, error) {
+	return s.mcpServer.RequestElicitation(ctx, req)
+}
+
+// NotifyResourcesChanged sends a notification to all connected clients
+// that the resource list has changed. Clients should re-list resources.
+func (s *Server) NotifyResourcesChanged(ctx context.Context) error {
+	return s.mcpServer.SendNotificationToClient(ctx, "notifications/resources/list_changed", nil)
+}
+
+// NotifyToolsChanged sends a notification to all connected clients
+// that the tool list has changed. Clients should re-list tools.
+func (s *Server) NotifyToolsChanged(ctx context.Context) error {
+	return s.mcpServer.SendNotificationToClient(ctx, "notifications/tools/list_changed", nil)
 }
 
 // Info returns the server's tool and resource information as JSON.
@@ -290,6 +529,24 @@ func (s *Server) registerTools() {
 
 	// Diff tools
 	s.registerDiffTools()
+
+	// Dry-run tools
+	s.registerDryRunTools()
+
+	// Config tools
+	s.registerConfigTools()
+
+	// Resolver reference extraction tools
+	s.registerRefsTools()
+
+	// Testing tools (scaffold, list)
+	s.registerTestingTools()
+
+	// Snapshot inspection & diff tools
+	s.registerSnapshotTools()
+
+	// Version tool
+	s.registerVersionTools()
 }
 
 // registerResources registers all MCP resources on the server.

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 )
 
 // registerActionTools registers action-related MCP tools.
@@ -19,6 +20,7 @@ func (s *Server) registerActionTools() {
 	previewActionTool := mcp.NewTool("preview_action",
 		mcp.WithDescription("Preview what each action in a solution's workflow would do WITHOUT executing it. Resolves all inputs (expanding CEL expressions, Go templates, and resolver references) and shows the final computed values each action would receive. This is an 'action dry-run' that shows the full picture before execution."),
 		mcp.WithTitleAnnotation("Preview Actions"),
+		mcp.WithToolIcons(toolIcons["action"]),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
@@ -41,7 +43,10 @@ func (s *Server) registerActionTools() {
 func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution YAML file"),
+		), nil
 	}
 
 	actionFilter := request.GetString("action", "")
@@ -53,7 +58,9 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		if pm, ok := p.(map[string]any); ok {
 			params = pm
 		} else {
-			return mcp.NewToolResultError("'params' must be an object (key-value pairs)"), nil
+			return newStructuredError(ErrCodeInvalidInput, "'params' must be an object (key-value pairs)",
+				WithField("params"),
+			), nil
 		}
 	}
 
@@ -62,7 +69,11 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Verify the file exists and is valid YAML. Use lint_solution to check."),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
 	}
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
@@ -71,19 +82,28 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	sol := prepResult.Solution
 
 	if !sol.Spec.HasWorkflow() {
-		return mcp.NewToolResultError("solution does not define a workflow — use preview_resolvers instead"), nil
+		return newStructuredError(ErrCodeInvalidInput, "solution does not define a workflow",
+			WithSuggestion("This solution has no spec.workflow section. Use preview_resolvers to see resolver outputs instead."),
+			WithRelatedTools("preview_resolvers"),
+		), nil
 	}
 
 	// Execute resolvers to get data for action inputs
 	resolverData, err := s.executeResolversForRender(sol, params)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
+			WithSuggestion("Check resolver configurations with preview_resolvers. Missing parameters can be passed via the params field."),
+			WithRelatedTools("preview_resolvers", "inspect_solution"),
+		), nil
 	}
 
 	// Build the action graph (this materializes inputs)
 	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to build action graph: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
+			WithSuggestion("Check action definitions and dependencies. Use lint_solution to find structural issues."),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
 	}
 
 	// Build structured preview response
@@ -97,20 +117,21 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		Backoff     string `json:"backoff,omitempty"`
 	}
 	type actionPreview struct {
-		Name               string            `json:"name"`
-		Description        string            `json:"description,omitempty"`
-		Provider           string            `json:"provider"`
-		MaterializedInputs map[string]any    `json:"materializedInputs,omitempty"`
-		DeferredInputs     map[string]string `json:"deferredInputs,omitempty"`
-		Dependencies       []string          `json:"dependencies,omitempty"`
-		When               string            `json:"when,omitempty"`
-		Section            string            `json:"section"`
-		Phase              int               `json:"phase"`
-		ForEach            *forEachPreview   `json:"forEach,omitempty"`
-		Retry              *retryPreview     `json:"retry,omitempty"`
-		Timeout            string            `json:"timeout,omitempty"`
-		OnError            string            `json:"onError,omitempty"`
-		Exclusive          []string          `json:"exclusive,omitempty"`
+		Name               string              `json:"name"`
+		Description        string              `json:"description,omitempty"`
+		Provider           string              `json:"provider"`
+		MaterializedInputs map[string]any      `json:"materializedInputs,omitempty"`
+		DeferredInputs     map[string]string   `json:"deferredInputs,omitempty"`
+		Dependencies       []string            `json:"dependencies,omitempty"`
+		When               string              `json:"when,omitempty"`
+		Section            string              `json:"section"`
+		Phase              int                 `json:"phase"`
+		ForEach            *forEachPreview     `json:"forEach,omitempty"`
+		Retry              *retryPreview       `json:"retry,omitempty"`
+		Timeout            string              `json:"timeout,omitempty"`
+		OnError            string              `json:"onError,omitempty"`
+		Exclusive          []string            `json:"exclusive,omitempty"`
+		SourcePos          *sourcepos.Position `json:"sourcePos,omitempty"`
 	}
 
 	previews := make([]actionPreview, 0)
@@ -150,6 +171,18 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 			Dependencies:       ea.Dependencies,
 			Section:            ea.Section,
 			Phase:              phaseMap[name],
+		}
+
+		// Enrich with source position if available
+		if sm := sol.SourceMap(); sm != nil {
+			// Try the section-specific path (actions vs finally)
+			path := "spec.workflow.actions." + ea.Name
+			if ea.Section == "finally" {
+				path = "spec.workflow.finally." + ea.Name
+			}
+			if pos, ok := sm.Get(path); ok {
+				preview.SourcePos = &pos
+			}
 		}
 
 		// Use fields from the embedded Action
@@ -209,7 +242,10 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 			availableNames = append(availableNames, name)
 		}
 		sort.Strings(availableNames)
-		return mcp.NewToolResultError(fmt.Sprintf("action %q not found. Available actions: %v", actionFilter, availableNames)), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("action %q not found. Available actions: %v", actionFilter, availableNames),
+			WithField("action"),
+			WithSuggestion(fmt.Sprintf("Use one of the available action names: %v", availableNames)),
+		), nil
 	}
 
 	response := map[string]any{

--- a/pkg/mcp/tools_action_test.go
+++ b/pkg/mcp/tools_action_test.go
@@ -118,6 +118,16 @@ spec:
 		require.NoError(t, json.Unmarshal([]byte(text), &output))
 		assert.NotNil(t, output["actions"])
 		assert.NotNil(t, output["resolverData"])
+
+		// Verify source position is included in action previews
+		actions := output["actions"].([]any)
+		require.NotEmpty(t, actions)
+		firstAction := actions[0].(map[string]any)
+		sourcePos := firstAction["sourcePos"]
+		require.NotNil(t, sourcePos, "sourcePos should be present for actions")
+		sp := sourcePos.(map[string]any)
+		assert.Greater(t, sp["line"], float64(0), "line should be > 0")
+		assert.Greater(t, sp["column"], float64(0), "column should be > 0")
 	})
 
 	t.Run("filter nonexistent action", func(t *testing.T) {

--- a/pkg/mcp/tools_auth.go
+++ b/pkg/mcp/tools_auth.go
@@ -16,12 +16,25 @@ func (s *Server) registerAuthTools() {
 	authStatusTool := mcp.NewTool("auth_status",
 		mcp.WithDescription("Report which auth handlers (e.g. entra, gcp, github) are configured and whether their tokens are valid. Auth handlers manage authentication and identity — they are NOT solution providers. Helps verify authentication is set up correctly before attempting operations that require it."),
 		mcp.WithTitleAnnotation("Auth Status"),
+		mcp.WithToolIcons(toolIcons["auth"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithRawOutputSchema(outputSchemaAuthStatus),
 	)
 	s.mcpServer.AddTool(authStatusTool, s.handleAuthStatus)
+
+	listAuthHandlersTool := mcp.NewTool("list_auth_handlers",
+		mcp.WithDescription("List all registered auth handlers with their supported flows and capabilities. Unlike auth_status which shows credential state, this tool shows what handlers are available and what they support (device-code, interactive, service-principal, workload-identity, PAT, metadata flows). Use this to understand which auth methods are available before attempting login."),
+		mcp.WithTitleAnnotation("List Auth Handlers"),
+		mcp.WithToolIcons(toolIcons["auth"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+	)
+	s.mcpServer.AddTool(listAuthHandlersTool, s.handleListAuthHandlers)
 }
 
 // authHandlerStatus represents the status of a single auth handler.
@@ -106,5 +119,57 @@ func (s *Server) handleAuthStatus(_ context.Context, _ mcp.CallToolRequest) (*mc
 	return mcp.NewToolResultJSON(map[string]any{
 		"handlers": statuses,
 		"count":    len(statuses),
+	})
+}
+
+// handleListAuthHandlers lists all registered auth handlers with their flows and capabilities.
+func (s *Server) handleListAuthHandlers(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.authReg == nil {
+		return mcp.NewToolResultJSON(map[string]any{
+			"handlers": []any{},
+			"message":  "No auth registry configured",
+		})
+	}
+
+	names := s.authReg.List()
+	if len(names) == 0 {
+		return mcp.NewToolResultJSON(map[string]any{
+			"handlers": []any{},
+			"message":  "No auth handlers registered",
+		})
+	}
+
+	type handlerInfo struct {
+		Name         string   `json:"name"`
+		DisplayName  string   `json:"displayName,omitempty"`
+		Flows        []string `json:"flows"`
+		Capabilities []string `json:"capabilities"`
+	}
+
+	handlers := make([]handlerInfo, 0, len(names))
+	for _, name := range names {
+		h, err := s.authReg.Get(name)
+		if err != nil {
+			continue
+		}
+
+		info := handlerInfo{
+			Name:        h.Name(),
+			DisplayName: h.DisplayName(),
+		}
+
+		for _, flow := range h.SupportedFlows() {
+			info.Flows = append(info.Flows, string(flow))
+		}
+		for _, cap := range h.Capabilities() {
+			info.Capabilities = append(info.Capabilities, string(cap))
+		}
+
+		handlers = append(handlers, info)
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"handlers": handlers,
+		"count":    len(handlers),
 	})
 }

--- a/pkg/mcp/tools_catalog.go
+++ b/pkg/mcp/tools_catalog.go
@@ -16,6 +16,7 @@ func (s *Server) registerCatalogTools() {
 	catalogListTool := mcp.NewTool("catalog_list",
 		mcp.WithDescription("List entries in the local catalog, optionally filtered by kind and name. The catalog stores solutions, providers, and auth handlers that have been published locally."),
 		mcp.WithTitleAnnotation("Catalog List"),
+		mcp.WithToolIcons(toolIcons["catalog"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -29,6 +30,26 @@ func (s *Server) registerCatalogTools() {
 		),
 	)
 	s.mcpServer.AddTool(catalogListTool, s.handleCatalogList)
+
+	catalogInspectTool := mcp.NewTool("catalog_inspect",
+		mcp.WithDescription("Show detailed metadata about a specific catalog artifact. Returns kind, name, version, digest, size, creation time, and annotations. Use 'catalog_list' first to discover available artifacts, then inspect a specific one for details."),
+		mcp.WithTitleAnnotation("Catalog Inspect"),
+		mcp.WithToolIcons(toolIcons["catalog"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("reference",
+			mcp.Required(),
+			mcp.Description("Artifact reference in the format 'name' or 'name@version' (e.g., 'my-solution', 'my-solution@1.2.3')"),
+		),
+		mcp.WithString("kind",
+			mcp.Required(),
+			mcp.Description("Artifact kind: solution, provider, auth-handler"),
+			mcp.Enum("solution", "provider", "auth-handler"),
+		),
+	)
+	s.mcpServer.AddTool(catalogInspectTool, s.handleCatalogInspect)
 }
 
 // handleCatalogList lists entries in the local catalog.
@@ -38,19 +59,26 @@ func (s *Server) handleCatalogList(_ context.Context, request mcp.CallToolReques
 
 	localCatalog, err := catalog.NewLocalCatalog(s.logger)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to initialize local catalog: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to initialize local catalog: %v", err),
+			WithSuggestion("Ensure the catalog directory exists and is accessible"),
+		), nil
 	}
 
 	// If kind is specified, list just that kind
 	if kind != "" {
 		artifactKind, ok := catalog.ParseArtifactKind(kind)
 		if !ok {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid kind %q. Valid kinds: solution, provider, auth-handler", kind)), nil
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid kind %q. Valid kinds: solution, provider, auth-handler", kind),
+				WithField("kind"),
+				WithSuggestion("Use one of: solution, provider, auth-handler"),
+			), nil
 		}
 
 		items, err := localCatalog.List(s.ctx, artifactKind, name)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list catalog entries: %v", err)), nil
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to list catalog entries: %v", err),
+				WithSuggestion("Check the catalog configuration"),
+			), nil
 		}
 
 		return mcp.NewToolResultJSON(map[string]any{
@@ -93,4 +121,76 @@ func (s *Server) handleCatalogList(_ context.Context, request mcp.CallToolReques
 		"kinds":      results,
 		"totalCount": totalCount,
 	})
+}
+
+// handleCatalogInspect returns detailed metadata about a specific catalog artifact.
+func (s *Server) handleCatalogInspect(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	reference, err := request.RequireString("reference")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("reference"),
+			WithSuggestion("Provide a catalog reference (e.g., 'my-solution@1.0.0' or 'my-solution')"),
+			WithRelatedTools("list_catalog"),
+		), nil
+	}
+
+	kindStr, err := request.RequireString("kind")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("kind"),
+			WithSuggestion("Provide an artifact kind: 'solution', 'provider', or 'auth-handler'"),
+		), nil
+	}
+
+	artifactKind, ok := catalog.ParseArtifactKind(kindStr)
+	if !ok {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid kind %q", kindStr),
+			WithField("kind"),
+			WithSuggestion("Valid kinds: solution, provider, auth-handler"),
+			WithRelatedTools("list_catalog"),
+		), nil
+	}
+
+	ref, err := catalog.ParseReference(artifactKind, reference)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid reference %q: %v", reference, err),
+			WithField("reference"),
+			WithSuggestion("Use format 'name@version' or just 'name' for latest"),
+			WithRelatedTools("list_catalog"),
+		), nil
+	}
+
+	localCatalog, err := catalog.NewLocalCatalog(s.logger)
+	if err != nil {
+		return newStructuredError(ErrCodeConfigError, fmt.Sprintf("failed to initialize local catalog: %v", err),
+			WithSuggestion("Check catalog configuration with get_config"),
+			WithRelatedTools("get_config"),
+		), nil
+	}
+
+	info, err := localCatalog.Resolve(s.ctx, ref)
+	if err != nil {
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("artifact not found: %v", err),
+			WithField("reference"),
+			WithSuggestion("Use list_catalog to see available artifacts"),
+			WithRelatedTools("list_catalog"),
+		), nil
+	}
+
+	result := map[string]any{
+		"kind":      string(info.Reference.Kind),
+		"name":      info.Reference.Name,
+		"digest":    info.Digest,
+		"size":      info.Size,
+		"createdAt": info.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		"catalog":   info.Catalog,
+	}
+	if info.Reference.Version != nil {
+		result["version"] = info.Reference.Version.String()
+	}
+	if len(info.Annotations) > 0 {
+		result["annotations"] = info.Annotations
+	}
+
+	return mcp.NewToolResultJSON(result)
 }

--- a/pkg/mcp/tools_cel.go
+++ b/pkg/mcp/tools_cel.go
@@ -21,6 +21,7 @@ func (s *Server) registerCELTools() {
 	listCELFunctionsTool := mcp.NewTool("list_cel_functions",
 		mcp.WithDescription("List all available CEL (Common Expression Language) functions. Includes both scafctl custom functions (map.merge, json.unmarshal, guid.new, etc.) and standard CEL built-in functions."),
 		mcp.WithTitleAnnotation("List CEL Functions"),
+		mcp.WithToolIcons(toolIcons["cel"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -41,10 +42,12 @@ func (s *Server) registerCELTools() {
 	evaluateCELTool := mcp.NewTool("evaluate_cel",
 		mcp.WithDescription("Evaluate a CEL (Common Expression Language) expression against provided data. Supports both inline data and file-based context. Data is accessible as '_' in the expression (e.g., '_.name'). Additional variables are accessible as top-level names."),
 		mcp.WithTitleAnnotation("Evaluate CEL"),
+		mcp.WithToolIcons(toolIcons["cel"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaEvaluateCEL),
 		mcp.WithString("expression",
 			mcp.Required(),
 			mcp.Description("CEL expression to evaluate (e.g., '_.items.map(i, i.name)', '_.count > 5')"),
@@ -85,7 +88,11 @@ func (s *Server) handleListCELFunctions(_ context.Context, request mcp.CallToolR
 			}
 		}
 		if len(filtered) == 0 {
-			return mcp.NewToolResultError(fmt.Sprintf("no CEL function matching %q found", name)), nil
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("no CEL function matching %q found", name),
+				WithField("name"),
+				WithSuggestion("Use list_cel_functions without a name filter to see all available functions"),
+				WithRelatedTools("list_cel_functions"),
+			), nil
 		}
 		functions = filtered
 	}
@@ -97,7 +104,10 @@ func (s *Server) handleListCELFunctions(_ context.Context, request mcp.CallToolR
 func (s *Server) handleEvaluateCEL(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	expression, err := request.RequireString("expression")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("expression"),
+			WithSuggestion("Provide a CEL expression string to evaluate"),
+		), nil
 	}
 
 	args := request.GetArguments()
@@ -108,18 +118,27 @@ func (s *Server) handleEvaluateCEL(_ context.Context, request mcp.CallToolReques
 	dataFile := request.GetString("data_file", "")
 
 	if hasData && data != nil && dataFile != "" {
-		return mcp.NewToolResultError("cannot specify both 'data' and 'data_file' — use one or the other"), nil
+		return newStructuredError(ErrCodeInvalidInput, "cannot specify both 'data' and 'data_file' — use one or the other",
+			WithField("data"),
+			WithSuggestion("Use 'data' for inline JSON data or 'data_file' for file-based data, not both"),
+		), nil
 	}
 
 	if dataFile != "" {
 		fileBytes, err := os.ReadFile(dataFile)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to read data file %q: %v", dataFile, err)), nil
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to read data file %q: %v", dataFile, err),
+				WithField("data_file"),
+				WithSuggestion("Check the file path exists and is readable"),
+			), nil
 		}
 
 		var fileData any
 		if err := yaml.Unmarshal(fileBytes, &fileData); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to parse data file %q: %v", dataFile, err)), nil
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to parse data file %q: %v", dataFile, err),
+				WithField("data_file"),
+				WithSuggestion("Ensure the file contains valid YAML or JSON"),
+			), nil
 		}
 		rootData = fileData
 	} else if hasData && data != nil {
@@ -132,14 +151,21 @@ func (s *Server) handleEvaluateCEL(_ context.Context, request mcp.CallToolReques
 		if varsMap, ok := vars.(map[string]any); ok {
 			additionalVars = varsMap
 		} else {
-			return mcp.NewToolResultError("'variables' must be an object (key-value pairs)"), nil
+			return newStructuredError(ErrCodeInvalidInput, "'variables' must be an object (key-value pairs)",
+				WithField("variables"),
+				WithSuggestion("Provide variables as a JSON object, e.g. {\"key\": \"value\"}"),
+			), nil
 		}
 	}
 
 	// Evaluate the expression
 	result, err := celexp.EvaluateExpression(s.ctx, expression, rootData, additionalVars)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("CEL evaluation failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("CEL evaluation failed: %v", err),
+			WithField("expression"),
+			WithSuggestion("Use validate_expression to check CEL syntax first"),
+			WithRelatedTools("validate_expression", "list_cel_functions"),
+		), nil
 	}
 
 	return mcp.NewToolResultJSON(map[string]any{

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -1,0 +1,247 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+// registerConfigTools registers configuration-related MCP tools.
+func (s *Server) registerConfigTools() {
+	getConfigTool := mcp.NewTool("get_config",
+		mcp.WithDescription("Return the current scafctl configuration. Shows catalogs, settings, logging, HTTP client, CEL, resolver, action, auth, and build configuration. Use the optional 'section' parameter to retrieve only a specific section. Sensitive fields (client secrets, tokens) are redacted."),
+		mcp.WithTitleAnnotation("Get Configuration"),
+		mcp.WithToolIcons(toolIcons["config"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaGetConfig),
+		mcp.WithString("section",
+			mcp.Description("Optional section to retrieve: 'catalogs', 'settings', 'logging', 'httpClient', 'cel', 'resolver', 'action', 'auth', 'build'. Omit to return the full configuration."),
+		),
+	)
+	s.mcpServer.AddTool(getConfigTool, s.handleGetConfig)
+
+	getConfigPathsTool := mcp.NewTool("get_config_paths",
+		mcp.WithDescription("Return all XDG-compliant filesystem paths used by scafctl. Shows config, data, cache, state, catalog, secrets, plugins, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout."),
+		mcp.WithTitleAnnotation("Get Config Paths"),
+		mcp.WithToolIcons(toolIcons["config"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaGetConfigPaths),
+	)
+	s.mcpServer.AddTool(getConfigPathsTool, s.handleGetConfigPaths)
+}
+
+// handleGetConfig returns the current configuration (with sensitive fields redacted).
+func (s *Server) handleGetConfig(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cfg := s.config
+	if cfg == nil {
+		cfg = config.FromContext(s.ctx)
+	}
+	if cfg == nil {
+		var err error
+		cfg, err = config.Global()
+		if err != nil {
+			return newStructuredError(ErrCodeConfigError, fmt.Sprintf("no configuration available: %v", err),
+				WithSuggestion("Run 'scafctl config init' to create a default configuration"),
+				WithRelatedTools("get_config_paths"),
+			), nil
+		}
+	}
+
+	sanitized := sanitizeConfig(cfg)
+	section := request.GetString("section", "")
+
+	if section == "" {
+		return mcp.NewToolResultJSON(sanitized)
+	}
+
+	// Return just the requested section
+	validSections := map[string]any{
+		"catalogs":   sanitized.Catalogs,
+		"settings":   sanitized.Settings,
+		"logging":    sanitized.Logging,
+		"httpClient": sanitized.HTTPClient,
+		"cel":        sanitized.CEL,
+		"resolver":   sanitized.Resolver,
+		"action":     sanitized.Action,
+		"auth":       sanitized.Auth,
+		"build":      sanitized.Build,
+	}
+
+	sectionData, ok := validSections[section]
+	if !ok {
+		validNames := make([]string, 0, len(validSections))
+		for k := range validSections {
+			validNames = append(validNames, k)
+		}
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unknown section %q. Valid sections: %v", section, validNames),
+			WithField("section"),
+			WithSuggestion("Omit the section parameter to get the full config"),
+		), nil
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"section": section,
+		"data":    sectionData,
+	})
+}
+
+// sanitizedConfig mirrors config.Config but with sensitive fields redacted.
+type sanitizedConfig struct {
+	Version    int                     `json:"version,omitempty"`
+	Catalogs   []sanitizedCatalog      `json:"catalogs"`
+	Settings   config.Settings         `json:"settings"`
+	Logging    config.LoggingConfig    `json:"logging"`
+	HTTPClient config.HTTPClientConfig `json:"httpClient"`
+	CEL        config.CELConfig        `json:"cel"`
+	Resolver   config.ResolverConfig   `json:"resolver"`
+	Action     config.ActionConfig     `json:"action"`
+	Auth       sanitizedAuth           `json:"auth"`
+	Build      config.BuildConfig      `json:"build"`
+}
+
+// sanitizedCatalog redacts auth tokens from catalog config.
+type sanitizedCatalog struct {
+	Name     string            `json:"name"`
+	Type     string            `json:"type"`
+	Path     string            `json:"path,omitempty"`
+	URL      string            `json:"url,omitempty"`
+	Auth     *sanitizedCatAuth `json:"auth,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type sanitizedCatAuth struct {
+	Type        string `json:"type"`
+	TokenEnvVar string `json:"tokenEnvVar,omitempty"`
+}
+
+// sanitizedAuth redacts client secrets and tokens from auth config.
+type sanitizedAuth struct {
+	Entra  *sanitizedEntraAuth  `json:"entra,omitempty"`
+	GitHub *sanitizedGitHubAuth `json:"github,omitempty"`
+	GCP    *sanitizedGCPAuth    `json:"gcp,omitempty"`
+}
+
+type sanitizedEntraAuth struct {
+	ClientID      string   `json:"clientId,omitempty"`
+	TenantID      string   `json:"tenantId,omitempty"`
+	DefaultScopes []string `json:"defaultScopes,omitempty"`
+}
+
+type sanitizedGitHubAuth struct {
+	ClientID      string   `json:"clientId,omitempty"`
+	Hostname      string   `json:"hostname,omitempty"`
+	DefaultScopes []string `json:"defaultScopes,omitempty"`
+}
+
+type sanitizedGCPAuth struct {
+	ClientID                  string   `json:"clientId,omitempty"`
+	GCPClientCredential       string   `json:"gcpClientCredential,omitempty"` // will be redacted
+	DefaultScopes             []string `json:"defaultScopes,omitempty"`
+	ImpersonateServiceAccount string   `json:"impersonateServiceAccount,omitempty"`
+	Project                   string   `json:"project,omitempty"`
+}
+
+const redactedValue = "***REDACTED***"
+
+// sanitizeConfig creates a sanitized copy of the config with sensitive values redacted.
+func sanitizeConfig(cfg *config.Config) sanitizedConfig {
+	s := sanitizedConfig{
+		Version:    cfg.Version,
+		Settings:   cfg.Settings,
+		Logging:    cfg.Logging,
+		HTTPClient: cfg.HTTPClient,
+		CEL:        cfg.CEL,
+		Resolver:   cfg.Resolver,
+		Action:     cfg.Action,
+		Build:      cfg.Build,
+	}
+
+	// Sanitize catalogs
+	s.Catalogs = make([]sanitizedCatalog, 0, len(cfg.Catalogs))
+	for _, cat := range cfg.Catalogs {
+		sc := sanitizedCatalog{
+			Name:     cat.Name,
+			Type:     cat.Type,
+			Path:     cat.Path,
+			URL:      cat.URL,
+			Metadata: cat.Metadata,
+		}
+		if cat.Auth != nil {
+			sc.Auth = &sanitizedCatAuth{
+				Type:        cat.Auth.Type,
+				TokenEnvVar: cat.Auth.TokenEnvVar,
+			}
+		}
+		s.Catalogs = append(s.Catalogs, sc)
+	}
+
+	// Sanitize auth — redact secrets
+	if cfg.Auth.Entra != nil {
+		s.Auth.Entra = &sanitizedEntraAuth{
+			ClientID:      cfg.Auth.Entra.ClientID,
+			TenantID:      cfg.Auth.Entra.TenantID,
+			DefaultScopes: cfg.Auth.Entra.DefaultScopes,
+		}
+	}
+	if cfg.Auth.GitHub != nil {
+		s.Auth.GitHub = &sanitizedGitHubAuth{
+			ClientID:      cfg.Auth.GitHub.ClientID,
+			Hostname:      cfg.Auth.GitHub.Hostname,
+			DefaultScopes: cfg.Auth.GitHub.DefaultScopes,
+		}
+	}
+	if cfg.Auth.GCP != nil {
+		gcp := &sanitizedGCPAuth{
+			ClientID:                  cfg.Auth.GCP.ClientID,
+			DefaultScopes:             cfg.Auth.GCP.DefaultScopes,
+			ImpersonateServiceAccount: cfg.Auth.GCP.ImpersonateServiceAccount,
+			Project:                   cfg.Auth.GCP.Project,
+		}
+		if cfg.Auth.GCP.ClientSecret != "" {
+			gcp.GCPClientCredential = redactedValue
+		}
+		s.Auth.GCP = gcp
+	}
+
+	return s
+}
+
+// handleGetConfigPaths returns all XDG-compliant filesystem paths used by scafctl.
+func (s *Server) handleGetConfigPaths(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	type pathEntry struct {
+		Name        string `json:"name"`
+		Path        string `json:"path"`
+		Description string `json:"description"`
+		XDGVariable string `json:"xdgVariable"`
+	}
+
+	entries := []pathEntry{
+		{Name: "config", Path: paths.ConfigDir(), Description: "Configuration files (config.yaml)", XDGVariable: "XDG_CONFIG_HOME"},
+		{Name: "data", Path: paths.DataDir(), Description: "Application data", XDGVariable: "XDG_DATA_HOME"},
+		{Name: "cache", Path: paths.CacheDir(), Description: "Cache root", XDGVariable: "XDG_CACHE_HOME"},
+		{Name: "state", Path: paths.StateDir(), Description: "Logs, history, session state", XDGVariable: "XDG_STATE_HOME"},
+		{Name: "catalog", Path: paths.CatalogDir(), Description: "Local artifact catalogs", XDGVariable: "XDG_DATA_HOME"},
+		{Name: "secrets", Path: paths.SecretsDirPath(), Description: "Credential storage", XDGVariable: "XDG_DATA_HOME"},
+		{Name: "httpCache", Path: paths.HTTPCacheDir(), Description: "HTTP response cache", XDGVariable: "XDG_CACHE_HOME"},
+		{Name: "buildCache", Path: paths.BuildCacheDir(), Description: "Build cache for solutions", XDGVariable: "XDG_CACHE_HOME"},
+		{Name: "plugins", Path: paths.PluginCacheDir(), Description: "Plugin cache", XDGVariable: "XDG_CACHE_HOME"},
+		{Name: "runtime", Path: paths.RuntimeDir(), Description: "Runtime sockets and pipes", XDGVariable: "XDG_RUNTIME_DIR"},
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"paths": entries,
+		"count": len(entries),
+	})
+}

--- a/pkg/mcp/tools_config_test.go
+++ b/pkg/mcp/tools_config_test.go
@@ -1,0 +1,206 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGetConfig(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Settings: config.Settings{
+			DefaultCatalog: "local",
+			NoColor:        false,
+			Quiet:          false,
+		},
+		Logging: config.LoggingConfig{
+			Level:  "none",
+			Format: "console",
+		},
+		Catalogs: []config.CatalogConfig{
+			{
+				Name: "local",
+				Type: "filesystem",
+				Path: "/tmp/catalogs",
+			},
+		},
+		Resolver: config.ResolverConfig{
+			Timeout:      "30s",
+			PhaseTimeout: "5m",
+		},
+		Auth: config.GlobalAuthConfig{
+			GCP: &config.GCPAuthConfig{
+				ClientID:     "my-client-id",
+				ClientSecret: "super-secret-value",
+				Project:      "my-project",
+			},
+		},
+	}
+
+	srv, err := NewServer(
+		WithServerVersion("test"),
+		WithServerConfig(cfg),
+	)
+	require.NoError(t, err)
+
+	t.Run("full config", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_config"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleGetConfig(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output sanitizedConfig
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		assert.Equal(t, 1, output.Version)
+		assert.Equal(t, "local", output.Settings.DefaultCatalog)
+		assert.Len(t, output.Catalogs, 1)
+		assert.Equal(t, "local", output.Catalogs[0].Name)
+	})
+
+	t.Run("specific section", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_config"
+		request.Params.Arguments = map[string]any{
+			"section": "settings",
+		}
+
+		result, err := srv.handleGetConfig(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, "settings", output["section"])
+
+		data := output["data"].(map[string]any)
+		assert.Equal(t, "local", data["defaultCatalog"])
+	})
+
+	t.Run("invalid section", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_config"
+		request.Params.Arguments = map[string]any{
+			"section": "nonexistent",
+		}
+
+		result, err := srv.handleGetConfig(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "nonexistent")
+	})
+
+	t.Run("sensitive fields are redacted", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_config"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleGetConfig(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.NotContains(t, text, "super-secret-value")
+		assert.Contains(t, text, redactedValue)
+		// Client ID should still be visible
+		assert.Contains(t, text, "my-client-id")
+	})
+
+	t.Run("no config available", func(t *testing.T) {
+		noConfigSrv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_config"
+		request.Params.Arguments = map[string]any{}
+
+		// This may succeed with global or fail gracefully
+		result, err := noConfigSrv.handleGetConfig(context.Background(), request)
+		require.NoError(t, err)
+		// Either way, it should not panic
+		assert.NotNil(t, result)
+	})
+}
+
+func TestSanitizeConfig(t *testing.T) {
+	t.Run("redacts GCP client secret", func(t *testing.T) {
+		cfg := &config.Config{
+			Auth: config.GlobalAuthConfig{
+				GCP: &config.GCPAuthConfig{
+					ClientID:     "visible-id",
+					ClientSecret: "should-be-hidden",
+					Project:      "my-proj",
+				},
+			},
+		}
+
+		sanitized := sanitizeConfig(cfg)
+		assert.Equal(t, "visible-id", sanitized.Auth.GCP.ClientID)
+		assert.Equal(t, redactedValue, sanitized.Auth.GCP.GCPClientCredential)
+		assert.Equal(t, "my-proj", sanitized.Auth.GCP.Project)
+	})
+
+	t.Run("empty secret not redacted", func(t *testing.T) {
+		cfg := &config.Config{
+			Auth: config.GlobalAuthConfig{
+				GCP: &config.GCPAuthConfig{
+					ClientID:     "visible-id",
+					ClientSecret: "",
+				},
+			},
+		}
+
+		sanitized := sanitizeConfig(cfg)
+		assert.Equal(t, "", sanitized.Auth.GCP.GCPClientCredential)
+	})
+
+	t.Run("nil auth sections", func(t *testing.T) {
+		cfg := &config.Config{
+			Auth: config.GlobalAuthConfig{},
+		}
+
+		sanitized := sanitizeConfig(cfg)
+		assert.Nil(t, sanitized.Auth.Entra)
+		assert.Nil(t, sanitized.Auth.GitHub)
+		assert.Nil(t, sanitized.Auth.GCP)
+	})
+
+	t.Run("catalogs with auth", func(t *testing.T) {
+		cfg := &config.Config{
+			Catalogs: []config.CatalogConfig{
+				{
+					Name: "remote",
+					Type: "oci",
+					URL:  "https://registry.example.com",
+					Auth: &config.AuthConfig{
+						Type:        "token",
+						TokenEnvVar: "MY_TOKEN",
+					},
+				},
+			},
+		}
+
+		sanitized := sanitizeConfig(cfg)
+		require.Len(t, sanitized.Catalogs, 1)
+		assert.Equal(t, "remote", sanitized.Catalogs[0].Name)
+		require.NotNil(t, sanitized.Catalogs[0].Auth)
+		assert.Equal(t, "token", sanitized.Catalogs[0].Auth.Type)
+		assert.Equal(t, "MY_TOKEN", sanitized.Catalogs[0].Auth.TokenEnvVar)
+	})
+}

--- a/pkg/mcp/tools_diff.go
+++ b/pkg/mcp/tools_diff.go
@@ -6,10 +6,9 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
+	"github.com/oakwood-commons/scafctl/pkg/soldiff"
 )
 
 // registerDiffTools registers diff/comparison MCP tools.
@@ -18,6 +17,8 @@ func (s *Server) registerDiffTools() {
 	diffSolutionTool := mcp.NewTool("diff_solution",
 		mcp.WithDescription("Compare two solution files and show structural differences. Identifies added, removed, and changed resolvers, actions, metadata, and test cases. Useful for reviewing changes before committing or understanding what was modified."),
 		mcp.WithTitleAnnotation("Diff Solution"),
+		mcp.WithToolIcons(toolIcons["diff"]),
+		mcp.WithDeferLoading(true),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -38,254 +39,31 @@ func (s *Server) registerDiffTools() {
 func (s *Server) handleDiffSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	pathA, err := request.RequireString("path_a")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path_a"),
+			WithSuggestion("Provide two solution file paths to compare"),
+		), nil
 	}
 	pathB, err := request.RequireString("path_b")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path_b"),
+			WithSuggestion("Provide two solution file paths to compare"),
+		), nil
 	}
 
-	solA, err := explain.LoadSolution(s.ctx, pathA)
+	result, err := soldiff.CompareFiles(s.ctx, pathA, pathB)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution A (%s): %v", pathA, err)), nil
-	}
-	solB, err := explain.LoadSolution(s.ctx, pathB)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution B (%s): %v", pathB, err)), nil
-	}
-
-	type change struct {
-		Field    string `json:"field"`
-		Type     string `json:"type"` // "added", "removed", "changed"
-		OldValue any    `json:"oldValue,omitempty"`
-		NewValue any    `json:"newValue,omitempty"`
-	}
-
-	var changes []change
-
-	// Compare metadata
-	if solA.Metadata.Name != solB.Metadata.Name {
-		changes = append(changes, change{Field: "metadata.name", Type: "changed", OldValue: solA.Metadata.Name, NewValue: solB.Metadata.Name})
-	}
-	if solA.Metadata.Description != solB.Metadata.Description {
-		changes = append(changes, change{Field: "metadata.description", Type: "changed", OldValue: solA.Metadata.Description, NewValue: solB.Metadata.Description})
-	}
-	if solA.Metadata.Version != nil && solB.Metadata.Version != nil {
-		if solA.Metadata.Version.String() != solB.Metadata.Version.String() {
-			changes = append(changes, change{Field: "metadata.version", Type: "changed", OldValue: solA.Metadata.Version.String(), NewValue: solB.Metadata.Version.String()})
-		}
-	}
-
-	// Compare resolvers
-	resolversA := make(map[string]bool)
-	resolversB := make(map[string]bool)
-	if solA.Spec.HasResolvers() {
-		for name := range solA.Spec.Resolvers {
-			resolversA[name] = true
-		}
-	}
-	if solB.Spec.HasResolvers() {
-		for name := range solB.Spec.Resolvers {
-			resolversB[name] = true
-		}
-	}
-
-	// Find added/removed resolvers
-	for name := range resolversB {
-		if !resolversA[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "added"})
-		}
-	}
-	for name := range resolversA {
-		if !resolversB[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "removed"})
-		}
-	}
-
-	// Check for changed resolvers (both exist)
-	for name := range resolversA {
-		if resolversB[name] {
-			rA := solA.Spec.Resolvers[name]
-			rB := solB.Spec.Resolvers[name]
-
-			if rA.Type != rB.Type {
-				changes = append(changes, change{
-					Field: fmt.Sprintf("spec.resolvers.%s.type", name), Type: "changed",
-					OldValue: string(rA.Type), NewValue: string(rB.Type),
-				})
-			}
-			if rA.Description != rB.Description {
-				changes = append(changes, change{
-					Field: fmt.Sprintf("spec.resolvers.%s.description", name), Type: "changed",
-					OldValue: rA.Description, NewValue: rB.Description,
-				})
-			}
-
-			// Compare primary provider
-			provA := ""
-			provB := ""
-			if rA.Resolve != nil && len(rA.Resolve.With) > 0 {
-				provA = rA.Resolve.With[0].Provider
-			}
-			if rB.Resolve != nil && len(rB.Resolve.With) > 0 {
-				provB = rB.Resolve.With[0].Provider
-			}
-			if provA != provB {
-				changes = append(changes, change{
-					Field: fmt.Sprintf("spec.resolvers.%s.provider", name), Type: "changed",
-					OldValue: provA, NewValue: provB,
-				})
-			}
-		}
-	}
-
-	// Compare actions
-	actionsA := make(map[string]bool)
-	actionsB := make(map[string]bool)
-	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Actions != nil {
-		for name := range solA.Spec.Workflow.Actions {
-			actionsA[name] = true
-		}
-	}
-	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Actions != nil {
-		for name := range solB.Spec.Workflow.Actions {
-			actionsB[name] = true
-		}
-	}
-
-	for name := range actionsB {
-		if !actionsA[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "added"})
-		}
-	}
-	for name := range actionsA {
-		if !actionsB[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "removed"})
-		}
-	}
-
-	// Check changed actions
-	for name := range actionsA {
-		if actionsB[name] {
-			aA := solA.Spec.Workflow.Actions[name]
-			aB := solB.Spec.Workflow.Actions[name]
-
-			if aA.Provider != aB.Provider {
-				changes = append(changes, change{
-					Field: fmt.Sprintf("spec.workflow.actions.%s.provider", name), Type: "changed",
-					OldValue: aA.Provider, NewValue: aB.Provider,
-				})
-			}
-			if aA.Description != aB.Description {
-				changes = append(changes, change{
-					Field: fmt.Sprintf("spec.workflow.actions.%s.description", name), Type: "changed",
-					OldValue: aA.Description, NewValue: aB.Description,
-				})
-			}
-		}
-	}
-
-	// Compare finally actions
-	finallyA := make(map[string]bool)
-	finallyB := make(map[string]bool)
-	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Finally != nil {
-		for name := range solA.Spec.Workflow.Finally {
-			finallyA[name] = true
-		}
-	}
-	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Finally != nil {
-		for name := range solB.Spec.Workflow.Finally {
-			finallyB[name] = true
-		}
-	}
-
-	for name := range finallyB {
-		if !finallyA[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "added"})
-		}
-	}
-	for name := range finallyA {
-		if !finallyB[name] {
-			changes = append(changes, change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "removed"})
-		}
-	}
-
-	// Compare test cases
-	var testsA, testsB map[string]bool
-	if solA.Spec.Testing != nil && solA.Spec.Testing.Cases != nil {
-		testsA = make(map[string]bool, len(solA.Spec.Testing.Cases))
-		for name := range solA.Spec.Testing.Cases {
-			testsA[name] = true
-		}
-	}
-	if solB.Spec.Testing != nil && solB.Spec.Testing.Cases != nil {
-		testsB = make(map[string]bool, len(solB.Spec.Testing.Cases))
-		for name := range solB.Spec.Testing.Cases {
-			testsB[name] = true
-		}
-	}
-
-	if testsA != nil || testsB != nil {
-		if testsA == nil {
-			testsA = make(map[string]bool)
-		}
-		if testsB == nil {
-			testsB = make(map[string]bool)
-		}
-
-		for name := range testsB {
-			if !testsA[name] {
-				changes = append(changes, change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "added"})
-			}
-		}
-		for name := range testsA {
-			if !testsB[name] {
-				changes = append(changes, change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "removed"})
-			}
-		}
-	}
-
-	// Workflow added/removed
-	if !solA.Spec.HasWorkflow() && solB.Spec.HasWorkflow() {
-		changes = append(changes, change{Field: "spec.workflow", Type: "added"})
-	} else if solA.Spec.HasWorkflow() && !solB.Spec.HasWorkflow() {
-		changes = append(changes, change{Field: "spec.workflow", Type: "removed"})
-	}
-
-	// Testing added/removed
-	if solA.Spec.Testing == nil && solB.Spec.Testing != nil {
-		changes = append(changes, change{Field: "spec.testing", Type: "added"})
-	} else if solA.Spec.Testing != nil && solB.Spec.Testing == nil {
-		changes = append(changes, change{Field: "spec.testing", Type: "removed"})
-	}
-
-	// Sort changes for deterministic output
-	sort.Slice(changes, func(i, j int) bool {
-		return changes[i].Field < changes[j].Field
-	})
-
-	// Count by type
-	added, removed, changed := 0, 0, 0
-	for _, c := range changes {
-		switch c.Type {
-		case "added":
-			added++
-		case "removed":
-			removed++
-		case "changed":
-			changed++
-		}
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("diff failed: %v", err),
+			WithSuggestion("Check that both file paths exist and contain valid solution YAML"),
+			WithRelatedTools("inspect_solution", "lint_solution"),
+		), nil
 	}
 
 	return mcp.NewToolResultJSON(map[string]any{
-		"pathA":   pathA,
-		"pathB":   pathB,
-		"changes": changes,
-		"summary": map[string]any{
-			"total":   len(changes),
-			"added":   added,
-			"removed": removed,
-			"changed": changed,
-		},
+		"pathA":   result.PathA,
+		"pathB":   result.PathB,
+		"changes": result.Changes,
+		"summary": result.Summary,
 	})
 }

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
+	"github.com/oakwood-commons/scafctl/pkg/dryrun"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+)
+
+// registerDryRunTools registers dry-run related MCP tools.
+func (s *Server) registerDryRunTools() {
+	dryRunTool := mcp.NewTool("dry_run_solution",
+		mcp.WithDescription("Perform a full dry-run of a solution: resolves all resolvers with providers in dry-run/mock mode (no side effects), then builds the action graph to show what each action WOULD do. Returns resolver outputs (mock values), action execution plan with materialized inputs, provider mock behaviors, and any warnings. Use this to understand the complete execution plan before actually running a solution."),
+		mcp.WithTitleAnnotation("Dry-Run Solution"),
+		mcp.WithToolIcons(toolIcons["dryrun"]),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithRawOutputSchema(outputSchemaDryRun),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+		mcp.WithObject("params",
+			mcp.Description("Input parameters as key-value pairs for parameter-type resolvers"),
+		),
+	)
+	s.mcpServer.AddTool(dryRunTool, s.handleDryRunSolution)
+}
+
+// handleDryRunSolution performs a full dry-run of a solution using the shared dryrun package.
+func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution file, catalog name, or URL"),
+		), nil
+	}
+
+	// Parse params
+	var params map[string]any
+	args := request.GetArguments()
+	if p, ok := args["params"]; ok && p != nil {
+		if pm, ok := p.(map[string]any); ok {
+			params = pm
+		} else {
+			return newStructuredError(ErrCodeInvalidInput, "'params' must be an object (key-value pairs)",
+				WithField("params"),
+				WithSuggestion("Provide params as a JSON object, e.g. {\"key\": \"value\"}"),
+			), nil
+		}
+	}
+
+	// Load solution
+	prepResult, err := prepare.Solution(s.ctx, path,
+		prepare.WithRegistry(s.registry),
+	)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the file exists and contains valid solution YAML"),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
+	}
+	if prepResult.Cleanup != nil {
+		defer prepResult.Cleanup()
+	}
+
+	sol := prepResult.Solution
+	reg := prepResult.Registry
+	if reg == nil {
+		reg, err = builtin.DefaultRegistry(s.ctx)
+		if err != nil {
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to create provider registry: %v", err),
+				WithSuggestion("This is an internal error — please report it"),
+			), nil
+		}
+	}
+
+	// Send progress notifications during dry-run
+	progress := newProgressReporter(s, request)
+	progress.setTotal(3)
+	progress.report(s.ctx, 1, "Loaded solution, executing resolvers in dry-run mode")
+
+	// Execute resolvers in dry-run mode
+	var resolverData map[string]any
+	if sol.Spec.HasResolvers() {
+		cfg := run.ResolverExecutionConfigFromContext(s.ctx)
+		cfg.DryRun = true
+
+		result, err := run.ExecuteResolvers(s.ctx, sol, params, reg, cfg)
+		if err != nil {
+			resolverData = make(map[string]any)
+		} else {
+			resolverData = result.Data
+		}
+	}
+
+	progress.report(s.ctx, 2, "Building action graph and generating report")
+
+	// Generate structured report
+	report, err := dryrun.Generate(s.ctx, sol, dryrun.Options{
+		Params:       params,
+		Registry:     reg,
+		ResolverData: resolverData,
+	})
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("dry-run failed: %v", err),
+			WithSuggestion("Check the solution configuration and try lint_solution first"),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
+	}
+
+	progress.report(s.ctx, 3, "Dry-run complete")
+
+	return mcp.NewToolResultJSON(report)
+}

--- a/pkg/mcp/tools_dryrun_test.go
+++ b/pkg/mcp/tools_dryrun_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDryRunSolution(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("missing path", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "dry_run_solution"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleDryRunSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("invalid params type", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "dry_run_solution"
+		request.Params.Arguments = map[string]any{
+			"path":   "/tmp/nonexistent-solution.yaml",
+			"params": "not-an-object",
+		}
+
+		result, err := srv.handleDryRunSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "params")
+	})
+
+	t.Run("nonexistent solution", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "dry_run_solution"
+		request.Params.Arguments = map[string]any{
+			"path": "/tmp/absolutely-nonexistent-solution.yaml",
+		}
+
+		result, err := srv.handleDryRunSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("valid solution dry run", func(t *testing.T) {
+		// Create a minimal solution file
+		solutionYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dry-run-test
+  version: 1.0.0
+  description: A minimal solution for dry-run testing
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello"
+`
+		tmpDir := t.TempDir()
+		solutionPath := filepath.Join(tmpDir, "solution.yaml")
+		require.NoError(t, os.WriteFile(solutionPath, []byte(solutionYAML), 0o644))
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "dry_run_solution"
+		request.Params.Arguments = map[string]any{
+			"path": solutionPath,
+		}
+
+		result, err := srv.handleDryRunSolution(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		if result.IsError {
+			t.Logf("dry run returned error (may be expected in test env): %s", text)
+			return
+		}
+
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		assert.Equal(t, true, output["dryRun"])
+		assert.Equal(t, "dry-run-test", output["solution"])
+		assert.Equal(t, true, output["hasResolvers"])
+	})
+}

--- a/pkg/mcp/tools_examples.go
+++ b/pkg/mcp/tools_examples.go
@@ -6,13 +6,9 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
-	"sort"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/examples"
 )
 
 // registerExampleTools registers example-related MCP tools.
@@ -21,6 +17,7 @@ func (s *Server) registerExampleTools() {
 	listExamplesTool := mcp.NewTool("list_examples",
 		mcp.WithDescription("List available scafctl example files. Examples demonstrate best practices for solutions, resolvers, actions, providers, and more. Filter by category (solutions, resolvers, actions, providers, exec, config, mcp, snapshots, catalog) or get all."),
 		mcp.WithTitleAnnotation("List Examples"),
+		mcp.WithToolIcons(toolIcons["example"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -36,6 +33,7 @@ func (s *Server) registerExampleTools() {
 	getExampleTool := mcp.NewTool("get_example",
 		mcp.WithDescription("Read the contents of a scafctl example file. Use list_examples first to find available examples, then use the path returned there."),
 		mcp.WithTitleAnnotation("Get Example"),
+		mcp.WithToolIcons(toolIcons["example"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -48,26 +46,15 @@ func (s *Server) registerExampleTools() {
 	s.mcpServer.AddTool(getExampleTool, s.handleGetExample)
 }
 
-// exampleItem represents an example file in the listing.
-type exampleItem struct {
-	Path        string `json:"path"`
-	Category    string `json:"category"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-}
-
 // handleListExamples lists available example files.
 func (s *Server) handleListExamples(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	category := request.GetString("category", "")
 
-	examplesDir, err := findExamplesDir()
+	items, err := examples.Scan(category)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("examples directory not found: %v", err)), nil
-	}
-
-	items, err := scanExamples(examplesDir, category)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to scan examples: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to scan examples: %v", err),
+			WithSuggestion("Check that the examples are properly embedded in the binary"),
+		), nil
 	}
 
 	if len(items) == 0 {
@@ -91,213 +78,21 @@ func (s *Server) handleListExamples(_ context.Context, request mcp.CallToolReque
 func (s *Server) handleGetExample(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Use list_examples to see available example paths"),
+			WithRelatedTools("list_examples"),
+		), nil
 	}
 
-	examplesDir, err := findExamplesDir()
+	content, err := examples.Read(path)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("examples directory not found: %v", err)), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("failed to read example: %v", err),
+			WithField("path"),
+			WithSuggestion("Use list_examples to see available example paths"),
+			WithRelatedTools("list_examples"),
+		), nil
 	}
 
-	// Security: ensure the path doesn't escape the examples directory
-	cleanPath := filepath.Clean(path)
-	if strings.Contains(cleanPath, "..") {
-		return mcp.NewToolResultError("path must not contain '..'"), nil
-	}
-
-	fullPath := filepath.Join(examplesDir, cleanPath)
-
-	// Verify the resolved path is under the examples directory
-	resolvedPath, err := filepath.Abs(fullPath)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
-	}
-	resolvedDir, err := filepath.Abs(examplesDir)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("invalid examples dir: %v", err)), nil
-	}
-	if !strings.HasPrefix(resolvedPath, resolvedDir) {
-		return mcp.NewToolResultError("path must be within the examples directory"), nil
-	}
-
-	content, err := os.ReadFile(fullPath)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to read example %q: %v", path, err)), nil
-	}
-
-	return mcp.NewToolResultText(string(content)), nil
-}
-
-// findExamplesDir locates the examples directory relative to the package source.
-// It walks up from the compiled binary's source location to find the project root.
-func findExamplesDir() (string, error) {
-	// Strategy 1: Find relative to this source file (works in development/testing)
-	_, thisFile, _, ok := runtime.Caller(0)
-	if ok {
-		// This file is at pkg/mcp/tools_examples.go
-		// Project root is ../../ from here
-		pkgDir := filepath.Dir(thisFile)
-		projectRoot := filepath.Join(pkgDir, "..", "..")
-		examplesDir := filepath.Join(projectRoot, "examples")
-		if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
-			return examplesDir, nil
-		}
-	}
-
-	// Strategy 2: Check current working directory
-	cwd, err := os.Getwd()
-	if err == nil {
-		examplesDir := filepath.Join(cwd, "examples")
-		if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
-			return examplesDir, nil
-		}
-	}
-
-	// Strategy 3: Walk up from cwd looking for examples/
-	if err == nil {
-		dir := cwd
-		for i := 0; i < 10; i++ {
-			examplesDir := filepath.Join(dir, "examples")
-			if info, err := os.Stat(examplesDir); err == nil && info.IsDir() {
-				return examplesDir, nil
-			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
-	}
-
-	return "", fmt.Errorf("could not locate examples directory")
-}
-
-// scanExamples walks the examples directory and returns structured items.
-func scanExamples(dir, categoryFilter string) ([]exampleItem, error) {
-	var items []exampleItem
-
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if info.IsDir() {
-			return nil
-		}
-
-		// Only include YAML files
-		ext := filepath.Ext(path)
-		if ext != ".yaml" && ext != ".yml" {
-			return nil
-		}
-
-		// Get the relative path from the examples dir
-		relPath, relErr := filepath.Rel(dir, path)
-		if relErr != nil {
-			return relErr
-		}
-
-		// Determine category from the first directory component
-		parts := strings.SplitN(relPath, string(filepath.Separator), 2)
-		category := ""
-		name := relPath
-		if len(parts) > 1 {
-			category = parts[0]
-			name = parts[1]
-		}
-
-		// Apply category filter
-		if categoryFilter != "" && category != categoryFilter {
-			return nil
-		}
-
-		// Skip intentionally bad examples
-		if strings.Contains(relPath, "bad-solution") {
-			return nil
-		}
-
-		item := exampleItem{
-			Path:     relPath,
-			Category: category,
-			Name:     name,
-		}
-
-		// Generate a description from the filename
-		item.Description = descriptionFromPath(relPath)
-
-		items = append(items, item)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Sort by category then name
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Category != items[j].Category {
-			return items[i].Category < items[j].Category
-		}
-		return items[i].Name < items[j].Name
-	})
-
-	return items, nil
-}
-
-// descriptionFromPath generates a human-readable description from a file path.
-func descriptionFromPath(path string) string {
-	descriptions := map[string]string{
-		// Solutions
-		"solutions/comprehensive/solution.yaml":   "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
-		"solutions/email-notifier/solution.yaml":  "Email notification solution with parameters, validation, and action workflow",
-		"solutions/terraform/solution.yaml":       "Terraform infrastructure scaffolding solution",
-		"solutions/k8s-clusters/solution.yaml":    "Kubernetes cluster provisioning solution",
-		"solutions/directory/solution.yaml":       "Directory provider examples (list, read, create, copy)",
-		"solutions/scaffold-demo/solution.yaml":   "Scaffold/template rendering demo solution",
-		"solutions/github-auth/solution.yaml":     "GitHub authentication and API access solution",
-		"solutions/composition/parent.yaml":       "Solution composition - parent that composes children",
-		"solutions/composition/child.yaml":        "Solution composition - child partial solution",
-		"solutions/taskfile/solution.yaml":        "Taskfile-based workflow solution",
-		"solutions/tested-solution/solution.yaml": "Solution with functional tests defined in spec.testing.cases",
-
-		// Actions
-		"actions/hello-world.yaml":              "Simple hello world action",
-		"actions/sequential-chain.yaml":         "Actions executed sequentially using dependsOn",
-		"actions/parallel-with-deps.yaml":       "Parallel actions with dependency ordering",
-		"actions/conditional-execution.yaml":    "Actions with conditional execution (when clauses)",
-		"actions/error-handling.yaml":           "Error handling with onError behavior",
-		"actions/finally-cleanup.yaml":          "Finally block for cleanup actions",
-		"actions/foreach-deploy.yaml":           "ForEach iteration over collections",
-		"actions/retry-backoff.yaml":            "Retry with exponential backoff",
-		"actions/conditional-retry.yaml":        "Retry with conditional retry logic (retryIf)",
-		"actions/complex-workflow.yaml":         "Complex workflow with all action features",
-		"actions/template-render.yaml":          "Template rendering action",
-		"actions/go-template-inline.yaml":       "Inline Go template action",
-		"actions/result-schema-validation.yaml": "Action result schema validation",
-
-		// Resolvers
-		"resolvers/hello-world.yaml":         "Simple static value resolver",
-		"resolvers/parameters.yaml":          "Parameter provider for user input",
-		"resolvers/dependencies.yaml":        "Resolver dependency chain (dependsOn)",
-		"resolvers/env-config.yaml":          "Environment variable resolver",
-		"resolvers/validation.yaml":          "Resolver validation rules",
-		"resolvers/transform-pipeline.yaml":  "Multi-step transform pipeline",
-		"resolvers/cel-basics.yaml":          "CEL expression basics in resolvers",
-		"resolvers/cel-builtins.yaml":        "CEL built-in functions reference",
-		"resolvers/cel-extensions.yaml":      "scafctl custom CEL extensions",
-		"resolvers/cel-transforms.yaml":      "CEL-based transform examples",
-		"resolvers/cel-common-patterns.yaml": "Common CEL patterns and recipes",
-		"resolvers/feature-flags.yaml":       "Feature flag resolver pattern",
-		"resolvers/identity.yaml":            "Identity/auth resolver pattern",
-		"resolvers/secrets.yaml":             "Secrets resolver pattern",
-	}
-
-	if desc, ok := descriptions[path]; ok {
-		return desc
-	}
-
-	// Fallback: generate from filename
-	name := filepath.Base(path)
-	name = strings.TrimSuffix(name, filepath.Ext(name))
-	name = strings.ReplaceAll(name, "-", " ")
-	name = strings.ReplaceAll(name, "_", " ")
-	return strings.Title(name) + " example" //nolint:staticcheck // strings.Title is fine for simple cases
+	return mcp.NewToolResultText(content), nil
 }

--- a/pkg/mcp/tools_examples_test.go
+++ b/pkg/mcp/tools_examples_test.go
@@ -6,11 +6,10 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/examples"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,13 +32,13 @@ func TestHandleListExamples(t *testing.T) {
 		var data map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &data))
 
-		examples, ok := data["examples"].([]any)
+		exs, ok := data["examples"].([]any)
 		require.True(t, ok, "expected examples array")
-		assert.Greater(t, len(examples), 0, "should find at least one example")
+		assert.Greater(t, len(exs), 0, "should find at least one example")
 
 		count, ok := data["count"].(float64)
 		require.True(t, ok)
-		assert.Equal(t, float64(len(examples)), count)
+		assert.Equal(t, float64(len(exs)), count)
 	})
 
 	t.Run("filters by category", func(t *testing.T) {
@@ -61,9 +60,9 @@ func TestHandleListExamples(t *testing.T) {
 		var data map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &data))
 
-		examples, ok := data["examples"].([]any)
+		exs, ok := data["examples"].([]any)
 		require.True(t, ok)
-		for _, ex := range examples {
+		for _, ex := range exs {
 			exMap := ex.(map[string]any)
 			assert.Equal(t, "actions", exMap["category"])
 		}
@@ -88,9 +87,9 @@ func TestHandleListExamples(t *testing.T) {
 		var data map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &data))
 
-		examples, ok := data["examples"].([]any)
+		exs, ok := data["examples"].([]any)
 		require.True(t, ok)
-		assert.Empty(t, examples)
+		assert.Empty(t, exs)
 	})
 }
 
@@ -108,10 +107,10 @@ func TestHandleGetExample(t *testing.T) {
 		text := extractText(t, listResult)
 		var data map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &data))
-		examples := data["examples"].([]any)
-		require.NotEmpty(t, examples, "need at least one action example")
+		exs := data["examples"].([]any)
+		require.NotEmpty(t, exs, "need at least one action example")
 
-		firstExample := examples[0].(map[string]any)
+		firstExample := exs[0].(map[string]any)
 		exPath := firstExample["path"].(string)
 
 		// Now get that example
@@ -177,39 +176,9 @@ func TestHandleGetExample(t *testing.T) {
 	})
 }
 
-func TestFindExamplesDir(t *testing.T) {
-	dir, err := findExamplesDir()
-	require.NoError(t, err)
-	assert.DirExists(t, dir)
-
-	// Verify it actually contains example files
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	assert.Greater(t, len(entries), 0)
-
-	// Check that expected subdirectories exist
-	hasActions := false
-	hasSolutions := false
-	for _, e := range entries {
-		if e.IsDir() {
-			switch e.Name() {
-			case "actions":
-				hasActions = true
-			case "solutions":
-				hasSolutions = true
-			}
-		}
-	}
-	assert.True(t, hasActions, "examples/ should have actions/ subdirectory")
-	assert.True(t, hasSolutions, "examples/ should have solutions/ subdirectory")
-}
-
-func TestScanExamples(t *testing.T) {
-	dir, err := findExamplesDir()
-	require.NoError(t, err)
-
+func TestExamplesScan(t *testing.T) {
 	t.Run("scans all examples", func(t *testing.T) {
-		items, err := scanExamples(dir, "")
+		items, err := examples.Scan("")
 		require.NoError(t, err)
 		assert.Greater(t, len(items), 0)
 
@@ -224,7 +193,7 @@ func TestScanExamples(t *testing.T) {
 	})
 
 	t.Run("filters by category", func(t *testing.T) {
-		items, err := scanExamples(dir, "solutions")
+		items, err := examples.Scan("solutions")
 		require.NoError(t, err)
 		for _, item := range items {
 			assert.Equal(t, "solutions", item.Category)
@@ -232,7 +201,7 @@ func TestScanExamples(t *testing.T) {
 	})
 
 	t.Run("skips bad-solution examples", func(t *testing.T) {
-		items, err := scanExamples(dir, "")
+		items, err := examples.Scan("")
 		require.NoError(t, err)
 		for _, item := range items {
 			assert.NotContains(t, item.Path, "bad-solution")
@@ -240,32 +209,32 @@ func TestScanExamples(t *testing.T) {
 	})
 }
 
-func TestDescriptionFromPath(t *testing.T) {
+func TestExamplesDescriptionFromPath(t *testing.T) {
 	t.Run("known path returns specific description", func(t *testing.T) {
-		desc := descriptionFromPath("actions/hello-world.yaml")
+		desc := examples.DescriptionFromPath("actions/hello-world.yaml")
 		assert.Equal(t, "Simple hello world action", desc)
 	})
 
 	t.Run("unknown path generates fallback", func(t *testing.T) {
-		desc := descriptionFromPath("custom/my-custom-thing.yaml")
+		desc := examples.DescriptionFromPath("custom/my-custom-thing.yaml")
 		assert.Contains(t, desc, "My Custom Thing")
 		assert.Contains(t, desc, "example")
 	})
 
 	t.Run("dashes replaced with spaces", func(t *testing.T) {
-		desc := descriptionFromPath("something/some-long-name.yaml")
+		desc := examples.DescriptionFromPath("something/some-long-name.yaml")
 		assert.Contains(t, desc, "Some Long Name")
 	})
 
 	t.Run("underscores replaced with spaces", func(t *testing.T) {
-		desc := descriptionFromPath("something/some_other_name.yaml")
+		desc := examples.DescriptionFromPath("something/some_other_name.yaml")
 		assert.Contains(t, desc, "Some Other Name")
 	})
 }
 
-func TestScanExamplesNonexistentDir(t *testing.T) {
-	items, err := scanExamples(filepath.Join(os.TempDir(), "nonexistent_dir_12345"), "")
-	// filepath.Walk returns an error for non-existent root
-	assert.Error(t, err)
-	assert.Empty(t, items)
+func TestExamplesCategories(t *testing.T) {
+	cats := examples.Categories()
+	assert.NotEmpty(t, cats)
+	assert.Contains(t, cats, "actions")
+	assert.Contains(t, cats, "solutions")
 }

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -14,10 +14,30 @@ import (
 
 // registerLintTools registers lint-related MCP tools.
 func (s *Server) registerLintTools() {
+	// list_lint_rules
+	listLintRulesTool := mcp.NewTool("list_lint_rules",
+		mcp.WithDescription("List all known lint rules with their severity, category, and a short description. Use this to discover available rules before calling explain_lint_rule for details."),
+		mcp.WithTitleAnnotation("List Lint Rules"),
+		mcp.WithToolIcons(toolIcons["lint"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("severity",
+			mcp.Description("Filter by severity level: 'error', 'warning', or 'info'. Omit to list all."),
+		),
+		mcp.WithString("category",
+			mcp.Description("Filter by category (e.g., 'structure', 'naming', 'provider', 'expression', 'schema'). Omit to list all."),
+		),
+	)
+	s.mcpServer.AddTool(listLintRulesTool, s.handleListLintRules)
+
 	// explain_lint_rule
 	explainLintRuleTool := mcp.NewTool("explain_lint_rule",
-		mcp.WithDescription("Get a detailed explanation and fix suggestions for a specific lint rule. When lint_solution returns findings with a ruleName, use this tool to understand what the rule checks for, why it matters, and how to fix it."),
+		mcp.WithDescription("Get a detailed explanation and fix suggestions for a specific lint rule. When lint_solution returns findings with a ruleName, use this tool to understand what the rule checks for, why it matters, and how to fix it. Call list_lint_rules first to discover available rule names."),
 		mcp.WithTitleAnnotation("Explain Lint Rule"),
+		mcp.WithToolIcons(toolIcons["lint"]),
+		mcp.WithDeferLoading(true),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -30,226 +50,69 @@ func (s *Server) registerLintTools() {
 	s.mcpServer.AddTool(explainLintRuleTool, s.handleExplainLintRule)
 }
 
-// lintRuleExplanation contains a detailed explanation of a lint rule.
-type lintRuleExplanation struct {
-	Rule        string   `json:"rule"`
-	Severity    string   `json:"severity"`
-	Category    string   `json:"category"`
-	Description string   `json:"description"`
-	Why         string   `json:"why"`
-	Fix         string   `json:"fix"`
-	Examples    []string `json:"examples,omitempty"`
+// lintRuleSummary is a compact view of a lint rule for listing.
+type lintRuleSummary struct {
+	Rule        string `json:"rule"`
+	Severity    string `json:"severity"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+// handleListLintRules returns all known lint rules with optional filtering.
+// Rules are sourced from the canonical lint.KnownRules registry.
+func (s *Server) handleListLintRules(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	severityFilter := request.GetString("severity", "")
+	categoryFilter := request.GetString("category", "")
+
+	allRules := lint.ListRules() // already sorted by severity, then name
+	rules := make([]lintRuleSummary, 0, len(allRules))
+	for _, r := range allRules {
+		if severityFilter != "" && r.Severity != severityFilter {
+			continue
+		}
+		if categoryFilter != "" && r.Category != categoryFilter {
+			continue
+		}
+		rules = append(rules, lintRuleSummary{
+			Rule:        r.Rule,
+			Severity:    r.Severity,
+			Category:    r.Category,
+			Description: r.Description,
+		})
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"count": len(rules),
+		"rules": rules,
+	})
 }
 
 // handleExplainLintRule returns a detailed explanation for a specific lint rule.
+// Data is sourced from the canonical lint.KnownRules registry.
 func (s *Server) handleExplainLintRule(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	rule, err := request.RequireString("rule")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("rule"),
+			WithSuggestion("Use list_lint_rules to see all available rule names"),
+			WithRelatedTools("list_lint_rules"),
+		), nil
 	}
 
-	explanation, ok := lintRuleExplanations[rule]
+	meta, ok := lint.GetRule(rule)
 	if !ok {
 		// List all known rules
-		known := make([]string, 0, len(lintRuleExplanations))
-		for k := range lintRuleExplanations {
-			known = append(known, k)
+		allRules := lint.ListRules()
+		known := make([]string, 0, len(allRules))
+		for _, r := range allRules {
+			known = append(known, r.Rule)
 		}
-		return mcp.NewToolResultError(fmt.Sprintf("unknown lint rule %q. Known rules: %s", rule, strings.Join(known, ", "))), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("unknown lint rule %q. Known rules: %s", rule, strings.Join(known, ", ")),
+			WithField("rule"),
+			WithSuggestion("Use list_lint_rules to see all available rule names"),
+			WithRelatedTools("list_lint_rules"),
+		), nil
 	}
 
-	return mcp.NewToolResultJSON(explanation)
-}
-
-// lintRuleExplanations maps rule names to detailed explanations.
-// These match the rules defined in pkg/cmd/scafctl/lint/lint.go.
-var lintRuleExplanations = map[string]lintRuleExplanation{
-	"empty-solution": {
-		Rule:        "empty-solution",
-		Severity:    string(lint.SeverityError),
-		Category:    "structure",
-		Description: "The solution has no resolvers defined under spec.resolvers and no workflow defined under spec.workflow.",
-		Why:         "A solution must have at least resolvers or a workflow to be useful. Without either, there's nothing to execute.",
-		Fix:         "Add at least one resolver under spec.resolvers or define a workflow with actions under spec.workflow.actions.",
-		Examples: []string{
-			"spec:\n  resolvers:\n    greeting:\n      type: string\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: Hello World",
-		},
-	},
-	"reserved-name": {
-		Rule:        "reserved-name",
-		Severity:    string(lint.SeverityError),
-		Category:    "naming",
-		Description: "A resolver uses a reserved name that conflicts with built-in variables.",
-		Why:         "Names like '__actions', '__error', '__item', '__index', and '_' are reserved for internal use in CEL expressions and forEach iterations.",
-		Fix:         "Rename the resolver to avoid reserved names. Use descriptive names like 'user-input' or 'api-response' instead.",
-		Examples:    []string{"Reserved names: __actions, __error, __item, __index, _"},
-	},
-	"unused-resolver": {
-		Rule:        "unused-resolver",
-		Severity:    string(lint.SeverityWarning),
-		Category:    "usage",
-		Description: "A resolver is defined but never referenced by any other resolver, action input, when clause, or expression.",
-		Why:         "Unused resolvers add complexity without benefit. They may indicate a typo in a reference or leftover code from refactoring.",
-		Fix:         "Either remove the unused resolver, reference it in an action input (rslvr: resolver-name), use it in a CEL expression (_.resolver_name), or add it as a dependency (dependsOn).",
-	},
-	"missing-provider": {
-		Rule:        "missing-provider",
-		Severity:    string(lint.SeverityError),
-		Category:    "provider",
-		Description: "A resolver step or action references a provider name that is not registered in the provider registry.",
-		Why:         "The solution cannot execute if it references providers that don't exist. This usually indicates a typo in the provider name.",
-		Fix:         "Use list_providers to see all available provider names. Common providers: static, parameter, env, http, cel, file, exec, directory, go-template, validation.",
-	},
-	"invalid-expression": {
-		Rule:        "invalid-expression",
-		Severity:    string(lint.SeverityError),
-		Category:    "expression",
-		Description: "A CEL expression (in a 'when' clause or 'expr' input) has a syntax error and cannot be parsed.",
-		Why:         "Invalid CEL expressions will cause runtime failures. Common issues include missing quotes around strings, unbalanced parentheses, and using unknown functions.",
-		Fix:         "Use validate_expression with type 'cel' to check the expression syntax. Use list_cel_functions to see available functions. Use evaluate_cel to test the expression with sample data.",
-	},
-	"invalid-template": {
-		Rule:        "invalid-template",
-		Severity:    string(lint.SeverityError),
-		Category:    "template",
-		Description: "A Go template (in a 'tmpl' input) has a syntax error and cannot be parsed.",
-		Why:         "Invalid Go templates will cause runtime failures. Common issues include unclosed actions (missing '}}'), unclosed control blocks (if/range/with without end), and unknown functions.",
-		Fix:         "Use validate_expression with type 'go-template' to check the template syntax. Use evaluate_go_template to test the template with sample data.",
-	},
-	"invalid-dependency": {
-		Rule:        "invalid-dependency",
-		Severity:    string(lint.SeverityError),
-		Category:    "dependency",
-		Description: "An action's dependsOn references an action name that does not exist in the workflow.",
-		Why:         "Actions with invalid dependencies cannot be scheduled for execution. This usually indicates a typo in the action name.",
-		Fix:         "Check the action names in spec.workflow.actions and ensure all dependsOn references match exactly. Names are case-sensitive.",
-	},
-	"empty-workflow": {
-		Rule:        "empty-workflow",
-		Severity:    string(lint.SeverityWarning),
-		Category:    "structure",
-		Description: "A workflow section is defined (spec.workflow) but contains no actions.",
-		Why:         "An empty workflow serves no purpose. If you only need resolvers, remove the workflow section entirely.",
-		Fix:         "Either add actions under spec.workflow.actions or remove spec.workflow entirely if you only need resolvers.",
-	},
-	"finally-with-foreach": {
-		Rule:        "finally-with-foreach",
-		Severity:    string(lint.SeverityError),
-		Category:    "validation",
-		Description: "An action in the spec.workflow.finally section uses forEach, which is not supported.",
-		Why:         "Finally actions are cleanup/teardown steps that must run reliably. forEach adds complexity and potential failure points that could prevent cleanup from completing.",
-		Fix:         "Remove the forEach from the finally action. If you need to iterate during cleanup, move the action to spec.workflow.actions and handle cleanup differently.",
-	},
-	"workflow-validation": {
-		Rule:        "workflow-validation",
-		Severity:    string(lint.SeverityError),
-		Category:    "validation",
-		Description: "The workflow has structural validation errors such as circular dependencies between actions.",
-		Why:         "Circular dependencies create infinite loops that prevent the workflow from completing. The dependency graph must be a DAG (directed acyclic graph).",
-		Fix:         "Use render_solution with graph_type 'action-deps' to visualize the dependency graph. Break cycles by reordering dependencies or removing unnecessary dependsOn references.",
-	},
-	"schema-violation": {
-		Rule:        "schema-violation",
-		Severity:    string(lint.SeverityError),
-		Category:    "schema",
-		Description: "The solution YAML violates the JSON Schema definition. This includes unknown fields, type mismatches, pattern violations, and constraint violations.",
-		Why:         "Schema violations indicate the YAML structure doesn't match what scafctl expects. This will cause parsing errors or unexpected behavior.",
-		Fix:         "Use get_solution_schema to see the expected schema. Common issues: unknown field names (typos), wrong types (string vs int), invalid metadata.name pattern (must be lowercase with hyphens, 3-60 chars).",
-	},
-	"unknown-provider-input": {
-		Rule:        "unknown-provider-input",
-		Severity:    string(lint.SeverityError),
-		Category:    "provider",
-		Description: "An input key passed to a provider is not declared in that provider's input schema.",
-		Why:         "Unknown inputs are silently ignored, which usually indicates a typo. The intended field won't receive its value.",
-		Fix:         "Use get_provider_schema with the provider name to see all valid input field names. For example, the exec provider requires 'command' (not 'cmd').",
-	},
-	"invalid-provider-input-type": {
-		Rule:        "invalid-provider-input-type",
-		Severity:    string(lint.SeverityError),
-		Category:    "provider",
-		Description: "A literal input value doesn't match the type expected by the provider's schema (e.g., passing a string where an integer is required).",
-		Why:         "Type mismatches cause runtime errors. The provider expects a specific type and will fail to process the wrong type.",
-		Fix:         "Use get_provider_schema to check the expected type for each input. Ensure literal values match (e.g., use '42' not 'forty-two' for integer fields).",
-	},
-	"invalid-test-name": {
-		Rule:        "invalid-test-name",
-		Severity:    string(lint.SeverityError),
-		Category:    "naming",
-		Description: "A test case name doesn't match the required naming pattern (lowercase with hyphens).",
-		Why:         "Test names must be lowercase with hyphens (e.g., 'my-test-case') for consistency and to work correctly with filtering.",
-		Fix:         "Rename the test to use only lowercase letters, numbers, and hyphens. Avoid spaces, underscores, and uppercase letters.",
-	},
-	"unbundled-test-file": {
-		Rule:        "unbundled-test-file",
-		Severity:    string(lint.SeverityError),
-		Category:    "bundling",
-		Description: "A test case references a file that is not covered by the solution's bundle.include patterns.",
-		Why:         "When the solution is published to the catalog, unbundled files won't be included, causing test failures.",
-		Fix:         "Add the file path or a glob pattern to bundle.include that covers the test file. Example: bundle:\n  include:\n    - 'tests/**'",
-	},
-	"unused-template": {
-		Rule:        "unused-template",
-		Severity:    string(lint.SeverityWarning),
-		Category:    "usage",
-		Description: "A test template (name starting with '_') is defined but not referenced by any test case via 'extends'.",
-		Why:         "Unused test templates add unnecessary complexity. They may indicate a typo in an extends reference.",
-		Fix:         "Either remove the unused template or reference it from a test case using 'extends: _template-name'.",
-	},
-	"missing-description": {
-		Rule:        "missing-description",
-		Severity:    string(lint.SeverityInfo),
-		Category:    "documentation",
-		Description: "A resolver or action does not have a description field.",
-		Why:         "Descriptions help others understand what each resolver/action does. They appear in inspect_solution output and documentation.",
-		Fix:         "Add a description field: description: \"Brief explanation of what this does\"",
-	},
-	"long-timeout": {
-		Rule:        "long-timeout",
-		Severity:    string(lint.SeverityInfo),
-		Category:    "performance",
-		Description: "An action has a timeout exceeding 10 minutes.",
-		Why:         "Very long timeouts may indicate a misconfiguration or an action that should be broken into smaller steps. They also delay failure detection.",
-		Fix:         "Consider reducing the timeout or breaking the action into smaller steps. If the long timeout is intentional, this is just an informational notice.",
-	},
-	"unused-finally": {
-		Rule:        "unused-finally",
-		Severity:    string(lint.SeverityInfo),
-		Category:    "structure",
-		Description: "A finally section is defined but there are no regular actions in the workflow.",
-		Why:         "Finally actions are cleanup steps that run after regular actions. Without regular actions, there's nothing to clean up after.",
-		Fix:         "Either add regular actions under spec.workflow.actions or remove the spec.workflow.finally section.",
-	},
-	"permissive-result-schema": {
-		Rule:        "permissive-result-schema",
-		Severity:    string(lint.SeverityInfo),
-		Category:    "schema",
-		Description: "An action's resultSchema is defined but doesn't specify a type, making it accept any value.",
-		Why:         "A result schema without a type constraint doesn't provide meaningful validation of action output.",
-		Fix:         "Add a 'type' field to the resultSchema: resultSchema:\n  type: object\n  properties:\n    status:\n      type: string",
-	},
-	"invalid-result-schema": {
-		Rule:        "invalid-result-schema",
-		Severity:    string(lint.SeverityError),
-		Category:    "schema",
-		Description: "An action's resultSchema is not a valid JSON Schema definition.",
-		Why:         "Invalid result schemas cannot be used to validate action outputs, causing runtime errors.",
-		Fix:         "Ensure the resultSchema follows JSON Schema syntax. Use get_solution_schema to see the expected format.",
-	},
-	"undefined-required-property": {
-		Rule:        "undefined-required-property",
-		Severity:    string(lint.SeverityError),
-		Category:    "schema",
-		Description: "A resultSchema lists a property in 'required' that is not defined in 'properties'.",
-		Why:         "Requiring a property that isn't defined means the validation will always fail for that property.",
-		Fix:         "Either add the missing property to 'properties' or remove it from the 'required' list.",
-	},
-	"schema-error": {
-		Rule:        "schema-error",
-		Severity:    string(lint.SeverityWarning),
-		Category:    "schema",
-		Description: "Schema validation could not be performed (schema generation failed).",
-		Why:         "This is an internal issue that prevents full validation. The solution may still work but hasn't been fully checked.",
-		Fix:         "This usually resolves itself. If persistent, check that the solution YAML is well-formed (valid YAML syntax).",
-	},
+	return mcp.NewToolResultJSON(meta)
 }

--- a/pkg/mcp/tools_lint_test.go
+++ b/pkg/mcp/tools_lint_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,13 +64,157 @@ func TestHandleExplainLintRule(t *testing.T) {
 	})
 
 	t.Run("all known rules have required fields", func(t *testing.T) {
-		for name, explanation := range lintRuleExplanations {
-			assert.NotEmpty(t, explanation.Rule, "rule %q missing Rule field", name)
-			assert.NotEmpty(t, explanation.Description, "rule %q missing Description", name)
-			assert.NotEmpty(t, explanation.Fix, "rule %q missing Fix", name)
-			assert.NotEmpty(t, explanation.Why, "rule %q missing Why", name)
-			assert.NotEmpty(t, explanation.Category, "rule %q missing Category", name)
-			assert.NotEmpty(t, explanation.Severity, "rule %q missing Severity", name)
+		for name, rule := range lint.KnownRules {
+			assert.NotEmpty(t, rule.Rule, "rule %q missing Rule field", name)
+			assert.NotEmpty(t, rule.Description, "rule %q missing Description", name)
+			assert.NotEmpty(t, rule.Fix, "rule %q missing Fix", name)
+			assert.NotEmpty(t, rule.Why, "rule %q missing Why", name)
+			assert.NotEmpty(t, rule.Category, "rule %q missing Category", name)
+			assert.NotEmpty(t, rule.Severity, "rule %q missing Severity", name)
+		}
+	})
+}
+
+func TestHandleListLintRules(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("all rules", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		count := int(output["count"].(float64))
+		assert.Equal(t, len(lint.KnownRules), count)
+
+		rules := output["rules"].([]any)
+		assert.Len(t, rules, len(lint.KnownRules))
+
+		// Verify sorted — errors should come before warnings, warnings before info
+		var prevSeverityOrder int
+		severityOrder := map[string]int{"error": 0, "warning": 1, "info": 2}
+		for _, r := range rules {
+			rule := r.(map[string]any)
+			so := severityOrder[rule["severity"].(string)]
+			assert.GreaterOrEqual(t, so, prevSeverityOrder, "rules should be sorted by severity priority")
+			prevSeverityOrder = so
+		}
+	})
+
+	t.Run("filter by severity", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{
+			"severity": "error",
+		}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		rules := output["rules"].([]any)
+		assert.Greater(t, len(rules), 0)
+		for _, r := range rules {
+			rule := r.(map[string]any)
+			assert.Equal(t, "error", rule["severity"])
+		}
+	})
+
+	t.Run("filter by category", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{
+			"category": "provider",
+		}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		rules := output["rules"].([]any)
+		assert.Greater(t, len(rules), 0)
+		for _, r := range rules {
+			rule := r.(map[string]any)
+			assert.Equal(t, "provider", rule["category"])
+		}
+	})
+
+	t.Run("filter by severity and category", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{
+			"severity": "error",
+			"category": "provider",
+		}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		rules := output["rules"].([]any)
+		assert.Greater(t, len(rules), 0)
+		for _, r := range rules {
+			rule := r.(map[string]any)
+			assert.Equal(t, "error", rule["severity"])
+			assert.Equal(t, "provider", rule["category"])
+		}
+	})
+
+	t.Run("no matches returns empty", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{
+			"category": "nonexistent-category",
+		}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, float64(0), output["count"])
+	})
+
+	t.Run("each rule has summary fields", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		rules := output["rules"].([]any)
+		for _, r := range rules {
+			rule := r.(map[string]any)
+			assert.NotEmpty(t, rule["rule"], "rule should have a name")
+			assert.NotEmpty(t, rule["severity"], "rule should have severity")
+			assert.NotEmpty(t, rule["category"], "rule should have category")
+			assert.NotEmpty(t, rule["description"], "rule should have description")
 		}
 	})
 }

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -19,6 +19,7 @@ func (s *Server) registerProviderTools() {
 	listProvidersTool := mcp.NewTool("list_providers",
 		mcp.WithDescription("List all available solution providers (e.g. http, static, file, cel, exec, directory). Solution providers are the building blocks of solutions — they fetch data, transform values, validate inputs, and execute actions. Returns name, description, capabilities, and category for each provider. To get full input/output schemas, examples, and CLI usage for a specific provider, call get_provider_schema with the provider name."),
 		mcp.WithTitleAnnotation("List Providers"),
+		mcp.WithToolIcons(toolIcons["provider"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -37,6 +38,7 @@ func (s *Server) registerProviderTools() {
 	getProviderSchemaTool := mcp.NewTool("get_provider_schema",
 		mcp.WithDescription("Get comprehensive information about a provider: input schema (properties with types, required/optional, defaults, validation), output schemas per capability, YAML usage examples, CLI usage examples, capabilities, and version info. ALWAYS call this before writing action or resolver YAML to verify exact field names, types, and which fields are required."),
 		mcp.WithTitleAnnotation("Get Provider Schema"),
+		mcp.WithToolIcons(toolIcons["provider"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -67,7 +69,9 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 	category := request.GetString("category", "")
 
 	if s.registry == nil {
-		return mcp.NewToolResultError("provider registry not available"), nil
+		return newStructuredError(ErrCodeConfigError, "provider registry not available",
+			WithSuggestion("Ensure the server was started with a provider registry"),
+		), nil
 	}
 
 	var providers []provider.Provider
@@ -102,7 +106,14 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 		items = append(items, item)
 	}
 
-	return mcp.NewToolResultJSON(items)
+	result, err := mcp.NewToolResultJSON(items)
+	if err != nil {
+		return nil, err
+	}
+	result.Content = append(result.Content,
+		mcp.NewResourceLink("provider://reference", "Provider Reference", "Compact reference of all providers", "application/json"),
+	)
+	return result, nil
 }
 
 // handleGetProviderSchema returns comprehensive provider information including
@@ -112,7 +123,11 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("name"),
+			WithSuggestion("Use list_providers to see available provider names"),
+			WithRelatedTools("list_providers"),
+		), nil
 	}
 
 	desc, err := explain.LookupProvider(s.ctx, name, s.registry)
@@ -125,7 +140,11 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 				availableNames = fmt.Sprintf(". Available providers: %v", names)
 			}
 		}
-		return mcp.NewToolResultError(fmt.Sprintf("provider %q not found%s", name, availableNames)), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("provider %q not found%s", name, availableNames),
+			WithField("name"),
+			WithSuggestion("Use list_providers to see available provider names"),
+			WithRelatedTools("list_providers"),
+		), nil
 	}
 
 	// Use BuildProviderDetail for a structured, AI-friendly response that includes:

--- a/pkg/mcp/tools_refs.go
+++ b/pkg/mcp/tools_refs.go
@@ -1,0 +1,184 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// registerRefsTools registers resolver reference extraction tools.
+func (s *Server) registerRefsTools() {
+	extractRefssTool := mcp.NewTool("extract_resolver_refs",
+		mcp.WithDescription("Extract resolver references (_.resolverName patterns) from Go templates or CEL expressions. Returns a list of referenced resolver names, which should be used to populate the 'dependsOn' field. Accepts inline text or a file path."),
+		mcp.WithTitleAnnotation("Extract Resolver References"),
+		mcp.WithToolIcons(toolIcons["refs"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("text",
+			mcp.Description("Inline Go template or CEL expression text to analyze"),
+		),
+		mcp.WithString("file",
+			mcp.Description("Path to a template file to analyze"),
+		),
+		mcp.WithString("type",
+			mcp.Description("Expression type: 'go-template' (default) or 'cel'"),
+		),
+	)
+	s.mcpServer.AddTool(extractRefssTool, s.handleExtractResolverRefs)
+}
+
+// handleExtractResolverRefs extracts resolver references from expressions.
+func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	text := request.GetString("text", "")
+	filePath := request.GetString("file", "")
+	exprType := request.GetString("type", "go-template")
+
+	if text == "" && filePath == "" {
+		return newStructuredError(ErrCodeInvalidInput, "either 'text' or 'file' must be provided",
+			WithSuggestion("Provide inline expression text via 'text' or a file path via 'file'"),
+		), nil
+	}
+
+	source := "inline"
+	content := text
+	if filePath != "" {
+		source = "file"
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("failed to read file %q: %v", filePath, err),
+				WithField("file"),
+				WithSuggestion("Check that the file path exists and is accessible"),
+			), nil
+		}
+		content = string(data)
+	}
+
+	var resolverNames []string
+	var err error
+
+	switch exprType {
+	case "go-template":
+		resolverNames, err = extractGoTemplateRefs(content)
+	case "cel":
+		resolverNames, err = extractCELRefs(content)
+	default:
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unsupported type %q", exprType),
+			WithField("type"),
+			WithSuggestion("Use 'go-template' or 'cel'"),
+		), nil
+	}
+
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to extract references: %v", err),
+			WithSuggestion("Check the expression syntax is valid"),
+			WithRelatedTools("evaluate_cel", "render_go_template"),
+		), nil
+	}
+
+	// Build detailed reference info (resolver → fields)
+	details := buildRefDetails(resolverNames)
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"source":     source,
+		"sourceType": exprType,
+		"references": uniqueResolverNames(details),
+		"count":      len(uniqueResolverNames(details)),
+		"details":    details,
+	})
+}
+
+// refDetail represents a resolver and its referenced fields.
+type refDetail struct {
+	Resolver string   `json:"resolver"`
+	Fields   []string `json:"fields"`
+}
+
+// extractGoTemplateRefs extracts resolver references from a Go template.
+func extractGoTemplateRefs(content string) ([]string, error) {
+	refs, err := gotmpl.GetGoTemplateReferences(content, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	var resolverPaths []string
+	for _, ref := range refs {
+		// Go template references start with "." — look for _.resolverName patterns
+		path := ref.Path
+		path = strings.TrimPrefix(path, ".")
+
+		// Resolver references are _.resolverName or ._.resolverName
+		if strings.HasPrefix(path, "_.") {
+			resolverPaths = append(resolverPaths, strings.TrimPrefix(path, "_."))
+		}
+	}
+
+	return resolverPaths, nil
+}
+
+// extractCELRefs extracts resolver references from a CEL expression.
+func extractCELRefs(content string) ([]string, error) {
+	expr := celexp.Expression(content)
+	vars, err := expr.GetUnderscoreVariables()
+	if err != nil {
+		return nil, err
+	}
+	return vars, nil
+}
+
+// buildRefDetails groups raw resolver paths into resolver → fields mapping.
+func buildRefDetails(paths []string) []refDetail {
+	resolverFields := make(map[string][]string)
+	for _, p := range paths {
+		parts := strings.SplitN(p, ".", 2)
+		resolverName := parts[0]
+		if len(parts) > 1 {
+			field := parts[1]
+			// Avoid duplicate fields
+			found := false
+			for _, f := range resolverFields[resolverName] {
+				if f == field {
+					found = true
+					break
+				}
+			}
+			if !found {
+				resolverFields[resolverName] = append(resolverFields[resolverName], field)
+			}
+		} else {
+			if _, exists := resolverFields[resolverName]; !exists {
+				resolverFields[resolverName] = []string{}
+			}
+		}
+	}
+
+	details := make([]refDetail, 0, len(resolverFields))
+	for name, fields := range resolverFields {
+		sort.Strings(fields)
+		details = append(details, refDetail{Resolver: name, Fields: fields})
+	}
+	sort.Slice(details, func(i, j int) bool {
+		return details[i].Resolver < details[j].Resolver
+	})
+	return details
+}
+
+// uniqueResolverNames extracts unique resolver names from details.
+func uniqueResolverNames(details []refDetail) []string {
+	names := make([]string, len(details))
+	for i, d := range details {
+		names[i] = d.Resolver
+	}
+	return names
+}

--- a/pkg/mcp/tools_refs_test.go
+++ b/pkg/mcp/tools_refs_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleExtractResolverRefs(t *testing.T) {
+	t.Run("extracts refs from go template", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "extract_resolver_refs"
+		request.Params.Arguments = map[string]any{
+			"text": "Hello {{ ._.config.host }}:{{ ._.config.port }} from {{ ._.environment.name }}",
+			"type": "go-template",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.Equal(t, "inline", data["source"])
+		assert.Equal(t, "go-template", data["sourceType"])
+
+		refs, ok := data["references"].([]any)
+		require.True(t, ok)
+		assert.GreaterOrEqual(t, len(refs), 2)
+	})
+
+	t.Run("extracts refs from cel expression", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "extract_resolver_refs"
+		request.Params.Arguments = map[string]any{
+			"text": "_.config.host + ':' + string(_.config.port)",
+			"type": "cel",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.Equal(t, "cel", data["sourceType"])
+		refs := data["references"].([]any)
+		assert.Contains(t, refs, "config")
+	})
+
+	t.Run("reads from file", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Create a temp file with a Go template
+		tmpDir := t.TempDir()
+		tmplPath := filepath.Join(tmpDir, "test.tmpl")
+		err = os.WriteFile(tmplPath, []byte("{{ ._.myresolver.value }}"), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "extract_resolver_refs"
+		request.Params.Arguments = map[string]any{
+			"file": tmplPath,
+			"type": "go-template",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.Equal(t, "file", data["source"])
+		refs := data["references"].([]any)
+		assert.Contains(t, refs, "myresolver")
+	})
+
+	t.Run("requires text or file", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("rejects unsupported type", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"text": "something",
+			"type": "python",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("no refs returns empty list", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"text": "Hello {{ .name }}",
+			"type": "go-template",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		count := data["count"].(float64)
+		assert.Equal(t, float64(0), count)
+	})
+}

--- a/pkg/mcp/tools_scaffold.go
+++ b/pkg/mcp/tools_scaffold.go
@@ -5,10 +5,9 @@ package mcp
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/scaffold"
 )
 
 // registerScaffoldTools registers solution scaffolding MCP tools.
@@ -17,6 +16,7 @@ func (s *Server) registerScaffoldTools() {
 	scaffoldSolutionTool := mcp.NewTool("scaffold_solution",
 		mcp.WithDescription("Generate a valid skeleton solution YAML from parameters. Produces a guaranteed-valid starting point with the correct structure, including metadata, resolvers, workflow, and tests based on selected features. The generated YAML can be immediately linted and customized."),
 		mcp.WithTitleAnnotation("Scaffold Solution"),
+		mcp.WithToolIcons(toolIcons["scaffold"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -34,9 +34,11 @@ func (s *Server) registerScaffoldTools() {
 		),
 		mcp.WithArray("features",
 			mcp.Description("Features to include in the scaffold. Options: parameters, resolvers, actions, transforms, validation, tests, composition"),
+			mcp.WithStringItems(),
 		),
 		mcp.WithArray("providers",
 			mcp.Description("Specific providers to include examples for (e.g., ['http', 'exec', 'cel']). Use list_providers to see available providers."),
+			mcp.WithStringItems(),
 		),
 	)
 	s.mcpServer.AddTool(scaffoldSolutionTool, s.handleScaffoldSolution)
@@ -46,12 +48,18 @@ func (s *Server) registerScaffoldTools() {
 func (s *Server) handleScaffoldSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("name"),
+			WithSuggestion("Provide a name for the solution (lowercase, hyphens allowed)"),
+		), nil
 	}
 
 	description, err := request.RequireString("description")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("description"),
+			WithSuggestion("Provide a brief description of what the solution does"),
+		), nil
 	}
 
 	version := request.GetString("version", "1.0.0")
@@ -81,224 +89,18 @@ func (s *Server) handleScaffoldSolution(_ context.Context, request mcp.CallToolR
 		}
 	}
 
-	// Default features if none specified
-	if len(features) == 0 {
-		features["parameters"] = true
-		features["resolvers"] = true
-	}
-
-	yaml := buildScaffoldYAML(name, description, version, features, providerNames)
+	result := scaffold.Solution(scaffold.Options{
+		Name:        name,
+		Description: description,
+		Version:     version,
+		Features:    features,
+		Providers:   providerNames,
+	})
 
 	return mcp.NewToolResultJSON(map[string]any{
-		"yaml":     yaml,
-		"filename": fmt.Sprintf("%s.yaml", name),
-		"features": featureKeys(features),
-		"nextSteps": []string{
-			"Save the YAML to a file",
-			"Customize the resolver and action values for your use case",
-			"Run lint_solution to validate the structure",
-			"Run preview_resolvers to test resolver outputs",
-			"Run get_run_command to see how to execute it",
-		},
+		"yaml":      result.YAML,
+		"filename":  result.Filename,
+		"features":  result.Features,
+		"nextSteps": result.NextSteps,
 	})
-}
-
-// buildScaffoldYAML generates solution YAML from scaffold parameters.
-func buildScaffoldYAML(name, description, version string, features map[string]bool, providers []string) string {
-	var b strings.Builder
-
-	// Header
-	b.WriteString("apiVersion: scafctl.io/v1\n")
-	b.WriteString("kind: Solution\n")
-	b.WriteString("metadata:\n")
-	fmt.Fprintf(&b, "  name: %s\n", name)
-	fmt.Fprintf(&b, "  version: \"%s\"\n", version)
-	fmt.Fprintf(&b, "  description: %s\n", description)
-	b.WriteString("  tags:\n")
-	b.WriteString("    - scaffold\n")
-	b.WriteString("\nspec:\n")
-
-	// Resolvers
-	if features["resolvers"] || features["parameters"] || features["transforms"] || features["validation"] {
-		b.WriteString("  resolvers:\n")
-
-		if features["parameters"] {
-			b.WriteString("    # User-provided input parameter\n")
-			b.WriteString("    input-name:\n")
-			b.WriteString("      type: string\n")
-			b.WriteString("      description: \"A user-provided input value\"\n")
-			b.WriteString("      example: \"my-value\"\n")
-			b.WriteString("      resolve:\n")
-			b.WriteString("        with:\n")
-			b.WriteString("          - provider: parameter\n")
-
-			if features["validation"] {
-				b.WriteString("      validate:\n")
-				b.WriteString("        with:\n")
-				b.WriteString("          - provider: validation\n")
-				b.WriteString("            inputs:\n")
-				b.WriteString("              expression: 'size(__self) >= 1 && size(__self) <= 100'\n")
-				b.WriteString("            message: \"Input must be between 1 and 100 characters\"\n")
-			}
-		}
-
-		if features["resolvers"] && !features["parameters"] {
-			b.WriteString("    # Static value resolver\n")
-			b.WriteString("    config-value:\n")
-			b.WriteString("      type: string\n")
-			b.WriteString("      description: \"A static configuration value\"\n")
-			b.WriteString("      resolve:\n")
-			b.WriteString("        with:\n")
-			b.WriteString("          - provider: static\n")
-			b.WriteString("            inputs:\n")
-			b.WriteString("              value: \"default-value\"\n")
-		}
-
-		if features["transforms"] {
-			b.WriteString("    # Transformed value\n")
-			b.WriteString("    processed:\n")
-			b.WriteString("      type: string\n")
-			b.WriteString("      description: \"A value processed through a transform\"\n")
-			if features["parameters"] {
-				b.WriteString("      dependsOn:\n")
-				b.WriteString("        - input-name\n")
-			}
-			b.WriteString("      resolve:\n")
-			b.WriteString("        with:\n")
-			b.WriteString("          - provider: static\n")
-			b.WriteString("            inputs:\n")
-			b.WriteString("              value: \"raw-data\"\n")
-			b.WriteString("      transform:\n")
-			b.WriteString("        with:\n")
-			b.WriteString("          - provider: cel\n")
-			b.WriteString("            inputs:\n")
-			b.WriteString("              expression: '__self.upperAscii()'\n")
-		}
-
-		// Provider-specific resolver examples
-		for _, p := range providers {
-			switch p {
-			case "http":
-				b.WriteString("    # HTTP API call\n")
-				b.WriteString("    api-data:\n")
-				b.WriteString("      type: object\n")
-				b.WriteString("      description: \"Data fetched from an API\"\n")
-				b.WriteString("      resolve:\n")
-				b.WriteString("        with:\n")
-				b.WriteString("          - provider: http\n")
-				b.WriteString("            inputs:\n")
-				b.WriteString("              url: \"https://api.example.com/data\"\n")
-				b.WriteString("              method: GET\n")
-			case "env":
-				b.WriteString("    # Environment variable\n")
-				b.WriteString("    env-value:\n")
-				b.WriteString("      type: string\n")
-				b.WriteString("      description: \"Value from environment variable\"\n")
-				b.WriteString("      resolve:\n")
-				b.WriteString("        with:\n")
-				b.WriteString("          - provider: env\n")
-				b.WriteString("            inputs:\n")
-				b.WriteString("              name: MY_ENV_VAR\n")
-			case "file":
-				b.WriteString("    # File content\n")
-				b.WriteString("    file-content:\n")
-				b.WriteString("      type: string\n")
-				b.WriteString("      description: \"Content read from a file\"\n")
-				b.WriteString("      resolve:\n")
-				b.WriteString("        with:\n")
-				b.WriteString("          - provider: file\n")
-				b.WriteString("            inputs:\n")
-				b.WriteString("              path: \"./config.json\"\n")
-			}
-		}
-	}
-
-	// Workflow / Actions
-	if features["actions"] {
-		b.WriteString("\n  workflow:\n")
-		b.WriteString("    actions:\n")
-
-		hasExec := false
-		for _, p := range providers {
-			switch p {
-			case "exec":
-				hasExec = true
-				b.WriteString("      # Execute a command\n")
-				b.WriteString("      run-command:\n")
-				b.WriteString("        description: \"Execute a shell command\"\n")
-				b.WriteString("        provider: exec\n")
-				b.WriteString("        inputs:\n")
-				b.WriteString("          command: \"echo 'Hello from scaffold'\"\n")
-			case "directory":
-				b.WriteString("      # Create a directory structure\n")
-				b.WriteString("      create-output:\n")
-				b.WriteString("        description: \"Create output directory\"\n")
-				b.WriteString("        provider: directory\n")
-				b.WriteString("        inputs:\n")
-				b.WriteString("          operation: create\n")
-				b.WriteString("          path: \"./output\"\n")
-			case "go-template":
-				b.WriteString("      # Render a template\n")
-				b.WriteString("      render-template:\n")
-				b.WriteString("        description: \"Render a Go template\"\n")
-				b.WriteString("        provider: go-template\n")
-				b.WriteString("        inputs:\n")
-				b.WriteString("          template: \"Hello {{ .Name }}\"\n")
-				b.WriteString("          output: \"./output/greeting.txt\"\n")
-			}
-		}
-
-		// Default action if no provider-specific ones were added
-		if !hasExec && len(providers) == 0 {
-			b.WriteString("      # Example action\n")
-			b.WriteString("      hello:\n")
-			b.WriteString("        description: \"A simple action\"\n")
-			b.WriteString("        provider: exec\n")
-			b.WriteString("        inputs:\n")
-			b.WriteString("          command:\n")
-			b.WriteString("            expr: '\"echo Hello, \" + resolvers.input_name'\n")
-		}
-	}
-
-	// Tests
-	if features["tests"] {
-		b.WriteString("\n  testing:\n")
-		b.WriteString("    cases:\n")
-		b.WriteString("      # Basic lint validation\n")
-		b.WriteString("      basic-render:\n")
-		b.WriteString("        description: \"Verify solution renders successfully\"\n")
-		b.WriteString("        command: [render, solution]\n")
-		b.WriteString("        args: [\"-o\", \"json\"]\n")
-
-		if features["parameters"] {
-			b.WriteString("        resolvers:\n")
-			b.WriteString("          input-name: \"test-value\"\n")
-		}
-
-		b.WriteString("        assertions:\n")
-		b.WriteString("          - expression: __exitCode == 0\n")
-
-		if features["parameters"] {
-			b.WriteString("          - expression: __output.resolvers.input_name == \"test-value\"\n")
-		}
-	}
-
-	// Composition
-	if features["composition"] {
-		b.WriteString("\n# Uncomment to compose with partial solutions:\n")
-		b.WriteString("# compose:\n")
-		b.WriteString("#   - ./common-resolvers.yaml\n")
-		b.WriteString("#   - ./shared-actions.yaml\n")
-	}
-
-	return b.String()
-}
-
-// featureKeys returns sorted keys from a features map.
-func featureKeys(features map[string]bool) []string {
-	keys := make([]string, 0, len(features))
-	for k := range features {
-		keys = append(keys, k)
-	}
-	return keys
 }

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -21,6 +21,7 @@ func (s *Server) registerSchemaTools() {
 	getSolutionSchemaTool := mcp.NewTool("get_solution_schema",
 		mcp.WithDescription("Get the full JSON Schema for a scafctl solution YAML file. This describes ALL valid fields, types, validation rules, and documentation for authoring a solution. Use this before creating or editing solution files."),
 		mcp.WithTitleAnnotation("Get Solution Schema"),
+		mcp.WithToolIcons(toolIcons["schema"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -35,6 +36,7 @@ func (s *Server) registerSchemaTools() {
 	explainKindTool := mcp.NewTool("explain_kind",
 		mcp.WithDescription("Get detailed field documentation for a scafctl type (kind). Works like 'kubectl explain' — shows field names, types, descriptions, validation rules, and examples. Available kinds: solution, resolver, action, workflow, spec, provider, schema, retry."),
 		mcp.WithTitleAnnotation("Explain Kind"),
+		mcp.WithToolIcons(toolIcons["schema"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -60,7 +62,9 @@ func (s *Server) handleGetSolutionSchema(_ context.Context, request mcp.CallTool
 
 	schemaBytes, err := schema.GenerateSolutionSchema()
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to generate solution schema: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to generate solution schema: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	return mcp.NewToolResultText(string(schemaBytes)), nil
@@ -70,12 +74,16 @@ func (s *Server) handleGetSolutionSchema(_ context.Context, request mcp.CallTool
 func (s *Server) handleGetSolutionSchemaField(field string) (*mcp.CallToolResult, error) {
 	schemaBytes, err := schema.GenerateSolutionSchema()
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to generate solution schema: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to generate solution schema: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	var doc map[string]any
 	if err := json.Unmarshal(schemaBytes, &doc); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to parse schema: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to parse schema: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	// Navigate the schema following the field path
@@ -88,15 +96,24 @@ func (s *Server) handleGetSolutionSchemaField(field string) (*mcp.CallToolResult
 			if ref, ok := current["$ref"].(string); ok {
 				resolved := resolveRef(doc, ref)
 				if resolved == nil {
-					return mcp.NewToolResultError(fmt.Sprintf("could not resolve $ref %q for field %q", ref, field)), nil
+					return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("could not resolve $ref %q for field %q", ref, field),
+						WithField("field"),
+						WithSuggestion("The schema references a definition that doesn't exist"),
+					), nil
 				}
 				current = resolved
 				props, ok = current["properties"].(map[string]any)
 				if !ok {
-					return mcp.NewToolResultError(fmt.Sprintf("field %q is not an object type", field)), nil
+					return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("field %q is not an object type", field),
+						WithField("field"),
+						WithSuggestion("This field is a scalar or array type, not an object with sub-fields"),
+					), nil
 				}
 			} else {
-				return mcp.NewToolResultError(fmt.Sprintf("field %q is not an object type (no properties)", field)), nil
+				return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("field %q is not an object type (no properties)", field),
+					WithField("field"),
+					WithSuggestion("This field is a scalar or array type, not an object with sub-fields"),
+				), nil
 			}
 		}
 
@@ -107,7 +124,10 @@ func (s *Server) handleGetSolutionSchemaField(field string) (*mcp.CallToolResult
 				available = append(available, k)
 			}
 			sort.Strings(available)
-			return mcp.NewToolResultError(fmt.Sprintf("field %q not found. Available fields: %s", part, strings.Join(available, ", "))), nil
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("field %q not found. Available fields: %s", part, strings.Join(available, ", ")),
+				WithField("field"),
+				WithSuggestion("Check the field name against the available fields listed above"),
+			), nil
 		}
 		current = fieldSchema
 	}
@@ -122,7 +142,9 @@ func (s *Server) handleGetSolutionSchemaField(field string) (*mcp.CallToolResult
 
 	result, err := json.MarshalIndent(current, "", "  ")
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal field schema: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to marshal field schema: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	return mcp.NewToolResultText(string(result)), nil
@@ -151,7 +173,10 @@ func resolveRef(doc map[string]any, ref string) map[string]any {
 func (s *Server) handleExplainKind(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	kindName, err := request.RequireString("kind")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("kind"),
+			WithSuggestion("Use explain_kind with a kind name like 'Solution', 'Resolver', 'Action'"),
+		), nil
 	}
 	field := request.GetString("field", "")
 
@@ -159,13 +184,19 @@ func (s *Server) handleExplainKind(_ context.Context, request mcp.CallToolReques
 	if !ok {
 		names := schema.GetGlobalRegistry().Names()
 		sort.Strings(names)
-		return mcp.NewToolResultError(fmt.Sprintf("kind %q not found. Available kinds: %s", kindName, strings.Join(names, ", "))), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("kind %q not found. Available kinds: %s", kindName, strings.Join(names, ", ")),
+			WithField("kind"),
+			WithSuggestion("Check the kind name against the available kinds listed above"),
+		), nil
 	}
 
 	if field != "" {
 		fieldInfo, err := schema.IntrospectField(kindDef.TypeInstance, field)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("field %q not found in %s: %v", field, kindName, err)), nil
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("field %q not found in %s: %v", field, kindName, err),
+				WithField("field"),
+				WithSuggestion("Use explain_kind without a field to see all available fields"),
+			), nil
 		}
 		return mcp.NewToolResultJSON(fieldInfo)
 	}
@@ -173,7 +204,9 @@ func (s *Server) handleExplainKind(_ context.Context, request mcp.CallToolReques
 	// Return full type info
 	info := kindDef.TypeInfo
 	if info == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("no type info available for kind %q", kindName)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("no type info available for kind %q", kindName),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	// Build a structured response

--- a/pkg/mcp/tools_snapshot.go
+++ b/pkg/mcp/tools_snapshot.go
@@ -1,0 +1,258 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+)
+
+// registerSnapshotTools registers snapshot inspection and diff tools.
+func (s *Server) registerSnapshotTools() {
+	showSnapshotTool := mcp.NewTool("show_snapshot",
+		mcp.WithDescription("Load and display a resolver execution snapshot. Shows solution metadata, execution timing, status (success/failure), parameter values, and per-resolver results (value, status, duration, provider). Use this to inspect past execution results for debugging."),
+		mcp.WithTitleAnnotation("Show Snapshot"),
+		mcp.WithToolIcons(toolIcons["snapshot"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to the snapshot JSON file"),
+		),
+		mcp.WithString("format",
+			mcp.Description("Output detail level: 'summary' (default), 'resolvers' (include per-resolver data), 'full' (everything including raw values)"),
+		),
+	)
+	s.mcpServer.AddTool(showSnapshotTool, s.handleShowSnapshot)
+
+	diffSnapshotsTool := mcp.NewTool("diff_snapshots",
+		mcp.WithDescription("Compare two resolver execution snapshots and show differences. Identifies resolvers with changed values, status changes (success→failure), additions, and removals. Useful for detecting regressions between runs or understanding the impact of solution changes."),
+		mcp.WithTitleAnnotation("Diff Snapshots"),
+		mcp.WithToolIcons(toolIcons["snapshot"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("before",
+			mcp.Required(),
+			mcp.Description("Path to the baseline (before) snapshot file"),
+		),
+		mcp.WithString("after",
+			mcp.Required(),
+			mcp.Description("Path to the comparison (after) snapshot file"),
+		),
+		mcp.WithBoolean("ignore_unchanged",
+			mcp.Description("Omit unchanged resolvers from the response. Default: true"),
+		),
+	)
+	s.mcpServer.AddTool(diffSnapshotsTool, s.handleDiffSnapshots)
+}
+
+// handleShowSnapshot loads a snapshot file and returns structured data.
+func (s *Server) handleShowSnapshot(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a resolver execution snapshot file"),
+		), nil
+	}
+	format := request.GetString("format", "summary")
+
+	snapshot, err := resolver.LoadSnapshot(path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load snapshot %q: %v", path, err),
+			WithField("path"),
+			WithSuggestion("Check that the file exists and is a valid snapshot JSON file"),
+		), nil
+	}
+
+	// Build resolver counts
+	counts := map[string]int{
+		"total":   len(snapshot.Resolvers),
+		"success": 0,
+		"failed":  0,
+		"skipped": 0,
+	}
+	for _, r := range snapshot.Resolvers {
+		switch r.Status {
+		case string(resolver.ExecutionStatusSuccess):
+			counts["success"]++
+		case string(resolver.ExecutionStatusFailed):
+			counts["failed"]++
+		case string(resolver.ExecutionStatusSkipped):
+			counts["skipped"]++
+		}
+	}
+
+	result := map[string]any{
+		"solution":       snapshot.Metadata.Solution,
+		"version":        snapshot.Metadata.Version,
+		"timestamp":      snapshot.Metadata.Timestamp,
+		"scafctlVersion": snapshot.Metadata.ScafctlVersion,
+		"duration":       snapshot.Metadata.TotalDuration,
+		"status":         snapshot.Metadata.Status,
+		"resolverCount":  counts,
+		"phases":         len(snapshot.Phases),
+		"parameters":     snapshot.Parameters,
+	}
+
+	if format == "resolvers" || format == "full" {
+		resolvers := make([]map[string]any, 0, len(snapshot.Resolvers))
+		for name, r := range snapshot.Resolvers {
+			entry := map[string]any{
+				"name":     name,
+				"status":   r.Status,
+				"duration": r.Duration,
+				"phase":    r.Phase,
+			}
+			if format == "full" {
+				entry["value"] = r.Value
+				entry["error"] = r.Error
+				entry["sensitive"] = r.Sensitive
+				entry["providerCalls"] = r.ProviderCalls
+				entry["valueSizeBytes"] = r.ValueSizeBytes
+				if len(r.FailedAttempts) > 0 {
+					entry["failedAttempts"] = r.FailedAttempts
+				}
+			}
+			resolvers = append(resolvers, entry)
+		}
+		result["resolvers"] = resolvers
+	}
+
+	return mcp.NewToolResultJSON(result)
+}
+
+// handleDiffSnapshots compares two snapshots and returns differences.
+func (s *Server) handleDiffSnapshots(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	beforePath, err := request.RequireString("before")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("before"),
+			WithSuggestion("Provide the path to the 'before' snapshot file"),
+		), nil
+	}
+	afterPath, err := request.RequireString("after")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("after"),
+			WithSuggestion("Provide the path to the 'after' snapshot file"),
+		), nil
+	}
+
+	ignoreUnchanged := request.GetBool("ignore_unchanged", true)
+
+	beforeSnap, err := resolver.LoadSnapshot(beforePath)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load before snapshot %q: %v", beforePath, err),
+			WithField("before"),
+			WithSuggestion("Check that the file exists and is a valid snapshot JSON file"),
+		), nil
+	}
+	afterSnap, err := resolver.LoadSnapshot(afterPath)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load after snapshot %q: %v", afterPath, err),
+			WithField("after"),
+			WithSuggestion("Check that the file exists and is a valid snapshot JSON file"),
+		), nil
+	}
+
+	diff := resolver.DiffSnapshotsWithOptions(beforeSnap, afterSnap, &resolver.DiffOptions{
+		IgnoreUnchanged: ignoreUnchanged,
+	})
+
+	// Build structured response matching the design doc schema
+	before := map[string]any{
+		"solution":  diff.Before.Solution,
+		"timestamp": diff.Before.Timestamp,
+		"status":    diff.Before.Status,
+	}
+	after := map[string]any{
+		"solution":  diff.After.Solution,
+		"timestamp": diff.After.Timestamp,
+		"status":    diff.After.Status,
+	}
+
+	added := make([]map[string]any, 0)
+	removed := make([]map[string]any, 0)
+	changed := make([]map[string]any, 0)
+	statusChanges := make([]map[string]any, 0)
+
+	for name, rd := range diff.Resolvers {
+		switch rd.Type {
+		case resolver.DiffTypeAdded:
+			entry := map[string]any{"name": name}
+			if rd.After != nil {
+				entry["value"] = rd.After.Value
+			}
+			added = append(added, entry)
+		case resolver.DiffTypeRemoved:
+			entry := map[string]any{"name": name}
+			if rd.Before != nil {
+				entry["value"] = rd.Before.Value
+			}
+			removed = append(removed, entry)
+		case resolver.DiffTypeUnchanged:
+			// Unchanged resolvers are not included in the diff output
+			continue
+		case resolver.DiffTypeModified:
+			// Separate status changes from value changes
+			hasStatusChange := false
+			fields := make([]map[string]any, 0)
+			for _, fc := range rd.Changes {
+				if fc.Field == "status" {
+					hasStatusChange = true
+					statusChanges = append(statusChanges, map[string]any{
+						"name":   name,
+						"before": fc.Before,
+						"after":  fc.After,
+					})
+				} else {
+					fields = append(fields, map[string]any{
+						"field":  fc.Field,
+						"before": fc.Before,
+						"after":  fc.After,
+					})
+				}
+			}
+			if len(fields) > 0 || !hasStatusChange {
+				entry := map[string]any{
+					"name":   name,
+					"fields": fields,
+				}
+				changed = append(changed, entry)
+			}
+		}
+	}
+
+	summary := map[string]any{
+		"added":         diff.Summary.Added,
+		"removed":       diff.Summary.Removed,
+		"changed":       diff.Summary.Modified,
+		"statusChanges": len(statusChanges),
+		"unchanged":     diff.Summary.Unchanged,
+	}
+
+	result := map[string]any{
+		"before": before,
+		"after":  after,
+		"changes": map[string]any{
+			"added":         added,
+			"removed":       removed,
+			"changed":       changed,
+			"statusChanges": statusChanges,
+		},
+		"summary": summary,
+	}
+
+	return mcp.NewToolResultJSON(result)
+}

--- a/pkg/mcp/tools_snapshot_test.go
+++ b/pkg/mcp/tools_snapshot_test.go
@@ -1,0 +1,454 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestSnapshot writes a resolver.Snapshot to a JSON file and returns the path.
+func writeTestSnapshot(t *testing.T, dir, name string, snap *resolver.Snapshot) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	data, err := json.MarshalIndent(snap, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+func TestHandleShowSnapshot(t *testing.T) {
+	baseSnap := &resolver.Snapshot{
+		Metadata: resolver.SnapshotMetadata{
+			Solution:       "my-solution",
+			Version:        "1.0.0",
+			Timestamp:      time.Date(2026, 2, 20, 15, 30, 0, 0, time.UTC),
+			ScafctlVersion: "0.15.0",
+			TotalDuration:  "2.3s",
+			Status:         "success",
+		},
+		Parameters: map[string]any{"env": "prod", "region": "us-east1"},
+		Resolvers: map[string]*resolver.SnapshotResolver{
+			"config": {
+				Value:         map[string]any{"host": "api.example.com"},
+				Status:        "success",
+				Phase:         1,
+				Duration:      "150ms",
+				ProviderCalls: 1,
+			},
+			"deploy": {
+				Value:         "ok",
+				Status:        "success",
+				Phase:         2,
+				Duration:      "1.2s",
+				ProviderCalls: 1,
+			},
+			"validate": {
+				Status:        "failed",
+				Phase:         2,
+				Duration:      "50ms",
+				ProviderCalls: 1,
+				Error:         "validation failed: invalid region",
+			},
+		},
+		Phases: []resolver.SnapshotPhase{
+			{Phase: 1, Duration: "200ms", Resolvers: []string{"config"}},
+			{Phase: 2, Duration: "1.5s", Resolvers: []string{"deploy", "validate"}},
+		},
+	}
+
+	t.Run("summary format", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		snapPath := writeTestSnapshot(t, tmpDir, "snap.json", baseSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "show_snapshot"
+		request.Params.Arguments = map[string]any{
+			"path": snapPath,
+		}
+
+		result, err := srv.handleShowSnapshot(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.Equal(t, "my-solution", data["solution"])
+		assert.Equal(t, "1.0.0", data["version"])
+		assert.Equal(t, "success", data["status"])
+		assert.Equal(t, "2.3s", data["duration"])
+		assert.Equal(t, float64(2), data["phases"])
+
+		counts := data["resolverCount"].(map[string]any)
+		assert.Equal(t, float64(3), counts["total"])
+		assert.Equal(t, float64(2), counts["success"])
+		assert.Equal(t, float64(1), counts["failed"])
+
+		// summary format should NOT include resolvers list
+		_, hasResolvers := data["resolvers"]
+		assert.False(t, hasResolvers)
+	})
+
+	t.Run("resolvers format", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		snapPath := writeTestSnapshot(t, tmpDir, "snap.json", baseSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"path":   snapPath,
+			"format": "resolvers",
+		}
+
+		result, err := srv.handleShowSnapshot(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		resolvers, ok := data["resolvers"].([]any)
+		require.True(t, ok)
+		assert.Len(t, resolvers, 3)
+
+		// resolvers format should include name, status, duration, phase but NOT value
+		for _, r := range resolvers {
+			entry := r.(map[string]any)
+			assert.Contains(t, entry, "name")
+			assert.Contains(t, entry, "status")
+			assert.Contains(t, entry, "duration")
+			assert.Contains(t, entry, "phase")
+			_, hasValue := entry["value"]
+			assert.False(t, hasValue, "resolvers format should not include value")
+		}
+	})
+
+	t.Run("full format includes values", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		snapPath := writeTestSnapshot(t, tmpDir, "snap.json", baseSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"path":   snapPath,
+			"format": "full",
+		}
+
+		result, err := srv.handleShowSnapshot(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		resolvers := data["resolvers"].([]any)
+		assert.Len(t, resolvers, 3)
+
+		// full format should include value and error fields
+		foundConfig := false
+		foundValidate := false
+		for _, r := range resolvers {
+			entry := r.(map[string]any)
+			name := entry["name"].(string)
+			if name == "config" {
+				foundConfig = true
+				assert.NotNil(t, entry["value"])
+			}
+			if name == "validate" {
+				foundValidate = true
+				assert.Equal(t, "validation failed: invalid region", entry["error"])
+			}
+		}
+		assert.True(t, foundConfig, "should have config resolver")
+		assert.True(t, foundValidate, "should have validate resolver")
+	})
+
+	t.Run("missing path returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleShowSnapshot(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/snapshot.json",
+		}
+
+		result, err := srv.handleShowSnapshot(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleDiffSnapshots(t *testing.T) {
+	beforeSnap := &resolver.Snapshot{
+		Metadata: resolver.SnapshotMetadata{
+			Solution:  "my-solution",
+			Timestamp: time.Date(2026, 2, 20, 15, 0, 0, 0, time.UTC),
+			Status:    "success",
+		},
+		Resolvers: map[string]*resolver.SnapshotResolver{
+			"config": {
+				Value:    map[string]any{"host": "old.example.com"},
+				Status:   "success",
+				Phase:    1,
+				Duration: "100ms",
+			},
+			"api-call": {
+				Value:    "ok",
+				Status:   "success",
+				Phase:    2,
+				Duration: "500ms",
+			},
+			"old-resolver": {
+				Value:    "removed",
+				Status:   "success",
+				Phase:    1,
+				Duration: "50ms",
+			},
+		},
+		Phases: []resolver.SnapshotPhase{
+			{Phase: 1, Duration: "150ms", Resolvers: []string{"config", "old-resolver"}},
+			{Phase: 2, Duration: "500ms", Resolvers: []string{"api-call"}},
+		},
+	}
+
+	afterSnap := &resolver.Snapshot{
+		Metadata: resolver.SnapshotMetadata{
+			Solution:  "my-solution",
+			Timestamp: time.Date(2026, 2, 20, 16, 0, 0, 0, time.UTC),
+			Status:    "success",
+		},
+		Resolvers: map[string]*resolver.SnapshotResolver{
+			"config": {
+				Value:    map[string]any{"host": "new.example.com"},
+				Status:   "success",
+				Phase:    1,
+				Duration: "120ms",
+			},
+			"api-call": {
+				Value:    "",
+				Status:   "failed",
+				Phase:    2,
+				Duration: "2s",
+				Error:    "connection refused",
+			},
+			"new-resolver": {
+				Value:    "added",
+				Status:   "success",
+				Phase:    1,
+				Duration: "30ms",
+			},
+		},
+		Phases: []resolver.SnapshotPhase{
+			{Phase: 1, Duration: "160ms", Resolvers: []string{"config", "new-resolver"}},
+			{Phase: 2, Duration: "2s", Resolvers: []string{"api-call"}},
+		},
+	}
+
+	t.Run("detects changes between snapshots", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		beforePath := writeTestSnapshot(t, tmpDir, "before.json", beforeSnap)
+		afterPath := writeTestSnapshot(t, tmpDir, "after.json", afterSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "diff_snapshots"
+		request.Params.Arguments = map[string]any{
+			"before": beforePath,
+			"after":  afterPath,
+		}
+
+		result, err := srv.handleDiffSnapshots(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		// Check before/after metadata
+		before := data["before"].(map[string]any)
+		assert.Equal(t, "my-solution", before["solution"])
+
+		after := data["after"].(map[string]any)
+		assert.Equal(t, "my-solution", after["solution"])
+
+		// Check summary
+		summary := data["summary"].(map[string]any)
+		assert.Equal(t, float64(1), summary["added"])
+		assert.Equal(t, float64(1), summary["removed"])
+
+		// Check changes structure exists
+		changes := data["changes"].(map[string]any)
+		assert.Contains(t, changes, "added")
+		assert.Contains(t, changes, "removed")
+		assert.Contains(t, changes, "changed")
+		assert.Contains(t, changes, "statusChanges")
+	})
+
+	t.Run("ignore_unchanged defaults to true", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		beforePath := writeTestSnapshot(t, tmpDir, "before.json", beforeSnap)
+		afterPath := writeTestSnapshot(t, tmpDir, "after.json", afterSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"before":           beforePath,
+			"after":            afterPath,
+			"ignore_unchanged": true,
+		}
+
+		result, err := srv.handleDiffSnapshots(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("missing before returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"after": "/some/path",
+		}
+
+		result, err := srv.handleDiffSnapshots(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing after returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"before": "/some/path",
+		}
+
+		result, err := srv.handleDiffSnapshots(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent before file returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		afterPath := writeTestSnapshot(t, tmpDir, "after.json", afterSnap)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"before": "/nonexistent.json",
+			"after":  afterPath,
+		}
+
+		result, err := srv.handleDiffSnapshots(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleAnalyzeExecutionPrompt(t *testing.T) {
+	t.Run("with snapshot only", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "analyze_execution"
+		request.Params.Arguments = map[string]string{
+			"snapshot_path": "/tmp/snapshot.json",
+			"problem":       "resolvers timing out",
+		}
+
+		result, err := srv.handleAnalyzeExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, result.Description, "Analyze execution")
+		require.Len(t, result.Messages, 1)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "/tmp/snapshot.json")
+		assert.Contains(t, text, "resolvers timing out")
+		assert.Contains(t, text, "show_snapshot")
+		assert.Contains(t, text, "No previous snapshot provided")
+	})
+
+	t.Run("with previous snapshot for comparison", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "analyze_execution"
+		request.Params.Arguments = map[string]string{
+			"snapshot_path":     "/tmp/bad-snapshot.json",
+			"previous_snapshot": "/tmp/good-snapshot.json",
+		}
+
+		result, err := srv.handleAnalyzeExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "diff_snapshots")
+		assert.Contains(t, text, "/tmp/good-snapshot.json")
+		assert.Contains(t, text, "/tmp/bad-snapshot.json")
+		assert.NotContains(t, text, "No previous snapshot provided")
+	})
+
+	t.Run("default problem description", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"snapshot_path": "/tmp/snapshot.json",
+		}
+
+		result, err := srv.handleAnalyzeExecutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "did not produce the expected results")
+	})
+}

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -24,6 +25,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 )
 
@@ -33,10 +35,12 @@ func (s *Server) registerSolutionTools() {
 	listSolutionsTool := mcp.NewTool("list_solutions",
 		mcp.WithDescription("List available solutions from the local catalog. Returns solution names, versions, descriptions, and tags."),
 		mcp.WithTitleAnnotation("List Solutions"),
+		mcp.WithToolIcons(toolIcons["solution"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaListSolutions),
 		mcp.WithString("name",
 			mcp.Description("Filter solutions by name (substring match). Omit to list all."),
 		),
@@ -47,10 +51,12 @@ func (s *Server) registerSolutionTools() {
 	inspectSolutionTool := mcp.NewTool("inspect_solution",
 		mcp.WithDescription("Get full solution metadata including resolvers, actions, tags, links, maintainers, and catalog info. Accepts a local file path, catalog name, or URL."),
 		mcp.WithTitleAnnotation("Inspect Solution"),
+		mcp.WithToolIcons(toolIcons["solution"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithRawOutputSchema(outputSchemaInspectSolution),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),
@@ -62,10 +68,12 @@ func (s *Server) registerSolutionTools() {
 	lintSolutionTool := mcp.NewTool("lint_solution",
 		mcp.WithDescription("Validate a solution file and return structured lint findings. Checks for unused resolvers, invalid dependencies, missing providers, invalid expressions, and more."),
 		mcp.WithTitleAnnotation("Lint Solution"),
+		mcp.WithToolIcons(toolIcons["lint"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaLintResult),
 		mcp.WithString("file",
 			mcp.Required(),
 			mcp.Description("Path to the solution YAML file"),
@@ -81,10 +89,12 @@ func (s *Server) registerSolutionTools() {
 	renderSolutionTool := mcp.NewTool("render_solution",
 		mcp.WithDescription("Render a solution's action graph, resolver dependency graph, or action dependency graph. Executes resolvers and builds the graph as structured JSON. Use graph_type to select the visualization: 'action' (default) renders the executable action graph, 'resolver' shows resolver dependency phases, 'action-deps' shows action dependency visualization."),
 		mcp.WithTitleAnnotation("Render Solution"),
+		mcp.WithToolIcons(toolIcons["solution"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithRawOutputSchema(outputSchemaRenderSolution),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),
@@ -103,10 +113,12 @@ func (s *Server) registerSolutionTools() {
 	previewResolversTool := mcp.NewTool("preview_resolvers",
 		mcp.WithDescription("Execute a solution's resolver chain and return each resolver's resolved value. This is the 'does it actually work?' step between writing YAML and running the full solution. Shows the resolved value, type, and status for every resolver. Accepts optional input parameters for parameter-type resolvers. Use the 'resolver' parameter to debug a single resolver and see its resolve/transform/validate pipeline in detail."),
 		mcp.WithTitleAnnotation("Preview Resolvers"),
+		mcp.WithToolIcons(toolIcons["solution"]),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithRawOutputSchema(outputSchemaPreviewResolvers),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),
@@ -124,6 +136,7 @@ func (s *Server) registerSolutionTools() {
 	runSolutionTestsTool := mcp.NewTool("run_solution_tests",
 		mcp.WithDescription("Execute functional tests defined in a solution YAML file (spec.testing.cases) or in a tests/ directory. Returns structured test results with pass/fail status, duration, and assertion details. Closes the write → lint → test loop entirely within the AI session."),
 		mcp.WithTitleAnnotation("Run Solution Tests"),
+		mcp.WithToolIcons(toolIcons["testing"]),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
@@ -151,6 +164,7 @@ func (s *Server) registerSolutionTools() {
 	getRunCommandTool := mcp.NewTool("get_run_command",
 		mcp.WithDescription("Get the exact CLI command to run a solution. Analyzes the solution to determine whether to use 'run solution' or 'run resolver', identifies required parameter-type resolvers, and returns the complete command with correct flags. Eliminates guesswork about which command form to use."),
 		mcp.WithTitleAnnotation("Get Run Command"),
+		mcp.WithToolIcons(toolIcons["action"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -169,18 +183,45 @@ func (s *Server) handleListSolutions(_ context.Context, request mcp.CallToolRequ
 
 	localCatalog, err := catalog.NewLocalCatalog(s.logger)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to initialize local catalog: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to initialize local catalog: %v", err),
+			WithSuggestion("Check your catalog configuration with get_config"),
+			WithRelatedTools("get_config", "catalog_list"),
+		), nil
 	}
 
 	items, err := localCatalog.List(s.ctx, catalog.ArtifactKindSolution, name)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to list solutions: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to list solutions: %v", err),
+			WithSuggestion("Check your catalog configuration with get_config"),
+			WithRelatedTools("get_config", "catalog_list"),
+		), nil
 	}
 
 	if len(items) == 0 {
+		// If catalog has no solutions, try discovering from workspace roots
+		workspaceFiles := s.discoverSolutionFiles(s.ctx)
+		if len(workspaceFiles) > 0 {
+			type discoveredSolution struct {
+				Path   string `json:"path"`
+				Source string `json:"source"`
+			}
+			discovered := make([]discoveredSolution, 0, len(workspaceFiles))
+			for _, f := range workspaceFiles {
+				discovered = append(discovered, discoveredSolution{
+					Path:   f,
+					Source: "workspace",
+				})
+			}
+			return mcp.NewToolResultJSON(map[string]any{
+				"solutions": discovered,
+				"message":   "No solutions in catalog, but found solution files in workspace roots",
+				"source":    "workspace_roots",
+			})
+		}
+
 		return mcp.NewToolResultJSON(map[string]any{
 			"solutions": []any{},
-			"message":   "No solutions found in local catalog",
+			"message":   "No solutions found in local catalog or workspace",
 		})
 	}
 
@@ -191,24 +232,43 @@ func (s *Server) handleListSolutions(_ context.Context, request mcp.CallToolRequ
 func (s *Server) handleInspectSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide a solution file path, catalog name, or URL"),
+		), nil
 	}
 
 	sol, err := explain.LoadSolution(s.ctx, path)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the file exists and contains valid YAML"),
+			WithRelatedTools("lint_solution"),
+		), nil
 	}
 
 	explanation := explain.BuildSolutionExplanation(sol)
 
-	return mcp.NewToolResultJSON(explanation)
+	result, err := mcp.NewToolResultJSON(explanation)
+	if err != nil {
+		return nil, err
+	}
+	result.Content = append(result.Content,
+		mcp.NewResourceLink("solution://"+path, "Solution YAML", "Raw solution YAML content", "application/x-yaml"),
+		mcp.NewResourceLink("solution://"+path+"/schema", "Input Schema", "Solution input schema", "application/schema+json"),
+		mcp.NewResourceLink("solution://"+path+"/graph", "Dependency Graph", "Resolver dependency graph", "application/json"),
+	)
+	return result, nil
 }
 
 // handleLintSolution validates a solution file and returns structured findings.
 func (s *Server) handleLintSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	file, err := request.RequireString("file")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("file"),
+			WithSuggestion("Provide the path to a solution YAML file"),
+		), nil
 	}
 	severity := request.GetString("severity", "info")
 
@@ -217,7 +277,38 @@ func (s *Server) handleLintSolution(_ context.Context, request mcp.CallToolReque
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		errMsg := err.Error()
+
+		// Detect cycle errors and provide actionable __self guidance
+		if strings.Contains(errMsg, "cycle detected") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("file"),
+				WithSuggestion("Circular dependency detected in resolvers. "+
+					"If a resolver's validate or transform phase references its own resolved value "+
+					"(e.g., _.myResolver.statusCode), replace it with __self (e.g., __self.statusCode). "+
+					"Using _.resolverName in validate/transform creates a self-referencing cycle. "+
+					"__self is the correct way to reference the current resolver's value in transform and validate phases."),
+				WithRelatedTools("render_solution", "lint_solution"),
+			), nil
+		}
+
+		// Detect YAML unmarshal errors and provide structural guidance
+		if strings.Contains(errMsg, "cannot unmarshal") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("file"),
+				WithSuggestion("YAML structure error. Each phase (resolve, transform, validate) must use the 'with' key "+
+					"containing an array of provider entries. Example:\n"+
+					"  validate:\n    with:\n      - provider: validation\n        inputs:\n          expression: \"__self.size() > 0\"\n"+
+					"Do NOT use a bare array directly under the phase key."),
+				WithRelatedTools("explain_kind", "get_solution_schema"),
+			), nil
+		}
+
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("file"),
+			WithSuggestion("Check the file exists and contains valid solution YAML"),
+			WithRelatedTools("inspect_solution"),
+		), nil
 	}
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
@@ -238,7 +329,10 @@ func (s *Server) handleLintSolution(_ context.Context, request mcp.CallToolReque
 func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide a solution file path, catalog name, or URL"),
+		), nil
 	}
 
 	graphType := request.GetString("graph_type", "action")
@@ -250,7 +344,10 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 		if pm, ok := p.(map[string]any); ok {
 			params = pm
 		} else {
-			return mcp.NewToolResultError("'params' must be an object (key-value pairs)"), nil
+			return newStructuredError(ErrCodeInvalidInput, "'params' must be an object (key-value pairs)",
+				WithField("params"),
+				WithSuggestion("Provide params as a JSON object, e.g. {\"key\": \"value\"}"),
+			), nil
 		}
 	}
 
@@ -259,7 +356,35 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		errMsg := err.Error()
+
+		// Detect cycle errors and provide actionable __self guidance
+		if strings.Contains(errMsg, "cycle detected") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("path"),
+				WithSuggestion("Circular dependency detected in resolvers. "+
+					"If a resolver's validate or transform phase references its own resolved value "+
+					"(e.g., _.myResolver.statusCode), replace it with __self (e.g., __self.statusCode). "+
+					"__self is the correct way to reference the current resolver's value in transform and validate phases."),
+				WithRelatedTools("lint_solution", "inspect_solution"),
+			), nil
+		}
+
+		// Detect YAML unmarshal errors and provide structural guidance
+		if strings.Contains(errMsg, "cannot unmarshal") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("path"),
+				WithSuggestion("YAML structure error. Each phase (resolve, transform, validate) must use the 'with' key "+
+					"containing an array of provider entries. Do NOT use a bare array directly under the phase key."),
+				WithRelatedTools("explain_kind", "get_solution_schema"),
+			), nil
+		}
+
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the file exists and contains valid solution YAML"),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
 	}
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
@@ -267,6 +392,14 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 
 	sol := prepResult.Solution
 	reg := prepResult.Registry
+
+	// Auto-fallback: if the user requested the default "action" graph but the
+	// solution has no workflow, automatically switch to the resolver graph
+	// instead of returning an error. This is the most common mistake when an
+	// AI agent calls render_solution on a resolver-only solution.
+	if graphType == "action" && !sol.Spec.HasWorkflow() && sol.Spec.HasResolvers() {
+		graphType = "resolver"
+	}
 
 	switch graphType {
 	case "resolver":
@@ -281,7 +414,10 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 // renderResolverGraph builds and returns the resolver dependency graph.
 func (s *Server) renderResolverGraph(sol *solution.Solution, reg *provider.Registry) (*mcp.CallToolResult, error) {
 	if !sol.Spec.HasResolvers() {
-		return mcp.NewToolResultError("solution does not define any resolvers"), nil
+		return newStructuredError(ErrCodeValidationError, "solution does not define any resolvers",
+			WithSuggestion("Add resolvers to the solution spec.resolvers section"),
+			WithRelatedTools("get_solution_schema", "scaffold_solution"),
+		), nil
 	}
 
 	resolvers := sol.Spec.ResolversToSlice()
@@ -293,7 +429,10 @@ func (s *Server) renderResolverGraph(sol *solution.Solution, reg *provider.Regis
 
 	graph, err := resolver.BuildGraph(resolvers, lookup)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to build resolver graph: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build resolver graph: %v", err),
+			WithSuggestion("Check resolver dependencies for cycles or missing references"),
+			WithRelatedTools("lint_solution", "extract_resolver_refs"),
+		), nil
 	}
 
 	// Also include ASCII diagram in the response for readability
@@ -314,19 +453,32 @@ func (s *Server) renderResolverGraph(sol *solution.Solution, reg *provider.Regis
 // renderActionGraph executes resolvers, builds, and renders the action graph.
 func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any) (*mcp.CallToolResult, error) { //nolint:unparam // error is always nil per MCP pattern
 	if !sol.Spec.HasWorkflow() {
-		return mcp.NewToolResultError("solution does not define a workflow"), nil
+		suggestion := "Add a spec.workflow section with actions to the solution"
+		if sol.Spec.HasResolvers() {
+			suggestion = "This solution only has resolvers and no workflow. Use graph_type='resolver' to render the resolver dependency graph, or add a spec.workflow section with actions"
+		}
+		return newStructuredError(ErrCodeValidationError, "solution does not define a workflow",
+			WithSuggestion(suggestion),
+			WithRelatedTools("get_solution_schema", "scaffold_solution"),
+		), nil
 	}
 
 	// Execute resolvers to get data for action inputs
 	resolverData, err := s.executeResolversForRender(sol, params)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
+			WithSuggestion("Check resolver configuration with preview_resolvers"),
+			WithRelatedTools("preview_resolvers", "lint_solution"),
+		), nil
 	}
 
 	// Build the action graph
 	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to build action graph: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
+			WithSuggestion("Check action dependencies and provider configurations"),
+			WithRelatedTools("lint_solution"),
+		), nil
 	}
 
 	// Render as JSON
@@ -338,7 +490,9 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 
 	rendered, err := action.Render(graph, renderOpts)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to render action graph: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to render action graph: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	// Embed resolver data alongside the graph for a complete picture
@@ -359,19 +513,28 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 // renderActionDepsGraph builds and returns the action dependency visualization.
 func (s *Server) renderActionDepsGraph(sol *solution.Solution, params map[string]any) (*mcp.CallToolResult, error) {
 	if !sol.Spec.HasWorkflow() {
-		return mcp.NewToolResultError("solution does not define a workflow"), nil
+		return newStructuredError(ErrCodeValidationError, "solution does not define a workflow",
+			WithSuggestion("Add a spec.workflow section with actions to the solution"),
+			WithRelatedTools("get_solution_schema", "scaffold_solution"),
+		), nil
 	}
 
 	// Execute resolvers to get data for action inputs
 	resolverData, err := s.executeResolversForRender(sol, params)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
+			WithSuggestion("Check resolver configuration with preview_resolvers"),
+			WithRelatedTools("preview_resolvers", "lint_solution"),
+		), nil
 	}
 
 	// Build the action graph
 	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to build action graph: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
+			WithSuggestion("Check action dependencies and provider configurations"),
+			WithRelatedTools("lint_solution"),
+		), nil
 	}
 
 	// Build visualization
@@ -429,7 +592,10 @@ func (s *Server) executeResolversForRender(sol *solution.Solution, params map[st
 func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution file"),
+		), nil
 	}
 
 	// Parse params
@@ -439,7 +605,10 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		if pm, ok := p.(map[string]any); ok {
 			params = pm
 		} else {
-			return mcp.NewToolResultError("'params' must be an object (key-value pairs)"), nil
+			return newStructuredError(ErrCodeInvalidInput, "'params' must be an object (key-value pairs)",
+				WithField("params"),
+				WithSuggestion("Pass params as a JSON object, e.g. {\"key\": \"value\"}"),
+			), nil
 		}
 	}
 
@@ -448,7 +617,29 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		errMsg := err.Error()
+
+		if strings.Contains(errMsg, "cycle detected") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("path"),
+				WithSuggestion("Circular dependency detected. In validate/transform phases, use __self instead of _.resolverName to reference the resolver's own value."),
+				WithRelatedTools("lint_solution"),
+			), nil
+		}
+
+		if strings.Contains(errMsg, "cannot unmarshal") {
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+				WithField("path"),
+				WithSuggestion("YAML structure error. Each phase (resolve, transform, validate) must use the 'with' key containing an array. Do NOT use a bare array."),
+				WithRelatedTools("explain_kind", "get_solution_schema"),
+			), nil
+		}
+
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check that the path points to a valid solution file"),
+			WithRelatedTools("lint_solution"),
+		), nil
 	}
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
@@ -464,10 +655,36 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		})
 	}
 
+	// Elicit missing parameter values: find parameter-type resolvers without provided values
+	if params == nil {
+		params = make(map[string]any)
+	}
+	var missingParamNames []string
+	missingDescriptions := make(map[string]string)
+	for name, rslvr := range sol.Spec.Resolvers {
+		if rslvr.Resolve != nil && len(rslvr.Resolve.With) > 0 && rslvr.Resolve.With[0].Provider == "parameter" {
+			if _, provided := params[name]; !provided {
+				missingParamNames = append(missingParamNames, name)
+				if rslvr.Description != "" {
+					missingDescriptions[name] = rslvr.Description
+				}
+			}
+		}
+	}
+	if len(missingParamNames) > 0 {
+		sort.Strings(missingParamNames)
+		for k, v := range s.elicitMissingParams(s.ctx, missingParamNames, missingDescriptions) {
+			params[k] = v
+		}
+	}
+
 	if reg == nil {
 		reg, err = builtin.DefaultRegistry(s.ctx)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to create provider registry: %v", err)), nil
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to create provider registry: %v", err),
+				WithSuggestion("Check provider configurations"),
+				WithRelatedTools("list_providers"),
+			), nil
 		}
 	}
 
@@ -475,10 +692,21 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	// Check if we're debugging a single resolver
 	resolverFilter := request.GetString("resolver", "")
 
+	// Send progress notifications during execution
+	progress := newProgressReporter(s, request)
+	progress.setTotal(3)
+	progress.report(s.ctx, 1, "Loading and validating solution")
+
+	progress.report(s.ctx, 2, fmt.Sprintf("Executing %d resolvers", len(sol.Spec.Resolvers)))
 	result, err := run.ExecuteResolvers(s.ctx, sol, params, reg, cfg)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolver execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
+			WithSuggestion("Check resolver configuration and dependencies"),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
 	}
+
+	progress.report(s.ctx, 3, "Building response")
 
 	// Build structured response with per-resolver details
 	type resolverPhaseInfo struct {
@@ -497,6 +725,7 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		Transform   []resolverPhaseInfo `json:"transform,omitempty"`
 		Validate    []resolverPhaseInfo `json:"validate,omitempty"`
 		When        string              `json:"when,omitempty"`
+		SourcePos   *sourcepos.Position `json:"sourcePos,omitempty"`
 	}
 
 	resolvers := make(map[string]resolverPreview, len(sol.Spec.Resolvers))
@@ -512,6 +741,13 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		preview := resolverPreview{
 			Description: rslvr.Description,
 			Type:        string(rslvr.Type),
+		}
+
+		// Enrich with source position if available
+		if sm := sol.SourceMap(); sm != nil {
+			if pos, ok := sm.Get("spec.resolvers." + name); ok {
+				preview.SourcePos = &pos
+			}
 		}
 
 		// Get the primary provider name
@@ -569,7 +805,10 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 				availableNames = append(availableNames, name)
 			}
 			sort.Strings(availableNames)
-			return mcp.NewToolResultError(fmt.Sprintf("resolver %q not found. Available resolvers: %v", resolverFilter, availableNames)), nil
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("resolver %q not found. Available resolvers: %v", resolverFilter, availableNames),
+				WithField("resolver"),
+				WithSuggestion(fmt.Sprintf("Use one of the available resolver names: %v", availableNames)),
+			), nil
 		}
 	}
 
@@ -583,14 +822,25 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		response["total"] = len(resolvers)
 	}
 
-	return mcp.NewToolResultJSON(response)
+	result2, err := mcp.NewToolResultJSON(response)
+	if err != nil {
+		return nil, err
+	}
+	result2.Content = append(result2.Content,
+		mcp.NewResourceLink("solution://"+path, "Solution YAML", "Raw solution YAML content", "application/x-yaml"),
+		mcp.NewResourceLink("solution://"+path+"/graph", "Dependency Graph", "Resolver dependency graph", "application/json"),
+	)
+	return result2, nil
 }
 
 // handleRunSolutionTests executes functional tests for a solution.
 func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution or directory containing solutions"),
+		), nil
 	}
 
 	filter := request.GetString("filter", "")
@@ -604,13 +854,19 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 
 	// Verify the path exists
 	if _, err := os.Stat(path); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("path not found: %v", err)), nil
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("path not found: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the path exists and is accessible"),
+		), nil
 	}
 
 	// Discover solutions with tests
 	solutions, err := soltesting.DiscoverSolutions(path)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("test discovery failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("test discovery failed: %v", err),
+			WithField("path"),
+			WithSuggestion("Ensure the path contains valid solutions with test configurations"),
+		), nil
 	}
 
 	if len(solutions) == 0 {
@@ -636,7 +892,9 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 	// Resolve binary path for subprocess execution
 	binaryPath, err := os.Executable()
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to resolve executable path: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to resolve executable path: %v", err),
+			WithSuggestion("Ensure the scafctl binary is accessible"),
+		), nil
 	}
 
 	// Build runner
@@ -656,13 +914,23 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 		runner.Filter.Tags = []string{tag}
 	}
 
+	// Send progress notifications during test execution
+	progress := newProgressReporter(s, request)
+	progress.setTotal(float64(len(solutions) + 2))
+	progress.report(s.ctx, 1, fmt.Sprintf("Discovered %d solution(s) with tests", len(solutions)))
+
 	// Execute tests
 	start := time.Now()
+	progress.report(s.ctx, 2, "Running tests...")
 	results, err := runner.Run(s.ctx, solutions)
 	elapsed := time.Since(start)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("test execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("test execution failed: %v", err),
+			WithSuggestion("Review test configurations and solution definitions"),
+			WithRelatedTools("lint_solution", "inspect_solution"),
+		), nil
 	}
+	progress.report(s.ctx, float64(len(solutions)+2), fmt.Sprintf("Tests complete (%s)", elapsed.String()))
 
 	// Build structured response
 	summary := soltesting.Summarize(results)
@@ -711,12 +979,19 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := request.RequireString("path")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution file"),
+		), nil
 	}
 
 	sol, err := explain.LoadSolution(s.ctx, path)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("loading solution: %v", err)), nil
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check that the path points to a valid solution file"),
+			WithRelatedTools("lint_solution"),
+		), nil
 	}
 
 	hasResolvers := sol.Spec.HasResolvers()
@@ -774,8 +1049,14 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 		}
 	}
 
-	// Build the full command string
-	fullCommand := fmt.Sprintf("%s -f %s", command, path)
+	// Build the full command string.
+	// Ensure relative paths have "./" prefix so VS Code chat does not
+	// auto-linkify bare filenames into content-reference URLs.
+	cmdPath := path
+	if !strings.HasPrefix(cmdPath, "/") && !strings.HasPrefix(cmdPath, "./") && !strings.HasPrefix(cmdPath, "../") && !strings.Contains(cmdPath, "://") {
+		cmdPath = "./" + cmdPath
+	}
+	fullCommand := fmt.Sprintf("%s -f %s", command, cmdPath)
 	for _, p := range parameters {
 		exampleVal := "<value>"
 		if p.Example != nil {
@@ -784,7 +1065,11 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 		fullCommand += fmt.Sprintf(" -r %s=%s", p.Name, exampleVal)
 	}
 
-	return mcp.NewToolResultJSON(map[string]any{
+	// Build result with content annotations.
+	// The command is primarily for the assistant, the explanation is for both.
+	assistantPriority := 1.0
+	userPriority := 0.8
+	result, err := mcp.NewToolResultJSON(map[string]any{
 		"command":      fullCommand,
 		"subcommand":   command,
 		"explanation":  explanation,
@@ -792,6 +1077,35 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 		"hasWorkflow":  hasWorkflow,
 		"hasResolvers": hasResolvers,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Add annotated text content: command for assistant, explanation for user
+	result.Content = append(result.Content,
+		mcp.TextContent{
+			Annotated: mcp.Annotated{
+				Annotations: &mcp.Annotations{
+					Audience: []mcp.Role{mcp.RoleAssistant},
+					Priority: &assistantPriority,
+				},
+			},
+			Type: "text",
+			Text: fmt.Sprintf("Run command: %s", fullCommand),
+		},
+		mcp.TextContent{
+			Annotated: mcp.Annotated{
+				Annotations: &mcp.Annotations{
+					Audience: []mcp.Role{mcp.RoleUser},
+					Priority: &userPriority,
+				},
+			},
+			Type: "text",
+			Text: fmt.Sprintf("Explanation: %s", explanation),
+		},
+	)
+
+	return result, nil
 }
 
 // isResolverDependency checks if candidateName is a direct or transitive dependency

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -117,6 +117,15 @@ spec:
 		require.NoError(t, json.Unmarshal([]byte(text), &explanation))
 		assert.Contains(t, explanation, "name")
 		assert.Equal(t, "test-inspect", explanation["name"])
+
+		// Verify resolvers include source positions
+		resolvers := explanation["resolvers"].([]any)
+		require.NotEmpty(t, resolvers)
+		firstResolver := resolvers[0].(map[string]any)
+		sourcePos := firstResolver["sourcePos"]
+		require.NotNil(t, sourcePos, "sourcePos should be present in inspection resolvers")
+		sp := sourcePos.(map[string]any)
+		assert.Greater(t, sp["line"], float64(0), "line should be > 0")
 	})
 }
 
@@ -290,7 +299,7 @@ func TestHandleRenderSolution(t *testing.T) {
 		}
 	})
 
-	t.Run("solution without workflow returns error for action graph", func(t *testing.T) {
+	t.Run("solution without workflow auto-falls back to resolver graph", func(t *testing.T) {
 		// Create a solution with only resolvers, no workflow
 		tmpDir := t.TempDir()
 		solFile := filepath.Join(tmpDir, "resolvers-only.yaml")
@@ -322,9 +331,12 @@ spec:
 
 		result, err := srv.handleRenderSolution(context.Background(), request)
 		require.NoError(t, err)
-		assert.True(t, result.IsError)
+		// Should auto-fallback to resolver graph instead of erroring
+		assert.False(t, result.IsError, "resolver-only solution should auto-fallback to resolver graph")
 		text := result.Content[0].(mcp.TextContent).Text
-		assert.Contains(t, text, "workflow")
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Contains(t, parsed, "nodes")
 	})
 
 	t.Run("solution without resolvers returns error for resolver graph", func(t *testing.T) {
@@ -516,6 +528,13 @@ spec:
 		assert.Equal(t, "Hello World", greeting["value"])
 		assert.Equal(t, "resolved", greeting["status"])
 		assert.Equal(t, "static", greeting["provider"])
+
+		// Verify source position is included
+		sourcePos := greeting["sourcePos"]
+		require.NotNil(t, sourcePos, "sourcePos should be present for resolvers")
+		sp := sourcePos.(map[string]any)
+		assert.Greater(t, sp["line"], float64(0), "line should be > 0")
+		assert.Greater(t, sp["column"], float64(0), "column should be > 0")
 	})
 
 	t.Run("invalid params type returns error", func(t *testing.T) {
@@ -740,6 +759,51 @@ spec: {}
 		assert.False(t, result.IsError)
 		text := result.Content[0].(mcp.TextContent).Text
 		assert.Contains(t, text, "error")
+	})
+
+	t.Run("bare filename gets ./ prefix in command", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "my-solution.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		// Change to tmpDir so bare filename resolves
+		origDir, _ := os.Getwd()
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { os.Chdir(origDir) })
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path": "my-solution.yaml", // bare filename, no ./
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		cmd := parsed["command"].(string)
+		assert.Contains(t, cmd, "-f ./my-solution.yaml", "bare filenames should get ./ prefix")
 	})
 }
 

--- a/pkg/mcp/tools_sprint6_test.go
+++ b/pkg/mcp/tools_sprint6_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCatalogInspect(t *testing.T) {
+	t.Run("missing reference", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"kind": "solution"}
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing kind", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"reference": "my-solution"}
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("invalid kind", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"reference": "my-solution", "kind": "invalid"}
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := extractText(t, result)
+		assert.Contains(t, text, "invalid kind")
+	})
+
+	t.Run("nonexistent artifact", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"reference": "nonexistent-solution-12345", "kind": "solution"}
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := extractText(t, result)
+		assert.Contains(t, text, "not found")
+	})
+}
+
+func TestHandleListAuthHandlers(t *testing.T) {
+	t.Run("no auth registry", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		result, err := srv.handleListAuthHandlers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		handlers := data["handlers"].([]any)
+		assert.Empty(t, handlers)
+	})
+}
+
+func TestHandleGetConfigPaths(t *testing.T) {
+	t.Run("returns all paths", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		result, err := srv.handleGetConfigPaths(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		pathList := data["paths"].([]any)
+		assert.GreaterOrEqual(t, len(pathList), 8)
+		count := data["count"].(float64)
+		assert.Equal(t, float64(len(pathList)), count)
+		names := make(map[string]bool)
+		for _, p := range pathList {
+			entry := p.(map[string]any)
+			names[entry["name"].(string)] = true
+			assert.NotEmpty(t, entry["path"])
+			assert.NotEmpty(t, entry["description"])
+			assert.NotEmpty(t, entry["xdgVariable"])
+		}
+		assert.True(t, names["config"])
+		assert.True(t, names["data"])
+		assert.True(t, names["cache"])
+		assert.True(t, names["catalog"])
+		assert.True(t, names["secrets"])
+	})
+}
+
+func TestHandleValidateExpressions(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"expressions": []any{
+				map[string]any{"expression": "1 + 2", "type": "cel"},
+				map[string]any{"expression": "Hello {{ .Name }}", "type": "go-template"},
+			},
+		}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		results := data["results"].([]any)
+		assert.Len(t, results, 2)
+		summary := data["summary"].(map[string]any)
+		assert.Equal(t, float64(2), summary["total"])
+		assert.Equal(t, float64(2), summary["valid"])
+		assert.Equal(t, float64(0), summary["invalid"])
+	})
+
+	t.Run("mixed valid and invalid", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"expressions": []any{
+				map[string]any{"expression": "1 + 2", "type": "cel"},
+				map[string]any{"expression": "{{ .Name", "type": "go-template"},
+				map[string]any{"expression": "1 +++ 2", "type": "cel"},
+			},
+		}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		summary := data["summary"].(map[string]any)
+		assert.Equal(t, float64(3), summary["total"])
+		assert.Equal(t, float64(1), summary["valid"])
+		assert.Equal(t, float64(2), summary["invalid"])
+	})
+
+	t.Run("empty expressions", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"expressions": []any{}}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing expressions", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("unknown expression type", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"expressions": []any{
+				map[string]any{"expression": "test", "type": "javascript"},
+			},
+		}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		results := data["results"].([]any)
+		r0 := results[0].(map[string]any)
+		assert.Equal(t, false, r0["valid"])
+		assert.Contains(t, r0["error"], "unknown expression type")
+	})
+}

--- a/pkg/mcp/tools_sprint7_test.go
+++ b/pkg/mcp/tools_sprint7_test.go
@@ -1,0 +1,262 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Phase 3B: migrate_solution prompt ---
+
+func TestHandleMigrateSolutionPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("add-composition migration", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Name = "migrate_solution"
+		request.Params.Arguments = map[string]string{
+			"path":       "solutions/my-app/solution.yaml",
+			"migration":  "add-composition",
+			"target_dir": "/tmp/migrated",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+		assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-app/solution.yaml")
+		assert.Contains(t, text, "add-composition")
+		assert.Contains(t, text, "/tmp/migrated")
+		assert.Contains(t, text, "inspect_solution")
+		assert.Contains(t, text, "lint_solution")
+		assert.Contains(t, text, "behavior-preserving")
+	})
+
+	t.Run("extract-templates migration", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "extract-templates",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "EXTRACT TEMPLATES")
+		assert.Contains(t, text, "extract_resolver_refs")
+	})
+
+	t.Run("upgrade-patterns migration", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "upgrade-patterns",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "UPGRADE PATTERNS")
+		assert.Contains(t, text, "get_provider_schema")
+	})
+
+	t.Run("unknown migration type falls back to generic", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "custom-refactor",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "custom-refactor")
+	})
+}
+
+// --- Phase 3C: optimize_solution prompt ---
+
+func TestHandleOptimizeSolutionPrompt(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("all focus (default)", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path": "solutions/my-app/solution.yaml",
+		}
+
+		result, err := srv.handleOptimizeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "solutions/my-app/solution.yaml")
+		assert.Contains(t, text, "all")
+		assert.Contains(t, text, "PERFORMANCE")
+		assert.Contains(t, text, "READABILITY")
+		assert.Contains(t, text, "TESTING")
+		assert.Contains(t, text, "inspect_solution")
+		assert.Contains(t, text, "render_solution")
+	})
+
+	t.Run("performance focus", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":  "solution.yaml",
+			"focus": "performance",
+		}
+
+		result, err := srv.handleOptimizeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "PERFORMANCE ANALYSIS")
+		assert.Contains(t, text, "parallel")
+	})
+
+	t.Run("readability focus", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":  "solution.yaml",
+			"focus": "readability",
+		}
+
+		result, err := srv.handleOptimizeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "READABILITY ANALYSIS")
+		assert.Contains(t, text, "naming")
+	})
+
+	t.Run("testing focus", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":  "solution.yaml",
+			"focus": "testing",
+		}
+
+		result, err := srv.handleOptimizeSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+		assert.Contains(t, text, "TESTING ANALYSIS")
+		assert.Contains(t, text, "list_tests")
+	})
+}
+
+// --- Phase 5B: Structured errors ---
+
+func TestStructuredErrors(t *testing.T) {
+	t.Run("newStructuredError with all options", func(t *testing.T) {
+		result := newStructuredError(ErrCodeInvalidInput, "field X is required",
+			WithField("x"),
+			WithSuggestion("Provide the x field"),
+			WithRelatedTools("tool_a", "tool_b"),
+		)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var te ToolError
+		require.NoError(t, json.Unmarshal([]byte(text), &te))
+		assert.Equal(t, ErrCodeInvalidInput, te.Code)
+		assert.Equal(t, "field X is required", te.Message)
+		assert.Equal(t, "x", te.Field)
+		assert.Equal(t, "Provide the x field", te.Suggestion)
+		assert.Equal(t, []string{"tool_a", "tool_b"}, te.Related)
+	})
+
+	t.Run("newStructuredError minimal", func(t *testing.T) {
+		result := newStructuredError(ErrCodeNotFound, "item not found")
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var te ToolError
+		require.NoError(t, json.Unmarshal([]byte(text), &te))
+		assert.Equal(t, ErrCodeNotFound, te.Code)
+		assert.Equal(t, "item not found", te.Message)
+		assert.Empty(t, te.Field)
+		assert.Empty(t, te.Suggestion)
+		assert.Nil(t, te.Related)
+	})
+
+	t.Run("catalog_inspect uses structured errors", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{"kind": "invalid-kind", "reference": "test"}
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := extractText(t, result)
+		var te ToolError
+		require.NoError(t, json.Unmarshal([]byte(text), &te))
+		assert.Equal(t, ErrCodeInvalidInput, te.Code)
+		assert.Contains(t, te.Message, "invalid kind")
+		assert.Equal(t, "kind", te.Field)
+		assert.NotEmpty(t, te.Suggestion)
+	})
+
+	t.Run("preview_action uses structured errors for missing path", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{}
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := extractText(t, result)
+		var te ToolError
+		require.NoError(t, json.Unmarshal([]byte(text), &te))
+		assert.Equal(t, ErrCodeInvalidInput, te.Code)
+		assert.Equal(t, "path", te.Field)
+	})
+}
+
+// --- Phase 5D: get_version tool ---
+
+func TestHandleGetVersion(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	result, err := srv.handleGetVersion(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := extractText(t, result)
+	var data map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &data))
+	assert.Contains(t, data, "version")
+	assert.Contains(t, data, "commit")
+	assert.Contains(t, data, "buildTime")
+	// Default values from settings.VersionInformation
+	assert.NotEmpty(t, data["version"])
+	assert.NotEmpty(t, data["commit"])
+	assert.NotEmpty(t, data["buildTime"])
+}
+
+// --- Phase 5C: Latency hints in serverInstructions ---
+
+func TestServerInstructionsContainLatencyGuide(t *testing.T) {
+	assert.Contains(t, serverInstructions, "Tool Latency Guide")
+	assert.Contains(t, serverInstructions, "Instant")
+	assert.Contains(t, serverInstructions, "Fast")
+	assert.Contains(t, serverInstructions, "Variable")
+	assert.Contains(t, serverInstructions, "get_version")
+}

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -22,6 +22,7 @@ func (s *Server) registerTemplateTools() {
 	evaluateGoTemplateTool := mcp.NewTool("evaluate_go_template",
 		mcp.WithDescription("Evaluate a Go template against provided data. Go templates use {{ .FieldName }} syntax and support pipelines, conditionals (if/else), ranges, and custom functions. Data is accessible via dot notation (e.g., {{ .Name }}, {{ .Items }}). Use this to test tmpl: fields in solution YAML before committing them."),
 		mcp.WithTitleAnnotation("Evaluate Go Template"),
+		mcp.WithToolIcons(toolIcons["template"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -53,6 +54,7 @@ func (s *Server) registerTemplateTools() {
 	validateExpressionTool := mcp.NewTool("validate_expression",
 		mcp.WithDescription("Validate a CEL expression or Go template for syntax errors WITHOUT executing it. Returns whether the expression/template is valid and any parse errors found. Use this for quick syntax checking of when clauses, expr fields, and tmpl fields in solution YAML."),
 		mcp.WithTitleAnnotation("Validate Expression"),
+		mcp.WithToolIcons(toolIcons["template"]),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -74,13 +76,40 @@ func (s *Server) registerTemplateTools() {
 		),
 	)
 	s.mcpServer.AddTool(validateExpressionTool, s.handleValidateExpression)
+
+	// validate_expressions (batch)
+	validateExpressionsTool := mcp.NewTool("validate_expressions",
+		mcp.WithDescription("Batch-validate multiple CEL and Go-template expressions in a single call. Each expression includes its content and type ('cel' or 'go-template'). Returns per-expression results with validity, errors, and references, plus a summary. More efficient than calling validate_expression multiple times."),
+		mcp.WithTitleAnnotation("Validate Expressions (Batch)"),
+		mcp.WithToolIcons(toolIcons["template"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithArray("expressions",
+			mcp.Required(),
+			mcp.Description("Array of objects with 'expression' (string) and 'type' ('cel' or 'go-template') fields"),
+			mcp.Items(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"expression": map[string]any{"type": "string", "description": "The expression to validate"},
+					"type":       map[string]any{"type": "string", "description": "Expression type: 'cel' or 'go-template'"},
+				},
+				"required": []string{"expression", "type"},
+			}),
+		),
+	)
+	s.mcpServer.AddTool(validateExpressionsTool, s.handleValidateExpressions)
 }
 
 // handleEvaluateGoTemplate evaluates a Go template against provided data.
 func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tmplContent, err := request.RequireString("template")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("template"),
+			WithSuggestion("Provide the Go template string to evaluate"),
+		), nil
 	}
 
 	args := request.GetArguments()
@@ -91,17 +120,26 @@ func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToo
 	dataFile := request.GetString("data_file", "")
 
 	if hasInlineData && inlineData != nil && dataFile != "" {
-		return mcp.NewToolResultError("cannot specify both 'data' and 'data_file' — use one or the other"), nil
+		return newStructuredError(ErrCodeInvalidInput, "cannot specify both 'data' and 'data_file' — use one or the other",
+			WithField("data"),
+			WithSuggestion("Use 'data' for inline JSON data or 'data_file' for file-based data, not both"),
+		), nil
 	}
 
 	if dataFile != "" {
 		fileBytes, err := os.ReadFile(dataFile)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to read data file %q: %v", dataFile, err)), nil
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to read data file %q: %v", dataFile, err),
+				WithField("data_file"),
+				WithSuggestion("Check the file path exists and is readable"),
+			), nil
 		}
 		var fileData any
 		if err := yaml.Unmarshal(fileBytes, &fileData); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to parse data file %q: %v", dataFile, err)), nil
+			return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to parse data file %q: %v", dataFile, err),
+				WithField("data_file"),
+				WithSuggestion("Ensure the file contains valid YAML or JSON"),
+			), nil
 		}
 		data = fileData
 	} else if hasInlineData && inlineData != nil {
@@ -129,7 +167,11 @@ func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToo
 	svc := gotmpl.NewService(nil)
 	result, err := svc.Execute(s.ctx, opts)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("template execution failed: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("template execution failed: %v", err),
+			WithField("template"),
+			WithSuggestion("Use validate_expression with type='go-template' to check syntax first"),
+			WithRelatedTools("validate_expression"),
+		), nil
 	}
 
 	// Also extract references for debugging help
@@ -150,12 +192,18 @@ func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToo
 func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	expression, err := request.RequireString("expression")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("expression"),
+			WithSuggestion("Provide the expression to validate"),
+		), nil
 	}
 
 	exprType, err := request.RequireString("type")
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("type"),
+			WithSuggestion("Specify 'cel' or 'go-template' as the expression type"),
+		), nil
 	}
 
 	switch exprType {
@@ -166,7 +214,10 @@ func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToo
 		rightDelim := request.GetString("right_delim", "")
 		return s.validateGoTemplate(expression, leftDelim, rightDelim)
 	default:
-		return mcp.NewToolResultError(fmt.Sprintf("unknown expression type %q — use 'cel' or 'go-template'", exprType)), nil
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unknown expression type %q — use 'cel' or 'go-template'", exprType),
+			WithField("type"),
+			WithSuggestion("Valid types are 'cel' and 'go-template'"),
+		), nil
 	}
 }
 
@@ -174,7 +225,9 @@ func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToo
 func (s *Server) validateCELExpression(expression string) (*mcp.CallToolResult, error) {
 	env, err := cel.NewEnv()
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to create CEL environment: %v", err)), nil
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to create CEL environment: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
 	}
 
 	_, issues := env.Parse(expression)
@@ -251,4 +304,151 @@ func (s *Server) validateGoTemplate(content, leftDelim, rightDelim string) (*mcp
 	}
 
 	return mcp.NewToolResultJSON(response)
+}
+
+// handleValidateExpressions batch-validates multiple CEL and Go-template expressions.
+func (s *Server) handleValidateExpressions(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	exprsRaw, ok := args["expressions"]
+	if !ok || exprsRaw == nil {
+		return newStructuredError(ErrCodeInvalidInput, "'expressions' is required",
+			WithField("expressions"),
+			WithSuggestion("Provide an array of {expression, type} objects"),
+		), nil
+	}
+
+	exprList, ok := exprsRaw.([]any)
+	if !ok {
+		return newStructuredError(ErrCodeInvalidInput, "'expressions' must be an array of {expression, type} objects",
+			WithField("expressions"),
+			WithSuggestion("Use an array format: [{\"expression\": \"...\", \"type\": \"cel\"}]"),
+		), nil
+	}
+
+	if len(exprList) == 0 {
+		return newStructuredError(ErrCodeInvalidInput, "'expressions' array must not be empty",
+			WithField("expressions"),
+			WithSuggestion("Provide at least one expression to validate"),
+		), nil
+	}
+
+	type validationResult struct {
+		Index      int      `json:"index"`
+		Expression string   `json:"expression"`
+		Type       string   `json:"type"`
+		Valid      bool     `json:"valid"`
+		Error      string   `json:"error,omitempty"`
+		References []string `json:"references,omitempty"`
+	}
+
+	results := make([]validationResult, 0, len(exprList))
+	validCount := 0
+	invalidCount := 0
+
+	for i, item := range exprList {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			results = append(results, validationResult{
+				Index: i,
+				Valid: false,
+				Error: "each item must be an object with 'expression' and 'type' fields",
+			})
+			invalidCount++
+			continue
+		}
+
+		expr, _ := obj["expression"].(string)
+		exprType, _ := obj["type"].(string)
+
+		if expr == "" {
+			results = append(results, validationResult{
+				Index: i,
+				Type:  exprType,
+				Valid: false,
+				Error: "'expression' field is required and must not be empty",
+			})
+			invalidCount++
+			continue
+		}
+
+		entry := validationResult{
+			Index:      i,
+			Expression: expr,
+			Type:       exprType,
+		}
+
+		switch exprType {
+		case "cel":
+			valid, errMsg := s.validateCELExpressionDirect(expr)
+			entry.Valid = valid
+			if errMsg != "" {
+				entry.Error = errMsg
+			}
+		case "go-template":
+			valid, errMsg, refs := s.validateGoTemplateDirect(expr)
+			entry.Valid = valid
+			if errMsg != "" {
+				entry.Error = errMsg
+			}
+			if len(refs) > 0 {
+				entry.References = refs
+			}
+		default:
+			entry.Valid = false
+			entry.Error = fmt.Sprintf("unknown expression type %q — use 'cel' or 'go-template'", exprType)
+		}
+
+		if entry.Valid {
+			validCount++
+		} else {
+			invalidCount++
+		}
+		results = append(results, entry)
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"results": results,
+		"summary": map[string]any{
+			"total":   len(results),
+			"valid":   validCount,
+			"invalid": invalidCount,
+		},
+	})
+}
+
+// validateCELExpressionDirect validates a CEL expression and returns (valid, errorMsg).
+func (s *Server) validateCELExpressionDirect(expression string) (bool, string) {
+	env, err := cel.NewEnv()
+	if err != nil {
+		return false, fmt.Sprintf("failed to create CEL environment: %v", err)
+	}
+	_, issues := env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return false, issues.Err().Error()
+	}
+	return true, ""
+}
+
+// validateGoTemplateDirect validates a Go template and returns (valid, errorMsg, references).
+func (s *Server) validateGoTemplateDirect(content string) (bool, string, []string) {
+	tmpl := template.New("mcp-batch-validate")
+	_, err := tmpl.Parse(content)
+	if err != nil {
+		return false, err.Error(), nil
+	}
+
+	// Extract references
+	opts := gotmpl.TemplateOptions{
+		Content: content,
+		Name:    "mcp-batch-validate",
+	}
+	svc := gotmpl.NewService(nil)
+	tmplRefs, _ := svc.GetReferences(s.ctx, opts)
+
+	var refs []string
+	for _, r := range tmplRefs {
+		refs = append(refs, r.Path)
+	}
+
+	return true, "", refs
 }

--- a/pkg/mcp/tools_testing.go
+++ b/pkg/mcp/tools_testing.go
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+)
+
+// registerTestingTools registers test scaffold and discovery MCP tools.
+func (s *Server) registerTestingTools() {
+	// generate_test_scaffold
+	genTestTool := mcp.NewTool("generate_test_scaffold",
+		mcp.WithDescription("Analyze a solution and generate a starter functional test scaffold. Examines resolvers (types, parameters, transforms) and workflow actions (providers, dependencies) to produce test cases with appropriate assertions. The generated YAML can be added to the solution's spec.testing section."),
+		mcp.WithTitleAnnotation("Generate Test Scaffold"),
+		mcp.WithToolIcons(toolIcons["testing"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to the solution file to generate tests for"),
+		),
+	)
+	s.mcpServer.AddTool(genTestTool, s.handleGenerateTestScaffold)
+
+	// list_tests
+	listTestsTool := mcp.NewTool("list_tests",
+		mcp.WithDescription("Discover and list functional tests defined in solutions without executing them. Returns test names, tags, commands, expected behavior, and skip status. Use this to understand what tests exist before calling run_solution_tests."),
+		mcp.WithTitleAnnotation("List Tests"),
+		mcp.WithToolIcons(toolIcons["testing"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Description("Path to a solution file or directory containing solutions with tests"),
+		),
+		mcp.WithString("filter",
+			mcp.Description("Filter test names by glob pattern (e.g., 'smoke-*')"),
+		),
+		mcp.WithString("tag",
+			mcp.Description("Filter tests by tag (e.g., 'smoke', 'validation')"),
+		),
+		mcp.WithBoolean("include_builtins",
+			mcp.Description("Include built-in tests (lint, parse). Default: false"),
+		),
+	)
+	s.mcpServer.AddTool(listTestsTool, s.handleListTests)
+}
+
+// handleGenerateTestScaffold generates a starter test scaffold for a solution.
+func (s *Server) handleGenerateTestScaffold(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide the path to a solution file"),
+			WithRelatedTools("inspect_solution"),
+		), nil
+	}
+
+	sol, err := explain.LoadSolution(s.ctx, path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the file exists and contains valid solution YAML"),
+			WithRelatedTools("lint_solution"),
+		), nil
+	}
+
+	input := &soltesting.ScaffoldInput{
+		Resolvers: sol.Spec.Resolvers,
+		Workflow:  sol.Spec.Workflow,
+	}
+
+	result := soltesting.Scaffold(input)
+
+	yamlBytes, err := soltesting.ScaffoldToYAML(result)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to generate YAML: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
+	}
+
+	// Analyze coverage
+	resolversWithTests := []string{}
+	resolversWithoutTests := []string{}
+	actionsWithTests := []string{}
+	actionsWithoutTests := []string{}
+
+	if sol.Spec.HasResolvers() {
+		for name := range sol.Spec.Resolvers {
+			testName := "resolve-" + name
+			if _, ok := result.Cases[testName]; ok {
+				resolversWithTests = append(resolversWithTests, name)
+			} else {
+				resolversWithoutTests = append(resolversWithoutTests, name)
+			}
+		}
+	}
+
+	if sol.Spec.HasWorkflow() && sol.Spec.Workflow.Actions != nil {
+		for name := range sol.Spec.Workflow.Actions {
+			testName := "action-" + name
+			if _, ok := result.Cases[testName]; ok {
+				actionsWithTests = append(actionsWithTests, name)
+			} else {
+				actionsWithoutTests = append(actionsWithoutTests, name)
+			}
+		}
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"yaml":      string(yamlBytes),
+		"testCount": len(result.Cases),
+		"coverage": map[string]any{
+			"resolversWithTests":    resolversWithTests,
+			"resolversWithoutTests": resolversWithoutTests,
+			"actionsWithTests":      actionsWithTests,
+			"actionsWithoutTests":   actionsWithoutTests,
+		},
+		"nextSteps": []string{
+			"Review and customize the test assertions",
+			"Add edge case tests for error conditions",
+			"Run run_solution_tests to verify tests pass",
+		},
+	})
+}
+
+// handleListTests discovers and lists tests without executing them.
+func (s *Server) handleListTests(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path := request.GetString("path", ".")
+	filter := request.GetString("filter", "")
+	tag := request.GetString("tag", "")
+
+	solutions, err := soltesting.DiscoverSolutions(path)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to discover tests: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the path exists and contains solution files with test sections"),
+			WithRelatedTools("generate_test_scaffold"),
+		), nil
+	}
+
+	// Apply filters
+	filterOpts := soltesting.FilterOptions{}
+	if filter != "" {
+		filterOpts.NamePatterns = []string{filter}
+	}
+	if tag != "" {
+		filterOpts.Tags = []string{tag}
+	}
+	if filterOpts.NamePatterns != nil || filterOpts.Tags != nil {
+		solutions = soltesting.FilterTests(solutions, filterOpts)
+	}
+
+	// Build response
+	type testInfo struct {
+		Name           string   `json:"name"`
+		Description    string   `json:"description,omitempty"`
+		Command        []string `json:"command,omitempty"`
+		Tags           []string `json:"tags,omitempty"`
+		Skip           bool     `json:"skip,omitempty"`
+		SkipReason     string   `json:"skipReason,omitempty"`
+		AssertionCount int      `json:"assertionCount"`
+	}
+
+	type solutionInfo struct {
+		Solution string     `json:"solution"`
+		File     string     `json:"file"`
+		Tests    []testInfo `json:"tests"`
+	}
+
+	var solutionResults []solutionInfo
+	totalTests := 0
+
+	for _, st := range solutions {
+		var tests []testInfo
+		for _, name := range soltesting.SortedTestNames(st) {
+			tc := st.Cases[name]
+			ti := testInfo{
+				Name:           name,
+				Description:    tc.Description,
+				Command:        tc.Command,
+				Tags:           tc.Tags,
+				Skip:           tc.Skip,
+				SkipReason:     tc.SkipReason,
+				AssertionCount: len(tc.Assertions),
+			}
+			tests = append(tests, ti)
+		}
+		totalTests += len(tests)
+
+		solutionResults = append(solutionResults, solutionInfo{
+			Solution: st.SolutionName,
+			File:     st.FilePath,
+			Tests:    tests,
+		})
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"solutions":      solutionResults,
+		"totalTests":     totalTests,
+		"totalSolutions": len(solutionResults),
+	})
+}

--- a/pkg/mcp/tools_testing_test.go
+++ b/pkg/mcp/tools_testing_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGenerateTestScaffold(t *testing.T) {
+	t.Run("generates scaffold for solution with resolvers", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Find a solution file with resolvers
+		solPath := findTestSolutionFile(t)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "generate_test_scaffold"
+		request.Params.Arguments = map[string]any{
+			"path": solPath,
+		}
+
+		result, err := srv.handleGenerateTestScaffold(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.NotEmpty(t, data["yaml"])
+		testCount := data["testCount"].(float64)
+		assert.Greater(t, testCount, float64(0))
+
+		coverage, ok := data["coverage"].(map[string]any)
+		require.True(t, ok)
+		assert.Contains(t, coverage, "resolversWithTests")
+		assert.Contains(t, coverage, "resolversWithoutTests")
+
+		nextSteps, ok := data["nextSteps"].([]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, nextSteps)
+	})
+
+	t.Run("requires path parameter", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleGenerateTestScaffold(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("errors on nonexistent file", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/solution.yaml",
+		}
+
+		result, err := srv.handleGenerateTestScaffold(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleListTests(t *testing.T) {
+	t.Run("discovers tests in solution file", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Find a solution with tests
+		solPath := findTestSolutionWithTests(t)
+		if solPath == "" {
+			t.Skip("no solution with tests found")
+		}
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_tests"
+		request.Params.Arguments = map[string]any{
+			"path": solPath,
+		}
+
+		result, err := srv.handleListTests(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		totalTests := data["totalTests"].(float64)
+		assert.Greater(t, totalTests, float64(0))
+
+		totalSolutions := data["totalSolutions"].(float64)
+		assert.Greater(t, totalSolutions, float64(0))
+
+		solutions, ok := data["solutions"].([]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, solutions)
+
+		firstSol := solutions[0].(map[string]any)
+		assert.NotEmpty(t, firstSol["solution"])
+		tests := firstSol["tests"].([]any)
+		assert.NotEmpty(t, tests)
+	})
+
+	t.Run("errors on nonexistent path", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/dir",
+		}
+
+		result, err := srv.handleListTests(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+// findTestSolutionFile locates a solution YAML file suitable for testing.
+func findTestSolutionFile(t *testing.T) string {
+	t.Helper()
+
+	// Try examples directory first
+	candidates := []string{
+		"examples/solutions/email-notifier/solution.yaml",
+		"examples/solutions/comprehensive/solution.yaml",
+		"examples/solutions/terraform/solution.yaml",
+	}
+
+	for _, c := range candidates {
+		path := filepath.Join(projectRoot(t), c)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	t.Fatal("no test solution file found")
+	return ""
+}
+
+// findTestSolutionWithTests locates a solution file that has spec.testing.cases.
+func findTestSolutionWithTests(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"examples/solutions/tested-solution/solution.yaml",
+		"examples/solutions/comprehensive/solution.yaml",
+	}
+
+	for _, c := range candidates {
+		path := filepath.Join(projectRoot(t), c)
+		if _, err := os.Stat(path); err == nil {
+			content, err := os.ReadFile(path)
+			if err == nil && contains(string(content), "testing:") {
+				return path
+			}
+		}
+	}
+
+	return ""
+}
+
+// projectRoot returns the project root directory.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	// pkg/mcp/ is 2 levels from root
+	dir, err := filepath.Abs(filepath.Join(".", "..", ".."))
+	require.NoError(t, err)
+	return dir
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && len(substr) > 0 && findString(s, substr) >= 0
+}
+
+func findString(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/mcp/tools_version.go
+++ b/pkg/mcp/tools_version.go
@@ -1,0 +1,35 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// registerVersionTools registers version-related MCP tools.
+func (s *Server) registerVersionTools() {
+	getVersionTool := mcp.NewTool("get_version",
+		mcp.WithDescription("Return the scafctl version, build time, and commit hash. Useful for environment context, bug reports, and compatibility checks."),
+		mcp.WithTitleAnnotation("Get Version"),
+		mcp.WithToolIcons(toolIcons["version"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithRawOutputSchema(outputSchemaVersion),
+	)
+	s.mcpServer.AddTool(getVersionTool, s.handleGetVersion)
+}
+
+// handleGetVersion returns the scafctl version information.
+func (s *Server) handleGetVersion(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultJSON(map[string]any{
+		"version":   settings.VersionInformation.BuildVersion,
+		"commit":    settings.VersionInformation.Commit,
+		"buildTime": settings.VersionInformation.BuildTime,
+	})
+}

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -146,6 +146,55 @@ func NewHTTPProvider() *HTTPProvider {
 					schemahelper.WithExample(30),
 					schemahelper.WithMaximum(*ptrs.Float64Ptr(300.0))),
 				"retry": schemahelper.AnyProp("Retry configuration for transient failures"),
+				"pagination": schemahelper.ObjectProp("Pagination configuration for automatically following paginated API responses", []string{"strategy", "maxPages"}, map[string]*jsonschema.Schema{
+					"strategy": schemahelper.StringProp("Pagination strategy to use",
+						schemahelper.WithEnum("offset", "pageNumber", "cursor", "linkHeader", "custom"),
+						schemahelper.WithExample("cursor")),
+					"maxPages": schemahelper.IntProp("Maximum number of pages to fetch (safety limit to prevent infinite loops)",
+						schemahelper.WithExample(10),
+						schemahelper.WithMaximum(*ptrs.Float64Ptr(10000)),
+						schemahelper.WithDefault(100)),
+					"offsetParam": schemahelper.StringProp("Query parameter name for offset (offset strategy, default: 'offset')",
+						schemahelper.WithExample("offset"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(100))),
+					"limitParam": schemahelper.StringProp("Query parameter name for limit (offset strategy, default: 'limit')",
+						schemahelper.WithExample("limit"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(100))),
+					"limit": schemahelper.IntProp("Page size for offset strategy",
+						schemahelper.WithExample(50),
+						schemahelper.WithMaximum(*ptrs.Float64Ptr(10000))),
+					"pageParam": schemahelper.StringProp("Query parameter name for page number (pageNumber strategy, default: 'page')",
+						schemahelper.WithExample("page"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(100))),
+					"pageSizeParam": schemahelper.StringProp("Query parameter name for page size (pageNumber strategy, default: 'pageSize')",
+						schemahelper.WithExample("pageSize"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(100))),
+					"pageSize": schemahelper.IntProp("Page size for pageNumber strategy",
+						schemahelper.WithExample(50),
+						schemahelper.WithMaximum(*ptrs.Float64Ptr(10000))),
+					"startPage": schemahelper.IntProp("Starting page number for pageNumber strategy (default: 1)",
+						schemahelper.WithExample(1),
+						schemahelper.WithDefault(1)),
+					"nextTokenPath": schemahelper.StringProp("CEL expression to extract the next cursor/token from the response body (cursor strategy)",
+						schemahelper.WithExample("body.nextToken"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+					"nextTokenParam": schemahelper.StringProp("Query parameter name to set the cursor/token on the next request (cursor strategy)",
+						schemahelper.WithExample("cursor"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(100))),
+					"nextURLPath": schemahelper.StringProp("CEL expression to extract the full next page URL from the response body (cursor strategy)",
+						schemahelper.WithExample("body['@odata.nextLink']"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+					"nextURL": schemahelper.StringProp("CEL expression that returns the full URL for the next request; null/empty stops pagination (custom strategy)",
+						schemahelper.WithMaxLength(*ptrs.IntPtr(1000))),
+					"nextParams": schemahelper.StringProp("CEL expression that returns a map of query params for the next request (custom strategy)",
+						schemahelper.WithMaxLength(*ptrs.IntPtr(1000))),
+					"stopWhen": schemahelper.StringProp("CEL expression evaluated against each response; if true, pagination stops. Available variables: statusCode, body, rawBody, headers, page",
+						schemahelper.WithExample("size(body.items) == 0"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+					"collectPath": schemahelper.StringProp("CEL expression to extract items from each page's response body. Items are accumulated across pages into a single array.",
+						schemahelper.WithExample("body.items"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+				}),
 				"authProvider": schemahelper.StringProp("Authentication provider to use for this request (e.g., 'entra'). When set, the provider will automatically obtain and inject an access token.",
 					schemahelper.WithExample("entra"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(50))),
@@ -155,20 +204,26 @@ func NewHTTPProvider() *HTTPProvider {
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"statusCode": schemahelper.IntProp("HTTP response status code", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string"),
-					"headers":    schemahelper.AnyProp("Response headers"),
+					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"statusCode": schemahelper.IntProp("HTTP response status code", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string"),
-					"headers":    schemahelper.AnyProp("Response headers"),
+					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success":    schemahelper.BoolProp("Whether the HTTP request completed successfully (2xx status)"),
-					"statusCode": schemahelper.IntProp("HTTP response status code", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string"),
-					"headers":    schemahelper.AnyProp("Response headers"),
+					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 			},
 			Examples: []provider.Example{
@@ -224,6 +279,102 @@ inputs:
   method: GET
   authProvider: entra
   scope: "https://graph.microsoft.com/.default"`,
+				},
+				{
+					Name:        "Cursor-based pagination",
+					Description: "Fetch all pages from an API using cursor-based pagination with a token extracted from the response body",
+					YAML: `name: fetch-all-items
+provider: http
+inputs:
+  url: "https://api.example.com/items"
+  method: GET
+  pagination:
+    strategy: cursor
+    maxPages: 10
+    nextTokenPath: "body.nextCursor"
+    nextTokenParam: "cursor"
+    collectPath: "body.items"
+    stopWhen: "body.nextCursor == null"`,
+				},
+				{
+					Name:        "Cursor-based pagination with nextURL",
+					Description: "Fetch all pages from a Microsoft Graph or OData API where the response body contains the full next page URL",
+					YAML: `name: fetch-graph-users
+provider: http
+inputs:
+  url: "https://graph.microsoft.com/v1.0/users?$top=100"
+  method: GET
+  authProvider: entra
+  scope: "https://graph.microsoft.com/.default"
+  pagination:
+    strategy: cursor
+    maxPages: 50
+    nextURLPath: "body['@odata.nextLink']"
+    collectPath: "body.value"`,
+				},
+				{
+					Name:        "Link header pagination",
+					Description: "Follow RFC 8288 Link header pagination (used by GitHub, GitLab, and other REST APIs)",
+					YAML: `name: fetch-github-repos
+provider: http
+inputs:
+  url: "https://api.github.com/users/octocat/repos?per_page=30"
+  method: GET
+  headers:
+    Accept: "application/vnd.github+json"
+  pagination:
+    strategy: linkHeader
+    maxPages: 5
+    collectPath: "body"`,
+				},
+				{
+					Name:        "Offset-based pagination",
+					Description: "Paginate through results using offset and limit query parameters",
+					YAML: `name: fetch-all-records
+provider: http
+inputs:
+  url: "https://api.example.com/records"
+  method: GET
+  pagination:
+    strategy: offset
+    maxPages: 20
+    limit: 50
+    offsetParam: "offset"
+    limitParam: "limit"
+    collectPath: "body.records"
+    stopWhen: "size(body.records) < 50"`,
+				},
+				{
+					Name:        "Page number pagination",
+					Description: "Paginate through results using page number and page size query parameters",
+					YAML: `name: fetch-paginated
+provider: http
+inputs:
+  url: "https://api.example.com/products"
+  method: GET
+  pagination:
+    strategy: pageNumber
+    maxPages: 10
+    pageSize: 25
+    pageParam: "page"
+    pageSizeParam: "per_page"
+    collectPath: "body.products"
+    stopWhen: "size(body.products) == 0"`,
+				},
+				{
+					Name:        "Custom pagination with CEL",
+					Description: "Use custom CEL expressions for full control over pagination logic",
+					YAML: `name: fetch-custom-paginated
+provider: http
+inputs:
+  url: "https://api.example.com/search?q=test"
+  method: GET
+  pagination:
+    strategy: custom
+    maxPages: 10
+    nextURL: "has(body.links) && has(body.links.next) ? body.links.next : ''"
+    collectPath: "body.results"
+    stopWhen: "!has(body.links) || !has(body.links.next)"`,
 				},
 			},
 		},
@@ -358,7 +509,20 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		}
 	}
 
-	return p.execute(ctx, httpc.NewClient(httpcCfg), method, urlStr, bodyContent, headers)
+	// Parse pagination configuration
+	pagCfg, err := parsePaginationConfig(inputs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	httpClient := httpc.NewClient(httpcCfg)
+
+	// If pagination is configured, use the paginated execution path
+	if pagCfg != nil {
+		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg)
+	}
+
+	return p.execute(ctx, httpClient, method, urlStr, bodyContent, headers)
 }
 
 // buildHTTPClientConfig translates provider timeout and retry config into an httpc.ClientConfig.

--- a/pkg/provider/builtin/httpprovider/pagination.go
+++ b/pkg/provider/builtin/httpprovider/pagination.go
@@ -1,0 +1,672 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// Pagination strategy constants.
+const (
+	StrategyOffset     = "offset"
+	StrategyPageNumber = "pageNumber"
+	StrategyCursor     = "cursor"
+	StrategyLinkHeader = "linkHeader"
+	StrategyCustom     = "custom"
+)
+
+// paginationConfig holds parsed pagination configuration for HTTP requests.
+type paginationConfig struct {
+	Strategy string // "offset", "pageNumber", "cursor", "linkHeader", "custom"
+	MaxPages int    // Safety limit to prevent infinite loops (required)
+
+	// --- offset strategy ---
+	OffsetParam string // Query parameter name for offset (default: "offset")
+	LimitParam  string // Query parameter name for limit (default: "limit")
+	Limit       int    // Page size (required for offset strategy)
+
+	// --- pageNumber strategy ---
+	PageParam     string // Query parameter name for page number (default: "page")
+	PageSizeParam string // Query parameter name for page size (default: "pageSize")
+	PageSize      int    // Page size (required for pageNumber strategy)
+	StartPage     int    // Starting page number (default: 1)
+
+	// --- cursor strategy ---
+	NextTokenPath  string // CEL expression to extract next cursor/token from response body
+	NextTokenParam string // Query parameter name to set the cursor/token on the next request
+	NextURLPath    string // CEL expression to extract full next URL from response body (alternative to NextTokenParam)
+
+	// --- custom strategy ---
+	NextURL    string // CEL expression that returns the full URL for the next request (null/empty = stop)
+	NextParams string // CEL expression that returns a map of query params for the next request
+
+	// --- universal ---
+	StopWhen    string // CEL expression evaluated against each response; true = stop paginating
+	CollectPath string // CEL expression to extract items from each page's response body
+}
+
+// defaultPaginationConfig returns defaults for pagination config.
+func defaultPaginationConfig() paginationConfig {
+	return paginationConfig{
+		MaxPages:      100,
+		StartPage:     1,
+		OffsetParam:   "offset",
+		LimitParam:    "limit",
+		PageParam:     "page",
+		PageSizeParam: "pageSize",
+	}
+}
+
+// parsePaginationConfig parses pagination configuration from inputs.
+// Returns nil if no pagination configuration is present.
+func parsePaginationConfig(inputs map[string]any) (*paginationConfig, error) {
+	paginationInput, ok := inputs["pagination"]
+	if !ok || paginationInput == nil {
+		return nil, nil
+	}
+
+	pagMap, ok := paginationInput.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("pagination: expected object, got %T", paginationInput)
+	}
+
+	cfg := defaultPaginationConfig()
+
+	// Required field: strategy
+	strategy, ok := pagMap["strategy"].(string)
+	if !ok || strategy == "" {
+		return nil, fmt.Errorf("pagination: strategy is required")
+	}
+	switch strategy {
+	case StrategyOffset, StrategyPageNumber, StrategyCursor, StrategyLinkHeader, StrategyCustom:
+		cfg.Strategy = strategy
+	default:
+		return nil, fmt.Errorf("pagination: unknown strategy %q (must be one of: offset, pageNumber, cursor, linkHeader, custom)", strategy)
+	}
+
+	// Required field: maxPages
+	if mp, ok := pagMap["maxPages"].(int); ok && mp > 0 {
+		cfg.MaxPages = mp
+	}
+	if mp, ok := pagMap["maxPages"].(float64); ok && mp > 0 {
+		cfg.MaxPages = int(mp)
+	}
+
+	// Universal optional fields
+	if sw, ok := pagMap["stopWhen"].(string); ok {
+		cfg.StopWhen = sw
+	}
+	if cp, ok := pagMap["collectPath"].(string); ok {
+		cfg.CollectPath = cp
+	}
+
+	// Strategy-specific fields
+	switch cfg.Strategy {
+	case StrategyOffset:
+		if op, ok := pagMap["offsetParam"].(string); ok && op != "" {
+			cfg.OffsetParam = op
+		}
+		if lp, ok := pagMap["limitParam"].(string); ok && lp != "" {
+			cfg.LimitParam = lp
+		}
+		if l, ok := pagMap["limit"].(int); ok && l > 0 {
+			cfg.Limit = l
+		}
+		if l, ok := pagMap["limit"].(float64); ok && l > 0 {
+			cfg.Limit = int(l)
+		}
+		if cfg.Limit <= 0 {
+			return nil, fmt.Errorf("pagination: limit is required for offset strategy")
+		}
+
+	case StrategyPageNumber:
+		if pp, ok := pagMap["pageParam"].(string); ok && pp != "" {
+			cfg.PageParam = pp
+		}
+		if psp, ok := pagMap["pageSizeParam"].(string); ok && psp != "" {
+			cfg.PageSizeParam = psp
+		}
+		if ps, ok := pagMap["pageSize"].(int); ok && ps > 0 {
+			cfg.PageSize = ps
+		}
+		if ps, ok := pagMap["pageSize"].(float64); ok && ps > 0 {
+			cfg.PageSize = int(ps)
+		}
+		if sp, ok := pagMap["startPage"].(int); ok && sp >= 0 {
+			cfg.StartPage = sp
+		}
+		if sp, ok := pagMap["startPage"].(float64); ok && sp >= 0 {
+			cfg.StartPage = int(sp)
+		}
+		if cfg.PageSize <= 0 {
+			return nil, fmt.Errorf("pagination: pageSize is required for pageNumber strategy")
+		}
+
+	case StrategyCursor:
+		if ntp, ok := pagMap["nextTokenPath"].(string); ok {
+			cfg.NextTokenPath = ntp
+		}
+		if ntparam, ok := pagMap["nextTokenParam"].(string); ok {
+			cfg.NextTokenParam = ntparam
+		}
+		if nup, ok := pagMap["nextURLPath"].(string); ok {
+			cfg.NextURLPath = nup
+		}
+		// Validate: must have nextTokenPath or nextURLPath
+		if cfg.NextTokenPath == "" && cfg.NextURLPath == "" {
+			return nil, fmt.Errorf("pagination: cursor strategy requires nextTokenPath or nextURLPath")
+		}
+		// If nextTokenPath is set, nextTokenParam is required
+		if cfg.NextTokenPath != "" && cfg.NextTokenParam == "" {
+			return nil, fmt.Errorf("pagination: nextTokenParam is required when nextTokenPath is set")
+		}
+
+	case StrategyLinkHeader:
+		// No additional config required — follows rel="next" automatically
+
+	case StrategyCustom:
+		if nu, ok := pagMap["nextURL"].(string); ok {
+			cfg.NextURL = nu
+		}
+		if np, ok := pagMap["nextParams"].(string); ok {
+			cfg.NextParams = np
+		}
+		if cfg.NextURL == "" && cfg.NextParams == "" {
+			return nil, fmt.Errorf("pagination: custom strategy requires nextURL or nextParams")
+		}
+	}
+
+	return &cfg, nil
+}
+
+// paginatedResponse holds the response data from a single page.
+type paginatedResponse struct {
+	StatusCode int
+	Body       string
+	Headers    map[string]any
+}
+
+// executePaginated performs paginated HTTP requests using the configured strategy.
+// It collects items from each page and returns a merged output.
+func (p *HTTPProvider) executePaginated(
+	ctx context.Context,
+	client *httpc.Client,
+	method, urlStr, bodyContent string,
+	headers map[string]any,
+	pagCfg *paginationConfig,
+) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	var allItems []any
+	var lastResponse *paginatedResponse
+	pageCount := 0
+	currentURL := urlStr
+
+	for pageCount < pagCfg.MaxPages {
+		pageCount++
+		lgr.V(1).Info("fetching page", "provider", ProviderName, "page", pageCount, "url", currentURL)
+
+		// Execute the request for this page
+		resp, err := p.doRequest(ctx, client, method, currentURL, bodyContent, headers)
+		if err != nil {
+			return nil, fmt.Errorf("%s: page %d request failed: %w", ProviderName, pageCount, err)
+		}
+		lastResponse = resp
+
+		// Parse body as JSON for CEL evaluation
+		var bodyData any
+		if resp.Body != "" {
+			if err := json.Unmarshal([]byte(resp.Body), &bodyData); err != nil {
+				// If body isn't JSON, make it available as a string
+				bodyData = resp.Body
+			}
+		}
+
+		// Build response context for CEL expressions
+		responseCtx := map[string]any{
+			"statusCode": resp.StatusCode,
+			"body":       bodyData,
+			"rawBody":    resp.Body,
+			"headers":    resp.Headers,
+			"page":       pageCount,
+		}
+
+		// Collect items from this page
+		if pagCfg.CollectPath != "" {
+			items, err := evaluateCEL(ctx, pagCfg.CollectPath, responseCtx)
+			if err != nil {
+				return nil, fmt.Errorf("%s: page %d collectPath evaluation failed: %w", ProviderName, pageCount, err)
+			}
+			if itemSlice, ok := items.([]any); ok {
+				allItems = append(allItems, itemSlice...)
+			} else if items != nil {
+				allItems = append(allItems, items)
+			}
+		} else if bodyData != nil {
+			// No collectPath: accumulate the raw body data
+			allItems = append(allItems, bodyData)
+		}
+
+		// Check stopWhen condition
+		if pagCfg.StopWhen != "" {
+			shouldStop, err := evaluateCEL(ctx, pagCfg.StopWhen, responseCtx)
+			if err != nil {
+				return nil, fmt.Errorf("%s: page %d stopWhen evaluation failed: %w", ProviderName, pageCount, err)
+			}
+			if boolVal, ok := shouldStop.(bool); ok && boolVal {
+				lgr.V(1).Info("pagination stopped by stopWhen condition", "page", pageCount)
+				break
+			}
+		}
+
+		// Determine next page URL based on strategy
+		nextURL, stop, err := p.resolveNextPage(ctx, pagCfg, currentURL, resp, responseCtx)
+		if err != nil {
+			return nil, fmt.Errorf("%s: page %d failed to resolve next page: %w", ProviderName, pageCount, err)
+		}
+		if stop {
+			lgr.V(1).Info("pagination completed", "page", pageCount, "reason", "no more pages")
+			break
+		}
+
+		currentURL = nextURL
+	}
+
+	lgr.V(1).Info("pagination finished", "totalPages", pageCount, "totalItems", len(allItems))
+
+	// Build output
+	return p.buildPaginatedOutput(lastResponse, allItems, pageCount)
+}
+
+// doRequest performs a single HTTP request and returns the parsed response.
+func (p *HTTPProvider) doRequest(
+	ctx context.Context,
+	client *httpc.Client,
+	method, urlStr, bodyContent string,
+	headers map[string]any,
+) (*paginatedResponse, error) {
+	var bodyReader io.Reader
+	if bodyContent != "" {
+		bodyReader = strings.NewReader(bodyContent)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Provide GetBody so the httpc OnUnauthorized hook can replay the body on an auth retry.
+	if bodyContent != "" {
+		capturedBody := bodyContent
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(capturedBody)), nil
+		}
+	}
+
+	for key, value := range headers {
+		if strValue, ok := value.(string); ok {
+			req.Header.Set(key, strValue)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	respHeaders := make(map[string]any)
+	for key, values := range resp.Header {
+		if len(values) == 1 {
+			respHeaders[key] = values[0]
+		} else {
+			respHeaders[key] = values
+		}
+	}
+
+	return &paginatedResponse{
+		StatusCode: resp.StatusCode,
+		Body:       string(respBody),
+		Headers:    respHeaders,
+	}, nil
+}
+
+// resolveNextPage determines the URL for the next page based on the pagination strategy.
+// Returns (nextURL, stop, error). If stop is true, pagination should end.
+func (p *HTTPProvider) resolveNextPage(
+	ctx context.Context,
+	pagCfg *paginationConfig,
+	currentURL string,
+	resp *paginatedResponse,
+	responseCtx map[string]any,
+) (string, bool, error) {
+	switch pagCfg.Strategy {
+	case StrategyOffset:
+		return resolveOffsetNext(currentURL, pagCfg, responseCtx)
+	case StrategyPageNumber:
+		return resolvePageNumberNext(currentURL, pagCfg, responseCtx)
+	case StrategyCursor:
+		return resolveCursorNext(ctx, currentURL, pagCfg, responseCtx)
+	case StrategyLinkHeader:
+		return resolveLinkHeaderNext(resp)
+	case StrategyCustom:
+		return resolveCustomNext(ctx, currentURL, pagCfg, responseCtx)
+	default:
+		return "", true, fmt.Errorf("unknown pagination strategy: %q", pagCfg.Strategy)
+	}
+}
+
+// resolveOffsetNext increments the offset parameter for the next page.
+func resolveOffsetNext(currentURL string, pagCfg *paginationConfig, responseCtx map[string]any) (string, bool, error) {
+	u, err := url.Parse(currentURL)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+
+	// Determine current offset
+	currentOffset := 0
+	if offsetStr := q.Get(pagCfg.OffsetParam); offsetStr != "" {
+		if parsed, err := strconv.Atoi(offsetStr); err == nil {
+			currentOffset = parsed
+		}
+	}
+
+	// Check if we got fewer items than the limit (last page)
+	page, _ := responseCtx["page"].(int)
+	if page > 1 {
+		if shouldStop := checkItemCountStop(responseCtx, pagCfg); shouldStop {
+			return "", true, nil
+		}
+	}
+
+	// Set next offset
+	nextOffset := currentOffset + pagCfg.Limit
+	q.Set(pagCfg.OffsetParam, strconv.Itoa(nextOffset))
+	q.Set(pagCfg.LimitParam, strconv.Itoa(pagCfg.Limit))
+	u.RawQuery = q.Encode()
+
+	return u.String(), false, nil
+}
+
+// resolvePageNumberNext increments the page number parameter for the next page.
+func resolvePageNumberNext(currentURL string, pagCfg *paginationConfig, responseCtx map[string]any) (string, bool, error) {
+	u, err := url.Parse(currentURL)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+
+	// Determine current page
+	currentPage := pagCfg.StartPage
+	if pageStr := q.Get(pagCfg.PageParam); pageStr != "" {
+		if parsed, err := strconv.Atoi(pageStr); err == nil {
+			currentPage = parsed
+		}
+	}
+
+	// Check if we got fewer items than pageSize (last page)
+	page, _ := responseCtx["page"].(int)
+	if page > 1 {
+		if shouldStop := checkItemCountStop(responseCtx, pagCfg); shouldStop {
+			return "", true, nil
+		}
+	}
+
+	// Set next page
+	nextPage := currentPage + 1
+	q.Set(pagCfg.PageParam, strconv.Itoa(nextPage))
+	q.Set(pagCfg.PageSizeParam, strconv.Itoa(pagCfg.PageSize))
+	u.RawQuery = q.Encode()
+
+	return u.String(), false, nil
+}
+
+// isNullOrEmpty checks if a CEL evaluation result represents an absent/null/empty value.
+// CEL null values are returned as structpb.NullValue (int32) after type conversion.
+func isNullOrEmpty(result any) bool {
+	if result == nil {
+		return true
+	}
+	// CEL null values come through as structpb.NullValue after conversion
+	if _, ok := result.(structpb.NullValue); ok {
+		return true
+	}
+	if s, ok := result.(string); ok {
+		return s == ""
+	}
+	return false
+}
+
+// resolveCursorNext extracts the cursor/token from the response and builds the next URL.
+func resolveCursorNext(ctx context.Context, currentURL string, pagCfg *paginationConfig, responseCtx map[string]any) (string, bool, error) {
+	// If nextURLPath is set, extract the full URL from the response body
+	if pagCfg.NextURLPath != "" {
+		result, err := evaluateCELForPagination(ctx, pagCfg.NextURLPath, responseCtx)
+		if err != nil {
+			return "", true, fmt.Errorf("nextURLPath evaluation failed: %w", err)
+		}
+		if isNullOrEmpty(result) {
+			return "", true, nil // No more pages
+		}
+		nextURL, ok := result.(string)
+		if !ok || nextURL == "" {
+			return "", true, nil // No more pages
+		}
+		return nextURL, false, nil
+	}
+
+	// Extract cursor token from response body
+	result, err := evaluateCELForPagination(ctx, pagCfg.NextTokenPath, responseCtx)
+	if err != nil {
+		return "", true, fmt.Errorf("nextTokenPath evaluation failed: %w", err)
+	}
+	if isNullOrEmpty(result) {
+		return "", true, nil // No more pages
+	}
+	nextToken, ok := result.(string)
+	if !ok {
+		// Try numeric token
+		nextToken = fmt.Sprintf("%v", result)
+	}
+	if nextToken == "" {
+		return "", true, nil // No more pages
+	}
+
+	// Set the cursor token as a query parameter
+	u, err := url.Parse(currentURL)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set(pagCfg.NextTokenParam, nextToken)
+	u.RawQuery = q.Encode()
+
+	return u.String(), false, nil
+}
+
+// linkHeaderRegex matches Link header entries like: <url>; rel="next"
+var linkHeaderRegex = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
+
+// resolveLinkHeaderNext extracts the next URL from the Link response header (RFC 8288).
+func resolveLinkHeaderNext(resp *paginatedResponse) (string, bool, error) {
+	linkHeader, ok := resp.Headers["Link"]
+	if !ok {
+		return "", true, nil // No Link header = no more pages
+	}
+
+	var linkStr string
+	switch v := linkHeader.(type) {
+	case string:
+		linkStr = v
+	case []string:
+		linkStr = strings.Join(v, ", ")
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		linkStr = strings.Join(parts, ", ")
+	default:
+		return "", true, nil
+	}
+
+	matches := linkHeaderRegex.FindStringSubmatch(linkStr)
+	if len(matches) < 2 {
+		return "", true, nil // No rel="next" link
+	}
+
+	return matches[1], false, nil
+}
+
+// resolveCustomNext uses CEL expressions to determine the next page URL.
+func resolveCustomNext(ctx context.Context, currentURL string, pagCfg *paginationConfig, responseCtx map[string]any) (string, bool, error) {
+	// If nextURL expression is set, evaluate it for the full URL
+	if pagCfg.NextURL != "" {
+		result, err := evaluateCELForPagination(ctx, pagCfg.NextURL, responseCtx)
+		if err != nil {
+			return "", true, fmt.Errorf("nextURL evaluation failed: %w", err)
+		}
+		if isNullOrEmpty(result) {
+			return "", true, nil
+		}
+		nextURL, ok := result.(string)
+		if !ok || nextURL == "" {
+			return "", true, nil
+		}
+		return nextURL, false, nil
+	}
+
+	// If nextParams expression is set, evaluate it for query parameter updates
+	if pagCfg.NextParams != "" {
+		result, err := evaluateCELForPagination(ctx, pagCfg.NextParams, responseCtx)
+		if err != nil {
+			return "", true, fmt.Errorf("nextParams evaluation failed: %w", err)
+		}
+		if isNullOrEmpty(result) {
+			return "", true, nil
+		}
+
+		paramsMap, ok := result.(map[string]any)
+		if !ok {
+			return "", true, fmt.Errorf("nextParams must evaluate to a map, got %T", result)
+		}
+		if len(paramsMap) == 0 {
+			return "", true, nil // Empty map = no more pages
+		}
+
+		u, err := url.Parse(currentURL)
+		if err != nil {
+			return "", true, fmt.Errorf("failed to parse URL: %w", err)
+		}
+		q := u.Query()
+		for k, v := range paramsMap {
+			q.Set(k, fmt.Sprintf("%v", v))
+		}
+		u.RawQuery = q.Encode()
+		return u.String(), false, nil
+	}
+
+	return "", true, nil
+}
+
+// checkItemCountStop checks if pagination should stop based on collected item count.
+// For offset and pageNumber strategies, if the response body is a JSON array and
+// has fewer items than the page size, we've reached the last page.
+func checkItemCountStop(responseCtx map[string]any, pagCfg *paginationConfig) bool {
+	bodyData := responseCtx["body"]
+
+	pageSize := pagCfg.Limit
+	if pagCfg.Strategy == StrategyPageNumber {
+		pageSize = pagCfg.PageSize
+	}
+
+	// If body is directly an array
+	if arr, ok := bodyData.([]any); ok {
+		return len(arr) < pageSize
+	}
+
+	return false
+}
+
+// evaluateCEL evaluates a CEL expression with the response context.
+// The response data is available as top-level variables: statusCode, body, rawBody, headers, page.
+func evaluateCEL(ctx context.Context, expression string, responseCtx map[string]any) (any, error) {
+	result, err := celexp.EvaluateExpression(ctx, expression, nil, responseCtx)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// evaluateCELForPagination evaluates a CEL expression for pagination control.
+// Unlike evaluateCEL, key-access errors (e.g., "no such key") are treated as nil
+// results rather than errors, since a missing key typically means "no more pages".
+func evaluateCELForPagination(ctx context.Context, expression string, responseCtx map[string]any) (any, error) {
+	result, err := celexp.EvaluateExpression(ctx, expression, nil, responseCtx)
+	if err != nil {
+		// Treat "no such key" errors as nil (no more pages)
+		if strings.Contains(err.Error(), "no such key") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// buildPaginatedOutput constructs the provider output for paginated requests.
+func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, items []any, pageCount int) (*provider.Output, error) {
+	// Marshal collected items to JSON for the body field
+	var bodyStr string
+	if len(items) > 0 {
+		bodyBytes, err := json.Marshal(items)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to marshal collected items: %w", ProviderName, err)
+		}
+		bodyStr = string(bodyBytes)
+	} else {
+		bodyStr = "[]"
+	}
+
+	var lastStatusCode int
+	var lastHeaders map[string]any
+	if lastResponse != nil {
+		lastStatusCode = lastResponse.StatusCode
+		lastHeaders = lastResponse.Headers
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"statusCode": lastStatusCode,
+			"body":       bodyStr,
+			"headers":    lastHeaders,
+			"pages":      pageCount,
+			"totalItems": len(items),
+		},
+	}, nil
+}

--- a/pkg/provider/builtin/httpprovider/pagination_test.go
+++ b/pkg/provider/builtin/httpprovider/pagination_test.go
@@ -1,0 +1,1158 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- parsePaginationConfig tests ---
+
+func TestParsePaginationConfig_NoPagination(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{})
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestParsePaginationConfig_NilPagination(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{"pagination": nil})
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestParsePaginationConfig_InvalidType(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{"pagination": "invalid"})
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "expected object")
+}
+
+func TestParsePaginationConfig_MissingStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"maxPages": 10,
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "strategy is required")
+}
+
+func TestParsePaginationConfig_UnknownStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "unknown",
+			"maxPages": 10,
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "unknown strategy")
+}
+
+func TestParsePaginationConfig_OffsetStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":    "offset",
+			"maxPages":    10,
+			"limit":       50,
+			"offsetParam": "skip",
+			"limitParam":  "take",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, StrategyOffset, cfg.Strategy)
+	assert.Equal(t, 10, cfg.MaxPages)
+	assert.Equal(t, 50, cfg.Limit)
+	assert.Equal(t, "skip", cfg.OffsetParam)
+	assert.Equal(t, "take", cfg.LimitParam)
+}
+
+func TestParsePaginationConfig_OffsetStrategy_MissingLimit(t *testing.T) {
+	_, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "offset",
+			"maxPages": 10,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit is required")
+}
+
+func TestParsePaginationConfig_OffsetStrategy_Defaults(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "offset",
+			"maxPages": 5,
+			"limit":    25,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "offset", cfg.OffsetParam)
+	assert.Equal(t, "limit", cfg.LimitParam)
+}
+
+func TestParsePaginationConfig_PageNumberStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":      "pageNumber",
+			"maxPages":      5,
+			"pageSize":      25,
+			"pageParam":     "p",
+			"pageSizeParam": "size",
+			"startPage":     0,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, StrategyPageNumber, cfg.Strategy)
+	assert.Equal(t, 25, cfg.PageSize)
+	assert.Equal(t, "p", cfg.PageParam)
+	assert.Equal(t, "size", cfg.PageSizeParam)
+	assert.Equal(t, 0, cfg.StartPage)
+}
+
+func TestParsePaginationConfig_PageNumberStrategy_MissingPageSize(t *testing.T) {
+	_, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "pageNumber",
+			"maxPages": 5,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pageSize is required")
+}
+
+func TestParsePaginationConfig_CursorStrategy_WithTokenPath(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       10,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, StrategyCursor, cfg.Strategy)
+	assert.Equal(t, "body.nextCursor", cfg.NextTokenPath)
+	assert.Equal(t, "cursor", cfg.NextTokenParam)
+}
+
+func TestParsePaginationConfig_CursorStrategy_WithNextURL(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":    "cursor",
+			"maxPages":    10,
+			"nextURLPath": "body['@odata.nextLink']",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "body['@odata.nextLink']", cfg.NextURLPath)
+}
+
+func TestParsePaginationConfig_CursorStrategy_MissingPaths(t *testing.T) {
+	_, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "cursor",
+			"maxPages": 10,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nextTokenPath or nextURLPath")
+}
+
+func TestParsePaginationConfig_CursorStrategy_MissingParam(t *testing.T) {
+	_, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":      "cursor",
+			"maxPages":      10,
+			"nextTokenPath": "body.next",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nextTokenParam is required")
+}
+
+func TestParsePaginationConfig_LinkHeaderStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":    "linkHeader",
+			"maxPages":    5,
+			"collectPath": "body",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, StrategyLinkHeader, cfg.Strategy)
+	assert.Equal(t, "body", cfg.CollectPath)
+}
+
+func TestParsePaginationConfig_CustomStrategy(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "custom",
+			"maxPages": 3,
+			"nextURL":  "body.links.next",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, StrategyCustom, cfg.Strategy)
+	assert.Equal(t, "body.links.next", cfg.NextURL)
+}
+
+func TestParsePaginationConfig_CustomStrategy_MissingExpressions(t *testing.T) {
+	_, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "custom",
+			"maxPages": 3,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nextURL or nextParams")
+}
+
+func TestParsePaginationConfig_Float64MaxPages(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy": "linkHeader",
+			"maxPages": float64(15),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 15, cfg.MaxPages)
+}
+
+func TestParsePaginationConfig_StopWhenAndCollectPath(t *testing.T) {
+	cfg, err := parsePaginationConfig(map[string]any{
+		"pagination": map[string]any{
+			"strategy":    "linkHeader",
+			"maxPages":    10,
+			"stopWhen":    "size(body) == 0",
+			"collectPath": "body.items",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "size(body) == 0", cfg.StopWhen)
+	assert.Equal(t, "body.items", cfg.CollectPath)
+}
+
+// --- Link header parsing tests ---
+
+func TestResolveLinkHeaderNext_WithRelNext(t *testing.T) {
+	resp := &paginatedResponse{
+		Headers: map[string]any{
+			"Link": `<https://api.example.com/items?page=2>; rel="next", <https://api.example.com/items?page=5>; rel="last"`,
+		},
+	}
+	nextURL, stop, err := resolveLinkHeaderNext(resp)
+	require.NoError(t, err)
+	assert.False(t, stop)
+	assert.Equal(t, "https://api.example.com/items?page=2", nextURL)
+}
+
+func TestResolveLinkHeaderNext_NoLinkHeader(t *testing.T) {
+	resp := &paginatedResponse{
+		Headers: map[string]any{},
+	}
+	_, stop, err := resolveLinkHeaderNext(resp)
+	require.NoError(t, err)
+	assert.True(t, stop)
+}
+
+func TestResolveLinkHeaderNext_NoRelNext(t *testing.T) {
+	resp := &paginatedResponse{
+		Headers: map[string]any{
+			"Link": `<https://api.example.com/items?page=1>; rel="prev"`,
+		},
+	}
+	_, stop, err := resolveLinkHeaderNext(resp)
+	require.NoError(t, err)
+	assert.True(t, stop)
+}
+
+func TestResolveLinkHeaderNext_MultipleHeaderValues(t *testing.T) {
+	resp := &paginatedResponse{
+		Headers: map[string]any{
+			"Link": []string{
+				`<https://api.example.com/items?page=1>; rel="prev"`,
+				`<https://api.example.com/items?page=3>; rel="next"`,
+			},
+		},
+	}
+	nextURL, stop, err := resolveLinkHeaderNext(resp)
+	require.NoError(t, err)
+	assert.False(t, stop)
+	assert.Equal(t, "https://api.example.com/items?page=3", nextURL)
+}
+
+// --- Offset strategy tests ---
+
+func TestResolveOffsetNext(t *testing.T) {
+	cfg := &paginationConfig{
+		Strategy:    StrategyOffset,
+		OffsetParam: "offset",
+		LimitParam:  "limit",
+		Limit:       50,
+	}
+	responseCtx := map[string]any{
+		"page": 1,
+		"body": []any{1, 2, 3}, // won't trigger stop on page 1
+	}
+
+	nextURL, stop, err := resolveOffsetNext("https://api.example.com/items?offset=0&limit=50", cfg, responseCtx)
+	require.NoError(t, err)
+	assert.False(t, stop)
+	assert.Contains(t, nextURL, "offset=50")
+	assert.Contains(t, nextURL, "limit=50")
+}
+
+func TestResolveOffsetNext_StopsOnEmptyPage(t *testing.T) {
+	cfg := &paginationConfig{
+		Strategy:    StrategyOffset,
+		OffsetParam: "offset",
+		LimitParam:  "limit",
+		Limit:       50,
+	}
+	responseCtx := map[string]any{
+		"page": 2,
+		"body": []any{1, 2, 3}, // fewer than limit=50
+	}
+
+	_, stop, err := resolveOffsetNext("https://api.example.com/items?offset=50&limit=50", cfg, responseCtx)
+	require.NoError(t, err)
+	assert.True(t, stop)
+}
+
+// --- Page number strategy tests ---
+
+func TestResolvePageNumberNext(t *testing.T) {
+	cfg := &paginationConfig{
+		Strategy:      StrategyPageNumber,
+		PageParam:     "page",
+		PageSizeParam: "pageSize",
+		PageSize:      25,
+		StartPage:     1,
+	}
+	responseCtx := map[string]any{
+		"page": 1,
+		"body": map[string]any{"items": []any{1, 2, 3}},
+	}
+
+	nextURL, stop, err := resolvePageNumberNext("https://api.example.com/items?page=1&pageSize=25", cfg, responseCtx)
+	require.NoError(t, err)
+	assert.False(t, stop)
+	assert.Contains(t, nextURL, "page=2")
+	assert.Contains(t, nextURL, "pageSize=25")
+}
+
+// --- Integration tests (full Execute with pagination) ---
+
+// newPaginatedServer creates a test server that serves paginated JSON responses.
+// Each page returns items and metadata for different pagination strategies.
+func newPaginatedServer(t *testing.T, totalItems, pageSize int) *httptest.Server {
+	t.Helper()
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1, "name": fmt.Sprintf("item-%d", i+1)}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		// Determine offset based on query params
+		offset := 0
+		if o := q.Get("offset"); o != "" {
+			offset, _ = strconv.Atoi(o)
+		} else if p := q.Get("page"); p != "" {
+			pageNum, _ := strconv.Atoi(p)
+			offset = (pageNum - 1) * pageSize
+		}
+
+		// Calculate page slice
+		end := offset + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		var pageItems []map[string]any
+		if offset < totalItems {
+			pageItems = items[offset:end]
+		} else {
+			pageItems = []map[string]any{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		resp := map[string]any{
+			"items": pageItems,
+			"total": totalItems,
+		}
+
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestHTTPProvider_Pagination_Offset(t *testing.T) {
+	totalItems := 7
+	pageSize := 3
+
+	server := newPaginatedServer(t, totalItems, pageSize)
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "offset",
+			"maxPages":    10,
+			"limit":       pageSize,
+			"offsetParam": "offset",
+			"limitParam":  "limit",
+			"collectPath": "body.items",
+			"stopWhen":    "size(body.items) == 0",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 200, data["statusCode"])
+
+	// Should have fetched multiple pages
+	pages, ok := data["pages"].(int)
+	require.True(t, ok)
+	assert.True(t, pages > 1, "expected multiple pages, got %d", pages)
+
+	// Parse the collected items
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+
+	// Verify items are correct
+	for i, item := range collectedItems {
+		id, _ := item["id"].(float64)
+		assert.Equal(t, float64(i+1), id)
+	}
+}
+
+func TestHTTPProvider_Pagination_PageNumber(t *testing.T) {
+	totalItems := 5
+	pageSize := 2
+
+	server := newPaginatedServer(t, totalItems, pageSize)
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items?page=1&pageSize=2",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":      "pageNumber",
+			"maxPages":      10,
+			"pageSize":      pageSize,
+			"pageParam":     "page",
+			"pageSizeParam": "pageSize",
+			"startPage":     1,
+			"collectPath":   "body.items",
+			"stopWhen":      "size(body.items) == 0",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 200, data["statusCode"])
+
+	pages := data["pages"].(int)
+	assert.True(t, pages > 1)
+
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+}
+
+func TestHTTPProvider_Pagination_Cursor(t *testing.T) {
+	totalItems := 6
+	pageSize := 2
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1, "name": fmt.Sprintf("item-%d", i+1)}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		offset := 0
+		if cursor != "" {
+			offset, _ = strconv.Atoi(cursor)
+		}
+
+		end := offset + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		pageItems := items[offset:end]
+
+		var nextCursor *string
+		if end < totalItems {
+			c := strconv.Itoa(end)
+			nextCursor = &c
+		}
+
+		resp := map[string]any{
+			"items":      pageItems,
+			"nextCursor": nextCursor,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       10,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 200, data["statusCode"])
+
+	pages := data["pages"].(int)
+	assert.Equal(t, 3, pages) // 6 items / 2 per page
+
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+}
+
+func TestHTTPProvider_Pagination_CursorNextURL(t *testing.T) {
+	totalItems := 4
+	pageSize := 2
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1}
+	}
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		offset := 0
+		if cursor != "" {
+			offset, _ = strconv.Atoi(cursor)
+		}
+
+		end := offset + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		pageItems := items[offset:end]
+
+		resp := map[string]any{
+			"value": pageItems,
+		}
+		if end < totalItems {
+			resp["@odata.nextLink"] = fmt.Sprintf("%s/items?cursor=%d", serverURL, end)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "cursor",
+			"maxPages":    10,
+			"nextURLPath": "body['@odata.nextLink']",
+			"collectPath": "body.value",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 2, pages) // 4 items / 2 per page
+
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+}
+
+func TestHTTPProvider_Pagination_LinkHeader(t *testing.T) {
+	totalItems := 6
+	pageSize := 2
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1}
+	}
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageStr := r.URL.Query().Get("page")
+		page := 1
+		if pageStr != "" {
+			page, _ = strconv.Atoi(pageStr)
+		}
+
+		offset := (page - 1) * pageSize
+		end := offset + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		pageItems := items[offset:end]
+
+		// Set Link header
+		totalPages := (totalItems + pageSize - 1) / pageSize
+		if page < totalPages {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/items?page=%d>; rel="next"`, serverURL, page+1))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(pageItems)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items?page=1",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "linkHeader",
+			"maxPages":    10,
+			"collectPath": "body",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 3, pages) // 6 items / 2 per page
+
+	totalCollected := data["totalItems"].(int)
+	assert.Equal(t, totalItems, totalCollected)
+}
+
+func TestHTTPProvider_Pagination_Custom_NextURL(t *testing.T) {
+	totalItems := 4
+	pageSize := 2
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1}
+	}
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offsetStr := r.URL.Query().Get("start")
+		offset := 0
+		if offsetStr != "" {
+			offset, _ = strconv.Atoi(offsetStr)
+		}
+
+		end := offset + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		pageItems := items[offset:end]
+
+		resp := map[string]any{
+			"results": pageItems,
+		}
+		if end < totalItems {
+			resp["links"] = map[string]any{
+				"next": fmt.Sprintf("%s/api?start=%d", serverURL, end),
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/api",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "custom",
+			"maxPages":    10,
+			"nextURL":     "has(body.links) && has(body.links.next) ? string(body.links.next) : ''",
+			"collectPath": "body.results",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 2, pages)
+
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+}
+
+func TestHTTPProvider_Pagination_Custom_NextParams(t *testing.T) {
+	totalItems := 6
+	pageSize := 2
+
+	items := make([]map[string]any, totalItems)
+	for i := 0; i < totalItems; i++ {
+		items[i] = map[string]any{"id": i + 1}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startStr := r.URL.Query().Get("start")
+		start := 0
+		if startStr != "" {
+			start, _ = strconv.Atoi(startStr)
+		}
+
+		end := start + pageSize
+		if end > totalItems {
+			end = totalItems
+		}
+		var pageItems []map[string]any
+		if start < totalItems {
+			pageItems = items[start:end]
+		} else {
+			pageItems = []map[string]any{}
+		}
+
+		resp := map[string]any{
+			"data":  pageItems,
+			"start": start,
+			"count": len(pageItems),
+			"total": totalItems,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "/api?start=0&count=2",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "custom",
+			"maxPages":    10,
+			"nextParams":  "int(body.start) + int(body.count) < int(body.total) ? {'start': string(int(body.start) + int(body.count)), 'count': '2'} : {}",
+			"collectPath": "body.data",
+			"stopWhen":    "size(body.data) == 0",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(collectedItems))
+}
+
+func TestHTTPProvider_Pagination_MaxPagesLimit(t *testing.T) {
+	// Server returns infinite pages
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []any{1, 2, 3},
+			"nextCursor": "always-more",
+		})
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       3,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 3, pages, "should stop at maxPages limit")
+}
+
+func TestHTTPProvider_Pagination_StopWhen(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var items []any
+		if requestCount <= 2 {
+			items = []any{requestCount}
+		} else {
+			items = []any{} // Empty on page 3
+		}
+
+		resp := map[string]any{
+			"items":      items,
+			"nextCursor": fmt.Sprintf("page%d", requestCount+1),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       10,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+			"stopWhen":       "size(body.items) == 0",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 3, pages, "should stop when items are empty")
+	totalItems := data["totalItems"].(int)
+	assert.Equal(t, 2, totalItems, "should have collected 2 items before empty page")
+}
+
+func TestHTTPProvider_Pagination_NoCollectPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+
+		resp := map[string]any{"data": "page-data"}
+		if cursor == "" {
+			resp["next"] = "page2"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       10,
+			"nextTokenPath":  "has(body.next) ? body.next : ''",
+			"nextTokenParam": "cursor",
+			// No collectPath — should accumulate raw body data
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 2, pages)
+	totalItems := data["totalItems"].(int)
+	assert.Equal(t, 2, totalItems)
+}
+
+func TestHTTPProvider_Pagination_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []any{},
+			"nextCursor": nil,
+		})
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       10,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 1, pages)
+	totalItems := data["totalItems"].(int)
+	assert.Equal(t, 0, totalItems)
+	assert.Equal(t, "[]", data["body"])
+}
+
+func TestHTTPProvider_Pagination_NonJSONResponse(t *testing.T) {
+	requestCount := 0
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "text/plain")
+
+		if requestCount == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?page=2>; rel="next"`, serverURL))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "page %d content", requestCount)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy": "linkHeader",
+			"maxPages": 5,
+			// No collectPath, body isn't JSON
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	// Non-JSON bodies are accumulated as string values
+	pages := data["pages"].(int)
+	assert.True(t, pages >= 1)
+}
+
+func TestHTTPProvider_Pagination_HTTPErrorStopsGracefully(t *testing.T) {
+	requestCount := 0
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Link", fmt.Sprintf(`<%s?page=2>; rel="next"`, serverURL))
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]any{1, 2, 3})
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]any{4, 5})
+			// No Link header = pagination stops
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL + "?page=1",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":    "linkHeader",
+			"maxPages":    10,
+			"collectPath": "body",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	pages := data["pages"].(int)
+	assert.Equal(t, 2, pages)
+}
+
+func TestHTTPProvider_Pagination_DescriptorHasPaginationSchema(t *testing.T) {
+	p := NewHTTPProvider()
+	schema := p.Descriptor().Schema
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Properties)
+
+	paginationProp, ok := schema.Properties["pagination"]
+	require.True(t, ok, "schema should have a 'pagination' property")
+	assert.Equal(t, "object", paginationProp.Type)
+	assert.Contains(t, paginationProp.Required, "strategy")
+	assert.Contains(t, paginationProp.Required, "maxPages")
+
+	// Verify key sub-properties exist
+	assert.Contains(t, paginationProp.Properties, "strategy")
+	assert.Contains(t, paginationProp.Properties, "maxPages")
+	assert.Contains(t, paginationProp.Properties, "collectPath")
+	assert.Contains(t, paginationProp.Properties, "stopWhen")
+	assert.Contains(t, paginationProp.Properties, "nextTokenPath")
+	assert.Contains(t, paginationProp.Properties, "nextURLPath")
+	assert.Contains(t, paginationProp.Properties, "nextURL")
+	assert.Contains(t, paginationProp.Properties, "nextParams")
+}
+
+func TestHTTPProvider_Pagination_OutputIncludesPagesAndTotalItems(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []any{"a", "b"},
+			"nextCursor": nil,
+		})
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       5,
+			"nextTokenPath":  "body.nextCursor",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 1, data["pages"])
+	assert.Equal(t, 2, data["totalItems"])
+	assert.Equal(t, 200, data["statusCode"])
+	assert.NotNil(t, data["headers"])
+}
+
+// Verify that non-paginated requests still work normally
+func TestHTTPProvider_NonPaginated_StillWorks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"hello"}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 200, data["statusCode"])
+	assert.Equal(t, `{"message":"hello"}`, data["body"])
+	// Non-paginated: no "pages" or "totalItems" field
+	_, hasPages := data["pages"]
+	assert.False(t, hasPages, "non-paginated response should not have 'pages' field")
+}

--- a/pkg/resolver/README.md
+++ b/pkg/resolver/README.md
@@ -221,6 +221,13 @@ transform:
 
 Explicit `dependsOn` dependencies are merged with auto-extracted dependencies.
 
+**Self-Reference Handling:**
+
+References to a resolver's own name (`_.myResolver`) in its `transform` or `validate` phase are automatically
+filtered from the dependency graph. These are semantically equivalent to `__self` and never create circular
+dependencies. Self-references in the `resolve` phase remain errors because a resolver cannot use its own value
+to bootstrap itself.
+
 **Provider-Specific Extraction:**
 
 Providers can implement custom dependency extraction via `ExtractDependencies` on their `Descriptor`. This is useful for providers with custom input formats:

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -47,14 +47,34 @@ func extractDependencies(r *Resolver, lookup DescriptorLookup) []string {
 		extractDepsFromResolvePhase(r.Resolve, deps, lookup)
 	}
 
-	// Extract from transform phase
+	// Extract from transform phase (self-refs collected separately).
+	//
+	// Using _.resolverName in transform/validate is always wrong — the resolver's
+	// own value is NOT stored in the context map (_.resolverName) until after ALL
+	// phases complete (see executor.go SetResult in the defer). The correct way to
+	// reference the current value is __self, which is injected via
+	// executeProviderWithSelf. This filter prevents a confusing "cycle detected"
+	// error from the DAG builder; the real issue is caught by the
+	// resolver-self-reference lint rule which gives an actionable suggestion.
 	if r.Transform != nil {
-		extractDepsFromTransformPhase(r.Transform, deps, lookup)
+		transformDeps := make(map[string]bool)
+		extractDepsFromTransformPhase(r.Transform, transformDeps, lookup)
+		for dep := range transformDeps {
+			if dep != r.Name {
+				deps[dep] = true
+			}
+		}
 	}
 
-	// Extract from validate phase
+	// Extract from validate phase (same self-ref filtering as transform above)
 	if r.Validate != nil {
-		extractDepsFromValidatePhase(r.Validate, deps, lookup)
+		validateDeps := make(map[string]bool)
+		extractDepsFromValidatePhase(r.Validate, validateDeps, lookup)
+		for dep := range validateDeps {
+			if dep != r.Name {
+				deps[dep] = true
+			}
+		}
 	}
 
 	// Convert to slice

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -394,6 +394,109 @@ func TestExtractDependencies(t *testing.T) {
 			// config appears in both dependsOn and when condition - should be deduplicated
 			want: []string{"config", "other"},
 		},
+		{
+			name: "self-reference in validate expression is not a dependency",
+			resolver: &Resolver{
+				Name: "publicSiteCheck",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "http",
+							Inputs: map[string]*ValueRef{
+								"url":    {Literal: "https://httpbin.org/get"},
+								"method": {Literal: "GET"},
+							},
+						},
+					},
+				},
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{
+							Provider: "validation",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr("_.publicSiteCheck.statusCode == 200")},
+							},
+						},
+					},
+				},
+			},
+			// _.publicSiteCheck inside publicSiteCheck's validate phase is __self, not a dependency
+			want: []string{},
+		},
+		{
+			name: "self-reference in transform expression is not a dependency",
+			resolver: &Resolver{
+				Name: "myResolver",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "static",
+							Inputs: map[string]*ValueRef{
+								"value": {Literal: "hello"},
+							},
+						},
+					},
+				},
+				Transform: &TransformPhase{
+					With: []ProviderTransform{
+						{
+							Provider: "cel",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr("_.myResolver + '-suffix'")},
+							},
+						},
+					},
+				},
+			},
+			// _.myResolver inside myResolver's transform phase is __self, not a dependency
+			want: []string{},
+		},
+		{
+			name: "self-reference in resolve phase IS a real dependency",
+			resolver: &Resolver{
+				Name: "selfRef",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "cel",
+							Inputs: map[string]*ValueRef{
+								"value": {Resolver: stringPtr("selfRef")},
+							},
+						},
+					},
+				},
+			},
+			// Self-reference in resolve phase is a genuine circular dependency
+			want: []string{"selfRef"},
+		},
+		{
+			name: "validate self-ref with other deps keeps other deps",
+			resolver: &Resolver{
+				Name: "checker",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "static",
+							Inputs: map[string]*ValueRef{
+								"value": {Literal: "test"},
+							},
+						},
+					},
+				},
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{
+							Provider: "validation",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr("_.checker != _.otherResolver")},
+							},
+						},
+					},
+				},
+			},
+			// _.checker is self-ref (filtered), _.otherResolver is a real dep
+			want: []string{"otherResolver"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -1,0 +1,288 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package scaffold provides solution scaffolding logic for generating
+// skeleton solution YAML files from parameters.
+package scaffold
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Options configures the scaffolding operation.
+type Options struct {
+	// Name is the solution name (lowercase with hyphens, 3-60 chars).
+	Name string `json:"name" doc:"Solution name" maxLength:"60" example:"my-solution"`
+	// Description is a brief description of what the solution does.
+	Description string `json:"description" doc:"Solution description" maxLength:"200" example:"Deploy to Kubernetes"`
+	// Version is the semver version string (default: "1.0.0").
+	Version string `json:"version" doc:"Semantic version" example:"1.0.0"`
+	// Features is a map of features to include in the scaffold.
+	// Valid keys: parameters, resolvers, actions, transforms, validation, tests, composition.
+	Features map[string]bool `json:"features" doc:"Features to include"`
+	// Providers lists specific providers to include examples for.
+	Providers []string `json:"providers" doc:"Provider-specific examples to include"`
+}
+
+// Result contains the output of a scaffolding operation.
+type Result struct {
+	// YAML is the generated solution YAML content.
+	YAML string `json:"yaml" doc:"Generated YAML content"`
+	// Filename is the suggested filename for the solution.
+	Filename string `json:"filename" doc:"Suggested filename" example:"./my-solution.yaml"`
+	// Features lists the features included in the scaffold.
+	Features []string `json:"features" doc:"Included features"`
+	// NextSteps provides guidance for the user.
+	NextSteps []string `json:"nextSteps" doc:"Recommended next steps"`
+}
+
+// ValidFeatures are the recognized feature names.
+var ValidFeatures = []string{
+	"parameters", "resolvers", "actions", "transforms",
+	"validation", "tests", "composition",
+}
+
+// Solution generates a skeleton solution YAML from the given options.
+// If no features are specified, defaults to parameters and resolvers.
+// If version is empty, defaults to "1.0.0".
+func Solution(opts Options) *Result {
+	if opts.Version == "" {
+		opts.Version = "1.0.0"
+	}
+
+	// Default features if none specified
+	if len(opts.Features) == 0 {
+		opts.Features = map[string]bool{
+			"parameters": true,
+			"resolvers":  true,
+			"actions":    true,
+			"transforms": true,
+			"validation": true,
+			"tests":      true,
+		}
+	}
+
+	yaml := BuildYAML(opts.Name, opts.Description, opts.Version, opts.Features, opts.Providers)
+
+	return &Result{
+		YAML:     yaml,
+		Filename: fmt.Sprintf("./%s.yaml", opts.Name),
+		Features: FeatureKeys(opts.Features),
+		NextSteps: []string{
+			"Save the YAML to a file",
+			"Customize the resolver and action values for your use case",
+			"Run lint_solution to validate the structure",
+			"Run preview_resolvers to test resolver outputs",
+			"Run get_run_command to see how to execute it",
+		},
+	}
+}
+
+// BuildYAML generates solution YAML from scaffold parameters.
+func BuildYAML(name, description, version string, features map[string]bool, providers []string) string {
+	var b strings.Builder
+
+	// Header
+	b.WriteString("apiVersion: scafctl.io/v1\n")
+	b.WriteString("kind: Solution\n")
+	b.WriteString("metadata:\n")
+	fmt.Fprintf(&b, "  name: %s\n", name)
+	fmt.Fprintf(&b, "  version: \"%s\"\n", version)
+	fmt.Fprintf(&b, "  description: %s\n", description)
+	b.WriteString("  tags:\n")
+	b.WriteString("    - scaffold\n")
+
+	// Resolvers
+	b.WriteString("\nspec:\n")
+	if features["resolvers"] || features["parameters"] || features["transforms"] || features["validation"] {
+		b.WriteString("  resolvers:\n")
+
+		if features["parameters"] {
+			b.WriteString("    # User-provided input parameter\n")
+			b.WriteString("    inputName:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A user-provided input value\"\n")
+			b.WriteString("      example: \"my-value\"\n")
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: parameter\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              key: inputName\n")
+			b.WriteString("          - provider: static\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              value: my-value\n")
+
+			if features["validation"] {
+				b.WriteString("      validate:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: validation\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              expression: 'size(__self) >= 1 && size(__self) <= 100'\n")
+				b.WriteString("            message: \"Input must be between 1 and 100 characters\"\n")
+			}
+		}
+
+		if features["resolvers"] && !features["parameters"] {
+			b.WriteString("    # Static value resolver\n")
+			b.WriteString("    config-value:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A static configuration value\"\n")
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: static\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              value: \"default-value\"\n")
+		}
+
+		if features["transforms"] {
+			b.WriteString("    # Transformed value\n")
+			b.WriteString("    processed:\n")
+			b.WriteString("      type: string\n")
+			b.WriteString("      description: \"A value processed through a transform\"\n")
+			if features["parameters"] {
+				b.WriteString("      dependsOn:\n")
+				b.WriteString("        - inputName\n")
+			}
+			b.WriteString("      resolve:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: static\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              value: \"raw-data\"\n")
+			b.WriteString("      transform:\n")
+			b.WriteString("        with:\n")
+			b.WriteString("          - provider: cel\n")
+			b.WriteString("            inputs:\n")
+			b.WriteString("              expression: '__self.upperAscii()'\n")
+		}
+
+		// Provider-specific resolver examples
+		for _, p := range providers {
+			switch p {
+			case "http":
+				b.WriteString("    # HTTP API call\n")
+				b.WriteString("    api-data:\n")
+				b.WriteString("      type: object\n")
+				b.WriteString("      description: \"Data fetched from an API\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: http\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              url: \"https://api.example.com/data\"\n")
+				b.WriteString("              method: GET\n")
+			case "env":
+				b.WriteString("    # Environment variable\n")
+				b.WriteString("    env-value:\n")
+				b.WriteString("      type: string\n")
+				b.WriteString("      description: \"Value from environment variable\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: env\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              name: MY_ENV_VAR\n")
+			case "file":
+				b.WriteString("    # File content\n")
+				b.WriteString("    file-content:\n")
+				b.WriteString("      type: string\n")
+				b.WriteString("      description: \"Content read from a file\"\n")
+				b.WriteString("      resolve:\n")
+				b.WriteString("        with:\n")
+				b.WriteString("          - provider: file\n")
+				b.WriteString("            inputs:\n")
+				b.WriteString("              path: \"./config.json\"\n")
+			}
+		}
+	}
+
+	// Workflow / Actions
+	if features["actions"] {
+		b.WriteString("\n  workflow:\n")
+		b.WriteString("    actions:\n")
+
+		hasExec := false
+		for _, p := range providers {
+			switch p {
+			case "exec":
+				hasExec = true
+				b.WriteString("      # Execute a command\n")
+				b.WriteString("      run-command:\n")
+				b.WriteString("        provider: exec\n")
+				b.WriteString("        description: \"Execute a shell command\"\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          command: \"echo 'Hello from scaffold'\"\n")
+			case "directory":
+				b.WriteString("      # Create a directory structure\n")
+				b.WriteString("      create-output:\n")
+				b.WriteString("        provider: directory\n")
+				b.WriteString("        description: \"Create output directory\"\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          operation: create\n")
+				b.WriteString("          path: \"./output\"\n")
+			case "go-template":
+				b.WriteString("      # Render a template\n")
+				b.WriteString("      render-template:\n")
+				b.WriteString("        provider: go-template\n")
+				b.WriteString("        description: \"Render a Go template\"\n")
+				b.WriteString("        inputs:\n")
+				b.WriteString("          template: \"Hello {{ .Name }}\"\n")
+				b.WriteString("          output: \"./output/greeting.txt\"\n")
+			}
+		}
+
+		// Default action if no provider-specific ones were added
+		if !hasExec && len(providers) == 0 {
+			b.WriteString("      # Example action\n")
+			b.WriteString("      hello:\n")
+			b.WriteString("        provider: exec\n")
+			b.WriteString("        description: \"A simple action\"\n")
+			b.WriteString("        inputs:\n")
+			b.WriteString("          command:\n")
+			if features["transforms"] {
+				b.WriteString("            expr: '\"echo Hello, \" + _.inputName + \" - processed: \" + _.processed'\n")
+			} else {
+				b.WriteString("            expr: '\"echo Hello, \" + _.inputName'\n")
+			}
+		}
+	}
+
+	// Tests
+	if features["tests"] {
+		b.WriteString("\n  testing:\n")
+		b.WriteString("    cases:\n")
+		b.WriteString("      # Verify resolvers produce expected values\n")
+		b.WriteString("      basic-resolve:\n")
+		b.WriteString("        description: \"Verify resolvers resolve successfully\"\n")
+		b.WriteString("        command: [run, resolver]\n")
+		if features["parameters"] {
+			b.WriteString("        args: [\"-o\", \"json\", \"-r\", \"inputName=test-value\"]\n")
+		} else {
+			b.WriteString("        args: [\"-o\", \"json\"]\n")
+		}
+		b.WriteString("        assertions:\n")
+		b.WriteString("          - expression: __exitCode == 0\n")
+		if features["parameters"] {
+			b.WriteString("          - expression: __output.inputName == \"test-value\"\n")
+		}
+	}
+
+	// Composition
+	if features["composition"] {
+		b.WriteString("\n# Uncomment to compose with partial solutions:\n")
+		b.WriteString("# compose:\n")
+		b.WriteString("#   - ./common-resolvers.yaml\n")
+		b.WriteString("#   - ./shared-actions.yaml\n")
+	}
+
+	return b.String()
+}
+
+// FeatureKeys returns sorted keys from a features map.
+func FeatureKeys(features map[string]bool) []string {
+	keys := make([]string, 0, len(features))
+	for k := range features {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/scaffold/scaffold_test.go
+++ b/pkg/scaffold/scaffold_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package scaffold
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolution_Defaults(t *testing.T) {
+	result := Solution(Options{
+		Name:        "my-solution",
+		Description: "A test solution",
+	})
+
+	require.NotNil(t, result)
+	assert.Equal(t, "./my-solution.yaml", result.Filename)
+	assert.Contains(t, result.YAML, "name: my-solution")
+	assert.Contains(t, result.YAML, "version: \"1.0.0\"")
+	assert.Contains(t, result.YAML, "description: A test solution")
+	assert.Contains(t, result.YAML, "provider: parameter")
+	assert.Contains(t, result.YAML, "key: inputName")
+	assert.Contains(t, result.YAML, "workflow:")
+	assert.Contains(t, result.YAML, "transform:")
+	assert.Contains(t, result.YAML, "validate:")
+	assert.Contains(t, result.YAML, "testing:")
+	assert.Contains(t, result.Features, "parameters")
+	assert.Contains(t, result.Features, "resolvers")
+	assert.Contains(t, result.Features, "actions")
+	assert.Contains(t, result.Features, "transforms")
+	assert.Contains(t, result.Features, "validation")
+	assert.Contains(t, result.Features, "tests")
+	assert.NotContains(t, result.Features, "composition")
+	assert.NotEmpty(t, result.NextSteps)
+}
+
+func TestSolution_AllFeatures(t *testing.T) {
+	result := Solution(Options{
+		Name:        "full-solution",
+		Description: "Everything enabled",
+		Version:     "2.0.0",
+		Features: map[string]bool{
+			"parameters":  true,
+			"resolvers":   true,
+			"actions":     true,
+			"transforms":  true,
+			"validation":  true,
+			"tests":       true,
+			"composition": true,
+		},
+	})
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.YAML, "version: \"2.0.0\"")
+	assert.Contains(t, result.YAML, "provider: parameter")
+	assert.Contains(t, result.YAML, "key: inputName")
+	assert.Contains(t, result.YAML, "transform:")
+	assert.Contains(t, result.YAML, "workflow:")
+	assert.Contains(t, result.YAML, "testing:")
+	assert.Contains(t, result.YAML, "compose:")
+	assert.Contains(t, result.YAML, "validate:")
+	assert.Contains(t, result.YAML, "-r")
+	assert.NotContains(t, result.YAML, "resolvers:\n          inputName:")
+}
+
+func TestSolution_WithProviders(t *testing.T) {
+	result := Solution(Options{
+		Name:        "provider-demo",
+		Description: "Provider examples",
+		Features: map[string]bool{
+			"resolvers": true,
+			"actions":   true,
+		},
+		Providers: []string{"http", "exec", "env"},
+	})
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.YAML, "provider: http")
+	assert.Contains(t, result.YAML, "provider: exec")
+	assert.Contains(t, result.YAML, "provider: env")
+}
+
+func TestSolution_ResolversOnly(t *testing.T) {
+	result := Solution(Options{
+		Name:        "resolvers-only",
+		Description: "Just resolvers",
+		Features: map[string]bool{
+			"resolvers": true,
+		},
+	})
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.YAML, "resolvers:")
+	assert.Contains(t, result.YAML, "provider: static")
+	assert.NotContains(t, result.YAML, "workflow:")
+}
+
+func TestBuildYAML_EmptyFeatures(t *testing.T) {
+	yaml := BuildYAML("empty", "empty solution", "1.0.0", map[string]bool{}, nil)
+	assert.Contains(t, yaml, "name: empty")
+	assert.Contains(t, yaml, "spec:")
+	assert.NotContains(t, yaml, "resolvers:")
+}
+
+func TestFeatureKeys(t *testing.T) {
+	keys := FeatureKeys(map[string]bool{
+		"zebra": true,
+		"apple": true,
+		"mango": true,
+	})
+	assert.Equal(t, []string{"apple", "mango", "zebra"}, keys)
+}
+
+func TestFeatureKeys_Empty(t *testing.T) {
+	keys := FeatureKeys(map[string]bool{})
+	assert.Empty(t, keys)
+}
+
+func TestSolution_CustomVersion(t *testing.T) {
+	result := Solution(Options{
+		Name:        "versioned",
+		Description: "Custom version",
+		Version:     "3.2.1",
+	})
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.YAML, "version: \"3.2.1\"")
+}
+
+func TestBuildYAML_ValidYAMLStructure(t *testing.T) {
+	yaml := BuildYAML("test", "Test solution", "1.0.0", map[string]bool{
+		"parameters": true,
+		"resolvers":  true,
+	}, nil)
+
+	// Verify basic YAML structure
+	assert.True(t, strings.HasPrefix(yaml, "apiVersion:"))
+	assert.Contains(t, yaml, "kind: Solution")
+	assert.Contains(t, yaml, "metadata:")
+	assert.Contains(t, yaml, "spec:")
+}

--- a/pkg/soldiff/soldiff.go
+++ b/pkg/soldiff/soldiff.go
@@ -1,0 +1,286 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package soldiff provides structural comparison of two solutions.
+package soldiff
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// Change represents a single structural difference between two solutions.
+type Change struct {
+	Field    string `json:"field"`
+	Type     string `json:"type"` // "added", "removed", "changed"
+	OldValue any    `json:"oldValue,omitempty"`
+	NewValue any    `json:"newValue,omitempty"`
+}
+
+// Result contains the diff output.
+type Result struct {
+	PathA   string   `json:"pathA"`
+	PathB   string   `json:"pathB"`
+	Changes []Change `json:"changes"`
+	Summary Summary  `json:"summary"`
+}
+
+// Summary counts changes by type.
+type Summary struct {
+	Total   int `json:"total"`
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+	Changed int `json:"changed"`
+}
+
+// Compare performs a structural comparison of two solutions.
+func Compare(solA, solB *solution.Solution) *Result {
+	var changes []Change
+
+	// Compare metadata
+	if solA.Metadata.Name != solB.Metadata.Name {
+		changes = append(changes, Change{Field: "metadata.name", Type: "changed", OldValue: solA.Metadata.Name, NewValue: solB.Metadata.Name})
+	}
+	if solA.Metadata.Description != solB.Metadata.Description {
+		changes = append(changes, Change{Field: "metadata.description", Type: "changed", OldValue: solA.Metadata.Description, NewValue: solB.Metadata.Description})
+	}
+	if solA.Metadata.Version != nil && solB.Metadata.Version != nil {
+		if solA.Metadata.Version.String() != solB.Metadata.Version.String() {
+			changes = append(changes, Change{Field: "metadata.version", Type: "changed", OldValue: solA.Metadata.Version.String(), NewValue: solB.Metadata.Version.String()})
+		}
+	}
+
+	// Compare resolvers
+	resolversA := make(map[string]bool)
+	resolversB := make(map[string]bool)
+	if solA.Spec.HasResolvers() {
+		for name := range solA.Spec.Resolvers {
+			resolversA[name] = true
+		}
+	}
+	if solB.Spec.HasResolvers() {
+		for name := range solB.Spec.Resolvers {
+			resolversB[name] = true
+		}
+	}
+
+	// Find added/removed resolvers
+	for name := range resolversB {
+		if !resolversA[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "added"})
+		}
+	}
+	for name := range resolversA {
+		if !resolversB[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.resolvers.%s", name), Type: "removed"})
+		}
+	}
+
+	// Check for changed resolvers (both exist)
+	for name := range resolversA {
+		if resolversB[name] {
+			rA := solA.Spec.Resolvers[name]
+			rB := solB.Spec.Resolvers[name]
+
+			if rA.Type != rB.Type {
+				changes = append(changes, Change{
+					Field: fmt.Sprintf("spec.resolvers.%s.type", name), Type: "changed",
+					OldValue: string(rA.Type), NewValue: string(rB.Type),
+				})
+			}
+			if rA.Description != rB.Description {
+				changes = append(changes, Change{
+					Field: fmt.Sprintf("spec.resolvers.%s.description", name), Type: "changed",
+					OldValue: rA.Description, NewValue: rB.Description,
+				})
+			}
+
+			// Compare primary provider
+			provA := ""
+			if rA.Resolve != nil && len(rA.Resolve.With) > 0 {
+				provA = rA.Resolve.With[0].Provider
+			}
+			provB := ""
+			if rB.Resolve != nil && len(rB.Resolve.With) > 0 {
+				provB = rB.Resolve.With[0].Provider
+			}
+			if provA != provB {
+				changes = append(changes, Change{
+					Field: fmt.Sprintf("spec.resolvers.%s.provider", name), Type: "changed",
+					OldValue: provA, NewValue: provB,
+				})
+			}
+		}
+	}
+
+	// Compare actions
+	actionsA := make(map[string]bool)
+	actionsB := make(map[string]bool)
+	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Actions != nil {
+		for name := range solA.Spec.Workflow.Actions {
+			actionsA[name] = true
+		}
+	}
+	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Actions != nil {
+		for name := range solB.Spec.Workflow.Actions {
+			actionsB[name] = true
+		}
+	}
+
+	for name := range actionsB {
+		if !actionsA[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "added"})
+		}
+	}
+	for name := range actionsA {
+		if !actionsB[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.workflow.actions.%s", name), Type: "removed"})
+		}
+	}
+
+	// Check changed actions
+	for name := range actionsA {
+		if actionsB[name] {
+			aA := solA.Spec.Workflow.Actions[name]
+			aB := solB.Spec.Workflow.Actions[name]
+
+			if aA.Provider != aB.Provider {
+				changes = append(changes, Change{
+					Field: fmt.Sprintf("spec.workflow.actions.%s.provider", name), Type: "changed",
+					OldValue: aA.Provider, NewValue: aB.Provider,
+				})
+			}
+			if aA.Description != aB.Description {
+				changes = append(changes, Change{
+					Field: fmt.Sprintf("spec.workflow.actions.%s.description", name), Type: "changed",
+					OldValue: aA.Description, NewValue: aB.Description,
+				})
+			}
+		}
+	}
+
+	// Compare finally actions
+	finallyA := make(map[string]bool)
+	finallyB := make(map[string]bool)
+	if solA.Spec.HasWorkflow() && solA.Spec.Workflow.Finally != nil {
+		for name := range solA.Spec.Workflow.Finally {
+			finallyA[name] = true
+		}
+	}
+	if solB.Spec.HasWorkflow() && solB.Spec.Workflow.Finally != nil {
+		for name := range solB.Spec.Workflow.Finally {
+			finallyB[name] = true
+		}
+	}
+
+	for name := range finallyB {
+		if !finallyA[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "added"})
+		}
+	}
+	for name := range finallyA {
+		if !finallyB[name] {
+			changes = append(changes, Change{Field: fmt.Sprintf("spec.workflow.finally.%s", name), Type: "removed"})
+		}
+	}
+
+	// Workflow added/removed
+	if !solA.Spec.HasWorkflow() && solB.Spec.HasWorkflow() {
+		changes = append(changes, Change{Field: "spec.workflow", Type: "added"})
+	} else if solA.Spec.HasWorkflow() && !solB.Spec.HasWorkflow() {
+		changes = append(changes, Change{Field: "spec.workflow", Type: "removed"})
+	}
+
+	// Compare test cases
+	var testsA, testsB map[string]bool
+	if solA.Spec.Testing != nil && solA.Spec.Testing.Cases != nil {
+		testsA = make(map[string]bool, len(solA.Spec.Testing.Cases))
+		for name := range solA.Spec.Testing.Cases {
+			testsA[name] = true
+		}
+	}
+	if solB.Spec.Testing != nil && solB.Spec.Testing.Cases != nil {
+		testsB = make(map[string]bool, len(solB.Spec.Testing.Cases))
+		for name := range solB.Spec.Testing.Cases {
+			testsB[name] = true
+		}
+	}
+
+	if testsA != nil || testsB != nil {
+		if testsA == nil {
+			testsA = make(map[string]bool)
+		}
+		if testsB == nil {
+			testsB = make(map[string]bool)
+		}
+
+		for name := range testsB {
+			if !testsA[name] {
+				changes = append(changes, Change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "added"})
+			}
+		}
+		for name := range testsA {
+			if !testsB[name] {
+				changes = append(changes, Change{Field: fmt.Sprintf("spec.testing.cases.%s", name), Type: "removed"})
+			}
+		}
+	}
+
+	// Testing added/removed
+	if solA.Spec.Testing == nil && solB.Spec.Testing != nil {
+		changes = append(changes, Change{Field: "spec.testing", Type: "added"})
+	} else if solA.Spec.Testing != nil && solB.Spec.Testing == nil {
+		changes = append(changes, Change{Field: "spec.testing", Type: "removed"})
+	}
+
+	// Sort changes for deterministic output
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Field < changes[j].Field
+	})
+
+	// Count by type
+	added, removed, changed := 0, 0, 0
+	for _, c := range changes {
+		switch c.Type {
+		case "added":
+			added++
+		case "removed":
+			removed++
+		case "changed":
+			changed++
+		}
+	}
+
+	return &Result{
+		Changes: changes,
+		Summary: Summary{
+			Total:   len(changes),
+			Added:   added,
+			Removed: removed,
+			Changed: changed,
+		},
+	}
+}
+
+// CompareFiles loads two solution files and compares them structurally.
+func CompareFiles(ctx context.Context, pathA, pathB string) (*Result, error) {
+	solA, err := explain.LoadSolution(ctx, pathA)
+	if err != nil {
+		return nil, fmt.Errorf("loading solution A (%s): %w", pathA, err)
+	}
+
+	solB, err := explain.LoadSolution(ctx, pathB)
+	if err != nil {
+		return nil, fmt.Errorf("loading solution B (%s): %w", pathB, err)
+	}
+
+	result := Compare(solA, solB)
+	result.PathA = pathA
+	result.PathB = pathB
+
+	return result, nil
+}

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"gopkg.in/yaml.v3"
 )
@@ -74,6 +75,10 @@ type Solution struct {
 
 	// path is an internal field for the file path where the solution was loaded from
 	path string `json:"-" yaml:"-"`
+
+	// sourceMap maps logical YAML paths to source positions (line/column).
+	// It is populated during FromYAML when the solution is loaded from YAML bytes.
+	sourceMap *sourcepos.SourceMap `json:"-" yaml:"-"`
 }
 
 // Metadata contains the descriptive information about a solution.
@@ -218,9 +223,22 @@ func (s *Solution) ToYAML() ([]byte, error) {
 }
 
 // FromYAML unmarshals the provided YAML data into the Solution struct.
+// It also builds a SourceMap that maps logical YAML paths to source positions.
 // It returns an error if the unmarshalling process fails.
 func (s *Solution) FromYAML(data []byte) error {
-	return yaml.Unmarshal(data, s)
+	if err := yaml.Unmarshal(data, s); err != nil {
+		return err
+	}
+
+	// Build source map for line/column tracking.
+	// This is a best-effort operation; parsing errors are non-fatal since we
+	// already successfully unmarshalled the data above.
+	sm, err := sourcepos.BuildSourceMap(data, s.path)
+	if err == nil {
+		s.sourceMap = sm
+	}
+
+	return nil
 }
 
 // UnmarshalFromBytes attempts to unmarshal the provided byte slice into the Solution struct.
@@ -268,6 +286,26 @@ func (s *Solution) GetPath() string {
 // It updates the internal path field with the provided value.
 func (s *Solution) SetPath(path string) {
 	s.path = path
+}
+
+// SourceMap returns the source map for this solution, if available.
+// The source map is populated during FromYAML and maps logical YAML paths
+// (e.g., "spec.resolvers.appName") to source positions (line, column, file).
+// Returns nil if the solution was not loaded from YAML or if source map building failed.
+func (s *Solution) SourceMap() *sourcepos.SourceMap {
+	if s == nil {
+		return nil
+	}
+	return s.sourceMap
+}
+
+// SetSourceMap sets the source map for this solution.
+// This is useful when composing solutions from multiple files.
+func (s *Solution) SetSourceMap(sm *sourcepos.SourceMap) {
+	if s == nil {
+		return
+	}
+	s.sourceMap = sm
 }
 
 // ApplyDefaults populates default values for optional top-level fields.

--- a/pkg/solution/walk/walk.go
+++ b/pkg/solution/walk/walk.go
@@ -1,0 +1,424 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package walk provides a visitor/walker pattern for traversing solution
+// structures. It eliminates duplicated traversal logic across lint, dependency
+// extraction, explain, and MCP tools by providing a single canonical Walk
+// function with composable visitor callbacks.
+package walk
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// Visitor defines optional callbacks for each node type in the solution tree.
+// All fields are optional -- set only the callbacks you need.
+// Return a non-nil error from any callback to abort the walk immediately.
+type Visitor struct {
+	Solution           func(sol *solution.Solution) error
+	Metadata           func(path string, meta *solution.Metadata) error
+	Catalog            func(path string, cat *solution.Catalog) error
+	Spec               func(path string, sp *solution.Spec) error
+	Resolver           func(path, name string, r *resolver.Resolver) error
+	ResolvePhase       func(path, resolverName string, rp *resolver.ResolvePhase) error
+	TransformPhase     func(path, resolverName string, tp *resolver.TransformPhase) error
+	ValidatePhase      func(path, resolverName string, vp *resolver.ValidatePhase) error
+	ProviderSource     func(path string, ps *resolver.ProviderSource) error
+	ProviderTransform  func(path string, pt *resolver.ProviderTransform) error
+	ProviderValidation func(path string, pv *resolver.ProviderValidation) error
+	Action             func(path, name, section string, act *action.Action) error
+	Workflow           func(path string, w *action.Workflow) error
+	ValueRef           func(path string, vr *spec.ValueRef) error
+	Condition          func(path, conditionKind string, expr *celexp.Expression) error
+	ForEach            func(path string, fe *spec.ForEachClause) error
+	TestSuite          func(path string, ts *soltesting.TestSuite) error
+	TestCase           func(path, name string, tc *soltesting.TestCase) error
+}
+
+// Walk traverses the solution tree calling visitor callbacks in depth-first order.
+// Map iterations (resolvers, actions, tests) are sorted by key for deterministic traversal.
+func Walk(sol *solution.Solution, v *Visitor) error {
+	if sol == nil || v == nil {
+		return nil
+	}
+
+	if v.Solution != nil {
+		if err := v.Solution(sol); err != nil {
+			return err
+		}
+	}
+
+	if v.Metadata != nil {
+		if err := v.Metadata("metadata", &sol.Metadata); err != nil {
+			return err
+		}
+	}
+
+	if v.Catalog != nil {
+		if err := v.Catalog("catalog", &sol.Catalog); err != nil {
+			return err
+		}
+	}
+
+	if v.Spec != nil {
+		if err := v.Spec("spec", &sol.Spec); err != nil {
+			return err
+		}
+	}
+
+	if err := walkResolvers(sol, v); err != nil {
+		return err
+	}
+
+	if err := walkWorkflow(sol, v); err != nil {
+		return err
+	}
+
+	return walkTesting(sol, v)
+}
+
+func walkResolvers(sol *solution.Solution, v *Visitor) error {
+	if !sol.Spec.HasResolvers() {
+		return nil
+	}
+
+	names := sortedKeys(sol.Spec.Resolvers)
+	for _, name := range names {
+		r := sol.Spec.Resolvers[name]
+		if r == nil {
+			continue
+		}
+
+		path := "spec.resolvers." + name
+
+		if v.Resolver != nil {
+			if err := v.Resolver(path, name, r); err != nil {
+				return err
+			}
+		}
+
+		if r.When != nil && r.When.Expr != nil {
+			if err := visitCondition(v, path+".when", "when", r.When.Expr); err != nil {
+				return err
+			}
+		}
+
+		if r.Resolve != nil {
+			if err := walkResolvePhase(v, path+".resolve", name, r.Resolve); err != nil {
+				return err
+			}
+		}
+
+		if r.Transform != nil {
+			if err := walkTransformPhase(v, path+".transform", name, r.Transform); err != nil {
+				return err
+			}
+		}
+
+		if r.Validate != nil {
+			if err := walkValidatePhase(v, path+".validate", name, r.Validate); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func walkResolvePhase(v *Visitor, resolvePath, resolverName string, rp *resolver.ResolvePhase) error {
+	if v.ResolvePhase != nil {
+		if err := v.ResolvePhase(resolvePath, resolverName, rp); err != nil {
+			return err
+		}
+	}
+
+	if rp.When != nil && rp.When.Expr != nil {
+		if err := visitCondition(v, resolvePath+".when", "when", rp.When.Expr); err != nil {
+			return err
+		}
+	}
+	if rp.Until != nil && rp.Until.Expr != nil {
+		if err := visitCondition(v, resolvePath+".until", "until", rp.Until.Expr); err != nil {
+			return err
+		}
+	}
+
+	for i := range rp.With {
+		src := &rp.With[i]
+		srcPath := fmt.Sprintf("%s.with[%d]", resolvePath, i)
+
+		if v.ProviderSource != nil {
+			if err := v.ProviderSource(srcPath, src); err != nil {
+				return err
+			}
+		}
+
+		if src.When != nil && src.When.Expr != nil {
+			if err := visitCondition(v, srcPath+".when", "when", src.When.Expr); err != nil {
+				return err
+			}
+		}
+
+		if err := walkInputs(v, srcPath+".inputs", src.Inputs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func walkTransformPhase(v *Visitor, transformPath, resolverName string, tp *resolver.TransformPhase) error {
+	if v.TransformPhase != nil {
+		if err := v.TransformPhase(transformPath, resolverName, tp); err != nil {
+			return err
+		}
+	}
+
+	if tp.When != nil && tp.When.Expr != nil {
+		if err := visitCondition(v, transformPath+".when", "when", tp.When.Expr); err != nil {
+			return err
+		}
+	}
+
+	for i := range tp.With {
+		t := &tp.With[i]
+		tPath := fmt.Sprintf("%s.with[%d]", transformPath, i)
+
+		if v.ProviderTransform != nil {
+			if err := v.ProviderTransform(tPath, t); err != nil {
+				return err
+			}
+		}
+
+		if t.When != nil && t.When.Expr != nil {
+			if err := visitCondition(v, tPath+".when", "when", t.When.Expr); err != nil {
+				return err
+			}
+		}
+
+		if t.ForEach != nil {
+			if err := walkForEach(v, tPath+".forEach", t.ForEach); err != nil {
+				return err
+			}
+		}
+
+		if err := walkInputs(v, tPath+".inputs", t.Inputs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func walkValidatePhase(v *Visitor, validatePath, resolverName string, vp *resolver.ValidatePhase) error {
+	if v.ValidatePhase != nil {
+		if err := v.ValidatePhase(validatePath, resolverName, vp); err != nil {
+			return err
+		}
+	}
+
+	if vp.When != nil && vp.When.Expr != nil {
+		if err := visitCondition(v, validatePath+".when", "when", vp.When.Expr); err != nil {
+			return err
+		}
+	}
+
+	for i := range vp.With {
+		pv := &vp.With[i]
+		pvPath := fmt.Sprintf("%s.with[%d]", validatePath, i)
+
+		if v.ProviderValidation != nil {
+			if err := v.ProviderValidation(pvPath, pv); err != nil {
+				return err
+			}
+		}
+
+		if err := walkInputs(v, pvPath+".inputs", pv.Inputs); err != nil {
+			return err
+		}
+
+		if pv.Message != nil {
+			if err := visitValueRef(v, pvPath+".message", pv.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func walkWorkflow(sol *solution.Solution, v *Visitor) error {
+	if sol.Spec.Workflow == nil {
+		return nil
+	}
+	w := sol.Spec.Workflow
+
+	if v.Workflow != nil {
+		if err := v.Workflow("spec.workflow", w); err != nil {
+			return err
+		}
+	}
+
+	if err := walkActions(v, "spec.workflow.actions", "actions", w.Actions); err != nil {
+		return err
+	}
+
+	return walkActions(v, "spec.workflow.finally", "finally", w.Finally)
+}
+
+func walkActions(v *Visitor, basePath, section string, actions map[string]*action.Action) error {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	names := sortedKeys(actions)
+	for _, name := range names {
+		act := actions[name]
+		if act == nil {
+			continue
+		}
+
+		path := basePath + "." + name
+
+		if v.Action != nil {
+			if err := v.Action(path, name, section, act); err != nil {
+				return err
+			}
+		}
+
+		if act.When != nil && act.When.Expr != nil {
+			if err := visitCondition(v, path+".when", "when", act.When.Expr); err != nil {
+				return err
+			}
+		}
+
+		if act.ForEach != nil {
+			if err := walkForEach(v, path+".forEach", act.ForEach); err != nil {
+				return err
+			}
+		}
+
+		if act.Retry != nil && act.Retry.RetryIf != nil {
+			if err := visitCondition(v, path+".retry.retryIf", "when", act.Retry.RetryIf); err != nil {
+				return err
+			}
+		}
+
+		if err := walkInputs(v, path+".inputs", act.Inputs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func walkTesting(sol *solution.Solution, v *Visitor) error {
+	if sol.Spec.Testing == nil {
+		return nil
+	}
+
+	ts := sol.Spec.Testing
+
+	if v.TestSuite != nil {
+		if err := v.TestSuite("spec.testing", ts); err != nil {
+			return err
+		}
+	}
+
+	if ts.Cases == nil {
+		return nil
+	}
+
+	names := sortedKeys(ts.Cases)
+	for _, name := range names {
+		tc := ts.Cases[name]
+		if tc == nil {
+			continue
+		}
+
+		path := "spec.testing.cases." + name
+
+		if v.TestCase != nil {
+			if err := v.TestCase(path, name, tc); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func walkInputs(v *Visitor, basePath string, inputs map[string]*spec.ValueRef) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(inputs))
+	for k := range inputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		vr := inputs[key]
+		if vr == nil {
+			continue
+		}
+		if err := visitValueRef(v, basePath+"."+key, vr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func walkForEach(v *Visitor, path string, fe *spec.ForEachClause) error {
+	if fe == nil {
+		return nil
+	}
+
+	if v.ForEach != nil {
+		if err := v.ForEach(path, fe); err != nil {
+			return err
+		}
+	}
+
+	if fe.In != nil {
+		if err := visitValueRef(v, path+".in", fe.In); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func visitValueRef(v *Visitor, path string, vr *spec.ValueRef) error {
+	if v.ValueRef == nil || vr == nil {
+		return nil
+	}
+	return v.ValueRef(path, vr)
+}
+
+func visitCondition(v *Visitor, path, kind string, expr *celexp.Expression) error {
+	if v.Condition == nil || expr == nil {
+		return nil
+	}
+	return v.Condition(path, kind, expr)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/solution/walk/walk_test.go
+++ b/pkg/solution/walk/walk_test.go
@@ -1,0 +1,196 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package walk
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalk_NilInputs(t *testing.T) {
+	assert.NoError(t, Walk(nil, &Visitor{}))
+	assert.NoError(t, Walk(&solution.Solution{}, nil))
+}
+
+func TestWalk_SolutionCallback(t *testing.T) {
+	var called bool
+	err := Walk(&solution.Solution{}, &Visitor{
+		Solution: func(_ *solution.Solution) error { called = true; return nil },
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestWalk_Resolvers(t *testing.T) {
+	expr := celexp.Expression("true")
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"alpha": {
+					Name: "alpha",
+					When: &resolver.Condition{Expr: &expr},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "parameter",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "hello"}},
+						}},
+					},
+				},
+				"beta": {
+					Name: "beta",
+					Transform: &resolver.TransformPhase{
+						With: []resolver.ProviderTransform{{Provider: "cel"}},
+					},
+				},
+				"nil_resolver": nil, // should be skipped
+			},
+		},
+	}
+
+	var names, provPaths, condPaths, vrPaths []string
+	err := Walk(sol, &Visitor{
+		Resolver: func(_, name string, _ *resolver.Resolver) error {
+			names = append(names, name)
+			return nil
+		},
+		ProviderSource: func(p string, _ *resolver.ProviderSource) error {
+			provPaths = append(provPaths, p)
+			return nil
+		},
+		ProviderTransform: func(p string, _ *resolver.ProviderTransform) error {
+			provPaths = append(provPaths, p)
+			return nil
+		},
+		Condition: func(p, _ string, _ *celexp.Expression) error {
+			condPaths = append(condPaths, p)
+			return nil
+		},
+		ValueRef: func(p string, _ *spec.ValueRef) error {
+			vrPaths = append(vrPaths, p)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "beta"}, names, "sorted order")
+	assert.Contains(t, provPaths, "spec.resolvers.alpha.resolve.with[0]")
+	assert.Contains(t, provPaths, "spec.resolvers.beta.transform.with[0]")
+	assert.Contains(t, condPaths, "spec.resolvers.alpha.when")
+	assert.Contains(t, vrPaths, "spec.resolvers.alpha.resolve.with[0].inputs.value")
+}
+
+func TestWalk_Workflow(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Workflow: &action.Workflow{
+				Actions: map[string]*action.Action{
+					"deploy":  {Provider: "exec"},
+					"nil_act": nil, // should be skipped
+				},
+				Finally: map[string]*action.Action{
+					"cleanup": {Provider: "exec"},
+				},
+			},
+		},
+	}
+	var names, sects []string
+	err := Walk(sol, &Visitor{
+		Action: func(_, name, section string, _ *action.Action) error {
+			names = append(names, name)
+			sects = append(sects, section)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, names, "deploy")
+	assert.Contains(t, names, "cleanup")
+}
+
+func TestWalk_Tests(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Testing: &soltesting.TestSuite{
+				Cases: map[string]*soltesting.TestCase{
+					"b-test": {Name: "b-test"},
+					"a-test": {Name: "a-test"},
+				},
+			},
+		},
+	}
+	var names []string
+	err := Walk(sol, &Visitor{
+		TestCase: func(_, name string, _ *soltesting.TestCase) error {
+			names = append(names, name)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a-test", "b-test"}, names, "sorted order")
+}
+
+func TestWalk_ErrorAborts(t *testing.T) {
+	sentinel := errors.New("stop")
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"a": {Name: "a"},
+				"b": {Name: "b"},
+				"c": {Name: "c"},
+			},
+		},
+	}
+	var n int
+	err := Walk(sol, &Visitor{
+		Resolver: func(_, _ string, _ *resolver.Resolver) error {
+			n++
+			if n == 2 {
+				return sentinel
+			}
+			return nil
+		},
+	})
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 2, n)
+}
+
+func TestWalk_ValidatePhase(t *testing.T) {
+	msg := &spec.ValueRef{Literal: "fail"}
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"v1": {
+					Name: "v1",
+					Validate: &resolver.ValidatePhase{
+						With: []resolver.ProviderValidation{{
+							Provider: "validation",
+							Message:  msg,
+						}},
+					},
+				},
+			},
+		},
+	}
+	var pvP, vrP []string
+	err := Walk(sol, &Visitor{
+		ProviderValidation: func(p string, _ *resolver.ProviderValidation) error {
+			pvP = append(pvP, p)
+			return nil
+		},
+		ValueRef: func(p string, _ *spec.ValueRef) error {
+			vrP = append(vrP, p)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"spec.resolvers.v1.validate.with[0]"}, pvP)
+	assert.Equal(t, []string{"spec.resolvers.v1.validate.with[0].message"}, vrP)
+}

--- a/pkg/sourcepos/sourcepos.go
+++ b/pkg/sourcepos/sourcepos.go
@@ -1,0 +1,193 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sourcepos provides source-location-aware parsing for YAML files.
+// It maps logical paths (e.g., "spec.resolvers.appName.resolve.with[0].inputs.value")
+// to source positions (line, column, file) in the original YAML document.
+//
+// This enables tools like lint, validation, and MCP diagnostics to report
+// precise source locations alongside logical paths.
+//
+// Usage:
+//
+//	sm, err := sourcepos.BuildSourceMap(yamlBytes, "solution.yaml")
+//	if err != nil { ... }
+//	if pos, ok := sm.Get("spec.resolvers.appName.resolve.with[0]"); ok {
+//	    fmt.Printf("line %d, column %d\n", pos.Line, pos.Column)
+//	}
+package sourcepos
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Position represents a location in a YAML source file.
+type Position struct {
+	// Line is the 1-based line number in the source file.
+	Line int `json:"line" yaml:"line" doc:"1-based line number in source file"`
+
+	// Column is the 1-based column number in the source file.
+	Column int `json:"column" yaml:"column" doc:"1-based column number in source file"`
+
+	// File is the source file path. This is important for compose scenarios
+	// where multiple files contribute to a single solution.
+	File string `json:"file,omitempty" yaml:"file,omitempty" doc:"Source file path (important for compose)"`
+}
+
+// String returns a human-readable representation of the position.
+func (p Position) String() string {
+	if p.File != "" {
+		return fmt.Sprintf("%s:%d:%d", p.File, p.Line, p.Column)
+	}
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+// IsZero returns true if the position has no meaningful location.
+func (p Position) IsZero() bool {
+	return p.Line == 0 && p.Column == 0
+}
+
+// SourceMap maps logical YAML paths to source positions.
+// It is built by walking a yaml.Node tree and recording each node's Line/Column.
+type SourceMap struct {
+	positions map[string]Position
+}
+
+// NewSourceMap creates a new empty SourceMap.
+func NewSourceMap() *SourceMap {
+	return &SourceMap{
+		positions: make(map[string]Position),
+	}
+}
+
+// Get returns the Position for the given logical path, if known.
+func (sm *SourceMap) Get(path string) (Position, bool) {
+	if sm == nil {
+		return Position{}, false
+	}
+	pos, ok := sm.positions[path]
+	return pos, ok
+}
+
+// Set records a position for the given logical path.
+func (sm *SourceMap) Set(path string, pos Position) {
+	if sm == nil {
+		return
+	}
+	sm.positions[path] = pos
+}
+
+// Len returns the number of recorded positions.
+func (sm *SourceMap) Len() int {
+	if sm == nil {
+		return 0
+	}
+	return len(sm.positions)
+}
+
+// Paths returns all recorded logical paths.
+func (sm *SourceMap) Paths() []string {
+	if sm == nil {
+		return nil
+	}
+	paths := make([]string, 0, len(sm.positions))
+	for p := range sm.positions {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// Merge incorporates all positions from another SourceMap.
+// If both maps have the same key, the other map's position wins.
+func (sm *SourceMap) Merge(other *SourceMap) {
+	if sm == nil || other == nil {
+		return
+	}
+	for path, pos := range other.positions {
+		sm.positions[path] = pos
+	}
+}
+
+// BuildSourceMap parses the YAML data and builds a SourceMap by walking the
+// yaml.Node tree. The file parameter is recorded in each Position for
+// multi-file (compose) scenarios.
+func BuildSourceMap(data []byte, file string) (*SourceMap, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML for source map: %w", err)
+	}
+
+	sm := NewSourceMap()
+	walkNode(&doc, "", file, sm)
+	return sm, nil
+}
+
+// walkNode recursively walks a yaml.Node tree, recording positions in the SourceMap.
+func walkNode(node *yaml.Node, path, file string, sm *SourceMap) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		// Document nodes contain a single child — the root mapping.
+		for _, child := range node.Content {
+			walkNode(child, path, file, sm)
+		}
+
+	case yaml.MappingNode:
+		// Record the mapping node itself only if the path hasn't been set yet
+		// (i.e. this is a root or stand-alone mapping, not one reached via a key).
+		if path != "" {
+			if _, exists := sm.positions[path]; !exists {
+				sm.Set(path, Position{Line: node.Line, Column: node.Column, File: file})
+			}
+		}
+
+		// Content is alternating key, value, key, value...
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valNode := node.Content[i+1]
+
+			key := keyNode.Value
+			var childPath string
+			if path == "" {
+				childPath = key
+			} else {
+				childPath = path + "." + key
+			}
+
+			// Record the key position (points to where the key starts).
+			sm.Set(childPath, Position{Line: keyNode.Line, Column: keyNode.Column, File: file})
+
+			// Recurse into the value.
+			walkNode(valNode, childPath, file, sm)
+		}
+
+	case yaml.SequenceNode:
+		// Record the sequence node itself only if the path hasn't been set yet.
+		if path != "" {
+			if _, exists := sm.positions[path]; !exists {
+				sm.Set(path, Position{Line: node.Line, Column: node.Column, File: file})
+			}
+		}
+
+		for i, child := range node.Content {
+			childPath := fmt.Sprintf("%s[%d]", path, i)
+			sm.Set(childPath, Position{Line: child.Line, Column: child.Column, File: file})
+			walkNode(child, childPath, file, sm)
+		}
+
+	case yaml.ScalarNode:
+		// Scalars are recorded at their parent's path (already set by the mapping handler).
+		// No children to recurse into.
+
+	case yaml.AliasNode:
+		// Follow the alias to its anchor.
+		if node.Alias != nil {
+			walkNode(node.Alias, path, file, sm)
+		}
+	}
+}

--- a/pkg/sourcepos/sourcepos_test.go
+++ b/pkg/sourcepos/sourcepos_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package sourcepos
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSourceMap_BasicMapping(t *testing.T) {
+	yamlData := []byte("apiVersion: v1\nkind: Solution\nmetadata:\n  name: test-solution\n  description: A test\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: hello\n")
+
+	sm, err := BuildSourceMap(yamlData, "test.yaml")
+	require.NoError(t, err)
+	assert.Greater(t, sm.Len(), 0)
+
+	pos, ok := sm.Get("apiVersion")
+	assert.True(t, ok)
+	assert.Equal(t, 1, pos.Line)
+	assert.Equal(t, "test.yaml", pos.File)
+
+	pos, ok = sm.Get("kind")
+	assert.True(t, ok)
+	assert.Equal(t, 2, pos.Line)
+
+	pos, ok = sm.Get("metadata.name")
+	assert.True(t, ok)
+	assert.Equal(t, 4, pos.Line)
+
+	pos, ok = sm.Get("spec.resolvers.appName")
+	assert.True(t, ok)
+	assert.Equal(t, 8, pos.Line)
+
+	pos, ok = sm.Get("spec.resolvers.appName.resolve.with[0]")
+	assert.True(t, ok)
+	assert.Equal(t, 11, pos.Line)
+
+	pos, ok = sm.Get("spec.resolvers.appName.resolve.with[0].inputs.value")
+	assert.True(t, ok)
+	assert.Equal(t, 13, pos.Line)
+}
+
+func TestBuildSourceMap_UnknownPath(t *testing.T) {
+	sm, err := BuildSourceMap([]byte("foo: bar"), "")
+	require.NoError(t, err)
+	_, ok := sm.Get("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestBuildSourceMap_InvalidYAML(t *testing.T) {
+	_, err := BuildSourceMap([]byte(":\n  :\n    :"), "bad.yaml")
+	assert.Error(t, err)
+}
+
+func TestBuildSourceMap_EmptyFile(t *testing.T) {
+	sm, err := BuildSourceMap([]byte(""), "empty.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, 0, sm.Len())
+}
+
+func TestPosition_String(t *testing.T) {
+	p1 := Position{Line: 10, Column: 5, File: "solution.yaml"}
+	assert.Equal(t, "solution.yaml:10:5", p1.String())
+
+	p2 := Position{Line: 3, Column: 1}
+	assert.Equal(t, "3:1", p2.String())
+}
+
+func TestPosition_IsZero(t *testing.T) {
+	assert.True(t, Position{}.IsZero())
+	assert.False(t, Position{Line: 1}.IsZero())
+	assert.False(t, Position{Column: 1}.IsZero())
+	assert.True(t, Position{File: "foo.yaml"}.IsZero())
+}
+
+func TestSourceMap_NilSafety(t *testing.T) {
+	var sm *SourceMap
+	_, ok := sm.Get("anything")
+	assert.False(t, ok)
+	assert.Equal(t, 0, sm.Len())
+	assert.Nil(t, sm.Paths())
+	sm.Set("foo", Position{Line: 1})
+	sm.Merge(NewSourceMap())
+}
+
+func TestSourceMap_Merge(t *testing.T) {
+	sm1 := NewSourceMap()
+	sm1.Set("a", Position{Line: 1, Column: 1, File: "file1.yaml"})
+	sm1.Set("b", Position{Line: 2, Column: 1, File: "file1.yaml"})
+
+	sm2 := NewSourceMap()
+	sm2.Set("b", Position{Line: 10, Column: 1, File: "file2.yaml"})
+	sm2.Set("c", Position{Line: 20, Column: 1, File: "file2.yaml"})
+
+	sm1.Merge(sm2)
+	assert.Equal(t, 3, sm1.Len())
+
+	pos, ok := sm1.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "file1.yaml", pos.File)
+
+	pos, ok = sm1.Get("b")
+	assert.True(t, ok)
+	assert.Equal(t, "file2.yaml", pos.File)
+	assert.Equal(t, 10, pos.Line)
+
+	pos, ok = sm1.Get("c")
+	assert.True(t, ok)
+	assert.Equal(t, "file2.yaml", pos.File)
+}
+
+func TestSourceMap_Paths(t *testing.T) {
+	sm := NewSourceMap()
+	sm.Set("z", Position{Line: 1})
+	sm.Set("a", Position{Line: 2})
+	sm.Set("m", Position{Line: 3})
+	paths := sm.Paths()
+	sort.Strings(paths)
+	assert.Equal(t, []string{"a", "m", "z"}, paths)
+}
+
+func TestBuildSourceMap_SequenceWithMappings(t *testing.T) {
+	yamlData := []byte("items:\n  - name: first\n    value: 1\n  - name: second\n    value: 2\n")
+	sm, err := BuildSourceMap(yamlData, "seq.yaml")
+	require.NoError(t, err)
+
+	pos, ok := sm.Get("items[0].name")
+	assert.True(t, ok)
+	assert.Equal(t, 2, pos.Line)
+
+	pos, ok = sm.Get("items[1].name")
+	assert.True(t, ok)
+	assert.Equal(t, 4, pos.Line)
+}
+
+func TestBuildSourceMap_DeeplyNested(t *testing.T) {
+	sm, err := BuildSourceMap([]byte("a:\n  b:\n    c:\n      d: value\n"), "")
+	require.NoError(t, err)
+	pos, ok := sm.Get("a.b.c.d")
+	assert.True(t, ok)
+	assert.Equal(t, 4, pos.Line)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3874,3 +3874,385 @@ func TestIntegration_MCPServeProtocol(t *testing.T) {
 	assert.NotEmpty(t, resp.Result.Instructions)
 	assert.NotNil(t, resp.Result.Capabilities.Tools)
 }
+
+// ============================================================================
+// Eval Command Tests
+// ============================================================================
+
+func TestIntegration_EvalCEL_Simple(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "cel", "--expression", "1 + 2")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "3")
+}
+
+func TestIntegration_EvalCEL_WithVar(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "cel", "--expression", "size(name) > 3", "-v", "name=hello")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "true")
+}
+
+func TestIntegration_EvalCEL_WithData(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "cel", "--expression", "_.name == 'hello'", "--data", `{"name": "hello"}`)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "true")
+}
+
+func TestIntegration_EvalCEL_JSON(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "cel", "--expression", "1 + 2", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "1 + 2", result["expression"])
+}
+
+func TestIntegration_EvalCEL_InvalidExpression(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "cel", "--expression", "invalid ++ syntax")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_EvalCEL_MissingExpression(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "cel")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_EvalTemplate_Simple(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "template", "-t", "hello {{ .name }}", "-v", "name=world")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hello world")
+}
+
+func TestIntegration_EvalTemplate_JSON(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "template", "-t", "hi {{ .name }}", "-v", "name=test", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Contains(t, result["output"], "hi test")
+}
+
+func TestIntegration_EvalTemplate_ShowRefs(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "template", "-t", "{{ .name }} {{ .age }}", "-v", "name=test", "-v", "age=25", "--show-refs")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "test")
+}
+
+func TestIntegration_EvalTemplate_MissingTemplate(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "template")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_EvalValidate_CELValid(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "size(name) > 3", "--type", "cel")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "valid")
+}
+
+func TestIntegration_EvalValidate_CELInvalid(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "invalid +++ (", "--type", "cel")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_EvalValidate_GoTemplateValid(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "{{ .name }}", "--type", "go-template")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "valid")
+}
+
+func TestIntegration_EvalValidate_GoTemplateInvalid(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "{{ .name", "--type", "go-template")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_EvalValidate_JSON(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "1 + 2", "--type", "cel", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, true, result["valid"])
+	assert.Equal(t, "cel", result["type"])
+}
+
+func TestIntegration_EvalValidate_UnsupportedType(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "test", "--type", "python")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+// ============================================================================
+// New Solution Command Tests
+// ============================================================================
+
+func TestIntegration_NewSolution_Basic(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "new", "solution", "-n", "test-app", "--description", "A test application")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "test-app")
+	assert.Contains(t, stdout, "A test application")
+}
+
+func TestIntegration_NewSolution_WithFeatures(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "new", "solution", "-n", "my-deploy", "--description", "Deploy to K8s",
+		"--features", "parameters,resolvers,actions")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "my-deploy")
+	assert.Contains(t, stdout, "resolvers")
+}
+
+func TestIntegration_NewSolution_WithProviders(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "new", "solution", "-n", "my-deploy", "--description", "Deploy",
+		"--providers", "exec,http")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "my-deploy")
+}
+
+func TestIntegration_NewSolution_ToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "solution.yaml")
+
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "file-test", "--description", "Written to file", "-o", outFile)
+	assert.Equal(t, 0, exitCode)
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "file-test")
+}
+
+func TestIntegration_NewSolution_MissingName(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "new", "solution", "--description", "Missing name")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_NewSolution_InvalidFeature(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "test", "--description", "Test", "--features", "invalid-feature")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_NewSolution_ScaffoldPassesLint(t *testing.T) {
+	// Scaffold with defaults, write to file, then lint — must produce zero findings.
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "solution.yaml")
+
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "lint-check", "--description", "Lint check", "-o", outFile)
+	require.Equal(t, 0, exitCode)
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", outFile, "-o", "json")
+	require.Equal(t, 0, exitCode, "lint should pass: %s", stdout)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, float64(0), result["errorCount"])
+	assert.Equal(t, float64(0), result["warnCount"])
+}
+
+func TestIntegration_NewSolution_ScaffoldRunsSuccessfully(t *testing.T) {
+	// Scaffold with defaults, write to file, then run — must execute without errors.
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "solution.yaml")
+
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "run-check", "--description", "Run check", "-o", outFile)
+	require.Equal(t, 0, exitCode)
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "solution", "-f", outFile, "-r", "inputName=world")
+	assert.Equal(t, 0, exitCode, "run should succeed: stdout=%s stderr=%s", stdout, stderr)
+	assert.Contains(t, stdout, "Hello")
+}
+
+func TestIntegration_NewSolution_AllFeaturesScaffoldPassesLint(t *testing.T) {
+	// Scaffold with all features, write to file, then lint.
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "solution.yaml")
+
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "all-features",
+		"--description", "All features", "--features",
+		"parameters,resolvers,actions,transforms,validation,tests,composition",
+		"-o", outFile)
+	require.Equal(t, 0, exitCode)
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", outFile, "-o", "json")
+	require.Equal(t, 0, exitCode, "lint should pass: %s", stdout)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, float64(0), result["errorCount"])
+	assert.Equal(t, float64(0), result["warnCount"])
+}
+
+func TestIntegration_NewSolution_ScaffoldFunctionalTestsPass(t *testing.T) {
+	// Scaffold with defaults, then run functional tests — all must pass (including builtins).
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "solution.yaml")
+
+	_, _, exitCode := runScafctl(t, "new", "solution", "-n", "func-test", "--description", "Functional test check", "-o", outFile)
+	require.Equal(t, 0, exitCode)
+
+	stdout, stderr, exitCode := runScafctl(t, "test", "functional", "-f", outFile, "--no-color")
+	assert.Equal(t, 0, exitCode, "functional tests should pass: stdout=%s stderr=%s", stdout, stderr)
+	assert.Contains(t, stdout, "0 failed")
+}
+
+// ============================================================================
+// Lint Rules/Explain Command Tests
+// ============================================================================
+
+func TestIntegration_LintRules_List(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "lint", "rules")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "RULE")
+	assert.Contains(t, stdout, "SEVERITY")
+}
+
+func TestIntegration_LintRules_FilterSeverity(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "lint", "rules", "--severity", "error")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "error")
+	assert.NotContains(t, stdout, "warning")
+}
+
+func TestIntegration_LintRules_JSON(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "lint", "rules", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var rules []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &rules))
+	assert.Greater(t, len(rules), 0)
+	assert.Contains(t, rules[0], "rule")
+	assert.Contains(t, rules[0], "severity")
+}
+
+func TestIntegration_LintExplain_KnownRule(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "lint", "explain", "missing-description")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "missing-description")
+	assert.Contains(t, stdout, "Severity")
+}
+
+func TestIntegration_LintExplain_UnknownRule(t *testing.T) {
+	_, _, exitCode := runScafctl(t, "lint", "explain", "nonexistent-rule")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_LintExplain_JSON(t *testing.T) {
+	stdout, _, exitCode := runScafctl(t, "lint", "explain", "missing-description", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "missing-description", result["rule"])
+}
+
+// ============================================================================
+// Examples Command Tests (Sprint 5)
+// ============================================================================
+
+func TestIntegration_Examples_Help(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "examples", "--help")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "list")
+	assert.Contains(t, stdout, "get")
+}
+
+func TestIntegration_Examples_List(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "examples", "list", "-o", "yaml")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "path:")
+	assert.Contains(t, stdout, "category:")
+	assert.Contains(t, stdout, "description:")
+}
+
+func TestIntegration_Examples_List_JSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "examples", "list", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var examples []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &examples))
+	assert.Greater(t, len(examples), 0)
+	assert.Contains(t, examples[0], "path")
+	assert.Contains(t, examples[0], "category")
+}
+
+func TestIntegration_Examples_List_FilterCategory(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "examples", "list", "--category", "solutions")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "solutions")
+}
+
+func TestIntegration_Examples_Get(t *testing.T) {
+	t.Parallel()
+	// Get a known example — resolver-demo.yaml is a top-level example
+	stdout, _, exitCode := runScafctl(t, "examples", "get", "resolver-demo.yaml")
+	assert.Equal(t, 0, exitCode)
+	assert.NotEmpty(t, stdout)
+}
+
+func TestIntegration_Examples_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "examples", "get", "nonexistent-example.yaml")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_Examples_Get_OutputFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "output.yaml")
+
+	_, _, exitCode := runScafctl(t, "examples", "get", "resolver-demo.yaml", "-o", outFile)
+	assert.Equal(t, 0, exitCode)
+
+	// Verify the file was written
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+// ============================================================================
+// Enhanced Dry-Run Tests (Sprint 5)
+// ============================================================================
+
+func TestIntegration_RunSolution_DryRun_EnhancedOutput(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/actions/hello-world.yaml",
+		"--dry-run",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	// Enhanced dry-run includes solution info and action plan
+	assert.Contains(t, stdout, "DRY RUN")
+	assert.Contains(t, stdout, "ACTION PLAN")
+}
+
+func TestIntegration_RunSolution_DryRun_JSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/actions/hello-world.yaml",
+		"--dry-run",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report))
+	assert.Equal(t, true, report["dryRun"])
+	assert.NotEmpty(t, report["solution"])
+}
+
+func TestIntegration_RunSolution_DryRun_YAML(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/actions/hello-world.yaml",
+		"--dry-run",
+		"-o", "yaml",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "dryRun: true")
+	assert.Contains(t, stdout, "solution:")
+}


### PR DESCRIPTION
Add extensive MCP server tooling and new CLI commands as part of a
developer experience improvement initiative (Phase 5+).

MCP Server:
- Add 20+ new MCP tools: action, auth, config, diff, dryrun, lint,
  refs, scaffold, schema, snapshot, template, testing, version
- Add completions, hooks, output schemas, progress tracking,
  capabilities, filtering, and structured error handling
- Significantly expand prompts and resources support
- Add icons and rich output schema definitions

New CLI Commands:
- eval cel: evaluate CEL expressions against data files
- eval template: render Go templates with data
- eval validate: validate configuration against JSON schema
- new solution: scaffold a new solution interactively
- examples list/get: browse and retrieve bundled examples

lint Enhancements:
- Add 'lint rules' subcommand to list available lint rules
- Add 'lint explain' subcommand for detailed rule documentation
- Expand rule definitions and test coverage

New Packages:
- pkg/dryrun: dry-run execution engine
- pkg/soldiff: solution diff computation between states
- pkg/sourcepos: YAML/JSON source position tracking
- pkg/solution/walk: solution directory walker
- pkg/examples: bundled example management
- pkg/scaffold: scaffolding logic extracted from commands

HTTP Provider:
- Add comprehensive pagination support: cursor, link-header,
  OData, offset, and page-number strategies

Resolver:
- Add dependency graph visualization and cycle detection tests

Documentation & Examples:
- Add tutorials for eval, linting, scaffolding, snapshots
- Add HTTP pagination provider examples
- Expand MCP server tutorial and design docs
- Add otel telemetry and shared library migration design docs