### PR TITLE
feat(auth): add diagnose command, enhance list/status/token/login com…

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -222,13 +222,58 @@ Behavior:
 - Exchanges token using OAuth2 client assertion grant
 - No user interaction required
 - Tokens are cached like other flows
-- Highest priority: takes precedence over service principal if both are configured
+- **Highest priority**: takes precedence over all other flows — stored refresh tokens (device code) and service principal credentials are bypassed when WIF env vars are present
 
-Logout clears stored credentials:
+### Flow Priority
+
+When `GetToken` is called, the Entra handler selects the flow in this order:
+
+| Priority | Flow | Condition |
+|----------|------|-----------|
+| 1 | Workload Identity | `AZURE_FEDERATED_TOKEN_FILE` or `AZURE_FEDERATED_TOKEN` is set and valid |
+| 2 | Service Principal | `AZURE_CLIENT_SECRET` is set |
+| 3 | Device Code (refresh token) | A refresh token is present in the system secret store |
+
+Only the first matching flow is used.
+
+### Isolation from Stored Refresh Tokens
+
+WIF and the device-code refresh token are **completely independent** and stored separately:
+
+- WIF reads only environment variables and the projected token file — it never reads, writes, or modifies `scafctl.auth.entra.refresh_token`
+- Running `scafctl auth login entra` with WIF env vars present does **not** clear or replace any stored refresh token
+- A refresh token from a prior device-code login may silently coexist in the secret store while WIF is active; `scafctl auth list` will display both
+
+### Fallback Behavior
+
+If WIF env vars are later removed or the token file disappears, the handler automatically falls through to the next available flow (service principal, then stored refresh token). No reconfiguration is required.
+
+This is useful in migration scenarios, for example when bootstrapping WIF on a cluster: a developer's device-code session is still usable outside the cluster without any changes.
+
+### Stale Stored Credentials
+
+Because WIF never clears the secret store, a refresh token from a previous device-code login may remain stored after WIF is deployed. While this token is never used while WIF is active, it still appears in `scafctl auth list` and counts against the 90-day idle expiry.
+
+If you want a clean state after switching to WIF, explicitly clear stored credentials:
 
 ~~~bash
 scafctl auth logout entra
 ~~~
+
+This removes the refresh token and access token cache without affecting WIF, which is entirely env-var driven.
+
+---
+
+## Refresh Token Rotation
+
+Entra ID issues a **new refresh token value** on every use of an existing refresh token (this is called rolling or rotating refresh tokens). Key points:
+
+- The **lifetime** of a refresh token is 90 days, measured as a **sliding window** — each successful use resets the 90-day clock
+- The old token value is invalidated and the new value is atomically stored in the secret store
+- This rotation is transparent to the user; from scafctl's perspective the session simply continues
+- A refresh token that has not been used for 90 consecutive days will expire and require re-authentication
+
+Scafctl handles rotation automatically in `mintToken()`: if the token response contains a new refresh token value, it is stored immediately before the access token is returned.
 
 ---
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -29,11 +29,13 @@ This tutorial walks you through setting up and using authentication in scafctl. 
    - [GCP Workload Identity Federation](#gcp-workload-identity-federation)
    - [GCP Metadata Server](#gcp-metadata-server-gcegkecloud-run)
 3. [Checking Auth Status](#checking-auth-status)
-4. [Using Auth in HTTP Providers](#using-auth-in-http-providers)
-5. [Getting Tokens for Debugging](#getting-tokens-for-debugging)
-6. [Configuration](#configuration)
-7. [Logging Out](#logging-out)
-8. [Troubleshooting](#troubleshooting)
+4. [Listing and Sorting Cached Tokens](#listing-and-sorting-cached-tokens)
+5. [Using Auth in HTTP Providers](#using-auth-in-http-providers)
+6. [Getting Tokens for Debugging](#getting-tokens-for-debugging)
+7. [Configuration](#configuration)
+8. [Logging Out](#logging-out)
+9. [Auth Diagnostics](#auth-diagnostics)
+10. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -95,6 +97,21 @@ Waiting for authentication...
 ✓ Successfully authenticated as user@example.com
   Tenant: contoso.onmicrosoft.com
 ```
+
+### Idempotent Login for Scripts (--skip-if-authenticated)
+
+Use `--skip-if-authenticated` to skip re-authentication if you're already logged in. The command exits `0` without prompting, making it safe to call at the start of scripts or CI jobs without disrupting an active session:
+
+```bash
+# Only login if not already authenticated
+scafctl auth login entra --skip-if-authenticated
+scafctl auth login github --skip-if-authenticated
+scafctl auth login gcp --skip-if-authenticated
+```
+
+When already authenticated this prints a message and exits `0`. Without the flag, the command prompts for re-authentication (or warns if already authenticated but continues).
+
+---
 
 ### Specifying a Tenant
 
@@ -397,6 +414,36 @@ echo "Getting access token for Azure Resource Manager..."
 scafctl auth token entra --scope "https://management.azure.com/.default"
 ```
 
+##### Flow Priority and Interaction with Stored Credentials
+
+The Entra handler selects which flow to use based on what is available at runtime, in this order:
+
+| Priority | Flow | What triggers it |
+|----------|------|------------------|
+| 1 (highest) | Workload Identity | `AZURE_FEDERATED_TOKEN_FILE` or `AZURE_FEDERATED_TOKEN` is set |
+| 2 | Service Principal | `AZURE_CLIENT_SECRET` is set |
+| 3 (lowest) | Device Code / Refresh Token | A refresh token is stored in the system secret store |
+
+**WIF does not touch the stored refresh token.**
+
+When WIF is active, the stored device-code refresh token (if any) is bypassed but **not deleted**. The two credential types live in completely separate storage:
+
+- WIF is entirely env-var driven — no reads or writes to `scafctl.auth.entra.refresh_token`
+- A prior device-code session silently coexists in the secret store while WIF is active
+- `scafctl auth list` will display both the WIF-sourced access tokens and any stored refresh token
+
+**Fallback behavior**: removing WIF env vars causes the handler to automatically fall through to the next available flow. If you have a stored refresh token, it resumes being used with no reconfiguration needed.
+
+**Stale stored credentials**: if you want a clean slate after switching to WIF, explicitly remove the stored device-code session:
+
+```bash
+scafctl auth logout entra
+```
+
+This removes the refresh token and cached access tokens without affecting WIF, which is entirely driven by environment variables.
+
+---
+
 ##### Troubleshooting Workload Identity
 
 **Error: "AADSTS70021: No matching federated identity record found"**
@@ -679,14 +726,116 @@ Handler   Status         Identity   Username   IdentityType        Scopes
 github    Authenticated  octocat    octocat    service-principal   gist, read:org, repo, workflow
 ```
 
-When not authenticated:
+When not authenticated, the `hint` field tells you the exact command to run:
 
 ```
-Handler   Status            Identity   Tenant   Expires
-entra     Not Authenticated -          -        -
-github    Not Authenticated -          -        -
-gcp       Not Authenticated -          -        -
+Handler   Status            Identity   Tenant   Expires   Hint
+entra     Not Authenticated -          -        -         run 'scafctl auth login entra' to authenticate
+github    Not Authenticated -          -        -         run 'scafctl auth login github' to authenticate
+gcp       Not Authenticated -          -        -         run 'scafctl auth login gcp' to authenticate
 ```
+
+### Scripting with --exit-code
+
+Use `--exit-code` to make the command exit non-zero when any handler is not authenticated — handy in CI pre-flight checks:
+
+```bash
+# Fail the script if not authenticated
+scafctl auth status entra --exit-code || { echo "Not authenticated. Run: scafctl auth login entra"; exit 1; }
+```
+
+### Proactive Expiry Warnings (--warn-within)
+
+Use `--warn-within <duration>` to exit non-zero if any authenticated token will expire within the given window. This catches near-expiry tokens **before** they cause a mid-job failure:
+
+```bash
+# Exit non-zero if any token expires within 10 minutes
+scafctl auth status --warn-within 10m
+
+# Check a specific handler
+scafctl auth status entra --warn-within 1h
+
+# Combine with --exit-code for a full CI pre-flight check
+scafctl auth status --exit-code --warn-within 15m || {
+  echo "Auth pre-flight failed — not authenticated or token expiring soon"
+  exit 1
+}
+```
+
+The JSON output includes a `cachedTokens` field showing how many access tokens are in the cache for each handler — useful for verifying token cache health:
+
+```bash
+scafctl auth status -o json | jq '.[].cachedTokens'
+```
+
+---
+
+## Listing and Sorting Cached Tokens
+
+The `auth list` command shows metadata for all cached tokens (refresh tokens and access tokens) without revealing the actual token values:
+
+```bash
+# Show all cached tokens for all handlers
+scafctl auth list
+
+# Show cached tokens for a single handler
+scafctl auth list entra
+scafctl auth list github
+scafctl auth list gcp
+
+# Show only expired tokens
+scafctl auth list --expired-only
+
+# Show only valid tokens
+scafctl auth list --valid-only
+
+# Sort by expiry (soonest expiring first — useful for spotting tokens about to expire)
+scafctl auth list --sort expires-at
+
+# Sort by handler name
+scafctl auth list --sort handler
+
+# Sort by scope
+scafctl auth list --sort scope
+
+# Output as JSON for scripting
+scafctl auth list -o json
+
+# Remove all expired access tokens from the cache (refresh tokens and valid tokens are preserved)
+scafctl auth list --purge-expired
+
+# Purge expired tokens for a specific handler
+scafctl auth list entra --purge-expired
+```
+
+**Sort fields:**
+
+| Flag value | Sorted by |
+|------------|-----------|
+| `handler` | Auth handler name |
+| `kind` | Token kind (`refresh` / `access`) |
+| `scope` | OAuth scope string |
+| `expires-at` | Expiry time (soonest first) |
+| `cached-at` | When the token was cached (oldest first) |
+
+The `getTokenCommand` column in the output shows the exact `scafctl auth token` command to retrieve each access token, making it easy to copy-paste for debugging.
+
+### Purging Expired Tokens (--purge-expired)
+
+Over time the token cache can accumulate expired access tokens. Use `--purge-expired` to clean them up. Refresh tokens and still-valid access tokens are **not** affected:
+
+```bash
+# Remove expired cache entries across all handlers
+scafctl auth list --purge-expired
+# Output:
+# ✓ Purged 2 expired access token(s) from entra.
+# ✓ Purged 0 expired access token(s) from github.
+
+# Purge only for a specific handler
+scafctl auth list gcp --purge-expired
+```
+
+> `--purge-expired` cannot be combined with `--expired-only` or `--valid-only` (it exits early without listing).
 
 ---
 
@@ -857,10 +1006,13 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default"
 
 # Get a GitHub token (uses scopes from login; --scope is not supported)
 scafctl auth token github
+
+# Get a GCP token
+scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform"
 ```
 
 > **Note:** The `--scope` flag is only supported on `auth token` for handlers
-> with the `scopes-on-token-request` capability (e.g., Entra ID). GitHub scopes
+> with the `scopes-on-token-request` capability (e.g., Entra ID and GCP). GitHub scopes
 > are fixed at login time — use `scafctl auth login github --scope <scope>` to
 > change them.
 
@@ -895,23 +1047,125 @@ If you need a fresh token regardless of cache state (e.g., after permission chan
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --force-refresh
 ```
 
-### Using the Token Directly
+### Printing the Raw Token (Scripting)
 
-You can use the token in other tools:
+Use `--raw` to print just the token value — ideal for shell scripting:
 
 ```bash
-# Use with curl (Entra / Microsoft Graph)
+# Assign to a variable
+export TOKEN=$(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --raw)
+
+# Use directly with curl
+curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user
+```
+
+### Shell Export (eval-compatible)
+
+Use `--export` to get a shell export statement you can `eval` into the current shell. The variable is named `<HANDLER>_TOKEN`:
+
+```bash
+# Add a GCP token to the current shell environment
+eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
+echo $GCP_TOKEN
+
+# Other handlers follow the same pattern
+eval $(scafctl auth token github --export)
+echo $GITHUB_TOKEN
+
+eval $(scafctl auth token entra --scope "https://management.azure.com/.default" --export)
+echo $ENTRA_TOKEN
+```
+
+### Emitting a Ready-to-Run curl Command
+
+Use `--curl` to print a `curl` command with the `Authorization` header already populated — great for quick API call reproduction without any `jq` piping:
+
+```bash
+# Emit a curl one-liner for Microsoft Graph
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
+  --curl --curl-url "https://graph.microsoft.com/v1.0/me"
+# Output:
+# curl -H "Authorization: Bearer eyJ..." "https://graph.microsoft.com/v1.0/me"
+
+# Emit a curl one-liner for GCP
+scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" \
+  --curl --curl-url "https://storage.googleapis.com/storage/v1/b?project=my-project"
+
+# Emit without a URL (useful to inspect — fills in a placeholder)
+scafctl auth token github --curl
+# Output:
+# curl -H "Authorization: Bearer ghp_..." "<URL>"
+```
+
+### Decoding the JWT (Header + Payload)
+
+Use `--decode` to inspect the full JWT structure — both the **header** and the **payload** — without needing an external decoder tool. Signature validation is intentionally skipped; this is for debugging only:
+
+```bash
+# Decode and display the full JWT (header and payload)
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
+
+# Output as JSON — filter with jq
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json \
+  | jq '{alg: .header.alg, audience: .payload.aud, upn: .payload.upn, expires: .payload.exp_human}'
+```
+
+Example output (table):
+
+```
+Key                   Value
+header.alg            RS256
+header.typ            JWT
+header.kid            abc123...
+payload.aud           https://graph.microsoft.com
+payload.iss           https://login.microsoftonline.com/...
+payload.sub           A3ECB230-...
+payload.oid           12345678-...
+payload.upn           user@example.com
+payload.roles         ["Directory.Read.All"]
+payload.exp           1740000000
+payload.exp_human     2026-02-19T22:13:20Z
+payload.iat_human     2026-02-19T21:13:20Z
+```
+
+The header section tells you the signing algorithm (`alg`), key ID (`kid`), and token type (`typ`) — useful for confirming which key was used and troubleshooting signature or algorithm policy issues.
+
+Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) are automatically augmented with a `_human` counterpart in RFC 3339 format.
+
+This is the single fastest way to check:
+- Which audience (`aud`) the token is for
+- Which roles or scopes are included (`roles`, `scp`)
+- Whether the token's expiry (`exp_human`) matches what you expect
+- Tenant, OID, and UPN for identity verification
+
+### Copying to Clipboard
+
+Use `--clip` to copy the token directly to your clipboard without it appearing in your terminal (useful when pasting into browser DevTools or Postman):
+
+```bash
+scafctl auth token entra --scope "https://management.azure.com/.default" --clip
+# Output: ✓ Token copied to clipboard (expires in 58m42s).
+```
+
+### Using the Token Directly
+
+Get the full token for use with other tools:
+
+```bash
+# Approach 1: --raw (simplest)
+curl -H "Authorization: Bearer $(scafctl auth token entra --scope 'https://graph.microsoft.com/.default' --raw)" \
+  https://graph.microsoft.com/v1.0/me
+
+# Approach 2: --curl (no jq required)
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
+  --curl --curl-url "https://graph.microsoft.com/v1.0/me" | bash
+
+# Approach 3: JSON output + jq (most flexible)
 TOKEN=$(scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json | jq -r '.accessToken')
 curl -H "Authorization: Bearer $TOKEN" https://graph.microsoft.com/v1.0/me
 
-# Use with curl (GitHub API)
-TOKEN=$(scafctl auth token github -o json | jq -r '.accessToken')
-curl -H "Authorization: Bearer $TOKEN" https://api.github.com/user/repos
-
-# Use with httpie
-scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json | \
-  jq -r '"Bearer " + .accessToken' | \
-  http GET https://graph.microsoft.com/v1.0/me Authorization:@-
+# GitHub API example
+curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user/repos
 ```
 
 ---
@@ -998,6 +1252,19 @@ scafctl auth logout entra
 
 # Logout from GitHub
 scafctl auth logout github
+
+# Logout from GCP
+scafctl auth logout gcp
+
+# Logout from all registered handlers at once (prompts for confirmation)
+scafctl auth logout --all
+
+# Skip the confirmation prompt (for scripts and CI)
+scafctl auth logout --all --yes
+scafctl auth logout --all -y
+
+# Force clear credentials even if not currently logged in
+scafctl auth logout entra --force
 ```
 
 This removes:
@@ -1006,10 +1273,102 @@ This removes:
 - All cached access tokens
 - Token metadata
 
+### Dry Run
+
+Use `--dry-run` to see which credentials would be removed without actually removing them. Useful before running `--all` in a shared or production environment:
+
+```bash
+# Preview what would be removed for Entra
+scafctl auth logout entra --dry-run
+# Output: [dry-run] Would log out from Microsoft Entra ID (cached tokens and refresh token would be removed).
+
+# Preview across all handlers
+scafctl auth logout --all --dry-run
+```
+
 ### Example Output
 
 ```
-✓ Successfully logged out from entra
+✓ Successfully logged out from Microsoft Entra ID.
+```
+
+---
+
+## Auth Diagnostics
+
+The `auth diagnose` command (alias: `auth doctor`) runs a series of health checks
+and reports any issues with your auth configuration. It's the first command to run
+when troubleshooting auth problems:
+
+```bash
+# Run all checks and print a human-readable report
+scafctl auth diagnose
+
+# Alias
+scafctl auth doctor
+
+# Scope checks to a single handler (skips checks for the others)
+scafctl auth diagnose entra
+scafctl auth diagnose github
+scafctl auth diagnose gcp
+
+# Also attempt a live token fetch for each authenticated handler
+scafctl auth diagnose --live-token
+
+# Scope live-token check to one handler
+scafctl auth diagnose entra --live-token
+
+# Output as JSON for automated pipelines
+scafctl auth diagnose -o json
+```
+
+### What It Checks
+
+| Category | What is checked |
+|----------|-----------------|
+| `registry` | Auth handlers are registered and available |
+| `config` | Config file presence; `auth.entra`, `auth.github`, `auth.gcp` sections |
+| `env` | Relevant environment variables (`AZURE_*`, `GITHUB_TOKEN`, `GOOGLE_*`) |
+| `clock-skew` | System clock is validated against an external time source; warns if skew exceeds 5 minutes (clock skew causes token validation failures) |
+| `handler` | Each handler's authentication status; hints for unauthenticated handlers |
+| `cache` | Token cache health — count and number of expired cached tokens |
+| `live` | *(Only with `--live-token`)* Performs an actual `GetToken` call to confirm end-to-end flow |
+
+### Example Output
+
+```
+✅ [ok]   auth registry: registered handlers: [entra gcp github]
+⚠️  [warn] config file: config file not found — using built-in defaults
+✅ [ok]   env GITHUB_TOKEN: GitHub personal access token — set
+✅ [ok]   env gcp: gcloud ADC: gcloud Application Default Credentials file found
+✅ [ok]   entra: authenticated: authenticated as "user@example.com", expires in 58m
+⚠️  [warn] entra: token cache: 3 cached token(s), 1 expired
+✅ [ok]   gcp: authenticated: authenticated as "gcloud ADC (application default credentials)"
+✅ [ok]   gcp: token cache: 1 cached token(s)
+⚠️  [warn] github: authenticated: not authenticated — run 'scafctl auth login github'
+
+⚠️ Diagnostics complete: 3 warning(s), 5 ok (no failures)
+```
+
+### Exit Codes
+
+| Condition | Exit code |
+|-----------|-----------|
+| All checks pass or warn | `0` |
+| Any check **fails** | non-zero |
+
+> Warnings (unauthenticated handler, expired tokens, missing config file) do **not** produce a
+> non-zero exit code on their own. Only hard failures (registry empty, handler init error) do.
+
+### Using in CI Preflight
+
+```bash
+# Verify end-to-end auth before running a pipeline
+scafctl auth diagnose --live-token
+if [ $? -ne 0 ]; then
+  echo "Auth health check failed. Check 'scafctl auth diagnose' output."
+  exit 1
+fi
 ```
 
 ---
@@ -1091,18 +1450,25 @@ If you're getting 403 (Forbidden) errors, the token may not have the required pe
 
 ### Checking Token Claims
 
-To debug token issues, get a token and decode it:
+Use `--decode` on `auth token` to inspect JWT claims directly without needing an
+external tool or manual base64 decoding:
 
 ```bash
-# Get the token
-TOKEN=$(scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json | jq -r '.accessToken')
+# Decode and display claims in table format (no signature validation)
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 
-# Decode the token (using jwt-cli or online decoder)
-echo $TOKEN | jwt decode -
-
-# Or decode just the payload (base64)
-echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+# Output as JSON for further processing (e.g., with jq)
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | jq '.aud,.upn,.roles'
 ```
+
+Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) are automatically augmented
+with a `_human` RFC 3339 counterpart so you can read them without converting.
+
+Useful things to verify:
+- `aud` — correct audience for the API you're calling
+- `scp` / `roles` — scopes or app roles granted
+- `exp_human` — actual token expiry in human-readable form
+- `upn` / `unique_name` / `preferred_username` — the authenticated identity
 
 ### Debug Logging
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -1,0 +1,233 @@
+# Auth Examples
+
+This directory contains examples and cheat-sheets for the `scafctl auth` commands.
+
+---
+
+## Quick Reference
+
+### Login
+
+```bash
+# Entra ID (device code — opens browser)
+scafctl auth login entra
+
+# GitHub (device code — opens browser)
+scafctl auth login github
+
+# GCP (browser OAuth)
+scafctl auth login gcp
+
+# Non-interactive flows
+scafctl auth login entra --flow service-principal   # requires AZURE_* env vars
+scafctl auth login github --flow pat                # requires GITHUB_TOKEN or GH_TOKEN
+scafctl auth login gcp --flow service-principal     # requires GOOGLE_APPLICATION_CREDENTIALS
+scafctl auth login gcp --flow gcloud-adc            # uses existing gcloud ADC file
+
+# Idempotent — skip if already authenticated (safe for scripts and CI)
+scafctl auth login entra --skip-if-authenticated
+scafctl auth login github --skip-if-authenticated
+scafctl auth login gcp --skip-if-authenticated
+```
+
+---
+
+## Diagnosing Auth Problems
+
+Run `auth diagnose` (alias: `auth doctor`) first when things go wrong.
+It checks everything in one shot:
+
+```bash
+scafctl auth diagnose
+```
+
+Output example:
+```
+✅ [ok]   auth registry: registered handlers: [entra gcp github]
+⚠️  [warn] config file: config file not found — using built-in defaults
+✅ [ok]   env GITHUB_TOKEN: GitHub personal access token — set
+✅ [ok]   entra: authenticated: authenticated as "user@example.com", expires in 58m
+⚠️  [warn] entra: token cache: 3 cached token(s), 1 expired
+⚠️  [warn] github: not authenticated — run 'scafctl auth login github'
+
+⚠️ Diagnostics complete: 3 warning(s), 5 ok (no failures)
+```
+
+Scope checks to a single handler (faster when you only care about one provider):
+
+```bash
+scafctl auth diagnose entra
+scafctl auth diagnose github
+```
+
+Also perform a live token fetch to confirm end-to-end:
+
+```bash
+scafctl auth diagnose --live-token
+
+# Scope live-token check to one handler
+scafctl auth diagnose entra --live-token
+```
+
+Get structured output for CI pipelines:
+
+```bash
+scafctl auth diagnose -o json
+```
+
+> The `clock-skew` check compares your system clock against an external time source and warns if the skew exceeds 5 minutes — a common but easy-to-miss cause of token validation failures.
+
+---
+
+## Checking Status with Hints
+
+When a handler is not authenticated, `auth status` now includes a `hint`:
+
+```bash
+scafctl auth status
+```
+
+```
+handler: github  authenticated: false  hint: run 'scafctl auth login github' to authenticate
+```
+
+Exit non-zero if not authenticated (for CI pre-flight):
+
+```bash
+scafctl auth status entra --exit-code
+```
+
+Exit non-zero if any token expires within a given window (`--warn-within`):
+
+```bash
+# Warn if any token expires within 10 minutes
+scafctl auth status --warn-within 10m
+
+# Combine with --exit-code for a single full pre-flight check
+scafctl auth status --exit-code --warn-within 15m
+```
+
+---
+
+## Listing and Sorting Cached Tokens
+
+```bash
+# List all cached tokens across all handlers
+scafctl auth list
+
+# Only expired tokens
+scafctl auth list --expired-only
+
+# Valid tokens only, sorted soonest-expiring first
+scafctl auth list --valid-only --sort expires-at
+
+# Sort by handler name
+scafctl auth list --sort handler
+
+# JSON output for scripting
+scafctl auth list -o json
+
+# Remove expired access tokens from the cache (keeps valid tokens and the refresh token)
+scafctl auth list --purge-expired
+scafctl auth list entra --purge-expired
+```
+
+The `getTokenCommand` column shows the exact `scafctl auth token` command to
+retrieve each access token — copy-paste it directly into your terminal.
+
+---
+
+## Token Debugging
+
+### Get a raw token (for scripting)
+
+```bash
+# Assign to a shell variable
+TOKEN=$(scafctl auth token entra --scope "https://graph.microsoft.com/.default" --raw)
+
+# Use directly inline
+curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user
+```
+
+### Export to the current shell (eval-compatible)
+
+```bash
+eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
+echo $GCP_TOKEN      # variable is named <HANDLER>_TOKEN
+
+eval $(scafctl auth token entra --scope "https://management.azure.com/.default" --export)
+echo $ENTRA_TOKEN
+```
+
+### Emit a ready-to-run curl command
+
+No jq or variable assignment needed:
+
+```bash
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
+    --curl --curl-url "https://graph.microsoft.com/v1.0/me"
+# Prints: curl -H "Authorization: Bearer eyJ..." "https://graph.microsoft.com/v1.0/me"
+
+# Run it immediately
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
+    --curl --curl-url "https://graph.microsoft.com/v1.0/me" | bash
+
+# No URL — uses <URL> placeholder for inspection
+scafctl auth token github --curl
+```
+
+### Decode JWT header + payload (no external tools needed)
+
+`--decode` shows both the JWT **header** (algorithm, key ID) and the **payload** (claims):
+
+```bash
+# Table format — immediately readable
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
+
+# JSON format — pipe to jq for filtering
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json \
+    | jq '{alg: .header.alg, kid: .header.kid, upn: .payload.upn, expires: .payload.exp_human, roles: .payload.roles}'
+```
+
+Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) automatically get a
+`_human` companion in RFC 3339 format.
+
+### Copy to clipboard (no terminal echo)
+
+```bash
+scafctl auth token entra --scope "https://management.azure.com/.default" --clip
+# ✓ Token copied to clipboard (expires in 58m42s).
+```
+
+---
+
+## Logging Out Safely
+
+```bash
+# Preview what would be removed (dry run)
+scafctl auth logout entra --dry-run
+
+# Preview across all handlers
+scafctl auth logout --all --dry-run
+
+# Actually log out
+scafctl auth logout entra
+
+# Log out from everything at once (prompts for confirmation)
+scafctl auth logout --all
+
+# Skip the confirmation prompt (for scripts and CI)
+scafctl auth logout --all --yes
+scafctl auth logout --all -y
+
+# Force clear even if not authenticated
+scafctl auth logout entra --force
+```
+
+---
+
+## Related
+
+- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) — full walkthrough
+- [HTTP Provider with Entra](../providers/http-entra.yaml) — example HTTP call with Entra auth
+- [GitHub API Provider](../providers/github-api.yaml) — example GitHub API call

--- a/examples/providers/http-entra.yaml
+++ b/examples/providers/http-entra.yaml
@@ -1,0 +1,13 @@
+# HTTP provider input - Microsoft Graph API call with Entra authentication
+#
+# Prerequisites:
+#   scafctl auth login entra --scope https://graph.microsoft.com/.default
+#
+# Usage:
+#   scafctl run provider http --input @examples/providers/http-entra.yaml
+url: https://graph.microsoft.com/v1.0/me
+method: GET
+headers:
+  Accept: application/json
+auth: entra
+scope: "https://graph.microsoft.com/.default"

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/oakwood-commons/scafctl
 go 1.25.4
 
 require (
-	charm.land/bubbles/v2 v2.0.0-rc.1
 	charm.land/bubbletea/v2 v2.0.0-rc.2
-	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106192539-4b304240aab7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/adrg/xdg v0.5.3
+	github.com/atotto/clipboard v0.1.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/danielgtaylor/huma/v2 v2.37.2
@@ -53,10 +52,11 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.1 // indirect
+	charm.land/bubbles/v2 v2.0.0-rc.1 // indirect
+	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106192539-4b304240aab7 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -123,7 +123,6 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
-github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
-github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=

--- a/pkg/auth/entra/cache.go
+++ b/pkg/auth/entra/cache.go
@@ -30,6 +30,7 @@ type CachedToken struct {
 	ExpiresAt   time.Time `json:"expiresAt"`
 	Scope       string    `json:"scope"`
 	CachedAt    time.Time `json:"cachedAt"`
+	SessionID   string    `json:"sessionId,omitempty"`
 }
 
 // NewTokenCache creates a new disk-based token cache.
@@ -64,6 +65,8 @@ func (c *TokenCache) Get(ctx context.Context, scope string) (*auth.Token, error)
 		TokenType:   cached.TokenType,
 		ExpiresAt:   cached.ExpiresAt,
 		Scope:       cached.Scope,
+		CachedAt:    cached.CachedAt,
+		SessionID:   cached.SessionID,
 	}, nil
 }
 
@@ -77,6 +80,7 @@ func (c *TokenCache) Set(ctx context.Context, scope string, token *auth.Token) e
 		ExpiresAt:   token.ExpiresAt,
 		Scope:       scope,
 		CachedAt:    time.Now(),
+		SessionID:   token.SessionID,
 	}
 
 	data, err := json.Marshal(cached)
@@ -115,6 +119,29 @@ func (c *TokenCache) Clear(ctx context.Context) error {
 	}
 
 	return lastErr
+}
+
+// PurgeExpired removes all expired access tokens from the cache.
+// Returns the number of tokens removed.
+func (c *TokenCache) PurgeExpired(ctx context.Context) (int, error) {
+	scopes, err := c.ListCachedScopes(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list cached scopes: %w", err)
+	}
+
+	purged := 0
+	for _, scope := range scopes {
+		token, err := c.Get(ctx, scope)
+		if err != nil || token == nil {
+			continue
+		}
+		if token.IsExpired() {
+			if delErr := c.Delete(ctx, scope); delErr == nil {
+				purged++
+			}
+		}
+	}
+	return purged, nil
 }
 
 // ListCachedScopes returns a list of scopes that have cached tokens.

--- a/pkg/auth/entra/device_flow.go
+++ b/pkg/auth/entra/device_flow.go
@@ -111,7 +111,7 @@ func (h *Handler) performDeviceCodeFlow(ctx context.Context, opts auth.LoginOpti
 	}
 
 	// Step 4: Store refresh token securely
-	if err := h.storeCredentials(ctx, tenantID, tokenResp, h.config.ClientID, scopes, auth.FlowDeviceCode); err != nil {
+	if err := h.storeCredentials(ctx, tenantID, tokenResp, h.config.ClientID, scopes, auth.FlowDeviceCode, ""); err != nil {
 		return nil, auth.NewError(HandlerName, "store_credentials", err)
 	}
 

--- a/pkg/auth/entra/handler.go
+++ b/pkg/auth/entra/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -39,6 +40,12 @@ const (
 	DefaultRefreshTokenLifetime = 90 * 24 * time.Hour
 )
 
+// authHTTPLogLevel is the verbosity offset applied to the base logger
+// before it is handed to the HTTP transport used by auth handlers.
+// This ensures auth HTTP calls only appear at high verbosity levels
+// (e.g. base V(0) + offset 5 → effective V(5)).
+const authHTTPLogLevel = 5
+
 // Handler implements auth.Handler for Microsoft Entra ID.
 type Handler struct {
 	config      *Config
@@ -47,6 +54,7 @@ type Handler struct {
 	httpClient  HTTPClient
 	graphClient GraphClient
 	tokenCache  *TokenCache
+	logger      logr.Logger
 }
 
 // Option configures the Handler.
@@ -101,6 +109,15 @@ func WithGraphClient(client GraphClient) Option {
 	}
 }
 
+// WithLogger sets the logger for the handler.
+// The logger is offset by authHTTPLogLevel before being passed to the HTTP
+// transport so that auth HTTP traffic only appears at high verbosity.
+func WithLogger(lgr logr.Logger) Option {
+	return func(h *Handler) {
+		h.logger = lgr
+	}
+}
+
 // New creates a new Entra auth handler.
 // Secret store initialization is deferred — if it fails, the handler is still
 // created so that metadata operations (Name, SupportedFlows, etc.) work.
@@ -126,14 +143,18 @@ func New(opts ...Option) (*Handler, error) {
 		}
 	}
 
+	// Compute the HTTP-level logger: offset by authHTTPLogLevel so that
+	// auth HTTP calls only appear at high verbosity.
+	httpLogger := h.logger.V(authHTTPLogLevel)
+
 	// Initialize HTTP client if not provided
 	if h.httpClient == nil {
-		h.httpClient = NewDefaultHTTPClient()
+		h.httpClient = NewDefaultHTTPClient(httpLogger)
 	}
 
 	// Initialize Graph client if not provided
 	if h.graphClient == nil {
-		h.graphClient = NewDefaultGraphClient()
+		h.graphClient = NewDefaultGraphClient(httpLogger)
 	}
 
 	// Initialize token cache with secret store (nil-safe: checked before use)
@@ -432,5 +453,76 @@ func getCachedOrAcquireToken[T any](
 	return token, nil
 }
 
-// Compile-time check that Handler implements auth.Handler.
-var _ auth.Handler = (*Handler)(nil)
+// Compile-time check that Handler implements auth.Handler, auth.TokenLister, and auth.TokenPurger.
+var (
+	_ auth.Handler     = (*Handler)(nil)
+	_ auth.TokenLister = (*Handler)(nil)
+	_ auth.TokenPurger = (*Handler)(nil)
+)
+
+// ListCachedTokens returns metadata for all tokens stored by the Entra handler.
+// It includes the long-lived refresh token (if any) and all minted access tokens
+// from the on-disk cache.  Actual token values are intentionally excluded.
+func (h *Handler) ListCachedTokens(ctx context.Context) ([]*auth.CachedTokenInfo, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	var results []*auth.CachedTokenInfo
+
+	// Refresh token
+	exists, _ := h.secretStore.Exists(ctx, SecretKeyRefreshToken)
+	if exists {
+		info := &auth.CachedTokenInfo{
+			Handler:   HandlerName,
+			TokenKind: "refresh",
+		}
+		if metadata, err := h.loadMetadata(ctx); err == nil && metadata != nil {
+			info.ExpiresAt = metadata.RefreshTokenExpiresAt
+			info.CachedAt = metadata.LastRefresh
+			info.Flow = metadata.LoginFlow
+			info.SessionID = metadata.SessionID
+		}
+		if !info.ExpiresAt.IsZero() {
+			info.IsExpired = time.Now().After(info.ExpiresAt)
+		}
+		results = append(results, info)
+	}
+
+	// Minted access tokens
+	if h.tokenCache != nil {
+		scopes, _ := h.tokenCache.ListCachedScopes(ctx)
+		for _, scope := range scopes {
+			token, err := h.tokenCache.Get(ctx, scope)
+			if err != nil || token == nil {
+				continue
+			}
+			results = append(results, &auth.CachedTokenInfo{
+				Handler:   HandlerName,
+				TokenKind: "access",
+				Scope:     scope,
+				TokenType: token.TokenType,
+				Flow:      token.Flow,
+				ExpiresAt: token.ExpiresAt,
+				CachedAt:  token.CachedAt,
+				IsExpired: token.IsExpired(),
+				SessionID: token.SessionID,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// PurgeExpiredTokens removes expired access tokens from the on-disk cache.
+// The refresh token and valid access tokens are left untouched.
+// Returns the number of tokens removed.
+func (h *Handler) PurgeExpiredTokens(ctx context.Context) (int, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return 0, err
+	}
+	if h.tokenCache == nil {
+		return 0, nil
+	}
+	return h.tokenCache.PurgeExpired(ctx)
+}

--- a/pkg/auth/entra/http.go
+++ b/pkg/auth/entra/http.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 )
 
@@ -33,7 +34,8 @@ type DefaultGraphClient struct {
 
 // NewDefaultGraphClient creates a new Graph API HTTP client.
 // Caching is disabled because membership responses must always be fresh.
-func NewDefaultGraphClient() *DefaultGraphClient {
+// The logger parameter controls HTTP-level logging; pass logr.Discard() to suppress.
+func NewDefaultGraphClient(logger logr.Logger) *DefaultGraphClient {
 	return &DefaultGraphClient{
 		client: httpc.NewClient(&httpc.ClientConfig{
 			Timeout:           30 * time.Second,
@@ -42,6 +44,7 @@ func NewDefaultGraphClient() *DefaultGraphClient {
 			RetryWaitMax:      30 * time.Second,
 			EnableCache:       false,
 			EnableCompression: false,
+			Logger:            logger,
 		}),
 	}
 }
@@ -64,7 +67,8 @@ type DefaultHTTPClient struct {
 
 // NewDefaultHTTPClient creates a new default HTTP client backed by httpc.
 // Caching is disabled because token-exchange responses must never be served from cache.
-func NewDefaultHTTPClient() *DefaultHTTPClient {
+// The logger parameter controls HTTP-level logging; pass logr.Discard() to suppress.
+func NewDefaultHTTPClient(logger logr.Logger) *DefaultHTTPClient {
 	return &DefaultHTTPClient{
 		client: httpc.NewClient(&httpc.ClientConfig{
 			Timeout:           30 * time.Second,
@@ -73,6 +77,7 @@ func NewDefaultHTTPClient() *DefaultHTTPClient {
 			RetryWaitMax:      30 * time.Second,
 			EnableCache:       false,
 			EnableCompression: false,
+			Logger:            logger,
 		}),
 	}
 }

--- a/pkg/auth/entra/http_test.go
+++ b/pkg/auth/entra/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,7 @@ func TestDefaultHTTPClient_PostForm(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewDefaultHTTPClient()
+	client := NewDefaultHTTPClient(logr.Discard())
 	ctx := context.Background()
 
 	data := map[string][]string{
@@ -48,7 +49,7 @@ func TestDefaultHTTPClient_PostForm_Cancelled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewDefaultHTTPClient()
+	client := NewDefaultHTTPClient(logr.Discard())
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 

--- a/pkg/auth/entra/token.go
+++ b/pkg/auth/entra/token.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
@@ -30,6 +31,12 @@ type TokenMetadata struct {
 	// (e.g. "device_code"). Stored so that tokens minted from a stored refresh
 	// token can report the originating flow to callers.
 	LoginFlow auth.Flow `json:"loginFlow,omitempty"`
+
+	// SessionID is a stable identifier for the authentication session.
+	// Generated once at login time and preserved across refresh-token rotations
+	// so that every access token minted from a given login can be traced back
+	// to the originating session.
+	SessionID string `json:"sessionId,omitempty"`
 }
 
 // mintToken creates a new access token for the specified scope.
@@ -126,7 +133,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// If we got a new refresh token, store it (token rotation)
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		lgr.V(1).Info("refresh token rotated, storing new token")
-		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp, metadata.ClientID, metadata.Scopes, metadata.LoginFlow); err != nil {
+		if err := h.storeCredentials(ctx, metadata.TenantID, &tokenResp, metadata.ClientID, metadata.Scopes, metadata.LoginFlow, metadata.SessionID); err != nil {
 			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
 		}
 	}
@@ -137,6 +144,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 		"expiresIn", tokenResp.ExpiresIn,
 		"expiresAt", expiresAt,
 		"scope", scope,
+		"sessionId", metadata.SessionID,
 	)
 
 	return &auth.Token{
@@ -145,6 +153,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 		ExpiresAt:   expiresAt,
 		Scope:       scope,
 		Flow:        metadata.LoginFlow,
+		SessionID:   metadata.SessionID,
 	}, nil
 }
 
@@ -156,7 +165,10 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 // surfaced later (e.g. in `auth status`).
 // loginFlow records the authentication flow (e.g. auth.FlowDeviceCode) so that
 // tokens minted from the stored refresh token can surface the originating flow.
-func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse, clientID string, scopes []string, loginFlow auth.Flow) error {
+// sessionID is a stable identifier for the authentication session.  Pass an
+// empty string on initial login to auto-generate a new ID; pass the existing
+// ID during refresh-token rotation to preserve the session lineage.
+func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenResp *TokenResponse, clientID string, scopes []string, loginFlow auth.Flow, sessionID string) error {
 	// Validate refresh token is present
 	if tokenResp.RefreshToken == "" {
 		return fmt.Errorf("no refresh token in response (offline_access scope may be missing)")
@@ -165,6 +177,11 @@ func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenRe
 	// Store refresh token
 	if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
 		return fmt.Errorf("failed to store refresh token: %w", err)
+	}
+
+	// Generate a new session ID on initial login; preserve across rotations.
+	if sessionID == "" {
+		sessionID = uuid.New().String()
 	}
 
 	// Extract claims and store metadata
@@ -184,6 +201,7 @@ func (h *Handler) storeCredentials(ctx context.Context, tenantID string, tokenRe
 		ClientID:              clientID,
 		Scopes:                scopes,
 		LoginFlow:             loginFlow,
+		SessionID:             sessionID,
 	}
 
 	metadataBytes, err := json.Marshal(metadata)

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -166,7 +166,7 @@ func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.R
 	}
 
 	// Store credentials
-	if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, scopes); err != nil {
+	if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, scopes, ""); err != nil {
 		return nil, fmt.Errorf("failed to store credentials: %w", err)
 	}
 
@@ -272,7 +272,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// Handle refresh token rotation
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		lgr.V(1).Info("refresh token rotated, storing new token")
-		if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, metadata.Scopes); err != nil {
+		if err := h.storeCredentials(ctx, &tokenResp, auth.FlowInteractive, metadata.Scopes, metadata.SessionID); err != nil {
 			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
 		}
 	}
@@ -284,6 +284,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 		TokenType:   tokenResp.TokenType,
 		ExpiresAt:   expiresAt,
 		Scope:       scope,
+		SessionID:   metadata.SessionID,
 	}, nil
 }
 

--- a/pkg/auth/gcp/cache.go
+++ b/pkg/auth/gcp/cache.go
@@ -28,6 +28,7 @@ type CachedToken struct {
 	ExpiresAt   time.Time `json:"expiresAt"`
 	Scope       string    `json:"scope"`
 	CachedAt    time.Time `json:"cachedAt"`
+	SessionID   string    `json:"sessionId,omitempty"`
 }
 
 // NewTokenCache creates a new disk-based token cache.
@@ -59,6 +60,8 @@ func (c *TokenCache) Get(ctx context.Context, scope string) (*auth.Token, error)
 		TokenType:   cached.TokenType,
 		ExpiresAt:   cached.ExpiresAt,
 		Scope:       cached.Scope,
+		CachedAt:    cached.CachedAt,
+		SessionID:   cached.SessionID,
 	}, nil
 }
 
@@ -72,6 +75,7 @@ func (c *TokenCache) Set(ctx context.Context, scope string, token *auth.Token) e
 		ExpiresAt:   token.ExpiresAt,
 		Scope:       scope,
 		CachedAt:    time.Now(),
+		SessionID:   token.SessionID,
 	}
 
 	data, err := json.Marshal(cached)
@@ -109,6 +113,29 @@ func (c *TokenCache) Clear(ctx context.Context) error {
 	}
 
 	return lastErr
+}
+
+// PurgeExpired removes all expired access tokens from the cache.
+// Returns the number of tokens removed.
+func (c *TokenCache) PurgeExpired(ctx context.Context) (int, error) {
+	scopes, err := c.ListCachedScopes(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list cached scopes: %w", err)
+	}
+
+	purged := 0
+	for _, scope := range scopes {
+		token, err := c.Get(ctx, scope)
+		if err != nil || token == nil {
+			continue
+		}
+		if token.IsExpired() {
+			if delErr := c.Delete(ctx, scope); delErr == nil {
+				purged++
+			}
+		}
+	}
+	return purged, nil
 }
 
 // ListCachedScopes returns a list of scopes that have cached tokens.

--- a/pkg/auth/gcp/handler.go
+++ b/pkg/auth/gcp/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -34,6 +35,10 @@ const (
 	DefaultTimeout = 5 * time.Minute
 )
 
+// authHTTPLogLevel is the verbosity offset applied to the base logger
+// before it is handed to the HTTP transport used by auth handlers.
+const authHTTPLogLevel = 5
+
 // Handler implements auth.Handler for Google Cloud Platform.
 type Handler struct {
 	config      *Config
@@ -41,6 +46,7 @@ type Handler struct {
 	secretErr   error // deferred error from secrets initialization
 	httpClient  HTTPClient
 	tokenCache  *TokenCache
+	logger      logr.Logger
 }
 
 // Option configures the Handler.
@@ -83,6 +89,15 @@ func WithHTTPClient(client HTTPClient) Option {
 	}
 }
 
+// WithLogger sets the logger for the handler.
+// The logger is offset by authHTTPLogLevel before being passed to the HTTP
+// transport so that auth HTTP traffic only appears at high verbosity.
+func WithLogger(lgr logr.Logger) Option {
+	return func(h *Handler) {
+		h.logger = lgr
+	}
+}
+
 // New creates a new GCP auth handler.
 // Secret store initialization is deferred — if it fails, the handler is still
 // created so that metadata operations (Name, SupportedFlows, etc.) work.
@@ -107,9 +122,13 @@ func New(opts ...Option) (*Handler, error) {
 		}
 	}
 
+	// Compute the HTTP-level logger: offset by authHTTPLogLevel so that
+	// auth HTTP calls only appear at high verbosity.
+	httpLogger := h.logger.V(authHTTPLogLevel)
+
 	// Initialize HTTP client if not provided
 	if h.httpClient == nil {
-		h.httpClient = NewDefaultHTTPClient()
+		h.httpClient = NewDefaultHTTPClient(httpLogger)
 	}
 
 	// Initialize token cache with secret store
@@ -453,5 +472,75 @@ func getCachedOrAcquireToken[T any](
 	return token, nil
 }
 
-// Compile-time check that Handler implements auth.Handler.
-var _ auth.Handler = (*Handler)(nil)
+// Compile-time check that Handler implements auth.Handler, auth.TokenLister, and auth.TokenPurger.
+var (
+	_ auth.Handler     = (*Handler)(nil)
+	_ auth.TokenLister = (*Handler)(nil)
+	_ auth.TokenPurger = (*Handler)(nil)
+)
+
+// ListCachedTokens returns metadata for all tokens stored by the GCP handler.
+// It includes the long-lived refresh token (ADC flow) and all minted access tokens
+// from the on-disk cache.  Actual token values are intentionally excluded.
+func (h *Handler) ListCachedTokens(ctx context.Context) ([]*auth.CachedTokenInfo, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	var results []*auth.CachedTokenInfo
+
+	// Refresh token (ADC browser flow)
+	exists, _ := h.secretStore.Exists(ctx, SecretKeyRefreshToken)
+	if exists {
+		info := &auth.CachedTokenInfo{
+			Handler:   HandlerName,
+			TokenKind: "refresh",
+		}
+		if metadata, err := h.loadMetadata(ctx); err == nil && metadata != nil {
+			info.ExpiresAt = metadata.RefreshTokenExpiresAt
+			info.Flow = metadata.Flow
+			info.SessionID = metadata.SessionID
+		}
+		if !info.ExpiresAt.IsZero() {
+			info.IsExpired = time.Now().After(info.ExpiresAt)
+		}
+		results = append(results, info)
+	}
+
+	// Minted access tokens
+	if h.tokenCache != nil {
+		scopes, _ := h.tokenCache.ListCachedScopes(ctx)
+		for _, scope := range scopes {
+			token, err := h.tokenCache.Get(ctx, scope)
+			if err != nil || token == nil {
+				continue
+			}
+			results = append(results, &auth.CachedTokenInfo{
+				Handler:   HandlerName,
+				TokenKind: "access",
+				Scope:     scope,
+				TokenType: token.TokenType,
+				Flow:      token.Flow,
+				ExpiresAt: token.ExpiresAt,
+				CachedAt:  token.CachedAt,
+				IsExpired: token.IsExpired(),
+				SessionID: token.SessionID,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// PurgeExpiredTokens removes expired access tokens from the on-disk cache.
+// The refresh token and valid access tokens are left untouched.
+// Returns the number of tokens removed.
+func (h *Handler) PurgeExpiredTokens(ctx context.Context) (int, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return 0, err
+	}
+	if h.tokenCache == nil {
+		return 0, nil
+	}
+	return h.tokenCache.PurgeExpired(ctx)
+}

--- a/pkg/auth/gcp/http.go
+++ b/pkg/auth/gcp/http.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 )
 
@@ -34,7 +35,8 @@ type DefaultHTTPClient struct {
 
 // NewDefaultHTTPClient creates a new DefaultHTTPClient backed by httpc.
 // Caching is disabled because metadata-server responses must never be served from cache.
-func NewDefaultHTTPClient() *DefaultHTTPClient {
+// The logger parameter controls HTTP-level logging; pass logr.Discard() to suppress.
+func NewDefaultHTTPClient(logger logr.Logger) *DefaultHTTPClient {
 	return &DefaultHTTPClient{
 		client: httpc.NewClient(&httpc.ClientConfig{
 			Timeout:           30 * time.Second,
@@ -43,6 +45,7 @@ func NewDefaultHTTPClient() *DefaultHTTPClient {
 			RetryWaitMax:      30 * time.Second,
 			EnableCache:       false,
 			EnableCompression: false,
+			Logger:            logger,
 		}),
 	}
 }

--- a/pkg/auth/gcp/http_test.go
+++ b/pkg/auth/gcp/http_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -112,7 +113,7 @@ func TestMockHTTPClient_Reset(t *testing.T) {
 }
 
 func TestDefaultHTTPClient(t *testing.T) {
-	client := NewDefaultHTTPClient()
+	client := NewDefaultHTTPClient(logr.Discard())
 	require.NotNil(t, client)
 }
 

--- a/pkg/auth/gcp/token.go
+++ b/pkg/auth/gcp/token.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
@@ -25,6 +26,10 @@ type TokenMetadata struct {
 	ImpersonateServiceAccount string       `json:"impersonateServiceAccount,omitempty"`
 	Scopes                    []string     `json:"scopes,omitempty"`
 	ServiceAccountEmail       string       `json:"serviceAccountEmail,omitempty"`
+
+	// SessionID is a stable identifier for the authentication session.
+	// Generated once at login time and preserved across refresh-token rotations.
+	SessionID string `json:"sessionId,omitempty"`
 }
 
 // TokenResponse represents the response from GCP token endpoints.
@@ -44,7 +49,7 @@ type TokenErrorResponse struct {
 }
 
 // storeCredentials securely stores the refresh token and metadata.
-func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, flow auth.Flow, scopes []string) error {
+func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, flow auth.Flow, scopes []string, sessionID string) error {
 	// Store refresh token if present (ADC browser flow)
 	if tokenResp.RefreshToken != "" {
 		if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
@@ -60,6 +65,11 @@ func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse
 		}
 	}
 
+	// Generate a new session ID on initial login; preserve across rotations.
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
 	metadata := &TokenMetadata{
 		Claims:                    claims,
 		Flow:                      flow,
@@ -67,6 +77,7 @@ func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse
 		Project:                   h.config.Project,
 		ImpersonateServiceAccount: h.config.ImpersonateServiceAccount,
 		Scopes:                    scopes,
+		SessionID:                 sessionID,
 	}
 
 	if tokenResp.RefreshToken != "" {
@@ -95,6 +106,7 @@ func (h *Handler) storeMetadataOnly(ctx context.Context, claims *auth.Claims, fl
 		Project:                   h.config.Project,
 		ImpersonateServiceAccount: h.config.ImpersonateServiceAccount,
 		Scopes:                    scopes,
+		SessionID:                 uuid.New().String(),
 	}
 
 	metadataBytes, err := json.Marshal(metadata)

--- a/pkg/auth/github/cache.go
+++ b/pkg/auth/github/cache.go
@@ -29,6 +29,7 @@ type CachedToken struct {
 	ExpiresAt   time.Time `json:"expiresAt"`
 	Scope       string    `json:"scope"`
 	CachedAt    time.Time `json:"cachedAt"`
+	SessionID   string    `json:"sessionId,omitempty"`
 }
 
 // NewTokenCache creates a new disk-based token cache.
@@ -62,6 +63,8 @@ func (c *TokenCache) Get(ctx context.Context, scope string) (*auth.Token, error)
 		TokenType:   cached.TokenType,
 		ExpiresAt:   cached.ExpiresAt,
 		Scope:       cached.Scope,
+		CachedAt:    cached.CachedAt,
+		SessionID:   cached.SessionID,
 	}, nil
 }
 
@@ -74,6 +77,7 @@ func (c *TokenCache) Set(ctx context.Context, scope string, token *auth.Token) e
 		ExpiresAt:   token.ExpiresAt,
 		Scope:       scope,
 		CachedAt:    time.Now(),
+		SessionID:   token.SessionID,
 	}
 
 	data, err := json.Marshal(cached)
@@ -111,6 +115,29 @@ func (c *TokenCache) Clear(ctx context.Context) error {
 		}
 	}
 	return lastErr
+}
+
+// PurgeExpired removes all expired access tokens from the cache.
+// Returns the number of tokens removed.
+func (c *TokenCache) PurgeExpired(ctx context.Context) (int, error) {
+	scopes, err := c.ListCachedScopes(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list cached scopes: %w", err)
+	}
+
+	purged := 0
+	for _, scope := range scopes {
+		token, err := c.Get(ctx, scope)
+		if err != nil || token == nil {
+			continue
+		}
+		if token.IsExpired() {
+			if delErr := c.Delete(ctx, scope); delErr == nil {
+				purged++
+			}
+		}
+	}
+	return purged, nil
 }
 
 // ListCachedScopes returns a list of scopes that have cached tokens.

--- a/pkg/auth/github/device_flow.go
+++ b/pkg/auth/github/device_flow.go
@@ -75,7 +75,7 @@ func (h *Handler) performDeviceCodeFlow(ctx context.Context, opts auth.LoginOpti
 	}
 
 	// Step 4: Store credentials securely and fetch claims
-	claims, err := h.storeCredentials(ctx, tokenResp, scopes)
+	claims, err := h.storeCredentials(ctx, tokenResp, scopes, "")
 	if err != nil {
 		return nil, auth.NewError(HandlerName, "store_credentials", err)
 	}

--- a/pkg/auth/github/handler.go
+++ b/pkg/auth/github/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -41,6 +42,10 @@ const (
 	DefaultMinPollInterval = 5 * time.Second
 )
 
+// authHTTPLogLevel is the verbosity offset applied to the base logger
+// before it is handed to the HTTP transport used by auth handlers.
+const authHTTPLogLevel = 5
+
 // Handler implements auth.Handler for GitHub.
 type Handler struct {
 	config      *Config
@@ -48,6 +53,7 @@ type Handler struct {
 	secretErr   error // deferred error from secrets initialization
 	httpClient  HTTPClient
 	tokenCache  *TokenCache
+	logger      logr.Logger
 }
 
 // Option configures the Handler.
@@ -90,6 +96,15 @@ func WithHTTPClient(client HTTPClient) Option {
 	}
 }
 
+// WithLogger sets the logger for the handler.
+// The logger is offset by authHTTPLogLevel before being passed to the HTTP
+// transport so that auth HTTP traffic only appears at high verbosity.
+func WithLogger(lgr logr.Logger) Option {
+	return func(h *Handler) {
+		h.logger = lgr
+	}
+}
+
 // New creates a new GitHub auth handler.
 // Secret store initialization is deferred — if it fails, the handler is still
 // created so that metadata operations (Name, SupportedFlows, etc.) work.
@@ -115,9 +130,13 @@ func New(opts ...Option) (*Handler, error) {
 		}
 	}
 
+	// Compute the HTTP-level logger: offset by authHTTPLogLevel so that
+	// auth HTTP calls only appear at high verbosity.
+	httpLogger := h.logger.V(authHTTPLogLevel)
+
 	// Initialize HTTP client if not provided
 	if h.httpClient == nil {
-		h.httpClient = NewDefaultHTTPClient()
+		h.httpClient = NewDefaultHTTPClient(httpLogger)
 	}
 
 	// Initialize token cache with secret store (nil-safe: checked before use)
@@ -422,5 +441,98 @@ func farFuture() time.Time {
 	return time.Now().Add(365 * 24 * time.Hour)
 }
 
-// Compile-time check that Handler implements auth.Handler.
-var _ auth.Handler = (*Handler)(nil)
+// Compile-time check that Handler implements auth.Handler, auth.TokenLister, and auth.TokenPurger.
+var (
+	_ auth.Handler     = (*Handler)(nil)
+	_ auth.TokenLister = (*Handler)(nil)
+	_ auth.TokenPurger = (*Handler)(nil)
+)
+
+// ListCachedTokens returns metadata for all tokens stored by the GitHub handler.
+// It includes the OAuth refresh token (device code flow), any directly stored
+// access token (PAT or non-expiring OAuth App), and all minted access tokens
+// from the on-disk cache.  Actual token values are intentionally excluded.
+func (h *Handler) ListCachedTokens(ctx context.Context) ([]*auth.CachedTokenInfo, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return nil, err
+	}
+
+	var results []*auth.CachedTokenInfo
+
+	// Refresh token (device code flow with token expiry enabled)
+	hasRefresh, _ := h.secretStore.Exists(ctx, SecretKeyRefreshToken)
+	if hasRefresh {
+		info := &auth.CachedTokenInfo{
+			Handler:   HandlerName,
+			TokenKind: "refresh",
+			Flow:      auth.FlowDeviceCode,
+		}
+		if metadata, err := h.loadMetadata(ctx); err == nil && metadata != nil {
+			info.ExpiresAt = metadata.RefreshTokenExpiresAt
+			info.CachedAt = metadata.LastRefresh
+			info.SessionID = metadata.SessionID
+		}
+		if !info.ExpiresAt.IsZero() {
+			info.IsExpired = time.Now().After(info.ExpiresAt)
+		}
+		results = append(results, info)
+	}
+
+	// Minted access tokens (short-lived and direct-stored)
+	if h.tokenCache != nil {
+		scopes, _ := h.tokenCache.ListCachedScopes(ctx)
+		for _, scope := range scopes {
+			token, err := h.tokenCache.Get(ctx, scope)
+			if err != nil || token == nil {
+				continue
+			}
+			results = append(results, &auth.CachedTokenInfo{
+				Handler:   HandlerName,
+				TokenKind: "access",
+				TokenType: token.TokenType,
+				Flow:      token.Flow,
+				ExpiresAt: token.ExpiresAt,
+				CachedAt:  token.CachedAt,
+				IsExpired: token.IsExpired(),
+				SessionID: token.SessionID,
+			})
+		}
+	}
+
+	// If no tokenCache entry for the default key but a direct access token exists
+	// (e.g. the user just logged in with PAT and has not yet called GetToken),
+	// show a basic entry so the token is visible.
+	if h.tokenCache != nil {
+		hasAccess, _ := h.secretStore.Exists(ctx, SecretKeyAccessToken)
+		if hasAccess {
+			_, cacheErr := h.tokenCache.Get(ctx, defaultCacheKey)
+			if cacheErr != nil {
+				info := &auth.CachedTokenInfo{
+					Handler:   HandlerName,
+					TokenKind: "access",
+					TokenType: "Bearer",
+				}
+				if metadata, err := h.loadMetadata(ctx); err == nil && metadata != nil {
+					info.CachedAt = metadata.LastRefresh
+					info.SessionID = metadata.SessionID
+				}
+				results = append(results, info)
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// PurgeExpiredTokens removes expired access tokens from the on-disk cache.
+// The refresh token and valid access tokens are left untouched.
+// Returns the number of tokens removed.
+func (h *Handler) PurgeExpiredTokens(ctx context.Context) (int, error) {
+	if err := h.ensureSecrets(); err != nil {
+		return 0, err
+	}
+	if h.tokenCache == nil {
+		return 0, nil
+	}
+	return h.tokenCache.PurgeExpired(ctx)
+}

--- a/pkg/auth/github/http.go
+++ b/pkg/auth/github/http.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 )
 
@@ -29,7 +30,8 @@ type DefaultHTTPClient struct {
 
 // NewDefaultHTTPClient creates a new DefaultHTTPClient backed by httpc.
 // Caching is disabled because token-exchange responses must never be served from cache.
-func NewDefaultHTTPClient() *DefaultHTTPClient {
+// The logger parameter controls HTTP-level logging; pass logr.Discard() to suppress.
+func NewDefaultHTTPClient(logger logr.Logger) *DefaultHTTPClient {
 	return &DefaultHTTPClient{
 		client: httpc.NewClient(&httpc.ClientConfig{
 			Timeout:           30 * time.Second,
@@ -38,6 +40,7 @@ func NewDefaultHTTPClient() *DefaultHTTPClient {
 			RetryWaitMax:      30 * time.Second,
 			EnableCache:       false,
 			EnableCompression: false,
+			Logger:            logger,
 		}),
 	}
 }

--- a/pkg/auth/github/token.go
+++ b/pkg/auth/github/token.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
@@ -22,6 +23,10 @@ type TokenMetadata struct {
 	ClientID              string       `json:"clientId,omitempty"`
 	Scopes                []string     `json:"scopes,omitempty"`
 	IdentityType          string       `json:"identityType,omitempty"`
+
+	// SessionID is a stable identifier for the authentication session.
+	// Generated once at login time and preserved across refresh-token rotations.
+	SessionID string `json:"sessionId,omitempty"`
 }
 
 // TokenResponse represents the response from the GitHub OAuth token endpoint.
@@ -106,10 +111,12 @@ func (h *Handler) refreshAccessToken(ctx context.Context, refreshToken, clientID
 		lgr.V(1).Info("refresh token rotated, storing new token")
 		metadata, _ := h.loadMetadata(ctx)
 		var scopes []string
+		var sessionID string
 		if metadata != nil {
 			scopes = metadata.Scopes
+			sessionID = metadata.SessionID
 		}
-		if _, err := h.storeCredentials(ctx, &tokenResp, scopes); err != nil {
+		if _, err := h.storeCredentials(ctx, &tokenResp, scopes, sessionID); err != nil {
 			lgr.V(1).Info("warning: failed to update refresh token", "error", err)
 		}
 	}
@@ -128,7 +135,7 @@ func (h *Handler) refreshAccessToken(ctx context.Context, refreshToken, clientID
 }
 
 // storeCredentials securely stores the refresh token (or access token) and metadata.
-func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, scopes []string) (*auth.Claims, error) {
+func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse, scopes []string, sessionID string) (*auth.Claims, error) {
 	// Store refresh token if present (OAuth App with token expiration enabled)
 	if tokenResp.RefreshToken != "" {
 		if err := h.secretStore.Set(ctx, SecretKeyRefreshToken, []byte(tokenResp.RefreshToken)); err != nil {
@@ -152,6 +159,11 @@ func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse
 		}
 	}
 
+	// Generate a new session ID on initial login; preserve across rotations.
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
 	// Determine refresh token expiry
 	var refreshTokenExpiresAt time.Time
 	if tokenResp.RefreshTokenExpiresIn > 0 {
@@ -166,6 +178,7 @@ func (h *Handler) storeCredentials(ctx context.Context, tokenResp *TokenResponse
 		ClientID:              h.config.ClientID,
 		Scopes:                scopes,
 		IdentityType:          string(auth.IdentityTypeUser),
+		SessionID:             sessionID,
 	}
 
 	metadataBytes, err := json.Marshal(metadata)

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -137,9 +137,16 @@ type Token struct {
 	TokenType   string
 	ExpiresAt   time.Time
 	Scope       string
+	// CachedAt records when this token was written to the on-disk cache.
+	// Zero value means the token was not loaded from the cache.
+	CachedAt time.Time
 	// Flow is the authentication flow that produced this token (e.g. "device_code",
 	// "service_principal", "workload_identity").  Empty string means unknown.
 	Flow Flow
+	// SessionID is a stable identifier linking this access token back to the
+	// authentication session (login) that produced it.  Generated once at login
+	// time and preserved across refresh-token rotations.
+	SessionID string
 }
 
 // IsValidFor returns true if the token will be valid for at least the specified duration.
@@ -166,4 +173,56 @@ func (t *Token) TimeUntilExpiry() time.Duration {
 		return 0
 	}
 	return remaining
+}
+
+// CachedTokenInfo holds display metadata for a cached token (refresh or access).
+// The actual token value is intentionally omitted — use 'auth token' to retrieve it.
+type CachedTokenInfo struct {
+	// Handler is the name of the auth handler that owns this token.
+	Handler string `json:"handler"`
+	// TokenKind is either "refresh" or "access".
+	TokenKind string `json:"tokenKind"`
+	// Scope is the OAuth scope associated with the token.
+	// Empty for refresh tokens that were not scope-specific.
+	Scope string `json:"scope,omitempty"`
+	// TokenType is the token type, e.g. "Bearer".
+	TokenType string `json:"tokenType,omitempty"`
+	// Flow is the authentication flow that produced the token.
+	Flow Flow `json:"flow,omitempty"`
+	// ExpiresAt is when the token expires.
+	ExpiresAt time.Time `json:"expiresAt,omitempty"`
+	// CachedAt is when the token was written to the on-disk cache.
+	CachedAt time.Time `json:"cachedAt,omitempty"`
+	// IsExpired indicates whether the token is past its expiry time.
+	IsExpired bool `json:"isExpired"`
+	// SessionID is the stable identifier of the authentication session that
+	// produced this token.  Present on both refresh and access entries, allowing
+	// callers to trace which login session minted a given access token.
+	SessionID string `json:"sessionId,omitempty"`
+}
+
+// TimeUntilExpiry returns the duration until this cached token expires.
+// Returns 0 if the token is already expired or has no expiry set.
+func (c *CachedTokenInfo) TimeUntilExpiry() time.Duration {
+	if c.ExpiresAt.IsZero() {
+		return 0
+	}
+	remaining := time.Until(c.ExpiresAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// TokenLister is an optional interface implemented by auth handlers that can
+// enumerate all cached tokens (both refresh and minted access tokens).
+type TokenLister interface {
+	ListCachedTokens(ctx context.Context) ([]*CachedTokenInfo, error)
+}
+
+// TokenPurger is an optional interface implemented by auth handlers that can
+// remove expired access tokens from the cache without affecting valid tokens
+// or the refresh token.  Returns the number of tokens removed.
+type TokenPurger interface {
+	PurgeExpiredTokens(ctx context.Context) (int, error)
 }

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -18,20 +18,25 @@ type MockHandler struct {
 	FlowsValue        []Flow
 	CapabilitiesValue []Capability
 
-	LoginResult    *Result
-	LoginErr       error
-	LogoutErr      error
-	StatusResult   *Status
-	StatusErr      error
-	GetTokenResult *Token
-	GetTokenErr    error
-	InjectAuthErr  error
+	LoginResult            *Result
+	LoginErr               error
+	LogoutErr              error
+	StatusResult           *Status
+	StatusErr              error
+	GetTokenResult         *Token
+	GetTokenErr            error
+	InjectAuthErr          error
+	ListCachedTokensResult []*CachedTokenInfo
+	ListCachedTokensErr    error
+	PurgeExpiredResult     int
+	PurgeExpiredErr        error
 
-	LoginCalls      []LoginOptions
-	LogoutCalls     int
-	StatusCalls     int
-	GetTokenCalls   []TokenOptions
-	InjectAuthCalls []TokenOptions
+	LoginCalls        []LoginOptions
+	LogoutCalls       int
+	StatusCalls       int
+	GetTokenCalls     []TokenOptions
+	InjectAuthCalls   []TokenOptions
+	PurgeExpiredCalls int
 }
 
 // NewMockHandler creates a new mock auth handler with default values.
@@ -106,6 +111,7 @@ func (m *MockHandler) Reset() {
 	m.StatusCalls = 0
 	m.GetTokenCalls = nil
 	m.InjectAuthCalls = nil
+	m.PurgeExpiredCalls = 0
 }
 
 func (m *MockHandler) SetAuthenticated(claims *Claims) {
@@ -134,4 +140,21 @@ func (m *MockHandler) SetTokenError(err error) {
 	m.GetTokenErr = err
 }
 
-var _ Handler = (*MockHandler)(nil)
+func (m *MockHandler) ListCachedTokens(_ context.Context) ([]*CachedTokenInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ListCachedTokensResult, m.ListCachedTokensErr
+}
+
+func (m *MockHandler) PurgeExpiredTokens(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PurgeExpiredCalls++
+	return m.PurgeExpiredResult, m.PurgeExpiredErr
+}
+
+var (
+	_ Handler     = (*MockHandler)(nil)
+	_ TokenLister = (*MockHandler)(nil)
+	_ TokenPurger = (*MockHandler)(nil)
+)

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -29,16 +29,18 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			features are available. For example, some handlers support per-request
 			scopes while others fix scopes at login time.
 
-			Use 'scafctl auth list' to see all registered handlers and their capabilities.
 			Use 'scafctl auth login <handler>' to authenticate.
 			Use 'scafctl auth status' to check current authentication status.
+			Use 'scafctl auth list' to show cached refresh and access token metadata.
 			Use 'scafctl auth logout <handler>' to clear credentials.
-			Use 'scafctl auth token <handler>' to display a token (for debugging).
+			Use 'scafctl auth token <handler>' to retrieve a token value (for debugging).
+			Use 'scafctl auth diagnose' to run health checks and troubleshoot issues.
 		`),
 		SilenceUsage: true,
 	}
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandDiagnose(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -25,15 +25,16 @@ func TestCommandAuth(t *testing.T) {
 
 	// Verify subcommands are added
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 5)
+	require.Len(t, subCmds, 6)
 
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
 		cmdNames[i] = c.Use
 	}
-	assert.Contains(t, cmdNames, "list")
+	assert.Contains(t, cmdNames, "diagnose")
+	assert.Contains(t, cmdNames, "list [handler]")
 	assert.Contains(t, cmdNames, "login <handler>")
-	assert.Contains(t, cmdNames, "logout <handler>")
+	assert.Contains(t, cmdNames, "logout [handler]")
 	assert.Contains(t, cmdNames, "status [handler]")
 	assert.Contains(t, cmdNames, "token <handler>")
 }

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -1,0 +1,558 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	entraauth "github.com/oakwood-commons/scafctl/pkg/auth/entra"
+	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
+	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// diagCheckStatus represents the result of a single diagnostic check.
+type diagCheckStatus string
+
+const (
+	diagOK   diagCheckStatus = "ok"
+	diagWarn diagCheckStatus = "warn"
+	diagFail diagCheckStatus = "fail"
+	diagInfo diagCheckStatus = "info"
+)
+
+// diagCheck represents one diagnostic check result.
+type diagCheck struct {
+	Category string          `json:"category"`
+	Check    string          `json:"check"`
+	Status   diagCheckStatus `json:"status"`
+	Message  string          `json:"message"`
+}
+
+// CommandDiagnose creates the 'auth diagnose' command.
+func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+	var liveToken bool
+
+	cmd := &cobra.Command{
+		Use:     "diagnose",
+		Aliases: []string{"doctor"},
+		Short:   "Run auth diagnostics and report any issues",
+		Long: heredoc.Doc(`
+			Run a series of diagnostic checks on the authentication configuration
+			and report any issues found.
+
+			Checks include:
+			  - Auth registry health (handlers registered)
+			  - Config file presence and auth sections
+			  - Environment variables for each handler
+			  - Clock skew (compares local time against an HTTPS server)
+			  - Current authentication status (are you logged in?)
+			  - Cached token health (expired tokens, missing tokens)
+
+			When a handler name is provided, the handler status and cache checks
+			are scoped to that handler only.
+
+			Use --live-token to also attempt a live token fetch for each authenticated
+			handler, confirming end-to-end token acquisition works.
+
+			Examples:
+			  # Run auth diagnostics (all handlers)
+			  scafctl auth diagnose
+
+			  # Run diagnostics for Entra only
+			  scafctl auth diagnose entra
+
+			  # Run diagnostics and attempt a live token fetch
+			  scafctl auth diagnose --live-token
+
+			  # Output diagnostics as JSON
+			  scafctl auth diagnose -o json
+		`),
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := writer.MustFromContext(ctx)
+
+			// When -o/--interactive/--expression is given, suppress human text and
+			// emit only the structured data at the end.
+			structuredOutput := cmd.Flags().Changed("output") || outputFlags.Interactive || outputFlags.Expression != ""
+
+			var checks []diagCheck
+			addCheck := func(c diagCheck) {
+				checks = append(checks, c)
+				if structuredOutput {
+					return
+				}
+				switch c.Status {
+				case diagOK:
+					w.Successf("[ok]   %s: %s", c.Check, c.Message)
+				case diagWarn:
+					w.Warningf("[warn] %s: %s", c.Check, c.Message)
+				case diagFail:
+					w.Errorf("[fail] %s: %s", c.Check, c.Message)
+				case diagInfo:
+					w.Infof("[info] %s: %s", c.Check, c.Message)
+				}
+			}
+
+			// ── 1. Auth registry ──────────────────────────────────────────────
+			handlerNames := listHandlers(ctx)
+			if len(handlerNames) == 0 {
+				addCheck(diagCheck{
+					Category: "registry",
+					Check:    "auth registry",
+					Status:   diagFail,
+					Message:  "no auth handlers registered — registry may not be initialised",
+				})
+			} else {
+				addCheck(diagCheck{
+					Category: "registry",
+					Check:    "auth registry",
+					Status:   diagOK,
+					Message:  fmt.Sprintf("registered handlers: %v", handlerNames),
+				})
+			}
+
+			// ── 2. Config file ────────────────────────────────────────────────
+			cfgPath, cfgPathErr := paths.SearchConfigFile()
+			if cfgPathErr != nil {
+				addCheck(diagCheck{
+					Category: "config",
+					Check:    "config file",
+					Status:   diagWarn,
+					Message:  "config file not found — using built-in defaults",
+				})
+			} else {
+				addCheck(diagCheck{
+					Category: "config",
+					Check:    "config file",
+					Status:   diagOK,
+					Message:  cfgPath,
+				})
+			}
+
+			// Auth sections in config
+			cfg := config.FromContext(ctx)
+			if cfg != nil {
+				if cfg.Auth.Entra != nil {
+					addCheck(diagCheck{
+						Category: "config",
+						Check:    "config entra section",
+						Status:   diagOK,
+						Message:  fmt.Sprintf("clientId=%q tenantId=%q", cfg.Auth.Entra.ClientID, cfg.Auth.Entra.TenantID),
+					})
+				}
+				if cfg.Auth.GitHub != nil {
+					addCheck(diagCheck{
+						Category: "config",
+						Check:    "config github section",
+						Status:   diagOK,
+						Message:  fmt.Sprintf("clientId=%q hostname=%q", cfg.Auth.GitHub.ClientID, cfg.Auth.GitHub.Hostname),
+					})
+				}
+				if cfg.Auth.GCP != nil {
+					addCheck(diagCheck{
+						Category: "config",
+						Check:    "config gcp section",
+						Status:   diagOK,
+						Message:  fmt.Sprintf("clientId=%q impersonate=%q", cfg.Auth.GCP.ClientID, cfg.Auth.GCP.ImpersonateServiceAccount),
+					})
+				}
+			}
+
+			// ── 3. Environment variables ──────────────────────────────────────
+			for _, c := range runEnvVarChecks() {
+				addCheck(c)
+			}
+
+			// ── 3.5. Clock skew ───────────────────────────────────────────────
+			addCheck(runClockSkewCheck())
+
+			// ── 4. Handler authentication status & token health ───────────────
+			// When a handler name is provided, scope checks to that handler only.
+			if len(args) > 0 {
+				handlerName := args[0]
+				if err := validateHandlerName(ctx, handlerName); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				handlerNames = []string{handlerName}
+			}
+
+			failCount := 0
+			for _, name := range handlerNames {
+				handler, err := getHandler(ctx, name)
+				if err != nil {
+					addCheck(diagCheck{
+						Category: "handler",
+						Check:    fmt.Sprintf("%s: init", name),
+						Status:   diagFail,
+						Message:  err.Error(),
+					})
+					failCount++
+					continue
+				}
+
+				status, err := handler.Status(ctx)
+				if err != nil {
+					addCheck(diagCheck{
+						Category: "handler",
+						Check:    fmt.Sprintf("%s: status", name),
+						Status:   diagFail,
+						Message:  err.Error(),
+					})
+					failCount++
+					continue
+				}
+
+				if !status.Authenticated {
+					addCheck(diagCheck{
+						Category: "handler",
+						Check:    fmt.Sprintf("%s: authenticated", name),
+						Status:   diagWarn,
+						Message:  fmt.Sprintf("not authenticated — run 'scafctl auth login %s'", name),
+					})
+					continue
+				}
+
+				identity := ""
+				if status.Claims != nil {
+					identity = status.Claims.DisplayIdentity()
+				}
+				msg := fmt.Sprintf("authenticated as %q", identity)
+				if !status.ExpiresAt.IsZero() {
+					msg += fmt.Sprintf(", expires in %s", humanDuration(time.Until(status.ExpiresAt)))
+				}
+				addCheck(diagCheck{
+					Category: "handler",
+					Check:    fmt.Sprintf("%s: authenticated", name),
+					Status:   diagOK,
+					Message:  msg,
+				})
+
+				// Cached token summary
+				if lister, ok := handler.(authpkg.TokenLister); ok {
+					tokens, err := lister.ListCachedTokens(ctx)
+					if err != nil {
+						addCheck(diagCheck{
+							Category: "cache",
+							Check:    fmt.Sprintf("%s: token cache", name),
+							Status:   diagWarn,
+							Message:  fmt.Sprintf("could not read cached tokens: %v", err),
+						})
+					} else {
+						expired := 0
+						for _, t := range tokens {
+							if t.IsExpired {
+								expired++
+							}
+						}
+						cacheMsg := fmt.Sprintf("%d cached token(s)", len(tokens))
+						cacheStatus := diagOK
+						if expired > 0 {
+							cacheMsg += fmt.Sprintf(", %d expired", expired)
+							cacheStatus = diagWarn
+						}
+						addCheck(diagCheck{
+							Category: "cache",
+							Check:    fmt.Sprintf("%s: token cache", name),
+							Status:   cacheStatus,
+							Message:  cacheMsg,
+						})
+					}
+				}
+
+				// Live token fetch
+				if liveToken && authpkg.HasCapability(handler.Capabilities(), authpkg.CapScopesOnTokenRequest) {
+					// Cannot do a generic live fetch without a scope — report info
+					addCheck(diagCheck{
+						Category: "live",
+						Check:    fmt.Sprintf("%s: live token", name),
+						Status:   diagInfo,
+						Message:  "handler requires --scope for token fetch; use 'scafctl auth token " + name + " --scope <scope>' to test manually",
+					})
+				} else if liveToken {
+					_, err := handler.GetToken(ctx, authpkg.TokenOptions{
+						MinValidFor: authpkg.DefaultMinValidFor,
+					})
+					if err != nil {
+						addCheck(diagCheck{
+							Category: "live",
+							Check:    fmt.Sprintf("%s: live token", name),
+							Status:   diagFail,
+							Message:  err.Error(),
+						})
+						failCount++
+					} else {
+						addCheck(diagCheck{
+							Category: "live",
+							Check:    fmt.Sprintf("%s: live token", name),
+							Status:   diagOK,
+							Message:  "token acquired successfully",
+						})
+					}
+				}
+			}
+
+			// ── 5. Summary ────────────────────────────────────────────────────
+			warnCount := 0
+			okCount := 0
+			for _, c := range checks {
+				switch c.Status {
+				case diagFail:
+					// counted above
+				case diagWarn:
+					warnCount++
+				case diagOK:
+					okCount++
+				case diagInfo:
+					// info checks do not affect counts
+				}
+			}
+
+			if !structuredOutput {
+				fmt.Fprintln(ioStreams.Out, "")
+				switch {
+				case failCount > 0:
+					w.Errorf("Diagnostics complete: %d failure(s), %d warning(s), %d ok", failCount, warnCount, okCount)
+				case warnCount > 0:
+					w.Warningf("Diagnostics complete: %d warning(s), %d ok (no failures)", warnCount, okCount)
+				default:
+					w.Successf("Diagnostics complete: all %d checks passed.", okCount)
+				}
+			}
+
+			// Structured output — only when explicitly requested.
+			if structuredOutput {
+				results := make([]map[string]any, 0, len(checks))
+				for _, c := range checks {
+					results = append(results, map[string]any{
+						"category": c.Category,
+						"check":    c.Check,
+						"status":   string(c.Status),
+						"message":  c.Message,
+					})
+				}
+				outputOpts := flags.NewKvxOutputOptionsFromFlags(
+					outputFlags.Output,
+					outputFlags.Interactive,
+					outputFlags.Expression,
+					kvx.WithOutputContext(ctx),
+					kvx.WithOutputNoColor(cliParams.NoColor),
+					kvx.WithOutputAppName("scafctl auth diagnose"),
+				)
+				outputOpts.IOStreams = ioStreams
+				return outputOpts.Write(results)
+			}
+
+			// Only return non-zero when explicitly requested (structured) or
+			// when running in human mode.
+			if failCount > 0 {
+				return exitcode.WithCode(fmt.Errorf("one or more diagnostic checks failed"), exitcode.GeneralError)
+			}
+			return nil
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	cmd.Flags().BoolVar(&liveToken, "live-token", false, "Attempt a live token fetch for each authenticated handler to confirm end-to-end health")
+
+	return cmd
+}
+
+// runEnvVarChecks checks common environment variables for all known auth handlers.
+func runEnvVarChecks() []diagCheck {
+	var checks []diagCheck
+
+	entraVars := []struct {
+		name, desc string
+	}{
+		{"AZURE_CLIENT_ID", "Entra service principal client ID"},
+		{"AZURE_TENANT_ID", "Entra tenant ID"},
+		{"AZURE_CLIENT_SECRET", "Entra client secret (service principal)"},
+		{"AZURE_FEDERATED_TOKEN_FILE", "Entra workload identity token file path"},
+		{"AZURE_FEDERATED_TOKEN", "Entra workload identity token (raw)"},
+	}
+	for _, v := range entraVars {
+		val := os.Getenv(v.name)
+		if val != "" {
+			checks = append(checks, diagCheck{
+				Category: "env",
+				Check:    fmt.Sprintf("env %s", v.name),
+				Status:   diagOK,
+				Message:  fmt.Sprintf("%s — set (%s)", v.desc, v.name),
+			})
+		}
+	}
+	if entraauth.HasServicePrincipalCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env entra: service-principal credentials",
+			Status:   diagOK,
+			Message:  "AZURE_CLIENT_ID + AZURE_TENANT_ID + AZURE_CLIENT_SECRET are all set",
+		})
+	}
+	if entraauth.HasWorkloadIdentityCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env entra: workload-identity credentials",
+			Status:   diagOK,
+			Message:  "workload identity environment detected (AZURE_FEDERATED_TOKEN_FILE or AZURE_FEDERATED_TOKEN)",
+		})
+	}
+
+	ghVars := []struct{ name, desc string }{
+		{"GITHUB_TOKEN", "GitHub personal access token"},
+		{"GH_TOKEN", "GitHub personal access token (alternate)"},
+	}
+	for _, v := range ghVars {
+		if os.Getenv(v.name) != "" {
+			checks = append(checks, diagCheck{
+				Category: "env",
+				Check:    fmt.Sprintf("env %s", v.name),
+				Status:   diagOK,
+				Message:  fmt.Sprintf("%s — set", v.desc),
+			})
+		}
+	}
+	if ghauth.HasPATCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env github: PAT credentials",
+			Status:   diagOK,
+			Message:  "GITHUB_TOKEN or GH_TOKEN is set",
+		})
+	}
+
+	gcpVars := []struct{ name, desc string }{
+		{"GOOGLE_APPLICATION_CREDENTIALS", "GCP service account key file path"},
+		{"GOOGLE_EXTERNAL_ACCOUNT", "GCP workload identity external account config"},
+		{"GOOGLE_CLOUD_PROJECT", "GCP project ID"},
+	}
+	for _, v := range gcpVars {
+		if os.Getenv(v.name) != "" {
+			checks = append(checks, diagCheck{
+				Category: "env",
+				Check:    fmt.Sprintf("env %s", v.name),
+				Status:   diagOK,
+				Message:  fmt.Sprintf("%s — set", v.desc),
+			})
+		}
+	}
+	if gcpauth.HasServiceAccountCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env gcp: service-account credentials",
+			Status:   diagOK,
+			Message:  "GOOGLE_APPLICATION_CREDENTIALS is set and points to a service account key",
+		})
+	}
+	if gcpauth.HasWorkloadIdentityCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env gcp: workload-identity credentials",
+			Status:   diagOK,
+			Message:  "GCP workload identity environment detected",
+		})
+	}
+	if gcpauth.HasGcloudADCCredentials() {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env gcp: gcloud ADC",
+			Status:   diagOK,
+			Message:  "gcloud Application Default Credentials file found",
+		})
+	}
+
+	if len(checks) == 0 {
+		checks = append(checks, diagCheck{
+			Category: "env",
+			Check:    "env: credential variables",
+			Status:   diagInfo,
+			Message:  "no auth-related environment variables detected (interactive login may still work)",
+		})
+	}
+
+	return checks
+}
+
+// runClockSkewCheck compares the local system clock against the Date header
+// returned by a well-known HTTPS endpoint (cloudflare.com).
+// A skew > 5 minutes can cause token validation failures.
+func runClockSkewCheck() diagCheck {
+	const endpoint = "https://cloudflare.com"
+	const maxSkew = 5 * time.Minute
+	const timeout = 4 * time.Second
+
+	client := &http.Client{Timeout: timeout}
+	before := time.Now()
+	resp, err := client.Head(endpoint) //nolint:noctx // no context needed for a simple diagnostic probe
+	if err != nil {
+		return diagCheck{
+			Category: "clock",
+			Check:    "clock skew",
+			Status:   diagWarn,
+			Message:  fmt.Sprintf("could not reach %s to check clock skew: %v", endpoint, err),
+		}
+	}
+	defer resp.Body.Close()
+	after := time.Now()
+	localMid := before.Add(after.Sub(before) / 2) // midpoint of the round-trip
+
+	dateHeader := resp.Header.Get("Date")
+	if dateHeader == "" {
+		return diagCheck{
+			Category: "clock",
+			Check:    "clock skew",
+			Status:   diagInfo,
+			Message:  fmt.Sprintf("no Date header returned by %s; cannot check clock skew", endpoint),
+		}
+	}
+
+	serverTime, err := http.ParseTime(dateHeader)
+	if err != nil {
+		return diagCheck{
+			Category: "clock",
+			Check:    "clock skew",
+			Status:   diagWarn,
+			Message:  fmt.Sprintf("could not parse Date header %q: %v", dateHeader, err),
+		}
+	}
+
+	skew := localMid.Sub(serverTime)
+	if skew < 0 {
+		skew = -skew
+	}
+
+	if skew > maxSkew {
+		return diagCheck{
+			Category: "clock",
+			Check:    "clock skew",
+			Status:   diagFail,
+			Message:  fmt.Sprintf("clock skew is %s (local: %s, server: %s) — token validation may fail (JWT nbf/exp checks require skew < 5m)", skew.Round(time.Second), localMid.UTC().Format(time.RFC3339), serverTime.UTC().Format(time.RFC3339)),
+		}
+	}
+
+	return diagCheck{
+		Category: "clock",
+		Check:    "clock skew",
+		Status:   diagOK,
+		Message:  fmt.Sprintf("clock skew is %s (within acceptable range)", skew.Round(time.Millisecond)),
+	}
+}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -13,6 +13,7 @@ import (
 	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
 // handlerContextKey is used for test injection of handlers.
@@ -116,6 +117,7 @@ func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDO
 	if entraCfg.ClientID != "" || entraCfg.TenantID != "" || len(entraCfg.DefaultScopes) > 0 {
 		opts = append(opts, entra.WithConfig(entraCfg))
 	}
+	opts = append(opts, entra.WithLogger(*logger.FromContext(ctx)))
 
 	return entra.New(opts...)
 }
@@ -144,6 +146,7 @@ func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, client
 	if ghCfg.ClientID != "" || ghCfg.Hostname != "" || len(ghCfg.DefaultScopes) > 0 {
 		opts = append(opts, ghauth.WithConfig(ghCfg))
 	}
+	opts = append(opts, ghauth.WithLogger(*logger.FromContext(ctx)))
 
 	return ghauth.New(opts...)
 }
@@ -172,6 +175,7 @@ func getGCPHandlerWithOverrides(ctx context.Context, clientIDOverride, impersona
 	if gcpCfg.ClientID != "" || gcpCfg.ImpersonateServiceAccount != "" || len(gcpCfg.DefaultScopes) > 0 {
 		opts = append(opts, gcpauth.WithConfig(gcpCfg))
 	}
+	opts = append(opts, gcpauth.WithLogger(*logger.FromContext(ctx)))
 
 	return gcpauth.New(opts...)
 }

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -5,7 +5,9 @@ package auth
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -19,35 +21,82 @@ import (
 )
 
 // CommandList creates the 'auth list' command.
+// It shows metadata for all cached tokens (refresh and minted access) for the
+// specified handler, or for all handlers when no argument is given.
+// Actual token values are never displayed; use 'auth token' for that.
 func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
+	var (
+		expiredOnly  bool
+		validOnly    bool
+		purgeExpired bool
+	)
+
+	var sortBy string
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List registered auth handlers",
+		Use:   "list [handler]",
+		Short: "Show cached refresh and access token metadata",
 		Long: heredoc.Doc(`
-			List all registered authentication handlers and their metadata.
+			Show metadata for all cached tokens (refresh and minted access tokens).
 
-			Displays handler name, display name, supported authentication flows,
-			and capabilities for each registered handler. This is useful for
-			discovering which handlers are available and what features they support.
+			By default all registered auth handlers are queried. When a handler name
+			is provided only that handler's cached tokens are shown.
+
+			The output includes token kind (refresh/access), scope, type, expiry,
+			cache time, and whether the token is currently expired.  Actual token
+			values are never displayed here — use 'scafctl auth token <handler>'
+			to retrieve a token value.
 
 			Examples:
-			  # List all auth handlers
+			  # Show tokens for all handlers
 			  scafctl auth list
+
+			  # Show tokens for Entra only
+			  scafctl auth list entra
+
+			  # Show tokens for GCP only
+			  scafctl auth list gcp
+
+			  # Show only expired tokens
+			  scafctl auth list --expired-only
+
+			  # Show only valid (non-expired) tokens
+			  scafctl auth list --valid-only
 
 			  # Output as JSON
 			  scafctl auth list -o json
 
 			  # Output as YAML
 			  scafctl auth list -o yaml
-		`),
+
+			  # Sort by expiry (soonest expiring first)
+			  scafctl auth list --sort expires-at
+
+			  # Sort by handler name
+			  scafctl auth list --sort handler
+
+			  # Remove expired access tokens from the cache (keeps valid tokens and the refresh token)
+			  scafctl auth list --purge-expired
+			  scafctl auth list entra --purge-expired
+			`),
 		Aliases:      []string{"ls"},
 		SilenceUsage: true,
-		Args:         cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
+
+			if expiredOnly && validOnly {
+				err := fmt.Errorf("--expired-only and --valid-only are mutually exclusive")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if purgeExpired && (expiredOnly || validOnly) {
+				err := fmt.Errorf("--purge-expired cannot be combined with --expired-only or --valid-only")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
 
 			handlerNames := listHandlers(ctx)
 			if len(handlerNames) == 0 {
@@ -56,7 +105,53 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
-			results := make([]map[string]any, 0, len(handlerNames))
+			// Filter to a single handler if specified
+			if len(args) > 0 {
+				handlerName := args[0]
+				if err := validateHandlerName(ctx, handlerName); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				handlerNames = []string{handlerName}
+			}
+
+			// --purge-expired: remove expired access tokens and return a summary.
+			if purgeExpired {
+				total := 0
+				for _, name := range handlerNames {
+					handler, err := getHandler(ctx, name)
+					if err != nil {
+						w.Warningf("Failed to initialize %s: %v", name, err)
+						continue
+					}
+					purger, ok := handler.(auth.TokenPurger)
+					if !ok {
+						w.Warningf("%s does not support token purging", name)
+						continue
+					}
+					n, err := purger.PurgeExpiredTokens(ctx)
+					if err != nil {
+						w.Warningf("Failed to purge expired tokens for %s: %v", name, err)
+						continue
+					}
+					if n > 0 {
+						w.Successf("Purged %d expired access token(s) from %s.", n, name)
+					} else {
+						w.Infof("No expired access tokens found in %s.", name)
+					}
+					total += n
+				}
+				if len(handlerNames) > 1 {
+					if total > 0 {
+						w.Successf("Total: purged %d expired access token(s).", total)
+					} else {
+						w.Infof("No expired access tokens found in any handler.")
+					}
+				}
+				return nil
+			}
+
+			results := make([]map[string]any, 0)
 
 			for _, name := range handlerNames {
 				handler, err := getHandler(ctx, name)
@@ -65,32 +160,53 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					continue
 				}
 
-				flows := handler.SupportedFlows()
-				flowStrs := make([]string, len(flows))
-				for i, f := range flows {
-					flowStrs[i] = string(f)
+				lister, ok := handler.(auth.TokenLister)
+				if !ok {
+					w.Warningf("%s does not support token listing", name)
+					continue
 				}
 
-				capabilities := handler.Capabilities()
-				capStrs := make([]string, len(capabilities))
-				for i, c := range capabilities {
-					capStrs[i] = string(c)
+				tokens, err := lister.ListCachedTokens(ctx)
+				if err != nil {
+					w.Warningf("Failed to list tokens for %s: %v", name, err)
+					continue
 				}
 
-				result := map[string]any{
-					"name":         handler.Name(),
-					"displayName":  handler.DisplayName(),
-					"flows":        strings.Join(flowStrs, ", "),
-					"capabilities": strings.Join(capStrs, ", "),
+				for _, t := range tokens {
+					results = append(results, cachedTokenInfoToMap(t))
 				}
-
-				results = append(results, result)
 			}
 
 			if len(results) == 0 {
-				err := fmt.Errorf("no auth handlers could be loaded")
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
+				w.Infof("No cached tokens found.")
+				return nil
+			}
+
+			// Apply --expired-only / --valid-only filters.
+			if expiredOnly || validOnly {
+				filtered := make([]map[string]any, 0, len(results))
+				for _, r := range results {
+					isExpired, _ := r["isExpired"].(bool)
+					if expiredOnly && isExpired {
+						filtered = append(filtered, r)
+					} else if validOnly && !isExpired {
+						filtered = append(filtered, r)
+					}
+				}
+				results = filtered
+			}
+
+			if len(results) == 0 {
+				w.Infof("No cached tokens matched the filter.")
+				return nil
+			}
+
+			// Apply --sort
+			if sortBy != "" {
+				if err := sortTokenResults(results, sortBy); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
 			}
 
 			outputOpts := flags.NewKvxOutputOptionsFromFlags(
@@ -108,23 +224,109 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	}
 
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	cmd.Flags().BoolVar(&expiredOnly, "expired-only", false, "Show only expired tokens")
+	cmd.Flags().BoolVar(&validOnly, "valid-only", false, "Show only valid (non-expired) tokens")
+	cmd.Flags().StringVar(&sortBy, "sort", "", "Sort results by field: handler, kind, scope, expires-at, cached-at")
+	cmd.Flags().BoolVar(&purgeExpired, "purge-expired", false, "Remove expired access tokens from the cache (the refresh token and valid tokens are preserved)")
 	return cmd
 }
 
-// flowsToStrings converts a slice of Flow to a slice of strings.
-func flowsToStrings(flows []auth.Flow) []string {
-	strs := make([]string, len(flows))
-	for i, f := range flows {
-		strs[i] = string(f)
+// sortTokenResults sorts the list results in-place by the given field name.
+func sortTokenResults(results []map[string]any, field string) error {
+	var key string
+	switch strings.ToLower(field) {
+	case "handler":
+		key = "handler"
+	case "kind":
+		key = "tokenKind"
+	case "scope":
+		key = "scope"
+	case "expires-at", "expiresat":
+		key = "expiresAt"
+	case "cached-at", "cachedat":
+		key = "cachedAt"
+	default:
+		return fmt.Errorf("unknown sort field %q: valid values are handler, kind, scope, expires-at, cached-at", field)
 	}
-	return strs
+
+	sort.Slice(results, func(i, j int) bool {
+		vi, vj := results[i][key], results[j][key]
+		// Time fields
+		if ti, ok := vi.(time.Time); ok {
+			if tj, ok := vj.(time.Time); ok {
+				return ti.Before(tj)
+			}
+		}
+		// String fields
+		si, _ := vi.(string)
+		sj, _ := vj.(string)
+		return si < sj
+	})
+	return nil
 }
 
-// capabilitiesToStrings converts a slice of Capability to a slice of strings.
-func capabilitiesToStrings(caps []auth.Capability) []string {
-	strs := make([]string, len(caps))
-	for i, c := range caps {
-		strs[i] = string(c)
+// cachedTokenInfoToMap converts a CachedTokenInfo into a map suitable for kvx output.
+func cachedTokenInfoToMap(t *auth.CachedTokenInfo) map[string]any {
+	row := map[string]any{
+		"handler":   t.Handler,
+		"tokenKind": t.TokenKind,
+		"isExpired": t.IsExpired,
 	}
-	return strs
+
+	if t.Scope != "" {
+		row["scope"] = t.Scope
+	}
+	if t.TokenType != "" {
+		row["tokenType"] = t.TokenType
+	}
+	if t.Flow != "" {
+		row["flow"] = string(t.Flow)
+	}
+	if t.SessionID != "" {
+		row["sessionId"] = t.SessionID
+	}
+	if !t.ExpiresAt.IsZero() {
+		row["expiresAt"] = t.ExpiresAt
+		if !t.IsExpired {
+			row["expiresIn"] = humanDuration(t.TimeUntilExpiry())
+		}
+	}
+	if !t.CachedAt.IsZero() {
+		row["cachedAt"] = t.CachedAt
+	}
+
+	// Only access tokens can be retrieved via 'auth token'; refresh tokens are
+	// used internally and have no direct retrieval command.
+	if t.TokenKind == "access" {
+		if t.Scope != "" {
+			row["getTokenCommand"] = fmt.Sprintf("scafctl auth token %s --scope %q --raw", t.Handler, t.Scope)
+		} else {
+			row["getTokenCommand"] = fmt.Sprintf("scafctl auth token %s --raw", t.Handler)
+		}
+	}
+
+	return row
+}
+
+// humanDuration formats a duration in a human-friendly way.
+func humanDuration(d time.Duration) string {
+	if d <= 0 {
+		return "expired"
+	}
+
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	switch {
+	case hours > 24:
+		days := hours / 24
+		return fmt.Sprintf("%dd%dh", days, hours%24)
+	case hours > 0:
+		return fmt.Sprintf("%dh%dm", hours, minutes)
+	case minutes > 0:
+		return fmt.Sprintf("%dm%ds", minutes, seconds)
+	default:
+		return fmt.Sprintf("%ds", seconds)
+	}
 }

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -13,13 +14,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandList_Success(t *testing.T) {
+func TestCommandList_NoTokens(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
 	mock := auth.NewMockHandler("entra")
-	mock.DisplayNameValue = "Microsoft Entra ID"
-	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode, auth.FlowServicePrincipal}
-	mock.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapTenantID}
+	mock.ListCachedTokensResult = nil
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No cached tokens found")
+}
+
+func TestCommandList_WithTokens(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	now := time.Now()
+	mock := auth.NewMockHandler("entra")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "entra",
+			TokenKind: "refresh",
+			Flow:      auth.FlowDeviceCode,
+			ExpiresAt: now.Add(89 * 24 * time.Hour),
+			CachedAt:  now.Add(-1 * time.Hour),
+			IsExpired: false,
+		},
+		{
+			Handler:   "entra",
+			TokenKind: "access",
+			Scope:     "https://graph.microsoft.com/.default",
+			TokenType: "Bearer",
+			Flow:      auth.FlowDeviceCode,
+			ExpiresAt: now.Add(55 * time.Minute),
+			CachedAt:  now.Add(-5 * time.Minute),
+			IsExpired: false,
+		},
+	}
 
 	ctx = withTestHandler(ctx, mock)
 
@@ -35,11 +74,36 @@ func TestCommandList_Success(t *testing.T) {
 
 	output := buf.String()
 	assert.Contains(t, output, "entra")
-	assert.Contains(t, output, "Microsoft Entra ID")
+	assert.Contains(t, output, "refresh")
+	assert.Contains(t, output, "access")
 	assert.Contains(t, output, "device_code")
-	assert.Contains(t, output, "service_principal")
-	assert.Contains(t, output, "scopes_on_login")
-	assert.Contains(t, output, "tenant_id")
+}
+
+func TestCommandList_FilterByHandler(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "entra",
+			TokenKind: "refresh",
+			ExpiresAt: time.Now().Add(89 * 24 * time.Hour),
+			IsExpired: false,
+		},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "entra")
 }
 
 func TestCommandList_NoHandlers(t *testing.T) {
@@ -57,13 +121,38 @@ func TestCommandList_NoHandlers(t *testing.T) {
 	assert.Contains(t, err.Error(), "no auth handlers registered")
 }
 
+func TestCommandList_TooManyArgs(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "github"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
 func TestCommandList_JSONOutput(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
+	now := time.Now()
 	mock := auth.NewMockHandler("github")
-	mock.DisplayNameValue = "GitHub"
-	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode, auth.FlowPAT}
-	mock.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin, auth.CapHostname}
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "github",
+			TokenKind: "access",
+			TokenType: "Bearer",
+			ExpiresAt: now.Add(8 * time.Hour),
+			CachedAt:  now.Add(-10 * time.Minute),
+			IsExpired: false,
+		},
+	}
 
 	ctx = withTestHandler(ctx, mock)
 
@@ -78,38 +167,28 @@ func TestCommandList_JSONOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, `"name"`)
+	assert.Contains(t, output, `"handler"`)
 	assert.Contains(t, output, `"github"`)
-	assert.Contains(t, output, `"displayName"`)
-	assert.Contains(t, output, `"flows"`)
-	assert.Contains(t, output, `"capabilities"`)
+	assert.Contains(t, output, `"tokenKind"`)
+	assert.Contains(t, output, `"access"`)
+	assert.Contains(t, output, `"isExpired"`)
+	assert.Contains(t, output, `"tokenType"`)
 }
 
-func TestCommandList_NoArgs(t *testing.T) {
-	ctx, _ := newTestContext(t)
-
-	mock := auth.NewMockHandler("test")
-	ctx = withTestHandler(ctx, mock)
-
-	cliParams := settings.NewCliParams()
-	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
-
-	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"extra-arg"})
-
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown command")
-}
-
-func TestCommandList_EmptyCapabilities(t *testing.T) {
+func TestCommandList_ExpiredToken(t *testing.T) {
 	ctx, buf := newTestContext(t)
 
-	mock := auth.NewMockHandler("custom")
-	mock.DisplayNameValue = "Custom Handler"
-	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode}
-	mock.CapabilitiesValue = nil
+	mock := auth.NewMockHandler("gcp")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "gcp",
+			TokenKind: "access",
+			TokenType: "Bearer",
+			Scope:     "https://www.googleapis.com/auth/cloud-platform",
+			ExpiresAt: time.Now().Add(-1 * time.Hour),
+			IsExpired: true,
+		},
+	}
 
 	ctx = withTestHandler(ctx, mock)
 
@@ -122,32 +201,25 @@ func TestCommandList_EmptyCapabilities(t *testing.T) {
 
 	err := cmd.Execute()
 	require.NoError(t, err)
-
-	output := buf.String()
-	assert.Contains(t, output, "custom")
-	assert.Contains(t, output, "Custom Handler")
+	assert.Contains(t, buf.String(), "gcp")
 }
 
-func TestFlowsToStrings(t *testing.T) {
-	flows := []auth.Flow{auth.FlowDeviceCode, auth.FlowServicePrincipal, auth.FlowPAT}
-	result := flowsToStrings(flows)
-
-	assert.Equal(t, []string{"device_code", "service_principal", "pat"}, result)
-}
-
-func TestFlowsToStrings_Empty(t *testing.T) {
-	result := flowsToStrings(nil)
-	assert.Len(t, result, 0)
-}
-
-func TestCapabilitiesToStrings(t *testing.T) {
-	caps := []auth.Capability{auth.CapScopesOnLogin, auth.CapTenantID, auth.CapHostname}
-	result := capabilitiesToStrings(caps)
-
-	assert.Equal(t, []string{"scopes_on_login", "tenant_id", "hostname"}, result)
-}
-
-func TestCapabilitiesToStrings_Empty(t *testing.T) {
-	result := capabilitiesToStrings(nil)
-	assert.Len(t, result, 0)
+func TestHumanDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		d        time.Duration
+		expected string
+	}{
+		{"zero", 0, "expired"},
+		{"negative", -5 * time.Second, "expired"},
+		{"seconds", 45 * time.Second, "45s"},
+		{"minutes", 5*time.Minute + 30*time.Second, "5m30s"},
+		{"hours", 2*time.Hour + 15*time.Minute, "2h15m"},
+		{"days", 3*24*time.Hour + 6*time.Hour, "3d6h"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, humanDuration(tc.d))
+		})
+	}
 }

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -36,6 +36,8 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 		federatedToken            string
 		scopes                    []string
 		impersonateServiceAccount string
+		force                     bool
+		skipIfAuthenticated       bool
 	)
 
 	cmd := &cobra.Command{
@@ -198,11 +200,11 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			// Route to handler-specific login logic
 			switch handlerName {
 			case "github":
-				return loginGitHub(ctx, w, flow, hostname, clientID, timeout, scopes)
+				return loginGitHub(ctx, w, flow, hostname, clientID, timeout, scopes, force, skipIfAuthenticated)
 			case "gcp":
-				return loginGCP(ctx, w, flow, clientID, impersonateServiceAccount, timeout, scopes)
+				return loginGCP(ctx, w, flow, clientID, impersonateServiceAccount, timeout, scopes, force, skipIfAuthenticated)
 			default:
-				return loginEntra(ctx, w, flow, tenantID, clientID, timeout, federatedToken, flowStr, scopes)
+				return loginEntra(ctx, w, flow, tenantID, clientID, timeout, federatedToken, flowStr, scopes, force, skipIfAuthenticated)
 			}
 		},
 	}
@@ -215,12 +217,14 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 	cmd.Flags().StringVar(&federatedToken, "federated-token", "", "Federated token for workload identity (requires federated_token capability)")
 	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scopes to request during login (requires scopes_on_login capability)")
 	cmd.Flags().StringVar(&impersonateServiceAccount, "impersonate-service-account", "", "GCP service account email to impersonate (gcp handler only)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Re-authenticate even if already logged in (logs out first)")
+	cmd.Flags().BoolVar(&skipIfAuthenticated, "skip-if-authenticated", false, "Exit successfully without re-authenticating if already logged in (idempotent for scripts)")
 
 	return cmd
 }
 
 // loginGitHub handles the login flow for the GitHub auth handler.
-func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname, clientID string, timeout time.Duration, scopes []string) error {
+func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname, clientID string, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
 	// Auto-detect PAT if env vars are set and no explicit flow.
 	// Skip auto-detection when user provides --scope flags, since scopes
 	// only apply to the device code flow (PAT scopes are fixed at creation).
@@ -242,8 +246,11 @@ func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
-	// Check if already authenticated (skip for PAT)
-	if flow != auth.FlowPAT {
+	// Force re-auth: log out first if already authenticated.
+	if force {
+		_ = handler.Logout(ctx) // best-effort; ignore error
+	} else if flow != auth.FlowPAT {
+		// Check if already authenticated (skip for PAT)
 		status, err := handler.Status(ctx)
 		if err != nil {
 			err = fmt.Errorf("failed to check auth status: %w", err)
@@ -253,8 +260,12 @@ func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname
 
 		if status.Authenticated {
 			identity := status.Claims.DisplayIdentity()
-			w.Infof("Already authenticated as %s", identity)
-			w.Info("Use 'scafctl auth logout github' to sign out first, or continue to re-authenticate.")
+			if skipIfAuthenticated {
+				w.Infof("Already authenticated as %s — skipping login.", identity)
+				return nil
+			}
+			w.Warningf("Already authenticated as %s.", identity)
+			w.Warning("Use 'scafctl auth logout github' to sign out first, or use --force to re-authenticate.")
 			w.Info("")
 		}
 	}
@@ -263,7 +274,7 @@ func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname
 }
 
 // loginGCP handles the login flow for the GCP auth handler.
-func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, impersonateServiceAccount string, timeout time.Duration, scopes []string) error {
+func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, impersonateServiceAccount string, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
 	// Auto-detect flow based on available credentials (highest priority first)
 	if flow == "" && gcpauth.HasWorkloadIdentityCredentials() {
 		flow = auth.FlowWorkloadIdentity
@@ -286,8 +297,11 @@ func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, i
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
-	// Check if already authenticated (skip for non-interactive flows)
-	if flow == auth.FlowInteractive || flow == auth.FlowGcloudADC {
+	// Force re-auth: log out first if already authenticated.
+	if force {
+		_ = handler.Logout(ctx) // best-effort; ignore error
+	} else if flow == auth.FlowInteractive || flow == auth.FlowGcloudADC {
+		// Check if already authenticated (skip for non-interactive flows)
 		status, err := handler.Status(ctx)
 		if err != nil {
 			err = fmt.Errorf("failed to check auth status: %w", err)
@@ -297,8 +311,12 @@ func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, i
 
 		if status.Authenticated {
 			identity := status.Claims.DisplayIdentity()
-			w.Infof("Already authenticated as %s", identity)
-			w.Info("Use 'scafctl auth logout gcp' to sign out first, or continue to re-authenticate.")
+			if skipIfAuthenticated {
+				w.Infof("Already authenticated as %s — skipping login.", identity)
+				return nil
+			}
+			w.Warningf("Already authenticated as %s.", identity)
+			w.Warning("Use 'scafctl auth logout gcp' to sign out first, or use --force to re-authenticate.")
 			w.Info("")
 		}
 	}
@@ -307,7 +325,7 @@ func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, i
 }
 
 // loginEntra handles the login flow for the Entra auth handler.
-func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID, clientID string, timeout time.Duration, federatedToken, flowStr string, scopes []string) error {
+func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID, clientID string, timeout time.Duration, federatedToken, flowStr string, scopes []string, force, skipIfAuthenticated bool) error {
 	// If --federated-token is provided, set the env var for workload identity
 	if federatedToken != "" {
 		if err := os.Setenv(entra.EnvAzureFederatedToken, federatedToken); err != nil {
@@ -344,8 +362,11 @@ func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID,
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
-	// Check if already authenticated (skip for service principal)
-	if flow != auth.FlowServicePrincipal {
+	// Force re-auth: log out first if already authenticated.
+	if force {
+		_ = handler.Logout(ctx) // best-effort; ignore error
+	} else if flow != auth.FlowServicePrincipal {
+		// Check if already authenticated (skip for service principal)
 		status, err := handler.Status(ctx)
 		if err != nil {
 			err = fmt.Errorf("failed to check auth status: %w", err)
@@ -361,8 +382,12 @@ func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID,
 			if identity == "" {
 				identity = status.Claims.Subject
 			}
-			w.Infof("Already authenticated as %s", identity)
-			w.Info("Use 'scafctl auth logout entra' to sign out first, or continue to re-authenticate.")
+			if skipIfAuthenticated {
+				w.Infof("Already authenticated as %s — skipping login.", identity)
+				return nil
+			}
+			w.Warningf("Already authenticated as %s.", identity)
+			w.Warning("Use 'scafctl auth logout entra' to sign out first, or use --force to re-authenticate.")
 			w.Info("")
 		}
 	}

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -10,20 +10,31 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/input"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
 
 // CommandLogout creates the 'auth logout' command.
-func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		all    bool
+		force  bool
+		dryRun bool
+		yes    bool
+	)
+
 	cmd := &cobra.Command{
-		Use:   "logout <handler>",
+		Use:   "logout [handler]",
 		Short: "Clear authentication credentials",
 		Long: heredoc.Doc(`
 			Clear stored authentication credentials for an auth handler.
 
 			This removes the stored refresh token, clears any cached access tokens,
 			and removes metadata.
+
+			Use --all to log out from every registered handler at once.
+			Use --force to clear credentials even when not currently authenticated.
 
 			Examples:
 			  # Logout from Entra ID
@@ -34,50 +45,115 @@ func CommandLogout(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 
 			  # Logout from GCP
 			  scafctl auth logout gcp
-		`),
+
+			  # Logout from all registered handlers at once
+			  scafctl auth logout --all
+
+			  # Force clear credentials even if not currently logged in
+			  scafctl auth logout entra --force
+
+			  # Force clear all handlers' credentials
+			  scafctl auth logout --all --force
+			  # Show what would be removed without actually removing anything
+			  scafctl auth logout entra --dry-run
+
+			  # Dry-run across all handlers
+		  scafctl auth logout --all --dry-run
+
+		  # Log out from all handlers, skipping the confirmation prompt
+		  scafctl auth logout --all --yes	`),
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args: func(_ *cobra.Command, args []string) error {
+			if all && len(args) > 0 {
+				return fmt.Errorf("cannot specify a handler name when --all is set")
+			}
+			if !all && len(args) != 1 {
+				return fmt.Errorf("accepts 1 arg(s) (handler name), received %d — or use --all to log out from all handlers", len(args))
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
-			handlerName := args[0]
 
-			// Validate handler name against registry
-			if err := validateHandlerName(ctx, handlerName); err != nil {
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.InvalidInput)
+			var handlerNames []string
+			if all {
+				handlerNames = listHandlers(ctx)
+				if len(handlerNames) == 0 {
+					err := fmt.Errorf("no auth handlers registered")
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.GeneralError)
+				}
+				// Require confirmation for --all unless --yes or --force is set.
+				in := input.New(ioStreams, cliParams)
+				confirmed, err := in.Confirm(input.NewConfirmOptions().
+					WithPrompt(fmt.Sprintf("Log out from all %d handler(s) %v?", len(handlerNames), handlerNames)).
+					WithSkipCondition(yes || force))
+				if err != nil {
+					w.Errorf("failed to read confirmation: %v", err)
+					return exitcode.WithCode(err, exitcode.GeneralError)
+				}
+				if !confirmed {
+					w.Info("Logout cancelled.")
+					return nil
+				}
+			} else {
+				handlerName := args[0]
+				if err := validateHandlerName(ctx, handlerName); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				handlerNames = []string{handlerName}
 			}
 
-			handler, err := getHandler(ctx, handlerName)
-			if err != nil {
-				err = fmt.Errorf("failed to initialize auth handler: %w", err)
-				w.Errorf("%v", err)
+			hadError := false
+			for _, handlerName := range handlerNames {
+				handler, err := getHandler(ctx, handlerName)
+				if err != nil {
+					w.Errorf("Failed to initialize auth handler %s: %v", handlerName, err)
+					hadError = true
+					continue
+				}
+
+				if !force {
+					// Check if authenticated first; skip logout if not.
+					status, err := handler.Status(ctx)
+					if err != nil {
+						w.Errorf("Failed to check auth status for %s: %v", handlerName, err)
+						hadError = true
+						continue
+					}
+					if !status.Authenticated {
+						w.Infof("Not currently authenticated with %s.", handler.DisplayName())
+						continue
+					}
+				}
+
+				if dryRun {
+					w.Infof("[dry-run] Would log out from %s (cached tokens and refresh token would be removed).", handler.DisplayName())
+					continue
+				}
+
+				if err := handler.Logout(ctx); err != nil {
+					w.Errorf("Logout failed for %s: %v", handlerName, err)
+					hadError = true
+					continue
+				}
+
+				w.Successf("Successfully logged out from %s.", handler.DisplayName())
+			}
+
+			if hadError {
+				err := fmt.Errorf("one or more logout operations failed")
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
-
-			// Check if authenticated first
-			status, err := handler.Status(ctx)
-			if err != nil {
-				err = fmt.Errorf("failed to check auth status: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			if !status.Authenticated {
-				w.Infof("Not currently authenticated with %s.", handler.DisplayName())
-				return nil
-			}
-
-			if err := handler.Logout(ctx); err != nil {
-				err = fmt.Errorf("logout failed: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			w.Successf("Successfully logged out from %s.", handler.DisplayName())
 			return nil
 		},
 	}
 
+	cmd.Flags().BoolVar(&all, "all", false, "Log out from all registered auth handlers")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Clear stored credentials even if not currently authenticated")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be removed without actually removing credentials")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip the confirmation prompt when using --all")
 	return cmd
 }

--- a/pkg/cmd/scafctl/auth/logout_test.go
+++ b/pkg/cmd/scafctl/auth/logout_test.go
@@ -116,6 +116,7 @@ func TestCommandLogout_Failure(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "logout failed")
-	assert.Contains(t, err.Error(), "failed to clear credentials")
+	assert.Contains(t, err.Error(), "one or more logout operations failed")
+	// The specific underlying error is printed to output, not wrapped in the returned error
+	assert.Contains(t, buf.String(), "failed to clear credentials")
 }

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -20,6 +21,8 @@ import (
 // CommandStatus creates the 'auth status' command.
 func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
+	var exitCodeFlag bool
+	var warnWithin time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "status [handler]",
@@ -28,6 +31,9 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			Show the current authentication status for auth handlers.
 
 			If no handler is specified, shows status for all registered handlers.
+
+			Use --exit-code to make the command exit non-zero when any handler
+			is not authenticated — useful for scripting and health checks.
 
 			Examples:
 			  # Show all auth status
@@ -44,6 +50,12 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			  # Output as JSON
 			  scafctl auth status -o json
+
+			  # Exit non-zero if not authenticated (for scripts)
+			  scafctl auth status entra --exit-code
+
+			  # Exit non-zero if any token expires within 10 minutes (pre-flight check)
+			  scafctl auth status --warn-within 10m
 		`),
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
@@ -82,6 +94,10 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					"authenticated": status.Authenticated,
 				}
 
+				if !status.Authenticated {
+					result["hint"] = fmt.Sprintf("run 'scafctl auth login %s' to authenticate", handlerName)
+				}
+
 				// Add identity type
 				if status.IdentityType != "" {
 					result["identityType"] = string(status.IdentityType)
@@ -112,6 +128,9 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					}
 					if !status.ExpiresAt.IsZero() {
 						result["expiresAt"] = status.ExpiresAt
+						if timeUntil := time.Until(status.ExpiresAt); timeUntil > 0 {
+							result["expiresIn"] = humanDuration(timeUntil)
+						}
 					}
 					if !status.LastRefresh.IsZero() {
 						result["lastRefresh"] = status.LastRefresh
@@ -120,6 +139,13 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 				if len(status.Scopes) > 0 {
 					result["scopes"] = status.Scopes
+				}
+
+				// Cached token count (when available).
+				if lister, ok := handler.(auth.TokenLister); ok {
+					if tokens, err := lister.ListCachedTokens(ctx); err == nil {
+						result["cachedTokens"] = len(tokens)
+					}
 				}
 
 				results = append(results, result)
@@ -141,10 +167,43 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			)
 			outputOpts.IOStreams = ioStreams
 
-			return outputOpts.Write(results)
+			if err := outputOpts.Write(results); err != nil {
+				return err
+			}
+
+			// If --exit-code is set, return non-zero when any handler is not authenticated.
+			if exitCodeFlag {
+				for _, r := range results {
+					if authenticated, ok := r["authenticated"].(bool); ok && !authenticated {
+						err := fmt.Errorf("one or more auth handlers are not authenticated")
+						return exitcode.WithCode(err, exitcode.GeneralError)
+					}
+				}
+			}
+
+			// If --warn-within is set, return non-zero when any authenticated handler's
+			// token expires within the given window.
+			if warnWithin > 0 {
+				for _, r := range results {
+					authenticated, _ := r["authenticated"].(bool)
+					if !authenticated {
+						continue
+					}
+					if expiresAt, ok := r["expiresAt"].(time.Time); ok {
+						if time.Until(expiresAt) < warnWithin {
+							err := fmt.Errorf("one or more tokens expire within %s", warnWithin)
+							w.Warningf("%v", err)
+							return exitcode.WithCode(err, exitcode.GeneralError)
+						}
+					}
+				}
+			}
+			return nil
 		},
 	}
 
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	cmd.Flags().BoolVar(&exitCodeFlag, "exit-code", false, "Exit non-zero if any handler is not authenticated (useful for scripting)")
+	cmd.Flags().DurationVar(&warnWithin, "warn-within", 0, "Exit non-zero if any authenticated handler's token expires within this duration (e.g. 10m, 1h)")
 	return cmd
 }

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -4,12 +4,15 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/atotto/clipboard"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -27,7 +30,13 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		scopes       []string
 		minValidFor  time.Duration
 		forceRefresh bool
+		force        bool
 		rawToken     bool
+		clip         bool
+		decode       bool
+		curl         bool
+		curlURL      string
+		exportToken  bool
 	)
 
 	cmd := &cobra.Command{
@@ -73,14 +82,33 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Get a GCP token for BigQuery
 			  scafctl auth token gcp --scope "https://www.googleapis.com/auth/bigquery"
-		  # Print just the raw token value (useful for scripting)
-		  export TOKEN=$(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --raw)		`),
+
+			  # Print just the raw token value (useful for scripting)
+			  export TOKEN=$(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --raw)
+
+# Decode and display the JWT header and claims from the token (no signature validation)
+		  scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
+
+		  # Decode as JSON for full structured output (header + payload both present)
+		  scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json
+
+			  # Emit a ready-to-run curl command with the token injected
+			  scafctl auth token entra --scope "https://management.azure.com/.default" --curl --curl-url "https://management.azure.com/subscriptions?api-version=2020-01-01"
+
+			  # Export the token as a shell variable (eval-compatible)
+			  eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
+		`),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.MustFromContext(ctx)
 			handlerName := args[0]
+
+			// --force is an alias for --force-refresh
+			if force {
+				forceRefresh = true
+			}
 
 			// Validate handler name against registry
 			if err := validateHandlerName(ctx, handlerName); err != nil {
@@ -140,6 +168,51 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return nil
 			}
 
+			if clip {
+				if err := clipboard.WriteAll(token.AccessToken); err != nil {
+					err = fmt.Errorf("failed to copy token to clipboard: %w", err)
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.GeneralError)
+				}
+				w.Successf("Token copied to clipboard (expires in %s).", humanDuration(token.TimeUntilExpiry()))
+				return nil
+			}
+
+			if exportToken {
+				varName := tokenExportVarName(handlerName)
+				fmt.Fprintf(ioStreams.Out, "export %s=%s\n", varName, token.AccessToken)
+				return nil
+			}
+
+			if curl {
+				url := curlURL
+				if url == "" {
+					url = "<URL>"
+				}
+				fmt.Fprintf(ioStreams.Out, "curl -H %q %q\n",
+					fmt.Sprintf("Authorization: %s %s", token.TokenType, token.AccessToken), url)
+				return nil
+			}
+
+			if decode {
+				decoded, decErr := decodeJWT(token.AccessToken)
+				if decErr != nil {
+					decErr = fmt.Errorf("failed to decode JWT: %w", decErr)
+					w.Errorf("%v", decErr)
+					return exitcode.WithCode(decErr, exitcode.GeneralError)
+				}
+				outputOpts := flags.NewKvxOutputOptionsFromFlags(
+					outputFlags.Output,
+					outputFlags.Interactive,
+					outputFlags.Expression,
+					kvx.WithOutputContext(ctx),
+					kvx.WithOutputNoColor(cliParams.NoColor),
+					kvx.WithOutputAppName("scafctl auth token --decode"),
+				)
+				outputOpts.IOStreams = ioStreams
+				return outputOpts.Write(decoded)
+			}
+
 			result := map[string]any{
 				"handler":     handlerName,
 				"flow":        string(token.Flow),
@@ -148,6 +221,10 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				"expiresAt":   token.ExpiresAt,
 				"expiresIn":   token.TimeUntilExpiry().String(),
 				"accessToken": token.AccessToken,
+			}
+
+			if token.SessionID != "" {
+				result["sessionId"] = token.SessionID
 			}
 
 			outputOpts := flags.NewKvxOutputOptionsFromFlags(
@@ -167,8 +244,74 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().StringSliceVar(&scopes, "scope", nil, "OAuth scope(s) for the token (required for handlers with scopes_on_token_request capability)")
 	cmd.Flags().DurationVar(&minValidFor, "min-valid-for", auth.DefaultMinValidFor, "Minimum time the token should be valid for")
 	cmd.Flags().BoolVarP(&forceRefresh, "force-refresh", "f", false, "Force acquiring a new token, ignoring any cached token")
+	cmd.Flags().BoolVar(&force, "force", false, "Force acquiring a new token, ignoring any cached token (alias for --force-refresh)")
 	cmd.Flags().BoolVar(&rawToken, "raw", false, "Print only the raw access token value (useful for scripting)")
+	cmd.Flags().BoolVar(&clip, "clip", false, "Copy the token to the clipboard instead of printing it")
+	cmd.Flags().BoolVar(&decode, "decode", false, "Decode and display JWT header and claims from the access token (no signature validation); use -o json for full structured output")
+	cmd.Flags().BoolVar(&curl, "curl", false, "Emit a ready-to-run curl command with the token injected")
+	cmd.Flags().StringVar(&curlURL, "curl-url", "", "URL to embed in the --curl output (default: '<URL>' placeholder)")
+	cmd.Flags().BoolVar(&exportToken, "export", false, "Output a shell export statement: eval $(scafctl auth token ... --export)")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd
+}
+
+// decodeJWT parses a JWT and returns a map with "header" and "payload" keys,
+// each containing the decoded claims for that section.
+// The token signature is NOT validated — this is for display/debugging only.
+func decodeJWT(tokenStr string) (map[string]any, error) {
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("not a valid JWT: expected at least 2 dot-separated segments, got %d", len(parts))
+	}
+
+	decodedHeader, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode JWT header: %w", err)
+	}
+	decodedPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode JWT payload: %w", err)
+	}
+
+	var header map[string]any
+	if err := json.Unmarshal(decodedHeader, &header); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT header JSON: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(decodedPayload, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload JSON: %w", err)
+	}
+
+	// Augment well-known unix timestamp fields in the payload with human-readable counterparts.
+	for _, field := range []string{"exp", "iat", "nbf", "auth_time"} {
+		if v, ok := payload[field]; ok {
+			if ts, ok := jwtFloat64(v); ok {
+				payload[field+"_human"] = time.Unix(int64(ts), 0).UTC().Format(time.RFC3339)
+			}
+		}
+	}
+
+	return map[string]any{
+		"header":  header,
+		"payload": payload,
+	}, nil
+}
+
+// jwtFloat64 converts a JSON-decoded numeric value to float64.
+func jwtFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+// tokenExportVarName returns the shell variable name used by --export.
+func tokenExportVarName(handlerName string) string {
+	return strings.ToUpper(handlerName) + "_TOKEN"
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -217,6 +217,7 @@ func Root(opts *RootOptions) *cobra.Command {
 					DefaultScopes: cfg.Auth.Entra.DefaultScopes,
 				}))
 			}
+			entraOpts = append(entraOpts, entra.WithLogger(*lgr))
 			entraHandler, err := entra.New(entraOpts...)
 			if err != nil {
 				lgr.V(1).Info("warning: failed to initialize Entra auth handler", "error", err)
@@ -235,6 +236,7 @@ func Root(opts *RootOptions) *cobra.Command {
 					DefaultScopes: cfg.Auth.GitHub.DefaultScopes,
 				}))
 			}
+			ghOpts = append(ghOpts, ghauth.WithLogger(*lgr))
 			ghHandler, err := ghauth.New(ghOpts...)
 			if err != nil {
 				lgr.V(1).Info("warning: failed to initialize GitHub auth handler", "error", err)
@@ -255,6 +257,7 @@ func Root(opts *RootOptions) *cobra.Command {
 					Project:                   cfg.Auth.GCP.Project,
 				}))
 			}
+			gcpOpts = append(gcpOpts, gcpauth.WithLogger(*lgr))
 			gcpHandler, err := gcpauth.New(gcpOpts...)
 			if err != nil {
 				lgr.V(1).Info("warning: failed to initialize GCP auth handler", "error", err)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1238,20 +1238,37 @@ func TestIntegration_AuthList(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "auth", "list")
 
 	assert.Equal(t, 0, exitCode)
-	// Should show the built-in handlers
-	assert.Contains(t, stdout, "entra")
-	assert.Contains(t, stdout, "github")
-	assert.Contains(t, stdout, "gcp")
+	// With no active login sessions the command succeeds and reports no tokens.
+	// If tokens are cached from a prior login the handler name would appear instead.
+	assert.True(t,
+		strings.Contains(stdout, "No cached tokens found") ||
+			strings.Contains(stdout, "entra") ||
+			strings.Contains(stdout, "github") ||
+			strings.Contains(stdout, "gcp"),
+		"expected no-token message or token rows, got: %q", stdout,
+	)
 }
 
 func TestIntegration_AuthListJSON(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "auth", "list", "-o", "json")
 
+	// Command should always exit 0 regardless of whether tokens are present.
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, `"name"`)
-	assert.Contains(t, stdout, `"flows"`)
-	assert.Contains(t, stdout, `"capabilities"`)
+	// When tokens are present they are returned as JSON; when absent the
+	// informational message is written to stderr/stdout without JSON.
+	if strings.Contains(stdout, `"handler"`) {
+		assert.Contains(t, stdout, `"tokenKind"`)
+	}
+}
+
+func TestIntegration_AuthListHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "list", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "handler")
+	assert.Contains(t, stdout, "refresh")
 }
 
 func TestIntegration_AuthTokenHelp(t *testing.T) {


### PR DESCRIPTION
…mands

Introduce a stable SessionID (UUID v4) that is generated once at login time and propagated through the entire token lifecycle, allowing any minted access token to be traced back to the originating authentication session.

**What changed**

- auth.Token and auth.CachedTokenInfo both carry a new SessionID field
- Each handler's TokenMetadata (entra, github, gcp) persists SessionID in the secret store
- storeCredentials() generates a new UUID on initial login (empty string passed) and preserves the existing ID across refresh-token rotations, maintaining session lineage even as the underlying token value changes
- All three token caches (entra, github, gcp) store and restore SessionID from disk so cached access tokens retain the link
- ListCachedTokens() surfaces SessionID on both refresh and access token entries, showing the correlation in 'scafctl auth list'
- 'scafctl auth token' output includes sessionId when present

**Why**

Entra (and GCP/GitHub with token expiry) silently rotate the refresh token value on every use. Without a stable identity, there is no way to tell whether two cached tokens came from the same login event or from separate logins, making audit and debugging difficult.

Add 'auth diagnose' command that runs structured checks across all auth handlers, reporting category/check/status/message results and exiting non-zero on any failure. Useful for CI pre-flight and troubleshooting.

Enhance 'auth list' with:
- --sort <field> (handler, kind, scope, expires-at, cached-at)
- --expired-only / --valid-only filters
- --purge-expired to clean stale access tokens from the cache
- getTokenCommand column showing the exact token retrieval command
- Separate cache.go per handler (entra, gcp, github) for isolated storage

Enhance 'auth status' with:
- --exit-code to exit non-zero when any handler is unauthenticated
- --warn-within <duration> to exit non-zero when a token expires soon
- hint field in output pointing to the login command when not authenticated

Enhance 'auth login' with:
- --skip-if-authenticated for idempotent login safe to call in scripts

Enhance 'auth token' with:
- --raw to print the raw token value for shell scripting / curl
- GCP now supports --scope on token request (scopes-on-token-request cap)

- Document Entra flow priority (WIF > service principal > device code), refresh token rotation (90-day sliding window), and WIF isolation from the stored refresh token. Update auth tutorial and add examples/auth/README.md with end-to-end examples for all new flags and capabilities.
- docs/design/auth.md: added Flow Priority table, Isolation from Stored Refresh Tokens section, Fallback Behavior, Stale Stored Credentials guidance, and Refresh Token Rotation explanation
- docs/tutorials/auth-tutorial.md: added Flow Priority and Interaction with Stored Credentials section under Workload Identity, clarifying that WIF never touches the stored refresh token and that removing WIF env vars falls back automatically to the stored session

Update integration tests to cover new commands and flags.
