### PR TITLE
feat(hclprovider): add format, validate, generate, and JSON output op…

### DIFF
--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -1209,7 +1209,7 @@ name: "api-key"
 
 ### hcl
 
-Parses HCL (HashiCorp Configuration Language) content and extracts structured block information. Supports Terraform and OpenTofu configuration files.
+Processes HCL (HashiCorp Configuration Language) content. Supports four operations: `parse` (default) extracts structured block information; `format` canonically formats; `validate` checks syntax; `generate` produces HCL from structured input. Accepts single files, multiple paths, or a directory of `.tf` files.
 
 ~~~yaml
 resolve:
@@ -1226,12 +1226,17 @@ resolve:
 **Capabilities:** `from`, `transform`
 
 **Inputs:**
-- `content` (optional): Raw HCL content to parse as a string
-- `path` (optional): Path to an HCL file to read and parse
+- `operation` (optional): `parse` (default), `format`, `validate`, or `generate`
+- `content` (optional): Raw HCL content to process as a string
+- `path` (optional): Path to a single HCL file
+- `paths` (optional): Array of HCL file paths — results are merged (parse) or returned per-file (format/validate)
+- `dir` (optional): Directory path — all `.tf`/`.tf.json` files are processed
+- `blocks` (optional): Structured block data for `generate` (same schema as parse output)
+- `output_format` (optional): Generation output format — `hcl` (default, native HCL syntax) or `json` (Terraform JSON syntax `.tf.json`)
 
-One of `content` or `path` must be provided, but not both.
+For `parse`/`format`/`validate`, provide exactly one of `content`, `path`, `paths`, or `dir` (mutually exclusive). For `generate`, use `blocks` and optionally `output_format`.
 
-**Output:** An object with arrays/maps for each block type:
+**Output (operation: parse):** An object with arrays/maps for each block type:
 - `variables`: Array of variable definitions (name, type, default, description, sensitive, nullable, validation)
 - `resources`: Array of resource blocks (type, name, attributes, sub-blocks)
 - `data`: Array of data source blocks (type, name, attributes, sub-blocks)
@@ -1243,6 +1248,25 @@ One of `content` or `path` must be provided, but not both.
 - `moved`: Array of moved blocks (from, to)
 - `import`: Array of import blocks (to, id, provider)
 - `check`: Array of check blocks (name, data, assertions)
+
+When multiple files are parsed (`paths`/`dir`), results are merged: arrays are concatenated, `locals` and `terraform` maps are merged (last-file-wins for conflicts).
+
+**Output (operation: format):**
+- `formatted`: The canonically formatted HCL content as a string
+- `changed`: Boolean indicating whether the formatter modified the content
+
+Multi-file format returns `{ files: [{filename, formatted, changed}, ...], changed: bool }`.
+
+**Output (operation: validate):**
+- `valid`: Boolean — `true` if no syntax errors
+- `error_count`: Number of error-level diagnostics
+- `diagnostics`: Array of diagnostic entries (severity, summary, detail, range)
+
+Multi-file validate returns `{ valid: bool, error_count: int, files: [...] }`.
+
+**Output (operation: generate):**
+- `hcl`: Generated HCL text string (native HCL syntax or Terraform JSON depending on `output_format`)
+- Metadata includes `output_format` (`hcl` or `json`) indicating which format was produced
 
 **Expression handling:** Literal values (strings, numbers, booleans, lists, maps) are evaluated to native types. Complex expressions (variable references, function calls, conditionals) are returned as raw source text strings.
 

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -38,7 +38,7 @@ Step-by-step guides for learning scafctl features.
 
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution with embedded and external shells
 - [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
-- [HCL Provider Tutorial](hcl-provider-tutorial.md) — Parse Terraform/OpenTofu HCL configuration files
+- [HCL Provider Tutorial](hcl-provider-tutorial.md) — Parse, format, validate, and generate Terraform/OpenTofu HCL configuration files
 - [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
 
 ## Extension Development

--- a/docs/tutorials/hcl-provider-tutorial.md
+++ b/docs/tutorials/hcl-provider-tutorial.md
@@ -17,14 +17,19 @@ This tutorial walks you through using the `hcl` provider to parse Terraform and 
 
 1. [Parsing Inline HCL Content](#parsing-inline-hcl-content)
 2. [Parsing HCL Files](#parsing-hcl-files)
-3. [Extracting Variables](#extracting-variables)
-4. [Extracting Resources](#extracting-resources)
-5. [Working with Modules](#working-with-modules)
-6. [Terraform Block Extraction](#terraform-block-extraction)
-7. [Combining with CEL Expressions](#combining-with-cel-expressions)
-8. [Transform Capability](#transform-capability)
-9. [Expression Handling](#expression-handling)
-10. [Common Patterns](#common-patterns)
+3. [Multi-File and Directory Support](#multi-file-and-directory-support)
+4. [Extracting Variables](#extracting-variables)
+5. [Extracting Resources](#extracting-resources)
+6. [Working with Modules](#working-with-modules)
+7. [Terraform Block Extraction](#terraform-block-extraction)
+8. [Combining with CEL Expressions](#combining-with-cel-expressions)
+9. [Transform Capability](#transform-capability)
+10. [Expression Handling](#expression-handling)
+11. [Common Patterns](#common-patterns)
+12. [Formatting HCL Content](#formatting-hcl-content)
+13. [Validating HCL Syntax](#validating-hcl-syntax)
+14. [Generating HCL from Structured Data](#generating-hcl-from-structured-data)
+15. [Generating Terraform JSON (`.tf.json`)](#generating-terraform-json-tfjson)
 
 ---
 
@@ -113,6 +118,93 @@ spec:
 The `path` input reads the file from disk and parses it. You must provide either `content` or `path`, not both.
 
 When using `path`, the `metadata.filename` in the output reflects the actual file path instead of the default `input.tf`.
+
+---
+
+## Multi-File and Directory Support
+
+The HCL provider can process multiple files at once. This is useful for real Terraform projects that split configuration across many `.tf` files.
+
+### Parse Multiple Files
+
+Use the `paths` input to specify an array of files. Parse results are **merged** — arrays are concatenated and maps are merged:
+
+```yaml
+spec:
+  resolvers:
+    fullConfig:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              paths:
+                - ./main.tf
+                - ./variables.tf
+                - ./outputs.tf
+```
+
+The metadata includes `filenames` (array) and `files` (count) instead of a single `filename`.
+
+### Parse a Directory
+
+Use `dir` to process all `.tf` and `.tf.json` files in a directory (non-recursive):
+
+```yaml
+spec:
+  resolvers:
+    infraConfig:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              dir: ./terraform/environments/prod
+```
+
+This automatically discovers all HCL files, reads them, and merges the parsed results.
+
+### Multi-File Format and Validate
+
+When `paths` or `dir` is used with `format` or `validate`, results are returned **per file** rather than merged:
+
+```yaml
+# Format all .tf files in a directory
+spec:
+  resolvers:
+    formatted:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              dir: ./terraform
+```
+
+Format output with multiple files:
+```json
+{
+  "files": [
+    { "filename": "./terraform/main.tf", "formatted": "...", "changed": true },
+    { "filename": "./terraform/vars.tf", "formatted": "...", "changed": false }
+  ],
+  "changed": true
+}
+```
+
+Validate output with multiple files:
+```json
+{
+  "valid": false,
+  "error_count": 2,
+  "files": [
+    { "filename": "main.tf", "valid": true, "error_count": 0, "diagnostics": [] },
+    { "filename": "bad.tf", "valid": false, "error_count": 2, "diagnostics": [...] }
+  ]
+}
+```
+
+### Source Selection Rules
+
+Exactly one of `content`, `path`, `paths`, or `dir` must be provided — they are mutually exclusive. For the `generate` operation, use `blocks` instead.
 
 ---
 
@@ -503,6 +595,345 @@ spec:
 
 ---
 
+## Formatting HCL Content
+
+The `format` operation canonically formats HCL content using the same rules as `terraform fmt`. It accepts the same `content` or `path` inputs as the `parse` operation and returns two fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formatted` | string | The canonically formatted HCL |
+| `changed` | bool | `true` if the formatter modified the input |
+
+### Format Inline Content
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fmt-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    result:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              content: |
+                variable "region" {
+                type=string
+                default="us-east-1"
+                }
+```
+
+Output:
+
+```json
+{
+  "data": {
+    "changed": true,
+    "formatted": "variable \"region\" {\n  type    = string\n  default = \"us-east-1\"\n}\n"
+  },
+  "metadata": {
+    "bytes": 52,
+    "filename": "input.tf",
+    "operation": "format"
+  }
+}
+```
+
+### Format a File
+
+```yaml
+spec:
+  resolvers:
+    result:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              path: ./main.tf
+```
+
+### Check Whether a File Needs Formatting
+
+Combine with a CEL expression to build a lint-style check:
+
+```yaml
+spec:
+  resolvers:
+    fmt:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              path: ./main.tf
+
+    check:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                resolvers.fmt.changed
+                  ? "main.tf needs formatting — run terraform fmt"
+                  : "main.tf is correctly formatted"
+```
+
+---
+
+## Validating HCL Syntax
+
+The `validate` operation checks HCL syntax without extracting blocks. It returns structured diagnostics, making it ideal for CI pipelines, pre-commit hooks, and configuration auditing.
+
+### Validate Inline Content
+
+```yaml
+spec:
+  resolvers:
+    checkSyntax:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              content: |
+                variable "region" {
+                  type    = string
+                  default = "us-east-1"
+                }
+```
+
+Output for valid HCL:
+
+```json
+{
+  "valid": true,
+  "error_count": 0,
+  "diagnostics": []
+}
+```
+
+### Validate a File
+
+```yaml
+spec:
+  resolvers:
+    validateMain:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              path: ./main.tf
+```
+
+### Validate a Directory
+
+```yaml
+spec:
+  resolvers:
+    validateAll:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              dir: ./terraform
+```
+
+When validating multiple files, the output aggregates results:
+
+```json
+{
+  "valid": false,
+  "error_count": 3,
+  "files": [
+    {
+      "filename": "main.tf",
+      "valid": true,
+      "error_count": 0,
+      "diagnostics": []
+    },
+    {
+      "filename": "bad.tf",
+      "valid": false,
+      "error_count": 3,
+      "diagnostics": [
+        {
+          "severity": "error",
+          "summary": "Invalid block definition",
+          "range": { "filename": "bad.tf", "start": { "line": 1, "column": 10 } }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Use Validate with CEL
+
+```yaml
+spec:
+  resolvers:
+    syntaxCheck:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              dir: ./terraform
+      expression: |
+        result.valid
+          ? "All files are syntactically correct"
+          : "Found " + string(result.error_count) + " syntax errors"
+```
+
+---
+
+## Generating HCL from Structured Data
+
+The `generate` operation produces HCL text from a structured map, using the same schema as the parse output. This enables round-trip workflows: parse HCL, transform the data, then generate updated HCL.
+
+### Basic Generation
+
+```yaml
+spec:
+  resolvers:
+    generated:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              blocks:
+                variables:
+                  - name: region
+                    type: string
+                    default: us-east-1
+                    description: "AWS region"
+                  - name: env
+                    type: string
+                    default: dev
+```
+
+Output:
+
+```json
+{
+  "hcl": "variable \"region\" {\n  type        = string\n  default     = \"us-east-1\"\n  description = \"AWS region\"\n}\n\nvariable \"env\" {\n  type    = string\n  default = \"dev\"\n}\n"
+}
+```
+
+### Generate Resources
+
+```yaml
+spec:
+  resolvers:
+    infraCode:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              blocks:
+                resources:
+                  - type: aws_instance
+                    name: web
+                    attributes:
+                      ami: ami-12345
+                      instance_type: t3.micro
+                      tags:
+                        Name: web-server
+                        Environment: prod
+```
+
+### Block Ordering
+
+Generated HCL follows Terraform convention ordering:
+1. `terraform`
+2. `variable`
+3. `locals`
+4. `data`
+5. `resource`
+6. `module`
+7. `output`
+8. `provider`
+9. `moved`
+10. `import`
+11. `check`
+
+### Round-Trip Workflow
+
+Parse existing HCL, transform it, and generate new HCL:
+
+```yaml
+spec:
+  resolvers:
+    original:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              path: ./main.tf
+
+    updated:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              blocks: "{{ .resolvers.original | toJson }}"
+```
+
+### Generating Terraform JSON (`.tf.json`)
+
+Set `output_format: json` to produce [Terraform JSON Configuration Syntax](https://developer.hashicorp.com/terraform/language/syntax/json) instead of native HCL:
+
+```yaml
+spec:
+  resolvers:
+    jsonConfig:
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              output_format: json
+              blocks:
+                variables:
+                  - name: region
+                    type: string
+                    default: us-east-1
+                resources:
+                  - type: aws_instance
+                    name: web
+                    attributes:
+                      ami: ami-12345
+                      instance_type: t3.micro
+```
+
+Output:
+
+```json
+{
+  "hcl": "{\n  \"variable\": {\n    \"region\": {\n      \"default\": \"us-east-1\",\n      \"type\": \"string\"\n    }\n  },\n  \"resource\": {\n    \"aws_instance\": {\n      \"web\": {\n        \"ami\": \"ami-12345\",\n        \"instance_type\": \"t3.micro\"\n      }\n    }\n  }\n}\n"
+}
+```
+
+The JSON output follows the [Terraform JSON Configuration Syntax](https://developer.hashicorp.com/terraform/language/syntax/json) specification:
+- Block types become top-level JSON keys (singular: `variable`, `resource`, not plural)
+- Single-label blocks (variable, module, output) nest by name: `{"variable": {"region": {...}}}`
+- Double-label blocks (resource, data) nest by type then name: `{"resource": {"aws_instance": {"web": {...}}}}`
+- Provider blocks with aliases produce arrays for the same provider name
+- Unlabeled blocks (moved, import) remain as arrays
+
+---
+
 ## Supported Block Types
 
 The HCL provider extracts the following Terraform/OpenTofu block types:
@@ -531,11 +962,38 @@ You can also run the HCL provider directly from the command line:
 # Parse a file
 scafctl run provider hcl --input path=./main.tf -o json
 
-# Dry run
+# Parse a directory
+scafctl run provider hcl --input dir=./terraform -o json
+
+# Format inline HCL
+scafctl run provider hcl --input operation=format --input 'content=variable "x" { type=string }' -o json
+
+# Format a file
+scafctl run provider hcl --input operation=format --input path=./main.tf -o json
+
+# Format all files in a directory
+scafctl run provider hcl --input operation=format --input dir=./terraform -o json
+
+# Validate a file
+scafctl run provider hcl --input operation=validate --input path=./main.tf -o json
+
+# Validate a directory
+scafctl run provider hcl --input operation=validate --input dir=./terraform -o json
+
+# Use a pre-built example input file
+scafctl run provider hcl --input @examples/providers/hcl-format.yaml -o json
+
+# Dry run (parse)
 scafctl run provider hcl --input path=./main.tf --dry-run
+
+# Dry run (format)
+scafctl run provider hcl --input operation=format --input path=./main.tf --dry-run
+
+# Dry run (validate)
+scafctl run provider hcl --input operation=validate --input path=./main.tf --dry-run
 ```
 
-Dry-run output returns the empty structure with a `dryRun` flag instead of actually parsing:
+Dry-run returns an empty structure without reading or modifying anything. For `parse`:
 
 ```json
 {
@@ -554,7 +1012,24 @@ Dry-run output returns the empty structure with a `dryRun` flag instead of actua
   },
   "dryRun": true,
   "metadata": {
-    "mode": "dry-run"
+    "mode": "dry-run",
+    "operation": "parse"
+  }
+}
+```
+
+For `format`:
+
+```json
+{
+  "data": {
+    "changed": false,
+    "formatted": ""
+  },
+  "dryRun": true,
+  "metadata": {
+    "mode": "dry-run",
+    "operation": "format"
   }
 }
 ```

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -525,7 +525,7 @@ transform:
 
 ## hcl
 
-Parse HCL (HashiCorp Configuration Language) content and extract structured block information from Terraform and OpenTofu configuration files.
+Process HCL (HashiCorp Configuration Language) content. Supports four operations: `parse` (default) extracts structured block information; `format` canonically formats; `validate` checks syntax; `generate` produces HCL from structured input. Accepts single files, multiple paths, or a directory of `.tf` files.
 
 ### Capabilities
 
@@ -535,12 +535,17 @@ Parse HCL (HashiCorp Configuration Language) content and extract structured bloc
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `content` | string | ❌ | Raw HCL content to parse |
-| `path` | string | ❌ | Path to an HCL file to read and parse |
+| `operation` | string | ❌ | `parse` (default), `format`, `validate`, or `generate` |
+| `content` | string | ❌ | Raw HCL content to process |
+| `path` | string | ❌ | Path to a single HCL file |
+| `paths` | array | ❌ | Array of HCL file paths (merged for parse; per-file for format/validate) |
+| `dir` | string | ❌ | Directory path — all `.tf`/`.tf.json` files are processed |
+| `blocks` | object | ❌ | Structured block data for `generate` (same schema as parse output) |
+| `output_format` | string | ❌ | Generation output format: `hcl` (default) or `json` (Terraform JSON syntax `.tf.json`) |
 
-One of `content` or `path` must be provided, but not both.
+**Source selection:** For `parse`/`format`/`validate`, provide exactly one of `content`, `path`, `paths`, or `dir` (mutually exclusive). For `generate`, use `blocks` and optionally `output_format`.
 
-### Output
+### Output — `parse` (default)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -556,10 +561,39 @@ One of `content` or `path` must be provided, but not both.
 | `import` | array | Import blocks (to, id, provider) |
 | `check` | array | Check blocks (name, data, assertions) |
 
+When multiple files are parsed (`paths` or `dir`), results are merged: arrays are concatenated, `locals` and `terraform` maps are merged (last-file-wins for conflicting keys).
+
+### Output — `format`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formatted` | string | The canonically formatted HCL content (single file) |
+| `changed` | bool | `true` if the formatter modified the content |
+
+Multi-file format returns `{ files: [{filename, formatted, changed}, ...], changed: bool }`.
+
+### Output — `validate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `valid` | bool | `true` if no syntax errors were found |
+| `error_count` | int | Number of error-level diagnostics |
+| `diagnostics` | array | Diagnostic entries with severity, summary, detail, range |
+
+Multi-file validate returns `{ valid: bool, error_count: int, files: [{filename, valid, error_count, diagnostics}, ...] }`.
+
+### Output — `generate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hcl` | string | Generated HCL text (native HCL syntax or Terraform JSON depending on `output_format`) |
+
+**Metadata** includes `output_format` (`hcl` or `json`) indicating which format was produced.
+
 ### Examples
 
 ```yaml
-# Parse inline HCL content
+# Parse inline HCL content (operation defaults to "parse")
 resolve:
   with:
     - provider: hcl
@@ -577,12 +611,89 @@ resolve:
       inputs:
         path: ./main.tf
 
+# Parse all .tf files in a directory (results merged)
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        dir: ./terraform
+
+# Parse multiple specific files
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        paths:
+          - ./main.tf
+          - ./variables.tf
+          - ./outputs.tf
+
 # Transform: parse HCL from another resolver's output
 transform:
   with:
     - provider: hcl
       inputs:
         content: "{{ .resolvers.tfFile.content }}"
+
+# Format inline HCL content
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: format
+        content: |
+          variable "region" {
+          type=string
+          default="us-east-1"
+          }
+
+# Format all files in a directory
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: format
+        dir: ./terraform
+
+# Validate HCL syntax
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: validate
+        path: ./main.tf
+
+# Generate HCL from structured data
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: generate
+        blocks:
+          variables:
+            - name: region
+              type: string
+              default: us-east-1
+              description: "AWS region"
+
+# Generate Terraform JSON (.tf.json) from structured data
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: generate
+        output_format: json
+        blocks:
+          variables:
+            - name: region
+              type: string
+              default: us-east-1
+          resources:
+            - type: aws_instance
+              name: web
+              attributes:
+                ami: ami-12345
+                instance_type: t3.micro
 ```
 
 ---

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -11,6 +11,10 @@ Example input files for use with `scafctl run provider --input @<file>`.
 | [github-api.yaml](github-api.yaml) | `http` | GitHub API call with authentication |
 | [exec-ls.yaml](exec-ls.yaml) | `exec` | Execute `ls -la` command |
 | [hcl-parse-variables.yaml](hcl-parse-variables.yaml) | `hcl` | Parse HCL content to extract variable definitions |
+| [hcl-format.yaml](hcl-format.yaml) | `hcl` | Format HCL content to canonical style |
+| [hcl-validate.yaml](hcl-validate.yaml) | `hcl` | Validate HCL syntax and return diagnostics |
+| [hcl-generate.yaml](hcl-generate.yaml) | `hcl` | Generate HCL from structured block data |
+| [hcl-generate-json.yaml](hcl-generate-json.yaml) | `hcl` | Generate Terraform JSON (`.tf.json`) from structured block data |
 
 ## Usage
 

--- a/examples/providers/hcl-format.yaml
+++ b/examples/providers/hcl-format.yaml
@@ -1,0 +1,18 @@
+# HCL provider input - format poorly-formatted Terraform content to canonical style
+# The 'changed' field in the output indicates whether the formatter modified the content.
+operation: format
+content: |
+  variable "region" {
+  type=string
+  default="us-east-1"
+  description="AWS region for resources"
+  }
+
+  resource "aws_s3_bucket" "data" {
+  bucket="my-data-bucket"
+  force_destroy=true
+  tags={
+  Environment="prod"
+  Owner="team-platform"
+  }
+  }

--- a/examples/providers/hcl-generate-json.yaml
+++ b/examples/providers/hcl-generate-json.yaml
@@ -1,0 +1,25 @@
+operation: generate
+output_format: json
+blocks:
+  variables:
+    - name: region
+      type: string
+      default: us-east-1
+      description: "AWS region"
+    - name: env
+      type: string
+      default: dev
+      description: "Environment name"
+  resources:
+    - type: aws_instance
+      name: web
+      attributes:
+        ami: ami-12345
+        instance_type: t3.micro
+        tags:
+          Name: web-server
+          Environment: prod
+  outputs:
+    - name: instance_id
+      value: aws_instance.web.id
+      description: "The instance ID"

--- a/examples/providers/hcl-generate.yaml
+++ b/examples/providers/hcl-generate.yaml
@@ -1,0 +1,21 @@
+operation: generate
+blocks:
+  variables:
+    - name: region
+      type: string
+      default: us-east-1
+      description: "AWS region"
+    - name: env
+      type: string
+      default: dev
+      description: "Environment name"
+  resources:
+    - type: aws_instance
+      name: web
+      attributes:
+        ami: ami-12345
+        instance_type: t3.micro
+  outputs:
+    - name: instance_id
+      value: aws_instance.web.id
+      description: "The instance ID"

--- a/examples/providers/hcl-validate.yaml
+++ b/examples/providers/hcl-validate.yaml
@@ -1,0 +1,11 @@
+operation: validate
+content: |
+  variable "region" {
+    type    = string
+    default = "us-east-1"
+  }
+
+  resource "aws_instance" "web" {
+    ami           = "ami-12345"
+    instance_type = "t3.micro"
+  }

--- a/pkg/provider/builtin/hclprovider/ctyhelpers.go
+++ b/pkg/provider/builtin/hclprovider/ctyhelpers.go
@@ -1,0 +1,35 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"math/big"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ctyStringVal creates a cty string value.
+func ctyStringVal(s string) cty.Value {
+	return cty.StringVal(s)
+}
+
+// ctyBoolVal creates a cty bool value.
+func ctyBoolVal(b bool) cty.Value {
+	return cty.BoolVal(b)
+}
+
+// ctyNumberIntVal creates a cty number value from int64.
+func ctyNumberIntVal(n int64) cty.Value {
+	return cty.NumberVal(new(big.Float).SetInt64(n))
+}
+
+// ctyNumberFloatVal creates a cty number value from float64.
+func ctyNumberFloatVal(f float64) cty.Value {
+	return cty.NumberFloatVal(f)
+}
+
+// hclwriteTokensForTraversal is a helper to generate tokens for a traversal reference.
+// This is unused currently but reserved for future expression-aware generation.
+var _ = hclwrite.TokensForValue // ensure hclwrite is used

--- a/pkg/provider/builtin/hclprovider/generate.go
+++ b/pkg/provider/builtin/hclprovider/generate.go
@@ -1,0 +1,464 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// GenerateHCL converts a structured map representation into canonical HCL text.
+// The input map follows the same schema as ParseHCL output: top-level keys are
+// block types (variable, resource, module, output, locals, provider, terraform,
+// moved, import, data, check) with arrays of block definitions.
+func GenerateHCL(input map[string]any) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	body := f.Body()
+
+	// blockOrder lists the input map keys in desired output order.
+	// The parse output uses plural keys (variables, resources, …), so we
+	// map each input key to the singular HCL block type for code generation.
+	type blockEntry struct {
+		inputKey  string // key in the input map (parse output schema)
+		blockType string // HCL block type name (singular)
+	}
+	blockOrder := []blockEntry{
+		{"terraform", "terraform"},
+		{"variables", "variable"},
+		{"locals", "locals"},
+		{"data", "data"},
+		{"resources", "resource"},
+		{"modules", "module"},
+		{"outputs", "output"},
+		{"providers", "provider"},
+		{"moved", "moved"},
+		{"import", "import"},
+		{"check", "check"},
+	}
+
+	needsNewline := false
+	for _, entry := range blockOrder {
+		val, ok := input[entry.inputKey]
+		if !ok {
+			continue
+		}
+
+		switch entry.inputKey {
+		case "terraform":
+			m, ok := val.(map[string]any)
+			if !ok || len(m) == 0 {
+				continue
+			}
+			if needsNewline {
+				body.AppendNewline()
+			}
+			generateTerraformBlock(body, m)
+			needsNewline = true
+
+		case "locals":
+			m, ok := val.(map[string]any)
+			if !ok || len(m) == 0 {
+				continue
+			}
+			if needsNewline {
+				body.AppendNewline()
+			}
+			generateLocalsBlock(body, m)
+			needsNewline = true
+
+		default:
+			items, ok := val.([]any)
+			if !ok || len(items) == 0 {
+				continue
+			}
+			for _, item := range items {
+				itemMap, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if needsNewline {
+					body.AppendNewline()
+				}
+				if err := generateBlock(body, entry.blockType, itemMap); err != nil {
+					return "", fmt.Errorf("generating %s block: %w", entry.blockType, err)
+				}
+				needsNewline = true
+			}
+		}
+	}
+
+	return string(f.Bytes()), nil
+}
+
+// generateBlock creates a single HCL block from a map definition.
+func generateBlock(body *hclwrite.Body, blockType string, def map[string]any) error {
+	labels := labelsForBlock(blockType, def)
+	block := body.AppendNewBlock(blockType, labels)
+	blockBody := block.Body()
+
+	// Get the attribute keys we should write, excluding label keys and sub-block keys.
+	skipKeys := labelKeySet(blockType)
+	skipKeys["blocks"] = true
+	skipKeys["attributes"] = true
+	skipKeys["validation"] = true
+	skipKeys["assertions"] = true
+	skipKeys["data"] = true // for check blocks
+
+	// Write promoted attributes first (well-known fields).
+	promoted := promotedKeysForBlock(blockType)
+	for _, key := range promoted {
+		if v, ok := def[key]; ok {
+			writeAttribute(blockBody, key, v)
+		}
+	}
+
+	// Write remaining attributes from the "attributes" map.
+	if attrs, ok := def["attributes"].(map[string]any); ok {
+		keys := sortedKeys(attrs)
+		for _, k := range keys {
+			writeAttribute(blockBody, k, attrs[k])
+		}
+	}
+
+	// Write validation sub-blocks (for variable blocks).
+	if validations, ok := def["validation"].([]any); ok {
+		for _, v := range validations {
+			if vm, ok := v.(map[string]any); ok {
+				valBlock := blockBody.AppendNewBlock("validation", nil)
+				valBody := valBlock.Body()
+				keys := sortedKeys(vm)
+				for _, k := range keys {
+					writeAttribute(valBody, k, vm[k])
+				}
+			}
+		}
+	}
+
+	// Write assertions sub-blocks (for check blocks).
+	if assertions, ok := def["assertions"].([]any); ok {
+		for _, a := range assertions {
+			if am, ok := a.(map[string]any); ok {
+				aBlock := blockBody.AppendNewBlock("assert", nil)
+				aBody := aBlock.Body()
+				keys := sortedKeys(am)
+				for _, k := range keys {
+					writeAttribute(aBody, k, am[k])
+				}
+			}
+		}
+	}
+
+	// Write data sub-blocks (for check blocks).
+	if dataBlocks, ok := def["data"].([]any); ok {
+		for _, d := range dataBlocks {
+			if dm, ok := d.(map[string]any); ok {
+				dataLabels := []string{}
+				if t, ok := dm["type"].(string); ok {
+					dataLabels = append(dataLabels, t)
+				}
+				if n, ok := dm["name"].(string); ok {
+					dataLabels = append(dataLabels, n)
+				}
+				dBlock := blockBody.AppendNewBlock("data", dataLabels)
+				if attrs, ok := dm["attributes"].(map[string]any); ok {
+					dBody := dBlock.Body()
+					keys := sortedKeys(attrs)
+					for _, k := range keys {
+						writeAttribute(dBody, k, attrs[k])
+					}
+				}
+			}
+		}
+	}
+
+	// Write generic sub-blocks from "blocks" array.
+	if blocks, ok := def["blocks"].([]any); ok {
+		for _, b := range blocks {
+			if bm, ok := b.(map[string]any); ok {
+				bType, _ := bm["type"].(string)
+				var bLabels []string
+				if ls, ok := bm["labels"].([]any); ok {
+					for _, l := range ls {
+						if s, ok := l.(string); ok {
+							bLabels = append(bLabels, s)
+						}
+					}
+				}
+				sub := blockBody.AppendNewBlock(bType, bLabels)
+				subBody := sub.Body()
+				if attrs, ok := bm["attributes"].(map[string]any); ok {
+					keys := sortedKeys(attrs)
+					for _, k := range keys {
+						writeAttribute(subBody, k, attrs[k])
+					}
+				}
+				// Recurse into nested blocks.
+				if nested, ok := bm["blocks"].([]any); ok {
+					for _, nb := range nested {
+						if nbm, ok := nb.(map[string]any); ok {
+							nbType, _ := nbm["type"].(string)
+							if err := generateBlock(subBody, nbType, nbm); err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// generateTerraformBlock creates a terraform { ... } block.
+func generateTerraformBlock(body *hclwrite.Body, def map[string]any) {
+	block := body.AppendNewBlock("terraform", nil)
+	blockBody := block.Body()
+
+	if rv, ok := def["required_version"].(string); ok {
+		writeAttribute(blockBody, "required_version", rv)
+	}
+
+	if rp, ok := def["required_providers"].(map[string]any); ok && len(rp) > 0 {
+		rpBlock := blockBody.AppendNewBlock("required_providers", nil)
+		rpBody := rpBlock.Body()
+		keys := sortedKeys(rp)
+		for _, k := range keys {
+			writeAttribute(rpBody, k, rp[k])
+		}
+	}
+
+	if backend, ok := def["backend"].(map[string]any); ok {
+		bType, _ := backend["type"].(string)
+		labels := []string{}
+		if bType != "" {
+			labels = append(labels, bType)
+		}
+		bBlock := blockBody.AppendNewBlock("backend", labels)
+		if attrs, ok := backend["attributes"].(map[string]any); ok {
+			bBody := bBlock.Body()
+			keys := sortedKeys(attrs)
+			for _, k := range keys {
+				writeAttribute(bBody, k, attrs[k])
+			}
+		}
+	}
+
+	if cloud, ok := def["cloud"].(map[string]any); ok && len(cloud) > 0 {
+		cBlock := blockBody.AppendNewBlock("cloud", nil)
+		cBody := cBlock.Body()
+		keys := sortedKeys(cloud)
+		for _, k := range keys {
+			writeAttribute(cBody, k, cloud[k])
+		}
+	}
+
+	if attrs, ok := def["attributes"].(map[string]any); ok {
+		keys := sortedKeys(attrs)
+		for _, k := range keys {
+			writeAttribute(blockBody, k, attrs[k])
+		}
+	}
+}
+
+// generateLocalsBlock creates a locals { ... } block.
+func generateLocalsBlock(body *hclwrite.Body, locals map[string]any) {
+	block := body.AppendNewBlock("locals", nil)
+	blockBody := block.Body()
+	keys := sortedKeys(locals)
+	for _, k := range keys {
+		writeAttribute(blockBody, k, locals[k])
+	}
+}
+
+// writeAttribute writes a key-value attribute to an hclwrite body.
+// Values are converted to HCL token representations.
+func writeAttribute(body *hclwrite.Body, key string, val any) {
+	tokens := valueToTokens(val)
+	body.SetAttributeRaw(key, tokens)
+}
+
+// valueToTokens converts a Go value into hclwrite tokens.
+func valueToTokens(val any) hclwrite.Tokens {
+	switch v := val.(type) {
+	case string:
+		// Check if the string looks like an HCL expression (references, function calls).
+		if looksLikeExpression(v) {
+			return hclwrite.TokensForIdentifier(v)
+		}
+		return hclwrite.TokensForValue(ctyStringVal(v))
+	case bool:
+		return hclwrite.TokensForValue(ctyBoolVal(v))
+	case int:
+		return hclwrite.TokensForValue(ctyNumberIntVal(int64(v)))
+	case int64:
+		return hclwrite.TokensForValue(ctyNumberIntVal(v))
+	case float64:
+		return hclwrite.TokensForValue(ctyNumberFloatVal(v))
+	case []any:
+		return tokensForList(v)
+	case map[string]any:
+		return tokensForObject(v)
+	case nil:
+		return hclwrite.TokensForIdentifier("null")
+	default:
+		return hclwrite.TokensForValue(ctyStringVal(fmt.Sprintf("%v", v)))
+	}
+}
+
+// tokensForList renders a Go slice as HCL list tokens: [a, b, c].
+func tokensForList(items []any) hclwrite.Tokens {
+	var src strings.Builder
+	src.WriteString("[")
+	for i, item := range items {
+		if i > 0 {
+			src.WriteString(", ")
+		}
+		src.WriteString(valueToHCLString(item))
+	}
+	src.WriteString("]")
+	return hclwrite.TokensForIdentifier(src.String())
+}
+
+// tokensForObject renders a Go map as HCL object tokens: {k = v, ...}.
+func tokensForObject(m map[string]any) hclwrite.Tokens {
+	if len(m) == 0 {
+		return hclwrite.TokensForIdentifier("{}")
+	}
+	var src strings.Builder
+	src.WriteString("{\n")
+	keys := sortedKeys(m)
+	for _, k := range keys {
+		src.WriteString("    ")
+		src.WriteString(k)
+		src.WriteString(" = ")
+		src.WriteString(valueToHCLString(m[k]))
+		src.WriteString("\n")
+	}
+	src.WriteString("  }")
+	return hclwrite.TokensForIdentifier(src.String())
+}
+
+// valueToHCLString renders a scalar Go value as an HCL literal string.
+func valueToHCLString(val any) string {
+	switch v := val.(type) {
+	case string:
+		if looksLikeExpression(v) {
+			return v
+		}
+		return fmt.Sprintf("%q", v)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%g", v)
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%q", fmt.Sprint(v))
+	}
+}
+
+// looksLikeExpression returns true if a string appears to be an HCL expression
+// rather than a plain string literal (e.g., variable references, function calls).
+func looksLikeExpression(s string) bool {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "var.") || strings.HasPrefix(s, "local.") ||
+		strings.HasPrefix(s, "module.") || strings.HasPrefix(s, "data.") ||
+		strings.HasPrefix(s, "each.") || strings.HasPrefix(s, "self.") ||
+		strings.HasPrefix(s, "count.") || strings.HasPrefix(s, "path.") {
+		return true
+	}
+	// Function calls like merge(...), lookup(...)
+	if strings.Contains(s, "(") && strings.HasSuffix(s, ")") {
+		return true
+	}
+	// Ternary: condition ? a : b
+	if strings.Contains(s, "?") && strings.Contains(s, ":") {
+		return true
+	}
+	return false
+}
+
+// labelsForBlock returns the appropriate HCL block labels based on block type.
+func labelsForBlock(blockType string, def map[string]any) []string {
+	switch blockType {
+	case "variable", "module", "output", "check":
+		if name, ok := def["name"].(string); ok {
+			return []string{name}
+		}
+	case "resource", "data":
+		var labels []string
+		if t, ok := def["type"].(string); ok {
+			labels = append(labels, t)
+		}
+		if n, ok := def["name"].(string); ok {
+			labels = append(labels, n)
+		}
+		return labels
+	case "provider":
+		if name, ok := def["name"].(string); ok {
+			return []string{name}
+		}
+	}
+	return nil
+}
+
+// labelKeySet returns a set of keys used as labels for a given block type.
+func labelKeySet(blockType string) map[string]bool {
+	switch blockType {
+	case "variable", "module", "output", "check":
+		return map[string]bool{"name": true}
+	case "resource", "data":
+		return map[string]bool{"type": true, "name": true}
+	case "provider":
+		return map[string]bool{"name": true}
+	default:
+		return map[string]bool{}
+	}
+}
+
+// promotedKeysForBlock returns well-known attribute keys that should be written
+// before generic attributes, in order. These are keys that ParseHCL promotes
+// out of the raw attributes map.
+func promotedKeysForBlock(blockType string) []string {
+	switch blockType {
+	case "variable":
+		return []string{"type", "default", "description", "sensitive", "nullable"}
+	case "output":
+		return []string{"value", "description", "sensitive", "depends_on"}
+	case "module":
+		return []string{"source", "version", "count", "for_each", "depends_on", "providers"}
+	case "provider":
+		return []string{"alias", "region"}
+	case "moved":
+		return []string{"from", "to"}
+	case "import":
+		return []string{"to", "id", "provider", "for_each"}
+	default:
+		return nil
+	}
+}
+
+// sortedKeys returns the keys of a map in sorted order.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/provider/builtin/hclprovider/generate_json.go
+++ b/pkg/provider/builtin/hclprovider/generate_json.go
@@ -1,0 +1,261 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GenerateHCLJSON converts a structured map representation into Terraform JSON
+// configuration syntax (.tf.json). The input uses the same schema as ParseHCL
+// output (plural keys: variables, resources, etc.) and the output follows the
+// Terraform JSON Configuration Syntax specification.
+//
+// See: https://developer.hashicorp.com/terraform/language/syntax/json
+func GenerateHCLJSON(input map[string]any) (string, error) {
+	result := make(map[string]any)
+
+	// Each block type is converted to its JSON representation.
+	// The JSON syntax uses block-type keys at the top level, with label nesting.
+
+	if tf, ok := input["terraform"].(map[string]any); ok && len(tf) > 0 {
+		result["terraform"] = convertTerraformJSON(tf)
+	}
+
+	if vars, ok := input["variables"].([]any); ok && len(vars) > 0 {
+		result["variable"] = convertSingleLabelBlocksJSON(vars)
+	}
+
+	if locals, ok := input["locals"].(map[string]any); ok && len(locals) > 0 {
+		result["locals"] = locals
+	}
+
+	if data, ok := input["data"].([]any); ok && len(data) > 0 {
+		result["data"] = convertDoubleLabelBlocksJSON(data)
+	}
+
+	if resources, ok := input["resources"].([]any); ok && len(resources) > 0 {
+		result["resource"] = convertDoubleLabelBlocksJSON(resources)
+	}
+
+	if modules, ok := input["modules"].([]any); ok && len(modules) > 0 {
+		result["module"] = convertSingleLabelBlocksJSON(modules)
+	}
+
+	if outputs, ok := input["outputs"].([]any); ok && len(outputs) > 0 {
+		result["output"] = convertSingleLabelBlocksJSON(outputs)
+	}
+
+	if providers, ok := input["providers"].([]any); ok && len(providers) > 0 {
+		result["provider"] = convertProviderBlocksJSON(providers)
+	}
+
+	if moved, ok := input["moved"].([]any); ok && len(moved) > 0 {
+		result["moved"] = convertUnlabeledBlocksJSON(moved)
+	}
+
+	if imports, ok := input["import"].([]any); ok && len(imports) > 0 {
+		result["import"] = convertUnlabeledBlocksJSON(imports)
+	}
+
+	if checks, ok := input["check"].([]any); ok && len(checks) > 0 {
+		result["check"] = convertSingleLabelBlocksJSON(checks)
+	}
+
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling JSON: %w", err)
+	}
+
+	return string(out) + "\n", nil
+}
+
+// convertTerraformJSON converts the terraform block to JSON syntax.
+// The terraform block is special: it has no labels and contains nested blocks
+// like required_providers and backend.
+func convertTerraformJSON(tf map[string]any) map[string]any {
+	result := make(map[string]any)
+
+	for k, v := range tf {
+		result[k] = v
+	}
+
+	return result
+}
+
+// convertSingleLabelBlocksJSON converts blocks with a single label (variable,
+// module, output, check) to the JSON syntax where the label becomes a key.
+// These blocks always use "name" as their label key.
+//
+// Input:  [{name: "region", type: "string", default: "us-east-1"}, ...]
+// Output: {"region": {type: "string", default: "us-east-1"}, ...}
+func convertSingleLabelBlocksJSON(blocks []any) map[string]any {
+	result := make(map[string]any)
+
+	for _, block := range blocks {
+		bm, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		label, _ := bm["name"].(string)
+		if label == "" {
+			continue
+		}
+
+		body := make(map[string]any)
+		for k, v := range bm {
+			if k == "name" {
+				continue
+			}
+			// Flatten "attributes" into the body for JSON syntax.
+			if k == "attributes" {
+				if attrs, ok := v.(map[string]any); ok {
+					for ak, av := range attrs {
+						body[ak] = av
+					}
+					continue
+				}
+			}
+			body[k] = v
+		}
+
+		result[label] = body
+	}
+
+	return result
+}
+
+// convertDoubleLabelBlocksJSON converts blocks with two labels (resource, data)
+// to the JSON syntax with nested label keys.
+//
+// Input:  [{type: "aws_instance", name: "web", attributes: {ami: "ami-123"}}]
+// Output: {"aws_instance": {"web": {ami: "ami-123"}}}
+func convertDoubleLabelBlocksJSON(blocks []any) map[string]any {
+	result := make(map[string]any)
+
+	for _, block := range blocks {
+		bm, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		typeName, _ := bm["type"].(string)
+		name, _ := bm["name"].(string)
+		if typeName == "" || name == "" {
+			continue
+		}
+
+		body := make(map[string]any)
+		for k, v := range bm {
+			if k == "type" || k == "name" {
+				continue
+			}
+			if k == "attributes" {
+				if attrs, ok := v.(map[string]any); ok {
+					for ak, av := range attrs {
+						body[ak] = av
+					}
+					continue
+				}
+			}
+			body[k] = v
+		}
+
+		typeMap, ok := result[typeName].(map[string]any)
+		if !ok {
+			typeMap = make(map[string]any)
+		}
+		typeMap[name] = body
+		result[typeName] = typeMap
+	}
+
+	return result
+}
+
+// convertProviderBlocksJSON converts provider blocks to JSON syntax.
+// Terraform JSON syntax allows multiple provider configurations via a map
+// where values can be objects or arrays of objects (for aliased providers).
+//
+// Input:  [{name: "aws", alias: "west", attributes: {region: "us-west-2"}}]
+// Output: {"aws": {"alias": "west", "region": "us-west-2"}}
+func convertProviderBlocksJSON(blocks []any) map[string]any {
+	result := make(map[string]any)
+
+	for _, block := range blocks {
+		bm, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := bm["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		body := make(map[string]any)
+		for k, v := range bm {
+			if k == "name" {
+				continue
+			}
+			if k == "attributes" {
+				if attrs, ok := v.(map[string]any); ok {
+					for ak, av := range attrs {
+						body[ak] = av
+					}
+					continue
+				}
+			}
+			body[k] = v
+		}
+
+		// If there's already an entry for this provider name, convert to array.
+		if existing, ok := result[name]; ok {
+			switch e := existing.(type) {
+			case []any:
+				result[name] = append(e, body)
+			default:
+				result[name] = []any{e, body}
+			}
+		} else {
+			result[name] = body
+		}
+	}
+
+	return result
+}
+
+// convertUnlabeledBlocksJSON converts blocks without labels (moved, import)
+// to an array of objects in JSON syntax.
+//
+// Input:  [{from: "aws_instance.old", to: "aws_instance.new"}]
+// Output: [{from: "aws_instance.old", to: "aws_instance.new"}]
+func convertUnlabeledBlocksJSON(blocks []any) []any {
+	result := make([]any, 0, len(blocks))
+
+	for _, block := range blocks {
+		bm, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		body := make(map[string]any)
+		for k, v := range bm {
+			if k == "attributes" {
+				if attrs, ok := v.(map[string]any); ok {
+					for ak, av := range attrs {
+						body[ak] = av
+					}
+					continue
+				}
+			}
+			body[k] = v
+		}
+
+		result = append(result, body)
+	}
+
+	return result
+}

--- a/pkg/provider/builtin/hclprovider/generate_json_test.go
+++ b/pkg/provider/builtin/hclprovider/generate_json_test.go
@@ -1,0 +1,436 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateHCLJSON_Variables(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{
+				"name":        "region",
+				"type":        "string",
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	vars, ok := parsed["variable"].(map[string]any)
+	require.True(t, ok)
+	region, ok := vars["region"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "string", region["type"])
+	assert.Equal(t, "us-east-1", region["default"])
+	assert.Equal(t, "AWS region", region["description"])
+}
+
+func TestGenerateHCLJSON_Resources(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "aws_instance",
+				"name": "web",
+				"attributes": map[string]any{
+					"ami":           "ami-12345",
+					"instance_type": "t3.micro",
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	resources := parsed["resource"].(map[string]any)
+	awsInstance := resources["aws_instance"].(map[string]any)
+	web := awsInstance["web"].(map[string]any)
+	assert.Equal(t, "ami-12345", web["ami"])
+	assert.Equal(t, "t3.micro", web["instance_type"])
+}
+
+func TestGenerateHCLJSON_DataSources(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"data": []any{
+			map[string]any{
+				"type": "aws_ami",
+				"name": "latest",
+				"attributes": map[string]any{
+					"most_recent": true,
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	ami := data["aws_ami"].(map[string]any)
+	latest := ami["latest"].(map[string]any)
+	assert.Equal(t, true, latest["most_recent"])
+}
+
+func TestGenerateHCLJSON_Outputs(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"outputs": []any{
+			map[string]any{
+				"name":        "id",
+				"value":       "aws_instance.web.id",
+				"description": "Instance ID",
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	outputs := parsed["output"].(map[string]any)
+	id := outputs["id"].(map[string]any)
+	assert.Equal(t, "aws_instance.web.id", id["value"])
+	assert.Equal(t, "Instance ID", id["description"])
+}
+
+func TestGenerateHCLJSON_Locals(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"locals": map[string]any{
+			"env":    "prod",
+			"region": "us-east-1",
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	locals := parsed["locals"].(map[string]any)
+	assert.Equal(t, "prod", locals["env"])
+	assert.Equal(t, "us-east-1", locals["region"])
+}
+
+func TestGenerateHCLJSON_Terraform(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"terraform": map[string]any{
+			"required_version": ">= 1.0",
+			"required_providers": map[string]any{
+				"aws": map[string]any{
+					"source":  "hashicorp/aws",
+					"version": "~> 5.0",
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	tf := parsed["terraform"].(map[string]any)
+	assert.Equal(t, ">= 1.0", tf["required_version"])
+	rp := tf["required_providers"].(map[string]any)
+	aws := rp["aws"].(map[string]any)
+	assert.Equal(t, "hashicorp/aws", aws["source"])
+}
+
+func TestGenerateHCLJSON_Modules(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"modules": []any{
+			map[string]any{
+				"name":   "vpc",
+				"source": "./modules/vpc",
+				"attributes": map[string]any{
+					"cidr": "10.0.0.0/16",
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	modules := parsed["module"].(map[string]any)
+	vpc := modules["vpc"].(map[string]any)
+	assert.Equal(t, "./modules/vpc", vpc["source"])
+	assert.Equal(t, "10.0.0.0/16", vpc["cidr"])
+}
+
+func TestGenerateHCLJSON_Providers(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"providers": []any{
+			map[string]any{
+				"name":  "aws",
+				"alias": "west",
+				"attributes": map[string]any{
+					"region": "us-west-2",
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	providers := parsed["provider"].(map[string]any)
+	aws := providers["aws"].(map[string]any)
+	assert.Equal(t, "west", aws["alias"])
+	assert.Equal(t, "us-west-2", aws["region"])
+}
+
+func TestGenerateHCLJSON_MultipleProvidersAliased(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"providers": []any{
+			map[string]any{
+				"name":  "aws",
+				"alias": "east",
+				"attributes": map[string]any{
+					"region": "us-east-1",
+				},
+			},
+			map[string]any{
+				"name":  "aws",
+				"alias": "west",
+				"attributes": map[string]any{
+					"region": "us-west-2",
+				},
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	providers := parsed["provider"].(map[string]any)
+	awsArr := providers["aws"].([]any)
+	require.Len(t, awsArr, 2)
+}
+
+func TestGenerateHCLJSON_Moved(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"moved": []any{
+			map[string]any{
+				"from": "aws_instance.old",
+				"to":   "aws_instance.new",
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	moved := parsed["moved"].([]any)
+	require.Len(t, moved, 1)
+	first := moved[0].(map[string]any)
+	assert.Equal(t, "aws_instance.old", first["from"])
+	assert.Equal(t, "aws_instance.new", first["to"])
+}
+
+func TestGenerateHCLJSON_Import(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"import": []any{
+			map[string]any{
+				"to": "aws_instance.web",
+				"id": "i-12345",
+			},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	imports := parsed["import"].([]any)
+	require.Len(t, imports, 1)
+	first := imports[0].(map[string]any)
+	assert.Equal(t, "aws_instance.web", first["to"])
+	assert.Equal(t, "i-12345", first["id"])
+}
+
+func TestGenerateHCLJSON_EmptyInput(t *testing.T) {
+	t.Parallel()
+	result, err := GenerateHCLJSON(map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}\n", result)
+}
+
+func TestGenerateHCLJSON_MultipleBlockTypes(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{"name": "env", "type": "string"},
+		},
+		"resources": []any{
+			map[string]any{"type": "aws_instance", "name": "web", "attributes": map[string]any{"ami": "ami-123"}},
+		},
+		"outputs": []any{
+			map[string]any{"name": "id", "value": "aws_instance.web.id"},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	assert.Contains(t, parsed, "variable")
+	assert.Contains(t, parsed, "resource")
+	assert.Contains(t, parsed, "output")
+}
+
+func TestGenerateHCLJSON_ValidJSON(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{"name": "region", "type": "string", "default": "us-east-1"},
+		},
+		"resources": []any{
+			map[string]any{"type": "aws_instance", "name": "web", "attributes": map[string]any{
+				"ami":           "ami-12345",
+				"instance_type": "t3.micro",
+				"tags":          map[string]any{"Name": "web-server"},
+			}},
+		},
+	}
+
+	result, err := GenerateHCLJSON(input)
+	require.NoError(t, err)
+
+	// Must be valid JSON
+	assert.True(t, json.Valid([]byte(result)))
+}
+
+// --- Provider-level integration tests ---
+
+func TestHCLProvider_Execute_Generate_JSON(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation":     "generate",
+		"output_format": "json",
+		"blocks": map[string]any{
+			"variables": []any{
+				map[string]any{
+					"name":    "region",
+					"type":    "string",
+					"default": "us-east-1",
+				},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	generated := data["hcl"].(string)
+	assert.True(t, json.Valid([]byte(generated)), "output should be valid JSON")
+	assert.Contains(t, generated, "variable")
+	assert.Contains(t, generated, "region")
+	assert.Equal(t, "generate", output.Metadata["operation"])
+	assert.Equal(t, "json", output.Metadata["output_format"])
+}
+
+func TestHCLProvider_Execute_Generate_JSON_DryRun(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation":     "generate",
+		"output_format": "json",
+		"blocks": map[string]any{
+			"variables": []any{
+				map[string]any{"name": "x", "type": "string"},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, "", data["hcl"])
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+	assert.Equal(t, "json", output.Metadata["output_format"])
+}
+
+func TestHCLProvider_Execute_Generate_DefaultFormat(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "generate",
+		"blocks": map[string]any{
+			"variables": []any{
+				map[string]any{"name": "x", "type": "string"},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	// Default format is HCL, not JSON
+	data := output.Data.(map[string]any)
+	generated := data["hcl"].(string)
+	assert.Contains(t, generated, `variable "x"`)
+	assert.False(t, json.Valid([]byte(generated)), "default output should be HCL, not JSON")
+	assert.Equal(t, "hcl", output.Metadata["output_format"])
+}

--- a/pkg/provider/builtin/hclprovider/generate_test.go
+++ b/pkg/provider/builtin/hclprovider/generate_test.go
@@ -1,0 +1,411 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateHCL_Variables(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{
+				"name":        "region",
+				"type":        "string",
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `variable "region"`)
+	assert.Contains(t, hcl, `"us-east-1"`)
+	assert.Contains(t, hcl, `"AWS region"`)
+}
+
+func TestGenerateHCL_Resources(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "aws_instance",
+				"name": "web",
+				"attributes": map[string]any{
+					"ami":           "ami-12345",
+					"instance_type": "t3.micro",
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `resource "aws_instance" "web"`)
+	assert.Contains(t, hcl, `"ami-12345"`)
+	assert.Contains(t, hcl, `"t3.micro"`)
+}
+
+func TestGenerateHCL_Outputs(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"outputs": []any{
+			map[string]any{
+				"name":        "result",
+				"value":       "var.region",
+				"description": "The region",
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `output "result"`)
+	assert.Contains(t, hcl, "var.region")
+	assert.Contains(t, hcl, `"The region"`)
+}
+
+func TestGenerateHCL_Locals(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"locals": map[string]any{
+			"env":    "prod",
+			"region": "us-east-1",
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "locals")
+	assert.Contains(t, hcl, `"prod"`)
+	assert.Contains(t, hcl, `"us-east-1"`)
+}
+
+func TestGenerateHCL_Terraform(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"terraform": map[string]any{
+			"required_version": ">= 1.0",
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "terraform")
+	assert.Contains(t, hcl, `">= 1.0"`)
+}
+
+func TestGenerateHCL_Modules(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"modules": []any{
+			map[string]any{
+				"name":   "vpc",
+				"source": "./modules/vpc",
+				"attributes": map[string]any{
+					"cidr": "10.0.0.0/16",
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `module "vpc"`)
+	assert.Contains(t, hcl, `"./modules/vpc"`)
+	assert.Contains(t, hcl, `"10.0.0.0/16"`)
+}
+
+func TestGenerateHCL_DataSources(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"data": []any{
+			map[string]any{
+				"type": "aws_ami",
+				"name": "latest",
+				"attributes": map[string]any{
+					"most_recent": true,
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `data "aws_ami" "latest"`)
+	assert.Contains(t, hcl, "most_recent")
+}
+
+func TestGenerateHCL_EmptyInput(t *testing.T) {
+	t.Parallel()
+	hcl, err := GenerateHCL(map[string]any{})
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(hcl))
+}
+
+func TestGenerateHCL_BoolAndNumericValues(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{
+				"name":      "enabled",
+				"default":   true,
+				"sensitive": false,
+			},
+			map[string]any{
+				"name":    "count",
+				"default": float64(3),
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "true")
+	assert.Contains(t, hcl, `variable "enabled"`)
+	assert.Contains(t, hcl, `variable "count"`)
+}
+
+func TestGenerateHCL_Providers(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"providers": []any{
+			map[string]any{
+				"name":  "aws",
+				"alias": "west",
+				"attributes": map[string]any{
+					"region": "us-west-2",
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, `provider "aws"`)
+	assert.Contains(t, hcl, "west")
+}
+
+func TestGenerateHCL_Moved(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"moved": []any{
+			map[string]any{
+				"from": "aws_instance.old",
+				"to":   "aws_instance.new",
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "moved")
+	assert.Contains(t, hcl, "aws_instance.old")
+	assert.Contains(t, hcl, "aws_instance.new")
+}
+
+func TestGenerateHCL_Import(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"import": []any{
+			map[string]any{
+				"to": "aws_instance.web",
+				"id": "i-12345",
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "import")
+	assert.Contains(t, hcl, "aws_instance.web")
+	assert.Contains(t, hcl, `"i-12345"`)
+}
+
+func TestGenerateHCL_MultipleBlockTypes(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{"name": "env", "type": "string"},
+		},
+		"resources": []any{
+			map[string]any{"type": "aws_instance", "name": "web", "attributes": map[string]any{"ami": "ami-123"}},
+		},
+		"outputs": []any{
+			map[string]any{"name": "id", "value": "aws_instance.web.id"},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+
+	// Check ordering: variables before resources before outputs.
+	varIdx := strings.Index(hcl, `variable "env"`)
+	resIdx := strings.Index(hcl, `resource "aws_instance" "web"`)
+	outIdx := strings.Index(hcl, `output "id"`)
+	assert.Greater(t, resIdx, varIdx, "resources should come after variables")
+	assert.Greater(t, outIdx, resIdx, "outputs should come after resources")
+}
+
+func TestHCLProvider_Execute_Generate(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "generate",
+		"blocks": map[string]any{
+			"variables": []any{
+				map[string]any{
+					"name":    "region",
+					"type":    "string",
+					"default": "us-east-1",
+				},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	hcl := data["hcl"].(string)
+	assert.Contains(t, hcl, `variable "region"`)
+	assert.Contains(t, hcl, `"us-east-1"`)
+	assert.Equal(t, "generate", output.Metadata["operation"])
+	assert.NotZero(t, output.Metadata["bytes"])
+}
+
+func TestHCLProvider_Execute_Generate_DryRun(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation": "generate",
+		"blocks": map[string]any{
+			"variables": []any{
+				map[string]any{"name": "x", "type": "string"},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, "", data["hcl"])
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+}
+
+func TestHCLProvider_Execute_Generate_MissingBlocks(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "generate",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocks")
+}
+
+func TestGenerateHCL_Expressions(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"outputs": []any{
+			map[string]any{
+				"name":  "id",
+				"value": "var.region",
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	// Expression-like values (var.*, local.*, etc.) should not be quoted
+	assert.Contains(t, hcl, "var.region")
+	assert.NotContains(t, hcl, `"var.region"`)
+}
+
+func TestGenerateHCL_NilValue(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{
+				"name":    "optional",
+				"default": nil,
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "null")
+}
+
+func TestGenerateHCL_ListAttribute(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "aws_security_group",
+				"name": "web",
+				"attributes": map[string]any{
+					"ingress_ports": []any{float64(80), float64(443)},
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "ingress_ports")
+	assert.Contains(t, hcl, "80")
+	assert.Contains(t, hcl, "443")
+}
+
+func TestGenerateHCL_MapAttribute(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "aws_instance",
+				"name": "web",
+				"attributes": map[string]any{
+					"tags": map[string]any{
+						"Name": "web-server",
+						"Env":  "prod",
+					},
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "tags")
+	assert.Contains(t, hcl, `"web-server"`)
+	assert.Contains(t, hcl, `"prod"`)
+}
+
+func TestGenerateHCL_VariableWithValidation(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"variables": []any{
+			map[string]any{
+				"name":        "region",
+				"type":        "string",
+				"description": "AWS region",
+				"validation": []any{
+					map[string]any{
+						"condition":     `can(regex("^us-", var.region))`,
+						"error_message": "Region must start with us-",
+					},
+				},
+			},
+		},
+	}
+	hcl, err := GenerateHCL(input)
+	require.NoError(t, err)
+	assert.Contains(t, hcl, "validation")
+	assert.Contains(t, hcl, "condition")
+	assert.Contains(t, hcl, "error_message")
+}

--- a/pkg/provider/builtin/hclprovider/hcl.go
+++ b/pkg/provider/builtin/hclprovider/hcl.go
@@ -4,13 +4,17 @@
 package hclprovider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
@@ -22,6 +26,8 @@ const ProviderName = "hcl"
 // FileReader abstracts filesystem access for testability.
 type FileReader interface {
 	ReadFile(path string) ([]byte, error)
+	// ListHCLFiles returns all .tf and .tf.json files in a directory (non-recursive).
+	ListHCLFiles(dir string) ([]string, error)
 }
 
 // Option is a functional option for configuring the HCL provider.
@@ -60,9 +66,31 @@ func (r *osFileReader) ReadFile(path string) ([]byte, error) {
 	return os.ReadFile(absPath)
 }
 
+func (r *osFileReader) ListHCLFiles(dir string) ([]string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dir: %w", err)
+	}
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory: %w", err)
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") {
+			files = append(files, filepath.Join(absDir, name))
+		}
+	}
+	return files, nil
+}
+
 // NewHCLProvider creates a new HCL provider instance.
 func NewHCLProvider(opts ...Option) *HCLProvider {
-	version := semver.MustParse("1.0.0")
+	version := semver.MustParse("2.0.0")
 
 	outputSchema := schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 		"variables": schemahelper.ArrayProp("Extracted variable blocks"),
@@ -82,31 +110,45 @@ func NewHCLProvider(opts ...Option) *HCLProvider {
 		fileReader: &osFileReader{},
 		descriptor: &provider.Descriptor{
 			Name:         ProviderName,
-			DisplayName:  "HCL Parser",
-			Description:  "Parses HCL (HashiCorp Configuration Language) content and extracts structured block information. Supports Terraform and OpenTofu configuration files including variables, resources, modules, outputs, locals, providers, and more.",
+			DisplayName:  "HCL",
+			Description:  "Processes HCL (HashiCorp Configuration Language) content. Supports parsing into structured data, formatting to canonical style, validating syntax, and generating HCL from structured input. Accepts single files, multiple paths, or a directory of .tf files.",
 			APIVersion:   "v1",
 			Version:      version,
 			Category:     "data",
 			Beta:         true,
-			Tags:         []string{"hcl", "terraform", "opentofu", "parse", "config"},
-			MockBehavior: "Returns a mock parsed structure with empty block arrays",
+			Tags:         []string{"hcl", "terraform", "opentofu", "parse", "format", "validate", "generate", "config"},
+			MockBehavior: "Returns a mock structure appropriate to the requested operation",
 			Capabilities: []provider.Capability{
 				provider.CapabilityFrom,
 				provider.CapabilityTransform,
 			},
 			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-				"content": schemahelper.StringProp("Raw HCL content to parse. Provide either 'content' or 'path', not both.",
+				"operation": schemahelper.StringProp("Operation to perform: 'parse' (default) extracts structured blocks; 'format' canonically formats; 'validate' checks syntax; 'generate' produces HCL from structured input.",
+					schemahelper.WithEnum("parse", "format", "validate", "generate")),
+				"content": schemahelper.StringProp("Raw HCL content to process. Provide 'content', 'path', 'paths', or 'dir' — these are mutually exclusive.",
 					schemahelper.WithMaxLength(10485760),
 				),
-				"path": schemahelper.StringProp("Path to an HCL file to read and parse. Provide either 'content' or 'path', not both.",
+				"path": schemahelper.StringProp("Path to a single HCL file. Mutually exclusive with 'content', 'paths', and 'dir'.",
 					schemahelper.WithMaxLength(4096),
 					schemahelper.WithExample("./main.tf"),
 				),
+				"paths": schemahelper.ArrayProp("Array of HCL file paths to process. Results are merged (parse) or returned per file (format/validate). Mutually exclusive with 'content', 'path', and 'dir'.",
+					schemahelper.WithMaxItems(1000),
+					schemahelper.WithItems(schemahelper.StringProp("Path to an HCL file")),
+				),
+				"dir": schemahelper.StringProp("Directory path. All .tf and .tf.json files in the directory are processed. Mutually exclusive with 'content', 'path', and 'paths'.",
+					schemahelper.WithMaxLength(4096),
+					schemahelper.WithExample("./terraform"),
+				),
+				"blocks":        schemahelper.AnyProp("Structured block data for the 'generate' operation. Uses the same schema as parse output: {variables: [...], resources: [...], ...}."),
+				"output_format": schemahelper.StringProp("Output format for the 'generate' operation: 'hcl' (default) produces native HCL syntax (.tf); 'json' produces Terraform JSON syntax (.tf.json).", schemahelper.WithEnum("hcl", "json")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom:      outputSchema,
 				provider.CapabilityTransform: outputSchema,
 			},
+			// Note: when operation=format the output schema is {formatted: string, changed: bool}.
+			// The schemas above describe the parse operation output.
 			Examples: []provider.Example{
 				{
 					Name:        "Parse inline HCL",
@@ -134,6 +176,29 @@ resolve:
         path: ./main.tf`,
 				},
 				{
+					Name:        "Parse a directory of .tf files",
+					Description: "Parse all .tf files in a directory and merge the results",
+					YAML: `name: tf-full
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        dir: ./terraform`,
+				},
+				{
+					Name:        "Parse multiple specific files",
+					Description: "Parse a list of specific .tf files and merge the results",
+					YAML: `name: tf-multi
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        paths:
+          - ./main.tf
+          - ./variables.tf
+          - ./outputs.tf`,
+				},
+				{
 					Name:        "Transform HCL from file provider",
 					Description: "Chain with the file provider to parse HCL content",
 					YAML: `name: tf-data
@@ -147,6 +212,92 @@ resolve:
     - provider: hcl
       inputs:
         content: "{{ .resolvers.tf-data.content }}"`,
+				},
+				{
+					Name:        "Format inline HCL",
+					Description: "Canonically format HCL content; output contains 'formatted' (string) and 'changed' (bool)",
+					YAML: `name: tf-fmt
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: format
+        content: |
+          variable "region" {
+          type=string
+          default="us-east-1"
+          }`,
+				},
+				{
+					Name:        "Format a directory",
+					Description: "Format all .tf files in a directory; returns per-file results",
+					YAML: `name: tf-fmt-dir
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: format
+        dir: ./terraform`,
+				},
+				{
+					Name:        "Validate HCL syntax",
+					Description: "Check HCL for syntax errors without parsing blocks",
+					YAML: `name: tf-validate
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: validate
+        path: ./main.tf`,
+				},
+				{
+					Name:        "Validate a directory",
+					Description: "Validate all .tf files in a directory",
+					YAML: `name: tf-validate-dir
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: validate
+        dir: ./terraform`,
+				},
+				{
+					Name:        "Generate HCL from structured data",
+					Description: "Produce HCL text from a map following the parse output schema",
+					YAML: `name: tf-gen
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: generate
+        blocks:
+          variables:
+            - name: region
+              type: string
+              default: us-east-1
+              description: "AWS region"
+          resources:
+            - type: aws_instance
+              name: web
+              attributes:
+                ami: ami-12345
+                instance_type: t3.micro`,
+				},
+				{
+					Name:        "Generate Terraform JSON from structured data",
+					Description: "Produce .tf.json format instead of native HCL",
+					YAML: `name: tf-gen-json
+resolve:
+  with:
+    - provider: hcl
+      inputs:
+        operation: generate
+        output_format: json
+        blocks:
+          variables:
+            - name: region
+              type: string
+              default: us-east-1`,
 				},
 			},
 			Links: []provider.Link{
@@ -174,7 +325,7 @@ func (p *HCLProvider) Descriptor() *provider.Descriptor {
 	return p.descriptor
 }
 
-// Execute parses HCL content and returns structured block information.
+// Execute processes HCL content according to the requested operation.
 func (p *HCLProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
@@ -185,71 +336,432 @@ func (p *HCLProvider) Execute(ctx context.Context, input any) (*provider.Output,
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName)
 
-	content, hasContent := inputs["content"].(string)
-	path, hasPath := inputs["path"].(string)
-
-	if !hasContent && !hasPath {
-		return nil, fmt.Errorf("%s: either 'content' or 'path' must be provided", ProviderName)
-	}
-	if hasContent && hasPath {
-		return nil, fmt.Errorf("%s: provide either 'content' or 'path', not both", ProviderName)
+	operation := "parse"
+	if op, ok := inputs["operation"].(string); ok && op != "" {
+		operation = op
 	}
 
-	if provider.DryRunFromContext(ctx) {
-		return &provider.Output{
-			Data: map[string]any{
-				"variables": []any{},
-				"resources": []any{},
-				"data":      []any{},
-				"modules":   []any{},
-				"outputs":   []any{},
-				"locals":    map[string]any{},
-				"providers": []any{},
-				"terraform": map[string]any{},
-				"moved":     []any{},
-				"import":    []any{},
-				"check":     []any{},
-			},
-			Metadata: map[string]any{"mode": "dry-run"},
-		}, nil
+	validOps := map[string]bool{"parse": true, "format": true, "validate": true, "generate": true}
+	if !validOps[operation] {
+		return nil, fmt.Errorf("%s: unsupported operation %q; must be one of: parse, format, validate, generate", ProviderName, operation)
 	}
 
-	var src []byte
-	filename := "input.tf"
-
-	if hasPath {
-		lgr.V(1).Info("reading HCL file", "path", path)
-		data, err := p.fileReader.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to read file %s: %w", ProviderName, path, err)
-		}
-		src = data
-		filename = path
-	} else {
-		src = []byte(content)
+	// Generate uses "blocks" input, not content/path/paths/dir.
+	if operation == "generate" {
+		return p.executeGenerate(ctx, lgr, inputs)
 	}
 
-	lgr.V(1).Info("parsing HCL content", "bytes", len(src), "filename", filename)
-
-	result, err := ParseHCL(src, filename)
+	// Resolve source(s) for parse/format/validate.
+	sources, err := p.resolveSources(inputs)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)
 	}
 
-	varCount, resCount, modCount := countBlocks(result)
+	if provider.DryRunFromContext(ctx) {
+		return dryRunOutput(operation, sources), nil
+	}
+
+	switch operation {
+	case "parse":
+		return p.executeParse(lgr, sources)
+	case "format":
+		return p.executeFormat(lgr, sources)
+	case "validate":
+		return p.executeValidate(lgr, sources)
+	default:
+		return nil, fmt.Errorf("%s: unhandled operation %q", ProviderName, operation)
+	}
+}
+
+// hclSource represents a single unit of HCL content to process.
+type hclSource struct {
+	filename string
+	data     []byte
+}
+
+// resolveSources resolves the input specification into one or more HCL source units.
+// Exactly one of content, path, paths, or dir must be provided.
+func (p *HCLProvider) resolveSources(inputs map[string]any) ([]hclSource, error) {
+	content, hasContent := inputs["content"].(string)
+	path, hasPath := inputs["path"].(string)
+	rawPaths, hasPaths := inputs["paths"]
+	dir, hasDir := inputs["dir"].(string)
+
+	// Validate mutual exclusivity.
+	set := 0
+	if hasContent {
+		set++
+	}
+	if hasPath {
+		set++
+	}
+	if hasPaths {
+		set++
+	}
+	if hasDir {
+		set++
+	}
+	if set == 0 {
+		return nil, fmt.Errorf("one of 'content', 'path', 'paths', or 'dir' must be provided")
+	}
+	if set > 1 {
+		return nil, fmt.Errorf("'content', 'path', 'paths', and 'dir' are mutually exclusive")
+	}
+
+	switch {
+	case hasContent:
+		return []hclSource{{filename: "input.tf", data: []byte(content)}}, nil
+
+	case hasPath:
+		data, err := p.fileReader.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", path, err)
+		}
+		return []hclSource{{filename: path, data: data}}, nil
+
+	case hasPaths:
+		return p.resolvePathsList(rawPaths)
+
+	case hasDir:
+		return p.resolveDir(dir)
+
+	default:
+		return nil, fmt.Errorf("one of 'content', 'path', 'paths', or 'dir' must be provided")
+	}
+}
+
+// resolvePathsList reads multiple files from a paths array.
+func (p *HCLProvider) resolvePathsList(rawPaths any) ([]hclSource, error) {
+	pathSlice, ok := rawPaths.([]any)
+	if !ok {
+		return nil, fmt.Errorf("'paths' must be an array of strings")
+	}
+	if len(pathSlice) == 0 {
+		return nil, fmt.Errorf("'paths' array must not be empty")
+	}
+	var sources []hclSource
+	for _, raw := range pathSlice {
+		filePath, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("each item in 'paths' must be a string, got %T", raw)
+		}
+		data, err := p.fileReader.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+		sources = append(sources, hclSource{filename: filePath, data: data})
+	}
+	return sources, nil
+}
+
+// resolveDir lists all .tf files in a directory and reads them.
+func (p *HCLProvider) resolveDir(dir string) ([]hclSource, error) {
+	files, err := p.fileReader.ListHCLFiles(dir)
+	if err != nil {
+		return nil, fmt.Errorf("listing directory %s: %w", dir, err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no .tf or .tf.json files found in directory: %s", dir)
+	}
+	var sources []hclSource
+	for _, f := range files {
+		data, err := p.fileReader.ReadFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", f, err)
+		}
+		sources = append(sources, hclSource{filename: f, data: data})
+	}
+	return sources, nil
+}
+
+// executeParse parses one or more HCL sources. Multiple sources are merged.
+func (p *HCLProvider) executeParse(lgr *logr.Logger, sources []hclSource) (*provider.Output, error) {
+	merged := emptyParseResult()
+	totalBytes := 0
+	var filenames []string
+
+	for _, src := range sources {
+		lgr.V(1).Info("parsing HCL content", "bytes", len(src.data), "filename", src.filename)
+		result, err := ParseHCL(src.data, src.filename)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", ProviderName, err)
+		}
+		mergeParseResults(merged, result)
+		totalBytes += len(src.data)
+		filenames = append(filenames, src.filename)
+	}
+
+	varCount, resCount, modCount := countBlocks(merged)
 	lgr.V(1).Info("provider completed", "provider", ProviderName,
+		"operation", "parse",
+		"files", len(sources),
 		"variables", varCount,
 		"resources", resCount,
 		"modules", modCount,
 	)
 
+	meta := map[string]any{
+		"operation": "parse",
+		"bytes":     totalBytes,
+		"files":     len(sources),
+	}
+	if len(sources) == 1 {
+		meta["filename"] = filenames[0]
+	} else {
+		meta["filenames"] = filenames
+	}
+
+	return &provider.Output{Data: merged, Metadata: meta}, nil
+}
+
+// executeFormat formats one or more HCL sources.
+func (p *HCLProvider) executeFormat(lgr *logr.Logger, sources []hclSource) (*provider.Output, error) {
+	if len(sources) == 1 {
+		src := sources[0]
+		lgr.V(1).Info("formatting HCL content", "bytes", len(src.data), "filename", src.filename)
+		formatted := hclwrite.Format(src.data)
+		changed := !bytes.Equal(src.data, formatted)
+		lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "format", "changed", changed)
+		return &provider.Output{
+			Data: map[string]any{
+				"formatted": string(formatted),
+				"changed":   changed,
+			},
+			Metadata: map[string]any{
+				"filename":  src.filename,
+				"bytes":     len(src.data),
+				"operation": "format",
+			},
+		}, nil
+	}
+
+	// Multi-file: return per-file results.
+	results := make([]any, 0, len(sources))
+	anyChanged := false
+	for _, src := range sources {
+		lgr.V(1).Info("formatting HCL content", "bytes", len(src.data), "filename", src.filename)
+		formatted := hclwrite.Format(src.data)
+		changed := !bytes.Equal(src.data, formatted)
+		if changed {
+			anyChanged = true
+		}
+		results = append(results, map[string]any{
+			"filename":  src.filename,
+			"formatted": string(formatted),
+			"changed":   changed,
+		})
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "format", "files", len(sources), "anyChanged", anyChanged)
 	return &provider.Output{
-		Data: result,
+		Data: map[string]any{
+			"files":   results,
+			"changed": anyChanged,
+		},
 		Metadata: map[string]any{
-			"filename": filename,
-			"bytes":    len(src),
+			"operation": "format",
+			"files":     len(sources),
 		},
 	}, nil
+}
+
+// executeValidate validates one or more HCL sources.
+func (p *HCLProvider) executeValidate(lgr *logr.Logger, sources []hclSource) (*provider.Output, error) {
+	if len(sources) == 1 {
+		src := sources[0]
+		lgr.V(1).Info("validating HCL content", "bytes", len(src.data), "filename", src.filename)
+		result := ValidateHCL(src.data, src.filename)
+		lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "validate", "valid", result["valid"])
+		return &provider.Output{
+			Data: result,
+			Metadata: map[string]any{
+				"filename":  src.filename,
+				"bytes":     len(src.data),
+				"operation": "validate",
+			},
+		}, nil
+	}
+
+	// Multi-file: return per-file results with aggregate validity.
+	results := make([]any, 0, len(sources))
+	allValid := true
+	totalErrors := 0
+	for _, src := range sources {
+		lgr.V(1).Info("validating HCL content", "bytes", len(src.data), "filename", src.filename)
+		result := ValidateHCL(src.data, src.filename)
+		result["filename"] = src.filename
+		if valid, ok := result["valid"].(bool); ok && !valid {
+			allValid = false
+		}
+		if ec, ok := result["error_count"].(int); ok {
+			totalErrors += ec
+		}
+		results = append(results, result)
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "validate", "files", len(sources), "allValid", allValid)
+	return &provider.Output{
+		Data: map[string]any{
+			"valid":       allValid,
+			"error_count": totalErrors,
+			"files":       results,
+		},
+		Metadata: map[string]any{
+			"operation": "validate",
+			"files":     len(sources),
+		},
+	}, nil
+}
+
+// executeGenerate generates HCL from structured input.
+func (p *HCLProvider) executeGenerate(ctx context.Context, lgr *logr.Logger, inputs map[string]any) (*provider.Output, error) {
+	outputFormat := "hcl"
+	if f, ok := inputs["output_format"].(string); ok && f != "" {
+		outputFormat = f
+	}
+
+	if provider.DryRunFromContext(ctx) {
+		return &provider.Output{
+			Data:     map[string]any{"hcl": ""},
+			Metadata: map[string]any{"mode": "dry-run", "operation": "generate", "output_format": outputFormat},
+		}, nil
+	}
+
+	blocks, ok := inputs["blocks"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: 'blocks' input is required for the generate operation and must be a map", ProviderName)
+	}
+
+	lgr.V(1).Info("generating HCL", "provider", ProviderName, "output_format", outputFormat)
+
+	var generated string
+	var err error
+
+	switch outputFormat {
+	case "json":
+		generated, err = GenerateHCLJSON(blocks)
+	default:
+		generated, err = GenerateHCL(blocks)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "generate", "output_format", outputFormat, "bytes", len(generated))
+	return &provider.Output{
+		Data: map[string]any{
+			"hcl": generated,
+		},
+		Metadata: map[string]any{
+			"operation":     "generate",
+			"output_format": outputFormat,
+			"bytes":         len(generated),
+		},
+	}, nil
+}
+
+// dryRunOutput returns an appropriate dry-run response for the given operation.
+func dryRunOutput(operation string, sources []hclSource) *provider.Output {
+	meta := map[string]any{"mode": "dry-run", "operation": operation}
+
+	switch operation {
+	case "format":
+		if len(sources) == 1 {
+			return &provider.Output{
+				Data:     map[string]any{"formatted": "", "changed": false},
+				Metadata: meta,
+			}
+		}
+		return &provider.Output{
+			Data:     map[string]any{"files": []any{}, "changed": false},
+			Metadata: meta,
+		}
+	case "validate":
+		if len(sources) == 1 {
+			return &provider.Output{
+				Data:     map[string]any{"valid": true, "error_count": 0, "diagnostics": []any{}},
+				Metadata: meta,
+			}
+		}
+		return &provider.Output{
+			Data:     map[string]any{"valid": true, "error_count": 0, "files": []any{}},
+			Metadata: meta,
+		}
+	default: // parse
+		return &provider.Output{
+			Data:     emptyParseResult(),
+			Metadata: meta,
+		}
+	}
+}
+
+// emptyParseResult returns the empty parse output structure.
+func emptyParseResult() map[string]any {
+	return map[string]any{
+		"variables": []any{},
+		"resources": []any{},
+		"data":      []any{},
+		"modules":   []any{},
+		"outputs":   []any{},
+		"locals":    map[string]any{},
+		"providers": []any{},
+		"terraform": map[string]any{},
+		"moved":     []any{},
+		"import":    []any{},
+		"check":     []any{},
+	}
+}
+
+// mergeParseResults merges the source parse result into the target, appending
+// arrays and merging maps.
+func mergeParseResults(target, source map[string]any) {
+	arrayKeys := []string{"variables", "resources", "data", "modules", "outputs", "providers", "moved", "import", "check"}
+	for _, key := range arrayKeys {
+		if srcArr, ok := source[key].([]any); ok && len(srcArr) > 0 {
+			if tgtArr, ok := target[key].([]any); ok {
+				target[key] = append(tgtArr, srcArr...)
+			} else {
+				target[key] = srcArr
+			}
+		}
+	}
+
+	// Merge locals maps.
+	if srcLocals, ok := source["locals"].(map[string]any); ok {
+		tgtLocals, _ := target["locals"].(map[string]any)
+		if tgtLocals == nil {
+			tgtLocals = map[string]any{}
+		}
+		for k, v := range srcLocals {
+			tgtLocals[k] = v
+		}
+		target["locals"] = tgtLocals
+	}
+
+	// Merge terraform block (later file wins for conflicting keys).
+	if srcTf, ok := source["terraform"].(map[string]any); ok && len(srcTf) > 0 {
+		tgtTf, _ := target["terraform"].(map[string]any)
+		if tgtTf == nil {
+			tgtTf = map[string]any{}
+		}
+		for k, v := range srcTf {
+			tgtTf[k] = v
+		}
+		target["terraform"] = tgtTf
+	}
+
+	// Merge top-level attributes if present.
+	if srcAttrs, ok := source["attributes"].(map[string]any); ok {
+		tgtAttrs, _ := target["attributes"].(map[string]any)
+		if tgtAttrs == nil {
+			tgtAttrs = map[string]any{}
+		}
+		for k, v := range srcAttrs {
+			tgtAttrs[k] = v
+		}
+		target["attributes"] = tgtAttrs
+	}
 }
 
 // countBlocks safely extracts the lengths of the variables, resources, and modules

--- a/pkg/provider/builtin/hclprovider/hcl_test.go
+++ b/pkg/provider/builtin/hclprovider/hcl_test.go
@@ -18,7 +18,7 @@ func TestHCLProvider_Descriptor(t *testing.T) {
 	desc := p.Descriptor()
 
 	assert.Equal(t, "hcl", desc.Name)
-	assert.Equal(t, "HCL Parser", desc.DisplayName)
+	assert.Equal(t, "HCL", desc.DisplayName)
 	assert.Equal(t, "v1", desc.APIVersion)
 	assert.NotNil(t, desc.Version)
 	assert.NotEmpty(t, desc.Description)
@@ -118,7 +118,7 @@ func TestHCLProvider_Execute_MissingInputs(t *testing.T) {
 	output, err := p.Execute(ctx, inputs)
 	assert.Error(t, err)
 	assert.Nil(t, output)
-	assert.Contains(t, err.Error(), "either 'content' or 'path' must be provided")
+	assert.Contains(t, err.Error(), "one of 'content', 'path', 'paths', or 'dir' must be provided")
 }
 
 func TestHCLProvider_Execute_BothInputs(t *testing.T) {
@@ -134,7 +134,7 @@ func TestHCLProvider_Execute_BothInputs(t *testing.T) {
 	output, err := p.Execute(ctx, inputs)
 	assert.Error(t, err)
 	assert.Nil(t, output)
-	assert.Contains(t, err.Error(), "provide either 'content' or 'path', not both")
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestHCLProvider_Execute_InvalidInputType(t *testing.T) {
@@ -301,4 +301,123 @@ output "result" {
 	assert.Equal(t, "result", outputs[0].(map[string]any)["name"])
 	assert.Equal(t, "hello", outputs[0].(map[string]any)["value"])
 	assert.Equal(t, "A test output", outputs[0].(map[string]any)["description"])
+}
+
+func TestHCLProvider_Execute_Format_UnformattedContent(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	// Poorly formatted HCL – compact attribute assignments with no spacing
+	unformatted := `variable "region" {
+type=string
+default="us-east-1"
+}`
+
+	inputs := map[string]any{
+		"operation": "format",
+		"content":   unformatted,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["changed"].(bool), "changed should be true for unformatted input")
+	formatted := data["formatted"].(string)
+	assert.NotEmpty(t, formatted)
+	assert.Contains(t, formatted, "type")
+	assert.Contains(t, formatted, "region")
+
+	meta := output.Metadata
+	assert.Equal(t, "format", meta["operation"])
+}
+
+func TestHCLProvider_Execute_Format_AlreadyFormatted(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	// Content already in canonical form – hclwrite.Format should return it unchanged.
+	alreadyFormatted := `variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+`
+
+	inputs := map[string]any{
+		"operation": "format",
+		"content":   alreadyFormatted,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.False(t, data["changed"].(bool), "changed should be false when content is already canonical")
+	assert.Equal(t, alreadyFormatted, data["formatted"].(string))
+}
+
+func TestHCLProvider_Execute_Format_WithFilePath(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider(WithFileReader(&MockFileReader{
+		Content: []byte(`resource "aws_s3_bucket" "b" {
+bucket="my-bucket"
+}`),
+	}))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "format",
+		"path":      "./main.tf",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["changed"].(bool))
+	assert.Contains(t, data["formatted"].(string), "aws_s3_bucket")
+
+	meta := output.Metadata
+	assert.Equal(t, "format", meta["operation"])
+	assert.Equal(t, "./main.tf", meta["filename"])
+}
+
+func TestHCLProvider_Execute_Format_DryRun(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation": "format",
+		"content":   `variable "x" { type=string }`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, "", data["formatted"])
+	assert.Equal(t, false, data["changed"])
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+}
+
+func TestHCLProvider_Execute_Format_InvalidOperation(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "unknown",
+		"content":   `variable "x" {}`,
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported operation")
 }

--- a/pkg/provider/builtin/hclprovider/mock.go
+++ b/pkg/provider/builtin/hclprovider/mock.go
@@ -13,6 +13,10 @@ type MockFileReader struct {
 	ReadFileErr bool
 	// Content is returned by ReadFile when ReadFileFunc is nil and ReadFileErr is false.
 	Content []byte
+	// ListHCLFilesFunc allows custom directory listing per test.
+	ListHCLFilesFunc func(dir string) ([]string, error)
+	// DirFiles is returned by ListHCLFiles when ListHCLFilesFunc is nil.
+	DirFiles []string
 }
 
 // ReadFile reads a file using the mock configuration.
@@ -24,4 +28,12 @@ func (m *MockFileReader) ReadFile(path string) ([]byte, error) {
 		return m.ReadFileFunc(path)
 	}
 	return m.Content, nil
+}
+
+// ListHCLFiles returns the configured list of HCL files for a directory.
+func (m *MockFileReader) ListHCLFiles(dir string) ([]string, error) {
+	if m.ListHCLFilesFunc != nil {
+		return m.ListHCLFilesFunc(dir)
+	}
+	return m.DirFiles, nil
 }

--- a/pkg/provider/builtin/hclprovider/multifile_test.go
+++ b/pkg/provider/builtin/hclprovider/multifile_test.go
@@ -1,0 +1,403 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- paths (multi-file) ----------
+
+func TestHCLProvider_Execute_Parse_Paths(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			files := map[string]string{
+				"./variables.tf": `variable "region" { type = string }`,
+				"./resources.tf": `resource "aws_instance" "web" { ami = "ami-123" }`,
+			}
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, fmt.Errorf("file not found: %s", path)
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"paths": []any{"./variables.tf", "./resources.tf"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+
+	// Variables from variables.tf
+	vars := data["variables"].([]any)
+	require.Len(t, vars, 1)
+	assert.Equal(t, "region", vars[0].(map[string]any)["name"])
+
+	// Resources from resources.tf
+	resources := data["resources"].([]any)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "aws_instance", resources[0].(map[string]any)["type"])
+
+	// Metadata should list both filenames and file count
+	assert.Equal(t, 2, output.Metadata["files"])
+	filenames := output.Metadata["filenames"].([]string)
+	assert.Len(t, filenames, 2)
+}
+
+func TestHCLProvider_Execute_Parse_Paths_Empty(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"paths": []any{},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestHCLProvider_Execute_Parse_Paths_InvalidType(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"paths": "not-an-array",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an array")
+}
+
+func TestHCLProvider_Execute_Parse_Paths_NonStringItem(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"paths": []any{123},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a string")
+}
+
+// ---------- dir ----------
+
+func TestHCLProvider_Execute_Parse_Dir(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		DirFiles: []string{"./terraform/main.tf", "./terraform/vars.tf"},
+		ReadFileFunc: func(path string) ([]byte, error) {
+			files := map[string]string{
+				"./terraform/main.tf": `resource "aws_s3_bucket" "b" { bucket = "my-bucket" }`,
+				"./terraform/vars.tf": `variable "name" { type = string }`,
+			}
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, fmt.Errorf("file not found: %s", path)
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"dir": "./terraform",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	vars := data["variables"].([]any)
+	require.Len(t, vars, 1)
+	assert.Equal(t, "name", vars[0].(map[string]any)["name"])
+
+	resources := data["resources"].([]any)
+	require.Len(t, resources, 1)
+
+	assert.Equal(t, 2, output.Metadata["files"])
+}
+
+func TestHCLProvider_Execute_Parse_Dir_Empty(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		DirFiles: []string{}, // No HCL files
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"dir": "./empty-dir",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .tf or .tf.json files found")
+}
+
+func TestHCLProvider_Execute_Parse_Dir_ListError(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ListHCLFilesFunc: func(dir string) ([]string, error) {
+			return nil, fmt.Errorf("permission denied")
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"dir": "./restricted",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+// ---------- format multi-file ----------
+
+func TestHCLProvider_Execute_Format_Paths(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			files := map[string]string{
+				"./a.tf": `variable "x" {
+type=string
+}`,
+				"./b.tf": `variable "y" {
+  type = string
+}
+`,
+			}
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, fmt.Errorf("file not found: %s", path)
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "format",
+		"paths":     []any{"./a.tf", "./b.tf"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["changed"].(bool), "at least one file should have changed")
+
+	files := data["files"].([]any)
+	require.Len(t, files, 2)
+
+	// a.tf should have changed
+	f0 := files[0].(map[string]any)
+	assert.True(t, f0["changed"].(bool))
+	assert.Equal(t, "./a.tf", f0["filename"])
+	assert.NotEmpty(t, f0["formatted"])
+
+	// b.tf should not have changed (already formatted)
+	f1 := files[1].(map[string]any)
+	assert.False(t, f1["changed"].(bool))
+}
+
+func TestHCLProvider_Execute_Format_Dir(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		DirFiles: []string{"./tf/main.tf", "./tf/vars.tf"},
+		ReadFileFunc: func(path string) ([]byte, error) {
+			return []byte(`resource "a" "b" {
+ami="x"
+}`), nil
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "format",
+		"dir":       "./tf",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	files := data["files"].([]any)
+	require.Len(t, files, 2)
+	assert.True(t, files[0].(map[string]any)["changed"].(bool))
+	assert.True(t, files[1].(map[string]any)["changed"].(bool))
+}
+
+func TestHCLProvider_Execute_Format_MultiDryRun(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			return []byte(`variable "x" {}`), nil
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation": "format",
+		"paths":     []any{"./a.tf", "./b.tf"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.False(t, data["changed"].(bool))
+	assert.Empty(t, data["files"].([]any))
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+}
+
+// ---------- validate multi-file with dir ----------
+
+func TestHCLProvider_Execute_Validate_Dir(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		DirFiles: []string{"./tf/ok.tf", "./tf/bad.tf"},
+		ReadFileFunc: func(path string) ([]byte, error) {
+			files := map[string]string{
+				"./tf/ok.tf":  `variable "x" { type = string }`,
+				"./tf/bad.tf": `invalid {{{ syntax`,
+			}
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, fmt.Errorf("not found: %s", path)
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"dir":       "./tf",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.False(t, data["valid"].(bool))
+	assert.Greater(t, data["error_count"].(int), 0)
+
+	files := data["files"].([]any)
+	require.Len(t, files, 2)
+}
+
+// ---------- mutual exclusivity ----------
+
+func TestHCLProvider_Execute_MutualExclusive_ContentAndPaths(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"content": `variable "x" {}`,
+		"paths":   []any{"./a.tf"},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestHCLProvider_Execute_MutualExclusive_PathAndDir(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"path": "./main.tf",
+		"dir":  "./terraform",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// ---------- mergeParseResults ----------
+
+func TestMergeParseResults(t *testing.T) {
+	t.Parallel()
+	target := emptyParseResult()
+	source := map[string]any{
+		"variables": []any{map[string]any{"name": "a"}},
+		"resources": []any{map[string]any{"type": "aws_instance", "name": "b"}},
+		"locals":    map[string]any{"key": "val"},
+		"terraform": map[string]any{"required_version": ">= 1.0"},
+	}
+
+	mergeParseResults(target, source)
+
+	assert.Len(t, target["variables"].([]any), 1)
+	assert.Len(t, target["resources"].([]any), 1)
+	assert.Equal(t, "val", target["locals"].(map[string]any)["key"])
+	assert.Equal(t, ">= 1.0", target["terraform"].(map[string]any)["required_version"])
+
+	// Merge again — should append
+	source2 := map[string]any{
+		"variables": []any{map[string]any{"name": "c"}},
+		"locals":    map[string]any{"other": "thing"},
+	}
+	mergeParseResults(target, source2)
+	assert.Len(t, target["variables"].([]any), 2)
+	assert.Equal(t, "thing", target["locals"].(map[string]any)["other"])
+	assert.Equal(t, "val", target["locals"].(map[string]any)["key"])
+}
+
+// ---------- parse single file metadata ----------
+
+func TestHCLProvider_Execute_Parse_SingleFile_Metadata(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"content": `variable "x" { type = string }`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	// Single file should have "filename" not "filenames"
+	assert.Equal(t, "input.tf", output.Metadata["filename"])
+	assert.Nil(t, output.Metadata["filenames"])
+	assert.Equal(t, 1, output.Metadata["files"])
+}
+
+// ---------- osFileReader.ListHCLFiles (unit) ----------
+
+func TestOsFileReader_ListHCLFiles_NonExistentDir(t *testing.T) {
+	t.Parallel()
+	r := &osFileReader{}
+	_, err := r.ListHCLFiles("/nonexistent_dir_12345")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading directory")
+}

--- a/pkg/provider/builtin/hclprovider/validate.go
+++ b/pkg/provider/builtin/hclprovider/validate.go
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ValidateHCL checks HCL content for syntax errors and returns structured
+// diagnostic information. It reports validity, error count, and detailed
+// diagnostics with severity, summary, detail, and source position.
+func ValidateHCL(src []byte, filename string) map[string]any {
+	if filename == "" {
+		filename = "input.tf"
+	}
+
+	_, diags := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+
+	result := map[string]any{
+		"valid":       !diags.HasErrors(),
+		"error_count": countDiagsBySeverity(diags, hcl.DiagError),
+		"diagnostics": diagnosticsToSlice(diags),
+	}
+
+	return result
+}
+
+// countDiagsBySeverity counts diagnostics matching a given severity.
+func countDiagsBySeverity(diags hcl.Diagnostics, sev hcl.DiagnosticSeverity) int {
+	count := 0
+	for _, d := range diags {
+		if d.Severity == sev {
+			count++
+		}
+	}
+	return count
+}
+
+// diagnosticsToSlice converts HCL diagnostics to a JSON-friendly slice.
+func diagnosticsToSlice(diags hcl.Diagnostics) []any {
+	result := make([]any, 0, len(diags))
+	for _, d := range diags {
+		entry := map[string]any{
+			"severity": severityString(d.Severity),
+			"summary":  d.Summary,
+		}
+		if d.Detail != "" {
+			entry["detail"] = d.Detail
+		}
+		if d.Subject != nil {
+			entry["range"] = rangeToMap(*d.Subject)
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// severityString converts a diagnostic severity to a human-readable string.
+func severityString(s hcl.DiagnosticSeverity) string {
+	switch s {
+	case hcl.DiagError:
+		return "error"
+	case hcl.DiagWarning:
+		return "warning"
+	case hcl.DiagInvalid:
+		return "invalid"
+	default:
+		return "unknown"
+	}
+}
+
+// rangeToMap converts an HCL source range to a map for JSON output.
+func rangeToMap(r hcl.Range) map[string]any {
+	return map[string]any{
+		"filename": r.Filename,
+		"start": map[string]any{
+			"line":   r.Start.Line,
+			"column": r.Start.Column,
+			"byte":   r.Start.Byte,
+		},
+		"end": map[string]any{
+			"line":   r.End.Line,
+			"column": r.End.Column,
+			"byte":   r.End.Byte,
+		},
+	}
+}

--- a/pkg/provider/builtin/hclprovider/validate_test.go
+++ b/pkg/provider/builtin/hclprovider/validate_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hclprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateHCL_ValidContent(t *testing.T) {
+	t.Parallel()
+	src := []byte(`variable "region" {
+  type    = string
+  default = "us-east-1"
+}`)
+	result := ValidateHCL(src, "main.tf")
+
+	assert.True(t, result["valid"].(bool))
+	assert.Equal(t, 0, result["error_count"])
+	diags := result["diagnostics"].([]any)
+	assert.Empty(t, diags)
+}
+
+func TestValidateHCL_InvalidContent(t *testing.T) {
+	t.Parallel()
+	src := []byte(`this is { not valid hcl !!!`)
+	result := ValidateHCL(src, "bad.tf")
+
+	assert.False(t, result["valid"].(bool))
+	assert.Greater(t, result["error_count"].(int), 0)
+
+	diags := result["diagnostics"].([]any)
+	require.NotEmpty(t, diags)
+
+	first := diags[0].(map[string]any)
+	assert.Equal(t, "error", first["severity"])
+	assert.NotEmpty(t, first["summary"])
+	assert.Contains(t, first, "range")
+
+	rng := first["range"].(map[string]any)
+	assert.Equal(t, "bad.tf", rng["filename"])
+	assert.Contains(t, rng, "start")
+	assert.Contains(t, rng, "end")
+}
+
+func TestValidateHCL_EmptyContent(t *testing.T) {
+	t.Parallel()
+	result := ValidateHCL([]byte(""), "empty.tf")
+
+	assert.True(t, result["valid"].(bool))
+	assert.Equal(t, 0, result["error_count"])
+}
+
+func TestValidateHCL_DefaultFilename(t *testing.T) {
+	t.Parallel()
+	src := []byte(`resource "a" "b" {}`)
+	result := ValidateHCL(src, "")
+
+	assert.True(t, result["valid"].(bool))
+}
+
+func TestHCLProvider_Execute_Validate_ValidContent(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"content": `variable "env" {
+  type    = string
+  default = "prod"
+}`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["valid"].(bool))
+	assert.Equal(t, 0, data["error_count"])
+	assert.Empty(t, data["diagnostics"].([]any))
+	assert.Equal(t, "validate", output.Metadata["operation"])
+}
+
+func TestHCLProvider_Execute_Validate_InvalidContent(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"content":   `resource "aws" "x" { bad syntax !!!`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err) // validate returns output, not an error
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.False(t, data["valid"].(bool))
+	assert.Greater(t, data["error_count"].(int), 0)
+	assert.NotEmpty(t, data["diagnostics"].([]any))
+}
+
+func TestHCLProvider_Execute_Validate_WithPath(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		Content: []byte(`output "result" { value = "hello" }`),
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"path":      "./outputs.tf",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["valid"].(bool))
+	assert.Equal(t, "./outputs.tf", output.Metadata["filename"])
+}
+
+func TestHCLProvider_Execute_Validate_DryRun(t *testing.T) {
+	t.Parallel()
+	p := NewHCLProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"content":   `variable "x" {}`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["valid"].(bool))
+	assert.Equal(t, 0, data["error_count"])
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+}
+
+func TestHCLProvider_Execute_Validate_MultiFile(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			files := map[string]string{
+				"./valid.tf":   `variable "x" { type = string }`,
+				"./invalid.tf": `this is not valid {{{`,
+			}
+			return []byte(files[path]), nil
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"paths":     []any{"./valid.tf", "./invalid.tf"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.False(t, data["valid"].(bool))
+	assert.Greater(t, data["error_count"].(int), 0)
+
+	files := data["files"].([]any)
+	require.Len(t, files, 2)
+
+	// First file is valid
+	f0 := files[0].(map[string]any)
+	assert.True(t, f0["valid"].(bool))
+	assert.Equal(t, "./valid.tf", f0["filename"])
+
+	// Second file is invalid
+	f1 := files[1].(map[string]any)
+	assert.False(t, f1["valid"].(bool))
+	assert.Equal(t, "./invalid.tf", f1["filename"])
+}
+
+func TestHCLProvider_Execute_Validate_MultiFileDryRun(t *testing.T) {
+	t.Parallel()
+	mockReader := &MockFileReader{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			return []byte(`variable "x" {}`), nil
+		},
+	}
+	p := NewHCLProvider(WithFileReader(mockReader))
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	inputs := map[string]any{
+		"operation": "validate",
+		"paths":     []any{"./a.tf", "./b.tf"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.True(t, data["valid"].(bool))
+	assert.Equal(t, 0, data["error_count"])
+	assert.Empty(t, data["files"].([]any))
+	assert.Equal(t, "dry-run", output.Metadata["mode"])
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -373,6 +373,51 @@ func TestIntegration_RunProvider_HCL_DryRun(t *testing.T) {
 	assert.Contains(t, stdout, "dryRun")
 }
 
+func TestIntegration_RunProvider_HCL_Validate(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "hcl",
+		"--input", "operation=validate",
+		"--input", "content=variable \"x\" { type = string }",
+		"-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "valid")
+}
+
+func TestIntegration_RunProvider_HCL_Generate(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "hcl",
+		"--input", "@examples/providers/hcl-generate.yaml",
+		"-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hcl")
+}
+
+func TestIntegration_RunProvider_HCL_GenerateJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "hcl",
+		"--input", "@examples/providers/hcl-generate-json.yaml",
+		"-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hcl")
+	assert.Contains(t, stdout, "variable")
+	assert.Contains(t, stdout, "resource")
+}
+
+func TestIntegration_RunProvider_HCL_Format(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "hcl",
+		"--input", "operation=format",
+		"--input", "content=variable \"x\" {\ntype=string\n}",
+		"-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "formatted")
+	assert.Contains(t, stdout, "changed")
+}
+
 // ============================================================================
 // Get Provider CLI Usage Tests
 // ============================================================================

--- a/tests/integration/solutions/providers/hcl/solution.yaml
+++ b/tests/integration/solutions/providers/hcl/solution.yaml
@@ -121,6 +121,102 @@ spec:
                   most_recent = true
                 }
 
+    formatUnformatted:
+      description: Format unformatted HCL content
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              content: |
+                variable "region" {
+                type=string
+                default="us-east-1"
+                }
+
+    formatAlreadyFormatted:
+      description: Format already-formatted HCL content
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: format
+              content: |
+                variable "region" {
+                  type    = string
+                  default = "us-east-1"
+                }
+
+    validateValid:
+      description: Validate valid HCL syntax
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              content: |
+                variable "region" {
+                  type    = string
+                  default = "us-east-1"
+                }
+
+    validateInvalid:
+      description: Validate invalid HCL syntax
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: validate
+              content: "this is { not valid hcl !!!"
+
+    generateVariables:
+      description: Generate HCL from structured variable data
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              blocks:
+                variables:
+                  - name: region
+                    type: string
+                    default: us-east-1
+                    description: "AWS region"
+
+    generateResources:
+      description: Generate HCL from structured resource data
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              blocks:
+                resources:
+                  - type: aws_instance
+                    name: web
+                    attributes:
+                      ami: ami-12345
+                      instance_type: t3.micro
+
+    generateJSON:
+      description: Generate Terraform JSON from structured data
+      resolve:
+        with:
+          - provider: hcl
+            inputs:
+              operation: generate
+              output_format: json
+              blocks:
+                variables:
+                  - name: region
+                    type: string
+                    default: us-east-1
+                resources:
+                  - type: aws_instance
+                    name: web
+                    attributes:
+                      ami: ami-12345
+
   testing:
     config:
       skipBuiltins: true
@@ -240,3 +336,61 @@ spec:
         assertions:
           - expression: __output.parseDataSources.data[0].type == "aws_ami"
           - expression: __output.parseDataSources.data[0].name == "ubuntu"
+
+      format-changed:
+        description: Verify formatting detects changes
+        extends: [_base]
+        assertions:
+          - expression: __output.formatUnformatted.changed == true
+          - expression: size(__output.formatUnformatted.formatted) > 0
+
+      format-unchanged:
+        description: Verify already-formatted content is unchanged
+        extends: [_base]
+        assertions:
+          - expression: __output.formatAlreadyFormatted.changed == false
+
+      validate-valid:
+        description: Verify valid HCL passes validation
+        extends: [_base]
+        assertions:
+          - expression: __output.validateValid.valid == true
+          - expression: __output.validateValid.error_count == 0
+          - expression: size(__output.validateValid.diagnostics) == 0
+
+      validate-invalid:
+        description: Verify invalid HCL fails validation
+        extends: [_base]
+        assertions:
+          - expression: __output.validateInvalid.valid == false
+          - expression: __output.validateInvalid.error_count > 0
+          - expression: size(__output.validateInvalid.diagnostics) > 0
+
+      validate-diagnostic-severity:
+        description: Verify diagnostic severity is reported
+        extends: [_base]
+        assertions:
+          - expression: __output.validateInvalid.diagnostics[0].severity == "error"
+
+      generate-variable-hcl:
+        description: Verify generated HCL contains variable block
+        extends: [_base]
+        assertions:
+          - expression: __output.generateVariables.hcl.contains("variable")
+          - expression: __output.generateVariables.hcl.contains("region")
+
+      generate-resource-hcl:
+        description: Verify generated HCL contains resource block
+        extends: [_base]
+        assertions:
+          - expression: __output.generateResources.hcl.contains("resource")
+          - expression: __output.generateResources.hcl.contains("aws_instance")
+
+      generate-json-valid:
+        description: Verify JSON generation produces valid JSON with correct structure
+        extends: [_base]
+        assertions:
+          - expression: __output.generateJSON.hcl.contains("\"variable\"")
+          - expression: __output.generateJSON.hcl.contains("\"region\"")
+          - expression: __output.generateJSON.hcl.contains("\"resource\"")
+          - expression: __output.generateJSON.hcl.contains("\"aws_instance\"")


### PR DESCRIPTION
…erations

Expand the HCL provider from parse-only to a full four-operation provider with multi-file/directory support and Terraform JSON generation.

Operations added:
- format: canonically formats HCL content using hclwrite; supports single file, multi-file (paths), and directory (dir) inputs with per-file results
- validate: checks HCL syntax and returns structured diagnostics (severity, summary, detail, range) for single or multi-file inputs
- generate: produces HCL text from a structured block map (same schema as parse output); supports all Terraform block types with conventional ordering

New inputs:
- paths: process multiple HCL files, merging results (parse) or returning per-file output (format/validate)
- dir: process all .tf/.tf.json files in a directory (non-recursive)
- blocks: structured input for the generate operation
- output_format: 'hcl' (default) or 'json' — generate Terraform JSON Configuration Syntax (.tf.json) with correct label nesting rules

Terraform JSON generation (output_format: json):
- Single-label blocks (variable, module, output, check) nest by name
- Double-label blocks (resource, data) nest by type then name
- Provider blocks with aliases convert to arrays per provider name
- Unlabeled blocks (moved, import) produce arrays of objects

Tests:
- 101 unit tests covering all operations, input sources, edge cases, dry-run, multi-file merge, diagnostics, and JSON output
- 25 integration test cases in solution.yaml across all operations
- 6 CLI integration tests including dry-run and JSON generation

Documentation:
- provider-reference.md: full input/output tables for all 4 operations, output_format field, 10 YAML examples
- hcl-provider-tutorial.md: 15-section tutorial covering all operations, multi-file patterns, round-trip workflows, and Terraform JSON generation
- providers.md design doc: updated inputs, outputs, and capabilities
- _index.md tutorial index: updated description
- examples/providers/: 5 example input files (parse, format, validate, generate, generate-json) with README
