### PR TITLE
feat(gotmpl): add Go template extension functions with sprig and HCL …

### DIFF
--- a/cmd/scafctl/scafctl.go
+++ b/cmd/scafctl/scafctl.go
@@ -12,6 +12,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/celexp/env"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
 	"github.com/oakwood-commons/scafctl/pkg/profiler"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
@@ -54,6 +56,10 @@ func run() error {
 	// Register env.GlobalCache as the cache factory for celexp package.
 	// This allows celexp to automatically use the global cache when no cache is specified.
 	celexp.SetCacheFactory(env.GlobalCache)
+
+	// Register Go template extension functions (sprig + custom) for the gotmpl package.
+	// This allows gotmpl.NewService(nil) to automatically include all extension functions.
+	gotmpl.SetExtensionFuncMapFactory(gotmplext.AllFuncMap)
 
 	cli := scafctl.Root(nil)
 	defer func() {

--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -1164,7 +1164,7 @@ Every new tool, prompt, and CLI command must have unit tests following existing 
 
 | Category | Count | Details |
 |----------|-------|---------|
-| New MCP Tools | 9 | `extract_resolver_refs`, `generate_test_scaffold`, `list_tests`, `show_snapshot`, `diff_snapshots`, `catalog_inspect`, `list_auth_handlers`, `get_config_paths`, `validate_expressions` |
+| New MCP Tools | 9 | `extract_resolver_refs`, `generate_test_scaffold`, `list_tests`, `show_snapshot`, `diff_snapshots`, `catalog_inspect`, `list_auth_handlers`, `get_config_paths`, `validate_expressions`, `list_go_template_functions` |
 | New MCP Prompts | 3 | `analyze_execution`, `migrate_solution`, `optimize_solution` |
 | New MCP Resources | 1 | `solution://{name}/tests` |
 | New CLI Commands | 9 | `eval cel`, `eval template`, `eval validate`, `new solution`, `lint rules`, `lint explain`, `examples list`, `examples get`, enhanced `--dry-run` |

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -578,6 +578,7 @@ The primary use case is AI-assisted solution authoring — helping users create 
 | `get_provider_schema` | Get JSON Schema for a provider's inputs | Yes |
 | `render_solution` | Render action graph without executing | Yes |
 | `list_cel_functions` | List all available CEL functions (built-in + scafctl custom) | Yes |
+| `list_go_template_functions` | List all available Go template extension functions (Sprig + custom) | Yes |
 | `evaluate_cel` | Test a CEL expression against sample data | Yes |
 | `explain_solution` | Explain a solution's configuration | Yes |
 | `explain_provider` | Explain a provider's capabilities and inputs | Yes |

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -298,6 +298,8 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
 
 1. **Get your Kubernetes cluster's OIDC issuer URL**:
 
+   {{< tabs "auth-oidc-issuer" >}}
+   {{< tab "Bash" >}}
    ```bash
    # For AKS
    az aks show --name <cluster-name> --resource-group <rg-name> \
@@ -306,6 +308,17 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
    # For other clusters (e.g., kind, minikube with OIDC enabled)
    kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer'
    ```
+   {{< /tab >}}
+   {{< tab "PowerShell" >}}
+   ```powershell
+   az aks show --name <cluster-name> --resource-group <rg-name> `
+     --query "oidcIssuerProfile.issuerUrl" -o tsv
+
+   # For other clusters
+   (kubectl get --raw /.well-known/openid-configuration | ConvertFrom-Json).issuer
+   ```
+   {{< /tab >}}
+   {{< /tabs >}}
 
 2. **Create the federated credential** via Azure Portal or CLI:
 
@@ -502,10 +515,21 @@ This means the token's claims don't match the federated credential configuration
 - Verify the `subject` matches your service account (`system:serviceaccount:<namespace>:<name>`)
 - Verify the `audience` in both the federated credential and `kubectl create token` command
 
+{{< tabs "auth-decode-token" >}}
+{{< tab "Bash" >}}
 ```bash
 # Decode the token to inspect its claims
 echo "$FEDERATED_TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Decode the token to inspect its claims
+$parts = $env:FEDERATED_TOKEN -split '\.'
+[System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($parts[1] + '=' * (4 - $parts[1].Length % 4))) | ConvertFrom-Json
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Check these claims match your federated credential:
 - `iss` (issuer)
@@ -534,6 +558,8 @@ echo "AZURE_FEDERATED_TOKEN: ${AZURE_FEDERATED_TOKEN:0:20}..." # First 20 chars
 
 Verify your cluster's OIDC configuration is accessible:
 
+{{< tabs "auth-oidc-discovery" >}}
+{{< tab "Bash" >}}
 ```bash
 # Get the OIDC configuration
 curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')/.well-known/openid-configuration" | jq .
@@ -541,6 +567,14 @@ curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer'
 # Get the JWKS (signing keys)
 curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri')" | jq .
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+$issuer = (kubectl get --raw /.well-known/openid-configuration | ConvertFrom-Json).issuer
+Invoke-RestMethod "$issuer/.well-known/openid-configuration"
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ---
 
@@ -954,9 +988,18 @@ scafctl auth status --exit-code --warn-within 15m || {
 
 The JSON output includes a `cachedTokens` field showing how many access tokens are in the cache for each handler — useful for verifying token cache health:
 
+{{< tabs "auth-cached-tokens" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl auth status -o json | jq '.[].cachedTokens'
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+(scafctl auth status -o json | ConvertFrom-Json).cachedTokens
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ---
 
@@ -1291,6 +1334,8 @@ scafctl auth token github --curl
 
 Use `--decode` to inspect the full JWT structure — both the **header** and the **payload** — without needing an external decoder tool. Signature validation is intentionally skipped; this is for debugging only:
 
+{{< tabs "auth-jwt-decode" >}}
+{{< tab "Bash" >}}
 ```bash
 # Decode and display the full JWT (header and payload)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
@@ -1299,6 +1344,17 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json \
   | jq '{alg: .header.alg, audience: .payload.aud, upn: .payload.upn, expires: .payload.exp_human}'
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
+
+# Output as JSON — use ConvertFrom-Json to filter
+$decoded = scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | ConvertFrom-Json
+$decoded | Select-Object @{N='alg';E={$_.header.alg}}, @{N='audience';E={$_.payload.aud}}, @{N='upn';E={$_.payload.upn}}, @{N='expires';E={$_.payload.exp_human}}
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Example output (table):
 
@@ -1341,6 +1397,8 @@ scafctl auth token entra --scope "https://management.azure.com/.default" --clip
 
 Get the full token for use with other tools:
 
+{{< tabs "auth-token-usage" >}}
+{{< tab "Bash" >}}
 ```bash
 # Approach 1: --raw (simplest)
 curl -H "Authorization: Bearer $(scafctl auth token entra --scope 'https://graph.microsoft.com/.default' --raw)" \
@@ -1357,6 +1415,19 @@ curl -H "Authorization: Bearer $TOKEN" https://graph.microsoft.com/v1.0/me
 # GitHub API example
 curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user/repos
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Approach 1: --raw (simplest)
+$token = scafctl auth token entra --scope 'https://graph.microsoft.com/.default' --raw
+Invoke-RestMethod -Uri 'https://graph.microsoft.com/v1.0/me' -Headers @{ Authorization = "Bearer $token" }
+
+# Approach 2: JSON output + ConvertFrom-Json
+$token = (scafctl auth token entra --scope 'https://graph.microsoft.com/.default' -o json | ConvertFrom-Json).accessToken
+Invoke-RestMethod -Uri 'https://graph.microsoft.com/v1.0/me' -Headers @{ Authorization = "Bearer $token" }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ---
 
@@ -1676,6 +1747,8 @@ If you're getting 403 (Forbidden) errors, the token may not have the required pe
 Use `--decode` on `auth token` to inspect JWT claims directly without needing an
 external tool or manual base64 decoding:
 
+{{< tabs "auth-troubleshoot-claims" >}}
+{{< tab "Bash" >}}
 ```bash
 # Decode and display claims in table format (no signature validation)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
@@ -1683,6 +1756,17 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 # Output as JSON for further processing (e.g., with jq)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | jq '.aud,.upn,.roles'
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
+
+# Output as JSON for further processing
+$decoded = scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | ConvertFrom-Json
+$decoded.aud, $decoded.upn, $decoded.roles
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) are automatically augmented
 with a `_human` RFC 3339 counterpart so you can read them without converting.

--- a/docs/tutorials/eval-tutorial.md
+++ b/docs/tutorials/eval-tutorial.md
@@ -13,7 +13,8 @@ The `eval` commands are developer tools for quick iteration:
 
 - **`eval cel`** — Evaluate CEL expressions with inline or file-based data
 - **`eval template`** — Render Go templates against JSON/YAML data
-- **`eval validate`** — Validate a solution file against the schema and lint rules
+
+For solution file validation, use the separate **`scafctl lint`** command (covered in [Section 3](#3-validating-solution-files-with-scafctl-lint) below).
 
 ```
 ┌──────────────┐         ┌──────────────┐         ┌──────────────┐
@@ -153,55 +154,91 @@ scafctl eval template --template-file config.tmpl \
 
 > **Tip:** Use `eval template` to preview scaffold/render actions before running the full solution workflow.
 
-## 3. Validating Solution Files
+## 3. Validating Solution Files with `scafctl lint`
+
+While `eval cel` and `eval template` test individual expressions and templates, use the **`scafctl lint`** command to validate entire solution files against the schema and lint rules.
+
+> **Note:** `scafctl lint` is a separate top-level command, not part of `eval`. It's included here because validation is a natural part of the expression development workflow.
 
 ### Basic Validation
 
 Check a solution file for schema errors and lint violations:
 
+{{< tabs "eval-lint-basic" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl eval validate -f solution.yaml
+scafctl lint -f solution.yaml
 ```
-
-### JSON Output
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl lint -f solution.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Get structured validation results:
 
+{{< tabs "eval-lint-json" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl eval validate -f solution.yaml -o json
+scafctl lint -f solution.yaml -o json
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl lint -f solution.yaml -o json
+```
+{{< /tab >}}
+{{< /tabs >}}
 
-This returns:
+### Filter by Severity
 
-```json
-{
-  "file": "solution.yaml",
-  "errorCount": 0,
-  "warnCount": 1,
-  "infoCount": 0,
-  "findings": [
-    {
-      "rule": "missing-description",
-      "severity": "warning",
-      "message": "Solution metadata should include a description",
-      "location": "metadata"
-    }
-  ]
-}
+Only show findings at or above a minimum severity level:
+
+```bash
+# Show only warnings and errors (skip info)
+scafctl lint -f solution.yaml --severity warning
 ```
 
 ### Quick Validation in Scripts
 
-Use quiet mode for CI/CD pipelines:
+Use quiet mode for CI/CD pipelines — returns exit code only (0 = clean, non-zero = errors):
 
+{{< tabs "eval-lint-quiet" >}}
+{{< tab "Bash" >}}
 ```bash
-if scafctl eval validate -f solution.yaml -o quiet; then
+if scafctl lint -f solution.yaml -o quiet; then
   echo "Valid!"
 else
   echo "Validation failed"
   exit 1
 fi
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl lint -f solution.yaml -o quiet
+if ($LASTEXITCODE -eq 0) { Write-Host "Valid!" } else { Write-Host "Validation failed"; exit 1 }
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+### Exploring Lint Rules
+
+List all available lint rules:
+
+```bash
+scafctl lint rules
+```
+
+Get a detailed explanation of a specific rule:
+
+```bash
+scafctl lint explain <rule-id>
+```
+
+See the [Linting Tutorial](linting-tutorial.md) for a deep dive into lint rules and custom validation workflows.
 
 ## 4. Common Workflows
 
@@ -236,10 +273,19 @@ scafctl eval template --template-file deploy.tmpl --data-file snapshot.json
 
 Add to your pre-commit hooks or CI pipeline:
 
+{{< tabs "eval-precommit" >}}
+{{< tab "Bash" >}}
 ```bash
 # Validate all solution files in a directory
-find . -name 'solution.yaml' -exec scafctl eval validate -f {} -o quiet \;
+find . -name 'solution.yaml' -exec scafctl lint -f {} -o quiet \;
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+Get-ChildItem -Recurse -Filter 'solution.yaml' | ForEach-Object { scafctl lint -f $_.FullName -o quiet }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -207,7 +207,7 @@ scafctl run solution -f solution.yaml --dry-run
 scafctl render solution -f solution.yaml
 
 # Show dependency graph
-scafctl resolver graph -f solution.yaml
+scafctl render solution --graph -f solution.yaml
 
 # List available providers
 scafctl get provider
@@ -235,7 +235,7 @@ scafctl examples get resolvers/hello-world.yaml -o hello.yaml
 scafctl eval cel '"hello".upperAscii()'
 
 # Validate a solution file
-scafctl eval validate -f solution.yaml
+scafctl lint -f solution.yaml
 
 # List lint rules
 scafctl lint rules

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -27,6 +27,10 @@ This tutorial walks you through using Go templates in scafctl to generate struct
 10. [Using `tmpl` for Dynamic Inputs](#using-tmpl-for-dynamic-inputs)
 11. [Generating Multiple Files with ForEach](#generating-multiple-files-with-foreach)
 12. [Putting It All Together: README Generator](#putting-it-all-together-readme-generator)
+13. [Using Sprig Functions](#using-sprig-functions)
+14. [Converting Data to HCL with toHcl](#converting-data-to-hcl-with-tohcl)
+15. [Serializing and Parsing YAML with toYaml / fromYaml](#serializing-and-parsing-yaml-with-toyaml--fromyaml)
+16. [Discovering Available Functions](#discovering-available-functions)
 
 ---
 
@@ -1391,6 +1395,316 @@ go run .
 
 ---
 
+## Using Sprig Functions
+
+scafctl includes [Sprig v3](https://masterminds.github.io/sprig/) — a library of 100+ utility functions for Go templates. These are available automatically in all `go-template` provider invocations.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-sprig.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-sprig
+  version: 1.0.0
+
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-demo
+              template: |
+                {{ "hello world" | upper | trunc 5 }}
+              data:
+                unused: placeholder
+
+    config:
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-dict
+              template: |
+                {{- $defaults := dict "port" 3000 "debug" false -}}
+                {{- $overrides := dict "port" 8080 "tls" true -}}
+                {{- $merged := merge $overrides $defaults -}}
+                port={{ $merged.port }}, tls={{ $merged.tls }}, debug={{ $merged.debug }}
+
+    formatted:
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-string
+              template: |
+                {{ "my-app-service" | camelcase }}
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```
+HELLO
+```
+
+The `upper` function uppercases the string, and `trunc 5` truncates it to 5 characters.
+
+Try the other resolvers:
+
+```bash
+scafctl run resolver -f template-sprig.yaml -e _.config -o yaml --hide-execution
+```
+
+```
+port=8080, tls=true, debug=false
+```
+
+```bash
+scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml --hide-execution
+```
+
+```
+MyAppService
+```
+
+### What You Learned
+
+- **Sprig is built in** — All Sprig v3 functions work in `go-template` templates with no extra configuration.
+- **Piping** — Use `|` to chain functions: `{{ "text" | upper | trunc 5 }}`.
+- **`dict` and `merge`** — Create and merge maps for configuration defaults.
+- **String helpers** — `camelcase`, `snakecase`, `kebabcase`, `title`, `upper`, `lower`, `trim`, `replace`, and many more.
+
+> **Tip:** See the [Sprig documentation](https://masterminds.github.io/sprig/) for the full list of available functions grouped by category: strings, math, dates, lists, dicts, crypto, encoding, and more.
+
+---
+
+## Converting Data to HCL with toHcl
+
+scafctl provides a custom `toHcl` function that converts Go data structures into HashiCorp Configuration Language (HCL) format. This is useful for generating Terraform configurations.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-tohcl.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-tohcl
+  version: 1.0.0
+
+spec:
+  resolvers:
+    config:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-bucket
+                region: us-east-1
+                tags:
+                  environment: production
+                  team: platform
+
+    hclOutput:
+      description: Generate HCL from structured data
+      type: string
+      dependsOn: [config]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: hcl-gen
+              template: |
+                resource "aws_s3_bucket" "main" {
+                  {{ toHcl .config | indent 2 }}
+                }
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```hcl
+resource "aws_s3_bucket" "main" {
+  name   = "my-bucket"
+  region = "us-east-1"
+  tags = {
+    environment = "production"
+    team        = "platform"
+  }
+}
+```
+
+### What You Learned
+
+- **`toHcl`** — Converts maps, lists, and primitives into HCL syntax.
+- **Nested structures** — Maps within maps render as nested HCL blocks.
+- **Combined with Sprig** — Use `indent` (from Sprig) to properly nest the generated HCL.
+- **Terraform workflows** — Generate provider blocks, resource definitions, and variable files from structured data.
+
+---
+
+## Serializing and Parsing YAML with toYaml / fromYaml
+
+scafctl provides custom `toYaml`, `fromYaml`, `mustToYaml`, and `mustFromYaml` functions for YAML serialization and deserialization. These fill the gap left by Sprig v3.3.0, which removed its YAML functions.
+
+### Step 1: Create the Solution File
+
+Create a file called `template-yaml.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-yaml
+  version: 1.0.0
+
+spec:
+  resolvers:
+    config:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-service
+                port: 8080
+                tags:
+                  env: production
+                  team: platform
+
+    yamlOutput:
+      description: Encode data as YAML
+      type: string
+      dependsOn: [config]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: yaml-gen
+              template: |
+                {{ toYaml .config }}
+
+    roundTrip:
+      description: Parse YAML and access fields
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: yaml-roundtrip
+              template: |
+                {{- $parsed := fromYaml "name: myapp\nport: 8080" -}}
+                name={{ $parsed.name }}, port={{ $parsed.port }}
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml --hide-execution
+```
+
+### Step 3: Check the Output
+
+```yaml
+name: my-service
+port: 8080
+tags:
+    env: production
+    team: platform
+```
+
+### Available YAML Functions
+
+| Function | Description |
+|----------|-------------|
+| `toYaml` | Encodes a value as a YAML string |
+| `fromYaml` | Decodes a YAML string into a `map[string]any` |
+| `mustToYaml` | Same as `toYaml` (errors propagate in Go templates) |
+| `mustFromYaml` | Same as `fromYaml` (errors propagate in Go templates) |
+
+### What You Learned
+
+- **`toYaml`** — Encodes any Go value (maps, lists, structs, primitives) as YAML.
+- **`fromYaml`** — Parses a YAML string back into a map for field access.
+- **Round-trips** — Combine `toYaml` and `fromYaml` for data transformation pipelines.
+- **`must*` variants** — Exist for Helm naming convention compatibility; behavior is identical in Go templates.
+
+---
+
+## Discovering Available Functions
+
+scafctl provides tools to explore all available Go template functions — both Sprig and custom.
+
+### Using the CLI
+
+List all available functions:
+
+```bash
+scafctl get go-template-functions
+```
+
+Filter to custom functions only:
+
+```bash
+scafctl get go-template-functions --custom
+```
+
+Filter to Sprig functions only:
+
+```bash
+scafctl get go-template-functions --sprig
+```
+
+Get details for a specific function:
+
+```bash
+scafctl get go-template-functions toHcl
+```
+
+Output as JSON:
+
+```bash
+scafctl get go-template-functions -o json
+```
+
+### Using the MCP Server
+
+If you use an AI agent with the scafctl MCP server, you can ask:
+
+> **You:** "What Go template functions are available for data formatting?"
+
+The AI calls `list_go_template_functions` and returns a curated list of matching functions with descriptions and examples.
+
+### What You Learned
+
+- **CLI discovery** — `scafctl get go-template-functions` lists all available functions with `--custom`, `--sprig`, and `-o json` flags.
+- **MCP discovery** — The `list_go_template_functions` tool lets AI agents search and filter functions.
+- **Function detail** — Pass a function name as an argument to see its full description, signature, and examples.
+
+---
+
 ## Provider Reference
 
 For a quick reference of all `go-template` provider inputs:
@@ -1419,3 +1733,5 @@ For a quick reference of all `go-template` provider inputs:
 - [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
 - [Actions Tutorial](actions-tutorial.md) — Use templates in action workflows
 - [Provider Reference](provider-reference.md) — Full `go-template` provider documentation
+- [Sprig Functions Reference](https://masterminds.github.io/sprig/) — Complete Sprig v3 function documentation
+- [MCP Server Tutorial](mcp-server-tutorial.md) — Use `list_go_template_functions` via AI agents

--- a/docs/tutorials/hcl-provider-tutorial.md
+++ b/docs/tutorials/hcl-provider-tutorial.md
@@ -979,11 +979,24 @@ scafctl run provider hcl --input operation=validate --input path=./main.tf -o js
 
 # Validate a directory
 scafctl run provider hcl --input operation=validate --input dir=./terraform -o json
+```
 
+{{< tabs "hcl-file-input" >}}
+{{< tab "Bash" >}}
+```bash
 # Use a pre-built example input file
 scafctl run provider hcl --input @examples/providers/hcl-format.yaml -o json
+```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Wrap @file in single quotes to avoid splatting operator
+scafctl run provider hcl --input '@examples/providers/hcl-format.yaml' -o json
+```
+{{< /tab >}}
+{{< /tabs >}}
 
-# Dry run (parse)
+```bash
 scafctl run provider hcl --input path=./main.tf --dry-run
 
 # Dry run (format)

--- a/docs/tutorials/logging-tutorial.md
+++ b/docs/tutorials/logging-tutorial.md
@@ -140,9 +140,22 @@ Output:
 
 Filter with `jq`:
 
+{{< tabs "logging-json-filter" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run solution -f solution.yaml --log-level debug --log-format json 2>&1 | jq 'select(.level == "error")'
 ```
+
+> **Note:** The above command uses [jq](https://jqlang.github.io/jq/), a command-line JSON processor. Install it separately if not already available.
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run solution -f solution.yaml --log-level debug --log-format json 2>&1 |
+  ForEach-Object { $_ | ConvertFrom-Json } |
+  Where-Object { $_.level -eq 'error' }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Log File Output
 

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -62,6 +62,7 @@ You should see JSON output listing all available tools:
     { "name": "lint_solution", "description": "Validate a solution file..." },
     { "name": "list_auth_handlers", "description": "List all registered auth handlers..." },
     { "name": "list_cel_functions", "description": "List all available CEL functions..." },
+    { "name": "list_go_template_functions", "description": "List all available Go template extension functions..." },
     { "name": "list_examples", "description": "List available scafctl example files..." },
     { "name": "list_providers", "description": "List all available providers..." },
     { "name": "list_solutions", "description": "List available solutions from the local catalog..." },
@@ -442,6 +443,42 @@ Here are the custom scafctl CEL functions for string manipulation:
 Use `evaluate_cel` to test any of these interactively.
 ```
 
+### Discover Go Template Functions
+
+No files needed.
+
+> **You:** "What Go template functions are available for string manipulation?"
+
+The AI calls `list_go_template_functions` and returns something like:
+
+```
+Here are some Go template functions for string manipulation:
+
+**Sprig Functions:**
+- **upper** — Convert to uppercase
+- **lower** — Convert to lowercase
+- **title** — Convert to title case
+- **trim** / **trimAll** / **trimPrefix** / **trimSuffix** — Trim whitespace or characters
+- **replace** — Replace occurrences of a substring
+- **camelcase** / **snakecase** / **kebabcase** — Case conversions
+- **contains** / **hasPrefix** / **hasSuffix** — String tests
+
+**Custom Functions:**
+- **toHcl** — Convert a Go object to HCL format
+- **toYaml** — Encode a Go value as a YAML string
+- **fromYaml** — Decode a YAML string into a map
+- **mustToYaml** — Same as toYaml (errors propagate in Go templates)
+- **mustFromYaml** — Same as fromYaml (errors propagate in Go templates)
+
+Use `evaluate_go_template` to test any of these interactively.
+```
+
+You can also filter to specific categories:
+
+> **You:** "List only the custom Go template functions"
+
+The AI calls `list_go_template_functions` with `custom_only: true` and returns the custom scafctl functions.
+
 ### Browse the Catalog
 
 This tool queries your local catalog. If you haven't added solutions to the catalog yet, the result will be empty.
@@ -615,6 +652,7 @@ The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"`
 | `inspect_solution` | Full solution metadata — resolvers, actions, tags, links, maintainers |
 | `lint_solution` | Validate a solution YAML file and return structured findings |
 | `list_cel_functions` | List CEL functions — custom scafctl functions, built-in, or by name |
+| `list_go_template_functions` | List Go template extension functions — Sprig, custom, or by name |
 | `list_examples` | List available scafctl example files with category filtering (solutions, resolvers, actions, providers, etc.) |
 | `list_providers` | List all providers with capability and category filtering |
 | `list_solutions` | List solutions from the local catalog with name filtering |

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -165,9 +165,19 @@ region: us-west-2
 ```
 
 Run with the file:
+{{< tabs "resolver-param-file" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run resolver -f greet.yaml -r @params.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Wrap @file in single quotes to avoid splatting operator
+scafctl run resolver -f greet.yaml -r '@params.yaml'
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Output:
 
@@ -1092,7 +1102,15 @@ Bob was filtered out of `parsed_data` because `active` was `false`. The `raw_dat
 
 When a resolver produces an array, the `transform.with.forEach` clause processes each element independently and collects results back into an array:
 
+Save this as `foreach-demo.yaml`:
+
 ```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: foreach-demo
+  version: 1.0.0
+
 spec:
   resolvers:
     doubled:
@@ -1114,9 +1132,18 @@ spec:
 
 Run it to see the result:
 
+{{< tabs "resolver-foreach-run" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl run resolver -f solution.yaml --resolver doubled -o json
+scafctl run resolver doubled -f foreach-demo.yaml -o json
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run resolver doubled -f foreach-demo.yaml -o json
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Filtering with `when` and `forEach`
 
@@ -1150,7 +1177,15 @@ forEach:
 
 For resolvers that produce arrays by resolving each element individually, use `forEach` directly in the `resolve` phase. This is useful when you want to iterate over an existing array and resolve a value for each item using provider logic or `when` conditions:
 
+Save this as `foreach-filter-demo.yaml`:
+
 ```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: foreach-filter-demo
+  version: 1.0.0
+
 spec:
   resolvers:
     allUsers:
@@ -1197,7 +1232,12 @@ With `filter: true` the output contains only matched items:
 Run it:
 
 ```bash
-scafctl run resolver -f solution.yaml --resolver activeUsers -o json
+scafctl run resolver activeUsers -f foreach-filter-demo.yaml -o json
+```
+
+```powershell
+# PowerShell
+scafctl run resolver activeUsers -f foreach-filter-demo.yaml -o json
 ```
 
 #### `filter` vs `keepSkipped`

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -125,9 +125,19 @@ headers:
 
 ### Run with File Input
 
+{{< tabs "runprov-file-input" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run provider http --input @inputs.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Wrap @file in single quotes to avoid splatting operator
+scafctl run provider http --input '@inputs.yaml'
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Output:
 
@@ -147,9 +157,18 @@ File and inline inputs are merged. When the same key appears in both,
 the values are combined into an array. To override a file value, omit
 that key from the file:
 
+{{< tabs "runprov-mixed-input" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run provider http --input @inputs.yaml --input timeout=30
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run provider http --input '@inputs.yaml' --input timeout=30
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 This loads all values from `inputs.yaml` and adds `timeout=30`.
 
@@ -218,17 +237,35 @@ scafctl run provider static --input value=hello -o quiet
 
 Explore complex output in an interactive TUI:
 
+{{< tabs "runprov-interactive" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl run provider http --input url=https://api.example.com -i
+scafctl run provider http --input url=https://httpbin.org/get -i
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run provider http --input url=https://httpbin.org/get -i
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### CEL Expressions
 
 Filter or transform output using CEL expressions:
 
+{{< tabs "runprov-cel-expr" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl run provider http --input url=https://api.example.com -e "_.data"
+scafctl run provider http --input url=https://httpbin.org/get -e "_.data"
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run provider http --input url=https://httpbin.org/get -e '_.data'
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Execution Metrics
 

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -457,11 +457,22 @@ Statistics:
 
 ### Graphviz DOT Format
 
+> **Prerequisite:** Requires [Graphviz](https://graphviz.org/) (`dot` command) to be installed.
+
 Generate DOT output and pipe it to Graphviz for a visual diagram:
 
+{{< tabs "runres-graph-dot" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run resolver --graph --graph-format=dot -f dep-demo.yaml | dot -Tpng > graph.png
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run resolver --graph --graph-format=dot -f dep-demo.yaml | dot -Tpng -o graph.png
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Mermaid Format
 
@@ -475,9 +486,20 @@ scafctl run resolver --graph --graph-format=mermaid -f dep-demo.yaml
 
 Get the graph as structured JSON for programmatic analysis:
 
+{{< tabs "runres-graph-json" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq .
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | ConvertFrom-Json
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+> **Bash users:** The above command uses [jq](https://jqlang.github.io/jq/), a command-line JSON processor. Install it separately if not already available.
 
 The JSON output includes:
 - **nodes**: List of resolvers with name, type, phase, provider, and conditional flag
@@ -508,6 +530,10 @@ The **providerSummary** shows per-provider statistics: resolver count, total dur
 
 The `dependencyGraph` in `__execution` includes a `diagrams` field with pre-rendered ASCII, DOT, and Mermaid representations. Use the `-e` flag (CEL expression) to extract a specific diagram:
 
+> **Prerequisite:** The DOT diagram commands below require [Graphviz](https://graphviz.org/) to be installed.
+
+{{< tabs "runres-extract-diagrams" >}}
+{{< tab "Bash" >}}
 ```bash
 # Extract the Mermaid diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.mermaid'
@@ -518,14 +544,38 @@ scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.
 # Extract the ASCII diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.ascii'
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+# Extract the Mermaid diagram
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.mermaid'
+
+# Extract the DOT diagram and render with Graphviz
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.dot' | dot -Tpng -o graph.png
+
+# Extract the ASCII diagram
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.ascii'
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 You can also extract diagrams when running only specific resolvers:
 
+{{< tabs "runres-extract-subset" >}}
+{{< tab "Bash" >}}
 ```bash
-# Get the Mermaid diagram for just log_level and health_check_endpoints (and their deps)
-scafctl run resolver log_level health_check_endpoints -f solution.yaml -o json \
+# Get the Mermaid diagram for just endpoint and unrelated (and their deps)
+scafctl run resolver endpoint unrelated -f dep-demo.yaml -o json \
   -e '_.__execution.dependencyGraph.diagrams.mermaid'
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run resolver endpoint unrelated -f dep-demo.yaml -o json `
+  -e '_.__execution.dependencyGraph.diagrams.mermaid'
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 This is useful for generating focused dependency visualizations of a resolver subset without rendering the full solution graph.
 
@@ -605,9 +655,18 @@ A common debugging workflow is to inspect how resolver dependencies cascade.
 
 ### Step 1: Visualize the Graph
 
+{{< tabs "runres-debug-graph" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl resolver graph -f dep-demo.yaml
+scafctl render solution --graph -f dep-demo.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl render solution --graph -f dep-demo.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Step 2: Run Target Resolver
 
@@ -629,6 +688,8 @@ This lets you progressively narrow down which resolver is producing unexpected o
 
 Pass parameters using `-r` flags, just like with `run solution`:
 
+{{< tabs "runres-params" >}}
+{{< tab "Bash" >}}
 ```bash
 # Key-value parameter
 scafctl run resolver -f parameterized.yaml -r env=staging
@@ -639,6 +700,19 @@ scafctl run resolver -f parameterized.yaml -r @params.yaml
 # Multiple parameters
 scafctl run resolver -f parameterized.yaml -r env=prod -r region=us-east1
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run resolver -f parameterized.yaml -r env=staging
+
+# Load parameters from file — wrap @file in single quotes to avoid splatting operator
+scafctl run resolver -f parameterized.yaml -r '@params.yaml'
+
+# Multiple parameters
+scafctl run resolver -f parameterized.yaml -r env=prod -r region=us-east1
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Example with Parameter Provider
 

--- a/docs/tutorials/scaffolding-tutorial.md
+++ b/docs/tutorials/scaffolding-tutorial.md
@@ -39,15 +39,33 @@ This generates a valid solution file with:
 
 Immediately validate the generated file:
 
+{{< tabs "scaffolding-lint-verify" >}}
+{{< tab "Bash" >}}
 ```bash
-scafctl eval validate -f my-app.yaml
+scafctl lint -f my-app.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl lint -f my-app.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Run it:
 
+{{< tabs "scaffolding-run-solution" >}}
+{{< tab "Bash" >}}
 ```bash
 scafctl run solution -f my-app.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl run solution -f my-app.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## 2. Choosing Providers
 
@@ -82,6 +100,8 @@ scafctl get provider http
 
 Instead of scaffolding from scratch, you can also start from an existing example:
 
+{{< tabs "scaffolding-from-examples" >}}
+{{< tab "Bash" >}}
 ```bash
 # Browse available solution examples
 scafctl examples list --category solutions
@@ -90,8 +110,17 @@ scafctl examples list --category solutions
 scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
 
 # Modify and validate
-scafctl eval validate -f my-solution.yaml
+scafctl lint -f my-solution.yaml
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl examples list --category solutions
+scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
+scafctl lint -f my-solution.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 This is useful when you want a more complete starting point with real patterns (parameters, validation, actions, composition).
 
@@ -131,22 +160,31 @@ scafctl new solution \
 
 Once your solution works, add functional tests:
 
+{{< tabs "scaffolding-add-tests" >}}
+{{< tab "Bash" >}}
 ```bash
-# View the testing section that was scaffolded
-scafctl eval validate -f my-solution.yaml
+# Validate the solution
+scafctl lint -f my-solution.yaml
 
 # Use the MCP server to generate test scaffolding (if using AI tools)
 # Or see the Functional Testing Tutorial for manual test writing
 ```
+{{< /tab >}}
+{{< tab "PowerShell" >}}
+```powershell
+scafctl lint -f my-solution.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## 5. Workflow
 
 The recommended scaffolding workflow:
 
 1. **Scaffold** — `scafctl new solution --name my-app --output my-app.yaml`
-2. **Validate** — `scafctl eval validate -f my-app.yaml`
+2. **Lint** — `scafctl lint -f my-app.yaml`
 3. **Edit** — Modify resolvers and actions for your needs
-4. **Lint** — `scafctl lint -f my-app.yaml`
+4. **Lint again** — `scafctl lint -f my-app.yaml`
 5. **Test** — `scafctl run resolver -f my-app.yaml` to verify resolvers
 6. **Run** — `scafctl run solution -f my-app.yaml` for the full workflow
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -136,6 +136,8 @@ Resolvers demonstrate dynamic value computation, validation, and transformation.
 | [identity.yaml](resolvers/identity.yaml) | Authentication identity info (requires auth) | `scafctl run resolver -f examples/resolvers/identity.yaml` |
 | [cel-extensions.yaml](resolvers/cel-extensions.yaml) | All custom CEL extension functions | `scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json` |
 | [cel-transforms.yaml](resolvers/cel-transforms.yaml) | Data transformation patterns with CEL | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o yaml` |
+| [go-template-sprig.yaml](resolvers/go-template-sprig.yaml) | Sprig v3 functions in Go templates | `scafctl run resolver -f examples/resolvers/go-template-sprig.yaml -o json` |
+| [go-template-extensions.yaml](resolvers/go-template-extensions.yaml) | Custom Go template extensions (toHcl, toYaml, fromYaml) | `scafctl run resolver -f examples/resolvers/go-template-extensions.yaml -o json` |
 
 ---
 

--- a/examples/resolvers/go-template-extensions.yaml
+++ b/examples/resolvers/go-template-extensions.yaml
@@ -1,0 +1,289 @@
+# Go Template Extension Functions Example
+# Demonstrates custom Go template extension functions provided by scafctl.
+# Includes toHcl for HCL generation and toYaml/fromYaml/mustToYaml/mustFromYaml
+# for YAML serialization (these were removed from Sprig v3.3.0).
+#
+# The `data` input merges its fields into the root template context.
+# To pass a map to toHcl/toYaml, nest it under a named key (e.g., data.config → .config).
+#
+# Run: scafctl run resolver -f examples/resolvers/go-template-extensions.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/go-template-extensions.yaml -o yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: go-template-extensions-showcase
+  version: 1.0.0
+  description: Demonstrates custom Go template extension functions
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # toHcl - Convert data to HCL format
+    # ─────────────────────────────────────────────
+
+    tohcl_simple_map:
+      description: "toHcl - Simple map to HCL"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-simple
+              template: |
+                {{ toHcl .config }}
+              data:
+                config:
+                  name: my-service
+                  port: 8080
+                  debug: false
+
+    tohcl_nested_map:
+      description: "toHcl - Nested map to HCL"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-nested
+              template: |
+                {{ toHcl .config }}
+              data:
+                config:
+                  name: my-bucket
+                  region: us-east-1
+                  tags:
+                    environment: production
+                    team: platform
+                    project: scafctl
+
+    tohcl_with_list:
+      description: "toHcl - Map with lists"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-list
+              template: |
+                {{ toHcl .config }}
+              data:
+                config:
+                  name: my-app
+                  allowed_origins:
+                    - https://example.com
+                    - https://api.example.com
+
+    tohcl_terraform_resource:
+      description: "toHcl - Generate a Terraform resource block"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-terraform
+              template: |
+                resource "aws_s3_bucket" "main" {
+                  {{ toHcl .config | indent 2 }}
+                }
+              data:
+                config:
+                  bucket: my-app-bucket
+                  acl: private
+                  versioning:
+                    enabled: true
+                  tags:
+                    Name: my-app-bucket
+                    Environment: production
+
+    tohcl_terraform_variable:
+      description: "toHcl - Generate Terraform variable blocks"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-vars
+              template: |
+                {{- range $name, $var := .variables }}
+                variable "{{ $name }}" {
+                  {{ toHcl $var | indent 2 }}
+                }
+                {{ end }}
+              data:
+                variables:
+                  project_name:
+                    description: The name of the project
+                    type: string
+                    default: my-project
+                  environment:
+                    description: The deployment environment
+                    type: string
+                    default: development
+
+    tohcl_complex:
+      description: "toHcl - Complex nested structure"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-complex
+              template: |
+                {{ toHcl .config }}
+              data:
+                config:
+                  ingress:
+                    from_port: 443
+                    to_port: 443
+                    protocol: tcp
+                    cidr_blocks:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                    description: Allow HTTPS
+                  egress:
+                    from_port: 0
+                    to_port: 0
+                    protocol: "-1"
+                    cidr_blocks:
+                      - 0.0.0.0/0
+
+    # ─────────────────────────────────────────────
+    # COMBINED - toHcl with Sprig functions
+    # ─────────────────────────────────────────────
+
+    combined_tohcl_sprig:
+      description: "Combining toHcl with Sprig indent and upper"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: combined
+              template: |
+                # Generated by scafctl
+                # Project: {{ .project | upper }}
+
+                resource "aws_instance" "web" {
+                  {{ toHcl .config | indent 2 }}
+                }
+              data:
+                project: my-service
+                config:
+                  ami: ami-0c55b159cbfafe1f0
+                  instance_type: t3.micro
+                  tags:
+                    Name: web-server
+                    ManagedBy: scafctl
+
+    # ─────────────────────────────────────────────
+    # toYaml - Encode data as YAML
+    # ─────────────────────────────────────────────
+
+    toyaml_simple_map:
+      description: "toYaml - Simple map to YAML"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: toyaml-simple
+              template: |
+                {{ toYaml .config }}
+              data:
+                config:
+                  name: my-service
+                  port: 8080
+                  debug: false
+
+    toyaml_nested_map:
+      description: "toYaml - Nested map to YAML"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: toyaml-nested
+              template: |
+                {{ toYaml .config }}
+              data:
+                config:
+                  name: my-app
+                  server:
+                    host: localhost
+                    port: 443
+                  tags:
+                    environment: production
+                    team: platform
+
+    toyaml_with_indent:
+      description: "toYaml - Combined with Sprig indent"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: toyaml-indent
+              template: |
+                metadata:
+                  labels:
+                    {{ toYaml .labels | indent 4 }}
+              data:
+                labels:
+                  app: my-service
+                  env: production
+                  team: platform
+
+    # ─────────────────────────────────────────────
+    # fromYaml - Parse YAML strings
+    # ─────────────────────────────────────────────
+
+    fromyaml_parse_and_access:
+      description: "fromYaml - Parse YAML and access fields"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: fromyaml-access
+              template: |
+                {{- $config := fromYaml "name: myapp\nport: 8080\nenabled: true" -}}
+                App: {{ $config.name }}, Port: {{ $config.port }}, Enabled: {{ $config.enabled }}
+
+    fromyaml_roundtrip:
+      description: "fromYaml - Round-trip with toYaml"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: fromyaml-roundtrip
+              template: |
+                {{- $original := dict "app" "scafctl" "version" "2.0" -}}
+                {{- $yaml := toYaml $original -}}
+                {{- $decoded := fromYaml $yaml -}}
+                Decoded app={{ $decoded.app }}, version={{ $decoded.version }}
+
+    # ─────────────────────────────────────────────
+    # COMBINED - YAML and HCL together
+    # ─────────────────────────────────────────────
+
+    combined_yaml_hcl:
+      description: "Combining toYaml and toHcl with same data"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: combined-formats
+              template: |
+                # YAML format:
+                {{ toYaml .config }}
+
+                # HCL format:
+                {{ toHcl .config }}
+              data:
+                config:
+                  name: my-service
+                  port: 8080
+                  debug: false

--- a/examples/resolvers/go-template-sprig.yaml
+++ b/examples/resolvers/go-template-sprig.yaml
@@ -1,0 +1,323 @@
+# Go Template Sprig Functions Example
+# Demonstrates Sprig v3 utility functions available in Go templates.
+# Each resolver showcases a different Sprig function category.
+#
+# Run: scafctl run resolver -f examples/resolvers/go-template-sprig.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/go-template-sprig.yaml -o yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: go-template-sprig-showcase
+  version: 1.0.0
+  description: Demonstrates Sprig v3 functions in Go templates
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # STRING - String manipulation functions
+    # ─────────────────────────────────────────────
+
+    string_upper:
+      description: "upper - Convert to uppercase"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-upper
+              template: '{{ "hello world" | upper }}'
+
+    string_lower:
+      description: "lower - Convert to lowercase"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-lower
+              template: '{{ "HELLO WORLD" | lower }}'
+
+    string_title:
+      description: "title - Convert to title case"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-title
+              template: '{{ "hello world from scafctl" | title }}'
+
+    string_camelcase:
+      description: "camelcase - Convert to camelCase"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-camel
+              template: '{{ "my-app-service" | camelcase }}'
+
+    string_snakecase:
+      description: "snakecase - Convert to snake_case"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-snake
+              template: '{{ "MyAppService" | snakecase }}'
+
+    string_kebabcase:
+      description: "kebabcase - Convert to kebab-case"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-kebab
+              template: '{{ "MyAppService" | kebabcase }}'
+
+    string_trunc:
+      description: "trunc - Truncate a string"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-trunc
+              template: '{{ "Hello, World!" | trunc 5 }}'
+
+    string_replace:
+      description: "replace - Replace occurrences"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-replace
+              template: '{{ "hello-world-app" | replace "-" "_" }}'
+
+    string_repeat:
+      description: "repeat - Repeat a string N times"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-repeat
+              template: '{{ "ab" | repeat 3 }}'
+
+    string_trim:
+      description: "trim / trimPrefix / trimSuffix"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: string-trim
+              template: '{{ "  hello  " | trim }}-{{ "hello-world" | trimPrefix "hello-" }}-{{ "app.yaml" | trimSuffix ".yaml" }}'
+
+    # ─────────────────────────────────────────────
+    # DICT - Dictionary/map operations
+    # ─────────────────────────────────────────────
+
+    dict_create:
+      description: "dict - Create a dictionary"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: dict-create
+              template: |
+                {{- $d := dict "name" "Alice" "role" "admin" -}}
+                name={{ $d.name }}, role={{ $d.role }}
+
+    dict_merge:
+      description: "merge - Merge dictionaries (first wins)"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: dict-merge
+              template: |
+                {{- $defaults := dict "port" 3000 "debug" false -}}
+                {{- $overrides := dict "port" 8080 "tls" true -}}
+                {{- $merged := merge $overrides $defaults -}}
+                port={{ $merged.port }}, tls={{ $merged.tls }}, debug={{ $merged.debug }}
+
+    dict_keys:
+      description: "keys - Get dictionary keys"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: dict-keys
+              template: |
+                {{- $d := dict "c" 3 "a" 1 "b" 2 -}}
+                {{- range $k := keys $d | sortAlpha -}}{{ $k }} {{ end }}
+
+    dict_hasKey:
+      description: "hasKey - Check if key exists"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: dict-haskey
+              template: |
+                {{- $d := dict "name" "Alice" -}}
+                has_name={{ hasKey $d "name" }}, has_age={{ hasKey $d "age" }}
+
+    # ─────────────────────────────────────────────
+    # LIST - List operations
+    # ─────────────────────────────────────────────
+
+    list_create:
+      description: "list - Create a list"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: list-create
+              template: |
+                {{- $l := list "alpha" "beta" "gamma" -}}
+                {{- range $l }}{{ . }} {{ end }}
+
+    list_append:
+      description: "append - Append to list"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: list-append
+              template: |
+                {{- $l := list "a" "b" -}}
+                {{- $l = append $l "c" -}}
+                {{- range $l }}{{ . }} {{ end }}
+
+    list_has:
+      description: "has - Check if list contains value"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: list-has
+              template: |
+                {{- $l := list "dev" "staging" "prod" -}}
+                has_prod={{ has "prod" $l }}, has_qa={{ has "qa" $l }}
+
+    list_without:
+      description: "without - Remove items from list"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: list-without
+              template: |
+                {{- $l := list "a" "b" "c" "d" -}}
+                {{- range without $l "b" "d" }}{{ . }} {{ end }}
+
+    list_uniq:
+      description: "uniq - Deduplicate list"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: list-uniq
+              template: |
+                {{- $l := list "a" "b" "a" "c" "b" -}}
+                {{- range uniq $l }}{{ . }} {{ end }}
+
+    # ─────────────────────────────────────────────
+    # MATH - Numeric operations
+    # ─────────────────────────────────────────────
+
+    math_add:
+      description: "add / sub / mul / div - Basic arithmetic"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: math-ops
+              template: 'add={{ add 10 5 }}, sub={{ sub 10 5 }}, mul={{ mul 3 4 }}, div={{ div 20 4 }}'
+
+    math_max_min:
+      description: "max / min - Find extremes"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: math-minmax
+              template: 'max={{ max 10 3 7 }}, min={{ min 10 3 7 }}'
+
+    # ─────────────────────────────────────────────
+    # DEFAULT - Default value handling
+    # ─────────────────────────────────────────────
+
+    default_value:
+      description: "default - Provide fallback values"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: default-val
+              template: |
+                {{- $empty := "" -}}
+                {{- $present := "hello" -}}
+                empty={{ $empty | default "fallback" }}, present={{ $present | default "fallback" }}
+
+    # ─────────────────────────────────────────────
+    # ENCODING - Base64 and other encoding
+    # ─────────────────────────────────────────────
+
+    encoding_base64:
+      description: "b64enc / b64dec - Base64 encode/decode"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: encoding-b64
+              template: |
+                {{- $encoded := "Hello, World!" | b64enc -}}
+                encoded={{ $encoded }}, decoded={{ $encoded | b64dec }}
+
+    # ─────────────────────────────────────────────
+    # TYPE CONVERSION - Type casting
+    # ─────────────────────────────────────────────
+
+    type_conversion:
+      description: "toString / toInt / toBool - Type conversions"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: type-conv
+              template: 'int={{ "42" | atoi }}, string={{ 42 | toString }}'
+
+    # ─────────────────────────────────────────────
+    # CHAINED - Combining multiple Sprig functions
+    # ─────────────────────────────────────────────
+
+    chained_pipeline:
+      description: "Chaining multiple Sprig functions in a pipeline"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: chained
+              template: '{{ "  My App Service  " | trim | kebabcase | lower }}'

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.0-rc.2
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/adrg/xdg v0.5.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
@@ -68,6 +69,8 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	charm.land/bubbles/v2 v2.0.0-rc.1 // indirect
 	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106192539-4b304240aab7 // indirect
+	dario.cat/mergo v1.0.1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
@@ -115,6 +118,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -127,7 +131,9 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
@@ -145,6 +151,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,16 @@ al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeX
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
+github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -189,6 +195,8 @@ github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGb
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
+github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
@@ -232,8 +240,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjcQQaQ=
 github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -299,6 +311,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -144,6 +144,12 @@ type ExtFunction struct {
 	Custom        bool            `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
+// GetName returns the function name, implementing the named interface
+// for use with generic filter helpers.
+func (f ExtFunction) GetName() string {
+	return f.Name
+}
+
 type Example struct {
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Expression  string   `json:"expression,omitempty" yaml:"expression,omitempty"`

--- a/pkg/cmd/scafctl/get/get.go
+++ b/pkg/cmd/scafctl/get/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/authhandler"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/gotmplfunction"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/provider"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/solution"
@@ -28,5 +29,6 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 	cCmd.AddCommand(solution.CommandSolution(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(resolver.CommandResolver(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(celfunction.CommandCelFunction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(gotmplfunction.CommandGotmplFunction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	return cCmd
 }

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -1,0 +1,331 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmplfunction
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	gotmpldetail "github.com/oakwood-commons/scafctl/pkg/gotmpl/detail"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// Options holds configuration for the get go-template-functions command
+type Options struct {
+	IOStreams *terminal.IOStreams
+	CliParams *settings.Run
+
+	// kvx output integration
+	flags.KvxOutputFlags
+
+	// Filter options
+	Custom bool // Show only custom (scafctl-specific) functions
+	Sprig  bool // Show only sprig library functions
+
+	// For dependency injection in tests
+	allFn    func() gotmpl.ExtFunctionList
+	customFn func() gotmpl.ExtFunctionList
+	sprigFn  func() gotmpl.ExtFunctionList
+}
+
+// CommandGotmplFunction creates the 'get go-template-functions' subcommand
+func CommandGotmplFunction(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	options := &Options{}
+
+	cCmd := &cobra.Command{
+		Use:     "go-template-functions",
+		Aliases: []string{"gotmpl-funcs", "gotmpl", "gtf"},
+		Short:   "List available Go template extension functions",
+		Long: `List all available Go template extension functions, including sprig
+library functions and custom scafctl-specific functions.
+
+By default, lists all functions. Use --custom or --sprig to filter.
+
+OUTPUT FORMATS:
+  table     Table view with key information (default)
+  json      Full function information as JSON
+  yaml      Full function information as YAML
+  quiet     Function names only (one per line)
+
+Examples:
+  # List all Go template functions
+  scafctl get go-template-functions
+
+  # List only custom scafctl functions
+  scafctl get go-template-functions --custom
+
+  # List only sprig library functions
+  scafctl get go-template-functions --sprig
+
+  # Output as JSON
+  scafctl get go-template-functions -o json
+
+  # Get details about a specific function
+  scafctl get go-template-functions toHcl
+
+  # Browse interactively
+  scafctl get go-template-functions -i`,
+		RunE: func(cCmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			ctx := settings.IntoContext(context.Background(), cliParams)
+
+			options.IOStreams = ioStreams
+			options.CliParams = cliParams
+
+			if len(args) > 0 {
+				return options.RunGetFunction(ctx, args[0])
+			}
+			return options.RunListFunctions(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	// Add output flags
+	validFormats := []string{"table", "json", "yaml", "quiet"}
+	cCmd.Flags().StringVarP(&options.Output, "output", "o", "",
+		fmt.Sprintf("Output format: %s", strings.Join(validFormats, ", ")))
+	cCmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", false,
+		"Launch interactive TUI for browsing functions")
+	cCmd.Flags().StringVarP(&options.Expression, "expression", "e", "",
+		"CEL expression to filter/transform output data")
+
+	// Filter flags
+	cCmd.Flags().BoolVar(&options.Custom, "custom", false, "Show only custom scafctl functions")
+	cCmd.Flags().BoolVar(&options.Sprig, "sprig", false, "Show only sprig library functions")
+
+	return cCmd
+}
+
+// getFunctions returns the appropriate function list based on flags
+func (o *Options) getFunctions() gotmpl.ExtFunctionList {
+	allFn := gotmplext.All
+	customFn := gotmplext.Custom
+	sprigFn := gotmplext.Sprig
+
+	// Allow test injection
+	if o.allFn != nil {
+		allFn = o.allFn
+	}
+	if o.customFn != nil {
+		customFn = o.customFn
+	}
+	if o.sprigFn != nil {
+		sprigFn = o.sprigFn
+	}
+
+	switch {
+	case o.Custom:
+		return customFn()
+	case o.Sprig:
+		return sprigFn()
+	default:
+		return allFn()
+	}
+}
+
+// RunListFunctions lists all Go template extension functions
+func (o *Options) RunListFunctions(ctx context.Context) error {
+	funcs := o.getFunctions()
+
+	// Interactive mode
+	if o.Interactive {
+		if !kvx.IsTerminal(o.IOStreams.Out) {
+			err := fmt.Errorf("interactive mode requires a terminal")
+			if w := writer.FromContext(ctx); w != nil {
+				w.Errorf("%v", err)
+			}
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	}
+
+	// Default (no -o flag): simple list
+	if o.Output == "" && !o.Interactive {
+		return o.printSimpleList(funcs)
+	}
+
+	// Build output data
+	output := gotmpldetail.BuildFunctionList(funcs)
+
+	return o.writeOutput(ctx, output)
+}
+
+// RunGetFunction gets details about a specific function
+func (o *Options) RunGetFunction(ctx context.Context, name string) error {
+	funcs := o.getFunctions()
+
+	// Find the function by name (case-insensitive)
+	var found *gotmpl.ExtFunction
+	for i := range funcs {
+		if strings.EqualFold(funcs[i].Name, name) {
+			found = &funcs[i]
+			break
+		}
+	}
+
+	if found == nil {
+		err := fmt.Errorf("go template function %q not found", name)
+		if w := writer.FromContext(ctx); w != nil {
+			w.Errorf("%v", err)
+		}
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	// Default: custom formatted view
+	if o.Output == "" && !o.Interactive {
+		return o.printFunctionDetail(found)
+	}
+
+	output := gotmpldetail.BuildFunctionDetail(found)
+	return o.writeOutput(ctx, output)
+}
+
+// printSimpleList prints a simple list of function names and descriptions
+func (o *Options) printSimpleList(funcs gotmpl.ExtFunctionList) error {
+	out := o.IOStreams.Out
+	noColor := o.CliParams.NoColor
+
+	for _, fn := range funcs {
+		name := fn.Name
+		if !noColor {
+			if fn.Custom {
+				name = "\033[1;32m" + name + "\033[0m" // Bold green for custom
+			} else {
+				name = "\033[1;94m" + name + "\033[0m" // Bold blue for sprig
+			}
+		}
+
+		desc := fn.Description
+		if len(desc) > 80 {
+			desc = desc[:77] + "..."
+		}
+		fmt.Fprintf(out, "  %s\n", name)
+		if desc != "" {
+			dimDesc := desc
+			if !noColor {
+				dimDesc = "\033[2m" + desc + "\033[0m"
+			}
+			fmt.Fprintf(out, "    %s\n", dimDesc)
+		}
+	}
+	return nil
+}
+
+// printFunctionDetail prints a nicely formatted function detail view
+func (o *Options) printFunctionDetail(fn *gotmpl.ExtFunction) error {
+	out := o.IOStreams.Out
+	noColor := o.CliParams.NoColor
+
+	keyStyle := func(s string) string {
+		if noColor {
+			return s
+		}
+		return "\033[1;94m" + s + "\033[0m"
+	}
+	dimStyle := func(s string) string {
+		if noColor {
+			return s
+		}
+		return "\033[2m" + s + "\033[0m"
+	}
+	tagStyle := func(s string) string {
+		if noColor {
+			return "[" + s + "]"
+		}
+		return "\033[38;5;85;48;5;235m " + s + " \033[0m"
+	}
+
+	// Name and type
+	fmt.Fprintf(out, "%s %s", keyStyle("Name:"), fn.Name)
+	if fn.Custom {
+		fmt.Fprintf(out, " %s", tagStyle("custom"))
+	} else {
+		fmt.Fprintf(out, " %s", tagStyle("sprig"))
+	}
+	fmt.Fprintln(out)
+
+	// Description
+	if fn.Description != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Description:"))
+		fmt.Fprintf(out, "  %s\n", fn.Description)
+	}
+
+	// Examples
+	if len(fn.Examples) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Examples:"))
+		for _, ex := range fn.Examples {
+			if ex.Description != "" {
+				fmt.Fprintf(out, "  %s\n", dimStyle(ex.Description))
+			}
+			if ex.Template != "" {
+				fmt.Fprintf(out, "    %s\n", ex.Template)
+			}
+		}
+	}
+
+	// Links
+	if len(fn.Links) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", keyStyle("Links:"))
+		for _, link := range fn.Links {
+			fmt.Fprintf(out, "  %s\n", link)
+		}
+	}
+
+	return nil
+}
+
+// writeOutput writes the output using kvx
+func (o *Options) writeOutput(ctx context.Context, data any) error {
+	if o.Output == "quiet" {
+		return o.writeQuietOutput(data)
+	}
+
+	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
+		o.Output,
+		o.Interactive,
+		o.Expression,
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName("scafctl get go-template-functions"),
+		kvx.WithOutputHelp("scafctl get go-template-functions", []string{
+			"Go Template Extension Functions Viewer",
+			"",
+			"Navigate: ↑↓ arrows | Back: ← | Enter: →",
+			"Search: / or F3 | Expression: F6",
+			"Copy path: F5 | Quit: q or F10",
+		}),
+	)
+	kvxOpts.IOStreams = o.IOStreams
+
+	return kvxOpts.Write(data)
+}
+
+// writeQuietOutput prints just the function names
+func (o *Options) writeQuietOutput(data any) error {
+	switch v := data.(type) {
+	case []map[string]any:
+		for _, item := range v {
+			if name, ok := item["name"].(string); ok {
+				fmt.Fprintln(o.IOStreams.Out, name)
+			}
+		}
+	case map[string]any:
+		if name, ok := v["name"].(string); ok {
+			fmt.Fprintln(o.IOStreams.Out, name)
+		}
+	}
+	return nil
+}

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -12,6 +12,8 @@ The `gotmpl` package provides a service-oriented wrapper around Go's standard `t
 - **Context Integration**: Full context support for logging and cancellation
 - **Structured Logging**: Detailed logging at multiple verbosity levels
 - **Reference Extraction**: Extract data field references from templates for dependency analysis
+- **Sprig Functions**: 100+ built-in utility functions via [Masterminds/sprig](https://masterminds.github.io/sprig/)
+- **Extension System**: Pluggable architecture for custom Go template functions (see `ext/` sub-packages)
 
 ## Installation
 
@@ -510,6 +512,196 @@ For high-performance scenarios:
 - Minimize replacements (only protect necessary strings)
 - Disable verbose logging in production
 - Consider caching parsed templates externally if needed
+
+## Extensions
+
+The `gotmpl/ext` package provides an extension system for registering additional template functions, mirroring the pattern in `pkg/celexp/ext`. Extensions are automatically available to all template executions via `NewService()` and `Execute()`.
+
+### Built-in Extensions
+
+#### Sprig Functions
+
+Over 100 utility functions from [Masterminds/sprig v3](https://masterminds.github.io/sprig/) are automatically available in all templates:
+
+```go
+// String functions
+{{ "hello" | upper }}        // "HELLO"
+{{ "HELLO" | lower }}        // "hello"
+{{ "  hello  " | trim }}     // "hello"
+{{ "hello" | repeat 3 }}     // "hellohellohello"
+
+// Data format functions
+{{ dict "key" "value" | toJson }}           // {"key":"value"}
+{{ dict "key" "value" | toPrettyJson }}     // formatted JSON
+
+// Math functions
+{{ add 1 2 }}                // 3
+{{ max 5 3 }}                // 5
+
+// Date functions
+{{ now | date "2006-01-02" }}  // today's date
+
+// List functions
+{{ list 1 2 3 | join "," }}    // "1,2,3"
+```
+
+See the [sprig documentation](https://masterminds.github.io/sprig/) for the full list.
+
+#### Custom Extensions
+
+##### toHcl
+
+Converts a Go object into HCL (HashiCorp Configuration Language) format:
+
+```go
+{{ dict "name" "myapp" "port" 8080 | toHcl }}
+// Output:
+// name = "myapp"
+// port = 8080
+
+// Nested objects become HCL blocks:
+{{ dict "server" (dict "host" "localhost" "port" 443) | toHcl }}
+// Output:
+// server {
+//   host = "localhost"
+//   port = 443
+// }
+```
+
+##### toYaml
+
+Encodes a Go value as a YAML string:
+
+```go
+{{ dict "name" "myapp" "port" 8080 | toYaml }}
+// Output:
+// name: myapp
+// port: 8080
+
+// Combined with indent for nested YAML:
+{{ .config | toYaml | indent 4 }}
+```
+
+##### fromYaml
+
+Decodes a YAML string into a `map[string]any`:
+
+```go
+{{ $parsed := fromYaml "name: myapp\nport: 8080" }}
+{{ $parsed.name }}  // "myapp"
+{{ $parsed.port }}  // 8080
+```
+
+##### mustToYaml / mustFromYaml
+
+Identical to `toYaml` and `fromYaml` respectively. In Go templates, errors always propagate, so behavior is the same. These exist for Helm naming convention compatibility.
+
+### Discovering Available Functions
+
+#### CLI
+
+```bash
+# List all available functions
+scafctl get go-template-functions
+
+# List only custom (non-sprig) functions
+scafctl get go-template-functions --custom
+
+# List only sprig functions
+scafctl get go-template-functions --sprig
+
+# Get details for a specific function
+scafctl get go-template-functions toHcl
+
+# Output as JSON
+scafctl get go-template-functions -o json
+```
+
+#### MCP Server
+
+The `list_go_template_functions` MCP tool exposes the same information:
+
+| Parameter     | Description                      |
+|---------------|----------------------------------|
+| `name`        | Filter by function name (substring match) |
+| `custom_only` | Show only custom extensions      |
+| `sprig_only`  | Show only sprig functions        |
+
+### Adding New Extensions
+
+To add a new custom template function:
+
+1. **Create a sub-package** under `pkg/gotmpl/ext/` (e.g., `ext/myfunc/`):
+
+```go
+package myfunc
+
+import (
+    "github.com/oakwood-commons/scafctl/pkg/gotmpl"
+    "text/template"
+)
+
+func MyFunc(input string) (string, error) {
+    // implementation
+    return result, nil
+}
+
+func MyFuncDef() gotmpl.ExtFunction {
+    return gotmpl.ExtFunction{
+        Name:        "myFunc",
+        Description: "Describes what myFunc does",
+        Custom:      true,
+        Links: []string{
+            "https://example.com/docs",
+        },
+        Examples: []gotmpl.Example{
+            {
+                Description: "Basic usage",
+                Template:    `{{ "input" | myFunc }}`,
+            },
+        },
+        Func: template.FuncMap{
+            "myFunc": MyFunc,
+        },
+    }
+}
+```
+
+2. **Register in the extension registry** (`pkg/gotmpl/ext/ext.go`):
+
+```go
+func Custom() gotmpl.ExtFunctionList {
+    return gotmpl.ExtFunctionList{
+        hcl.ToHclFunc(),
+        extyaml.ToYamlFunc(),
+        extyaml.FromYamlFunc(),
+        extyaml.MustToYamlFunc(),
+        extyaml.MustFromYamlFunc(),
+        myfunc.MyFuncDef(), // Add here
+    }
+}
+```
+
+3. **Add tests** in `ext/myfunc/myfunc_test.go`
+
+The function will be automatically available in all templates, the MCP server, and the CLI.
+
+### Architecture
+
+Extensions use a factory pattern to avoid import cycles:
+
+```
+cmd/scafctl/scafctl.go
+  └─ gotmpl.SetExtensionFuncMapFactory(gotmplext.AllFuncMap)  // Wire at init
+
+pkg/gotmpl/gotmpl.go
+  └─ NewService() calls factory → gets merged FuncMap
+  └─ Execute() calls NewService(nil) → extensions included automatically
+
+pkg/gotmpl/ext/ext.go
+  └─ All() = Sprig() + Custom()
+  └─ AllFuncMap() merges all into template.FuncMap
+```
 
 ## Related Packages
 

--- a/pkg/gotmpl/detail/detail.go
+++ b/pkg/gotmpl/detail/detail.go
@@ -1,0 +1,53 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package detail provides functions for building structured output
+// representations of Go template extension functions.
+package detail
+
+import (
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// BuildFunctionList builds structured output for a list of Go template extension functions.
+func BuildFunctionList(funcs gotmpl.ExtFunctionList) []map[string]any {
+	output := make([]map[string]any, 0, len(funcs))
+	for _, fn := range funcs {
+		output = append(output, BuildFunctionDetail(&fn))
+	}
+	return output
+}
+
+// BuildFunctionDetail builds structured output for a single Go template extension function.
+func BuildFunctionDetail(fn *gotmpl.ExtFunction) map[string]any {
+	m := map[string]any{
+		"name":   fn.Name,
+		"custom": fn.Custom,
+	}
+
+	if fn.Description != "" {
+		m["description"] = fn.Description
+	}
+	if len(fn.Links) > 0 {
+		m["links"] = fn.Links
+	}
+	if len(fn.Examples) > 0 {
+		examples := make([]map[string]any, 0, len(fn.Examples))
+		for _, ex := range fn.Examples {
+			exMap := map[string]any{}
+			if ex.Description != "" {
+				exMap["description"] = ex.Description
+			}
+			if ex.Template != "" {
+				exMap["template"] = ex.Template
+			}
+			if len(ex.Links) > 0 {
+				exMap["links"] = ex.Links
+			}
+			examples = append(examples, exMap)
+		}
+		m["examples"] = examples
+	}
+
+	return m
+}

--- a/pkg/gotmpl/detail/detail_test.go
+++ b/pkg/gotmpl/detail/detail_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package detail
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFunctionDetail_Full(t *testing.T) {
+	fn := gotmpl.ExtFunction{
+		Name:        "toHcl",
+		Description: "Converts to HCL format",
+		Custom:      true,
+		Links:       []string{"https://example.com"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a map",
+				Template:    `{{ .data | toHcl }}`,
+			},
+		},
+	}
+
+	result := BuildFunctionDetail(&fn)
+
+	assert.Equal(t, "toHcl", result["name"])
+	assert.Equal(t, true, result["custom"])
+	assert.Equal(t, "Converts to HCL format", result["description"])
+	assert.Equal(t, []string{"https://example.com"}, result["links"])
+
+	examples, ok := result["examples"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, examples, 1)
+	assert.Equal(t, "Convert a map", examples[0]["description"])
+	assert.Equal(t, `{{ .data | toHcl }}`, examples[0]["template"])
+}
+
+func TestBuildFunctionDetail_Minimal(t *testing.T) {
+	fn := gotmpl.ExtFunction{
+		Name:   "upper",
+		Custom: false,
+	}
+
+	result := BuildFunctionDetail(&fn)
+
+	assert.Equal(t, "upper", result["name"])
+	assert.Equal(t, false, result["custom"])
+	assert.NotContains(t, result, "description")
+	assert.NotContains(t, result, "links")
+	assert.NotContains(t, result, "examples")
+}
+
+func TestBuildFunctionList(t *testing.T) {
+	funcs := gotmpl.ExtFunctionList{
+		{Name: "upper", Custom: false, Description: "To uppercase"},
+		{Name: "toHcl", Custom: true, Description: "Converts to HCL"},
+	}
+
+	result := BuildFunctionList(funcs)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "upper", result[0]["name"])
+	assert.Equal(t, "toHcl", result[1]["name"])
+}
+
+func TestBuildFunctionDetail_WithExampleLinks(t *testing.T) {
+	fn := gotmpl.ExtFunction{
+		Name: "test",
+		Examples: []gotmpl.Example{
+			{
+				Description: "Example with links",
+				Template:    `{{ test }}`,
+				Links:       []string{"https://example.com/doc"},
+			},
+		},
+	}
+
+	result := BuildFunctionDetail(&fn)
+
+	examples, ok := result["examples"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, examples, 1)
+	assert.Equal(t, []string{"https://example.com/doc"}, examples[0]["links"])
+}

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -1,0 +1,337 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ext provides the Go template extension function registry.
+// It aggregates both third-party (sprig) and custom scafctl-specific
+// template functions, making them discoverable via MCP tools and CLI commands.
+//
+// This follows the same pattern as pkg/celexp/ext for CEL extensions.
+package ext
+
+import (
+	"sort"
+	"text/template"
+
+	sprig "github.com/Masterminds/sprig/v3"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/hcl"
+	extyaml "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/yaml"
+)
+
+// Sprig returns a list of ExtFunction entries for all sprig template functions.
+// Each function is wrapped with metadata for discoverability. These are marked
+// as Custom=false since they come from the third-party sprig library.
+//
+// Example usage:
+//
+//	funcs := ext.Sprig()
+//	for _, f := range funcs {
+//	    fmt.Printf("Sprig Function: %s\n", f.Name)
+//	}
+func Sprig() gotmpl.ExtFunctionList {
+	funcMap := sprig.FuncMap()
+
+	// Sort keys for deterministic ordering
+	keys := make([]string, 0, len(funcMap))
+	for k := range funcMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	funcs := make(gotmpl.ExtFunctionList, 0, len(keys))
+	for _, name := range keys {
+		fn := funcMap[name]
+		funcs = append(funcs, gotmpl.ExtFunction{
+			Name:        name,
+			Description: sprigDescription(name),
+			Custom:      false,
+			Links:       []string{"https://masterminds.github.io/sprig/"},
+			Func: template.FuncMap{
+				name: fn,
+			},
+		})
+	}
+
+	return funcs
+}
+
+// Custom returns a list of custom scafctl-specific Go template extension functions.
+// These are functions with Custom=true that extend Go templates with
+// project-specific functionality.
+//
+// Example usage:
+//
+//	funcs := ext.Custom()
+//	for _, f := range funcs {
+//	    fmt.Printf("Custom Function: %s (%s)\n", f.Name, f.Description)
+//	}
+func Custom() gotmpl.ExtFunctionList {
+	return gotmpl.ExtFunctionList{
+		// HCL functions
+		hcl.ToHclFunc(),
+
+		// YAML functions (removed from Sprig v3.3.0)
+		extyaml.ToYamlFunc(),
+		extyaml.FromYamlFunc(),
+		extyaml.MustToYamlFunc(),
+		extyaml.MustFromYamlFunc(),
+	}
+}
+
+// All returns a combined list of all Go template extension functions, including
+// both sprig functions and custom scafctl-specific functions.
+// Custom functions are listed after sprig functions so they take precedence
+// when merged into a template.FuncMap.
+//
+// Example usage:
+//
+//	funcs := ext.All()
+//	funcMap := funcs.FuncMap()
+func All() gotmpl.ExtFunctionList {
+	sprigFuncs := Sprig()
+	customFuncs := Custom()
+
+	all := make(gotmpl.ExtFunctionList, 0, len(sprigFuncs)+len(customFuncs))
+	all = append(all, sprigFuncs...)
+	all = append(all, customFuncs...)
+
+	return all
+}
+
+// AllFuncMap is a convenience function that returns a merged template.FuncMap
+// containing all extension functions (sprig + custom).
+func AllFuncMap() template.FuncMap {
+	return All().FuncMap()
+}
+
+// sprigDescription returns a short description for well-known sprig functions.
+// For functions without a specific description, a generic one is returned.
+func sprigDescription(name string) string {
+	descriptions := map[string]string{ //nolint:gosec // G101 false positive: not credentials, these are function descriptions
+		// String functions
+		"trim":                   "Removes leading and trailing whitespace",
+		"trimAll":                "Removes all occurrences of a character from a string",
+		"trimSuffix":             "Removes a suffix from a string",
+		"trimPrefix":             "Removes a prefix from a string",
+		"upper":                  "Converts a string to uppercase",
+		"lower":                  "Converts a string to lowercase",
+		"title":                  "Converts a string to title case",
+		"untitle":                "Removes title casing from a string",
+		"repeat":                 "Repeats a string N times",
+		"substr":                 "Gets a substring",
+		"nospace":                "Removes all whitespace from a string",
+		"trunc":                  "Truncates a string to a given length",
+		"abbrev":                 "Abbreviates a string with ellipses",
+		"abbrevboth":             "Abbreviates both sides of a string",
+		"initials":               "Gets the initials from a string",
+		"randAlphaNum":           "Generates a random alphanumeric string",
+		"randAlpha":              "Generates a random alphabetic string",
+		"randAscii":              "Generates a random ASCII string",
+		"randNumeric":            "Generates a random numeric string",
+		"swapcase":               "Swaps the case of a string",
+		"shuffle":                "Shuffles the characters in a string",
+		"snakecase":              "Converts a string to snake_case",
+		"camelcase":              "Converts a string to camelCase",
+		"kebabcase":              "Converts a string to kebab-case",
+		"wrap":                   "Wraps text at a given column count",
+		"wrapWith":               "Wraps text at a given column with a custom delimiter",
+		"contains":               "Tests if a string contains a substring",
+		"hasPrefix":              "Tests if a string has a given prefix",
+		"hasSuffix":              "Tests if a string has a given suffix",
+		"quote":                  "Wraps a string in double quotes",
+		"squote":                 "Wraps a string in single quotes",
+		"cat":                    "Concatenates multiple strings with spaces",
+		"indent":                 "Indents every line of a string",
+		"nindent":                "Indents every line of a string and prepends a newline",
+		"replace":                "Replaces occurrences of a string",
+		"plural":                 "Pluralizes a string",
+		"sha1sum":                "Generates a SHA-1 hash",
+		"sha256sum":              "Generates a SHA-256 hash",
+		"adler32sum":             "Generates an Adler-32 checksum",
+		"toString":               "Converts a value to a string",
+		"toStrings":              "Converts a list of values to a list of strings",
+		"join":                   "Joins a list of strings with a separator",
+		"splitList":              "Splits a string into a list",
+		"split":                  "Splits a string and returns a map",
+		"splitn":                 "Splits a string with a limit",
+		"regexMatch":             "Tests if a string matches a regular expression",
+		"regexFind":              "Finds the first match of a regex",
+		"regexFindAll":           "Finds all matches of a regex",
+		"regexReplaceAll":        "Replaces all regex matches",
+		"regexReplaceAllLiteral": "Replaces all regex matches with a literal string",
+		"regexSplit":             "Splits a string by a regex",
+		"regexQuoteMeta":         "Quotes regex metacharacters",
+
+		// Math functions
+		"add":     "Adds numbers together",
+		"add1":    "Adds 1 to a number",
+		"sub":     "Subtracts one number from another",
+		"div":     "Divides one number by another (integer division)",
+		"mod":     "Returns the remainder of integer division",
+		"mul":     "Multiplies numbers together",
+		"max":     "Returns the largest of a list of integers",
+		"min":     "Returns the smallest of a list of integers",
+		"floor":   "Returns the greatest integer less than or equal to the value",
+		"ceil":    "Returns the least integer greater than or equal to the value",
+		"round":   "Rounds a float to a given number of decimal places",
+		"len":     "Returns the length of a value",
+		"biggest": "Returns the largest of a list of integers (alias for max)",
+
+		// Integer / conversion
+		"int":       "Converts a value to int",
+		"int64":     "Converts a value to int64",
+		"float64":   "Converts a value to float64",
+		"toDecimal": "Converts a Unix octal to decimal",
+		"atoi":      "Converts a string to an integer",
+		"seq":       "Generates a sequence of integers",
+
+		// Date functions
+		"now":            "Returns the current time",
+		"ago":            "Returns the duration since a time",
+		"date":           "Formats a date",
+		"dateInZone":     "Formats a date in a given timezone",
+		"dateModify":     "Modifies a date by adding a duration",
+		"duration":       "Formats a duration",
+		"durationRound":  "Rounds a duration to the nearest unit",
+		"htmlDate":       "Formats a date for HTML date inputs",
+		"htmlDateInZone": "Formats a date for HTML date inputs with timezone",
+		"unixEpoch":      "Returns the Unix epoch timestamp",
+		"toDate":         "Parses a date string",
+		"mustToDate":     "Parses a date string, returning an error on failure",
+		"mustDateModify": "Modifies a date, returning an error on failure",
+
+		// Default functions
+		"default":          "Returns a default value if the input is empty",
+		"empty":            "Returns true if the value is empty",
+		"coalesce":         "Returns the first non-empty value",
+		"all":              "Returns true if all values are non-empty",
+		"any":              "Returns true if any value is non-empty",
+		"compact":          "Removes empty values from a list",
+		"ternary":          "Returns one of two values based on a boolean",
+		"fromJson":         "Decodes a JSON string into an object",
+		"toJson":           "Encodes a value as a JSON string",
+		"toPrettyJson":     "Encodes a value as a pretty-printed JSON string",
+		"toRawJson":        "Encodes a value as a raw JSON string (no HTML escaping)",
+		"mustFromJson":     "Decodes JSON, returning an error on failure",
+		"mustToJson":       "Encodes to JSON, returning an error on failure",
+		"mustToPrettyJson": "Encodes to pretty JSON, returning an error on failure",
+		"mustToRawJson":    "Encodes to raw JSON, returning an error on failure",
+
+		// Encoding functions
+		"b64enc": "Encodes a string to base64",
+		"b64dec": "Decodes a base64 string",
+		"b32enc": "Encodes a string to base32",
+		"b32dec": "Decodes a base32 string",
+
+		// List functions
+		"list":        "Creates a list from arguments",
+		"first":       "Returns the first element of a list",
+		"rest":        "Returns all but the first element of a list",
+		"last":        "Returns the last element of a list",
+		"initial":     "Returns all but the last element of a list",
+		"append":      "Appends an element to a list",
+		"prepend":     "Prepends an element to a list",
+		"concat":      "Concatenates lists",
+		"reverse":     "Reverses a list",
+		"uniq":        "Removes duplicates from a list",
+		"without":     "Removes elements from a list",
+		"has":         "Tests if a list contains an element",
+		"slice":       "Returns a slice of a list",
+		"until":       "Generates a list of integers from 0 to N-1",
+		"untilStep":   "Generates a list of integers with a step",
+		"sortAlpha":   "Sorts a list of strings alphabetically",
+		"chunk":       "Splits a list into chunks of a given size",
+		"mustAppend":  "Appends to a list, returning an error on failure",
+		"mustPrepend": "Prepends to a list, returning an error on failure",
+		"mustFirst":   "Returns the first element, returning an error on empty list",
+		"mustLast":    "Returns the last element, returning an error on empty list",
+		"mustInitial": "Returns all but the last, returning an error on empty list",
+		"mustRest":    "Returns all but the first, returning an error on empty list",
+		"mustReverse": "Reverses a list, returning an error on failure",
+		"mustSlice":   "Returns a slice, returning an error on failure",
+		"mustCompact": "Removes empty values, returning an error on failure",
+		"mustUniq":    "Removes duplicates, returning an error on failure",
+		"mustWithout": "Removes elements, returning an error on failure",
+		"mustHas":     "Tests containment, returning an error on failure",
+		"mustChunk":   "Splits into chunks, returning an error on failure",
+
+		// Dict functions
+		"dict":               "Creates a new dictionary (map)",
+		"get":                "Gets a value from a dictionary",
+		"set":                "Sets a value in a dictionary",
+		"unset":              "Removes a key from a dictionary",
+		"hasKey":             "Tests if a dictionary has a key",
+		"pluck":              "Extracts values for a key from a list of dictionaries",
+		"keys":               "Returns the keys of a dictionary",
+		"values":             "Returns the values of a dictionary",
+		"pick":               "Creates a new dictionary with only the specified keys",
+		"omit":               "Creates a new dictionary without the specified keys",
+		"merge":              "Merges two or more dictionaries",
+		"mergeOverwrite":     "Merges dictionaries, overwriting existing keys",
+		"mustMerge":          "Merges dictionaries, returning an error on failure",
+		"mustMergeOverwrite": "Merges with overwrite, returning an error on failure",
+		"dig":                "Traverses a nested dictionary by path",
+		"deepCopy":           "Creates a deep copy of an object",
+		"mustDeepCopy":       "Creates a deep copy, returning an error on failure",
+
+		// Type testing
+		"kindOf":     "Returns the kind of a value",
+		"kindIs":     "Tests if a value has a specific kind",
+		"typeOf":     "Returns the type of a value",
+		"typeIs":     "Tests if a value has a specific type",
+		"typeIsLike": "Tests if a value has a type similar to a given type",
+		"deepEqual":  "Tests deep equality of two values",
+
+		// Crypto functions
+		"genPrivateKey":            "Generates a private key (RSA, DSA, ECDSA)",
+		"derivePassword":           "Derives a password from a master password",
+		"buildCustomCert":          "Builds a custom TLS certificate",
+		"genCA":                    "Generates a Certificate Authority",
+		"genCAWithKey":             "Generates a CA with a given key",
+		"genSelfSignedCert":        "Generates a self-signed certificate",
+		"genSelfSignedCertWithKey": "Generates a self-signed certificate with a given key",
+		"genSignedCert":            "Generates a signed certificate",
+		"genSignedCertWithKey":     "Generates a signed certificate with a given key",
+		"encryptAES":               "Encrypts a string with AES-CBC",
+		"decryptAES":               "Decrypts an AES-CBC encrypted string",
+		"htpasswd":                 "Generates an Apache htpasswd hash",
+		"bcrypt":                   "Generates a bcrypt hash",
+
+		// UUID
+		"uuidv4": "Generates a UUID v4",
+
+		// OS / environment
+		"env":       "Reads an environment variable",
+		"expandenv": "Expands environment variables in a string",
+
+		// Path functions
+		"base":    "Returns the last element of a path",
+		"dir":     "Returns the directory portion of a path",
+		"ext":     "Returns the file extension",
+		"clean":   "Cleans a path",
+		"isAbs":   "Tests if a path is absolute",
+		"osBase":  "Returns the last element of a path (OS-specific)",
+		"osDir":   "Returns the directory portion of a path (OS-specific)",
+		"osExt":   "Returns the file extension (OS-specific)",
+		"osClean": "Cleans a path (OS-specific)",
+		"osIsAbs": "Tests if a path is absolute (OS-specific)",
+
+		// Semver
+		"semver":        "Parses a semantic version string",
+		"semverCompare": "Compares two semantic versions",
+
+		// Flow / URL
+		"fail":     "Causes the template to fail with an error message",
+		"urlParse": "Parses a URL string",
+		"urlJoin":  "Joins URL components",
+
+		// Network
+		"getHostByName": "Resolves a hostname to an IP address",
+	}
+
+	if desc, ok := descriptions[name]; ok {
+		return desc
+	}
+
+	return "Sprig template function"
+}

--- a/pkg/gotmpl/ext/ext_test.go
+++ b/pkg/gotmpl/ext/ext_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAll_ContainsSprigAndCustom(t *testing.T) {
+	all := All()
+	funcMap := all.FuncMap()
+
+	// Should contain sprig functions
+	assert.Contains(t, funcMap, "upper")
+	assert.Contains(t, funcMap, "lower")
+	assert.Contains(t, funcMap, "toJson")
+	assert.Contains(t, funcMap, "dict")
+	assert.Contains(t, funcMap, "trim")
+
+	// Should contain custom functions
+	assert.Contains(t, funcMap, "toHcl")
+	assert.Contains(t, funcMap, "toYaml")
+	assert.Contains(t, funcMap, "fromYaml")
+	assert.Contains(t, funcMap, "mustToYaml")
+	assert.Contains(t, funcMap, "mustFromYaml")
+}
+
+func TestSprig_ReturnsSprigFunctions(t *testing.T) {
+	funcs := Sprig()
+
+	require.NotEmpty(t, funcs)
+
+	// Verify non-custom flag
+	for _, fn := range funcs {
+		assert.False(t, fn.Custom, "sprig function %q should have Custom=false", fn.Name)
+		assert.NotEmpty(t, fn.Name, "function name should not be empty")
+		assert.NotNil(t, fn.Func, "function map should not be nil for %q", fn.Name)
+		assert.NotEmpty(t, fn.Links, "links should not be empty for %q", fn.Name)
+	}
+
+	// Check a known function exists
+	found := false
+	for _, fn := range funcs {
+		if fn.Name == "upper" {
+			found = true
+			assert.Equal(t, "Converts a string to uppercase", fn.Description)
+			break
+		}
+	}
+	assert.True(t, found, "should find 'upper' in sprig functions")
+}
+
+func TestCustom_ReturnsCustomFunctions(t *testing.T) {
+	funcs := Custom()
+
+	require.NotEmpty(t, funcs)
+
+	// Verify custom flag
+	for _, fn := range funcs {
+		assert.True(t, fn.Custom, "custom function %q should have Custom=true", fn.Name)
+		assert.NotEmpty(t, fn.Name, "function name should not be empty")
+		assert.NotNil(t, fn.Func, "function map should not be nil for %q", fn.Name)
+	}
+
+	// Check toHcl exists
+	found := false
+	for _, fn := range funcs {
+		if fn.Name == "toHcl" {
+			found = true
+			assert.NotEmpty(t, fn.Description)
+			assert.NotEmpty(t, fn.Examples)
+			break
+		}
+	}
+	assert.True(t, found, "should find 'toHcl' in custom functions")
+
+	// Check YAML functions exist
+	yamlFuncs := []string{"toYaml", "fromYaml", "mustToYaml", "mustFromYaml"}
+	for _, name := range yamlFuncs {
+		foundYaml := false
+		for _, fn := range funcs {
+			if fn.Name == name {
+				foundYaml = true
+				assert.NotEmpty(t, fn.Description, "YAML function %q should have a description", name)
+				break
+			}
+		}
+		assert.True(t, foundYaml, "should find %q in custom functions", name)
+	}
+}
+
+func TestAll_CustomOverridesSprig(t *testing.T) {
+	all := All()
+
+	// Verify that custom functions come after sprig in the list
+	sprigCount := len(Sprig())
+	customCount := len(Custom())
+	assert.Equal(t, sprigCount+customCount, len(all))
+
+	// Last entries should be custom
+	for i := sprigCount; i < len(all); i++ {
+		assert.True(t, all[i].Custom, "entries after sprig should be custom")
+	}
+}
+
+func TestAllFuncMap_ReturnsNonNilMap(t *testing.T) {
+	funcMap := AllFuncMap()
+	require.NotNil(t, funcMap)
+	assert.NotEmpty(t, funcMap)
+}
+
+func TestSprig_HasDescriptions(t *testing.T) {
+	funcs := Sprig()
+
+	// All sprig functions should have some description
+	for _, fn := range funcs {
+		assert.NotEmpty(t, fn.Description, "function %q should have a description", fn.Name)
+	}
+}
+
+func TestAll_NoDuplicateNames(t *testing.T) {
+	all := All()
+
+	seen := make(map[string]bool)
+	for _, fn := range all {
+		if seen[fn.Name] {
+			t.Errorf("duplicate function name: %q", fn.Name)
+		}
+		seen[fn.Name] = true
+	}
+}

--- a/pkg/gotmpl/ext/hcl/hcl.go
+++ b/pkg/gotmpl/ext/hcl/hcl.go
@@ -1,0 +1,267 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hcl provides a Go template extension function for converting
+// Go objects into HCL (HashiCorp Configuration Language) format.
+package hcl
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// ToHclFunc returns an ExtFunction that converts a Go object into HCL format.
+//
+// The function accepts any Go value (struct, map, slice, primitive) and returns
+// its HCL string representation. Structs and maps are converted to HCL attribute
+// assignments, slices become HCL lists, and nested structs/maps become HCL blocks.
+//
+// Example usage in a Go template:
+//
+//	{{ .data | toHcl }}
+//	{{ toHcl .config }}
+func ToHclFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "toHcl",
+		Description: "Converts a Go object into HCL (HashiCorp Configuration Language) format. Accepts structs, maps, slices, and primitives. Returns the HCL representation as a string.",
+		Custom:      true,
+		Links:       []string{"https://github.com/hashicorp/hcl"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a map to HCL",
+				Template:    `{{ dict "name" "myapp" "port" 8080 | toHcl }}`,
+			},
+			{
+				Description: "Convert template data to HCL",
+				Template:    `{{ .config | toHcl }}`,
+			},
+			{
+				Description: "Convert a nested structure to HCL",
+				Template:    `{{ dict "server" (dict "host" "localhost" "port" 443) | toHcl }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"toHcl": ToHcl,
+		},
+	}
+}
+
+// ToHcl converts a Go object to its HCL string representation.
+//
+// For example:
+//
+//	obj := map[string]any{"key": "value"}
+//	ToHcl(obj) // returns: key = "value"\n
+//
+// Parameters:
+//
+//	obj any: The Go object to convert. Supports structs, maps, slices, and primitives.
+//
+// Returns:
+//
+//	string: The HCL representation of the Go object.
+//	error: An error if the conversion fails.
+func ToHcl(obj any) (string, error) {
+	if obj == nil {
+		return "", nil
+	}
+
+	// Normalize the input: convert structs and complex types to map[string]any
+	// via JSON round-trip for consistent handling
+	normalized, err := normalize(obj)
+	if err != nil {
+		return "", fmt.Errorf("toHcl: failed to normalize input: %w", err)
+	}
+
+	var buf strings.Builder
+	if err := writeHcl(&buf, normalized, 0); err != nil {
+		return "", fmt.Errorf("toHcl: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// normalize converts any Go value to a JSON-friendly representation
+// (map[string]any, []any, or primitives) via JSON round-trip.
+func normalize(obj any) (any, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	var result any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	return result, nil
+}
+
+// writeHcl recursively writes HCL-formatted output for a normalized value.
+func writeHcl(buf *strings.Builder, value any, indent int) error {
+	switch v := value.(type) {
+	case map[string]any:
+		return writeHclMap(buf, v, indent)
+	case []any:
+		return writeHclList(buf, v, indent)
+	default:
+		// Primitive at top level — not valid HCL on its own
+		return fmt.Errorf("top-level value must be a map/object, got %T", value)
+	}
+}
+
+// writeHclMap writes a map as HCL attributes and blocks.
+func writeHclMap(buf *strings.Builder, m map[string]any, indent int) error {
+	prefix := strings.Repeat("  ", indent)
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val := m[key]
+
+		switch v := val.(type) {
+		case map[string]any:
+			// Nested map becomes an HCL block
+			fmt.Fprintf(buf, "%s%s {\n", prefix, key)
+			if err := writeHclMap(buf, v, indent+1); err != nil {
+				return err
+			}
+			fmt.Fprintf(buf, "%s}\n", prefix)
+
+		case []any:
+			if isListOfMaps(v) {
+				// List of maps becomes repeated blocks
+				for _, item := range v {
+					itemMap, ok := item.(map[string]any)
+					if !ok {
+						return fmt.Errorf("expected map in list of maps for key %q, got %T", key, item)
+					}
+					fmt.Fprintf(buf, "%s%s {\n", prefix, key)
+					if err := writeHclMap(buf, itemMap, indent+1); err != nil {
+						return err
+					}
+					fmt.Fprintf(buf, "%s}\n", prefix)
+				}
+			} else {
+				// Simple list becomes an HCL list attribute
+				fmt.Fprintf(buf, "%s%s = ", prefix, key)
+				if err := writeHclListValue(buf, v, indent); err != nil {
+					return err
+				}
+				buf.WriteString("\n")
+			}
+
+		default:
+			// Primitive attribute
+			fmt.Fprintf(buf, "%s%s = %s\n", prefix, key, formatHclValue(val))
+		}
+	}
+
+	return nil
+}
+
+// writeHclList writes a top-level list (array of blocks).
+func writeHclList(buf *strings.Builder, list []any, indent int) error {
+	if len(list) == 0 {
+		return nil
+	}
+
+	for _, item := range list {
+		switch v := item.(type) {
+		case map[string]any:
+			if err := writeHclMap(buf, v, indent); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("top-level list elements must be maps/objects, got %T", v)
+		}
+	}
+
+	return nil
+}
+
+// writeHclListValue writes a list value in HCL list syntax: [val1, val2, ...]
+func writeHclListValue(buf *strings.Builder, list []any, _ int) error {
+	buf.WriteString("[")
+	for i, item := range list {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		switch item.(type) {
+		case map[string]any:
+			return fmt.Errorf("mixed lists with nested objects are not supported in HCL list syntax; use blocks instead")
+		default:
+			buf.WriteString(formatHclValue(item))
+		}
+	}
+	buf.WriteString("]")
+	return nil
+}
+
+// formatHclValue formats a primitive Go value as an HCL literal.
+func formatHclValue(val any) string {
+	if val == nil {
+		return "null"
+	}
+
+	v := reflect.ValueOf(val)
+
+	//exhaustive:enforce
+	switch v.Kind() {
+	case reflect.String:
+		return fmt.Sprintf("%q", v.String())
+	case reflect.Bool:
+		return fmt.Sprintf("%t", v.Bool())
+	case reflect.Float64, reflect.Float32:
+		f := v.Float()
+		// If the float is actually an integer value, format without decimal
+		if f == float64(int64(f)) {
+			return fmt.Sprintf("%d", int64(f))
+		}
+		return fmt.Sprintf("%g", f)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d", v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d", v.Uint())
+	case reflect.Invalid,
+		reflect.Uintptr,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Array,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice,
+		reflect.Struct,
+		reflect.UnsafePointer:
+		return fmt.Sprintf("%q", fmt.Sprintf("%v", val))
+	}
+
+	return fmt.Sprintf("%q", fmt.Sprintf("%v", val))
+}
+
+// isListOfMaps returns true if all elements in the list are maps.
+func isListOfMaps(list []any) bool {
+	if len(list) == 0 {
+		return false
+	}
+	for _, item := range list {
+		if _, ok := item.(map[string]any); !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/gotmpl/ext/hcl/hcl_test.go
+++ b/pkg/gotmpl/ext/hcl/hcl_test.go
@@ -1,0 +1,234 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToHcl_SimpleMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "simple string attribute",
+			input: map[string]any{"key": "value"},
+			want:  "key = \"value\"\n",
+		},
+		{
+			name:  "multiple attributes sorted",
+			input: map[string]any{"name": "myapp", "region": "us-east-1"},
+			want:  "name = \"myapp\"\nregion = \"us-east-1\"\n",
+		},
+		{
+			name:  "integer attribute",
+			input: map[string]any{"port": float64(8080)},
+			want:  "port = 8080\n",
+		},
+		{
+			name:  "boolean attribute",
+			input: map[string]any{"enabled": true},
+			want:  "enabled = true\n",
+		},
+		{
+			name:  "float attribute",
+			input: map[string]any{"ratio": 3.14},
+			want:  "ratio = 3.14\n",
+		},
+		{
+			name:  "null attribute",
+			input: map[string]any{"value": nil},
+			want:  "value = null\n",
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToHcl(tt.input)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestToHcl_NestedMap(t *testing.T) {
+	input := map[string]any{
+		"server": map[string]any{
+			"host": "localhost",
+			"port": float64(443),
+		},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	expected := "server {\n  host = \"localhost\"\n  port = 443\n}\n"
+	assert.Equal(t, expected, result)
+}
+
+func TestToHcl_DeeplyNested(t *testing.T) {
+	input := map[string]any{
+		"database": map[string]any{
+			"primary": map[string]any{
+				"host": "db.example.com",
+				"port": float64(5432),
+			},
+		},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	expected := "database {\n  primary {\n    host = \"db.example.com\"\n    port = 5432\n  }\n}\n"
+	assert.Equal(t, expected, result)
+}
+
+func TestToHcl_ListOfPrimitives(t *testing.T) {
+	input := map[string]any{
+		"tags": []any{"web", "production", "v2"},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	expected := "tags = [\"web\", \"production\", \"v2\"]\n"
+	assert.Equal(t, expected, result)
+}
+
+func TestToHcl_ListOfNumbers(t *testing.T) {
+	input := map[string]any{
+		"ports": []any{float64(80), float64(443), float64(8080)},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	expected := "ports = [80, 443, 8080]\n"
+	assert.Equal(t, expected, result)
+}
+
+func TestToHcl_ListOfMaps(t *testing.T) {
+	input := map[string]any{
+		"ingress": []any{
+			map[string]any{"from_port": float64(80), "protocol": "tcp"},
+			map[string]any{"from_port": float64(443), "protocol": "tcp"},
+		},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "ingress {\n")
+	assert.Contains(t, result, "from_port = 80")
+	assert.Contains(t, result, "from_port = 443")
+	assert.Contains(t, result, "protocol = \"tcp\"")
+}
+
+func TestToHcl_Struct(t *testing.T) {
+	type Config struct {
+		Name    string `json:"name"`
+		Port    int    `json:"port"`
+		Enabled bool   `json:"enabled"`
+	}
+
+	input := Config{
+		Name:    "myservice",
+		Port:    8080,
+		Enabled: true,
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "name = \"myservice\"")
+	assert.Contains(t, result, "port = 8080")
+	assert.Contains(t, result, "enabled = true")
+}
+
+func TestToHcl_NestedStruct(t *testing.T) {
+	type Server struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	}
+	type Config struct {
+		Server Server `json:"server"`
+	}
+
+	input := Config{
+		Server: Server{
+			Host: "localhost",
+			Port: 443,
+		},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "server {")
+	assert.Contains(t, result, "host = \"localhost\"")
+	assert.Contains(t, result, "port = 443")
+}
+
+func TestToHcl_EmptyMap(t *testing.T) {
+	input := map[string]any{}
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+}
+
+func TestToHcl_TopLevelPrimitive(t *testing.T) {
+	_, err := ToHcl("hello")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "top-level value must be a map/object")
+}
+
+func TestToHcl_ComplexExample(t *testing.T) {
+	input := map[string]any{
+		"ami":           "abc-123",
+		"instance_type": "t2.micro",
+		"network_interface": map[string]any{
+			"device_index":         float64(0),
+			"network_interface_id": "eni-12345",
+		},
+		"tags": []any{"web", "prod"},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "ami = \"abc-123\"")
+	assert.Contains(t, result, "instance_type = \"t2.micro\"")
+	assert.Contains(t, result, "network_interface {")
+	assert.Contains(t, result, "device_index = 0")
+	assert.Contains(t, result, "network_interface_id = \"eni-12345\"")
+	assert.Contains(t, result, "tags = [\"web\", \"prod\"]")
+}
+
+func TestToHclFunc_Metadata(t *testing.T) {
+	fn := ToHclFunc()
+	assert.Equal(t, "toHcl", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.NotEmpty(t, fn.Links)
+	assert.Contains(t, fn.Func, "toHcl")
+}
+
+func TestToHcl_StringEscaping(t *testing.T) {
+	input := map[string]any{
+		"message": "hello \"world\"",
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "message = \"hello \\\"world\\\"\"")
+}

--- a/pkg/gotmpl/ext/yaml/yaml.go
+++ b/pkg/gotmpl/ext/yaml/yaml.go
@@ -1,0 +1,179 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package yaml provides Go template extension functions for YAML
+// serialization and deserialization.
+//
+// These functions fill the gap left by Sprig v3.3.0, which removed
+// toYaml/fromYaml when it dropped the gopkg.in/yaml.v2 dependency.
+// This package re-implements them using gopkg.in/yaml.v3.
+package yaml
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	goyaml "gopkg.in/yaml.v3"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// ToYamlFunc returns an ExtFunction that encodes a Go value as a YAML string.
+//
+// Example usage in a Go template:
+//
+//	{{ .data | toYaml }}
+//	{{ toYaml .config }}
+func ToYamlFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "toYaml",
+		Description: "Encodes a value as a YAML string. Accepts any Go value (maps, slices, structs, primitives) and returns its YAML representation.",
+		Custom:      true,
+		Links:       []string{"https://pkg.go.dev/gopkg.in/yaml.v3"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a map to YAML",
+				Template:    `{{ dict "name" "myapp" "port" 8080 | toYaml }}`,
+			},
+			{
+				Description: "Convert template data to YAML",
+				Template:    `{{ .config | toYaml }}`,
+			},
+			{
+				Description: "Combined with indent for nesting",
+				Template:    `{{ .data | toYaml | indent 4 }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"toYaml": ToYaml,
+		},
+	}
+}
+
+// FromYamlFunc returns an ExtFunction that decodes a YAML string into a map.
+//
+// Example usage in a Go template:
+//
+//	{{ .yamlString | fromYaml }}
+//	{{ (fromYaml .yamlString).fieldName }}
+func FromYamlFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "fromYaml",
+		Description: "Decodes a YAML string into a map[string]any. Returns an empty map if the input is empty.",
+		Custom:      true,
+		Links:       []string{"https://pkg.go.dev/gopkg.in/yaml.v3"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Parse a YAML string and access a field",
+				Template:    `{{ "name: myapp\nport: 8080" | fromYaml | get "name" }}`,
+			},
+			{
+				Description: "Round-trip: create YAML and parse it back",
+				Template:    `{{ dict "env" "prod" | toYaml | fromYaml | get "env" }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"fromYaml": FromYaml,
+		},
+	}
+}
+
+// MustToYamlFunc returns an ExtFunction identical to toYaml.
+// In Go templates, both toYaml and mustToYaml return (string, error);
+// the template engine surfaces errors automatically. This variant exists
+// for naming compatibility with Helm conventions.
+func MustToYamlFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "mustToYaml",
+		Description: "Encodes a value as a YAML string, returning an error on failure. Identical to toYaml in behavior (Go templates always propagate errors).",
+		Custom:      true,
+		Links:       []string{"https://pkg.go.dev/gopkg.in/yaml.v3"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Encode a value as YAML (error-propagating)",
+				Template:    `{{ .config | mustToYaml }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"mustToYaml": ToYaml,
+		},
+	}
+}
+
+// MustFromYamlFunc returns an ExtFunction identical to fromYaml.
+// In Go templates, both fromYaml and mustFromYaml return (map[string]any, error);
+// the template engine surfaces errors automatically. This variant exists
+// for naming compatibility with Helm conventions.
+func MustFromYamlFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "mustFromYaml",
+		Description: "Decodes a YAML string into a map[string]any, returning an error on failure. Identical to fromYaml in behavior (Go templates always propagate errors).",
+		Custom:      true,
+		Links:       []string{"https://pkg.go.dev/gopkg.in/yaml.v3"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Parse YAML with error propagation",
+				Template:    `{{ .yamlInput | mustFromYaml }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"mustFromYaml": FromYaml,
+		},
+	}
+}
+
+// ToYaml encodes a Go value as a YAML string.
+// Returns an empty string for nil input. The trailing newline added by
+// the YAML encoder is trimmed for cleaner template composition.
+//
+// Parameters:
+//
+//	v any: The Go value to encode. Supports maps, slices, structs, and primitives.
+//
+// Returns:
+//
+//	string: The YAML representation of the value.
+//	error: An error if encoding fails.
+func ToYaml(v any) (string, error) {
+	if v == nil {
+		return "", nil
+	}
+
+	data, err := goyaml.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("toYaml: failed to marshal: %w", err)
+	}
+
+	// Trim the trailing newline that yaml.Marshal always appends,
+	// so templates can control whitespace themselves.
+	return strings.TrimSuffix(string(data), "\n"), nil
+}
+
+// FromYaml decodes a YAML string into a map[string]any.
+// Returns an empty map for empty input.
+//
+// Parameters:
+//
+//	str string: The YAML string to decode.
+//
+// Returns:
+//
+//	map[string]any: The decoded YAML data.
+//	error: An error if decoding fails.
+func FromYaml(str string) (map[string]any, error) {
+	if strings.TrimSpace(str) == "" {
+		return map[string]any{}, nil
+	}
+
+	var result map[string]any
+	if err := goyaml.Unmarshal([]byte(str), &result); err != nil {
+		return nil, fmt.Errorf("fromYaml: failed to unmarshal: %w", err)
+	}
+
+	if result == nil {
+		return map[string]any{}, nil
+	}
+
+	return result, nil
+}

--- a/pkg/gotmpl/ext/yaml/yaml_test.go
+++ b/pkg/gotmpl/ext/yaml/yaml_test.go
@@ -1,0 +1,277 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToYaml_SimpleValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "simple map",
+			input: map[string]any{"name": "myapp"},
+			want:  "name: myapp",
+		},
+		{
+			name:  "boolean value",
+			input: map[string]any{"enabled": true},
+			want:  "enabled: true",
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "string value",
+			input: map[string]any{"msg": "hello world"},
+			want:  "msg: hello world",
+		},
+		{
+			name:  "integer value",
+			input: map[string]any{"count": 42},
+			want:  "count: 42",
+		},
+		{
+			name:  "float value",
+			input: map[string]any{"ratio": 3.14},
+			want:  "ratio: 3.14",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToYaml(tt.input)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestToYaml_NestedMap(t *testing.T) {
+	input := map[string]any{
+		"server": map[string]any{
+			"host": "localhost",
+			"port": 443,
+		},
+	}
+
+	result, err := ToYaml(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "server:")
+	assert.Contains(t, result, "host: localhost")
+	assert.Contains(t, result, "port: 443")
+}
+
+func TestToYaml_List(t *testing.T) {
+	input := map[string]any{
+		"tags": []string{"web", "production"},
+	}
+
+	result, err := ToYaml(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "tags:")
+	assert.Contains(t, result, "- web")
+	assert.Contains(t, result, "- production")
+}
+
+func TestToYaml_EmptyMap(t *testing.T) {
+	input := map[string]any{}
+	result, err := ToYaml(input)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", result)
+}
+
+func TestToYaml_Struct(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+		Port int    `yaml:"port"`
+	}
+
+	input := Config{Name: "svc", Port: 8080}
+	result, err := ToYaml(input)
+	require.NoError(t, err)
+	assert.Contains(t, result, "name: svc")
+	assert.Contains(t, result, "port: 8080")
+}
+
+func TestToYaml_NoTrailingNewline(t *testing.T) {
+	input := map[string]any{"key": "value"}
+	result, err := ToYaml(input)
+	require.NoError(t, err)
+	assert.False(t, len(result) > 0 && result[len(result)-1] == '\n',
+		"result should not end with a newline")
+}
+
+func TestFromYaml_SimpleMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantKey string
+		wantVal any
+		wantErr string
+	}{
+		{
+			name:    "simple key-value",
+			input:   "name: myapp",
+			wantKey: "name",
+			wantVal: "myapp",
+		},
+		{
+			name:    "integer value",
+			input:   "port: 8080",
+			wantKey: "port",
+			wantVal: 8080,
+		},
+		{
+			name:    "boolean value",
+			input:   "enabled: true",
+			wantKey: "enabled",
+			wantVal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FromYaml(tt.input)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVal, result[tt.wantKey])
+		})
+	}
+}
+
+func TestFromYaml_NestedMap(t *testing.T) {
+	yamlInput := "server:\n  host: localhost\n  port: 443"
+	result, err := FromYaml(yamlInput)
+	require.NoError(t, err)
+
+	server, ok := result["server"].(map[string]any)
+	require.True(t, ok, "server should be a map")
+	assert.Equal(t, "localhost", server["host"])
+	assert.Equal(t, 443, server["port"])
+}
+
+func TestFromYaml_List(t *testing.T) {
+	yamlInput := "tags:\n  - web\n  - production"
+	result, err := FromYaml(yamlInput)
+	require.NoError(t, err)
+
+	tags, ok := result["tags"].([]any)
+	require.True(t, ok, "tags should be a list")
+	assert.Equal(t, []any{"web", "production"}, tags)
+}
+
+func TestFromYaml_EmptyInput(t *testing.T) {
+	result, err := FromYaml("")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{}, result)
+
+	result2, err2 := FromYaml("   \n  ")
+	require.NoError(t, err2)
+	assert.Equal(t, map[string]any{}, result2)
+}
+
+func TestFromYaml_InvalidYaml(t *testing.T) {
+	_, err := FromYaml("invalid: [yaml: {{")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fromYaml")
+}
+
+func TestRoundTrip(t *testing.T) {
+	original := map[string]any{
+		"name": "myapp",
+		"port": 8080,
+		"tags": []any{"web", "prod"},
+	}
+
+	yamlStr, err := ToYaml(original)
+	require.NoError(t, err)
+
+	decoded, err := FromYaml(yamlStr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "myapp", decoded["name"])
+	assert.Equal(t, 8080, decoded["port"])
+}
+
+func TestToYamlFunc_Metadata(t *testing.T) {
+	fn := ToYamlFunc()
+	assert.Equal(t, "toYaml", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.NotEmpty(t, fn.Links)
+	assert.Contains(t, fn.Func, "toYaml")
+}
+
+func TestFromYamlFunc_Metadata(t *testing.T) {
+	fn := FromYamlFunc()
+	assert.Equal(t, "fromYaml", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.NotEmpty(t, fn.Links)
+	assert.Contains(t, fn.Func, "fromYaml")
+}
+
+func TestMustToYamlFunc_Metadata(t *testing.T) {
+	fn := MustToYamlFunc()
+	assert.Equal(t, "mustToYaml", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.Contains(t, fn.Func, "mustToYaml")
+}
+
+func TestMustFromYamlFunc_Metadata(t *testing.T) {
+	fn := MustFromYamlFunc()
+	assert.Equal(t, "mustFromYaml", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.Contains(t, fn.Func, "mustFromYaml")
+}
+
+func TestMustToYaml_SameBehavior(t *testing.T) {
+	input := map[string]any{"key": "value"}
+
+	toResult, toErr := ToYaml(input)
+	require.NoError(t, toErr)
+
+	mustFn := MustToYamlFunc()
+	mustFunc := mustFn.Func["mustToYaml"]
+	mustResult, mustErr := mustFunc.(func(any) (string, error))(input)
+	require.NoError(t, mustErr)
+
+	assert.Equal(t, toResult, mustResult)
+}
+
+func TestMustFromYaml_SameBehavior(t *testing.T) {
+	fromResult, fromErr := FromYaml("name: myapp")
+	require.NoError(t, fromErr)
+
+	mustFn := MustFromYamlFunc()
+	mustFunc := mustFn.Func["mustFromYaml"]
+	mustResult, mustErr := mustFunc.(func(string) (map[string]any, error))("name: myapp")
+	require.NoError(t, mustErr)
+
+	assert.Equal(t, fromResult, mustResult)
+}

--- a/pkg/gotmpl/ext_types.go
+++ b/pkg/gotmpl/ext_types.go
@@ -1,0 +1,63 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import "text/template"
+
+// ExtFunction describes a Go template function extension with metadata
+// for discoverability via MCP tools and CLI commands.
+type ExtFunction struct {
+	// Name is the function name as used in templates (e.g., "toHcl", "upper")
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Description is a human-readable description of the function
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Links contains reference URLs (documentation, source code, etc.)
+	Links []string `json:"links,omitempty" yaml:"links,omitempty"`
+
+	// Examples provides usage examples for documentation and discoverability
+	Examples []Example `json:"examples,omitempty" yaml:"examples,omitempty"`
+
+	// Custom indicates whether this is a scafctl-specific function (true)
+	// or a third-party/built-in function (false, e.g., sprig functions)
+	Custom bool `json:"custom,omitempty" yaml:"custom,omitempty"`
+
+	// Func is the template.FuncMap entry for this function.
+	// Excluded from JSON/YAML serialization.
+	Func template.FuncMap `json:"-" yaml:"-"`
+}
+
+// Example describes a usage example for a Go template function.
+type Example struct {
+	// Description explains what the example demonstrates
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Template is the Go template snippet showing usage
+	Template string `json:"template,omitempty" yaml:"template,omitempty"`
+
+	// Links contains reference URLs for the example
+	Links []string `json:"links,omitempty" yaml:"links,omitempty"`
+}
+
+// ExtFunctionList is a list of ExtFunction entries.
+type ExtFunctionList []ExtFunction
+
+// GetName returns the function name, implementing the named interface
+// for use with generic filter helpers.
+func (f ExtFunction) GetName() string {
+	return f.Name
+}
+
+// FuncMap merges all individual Func entries into a single template.FuncMap.
+// Later entries override earlier ones if they share the same function name.
+func (l ExtFunctionList) FuncMap() template.FuncMap {
+	merged := make(template.FuncMap, len(l))
+	for _, fn := range l {
+		for k, v := range fn.Func {
+			merged[k] = v
+		}
+	}
+	return merged
+}

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -8,10 +8,19 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+var (
+	// extensionFuncMapFactory is the factory function that provides extension functions.
+	// Set via SetExtensionFuncMapFactory during application initialization.
+	extensionFuncMapFactory func() template.FuncMap
+	extensionFuncMapOnce    sync.Once
+	extensionFuncMapMu      sync.RWMutex
 )
 
 const (
@@ -104,8 +113,62 @@ type Service struct {
 	defaultFuncs template.FuncMap
 }
 
-// NewService creates a new template service with optional default functions
-func NewService(defaultFuncs template.FuncMap) *Service {
+// SetExtensionFuncMapFactory sets the factory function used to provide extension
+// template functions (sprig + custom). This should be called once during
+// application initialization to wire in extension functions without creating
+// import cycles.
+//
+// This function is thread-safe and uses sync.Once to ensure it's only set once.
+//
+// Example (called during application initialization):
+//
+//	gotmpl.SetExtensionFuncMapFactory(ext.AllFuncMap)
+func SetExtensionFuncMapFactory(factory func() template.FuncMap) {
+	extensionFuncMapOnce.Do(func() {
+		extensionFuncMapMu.Lock()
+		defer extensionFuncMapMu.Unlock()
+		extensionFuncMapFactory = factory
+	})
+}
+
+// getExtensionFuncMap returns the extension function map from the factory.
+// Returns an empty FuncMap if no factory has been set.
+func getExtensionFuncMap() template.FuncMap {
+	extensionFuncMapMu.RLock()
+	defer extensionFuncMapMu.RUnlock()
+	if extensionFuncMapFactory != nil {
+		return extensionFuncMapFactory()
+	}
+	return make(template.FuncMap)
+}
+
+// NewService creates a new template service with all registered extension
+// functions (sprig + custom scafctl extensions) available by default.
+// If additionalFuncs is provided, those functions are merged on top of the
+// extensions, allowing callers to override any extension function.
+//
+// Extension functions are provided via SetExtensionFuncMapFactory, which
+// should be called during application initialization.
+//
+// Use NewServiceRaw to create a service without auto-registered extensions.
+func NewService(additionalFuncs template.FuncMap) *Service {
+	// Start with all extension functions (sprig + custom)
+	defaultFuncs := getExtensionFuncMap()
+
+	// Merge caller-provided functions on top (overrides extensions)
+	for k, v := range additionalFuncs {
+		defaultFuncs[k] = v
+	}
+
+	return &Service{
+		defaultFuncs: defaultFuncs,
+	}
+}
+
+// NewServiceRaw creates a new template service without any auto-registered
+// extension functions. Only the explicitly provided functions will be available.
+// Use this when you want a bare template service without sprig or custom extensions.
+func NewServiceRaw(defaultFuncs template.FuncMap) *Service {
 	if defaultFuncs == nil {
 		defaultFuncs = make(template.FuncMap)
 	}

--- a/pkg/mcp/function_filter.go
+++ b/pkg/mcp/function_filter.go
@@ -1,0 +1,47 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// filterAndReturnNamedFunctions filters a slice of named items by substring match on Name,
+// then returns the result as JSON. This deduplicates the shared filter-by-name logic
+// between handleListCELFunctions and handleListGoTemplateFunctions.
+//
+// Parameters:
+//   - functions: the slice to filter (elements must implement GetName())
+//   - name: name substring to filter by (empty means no filter)
+//   - funcKind: human-readable kind for error messages (e.g., "CEL function", "Go template function")
+//   - toolName: MCP tool name for error suggestions
+func filterAndReturnNamedFunctions[T interface{ GetName() string }](
+	functions []T,
+	name string,
+	funcKind string,
+	toolName string,
+) (*mcp.CallToolResult, error) {
+	if name != "" {
+		filtered := functions[:0:0]
+		nameLower := strings.ToLower(name)
+		for _, f := range functions {
+			if strings.Contains(strings.ToLower(f.GetName()), nameLower) {
+				filtered = append(filtered, f)
+			}
+		}
+		if len(filtered) == 0 {
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("no %s matching %q found", funcKind, name),
+				WithField("name"),
+				WithSuggestion(fmt.Sprintf("Use %s without a name filter to see all available functions", toolName)),
+				WithRelatedTools(toolName),
+			), nil
+		}
+		functions = filtered
+	}
+
+	return mcp.NewToolResultJSON(functions)
+}

--- a/pkg/mcp/tools_cel.go
+++ b/pkg/mcp/tools_cel.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -78,26 +77,10 @@ func (s *Server) handleListCELFunctions(_ context.Context, request mcp.CallToolR
 		functions = ext.BuiltIn()
 	}
 
-	// If searching by name, filter
-	if name != "" {
-		filtered := functions[:0:0]
-		nameLower := strings.ToLower(name)
-		for _, f := range functions {
-			if strings.Contains(strings.ToLower(f.Name), nameLower) {
-				filtered = append(filtered, f)
-			}
-		}
-		if len(filtered) == 0 {
-			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("no CEL function matching %q found", name),
-				WithField("name"),
-				WithSuggestion("Use list_cel_functions without a name filter to see all available functions"),
-				WithRelatedTools("list_cel_functions"),
-			), nil
-		}
-		functions = filtered
-	}
-
-	return mcp.NewToolResultJSON(functions)
+	return filterAndReturnNamedFunctions(
+		functions, name,
+		"CEL function", "list_cel_functions",
+	)
 }
 
 // handleEvaluateCEL evaluates a CEL expression against provided data.

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
 	"sigs.k8s.io/yaml"
 )
 
@@ -100,6 +101,27 @@ func (s *Server) registerTemplateTools() {
 		),
 	)
 	s.mcpServer.AddTool(validateExpressionsTool, s.handleValidateExpressions)
+
+	// list_go_template_functions
+	listGoTemplateFunctionsTool := mcp.NewTool("list_go_template_functions",
+		mcp.WithDescription("List all available Go template extension functions. Includes both sprig functions (upper, lower, toJson, dict, etc.) and custom scafctl-specific functions (toHcl, toYaml, fromYaml, mustToYaml, mustFromYaml)."),
+		mcp.WithTitleAnnotation("List Go Template Functions"),
+		mcp.WithToolIcons(toolIcons["template"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithBoolean("custom_only",
+			mcp.Description("If true, only return scafctl custom functions (e.g., toHcl, toYaml, fromYaml)"),
+		),
+		mcp.WithBoolean("sprig_only",
+			mcp.Description("If true, only return sprig library functions"),
+		),
+		mcp.WithString("name",
+			mcp.Description("Get details for a specific function by name (substring match)"),
+		),
+	)
+	s.mcpServer.AddTool(listGoTemplateFunctionsTool, s.handleListGoTemplateFunctions)
 }
 
 // handleEvaluateGoTemplate evaluates a Go template against provided data.
@@ -186,6 +208,25 @@ func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToo
 	}
 
 	return mcp.NewToolResultJSON(response)
+}
+
+// handleListGoTemplateFunctions lists available Go template extension functions.
+func (s *Server) handleListGoTemplateFunctions(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	customOnly := request.GetBool("custom_only", false)
+	sprigOnly := request.GetBool("sprig_only", false)
+	name := request.GetString("name", "")
+
+	functions := gotmplext.All()
+	if customOnly {
+		functions = gotmplext.Custom()
+	} else if sprigOnly {
+		functions = gotmplext.Sprig()
+	}
+
+	return filterAndReturnNamedFunctions(
+		functions, name,
+		"Go template function", "list_go_template_functions",
+	)
 }
 
 // handleValidateExpression validates a CEL expression or Go template for syntax errors.

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -169,7 +169,7 @@ func BuildYAML(name, description, version string, features map[string]bool, prov
 				b.WriteString("        with:\n")
 				b.WriteString("          - provider: http\n")
 				b.WriteString("            inputs:\n")
-				b.WriteString("              url: \"https://api.example.com/data\"\n")
+				b.WriteString("              url: \"https://httpbin.org/get\"\n")
 				b.WriteString("              method: GET\n")
 			case "env":
 				b.WriteString("    # Environment variable\n")
@@ -180,6 +180,7 @@ func BuildYAML(name, description, version string, features map[string]bool, prov
 				b.WriteString("        with:\n")
 				b.WriteString("          - provider: env\n")
 				b.WriteString("            inputs:\n")
+				b.WriteString("              operation: get\n")
 				b.WriteString("              name: MY_ENV_VAR\n")
 			case "file":
 				b.WriteString("    # File content\n")

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -222,6 +222,79 @@ func TestIntegration_GetCelFunctionDetail(t *testing.T) {
 }
 
 // ============================================================================
+// Get Go Template Functions Tests
+// ============================================================================
+
+func TestIntegration_GetGoTemplateFunctions(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions")
+
+	assert.Equal(t, 0, exitCode)
+	// Should list both sprig and custom functions
+	assert.Contains(t, stdout, "upper")
+	assert.Contains(t, stdout, "toHcl")
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "fromYaml")
+}
+
+func TestIntegration_GetGoTemplateFunctionsCustom(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "--custom")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toHcl")
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "fromYaml")
+	assert.Contains(t, stdout, "mustToYaml")
+	assert.Contains(t, stdout, "mustFromYaml")
+}
+
+func TestIntegration_GetGoTemplateFunctionsSprig(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "--sprig")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "upper")
+	assert.Contains(t, stdout, "lower")
+}
+
+func TestIntegration_GetGoTemplateFunctionsJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"name\"")
+	assert.Contains(t, stdout, "\"custom\"")
+}
+
+func TestIntegration_GetGoTemplateFunctionsQuiet(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "-o", "quiet")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toHcl")
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "fromYaml")
+}
+
+func TestIntegration_GetGoTemplateFunctionDetail(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "toHcl")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toHcl")
+}
+
+func TestIntegration_GetGoTemplateFunctionDetailToYaml(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "go-template-functions", "toYaml")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "YAML")
+}
+
+// ============================================================================
 // Explain Schema Tests
 // ============================================================================
 

--- a/tests/integration/solutions/README.md
+++ b/tests/integration/solutions/README.md
@@ -37,6 +37,7 @@ tests/integration/solutions/
 │   ├── file/                 # File read/write/exists
 │   ├── directory/            # Directory list/mkdir
 │   ├── go-template/          # Go template rendering
+│   ├── go-template-extensions/ # Go template extensions (Sprig + toHcl + toYaml/fromYaml)
 │   ├── validation/           # Match/notMatch/expression validation
 │   ├── sleep/                # Sleep/timing
 │   ├── http/                 # HTTP requests (via mock server)
@@ -82,7 +83,7 @@ tests/integration/solutions/
 |-----|-------------|
 | `smoke` | Quick verification tests, good for CI gates |
 | `provider` | Provider-specific tests |
-| `static`, `env`, `cel`, `exec`, `file`, `directory`, `go-template`, `hcl`, `validation`, `sleep` | Individual provider tests |
+| `static`, `env`, `cel`, `exec`, `file`, `directory`, `go-template`, `go-template-extensions`, `hcl`, `validation`, `sleep` | Individual provider tests |
 | `http` | HTTP provider tests (uses mock server) |
 | `git` | Git provider tests (uses local bare repo) |
 | `debug` | Debug provider tests |

--- a/tests/integration/solutions/providers/go-template-extensions/solution.yaml
+++ b/tests/integration/solutions/providers/go-template-extensions/solution.yaml
@@ -1,0 +1,670 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-go-template-extensions
+  version: 1.0.0
+  description: |
+    Functional tests for Go template extension functions.
+    Verifies Sprig v3 functions and custom scafctl extensions (toHcl, toYaml, fromYaml, mustToYaml, mustFromYaml).
+
+spec:
+  resolvers:
+    # ─────────────────────────────────────────────
+    # Sprig String Functions
+    # ─────────────────────────────────────────────
+
+    sprigUpper:
+      description: Sprig upper function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-upper
+              template: '{{ "hello" | upper }}'
+
+    sprigLower:
+      description: Sprig lower function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-lower
+              template: '{{ "HELLO" | lower }}'
+
+    sprigTitle:
+      description: Sprig title function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-title
+              template: '{{ "hello world" | title }}'
+
+    sprigCamelcase:
+      description: Sprig camelcase function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-camel
+              template: '{{ "my-app-service" | camelcase }}'
+
+    sprigSnakecase:
+      description: Sprig snakecase function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-snake
+              template: '{{ "MyApp" | snakecase }}'
+
+    sprigKebabcase:
+      description: Sprig kebabcase function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-kebab
+              template: '{{ "MyApp" | kebabcase }}'
+
+    sprigTrim:
+      description: Sprig trim function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-trim
+              template: '{{ "  hello  " | trim }}'
+
+    sprigReplace:
+      description: Sprig replace function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-replace
+              template: '{{ "hello-world" | replace "-" "_" }}'
+
+    sprigTrunc:
+      description: Sprig trunc function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-trunc
+              template: '{{ "Hello, World!" | trunc 5 }}'
+
+    sprigRepeat:
+      description: Sprig repeat function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-repeat
+              template: '{{ "ab" | repeat 3 }}'
+
+    # ─────────────────────────────────────────────
+    # Sprig Dict Functions
+    # ─────────────────────────────────────────────
+
+    sprigDict:
+      description: Sprig dict creation
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-dict
+              template: |
+                {{- $d := dict "name" "Alice" "role" "admin" -}}
+                name={{ $d.name }}, role={{ $d.role }}
+
+    sprigMerge:
+      description: Sprig merge function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-merge
+              template: |
+                {{- $a := dict "port" 3000 "debug" false -}}
+                {{- $b := dict "port" 8080 "tls" true -}}
+                {{- $m := merge $b $a -}}
+                port={{ $m.port }}, tls={{ $m.tls }}, debug={{ $m.debug }}
+
+    sprigHasKey:
+      description: Sprig hasKey function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-haskey
+              template: |
+                {{- $d := dict "name" "Alice" -}}
+                has_name={{ hasKey $d "name" }}, has_age={{ hasKey $d "age" }}
+
+    # ─────────────────────────────────────────────
+    # Sprig List Functions
+    # ─────────────────────────────────────────────
+
+    sprigList:
+      description: Sprig list creation
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-list
+              template: |
+                {{- $l := list "a" "b" "c" -}}
+                {{ $l | join "," }}
+
+    sprigHas:
+      description: Sprig has function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-has
+              template: |
+                {{- $l := list "dev" "staging" "prod" -}}
+                has_prod={{ has "prod" $l }}, has_qa={{ has "qa" $l }}
+
+    # ─────────────────────────────────────────────
+    # Sprig Math Functions
+    # ─────────────────────────────────────────────
+
+    sprigMath:
+      description: Sprig arithmetic functions
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-math
+              template: 'add={{ add 10 5 }}, sub={{ sub 10 5 }}, mul={{ mul 3 4 }}'
+
+    # ─────────────────────────────────────────────
+    # Sprig Default and Encoding
+    # ─────────────────────────────────────────────
+
+    sprigDefault:
+      description: Sprig default function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-default
+              template: '{{ "" | default "fallback" }}'
+
+    sprigBase64:
+      description: Sprig base64 encode/decode
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-b64
+              template: '{{ "hello" | b64enc | b64dec }}'
+
+    # ─────────────────────────────────────────────
+    # Custom toHcl Function
+    # ─────────────────────────────────────────────
+
+    toHclSimpleData:
+      description: Data for simple toHcl test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-service
+                port: 8080
+
+    toHclSimple:
+      description: toHcl with simple map
+      dependsOn: [toHclSimpleData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-simple
+              template: '{{ toHcl .toHclSimpleData }}'
+
+    toHclNestedData:
+      description: Data for nested toHcl test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-bucket
+                tags:
+                  env: production
+                  team: platform
+
+    toHclNested:
+      description: toHcl with nested map
+      dependsOn: [toHclNestedData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-nested
+              template: '{{ toHcl .toHclNestedData }}'
+
+    toHclListData:
+      description: Data for list toHcl test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-app
+                ports:
+                  - 80
+                  - 443
+
+    toHclList:
+      description: toHcl with list values
+      dependsOn: [toHclListData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-list
+              template: '{{ toHcl .toHclListData }}'
+
+    toHclIndentData:
+      description: Data for indent toHcl test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                ami: ami-12345678
+                instance_type: t3.micro
+
+    toHclWithIndent:
+      description: toHcl combined with Sprig indent
+      dependsOn: [toHclIndentData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-indent
+              template: |
+                resource "aws_instance" "web" {
+                  {{ toHcl .toHclIndentData | indent 2 }}
+                }
+
+    # ─────────────────────────────────────────────
+    # Custom YAML Functions (toYaml, fromYaml, mustToYaml, mustFromYaml)
+    # ─────────────────────────────────────────────
+
+    toYamlData:
+      description: Data for toYaml test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-service
+                port: 8080
+                debug: false
+
+    toYamlSimple:
+      description: toYaml with simple map
+      dependsOn: [toYamlData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: toyaml-simple
+              template: '{{ toYaml .toYamlData }}'
+
+    toYamlNestedData:
+      description: Data for nested toYaml test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-app
+                server:
+                  host: localhost
+                  port: 443
+
+    toYamlNested:
+      description: toYaml with nested map
+      dependsOn: [toYamlNestedData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: toyaml-nested
+              template: '{{ toYaml .toYamlNestedData }}'
+
+    fromYamlTest:
+      description: fromYaml parsing and field access
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: fromyaml-basic
+              template: |
+                {{- $parsed := fromYaml "name: myapp\nport: 8080" -}}
+                name={{ $parsed.name }}, port={{ $parsed.port }}
+
+    mustToYamlData:
+      description: Data for mustToYaml test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                env: production
+                replicas: 3
+
+    mustToYamlTest:
+      description: mustToYaml encoding
+      dependsOn: [mustToYamlData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: musttoyaml-basic
+              template: '{{ mustToYaml .mustToYamlData }}'
+
+    mustFromYamlTest:
+      description: mustFromYaml parsing
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: mustfromyaml-basic
+              template: |
+                {{- $parsed := mustFromYaml "env: staging\nreplicas: 2" -}}
+                env={{ $parsed.env }}, replicas={{ $parsed.replicas }}
+
+    yamlRoundTrip:
+      description: YAML round-trip via toYaml and fromYaml
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: yaml-roundtrip
+              template: |
+                {{- $original := dict "app" "scafctl" "version" "1.0" -}}
+                {{- $yaml := toYaml $original -}}
+                {{- $decoded := fromYaml $yaml -}}
+                app={{ $decoded.app }}, version={{ $decoded.version }}
+
+  testing:
+    config:
+      skipBuiltins: true
+
+    cases:
+      _base:
+        description: Base template for go-template extension tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, go-template, extensions]
+        assertions:
+          - expression: __exitCode == 0
+
+      # Sprig string tests
+      sprig-upper:
+        description: Verify Sprig upper
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigUpper == "HELLO"'
+
+      sprig-lower:
+        description: Verify Sprig lower
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigLower == "hello"'
+
+      sprig-title:
+        description: Verify Sprig title
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigTitle == "Hello World"'
+
+      sprig-camelcase:
+        description: Verify Sprig camelcase
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigCamelcase == "MyAppService"'
+
+      sprig-snakecase:
+        description: Verify Sprig snakecase
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigSnakecase == "my_app"'
+
+      sprig-kebabcase:
+        description: Verify Sprig kebabcase
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigKebabcase == "my-app"'
+
+      sprig-trim:
+        description: Verify Sprig trim
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigTrim == "hello"'
+
+      sprig-replace:
+        description: Verify Sprig replace
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigReplace == "hello_world"'
+
+      sprig-trunc:
+        description: Verify Sprig trunc
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigTrunc == "Hello"'
+
+      sprig-repeat:
+        description: Verify Sprig repeat
+        extends: [_base]
+        tags: [sprig, string]
+        assertions:
+          - expression: '__output.sprigRepeat == "ababab"'
+
+      # Sprig dict tests
+      sprig-dict:
+        description: Verify Sprig dict creation
+        extends: [_base]
+        tags: [sprig, dict]
+        assertions:
+          - expression: '__output.sprigDict.contains("name=Alice")'
+          - expression: '__output.sprigDict.contains("role=admin")'
+
+      sprig-merge:
+        description: Verify Sprig merge
+        extends: [_base]
+        tags: [sprig, dict]
+        assertions:
+          - expression: '__output.sprigMerge.contains("port=8080")'
+          - expression: '__output.sprigMerge.contains("tls=true")'
+          - expression: '__output.sprigMerge.contains("debug=false")'
+
+      sprig-haskey:
+        description: Verify Sprig hasKey
+        extends: [_base]
+        tags: [sprig, dict]
+        assertions:
+          - expression: '__output.sprigHasKey.contains("has_name=true")'
+          - expression: '__output.sprigHasKey.contains("has_age=false")'
+
+      # Sprig list tests
+      sprig-list-join:
+        description: Verify Sprig list and join
+        extends: [_base]
+        tags: [sprig, list]
+        assertions:
+          - expression: '__output.sprigList.contains("a,b,c")'
+
+      sprig-has:
+        description: Verify Sprig has
+        extends: [_base]
+        tags: [sprig, list]
+        assertions:
+          - expression: '__output.sprigHas.contains("has_prod=true")'
+          - expression: '__output.sprigHas.contains("has_qa=false")'
+
+      # Sprig math tests
+      sprig-math:
+        description: Verify Sprig arithmetic
+        extends: [_base]
+        tags: [sprig, math]
+        assertions:
+          - expression: '__output.sprigMath.contains("add=15")'
+          - expression: '__output.sprigMath.contains("sub=5")'
+          - expression: '__output.sprigMath.contains("mul=12")'
+
+      # Sprig default and encoding tests
+      sprig-default:
+        description: Verify Sprig default
+        extends: [_base]
+        tags: [sprig]
+        assertions:
+          - expression: '__output.sprigDefault == "fallback"'
+
+      sprig-base64:
+        description: Verify Sprig base64 roundtrip
+        extends: [_base]
+        tags: [sprig, encoding]
+        assertions:
+          - expression: '__output.sprigBase64 == "hello"'
+
+      # Custom toHcl tests
+      tohcl-simple:
+        description: Verify toHcl with simple map
+        extends: [_base]
+        tags: [custom, toHcl]
+        assertions:
+          - expression: '__output.toHclSimple.contains("name")'
+          - expression: '__output.toHclSimple.contains("my-service")'
+          - expression: '__output.toHclSimple.contains("port")'
+
+      tohcl-nested:
+        description: Verify toHcl with nested map
+        extends: [_base]
+        tags: [custom, toHcl]
+        assertions:
+          - expression: '__output.toHclNested.contains("name")'
+          - expression: '__output.toHclNested.contains("tags")'
+          - expression: '__output.toHclNested.contains("production")'
+
+      tohcl-list:
+        description: Verify toHcl with list values
+        extends: [_base]
+        tags: [custom, toHcl]
+        assertions:
+          - expression: '__output.toHclList.contains("ports")'
+
+      tohcl-with-indent:
+        description: Verify toHcl with Sprig indent
+        extends: [_base]
+        tags: [custom, toHcl, sprig]
+        assertions:
+          - expression: '__output.toHclWithIndent.contains("resource")'
+          - expression: '__output.toHclWithIndent.contains("ami")'
+          - expression: '__output.toHclWithIndent.contains("instance_type")'
+
+      # Custom YAML function tests
+      toyaml-simple:
+        description: Verify toYaml with simple map
+        extends: [_base]
+        tags: [custom, toYaml]
+        assertions:
+          - expression: '__output.toYamlSimple.contains("name: my-service")'
+          - expression: '__output.toYamlSimple.contains("port: 8080")'
+          - expression: '__output.toYamlSimple.contains("debug: false")'
+
+      toyaml-nested:
+        description: Verify toYaml with nested map
+        extends: [_base]
+        tags: [custom, toYaml]
+        assertions:
+          - expression: '__output.toYamlNested.contains("name: my-app")'
+          - expression: '__output.toYamlNested.contains("server:")'
+          - expression: '__output.toYamlNested.contains("host: localhost")'
+
+      fromyaml-basic:
+        description: Verify fromYaml parsing and field access
+        extends: [_base]
+        tags: [custom, fromYaml]
+        assertions:
+          - expression: '__output.fromYamlTest.contains("name=myapp")'
+          - expression: '__output.fromYamlTest.contains("port=8080")'
+
+      musttoyaml-basic:
+        description: Verify mustToYaml encoding
+        extends: [_base]
+        tags: [custom, mustToYaml]
+        assertions:
+          - expression: '__output.mustToYamlTest.contains("env: production")'
+          - expression: '__output.mustToYamlTest.contains("replicas: 3")'
+
+      mustfromyaml-basic:
+        description: Verify mustFromYaml parsing
+        extends: [_base]
+        tags: [custom, mustFromYaml]
+        assertions:
+          - expression: '__output.mustFromYamlTest.contains("env=staging")'
+          - expression: '__output.mustFromYamlTest.contains("replicas=2")'
+
+      yaml-roundtrip:
+        description: Verify YAML round-trip via toYaml and fromYaml
+        extends: [_base]
+        tags: [custom, toYaml, fromYaml]
+        assertions:
+          - expression: '__output.yamlRoundTrip.contains("app=scafctl")'
+          - expression: '__output.yamlRoundTrip.contains("version=1.0")'

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -108,6 +108,53 @@ spec:
                 version: {{.version}}
                 featureCount: {{len .features}}
 
+    sprigUpperTemplate:
+      description: Sprig upper function
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-upper
+              template: '{{ "hello world" | upper }}'
+
+    sprigDictTemplate:
+      description: Sprig dict and merge functions
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: sprig-dict
+              template: |
+                {{- $defaults := dict "port" 3000 "debug" false -}}
+                {{- $overrides := dict "port" 8080 "tls" true -}}
+                {{- $merged := merge $overrides $defaults -}}
+                port={{ $merged.port }}, tls={{ $merged.tls }}, debug={{ $merged.debug }}
+
+    toHclData:
+      description: Data for toHcl test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-service
+                port: 8080
+
+    toHclTemplate:
+      description: Custom toHcl function
+      dependsOn: [toHclData]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-test
+              template: '{{ toHcl .toHclData }}'
+
   testing:
     config:
       skipBuiltins: true
@@ -149,3 +196,28 @@ spec:
           - expression: '__output.multilineTemplate.contains("name: my-service")'
           - expression: '__output.multilineTemplate.contains("version: 2.1.0")'
           - expression: '__output.multilineTemplate.contains("featureCount: 3")'
+
+      sprig-upper:
+        description: Verify Sprig upper function
+        extends: [_base]
+        tags: [sprig]
+        assertions:
+          - expression: '__output.sprigUpperTemplate == "HELLO WORLD"'
+
+      sprig-dict-merge:
+        description: Verify Sprig dict and merge functions
+        extends: [_base]
+        tags: [sprig]
+        assertions:
+          - expression: '__output.sprigDictTemplate.contains("port=8080")'
+          - expression: '__output.sprigDictTemplate.contains("tls=true")'
+          - expression: '__output.sprigDictTemplate.contains("debug=false")'
+
+      tohcl-basic:
+        description: Verify custom toHcl function
+        extends: [_base]
+        tags: [custom, toHcl]
+        assertions:
+          - expression: '__output.toHclTemplate.contains("name")'
+          - expression: '__output.toHclTemplate.contains("my-service")'
+          - expression: '__output.toHclTemplate.contains("port")'


### PR DESCRIPTION
…support

Add a comprehensive Go template extension system with the following capabilities:

- New pkg/gotmpl/ext/ package providing custom scafctl-specific functions (toHcl, fromHcl, etc.) and full sprig library function integration
- New pkg/gotmpl/ext/hcl/ sub-package for HCL encode/decode template functions
- New pkg/gotmpl/detail/ package for function introspection and documentation
- New CLI command 'scafctl get go-template-functions' (aliases: gotmpl-funcs, gotmpl, gtf) supporting table/json/yaml/quiet output, --custom/--sprig filters, interactive TUI mode, and per-function detail lookup
- New MCP tool (tools_template.go) exposing template function listing to MCP server consumers
- New example resolver files demonstrating sprig and custom extension usage
- Updated tutorials: go-templates, HCL provider, run-resolver, scaffolding, eval, auth, MCP server, logging, and resolver tutorials
- Integration tests for the new get go-template-functions command
- Integration solution tests for go-template and go-template-extensions providers
