### PR TITLE
feat: add github/http-poll/metadata providers, CEL regex ext, go-temp…

### DIFF
--- a/docs/design/functional-testing.md
+++ b/docs/design/functional-testing.md
@@ -46,7 +46,7 @@ This is the primary mechanism for validating solutions in CI and during developm
 | Selective builtin skip | ✅ Done | `SkipBuiltinsValue` with custom unmarshal |
 | In-process command execution | ✅ Done | `Root()` with `*RootOptions`, `CommandBuilder` |
 | Concurrency control | ✅ Done | `-j` flag, `--sequential` as sugar for `-j 1` |
-| Conditional skip (`skipExpression`) | ✅ Done | CEL-based runtime skip evaluation |
+| Conditional skip (CEL `skip` expression) | ✅ Done | CEL-based runtime skip evaluation |
 | Test retries | ✅ Done | `retries` field for flaky test resilience |
 | Suite-level cleanup | ✅ Done | `testing.config.cleanup` for teardown after all tests |
 | File size guard | ✅ Done | Cap `files[].content` at 10MB to prevent OOM |
@@ -277,9 +277,8 @@ cases:
     expectFailure: <bool>
     exitCode: <int>
     timeout: <string>  # Go duration format, e.g., "30s", "2m"
-    skip: <bool>
+    skip: <bool | Expression>
     skipReason: <string>
-    skipExpression: <Expression>
     retries: <int>
 ~~~
 
@@ -304,9 +303,8 @@ Each test case is a named entry under `spec.testing.cases`. The maximum number o
 | `expectFailure` | `bool` | No | `false` | When `true`, the test passes if the command exits non-zero |
 | `exitCode` | `int` | No | — | Exact expected exit code. **Mutually exclusive** with `expectFailure` — setting both is a validation error |
 | `timeout` | `string` | No | `"30s"` | Per-test timeout as a Go duration string (e.g., `"30s"`, `"2m"`, `"1m30s"`). Parsed via a custom `Duration` type with string-based YAML/JSON marshalling |
-| `skip` | `bool` | No | `false` | Skip this test |
+| `skip` | `bool \| Expression` | No | `false` | Skip this test. When `true`, unconditionally skip. When a CEL expression string, evaluated at discovery time — if `true`, the test is skipped. Context variables: `os` (GOOS), `arch` (GOARCH), `env` (environment variables map), `subprocess` (bool). Example: `'os == "windows"'` |
 | `skipReason` | `string` | No | — | Human-readable reason for skipping. Shown in test output |
-| `skipExpression` | `Expression` | No | — | CEL expression evaluated at discovery time. If `true`, the test is skipped with the expression as the reason. Context variables: `os` (GOOS), `arch` (GOARCH), `env` (environment variables map). Example: `'os == "windows"'` |
 | `retries` | `int` | No | `0` | Number of retry attempts for a failing test. The test passes if any attempt succeeds. Retry count shown in output: `PASS (retry 2/3)` |
 
 ---
@@ -525,7 +523,6 @@ Test names starting with `_` are **templates** — they are not executed directl
 | `skip` | Child wins if set |
 | `injectFile` | Child wins if set |
 | `snapshot` | Child wins if set |
-| `skipExpression` | Child wins if set |
 | `retries` | Child wins if set |
 
 ### Example
@@ -904,7 +901,7 @@ For each test case:
 1. Resolve `extends` chains and merge inherited fields
 2. Validate test name matches `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`
 3. If `skip: true` → status `skip`, stop
-4. If `skipExpression` is set → evaluate CEL expression with `os`, `arch`, `env` context. If `true` → status `skip` with expression as reason, stop
+4. If `skip` is a CEL expression → evaluate with `os`, `arch`, `env`, `subprocess` context. If `true` → status `skip` with expression as reason, stop
 5. Create temp sandbox and copy solution + bundle files + test files
 6. Snapshot sandbox file list and modification times
 7. Run init steps sequentially; if any fails → status `error`, run cleanup, stop
@@ -1197,9 +1194,8 @@ type TestCase struct {
     ExpectFailure bool              `json:"expectFailure,omitempty" yaml:"expectFailure,omitempty" doc:"Pass if command exits non-zero"`
     ExitCode      *int              `json:"exitCode,omitempty" yaml:"exitCode,omitempty" doc:"Exact expected exit code. Mutually exclusive with expectFailure"`
     Timeout       *Duration         `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Per-test timeout as Go duration string" example:"30s"`
-    Skip          bool              `json:"skip,omitempty" yaml:"skip,omitempty" doc:"Skip this test"`
+    Skip          SkipValue         `json:"skip,omitempty" yaml:"skip,omitempty" doc:"Skip this test: true for unconditional, or a CEL expression string for conditional skip"`
     SkipReason    string            `json:"skipReason,omitempty" yaml:"skipReason,omitempty" doc:"Human-readable skip reason"`
-    SkipExpression celexp.Expression `json:"skipExpression,omitempty" yaml:"skipExpression,omitempty" doc:"CEL expression evaluated at discovery time. If true, test is skipped. Context: os, arch, env"`
     Retries       int               `json:"retries,omitempty" yaml:"retries,omitempty" doc:"Number of retry attempts for failing tests" maximum:"10"`
 }
 
@@ -1500,7 +1496,7 @@ The planned tutorial at `docs/tutorials/functional-testing.md` should cover:
 3. **Test inheritance** — `_`-prefixed templates, `extends` chains, merge behavior for args/assertions/tags
 4. **Snapshots** — golden file workflow, `--update-snapshots`, normalization pipeline
 5. **CI integration** — JUnit XML reporting with `--report-file`, exit codes, `--fail-fast` patterns
-6. **Advanced features** — init/cleanup steps, test files, `skipExpression`, retries, suite-level setup
+6. **Advanced features** — init/cleanup steps, test files, conditional `skip` expressions, retries, suite-level setup
 
 The example solution at `examples/solutions/tested-solution/` should include:
 
@@ -1555,7 +1551,7 @@ The example solution at `examples/solutions/tested-solution/` should include:
 - **`__output` nil when unsupported**: diagnostic error rather than empty map to prevent silent assertion failures
 - **Concurrency control**: `-j N` flag with `--sequential` as sugar for `-j 1` — standard test runner pattern
 - **File size guard**: 10MB cap on `files[].content` to prevent OOM without blocking tests
-- **Conditional skip via CEL**: `skipExpression` field evaluated at discovery time with `os`, `arch`, `env` context
+- **Conditional skip via CEL**: `skip` field accepts either `true` or a CEL expression string, evaluated at discovery time with `os`, `arch`, `env`, `subprocess` context
 - **Test retries**: `retries` field for flaky test resilience, capped at 10 attempts
 - **Suite-level cleanup**: `testing.config.cleanup` runs after all tests, symmetric with `testing.config.setup`
 - **Compose `testing.config` merge**: `setup`/`cleanup` steps appended in compose-file order (new merge strategy); `skipBuiltins` uses `true`-wins for bool, union for lists

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -33,12 +33,14 @@ Step-by-step guides for learning scafctl features.
 - [Solution Scaffolding Tutorial](scaffolding-tutorial.md) — Create new solutions with `scafctl new solution`
 - [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
+- [Validation Patterns Tutorial](validation-patterns-tutorial.md) — Input constraints, runtime validation, and common regex/CEL patterns
 
 ## Reference
 
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution with embedded and external shells
 - [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
 - [HCL Provider Tutorial](hcl-provider-tutorial.md) — Parse, format, validate, and generate Terraform/OpenTofu HCL configuration files
+- [Provider Output Shapes](provider-output-shapes.md) — Quick reference for provider output data shapes
 - [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
 
 ## Extension Development

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -274,7 +274,7 @@ size("hello")                         // 5
 
 ## Custom Extension Functions
 
-scafctl extends CEL with project-specific functions for arrays, maps, strings, filepath, GUID, sorting, time, marshalling, and debugging.
+scafctl extends CEL with project-specific functions for arrays, maps, strings, regex, filepath, GUID, sorting, time, marshalling, and debugging.
 
 > **▶ Try it:** All custom extension functions are demonstrated in a single runnable file — [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml):
 > ```bash
@@ -409,6 +409,62 @@ normalizedName:
       - provider: cel
         inputs:
           expression: "strings.clean(_.rawName)"
+```
+
+### Regex
+
+Regular expression functions using RE2 syntax.
+
+```cel
+// Test if a string matches a pattern
+regex.match("^Hello", "Hello World")
+// → true
+
+regex.match("[0-9]+", "no digits")
+// → false
+
+// Replace all occurrences of a pattern
+regex.replace("abc123def456", "[0-9]+", "#")
+// → "abc#def#"
+
+regex.replace("hello world foo", "\\s+", "-")
+// → "hello-world-foo"
+
+// Find all matches
+regex.findAll("[0-9]+", "abc123def456")
+// → ["123", "456"]
+
+regex.findAll("[a-zA-Z]+", "hello 123 world")
+// → ["hello", "world"]
+
+// Split a string by a pattern
+regex.split("\\s+", "hello   world   foo")
+// → ["hello", "world", "foo"]
+
+regex.split("[,;]+", "a,b;c,,d")
+// → ["a", "b", "c", "d"]
+```
+
+**Use case — validate and sanitize input:**
+
+```yaml
+sanitizedName:
+  type: string
+  dependsOn: [rawInput]
+  resolve:
+    with:
+      - provider: cel
+        inputs:
+          expression: 'regex.replace(_.rawInput, "[^a-zA-Z0-9-]", "")'
+
+isValidEmail:
+  type: bool
+  dependsOn: [email]
+  resolve:
+    with:
+      - provider: cel
+        inputs:
+          expression: 'regex.match("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", _.email)'
 ```
 
 ### Filepath
@@ -877,6 +933,10 @@ deployments:
 | `map.merge(a, b)` | Merge maps (b wins) |
 | `map.recurse(list, ids, idField, depsField)` | Resolve transitive deps |
 | `out.nil(val)` | Discard value, return null |
+| `regex.match(pattern, input)` | Test if input matches regex pattern (RE2) |
+| `regex.replace(input, pattern, replacement)` | Replace all regex matches |
+| `regex.findAll(pattern, input)` | Find all regex matches as list |
+| `regex.split(pattern, input)` | Split string by regex pattern |
 | `sort.objects(list, prop)` | Sort objects ascending |
 | `sort.objectsDescending(list, prop)` | Sort objects descending |
 | `strings.clean(str)` | Lowercase + remove separators |

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -276,7 +276,7 @@ Multiple templates can be specified — they are applied left to right. The reso
 
 | Field | Merge Behavior |
 |-------|----------------|
-| `command`, `description`, `timeout`, `expectFailure`, `exitCode`, `skip`, `injectFile`, `snapshot`, `skipExpression`, `retries` | Child wins if set |
+| `command`, `description`, `timeout`, `expectFailure`, `exitCode`, `skip`, `injectFile`, `snapshot`, `retries` | Child wins if set |
 | `args` | Appended (base args first, then child) |
 | `assertions` | Appended (base first, then child) |
 | `files`, `tags` | Appended (deduplicated) |
@@ -535,20 +535,20 @@ cases:
 
 ### Conditional Skip
 
-Skip based on runtime conditions using CEL expressions with `os`, `arch`, and `env` context:
+Skip based on runtime conditions using CEL expressions with `os`, `arch`, `subprocess`, and `env` context:
 
 ```yaml
 cases:
   linux-only:
     description: Only runs on Linux
-    skipExpression: 'os != "linux"'
+    skip: 'os != "linux"'
     command: [run, solution]
     assertions:
       - expression: __exitCode == 0
 
   ci-only:
     description: Only runs in CI
-    skipExpression: '!("CI" in env)'
+    skip: '!("CI" in env)'
     command: [run, solution]
     assertions:
       - expression: __exitCode == 0
@@ -672,6 +672,101 @@ config:
   skipBuiltins:
     - resolve-defaults
     - render-defaults
+```
+
+---
+
+## Mock Services
+
+Test solutions that depend on external services by configuring mock HTTP servers and exec command stubs in `testing.config.services`.
+
+### HTTP Mock Servers
+
+Mock HTTP servers start automatically before tests and shut down after. Each mock binds to a random port and injects the base URL into a resolver:
+
+```yaml
+spec:
+  testing:
+    config:
+      services:
+        - type: http
+          portEnv: mockBaseUrl     # resolver name that receives the base URL
+          routes:
+            - path: /api/users
+              method: GET
+              status: 200
+              body: '[{"name":"alice"},{"name":"bob"}]'
+              headers:
+                Content-Type: application/json
+            - path: /api/echo
+              method: POST
+              status: 201
+              echo: true           # echoes back the request body + method
+            - path: /api/slow
+              method: GET
+              status: 200
+              body: '{"status":"ok"}'
+              delay: 2s            # simulates latency
+```
+
+Routes support:
+- **Static responses**: `body`, `status`, `headers`
+- **Echo mode**: `echo: true` returns the request body and method
+- **Latency simulation**: `delay: 2s`
+- **Health endpoint**: Every mock has a `/__health` endpoint for readiness
+
+### Exec Mock Services
+
+Mock exec commands by defining rules that intercept `exec` provider calls. Rules match by exact command or regex pattern:
+
+```yaml
+spec:
+  testing:
+    config:
+      services:
+        - type: exec
+          rules:
+            - command: "kubectl get pods -n production"
+              stdout: "NAME  READY  STATUS\nweb-1  1/1  Running"
+              exitCode: 0
+            - pattern: "^terraform plan.*"
+              stdout: "No changes. Infrastructure is up-to-date."
+              exitCode: 0
+            - pattern: "^curl.*"
+              stderr: "connection refused"
+              exitCode: 7
+```
+
+Rule fields:
+- `command`: Exact command string to match
+- `pattern`: Regex pattern to match against the command
+- `stdout`: Simulated stdout output
+- `stderr`: Simulated stderr output
+- `exitCode`: Simulated exit code (default: 0)
+
+When `passthrough: true` is set on the service, unmatched commands execute normally. Without it, unmatched commands return an error.
+
+### Combining Services
+
+You can use both HTTP and exec mocks together:
+
+```yaml
+spec:
+  testing:
+    config:
+      services:
+        - type: http
+          portEnv: apiBaseUrl
+          routes:
+            - path: /api/deploy
+              method: POST
+              status: 200
+              body: '{"id":"deploy-123"}'
+        - type: exec
+          rules:
+            - command: "kubectl rollout status deployment/web"
+              stdout: "deployment rolled out"
+              exitCode: 0
 ```
 
 ---

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -30,7 +30,11 @@ This tutorial walks you through using Go templates in scafctl to generate struct
 13. [Using Sprig Functions](#using-sprig-functions)
 14. [Converting Data to HCL with toHcl](#converting-data-to-hcl-with-tohcl)
 15. [Serializing and Parsing YAML with toYaml / fromYaml](#serializing-and-parsing-yaml-with-toyaml--fromyaml)
-16. [Discovering Available Functions](#discovering-available-functions)
+16. [DNS-Safe Strings with slugify / toDnsString](#dns-safe-strings-with-slugify--todnsstring)
+17. [Filtering Lists with where / selectField](#filtering-lists-with-where--selectfield)
+18. [Inline CEL with cel](#inline-cel-with-cel)
+19. [Debugging Template Type Errors](#debugging-template-type-errors)
+20. [Discovering Available Functions](#discovering-available-functions)
 
 ---
 
@@ -1653,6 +1657,200 @@ tags:
 
 ---
 
+## DNS-Safe Strings with slugify / toDnsString
+
+scafctl provides two functions for converting arbitrary strings into DNS-safe labels (RFC 1123):
+
+- **`slugify`** — Converts a string to lowercase, replaces non-alphanumeric characters with hyphens, collapses consecutive hyphens, and trims leading/trailing hyphens. Max 63 characters.
+- **`toDnsString`** — Alias for `slugify` with the same behavior. Use whichever name reads better in your template.
+
+### Example
+
+```yaml
+spec:
+  resolvers:
+    project-name:
+      type: static
+      from:
+        value: "My Cool Project! (v2)"
+
+    dns-label:
+      type: go-template
+      dependsOn: [project-name]
+      transform:
+        template: '{{ slugify .project-name }}'
+        name: slugify-demo
+```
+
+```bash
+scafctl run resolver -f slugify-demo.yaml -e _.dns-label
+# Output: my-cool-project-v2
+```
+
+### Key behaviors
+
+- Unicode letters are transliterated where possible, others become hyphens
+- Leading/trailing hyphens are trimmed
+- Consecutive hyphens are collapsed to one
+- Empty result returns `"unnamed"`
+- Output is truncated to 63 characters (DNS label limit)
+
+---
+
+## Filtering Lists with where / selectField
+
+Two collection functions let you filter and project lists of maps without CEL:
+
+- **`where key value list`** — Returns items where `item[key] == value`
+- **`selectField key list`** — Returns a list of `item[key]` values (like SQL SELECT)
+
+### Filtering with where
+
+```yaml
+spec:
+  resolvers:
+    services:
+      type: static
+      from:
+        value:
+          - name: api
+            active: true
+          - name: legacy
+            active: false
+          - name: web
+            active: true
+
+    active-only:
+      type: go-template
+      dependsOn: [services]
+      transform:
+        template: '{{ where "active" true .services | toYaml }}'
+        name: where-demo
+```
+
+Result: only `api` and `web` items are returned.
+
+### Projecting with selectField
+
+```yaml
+    service-names:
+      type: go-template
+      dependsOn: [services]
+      transform:
+        template: '{{ selectField "name" .services | toYaml }}'
+        name: select-demo
+```
+
+Result: `["api", "legacy", "web"]`
+
+### Combining with pipes
+
+```yaml
+    active-names:
+      type: go-template
+      dependsOn: [services]
+      transform:
+        template: '{{ where "active" true .services | selectField "name" | toYaml }}'
+        name: combined-demo
+```
+
+Result: `["api", "web"]`
+
+---
+
+## Inline CEL with cel
+
+The `cel` function lets you evaluate a CEL expression directly inside a Go template. This is useful when you need CEL's powerful list operations alongside Go template's text rendering.
+
+**Syntax:** `{{ cel "expression" data }}`
+
+The data argument becomes `_` in the CEL expression (same as the `expr` field convention).
+
+### Example
+
+```yaml
+spec:
+  resolvers:
+    services:
+      type: static
+      from:
+        value:
+          - name: api
+            port: 8080
+            active: true
+          - name: legacy
+            port: 9090
+            active: false
+
+    summary:
+      type: go-template
+      dependsOn: [services]
+      transform:
+        template: |
+          Active services: {{ cel "size(_.services.filter(s, s.active == true))" . }}
+          Total ports: {{ cel "_.services.map(s, s.port).reduce(a, b, a + b)" . }}
+        name: cel-in-template
+```
+
+### When to use cel vs pure Go template
+
+- Use `cel` when you need list filtering, mapping, or aggregation that would be verbose in Go templates
+- Use pure Go template for text formatting, conditionals, and simple iteration
+- The `cel` function returns a string — use it for interpolation, not for complex data structures
+
+---
+
+## Debugging Template Type Errors
+
+When a Go template fails at execution time, scafctl provides **diagnostic hints** to help you identify the root cause quickly. Instead of raw Go stack traces, you get:
+
+- **What went wrong** — a plain-language explanation of the error category
+- **Data context** — the Go type and available top-level keys of the template data
+- **Actionable fix** — what to check or change
+
+### Common Error Categories
+
+| Error | Diagnostic Hint |
+|-------|----------------|
+| Nil pointer dereference | "A value used in the template is nil. Check that all referenced resolver fields have been resolved before this template runs." |
+| Range over non-iterable | "The 'range' action received a non-iterable value. Ensure the variable is a list/slice or map, not a string or number." |
+| Missing field | "A referenced field does not exist on the data object. Double-check field names and casing." |
+| Undefined function | "A template function is not registered. Available custom functions: slugify, toDnsString, where, selectField, cel, toHcl, toYaml, fromYaml." |
+| Wrong number of args | "A function or method was called with the wrong number of arguments. Check the function signature." |
+| Missing map key | "A map key was not found. Use 'index' to safely access map keys, or set missingKey to 'zero' or 'default'." |
+
+### Example Error Output
+
+Say you have a template that tries to range over a string:
+
+```yaml
+resolvers:
+  greeting:
+    type: go-template
+    transform:
+      template: '{{ range .name }}{{ . }}{{ end }}'
+      name: bad-range
+```
+
+If `.name` resolves to the string `"Alice"` instead of a list, the error output includes:
+
+```
+execution error: template: bad-range:1:9: executing "bad-range" at <.name>:
+  range can't iterate over Alice
+Hints: The 'range' action received a non-iterable value. Ensure the variable
+  is a list/slice or map, not a string or number. |
+  Template data type: map[string]interface {} |
+  Available top-level keys: name
+```
+
+### Tips
+
+- Set `missingKey: "error"` to catch typos in field names at execution time instead of silently rendering empty strings
+- Use `{{ printf "%T" .myField }}` to inspect the type of a value at runtime
+- Check `dependsOn` to ensure all upstream resolvers are resolved before the template runs
+
+---
+
 ## Discovering Available Functions
 
 scafctl provides tools to explore all available Go template functions — both Sprig and custom.
@@ -1705,6 +1903,86 @@ The AI calls `list_go_template_functions` and returns a curated list of matching
 
 ---
 
+## Ignored Blocks
+
+When templates contain syntax that conflicts with Go template delimiters (e.g., Terraform `${}`, Helm double braces, GitHub Actions `${{ }}`, or PromQL), you can preserve those sections literally using `ignoredBlocks`.
+
+### Start/End Mode (Multi-line)
+
+Define pairs of start/end markers. Content between matched markers passes through without template processing:
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: terraform-module
+        template: |
+          resource "aws_instance" "main" {
+            ami           = "{{ .ami }}"
+            instance_type = "{{ .instanceType }}"
+            /*scafctl:ignore:start*/
+            tags = {
+              Name = "${var.name}-${var.env}"
+            }
+            /*scafctl:ignore:end*/
+          }
+        ignoredBlocks:
+          - start: "/*scafctl:ignore:start*/"
+            end: "/*scafctl:ignore:end*/"
+```
+
+The markers themselves are preserved in the output. The content between them — including Go template-like syntax, interpolations, and special characters — passes through unchanged.
+
+### Line Mode (Single-line)
+
+When only a single line needs to be preserved, use `line` instead of wrapping it in start/end markers. Every line containing the marker substring is preserved literally:
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: github-workflow
+        template: |
+          name: Deploy {{ .appName }}
+          on: [push]
+          jobs:
+            deploy:
+              runs-on: ubuntu-latest
+              steps:
+                - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+                - run: echo ${{ github.sha }}  # scafctl:ignore
+                - run: echo "deployed"
+        ignoredBlocks:
+          - line: "# scafctl:ignore"
+```
+
+Append the marker as an inline comment on any line that should be ignored. Only those lines are protected — the rest of the template renders normally.
+
+> **Note:** `line` and `start`/`end` are mutually exclusive within a single entry. Different entries can use different modes.
+
+### Multiple Ignored Blocks
+
+You can define multiple marker pairs and use them multiple times in a single template:
+
+```yaml
+ignoredBlocks:
+  - start: "# BEGIN TERRAFORM"
+    end: "# END TERRAFORM"
+  - start: "{{/* skip:start */}}"
+    end: "{{/* skip:end */}}"
+```
+
+### Use Cases
+
+- **Terraform/OpenTofu** — Preserve `${var.name}` interpolations
+- **Helm** — Preserve Helm `{{ .Values.x }}` while processing outer scafctl templates
+- **PromQL** — Preserve `rate(metric{label="x"}[5m])` in monitoring configs
+- **Pre-existing templates** — Mix scafctl template logic with other template engines in the same file
+
+---
+
 ## Provider Reference
 
 For a quick reference of all `go-template` provider inputs:
@@ -1717,6 +1995,7 @@ For a quick reference of all `go-template` provider inputs:
 | `leftDelim` | string | ❌ | Custom left delimiter (default: `{{`) |
 | `rightDelim` | string | ❌ | Custom right delimiter (default: `}}`) |
 | `data` | any | ❌ | Additional data merged into template context |
+| `ignoredBlocks` | array | ❌ | Blocks to pass through literally. Each entry: `{ start, end }` markers OR `{ line }` marker |
 
 ---
 

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -237,6 +237,40 @@ resolvers:
             value: "hello"
 ```
 
+### Unreachable Test Path
+
+```yaml
+# Before (triggers warning — file doesn't exist)
+testing:
+  cases:
+    my-test:
+      files:
+        - testdata/config.json   # this file doesn't exist
+      command: [render, solution]
+      assertions:
+        - expression: __exitCode == 0
+
+# After (use correct path, glob, or directory)
+testing:
+  cases:
+    my-test:
+      files:
+        - testdata/config.yaml     # exact file that exists
+        - templates/*.yaml          # glob pattern matching files
+        - data/                     # entire directory
+      command: [render, solution]
+      assertions:
+        - expression: __exitCode == 0
+```
+
+The `unreachable-test-path` rule detects `files` entries in test cases that reference paths not found on disk and don't match any files via glob expansion. This catches typos and stale references before they cause confusing sandbox setup failures.
+
+For more details:
+
+```bash
+scafctl lint explain unreachable-test-path
+```
+
 ## 6. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -54,6 +54,7 @@ You should see JSON output listing all available tools:
     { "name": "diff_snapshots", "description": "Diff two resolver snapshots..." },
     { "name": "evaluate_cel", "description": "Evaluate a CEL expression..." },
     { "name": "evaluate_go_template", "description": "Evaluate a Go template against provided data..." },
+    { "name": "explain_concepts", "description": "Look up and explain scafctl concepts..." },
     { "name": "extract_resolver_refs", "description": "Find all resolver cross-references in a solution..." },
     { "name": "generate_test_scaffold", "description": "Generate functional test cases for a solution..." },
     { "name": "get_config_paths", "description": "List all XDG-compliant paths used by scafctl..." },
@@ -634,6 +635,22 @@ The AI calls `list_examples` with `category: "actions"` to see all available act
 
 The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"` to get a practical reference, then uses `get_solution_schema` to verify the structure.
 
+#### Explain a Concept
+
+> **You:** "What is a resolver and how does it work?"
+
+The AI calls `explain_concepts` with `name: "resolver"` and returns a detailed explanation including the concept summary, category, examples, and related concepts.
+
+> **You:** "What testing concepts does scafctl support?"
+
+The AI calls `explain_concepts` with `category: "testing"` and gets summaries for all testing-related concepts — functional testing, test sandbox, test scaffold, and test assertions.
+
+#### Inspect Solution File Dependencies
+
+> **You:** "What files does my solution depend on?"
+
+The AI calls `inspect_solution` with `path: "solution.yaml"` and the response includes a `fileDependencies` array listing all external files referenced by providers (e.g., template files loaded via `go-template`, HCL files via `hcl`), along with which resolver references each file.
+
 ## 7. Available Tools Reference
 
 | Tool | Description |
@@ -643,28 +660,31 @@ The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"`
 | `diff_solution` | Compare two solution files structurally — shows added, removed, and changed resolvers, actions, metadata, and tests |
 | `evaluate_cel` | Evaluate a CEL expression with inline data, variables, or file-based context |
 | `evaluate_go_template` | Evaluate a Go template against provided data, returning rendered output and referenced fields |
+| `explain_error` | Explain a scafctl error message — root cause, resolution steps, related tools, and example fixes |
 | `explain_kind` | Explain any registered kind (solution, resolver, action, etc.) — shows all fields, types, descriptions, and validation tags |
 | `explain_lint_rule` | Get a detailed explanation of a lint rule — description, severity, category, why it matters, how to fix it, and examples |
 | `get_example` | Read the contents of a scafctl example file. Use `list_examples` first to find available examples |
 | `get_provider_schema` | Get comprehensive provider info: input schema (with per-property required), output schemas, examples, CLI usage |
+| `get_provider_output_shape` | Get the output schema for a provider. Optionally filter by capability (`from`, `transform`, `action`) |
 | `get_solution_schema` | Get the full JSON Schema for the solution YAML file format. Optionally drill into a specific field (e.g., `metadata`, `spec`) |
 | `get_run_command` | Get the exact CLI command to run a solution (determines run solution vs run resolver) |
-| `inspect_solution` | Full solution metadata — resolvers, actions, tags, links, maintainers |
+| `explain_concepts` | Look up and explain scafctl concepts (resolvers, providers, testing, CEL, etc.). Use without arguments to list all, or provide a name/query/category |
+| `inspect_solution` | Full solution metadata — resolvers, actions, tags, links, maintainers, and file dependencies |
 | `lint_solution` | Validate a solution YAML file and return structured findings |
-| `list_cel_functions` | List CEL functions — custom scafctl functions, built-in, or by name |
+| `list_cel_functions` | List CEL functions — custom scafctl functions, built-in, or by name. Use `category` to filter (e.g., `strings`, `collections`, `encoding`) |
 | `list_go_template_functions` | List Go template extension functions — Sprig, custom, or by name |
 | `list_examples` | List available scafctl example files with category filtering (solutions, resolvers, actions, providers, etc.) |
 | `list_providers` | List all providers with capability and category filtering |
 | `list_solutions` | List solutions from the local catalog with name filtering |
 | `preview_action` | Preview what each action in a workflow would do WITHOUT executing — shows materialized inputs, deferred values, phases, and dependencies |
-| `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value. Use `resolver` param to focus on a single resolver and its dependencies |
+| `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value, output schema, and source positions. Use `resolver` param to focus on a single resolver and its dependencies |
 | `render_solution` | Render action, resolver, or action-deps graphs as structured JSON |
 | `run_solution_tests` | Execute functional tests defined in a solution and return structured results. Use `verbose=true` for full assertion details |
 | `scaffold_solution` | Generate a complete skeleton solution YAML from parameters — name, description, features, and providers |
 | `validate_expression` | Syntax-check a CEL expression or Go template without executing it — returns validity, errors, and referenced fields |
 | `catalog_inspect` | Get detailed metadata for a specific catalog artifact — version, kind, digest, created timestamp, and dependency list |
 | `extract_resolver_refs` | Find all resolver cross-references (`_.resolverName`) in a solution — shows which resolvers reference which others |
-| `generate_test_scaffold` | Generate functional test case scaffolding for a solution — creates test YAML with assertions and tags based on the solution's resolvers and actions |
+| `generate_test_scaffold` | Generate functional test case scaffolding for a solution — creates test YAML with assertions, tags, auto-populated file dependencies, and sandbox guidance |
 | `list_tests` | List functional tests defined in a solution's `spec.testing.cases` — shows test names, descriptions, assertions, and tags |
 | `show_snapshot` | Display the contents of a resolver execution snapshot file — resolver values, timing, status, and errors |
 | `diff_snapshots` | Compare two resolver snapshots and return structured diffs — added, removed, modified, and unchanged resolvers |
@@ -672,6 +692,7 @@ The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"`
 | `get_config_paths` | List all XDG-compliant paths used by scafctl — config, data, cache, state, secrets, plugins, and runtime directories |
 | `validate_expressions` | Batch-validate multiple CEL expressions or Go templates — returns validity, errors, and referenced fields for each |
 | `get_version` | Return scafctl version, commit SHA, and build timestamp |
+| `dry_run_solution` | Dry-run a solution without executing providers. Use `mock_data` to inject custom mock values per resolver |
 
 ## 8. Available Resources
 

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -1,0 +1,243 @@
+---
+title: "Provider Output Shapes"
+weight: 18
+---
+
+# Provider Output Shapes
+
+Quick reference for what each built-in provider returns in resolver output — the data shape you can access via `_.resolverName` in CEL expressions and Go templates.
+
+## How Provider Output Works
+
+When a resolver uses a provider, the resolved value becomes accessible to other resolvers. The **output shape** determines what fields are available:
+
+```
+┌─────────────────────┐         ┌──────────────────┐
+│ Resolver: api_data  │         │ Resolver: summary │
+│ provider: http      │  ───►   │ expr: _.api_data  │
+│ output: {           │         │   .body.items     │
+│   body: {...}       │         │   | size()        │
+│   statusCode: 200   │         └──────────────────┘
+│   headers: {...}    │
+│ }                   │
+└─────────────────────┘
+```
+
+> **Tip:** Use the MCP tool `get_provider_output_shape` to query output schemas programmatically, or `get_provider_schema` for full provider documentation.
+
+---
+
+## Core Providers
+
+### `static`
+Returns the literal value as-is.
+
+| Capability | Output | Type |
+|-----------|--------|------|
+| from | `<value>` | any |
+| transform | `<value>` | any |
+
+```yaml
+# Output is whatever you set as the value
+resolve:
+  with:
+    - provider: static
+      inputs:
+        value: "hello"
+# _.my_resolver == "hello"
+```
+
+### `cel`
+Returns the result of evaluating a CEL expression.
+
+| Capability | Output | Type |
+|-----------|--------|------|
+| from | `<expression result>` | any |
+| transform | `<expression result>` | any |
+
+```yaml
+# Output is the CEL evaluation result
+resolve:
+  with:
+    - provider: cel
+      inputs:
+        expression: "size(_.items)"
+# _.my_resolver == 42  (or whatever the expression returns)
+```
+
+### `parameter`
+Returns the value from CLI `-r key=value` flags.
+
+| Capability | Output | Type |
+|-----------|--------|------|
+| from | `<parameter value>` | string |
+
+### `env`
+Returns the value of an environment variable.
+
+| Capability | Output | Type |
+|-----------|--------|------|
+| from | `<env value>` | string |
+
+---
+
+## Data Providers
+
+### `http`
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| from / transform | `body` | any (string or parsed JSON if autoParseJson) | Response body |
+| | `statusCode` | int | HTTP status code |
+| | `headers` | map[string]string | Response headers |
+| action | `body` | any | Response body |
+| | `statusCode` | int | HTTP status code |
+| | `headers` | map[string]string | Response headers |
+| | `success` | bool | Whether statusCode < 400 |
+
+```yaml
+# Access HTTP response fields
+transform:
+  with:
+    - provider: cel
+      inputs:
+        expression: "_.api_data.body.items[0].name"
+```
+
+### `github`
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| from / transform | `result` | any | API response (structure varies by operation) |
+
+**Operation output shapes:**
+
+| Operation | `result` type | Key fields |
+|-----------|--------------|------------|
+| `get_repo` | object | `name`, `full_name`, `description`, `default_branch`, `private`, `html_url` |
+| `get_file` | object | `name`, `content`, `decoded_content`, `sha`, `size`, `type` |
+| `list_releases` | array | Each: `tag_name`, `name`, `body`, `published_at`, `prerelease` |
+| `get_latest_release` | object | `tag_name`, `name`, `body`, `published_at` |
+| `list_pull_requests` | array | Each: `number`, `title`, `state`, `user`, `created_at` |
+| `get_pull_request` | object | `number`, `title`, `state`, `body`, `user`, `mergeable` |
+
+```yaml
+# Access GitHub API results
+transform:
+  with:
+    - provider: cel
+      inputs:
+        expression: "_.repo_info.result.default_branch"
+```
+
+### `file`
+Returns file content.
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| from | `content` | string | Raw file content |
+| | `path` | string | Resolved file path |
+| | `size` | int | File size in bytes |
+
+### `directory`
+Returns directory listings.
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| from | `entries` | array | Directory entries |
+| | `path` | string | Directory path |
+
+Each entry: `{ name, path, isDir, size, modTime }`
+
+---
+
+## Processing Providers
+
+### `exec`
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| from / transform | `stdout` | string | Standard output |
+| | `stderr` | string | Standard error |
+| | `exitCode` | int | Exit code |
+| | `command` | string | Full command string |
+| | `shell` | string | Shell used |
+| action | `success` | bool | Whether exit code is 0 |
+| | `stdout` | string | Standard output |
+| | `stderr` | string | Standard error |
+| | `exitCode` | int | Exit code |
+| | `command` | string | Full command string |
+| | `shell` | string | Shell used |
+
+```yaml
+# Parse exec output
+transform:
+  with:
+    - provider: cel
+      inputs:
+        expression: "_.git_info.stdout.trim()"
+```
+
+### `go-template`
+Returns rendered template output.
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| transform | `<rendered text>` | string | Template output as string |
+
+### `hcl`
+Varies by operation — parse returns structured data, format/validate return strings.
+
+### `validation`
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| validation | `valid` | bool | Always `true` on success |
+| | `details` | string | `"all validations passed"` |
+
+---
+
+## Discovering Output Shapes
+
+### CLI
+
+```bash
+# View full provider info including output schemas
+scafctl get provider http -o json
+
+# View all providers
+scafctl get providers
+```
+
+### MCP Tools
+
+```
+# Get output shape for a specific provider
+get_provider_output_shape(name: "http", capability: "from")
+
+# Get full provider docs
+get_provider_schema(name: "http")
+```
+
+### In CEL Expressions
+
+When writing CEL that references resolver output, the shape depends on the provider used:
+
+```yaml
+# HTTP provider → access .body, .statusCode, .headers
+expression: "_.api_call.body.count > 0"
+
+# Exec provider → access .stdout, .exitCode
+expression: "_.cmd_result.exitCode == 0"
+
+# Static/CEL provider → direct value
+expression: "_.my_string == 'expected'"
+```
+
+---
+
+## Next Steps
+
+- [Provider Reference](provider-reference.md) — complete documentation for all providers
+- [CEL Expressions Tutorial](cel-tutorial.md) — use output fields in expressions
+- [Resolver Tutorial](resolver-tutorial.md) — chain resolvers using output data

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -32,10 +32,12 @@ Providers are execution primitives used by resolvers and actions. Each provider 
 | [exec](#exec) | ✅ | ✅ | ❌ | ✅ |
 | [file](#file) | ✅ | ✅ | ❌ | ✅ |
 | [git](#git) | ✅ | ❌ | ❌ | ✅ |
+| [github](#github) | ✅ | ✅ | ❌ | ❌ |
 | [go-template](#go-template) | ❌ | ✅ | ❌ | ✅ |
 | [hcl](#hcl) | ✅ | ✅ | ❌ | ❌ |
 | [http](#http) | ✅ | ✅ | ❌ | ✅ |
 | [identity](#identity) | ✅ | ❌ | ❌ | ❌ |
+| [metadata](#metadata) | ✅ | ❌ | ❌ | ❌ |
 | [parameter](#parameter) | ✅ | ❌ | ❌ | ❌ |
 | [secret](#secret) | ✅ | ❌ | ❌ | ❌ |
 | [sleep](#sleep) | ✅ | ✅ | ✅ | ✅ |
@@ -482,6 +484,93 @@ inputs:
 
 ---
 
+## github
+
+Retrieve data from the GitHub REST API. Supports repository info, file content, releases, and pull requests. Uses the configured GitHub auth handler automatically.
+
+> For arbitrary HTTP requests to GitHub, use the `http` provider with `auth: github`.
+
+### Capabilities
+
+`from`, `transform`
+
+### Inputs
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `operation` | string | ✅ | API operation: `get_repo`, `get_file`, `list_releases`, `get_latest_release`, `list_pull_requests`, `get_pull_request` |
+| `owner` | string | ✅ | Repository owner (user or organization) |
+| `repo` | string | ✅ | Repository name |
+| `path` | string | ❌ | File path within the repository (for `get_file`) |
+| `ref` | string | ❌ | Git reference (branch, tag, or commit SHA). Defaults to repo's default branch |
+| `number` | int | ❌ | Pull request number (for `get_pull_request`) |
+| `state` | string | ❌ | Filter by state: `open`, `closed`, `all` (default: `open`) |
+| `per_page` | int | ❌ | Results per page, 1–100 (default: 30) |
+| `api_base` | string | ❌ | GitHub API base URL (default: `https://api.github.com`). Set for GitHub Enterprise. |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `result` | any | API response — structure varies by operation (see below) |
+
+**Operation output shapes:**
+
+| Operation | `result` type | Key fields |
+|-----------|--------------|------------|
+| `get_repo` | object | `name`, `full_name`, `description`, `default_branch`, `private`, `html_url` |
+| `get_file` | object | `name`, `content`, `decoded_content`, `sha`, `size`, `type` |
+| `list_releases` | array | Each: `tag_name`, `name`, `body`, `published_at`, `prerelease` |
+| `get_latest_release` | object | `tag_name`, `name`, `body`, `published_at` |
+| `list_pull_requests` | array | Each: `number`, `title`, `state`, `user`, `created_at` |
+| `get_pull_request` | object | `number`, `title`, `state`, `body`, `user`, `mergeable` |
+
+### Examples
+
+```yaml
+# Get repository info
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: get_repo
+        owner: octocat
+        repo: hello-world
+
+# Get file content from a specific branch
+transform:
+  with:
+    - provider: github
+      inputs:
+        operation: get_file
+        owner: octocat
+        repo: hello-world
+        path: README.md
+        ref: main
+
+# Get latest release
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: get_latest_release
+        owner: cli
+        repo: cli
+
+# List open pull requests
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: list_pull_requests
+        owner: golang
+        repo: go
+        state: open
+        per_page: 10
+```
+
+---
+
 ## go-template
 
 Transform data using Go text/template syntax.
@@ -500,10 +589,63 @@ Transform data using Go text/template syntax.
 | `leftDelim` | string | ❌ | Left delimiter (default: `{{`) |
 | `rightDelim` | string | ❌ | Right delimiter (default: `}}`) |
 | `data` | any | ❌ | Additional data to merge with resolver context |
+| `ignoredBlocks` | array | ❌ | Blocks to pass through literally without template processing. Each entry uses EITHER `{ start, end }` markers (multi-line) OR `{ line }` marker (single-line). Content is preserved as-is. |
 
 ### Output
 
 Returns the rendered template as a string.
+
+### Ignored Blocks
+
+Use `ignoredBlocks` to bypass template rendering for specific sections. This is useful when templates contain syntax that conflicts with Go template delimiters (e.g., Terraform `${}`, Helm `{{ }}`, GitHub Actions `${{ }}`).
+
+#### Start/End Mode (Multi-line)
+
+Define `start` and `end` markers. All content between matched markers (inclusive) is preserved:
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: terraform-config
+        template: |
+          resource "aws_instance" "main" {
+            ami           = "{{ .ami }}"
+            instance_type = "{{ .instanceType }}"
+            /*scafctl:ignore:start*/
+            tags = {
+              Name = "${var.name}"
+            }
+            /*scafctl:ignore:end*/
+          }
+        ignoredBlocks:
+          - start: "/*scafctl:ignore:start*/"
+            end: "/*scafctl:ignore:end*/"
+```
+
+#### Line Mode (Single-line)
+
+Define a `line` marker. Every line containing that substring is preserved literally:
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: workflow-config
+        template: |
+          name: Deploy {{ .appName }}
+          steps:
+            - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+            - run: echo "deployed"
+        ignoredBlocks:
+          - line: "# scafctl:ignore"
+```
+
+> **Note:** `line` and `start`/`end` are mutually exclusive within a single entry, but different entries can use different modes.
+
+The content between `start` and `end` markers (including the markers themselves) passes through unchanged. For `line` mode, the entire line containing the marker is preserved.
 
 ### Examples
 
@@ -719,6 +861,8 @@ HTTP client for API calls with built-in pagination support for fetching data acr
 | `auth` | string | ❌ | Auth provider (e.g., `entra`, `github`) |
 | `scope` | string | ❌ | OAuth scope for authentication |
 | `pagination` | object | ❌ | Pagination configuration (see below) |
+| `autoParseJson` | bool | ❌ | Parse response body as JSON when Content-Type is `application/json`. Enables direct field access (e.g., `_.result.body.items`) |
+| `poll` | object | ❌ | Polling configuration — re-execute request until a condition is met (see below) |
 
 ### Pagination
 
@@ -789,12 +933,40 @@ Full control using CEL expressions.
 | `nextURL` | string | CEL expression returning the full next page URL (empty string = stop) |
 | `nextParams` | string | CEL expression returning a map of query params for the next request (empty map = stop) |
 
+### Polling
+
+The `poll` input enables re-executing the request until a response condition is met. This is different from `retry` (which handles transient failures) — polling re-executes on successful responses until the content matches expectations.
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `until` | string | ✅ | CEL expression evaluated against the response. Polling stops when this returns `true`. Available variables: `body` (parsed if JSON), `statusCode`, `headers` |
+| `failWhen` | string | ❌ | CEL expression that triggers immediate failure (e.g., terminal error states) |
+| `interval` | string | ❌ | Duration between polls (default: `5s`). Format: `1s`, `30s`, `2m` |
+| `maxAttempts` | int | ❌ | Maximum number of poll attempts (default: 60) |
+
+```yaml
+# Wait for deployment to complete
+resolve:
+  with:
+    - provider: http
+      inputs:
+        url: https://api.example.com/deployments/123/status
+        method: GET
+        auth: entra
+        autoParseJson: true
+        poll:
+          until: 'body.status == "succeeded"'
+          failWhen: 'body.status == "failed"'
+          interval: 10s
+          maxAttempts: 30
+```
+
 ### Output
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `statusCode` | int | HTTP status code (last page when paginating) |
-| `body` | string | Response body. When paginating with `collectPath`, contains JSON array of all collected items |
+| `body` | any | Response body as string, or parsed JSON object when `autoParseJson: true`. When paginating with `collectPath`, contains JSON array of all collected items |
 | `headers` | object | Response headers (last page when paginating) |
 | `success` | bool | Whether request succeeded (action only) |
 | `pages` | int | Number of pages fetched (only when paginating) |
@@ -976,6 +1148,58 @@ resolve:
       inputs:
         operation: claims
         handler: github
+```
+
+---
+
+## metadata
+
+Return structured metadata about a solution. Accepts arbitrary key-value pairs and returns them as a map, optionally returning a single field by key. Useful for exposing solution name, version, description, tags, and custom attributes to templates and downstream resolvers.
+
+### Capabilities
+
+`from`
+
+### Inputs
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `field` | string | ❌ | Return only this single field from the metadata map instead of the full map |
+| *(any key)* | any | ❌ | Arbitrary metadata key-value pairs |
+
+### Output
+
+When `field` is set: the value of that specific key.
+When `field` is omitted: a map of all provided key-value pairs (excluding `field` itself).
+
+### Examples
+
+**Full metadata map:**
+
+```yaml
+resolvers:
+  solution-meta:
+    type: metadata
+    from:
+      name: my-solution
+      version: 2.1.0
+      description: Scaffolds a GCP project
+      category: infrastructure
+      tags:
+        - gcp
+        - terraform
+```
+
+**Single field extraction:**
+
+```yaml
+resolvers:
+  solution-name:
+    type: metadata
+    from:
+      field: name
+      name: my-solution
+      version: 2.1.0
 ```
 
 ---

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -706,6 +706,59 @@ Output:
 - `continue` (default): Try the next source in the list. The resolve phase acts as an implicit fallback chain.
 - `fail`: Stop execution immediately and return the error without trying remaining sources.
 
+### Custom Error Messages
+
+Use the `messages` field to replace default error text with user-friendly messages. The `messages.error` field supports static strings, CEL expressions (`expr:`), and Go templates (`tmpl:`):
+
+```yaml
+# messages-error.yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: custom-error-messages
+  version: 1.0.0
+
+spec:
+  resolvers:
+    port:
+      description: Application port number
+      messages:
+        error: "Port must be between 1024 and 65535. Got: {{ .__error }}"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              name: port
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              rules:
+                - expr: "int(__self) >= 1024 && int(__self) <= 65535"
+                  message: invalid port range
+
+    apiEndpoint:
+      description: API endpoint URL
+      messages:
+        error:
+          expr: "'Failed to reach API endpoint. Error: ' + __error"
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/health
+              method: GET
+```
+
+The `messages.error` value is evaluated when any phase fails (resolve, transform, or validate). Two variables are available:
+
+| Variable | Description |
+|----------|-------------|
+| `_` | The resolver data map (all resolved values so far) |
+| `__error` | The original error message string |
+
+When a custom error message is set, it replaces the default error text in all output — CLI, MCP tools, and snapshot captures.
+
 ---
 
 ## Working with HTTP APIs

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -1,0 +1,457 @@
+---
+title: "Validation Patterns Tutorial"
+weight: 17
+---
+
+# Validation Patterns Tutorial
+
+Learn how to validate resolver outputs, enforce constraints on inputs, and use schema validation to catch issues early.
+
+## Overview
+
+scafctl offers multiple validation layers that work together to ensure configuration correctness:
+
+```
+┌─────────────────────────────────────────────┐
+│             Solution YAML                    │
+├─────────┬──────────┬──────────┬─────────────┤
+│  Lint   │  Schema  │ Validate │  Result     │
+│  Rules  │  Helper  │ Provider │  Schema     │
+│         │  Tags    │          │             │
+├─────────┴──────────┴──────────┴─────────────┤
+│      Runtime Validation (CEL + Regex)        │
+└─────────────────────────────────────────────┘
+```
+
+- **Schema helper tags** — provider-level input constraints (type, length, pattern, enum)
+- **Validation provider** — runtime regex and CEL-based checks on resolver values
+- **Result schemas** — JSON Schema validation of action outputs
+- **Lint rules** — static analysis at `scafctl lint` time
+
+---
+
+## 1. Schema-Level Validation with Provider Inputs
+
+Provider schemas use JSON Schema constraints to reject invalid input before execution.
+
+### Available Constraints
+
+| Constraint | Applies To | Helper Function | Description |
+|------------|-----------|----------------|-------------|
+| `enum` | strings, ints | `WithEnum(vals...)` | Restrict to allowed values |
+| `pattern` | strings | `WithPattern(regex)` | Must match regex |
+| `minLength` / `maxLength` | strings | `WithMinLength(n)` / `WithMaxLength(n)` | String length bounds |
+| `minimum` / `maximum` | numbers | `WithMinimum(n)` / `WithMaximum(n)` | Numeric range bounds |
+| `minItems` / `maxItems` | arrays | `WithMinItems(n)` / `WithMaxItems(n)` | Array size bounds |
+| `format` | strings | `WithFormat(fmt)` | Semantic format hint (`uri`, `email`, `date`, `uuid`) |
+| `default` | any | `WithDefault(val)` | Default value if omitted |
+
+### Example: Provider Schema in Go
+
+```go
+schema := schemahelper.ObjectSchema(
+    []string{"name", "environment"}, // required fields
+    map[string]*jsonschema.Schema{
+        "name": schemahelper.StringProp("Service name",
+            schemahelper.WithPattern(`^[a-z][a-z0-9-]*$`),
+            schemahelper.WithMinLength(3),
+            schemahelper.WithMaxLength(63),
+            schemahelper.WithExample("my-service"),
+        ),
+        "environment": schemahelper.StringProp("Target environment",
+            schemahelper.WithEnum("development", "staging", "production"),
+            schemahelper.WithExample("production"),
+        ),
+        "replicas": schemahelper.IntProp("Number of replicas",
+            schemahelper.WithMinimum(1),
+            schemahelper.WithMaximum(100),
+            schemahelper.WithDefault(3),
+        ),
+        "tags": schemahelper.ArrayProp("Resource tags",
+            schemahelper.WithMaxItems(20),
+            schemahelper.WithItems(schemahelper.StringProp("tag value",
+                schemahelper.WithMaxLength(128),
+            )),
+        ),
+        "callback_url": schemahelper.StringProp("Webhook callback URL",
+            schemahelper.WithFormat("uri"),
+        ),
+    },
+)
+```
+
+When a resolver passes invalid input to this provider, the lint system catches it at analysis time:
+
+```bash
+scafctl lint my-solution.yaml
+```
+
+```
+ERROR [invalid-provider-input-type] resolver 'deploy': input 'replicas' expects integer, got string
+ERROR [schema-violation] resolver 'deploy': input 'name' does not match pattern '^[a-z][a-z0-9-]*$'
+```
+
+---
+
+## 2. Runtime Validation with the `validation` Provider
+
+The `validation` provider runs checks during the **validate phase** of a resolver, or as a standalone transform.
+
+### Pattern: Regex Matching
+
+Validate string values against regex patterns:
+
+```yaml
+# examples/providers/validation/regex-patterns.yaml
+apiVersion: scafctl.io/v1alpha1
+kind: Solution
+metadata:
+  name: regex-validation-demo
+spec:
+  resolvers:
+    - name: email
+      value: "user@example.com"
+      validate:
+        with:
+          - provider: validation
+            input:
+              match: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+              message: "Must be a valid email address"
+
+    - name: semver
+      value: "v1.2.3"
+      validate:
+        with:
+          - provider: validation
+            input:
+              match: '^v?\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$'
+              message: "Must be a valid semantic version"
+
+    - name: k8s_name
+      value: "my-service-01"
+      validate:
+        with:
+          - provider: validation
+            input:
+              match: '^[a-z][a-z0-9-]{0,61}[a-z0-9]$'
+              notMatch: '--'
+              message: "Must be a valid Kubernetes resource name"
+```
+
+> **▶ Try it:**
+> ```bash
+> scafctl run solution regex-patterns.yaml
+> ```
+
+### Pattern: CEL Expression Validation
+
+Use CEL expressions for complex, type-aware validation:
+
+```yaml
+# examples/providers/validation/cel-validation.yaml
+apiVersion: scafctl.io/v1alpha1
+kind: Solution
+metadata:
+  name: cel-validation-demo
+spec:
+  resolvers:
+    - name: port
+      value: 8080
+      validate:
+        with:
+          - provider: validation
+            input:
+              expression: "__self >= 1024 && __self <= 65535"
+              message: "Port must be in the unprivileged range (1024-65535)"
+
+    - name: environment
+      value: "staging"
+      validate:
+        with:
+          - provider: validation
+            input:
+              expression: "__self in ['development', 'staging', 'production']"
+              message: "Environment must be one of: development, staging, production"
+
+    - name: password
+      value: "SecureP@ss1"
+      validate:
+        with:
+          - provider: validation
+            input:
+              match: '.{8,}'
+              message: "Password must be at least 8 characters"
+          - provider: validation
+            input:
+              match: '[A-Z]'
+              message: "Password must contain an uppercase letter"
+          - provider: validation
+            input:
+              match: '[0-9]'
+              message: "Password must contain a digit"
+          - provider: validation
+            input:
+              match: '[!@#$%^&*]'
+              message: "Password must contain a special character"
+```
+
+> **Tip:** `__self` refers to the resolver's current value inside validate and transform phases. Use `_` to access the full resolver data map for cross-field validation.
+
+### Pattern: Cross-Field Validation
+
+Validate relationships between different resolver values:
+
+```yaml
+apiVersion: scafctl.io/v1alpha1
+kind: Solution
+metadata:
+  name: cross-field-validation
+spec:
+  resolvers:
+    - name: min_replicas
+      value: 2
+
+    - name: max_replicas
+      value: 10
+      validate:
+        with:
+          - provider: validation
+            input:
+              expression: "__self >= _.min_replicas"
+              message: "max_replicas must be >= min_replicas"
+
+    - name: environment
+      value: "production"
+
+    - name: replicas
+      value: 3
+      validate:
+        with:
+          - provider: validation
+            input:
+              expression: |
+                _.environment == 'production'
+                  ? __self >= 3
+                  : __self >= 1
+              message: "Production requires at least 3 replicas"
+```
+
+---
+
+## 3. Action Result Schema Validation
+
+Actions can define a `resultSchema` to validate their output structure using JSON Schema:
+
+```yaml
+apiVersion: scafctl.io/v1alpha1
+kind: Solution
+metadata:
+  name: result-schema-demo
+spec:
+  resolvers:
+    - name: config
+      resolve:
+        with:
+          - provider: http
+            input:
+              method: GET
+              url: https://api.example.com/config
+
+  actions:
+    - name: deploy
+      resultSchema:
+        type: object
+        required:
+          - status
+          - deploymentId
+        properties:
+          status:
+            type: string
+            enum: [success, pending, failed]
+          deploymentId:
+            type: string
+            pattern: "^deploy-[a-f0-9]{8}$"
+          instances:
+            type: array
+            minItems: 1
+            items:
+              type: object
+              required: [id, region]
+              properties:
+                id:
+                  type: string
+                region:
+                  type: string
+                  enum: [us-east-1, us-west-2, eu-west-1]
+        additionalProperties: false
+      steps:
+        - provider: exec
+          input:
+            command: "echo '{\"status\":\"success\",\"deploymentId\":\"deploy-a1b2c3d4\",\"instances\":[{\"id\":\"i-1\",\"region\":\"us-east-1\"}]}'"
+```
+
+If the action output doesn't match the schema, execution fails with a clear error:
+
+```
+ERROR: action 'deploy' result does not match schema: property 'status' must be one of [success, pending, failed]
+```
+
+---
+
+## 4. Lint-Time Static Validation
+
+`scafctl lint` catches issues without executing the solution:
+
+```bash
+scafctl lint my-solution.yaml
+```
+
+### Key Validation Rules
+
+| Rule | Severity | What It Catches |
+|------|----------|----------------|
+| `schema-violation` | error | Unknown fields, type mismatches, pattern violations |
+| `unknown-provider-input` | error | Input key not in provider's schema |
+| `invalid-provider-input-type` | error | Literal value wrong type for field |
+| `invalid-expression` | error | CEL syntax errors |
+| `invalid-template` | error | Go template syntax errors |
+| `finally-with-foreach` | error | `forEach` in `finally` block (unsupported) |
+| `resolver-self-reference` | error | Using `_.name` instead of `__self` in validate/transform |
+| `permissive-result-schema` | info | `resultSchema` without `type` constraint |
+| `undefined-required-property` | error | Required property not defined in `properties` |
+
+```bash
+# Lint with auto-fix where possible
+scafctl lint --fix my-solution.yaml
+
+# Lint all solutions in a directory
+scafctl lint ./solutions/
+```
+
+---
+
+## 5. Common Validation Patterns Reference
+
+### String Patterns
+
+```yaml
+# Email
+match: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+
+# URL (http/https)
+match: '^https?://[^\s/$.?#].[^\s]*$'
+
+# Semantic version
+match: '^v?\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'
+
+# Kubernetes resource name (RFC 1123)
+match: '^[a-z][a-z0-9-]{0,61}[a-z0-9]$'
+
+# UUID
+match: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+# IPv4 address
+match: '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+
+# CIDR notation
+match: '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$'
+
+# ISO 8601 date
+match: '^\d{4}-\d{2}-\d{2}$'
+```
+
+### Numeric Constraints with CEL
+
+```yaml
+# Port range
+expression: "__self >= 1 && __self <= 65535"
+
+# Unprivileged port
+expression: "__self >= 1024 && __self <= 65535"
+
+# Percentage
+expression: "__self >= 0.0 && __self <= 100.0"
+
+# Memory limit (MB, must be power of 2)
+expression: "__self > 0 && __self % 2 == 0"
+
+# Timeout (1s to 5min)
+expression: "__self >= 1 && __self <= 300"
+```
+
+### Collection Constraints with CEL
+
+```yaml
+# Non-empty array
+expression: "size(__self) > 0"
+
+# Array max size
+expression: "size(__self) <= 50"
+
+# All items match pattern
+expression: "__self.all(item, item.matches('^[a-z-]+$'))"
+
+# At least one item meets criteria
+expression: "__self.exists(item, item.startsWith('prod-'))"
+
+# No duplicates
+expression: "size(__self) == size(__self.distinct())"
+
+# Map has required keys
+expression: "has(__self.region) && has(__self.zone)"
+```
+
+### Multi-Rule Composition
+
+Apply multiple validation rules by chaining `validation` provider entries:
+
+```yaml
+validate:
+  with:
+    - provider: validation
+      input:
+        match: '.{8,}'
+        message: "Must be at least 8 characters"
+    - provider: validation
+      input:
+        match: '[A-Z]'
+        message: "Must contain an uppercase letter"
+    - provider: validation
+      input:
+        notMatch: '\s'
+        message: "Must not contain whitespace"
+    - provider: validation
+      input:
+        expression: "__self != _.username"
+        message: "Must not match the username"
+```
+
+---
+
+## 6. Validation Failure Diagnostics
+
+When validation fails, scafctl provides structured error messages. Use the MCP `explain_error` tool or inspect the output directly:
+
+```bash
+# Run with verbose output to see validation details
+scafctl run solution my-solution.yaml -v 2
+```
+
+Common validation error patterns and their meaning:
+
+| Error Pattern | Cause | Fix |
+|--------------|-------|-----|
+| `validation failed: match` | Value didn't match the regex in `match` | Check the regex or the input value |
+| `validation failed: notMatch` | Value matched the regex in `notMatch` | Ensure value doesn't contain forbidden pattern |
+| `validation failed: expression` | CEL expression returned `false` | Review the expression and input data |
+| `'field' is required for X operation` | Missing required provider input | Add the field to your resolver input |
+| `unknown operation` | Invalid operation value | Check the provider's `enum` list |
+
+---
+
+## Next Steps
+
+- [CEL Expressions Tutorial](cel-tutorial.md) — dive deeper into CEL functions for validation
+- [Linting Tutorial](linting-tutorial.md) — static analysis and auto-fix
+- [Functional Testing Tutorial](functional-testing.md) — automated tests that verify validation behavior
+- [Provider Reference](provider-reference.md) — full schema docs for all providers

--- a/examples/providers/github-provider.yaml
+++ b/examples/providers/github-provider.yaml
@@ -1,0 +1,9 @@
+# GitHub provider examples — retrieve GitHub data without raw HTTP calls.
+# Requires GitHub authentication: scafctl auth login github
+#
+# Run: scafctl run provider -f examples/providers/github-provider.yaml
+
+# Get repository info
+operation: get_repo
+owner: cli
+repo: cli

--- a/examples/providers/http-autoparse.yaml
+++ b/examples/providers/http-autoparse.yaml
@@ -1,0 +1,8 @@
+# HTTP provider with autoParseJson — parse JSON responses automatically.
+# Instead of getting a raw string body, get a structured object for direct field access.
+#
+# Run: scafctl run provider -f examples/providers/http-autoparse.yaml
+
+url: https://httpbin.org/get
+method: GET
+autoParseJson: true

--- a/examples/providers/http-poll.yaml
+++ b/examples/providers/http-poll.yaml
@@ -1,0 +1,12 @@
+# HTTP provider with polling — re-execute requests until a condition is met.
+# Useful for waiting on async operations like deployments or CI pipelines.
+#
+# Run: scafctl run provider -f examples/providers/http-poll.yaml
+
+url: https://httpbin.org/get
+method: GET
+autoParseJson: true
+poll:
+  until: 'statusCode == 200'
+  interval: 2s
+  maxAttempts: 3

--- a/examples/providers/metadata-full.yaml
+++ b/examples/providers/metadata-full.yaml
@@ -1,0 +1,13 @@
+# Metadata provider example — expose solution metadata as resolver data
+#
+# The metadata provider accepts arbitrary key-value pairs and returns them
+# as a map. Use the optional "field" key to return a single value.
+
+# Full metadata map
+name: my-solution
+version: 2.1.0
+description: Scaffolds a GCP project
+category: infrastructure
+tags:
+  - gcp
+  - terraform

--- a/examples/providers/metadata-single-field.yaml
+++ b/examples/providers/metadata-single-field.yaml
@@ -1,0 +1,8 @@
+# Metadata provider — extract a single field
+#
+# Set "field" to the key you want returned as a scalar value
+# instead of the full metadata map.
+
+field: name
+name: my-solution
+version: 2.1.0

--- a/examples/resolvers/cel-extensions.yaml
+++ b/examples/resolvers/cel-extensions.yaml
@@ -127,6 +127,67 @@ spec:
               expression: 'strings.title("hello world from scafctl")'
 
     # ─────────────────────────────────────────────
+    # REGEX - Regular expression operations
+    # ─────────────────────────────────────────────
+
+    regex_match:
+      description: "regex.match - Test if a string matches a pattern"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "starts_with_hello": regex.match("^Hello", "Hello World"),
+                  "has_digits": regex.match("[0-9]+", "abc123"),
+                  "email_valid": regex.match("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", "user@example.com"),
+                  "no_match": regex.match("^xyz", "Hello World")
+                }
+
+    regex_replace:
+      description: "regex.replace - Replace all occurrences of a pattern"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "digits_to_hash": regex.replace("abc123def456", "[0-9]+", "#"),
+                  "spaces_to_dashes": regex.replace("hello world foo", "\\s+", "-"),
+                  "strip_special": regex.replace("hello! @world#", "[^a-zA-Z0-9 ]", "")
+                }
+
+    regex_find_all:
+      description: "regex.findAll - Find all matches of a pattern"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "digits": regex.findAll("[0-9]+", "abc123def456ghi789"),
+                  "words": regex.findAll("[a-zA-Z]+", "hello 123 world 456"),
+                  "no_matches": regex.findAll("[0-9]+", "no digits here")
+                }
+
+    regex_split:
+      description: "regex.split - Split a string by a pattern"
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                {
+                  "by_whitespace": regex.split("\\s+", "hello   world   foo"),
+                  "by_delimiters": regex.split("[,;]+", "a,b;c,,d"),
+                  "by_digits": regex.split("[0-9]+", "abc123def456ghi")
+                }
+
+    # ─────────────────────────────────────────────
     # FILEPATH - Path operations
     # ─────────────────────────────────────────────
 

--- a/examples/resolvers/go-template-ignored-blocks.yaml
+++ b/examples/resolvers/go-template-ignored-blocks.yaml
@@ -1,0 +1,86 @@
+# Go-template ignoredBlocks — preserve literal content that conflicts with
+# Go template delimiters.
+#
+# Two modes:
+#   1. start/end — Multi-line block markers. Content between markers passes through unchanged.
+#   2. line      — Every line containing the marker substring is preserved literally.
+#
+# Run: scafctl run solution -f examples/resolvers/go-template-ignored-blocks.yaml -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: go-template-ignored-blocks
+  version: 1.0.0
+  description: Demonstrates ignoredBlocks to preserve literal content in Go templates.
+
+spec:
+  resolvers:
+    instanceType:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: t3.medium
+
+    # --- start/end mode: multi-line block ---
+    terraformConfig:
+      description: Generates Terraform with mixed scafctl + Terraform syntax
+      dependsOn: [instanceType]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: terraform
+              template: |
+                resource "aws_instance" "main" {
+                  ami           = "ami-0123456789"
+                  instance_type = "{{ .instanceType }}"
+                  /*scafctl:ignore:start*/
+                  tags = {
+                    Name = "${var.project}-${var.env}"
+                    ManagedBy = "terraform"
+                  }
+                  /*scafctl:ignore:end*/
+                }
+              ignoredBlocks:
+                - start: "/*scafctl:ignore:start*/"
+                  end: "/*scafctl:ignore:end*/"
+
+    appName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+
+    # --- line mode: single-line ignore ---
+    githubWorkflow:
+      description: Preserve GitHub Actions expressions on specific lines
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: workflow
+              template: |
+                name: Deploy {{ .appName }}
+                on: [push]
+                jobs:
+                  deploy:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+                      - run: echo ${{ github.sha }}  # scafctl:ignore
+              ignoredBlocks:
+                - line: "# scafctl:ignore"

--- a/examples/resolvers/messages.yaml
+++ b/examples/resolvers/messages.yaml
@@ -1,0 +1,50 @@
+# Custom error messages — replace default error text with user-friendly messages.
+# The messages.error field supports static strings, CEL expressions, and Go templates.
+#
+# Run: scafctl run solution -f examples/resolvers/messages.yaml -r port=80 -o json
+# (Port 80 will trigger the validation error with the custom message)
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: custom-error-messages
+  version: 1.0.0
+  description: Demonstrates custom error messages on resolver failures.
+
+spec:
+  resolvers:
+    port:
+      description: Application port number (must be 1024-65535)
+      messages:
+        error:
+          tmpl: "Invalid port '{{ .__error }}'. Please use a port between 1024 and 65535."
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              name: port
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              rules:
+                - expr: "int(__self) >= 1024 && int(__self) <= 65535"
+                  message: port out of allowed range
+
+    environment:
+      description: Deployment environment
+      messages:
+        error:
+          expr: "'Environment resolution failed: ' + __error"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              name: environment
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              rules:
+                - expr: '__self in ["dev", "staging", "production"]'
+                  message: must be dev, staging, or production

--- a/examples/solutions/template-functions/solution.yaml
+++ b/examples/solutions/template-functions/solution.yaml
@@ -1,0 +1,151 @@
+# Template Functions Demo
+#
+# Demonstrates the custom Go template functions available in scafctl:
+#   slugify, toDnsString, where, selectField, cel, toHcl, toYaml, fromYaml
+#
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-functions-demo
+  version: 1.0.0
+  displayName: Template Functions Demo
+  description: Demonstrates scafctl custom Go template functions
+  category: demo
+  tags:
+    - templates
+    - functions
+    - demo
+
+spec:
+  resolvers:
+    # Source data
+    project-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "My Cool Project!"
+
+    services:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api-gateway
+                  port: 8080
+                  active: true
+                - name: auth-service
+                  port: 8081
+                  active: true
+                - name: legacy-proxy
+                  port: 9090
+                  active: false
+
+    # slugify — convert any string to a DNS-safe slug
+    slugified-name:
+      dependsOn: [project-name]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ slugify (index . "project-name") }}'
+              name: slugify-demo
+      # Result: "my-cool-project"
+
+    # toDnsString — strict RFC 1123 DNS label
+    dns-label:
+      dependsOn: [project-name]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ toDnsString (index . "project-name") }}'
+              name: dns-demo
+      # Result: "my-cool-project"
+
+    # where — filter a list by field value
+    active-services:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ where "active" true .services | toYaml }}'
+              name: where-demo
+      # Returns only services where active == true
+
+    # selectField — extract a single field from each item
+    service-names:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ selectField "name" .services | toYaml }}'
+              name: select-demo
+      # Returns: ["api-gateway", "auth-service", "legacy-proxy"]
+
+    # cel — inline CEL expression in a Go template
+    active-count:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ cel "size(_.services.filter(s, s.active == true))" . }}'
+              name: cel-demo
+      # Returns: "2"
+
+    # toYaml / fromYaml — round-trip YAML serialization
+    yaml-roundtrip:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: |
+                {{ $yaml := toYaml .services }}
+                {{ $parsed := fromYaml $yaml }}
+                Service count: {{ len $parsed }}
+              name: yaml-demo
+
+    # Solution metadata via metadata provider
+    solution-meta:
+      resolve:
+        with:
+          - provider: metadata
+            inputs:
+              name: template-functions-demo
+              version: 1.0.0
+              category: demo

--- a/examples/solutions/tested-solution/README.md
+++ b/examples/solutions/tested-solution/README.md
@@ -21,7 +21,7 @@ Demonstrates functional testing features in scafctl.
 | `expectFailure` | `expect-failure` |
 | Per-test `timeout` | `timeout-test` |
 | Static `skip` / `skipReason` | `skip-static` |
-| Conditional `skipExpression` | `skip-conditional` |
+| Conditional `skip` (CEL expression) | `skip-conditional` |
 | `retries` | `retry-test` |
 
 ## Running

--- a/examples/solutions/tested-solution/solution.yaml
+++ b/examples/solutions/tested-solution/solution.yaml
@@ -260,7 +260,7 @@ spec:
 
       skip-conditional:
         description: Demonstrate conditional skip (skips on Windows)
-        skipExpression: 'os == "windows"'
+        skip: 'os == "windows"'
         extends: [_resolver-base]
         tags: [skip]
         assertions:

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -136,6 +136,7 @@ type VarInfo struct {
 
 type ExtFunction struct {
 	Name          string          `json:"name,omitempty" yaml:"name,omitempty"`
+	Category      string          `json:"category,omitempty" yaml:"category,omitempty"`
 	Links         []string        `json:"links,omitempty" yaml:"links,omitempty"`
 	Examples      []Example       `json:"examples,omitempty" yaml:"examples,omitempty"`
 	Description   string          `json:"description,omitempty" yaml:"description,omitempty"`

--- a/pkg/celexp/context.go
+++ b/pkg/celexp/context.go
@@ -6,6 +6,9 @@ package celexp
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/conversion"
@@ -140,13 +143,16 @@ func EvaluateExpression(
 	compileOpts := append([]Option{WithContext(ctx)}, opts...)
 	compiled, err := expr.Compile(envOpts, compileOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile expression: %w", err)
+		availableVars := describeAvailableVars(rootData, additionalVars)
+		return nil, fmt.Errorf("failed to compile expression %q: %w\nAvailable variables: %s", exprStr, err, availableVars)
 	}
 
 	// Evaluate the expression
 	result, err := compiled.Eval(celVars)
 	if err != nil {
-		return nil, fmt.Errorf("failed to evaluate expression: %w", err)
+		availableVars := describeAvailableVars(rootData, additionalVars)
+		dataShape := describeDataShape(rootData)
+		return nil, fmt.Errorf("failed to evaluate expression %q: %w\nAvailable variables: %s\nData shape of _: %s", exprStr, err, availableVars, dataShape)
 	}
 
 	// Convert CEL types to Go types (handles deep conversion for arrays, maps, etc.)
@@ -154,4 +160,133 @@ func EvaluateExpression(
 	convertedResult := conversion.CelValueToGo(goResult)
 
 	return convertedResult, nil
+}
+
+// describeAvailableVars returns a human-readable summary of available variable names.
+// This is used in error messages to help users understand what variables they can reference.
+func describeAvailableVars(rootData any, additionalVars map[string]any) string {
+	var names []string
+	if rootData != nil {
+		names = append(names, "_")
+	}
+	for k := range additionalVars {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}
+
+// describeDataShape returns a concise summary of a data value's structure.
+// For maps, it shows top-level keys and their Go types.
+// For slices, it shows the element type if uniform, or "mixed" otherwise.
+// For scalar types, it returns the Go type name.
+// This is used in error messages to help users understand the shape of `_`.
+//
+// The output never includes values — only keys and types — to avoid leaking
+// sensitive data in error messages.
+func describeDataShape(data any) string {
+	if data == nil {
+		return "(nil)"
+	}
+
+	v := reflect.ValueOf(data)
+
+	switch v.Kind() { //nolint:exhaustive // Only map/slice/array need special handling; everything else falls through to describeType.
+	case reflect.Map:
+		if v.Len() == 0 {
+			return "{} (empty map)"
+		}
+
+		keys := make([]string, 0, v.Len())
+		for _, k := range v.MapKeys() {
+			keys = append(keys, k.String())
+		}
+		sort.Strings(keys)
+
+		// Truncate if too many keys
+		const maxKeys = 20
+		truncated := false
+		if len(keys) > maxKeys {
+			keys = keys[:maxKeys]
+			truncated = true
+		}
+
+		parts := make([]string, 0, len(keys))
+		for _, key := range keys {
+			val := v.MapIndex(reflect.ValueOf(key))
+			if val.IsValid() {
+				parts = append(parts, fmt.Sprintf("%s: %s", key, describeType(val.Interface())))
+			}
+		}
+
+		result := "{" + strings.Join(parts, ", ") + "}"
+		if truncated {
+			result += fmt.Sprintf(" (and %d more keys)", v.Len()-maxKeys)
+		}
+		return result
+
+	case reflect.Slice, reflect.Array:
+		if v.Len() == 0 {
+			return "[] (empty list)"
+		}
+		return fmt.Sprintf("[%s] (len=%d)", describeElementTypes(v), v.Len())
+
+	default: // reflect.String, reflect.Bool, reflect.Int*, reflect.Uint*, reflect.Float*, reflect.Struct, etc.
+		return describeType(data)
+	}
+}
+
+// describeType returns a concise type description for a value.
+func describeType(v any) string {
+	if v == nil {
+		return "nil"
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() { //nolint:exhaustive // Exhaustive listing not needed; default formats with %T.
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "bool"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return "int"
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "uint"
+	case reflect.Float32, reflect.Float64:
+		return "float"
+	case reflect.Map:
+		return "map"
+	case reflect.Slice, reflect.Array:
+		return "list"
+	default: // reflect.Struct, reflect.Ptr, reflect.Chan, reflect.Func, etc.
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+// describeElementTypes returns a description of element types in a slice/array.
+func describeElementTypes(v reflect.Value) string {
+	if v.Len() == 0 {
+		return "empty"
+	}
+
+	types := make(map[string]bool)
+	for i := 0; i < v.Len() && i < 10; i++ {
+		elem := v.Index(i)
+		if elem.IsValid() {
+			types[describeType(elem.Interface())] = true
+		}
+	}
+
+	typeNames := make([]string, 0, len(types))
+	for t := range types {
+		typeNames = append(typeNames, t)
+	}
+	sort.Strings(typeNames)
+
+	if len(typeNames) == 1 {
+		return typeNames[0]
+	}
+	return strings.Join(typeNames, "|")
 }

--- a/pkg/celexp/context_test.go
+++ b/pkg/celexp/context_test.go
@@ -521,3 +521,133 @@ func TestEvaluateExpression_IntRootData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(25), result)
 }
+
+// Tests for enriched error messages
+
+func TestEvaluateExpression_CompilationError_EnrichedMessage(t *testing.T) {
+	ctx := context.Background()
+	rootData := map[string]any{
+		"name": "test",
+	}
+	additionalVars := map[string]any{
+		"x": int64(10),
+	}
+
+	_, err := EvaluateExpression(ctx, "_.invalidSyntax(((", rootData, additionalVars)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, `failed to compile expression "_.invalidSyntax((("`)
+	assert.Contains(t, errMsg, "Available variables:")
+	assert.Contains(t, errMsg, "_")
+	assert.Contains(t, errMsg, "x")
+}
+
+func TestEvaluateExpression_EvaluationError_EnrichedMessage(t *testing.T) {
+	ctx := context.Background()
+	rootData := map[string]any{
+		"items": []any{int64(1), int64(2)},
+	}
+
+	_, err := EvaluateExpression(ctx, "_.items[10]", rootData, nil)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, `failed to evaluate expression "_.items[10]"`)
+	assert.Contains(t, errMsg, "Available variables:")
+	assert.Contains(t, errMsg, "_")
+	assert.Contains(t, errMsg, "Data shape of _:")
+	assert.Contains(t, errMsg, "items")
+}
+
+func TestEvaluateExpression_CompilationError_NoRootData(t *testing.T) {
+	ctx := context.Background()
+	additionalVars := map[string]any{
+		"foo": "bar",
+	}
+
+	_, err := EvaluateExpression(ctx, "bad(((syntax", nil, additionalVars)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "Available variables:")
+	assert.Contains(t, errMsg, "foo")
+	assert.NotContains(t, errMsg, "_, ")
+}
+
+// Tests for describeAvailableVars
+
+func TestDescribeAvailableVars_RootDataAndAdditional(t *testing.T) {
+	result := describeAvailableVars(map[string]any{"key": "val"}, map[string]any{"x": 1, "y": 2})
+	assert.Contains(t, result, "_")
+	assert.Contains(t, result, "x")
+	assert.Contains(t, result, "y")
+}
+
+func TestDescribeAvailableVars_RootDataOnly(t *testing.T) {
+	result := describeAvailableVars("hello", nil)
+	assert.Equal(t, "_", result)
+}
+
+func TestDescribeAvailableVars_AdditionalOnly(t *testing.T) {
+	result := describeAvailableVars(nil, map[string]any{"a": 1, "b": 2})
+	assert.Contains(t, result, "a")
+	assert.Contains(t, result, "b")
+	assert.NotContains(t, result, "_")
+}
+
+func TestDescribeAvailableVars_None(t *testing.T) {
+	result := describeAvailableVars(nil, nil)
+	assert.Equal(t, "(none)", result)
+}
+
+// Tests for describeDataShape
+
+func TestDescribeDataShape_Nil(t *testing.T) {
+	assert.Equal(t, "(nil)", describeDataShape(nil))
+}
+
+func TestDescribeDataShape_EmptyMap(t *testing.T) {
+	result := describeDataShape(map[string]any{})
+	assert.Equal(t, "{} (empty map)", result)
+}
+
+func TestDescribeDataShape_MapWithEntries(t *testing.T) {
+	data := map[string]any{
+		"name":  "test",
+		"count": int64(42),
+		"items": []any{1, 2, 3},
+	}
+	result := describeDataShape(data)
+	assert.Contains(t, result, "name: string")
+	assert.Contains(t, result, "count: int")
+	assert.Contains(t, result, "items: list")
+}
+
+func TestDescribeDataShape_EmptySlice(t *testing.T) {
+	result := describeDataShape([]any{})
+	assert.Equal(t, "[] (empty list)", result)
+}
+
+func TestDescribeDataShape_SliceOfStrings(t *testing.T) {
+	result := describeDataShape([]any{"a", "b", "c"})
+	assert.Contains(t, result, "string")
+	assert.Contains(t, result, "len=3")
+}
+
+func TestDescribeDataShape_String(t *testing.T) {
+	assert.Equal(t, "string", describeDataShape("hello"))
+}
+
+func TestDescribeDataShape_Int(t *testing.T) {
+	assert.Equal(t, "int", describeDataShape(int64(42)))
+}
+
+func TestDescribeDataShape_Bool(t *testing.T) {
+	assert.Equal(t, "bool", describeDataShape(true))
+}
+
+func TestDescribeDataShape_NestedMap(t *testing.T) {
+	data := map[string]any{
+		"inner": map[string]any{"nested": "value"},
+	}
+	result := describeDataShape(data)
+	assert.Contains(t, result, "inner: map")
+}

--- a/pkg/celexp/ext/ext.go
+++ b/pkg/celexp/ext/ext.go
@@ -4,6 +4,7 @@
 package ext
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/google/cel-go/cel"
@@ -16,6 +17,7 @@ import (
 	celmap "github.com/oakwood-commons/scafctl/pkg/celexp/ext/map"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/marshalling"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/out"
+	celregex "github.com/oakwood-commons/scafctl/pkg/celexp/ext/regex"
 	celsort "github.com/oakwood-commons/scafctl/pkg/celexp/ext/sort"
 	celstrings "github.com/oakwood-commons/scafctl/pkg/celexp/ext/strings"
 	celtime "github.com/oakwood-commons/scafctl/pkg/celexp/ext/time"
@@ -69,6 +71,7 @@ func BuiltIn() celexp.ExtFunctionList {
 	funcs := celexp.ExtFunctionList{
 		{
 			Name:        "strings",
+			Category:    "strings",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/strings.go"},
 			Description: "String manipulation functions",
 			Custom:      false,
@@ -146,6 +149,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "lists",
+			Category:    "collections",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/lists.go"},
 			Description: "List manipulation functions",
 			Custom:      false,
@@ -195,6 +199,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "bindings",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/bindings.go"},
 			Description: "Dynamic bindings for local variables in expressions",
 			Custom:      false,
@@ -224,6 +229,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "encoders",
+			Category:    "encoding",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/encoders.go"},
 			Description: "Encoding and decoding functions",
 			Custom:      false,
@@ -241,6 +247,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "math",
+			Category:    "math",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/math.go"},
 			Description: "Mathematical functions",
 			Custom:      false,
@@ -330,6 +337,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "protos",
+			Category:    "encoding",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/protos.go"},
 			Description: "Protobuf related functions for proto2 extension fields",
 			Custom:      false,
@@ -359,6 +367,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "sets",
+			Category:    "collections",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/ext/sets.go"},
 			Description: "Set manipulation functions",
 			Custom:      false,
@@ -414,6 +423,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		// It is disabled by default for better UX with dynamic configuration data.
 		{
 			Name:        "eagerlyValidateDeclarations",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/e2bc9c90751b39e3b8401b6394e5f4dab2d48808/cel/options.go#L167C4-L177"},
 			Description: "EagerlyValidateDeclarations ensures that any collisions between configured declarations are caught at the time of the `NewEnv` call. This is useful for bootstrapping a base cel.Env value. Calls to base Env.Extend() will be significantly faster when declarations are eagerly validated as declarations will be collision-checked at most once and only incrementally by way of Extend. Disabled by default as not all environments are used for type-checking.",
 			Custom:      false,
@@ -422,6 +432,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "defaultUTCTimeZone",
+			Category:    "time",
 			Links:       []string{"https://github.com/google/cel-go/blob/e2bc9c90751b39e3b8401b6394e5f4dab2d48808/cel/options.go#L836-L840"},
 			Description: "DefaultUTCTimeZone ensures that time-based operations use the UTC timezone rather than the input time's local timezone",
 			Custom:      false,
@@ -435,6 +446,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "crossTypeNumericComparisons",
+			Category:    "math",
 			Links:       []string{"https://github.com/google/cel-go/blob/e2bc9c90751b39e3b8401b6394e5f4dab2d48808/cel/options.go#L831-L834"},
 			Description: "CrossTypeNumericComparisons makes it possible to compare across numeric types, e.g. double < int",
 			Custom:      false,
@@ -452,6 +464,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "optionalTypes",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/e2bc9c90751b39e3b8401b6394e5f4dab2d48808/cel/library.go#L207-L368"},
 			Description: "OptionalTypes enable support for optional syntax and types in CEL. The optional value type makes it possible to express whether variables have been provided, whether a result has been computed, and in the future whether an object field path, map key value, or list index has a value",
 			Custom:      false,
@@ -549,6 +562,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		},
 		{
 			Name:        "astValidators",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/cel/validator.go"},
 			Description: "ASTValidators enable various AST validation options. The available validators are: ValidateDurationLiterals, ValidateTimestampLiterals, ValidateRegexLiterals, and optionally ValidateHomogeneousAggregateLiterals (controlled by feature flag)",
 			Custom:      false,
@@ -580,6 +594,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		// Add the standalone option
 		funcs = append(funcs, celexp.ExtFunction{
 			Name:        "homogeneousAggregateLiterals",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/e2bc9c90751b39e3b8401b6394e5f4dab2d48808/cel/options.go#L179-L186"},
 			Description: "HomogeneousAggregateLiterals disables mixed type list and map literal values. Note: heterogeneous aggregates are still possible when provided as variables, via conversion of well-known dynamic types, or with unchecked expressions. This option is DISABLED by default - enable with ext.SetHomogeneousAggregateLiterals(true)",
 			Custom:      false,
@@ -603,6 +618,7 @@ func BuiltIn() celexp.ExtFunctionList {
 		// Also add the AST validator version
 		funcs = append(funcs, celexp.ExtFunction{
 			Name:        "astValidatorHomogeneousAggregateLiterals",
+			Category:    "language",
 			Links:       []string{"https://github.com/google/cel-go/blob/master/cel/validator.go"},
 			Description: "AST validator for HomogeneousAggregateLiterals (only included when feature flag is enabled)",
 			Custom:      false,
@@ -691,7 +707,7 @@ func SetFunctionNames(funcs celexp.ExtFunctionList) error {
 //	    fmt.Printf("Custom Function: %s (%s)\n", f.Name, f.Description)
 //	}
 func Custom() celexp.ExtFunctionList {
-	return celexp.ExtFunctionList{
+	funcs := celexp.ExtFunctionList{
 		// Arrays functions
 		arrays.StringAddFunc(),
 		arrays.StringsUniqueFunc(),
@@ -728,6 +744,12 @@ func Custom() celexp.ExtFunctionList {
 		// Out functions
 		out.NilFunc(),
 
+		// Regex functions
+		celregex.MatchFunc(),
+		celregex.ReplaceFunc(),
+		celregex.FindAllFunc(),
+		celregex.SplitFunc(),
+
 		// Sort functions
 		celsort.ObjectsFunc(),
 		celsort.ObjectsDescendingFunc(),
@@ -740,6 +762,38 @@ func Custom() celexp.ExtFunctionList {
 		celtime.NowFunc(),
 		celtime.NowFmtFunc(),
 	}
+
+	// Assign categories based on function name prefix
+	categoryMap := map[string]string{
+		"arrays.":  "collections",
+		"debug.":   "debug",
+		"filepath": "filepath",
+		"guid.":    "utility",
+		"map.":     "collections",
+		"json.":    "encoding",
+		"yaml.":    "encoding",
+		"out.":     "utility",
+		"regex.":   "strings",
+		"sort.":    "collections",
+		"strings.": "strings",
+		"time.":    "time",
+	}
+	for i := range funcs {
+		if funcs[i].Category != "" {
+			continue
+		}
+		for prefix, cat := range categoryMap {
+			if strings.HasPrefix(funcs[i].Name, prefix) {
+				funcs[i].Category = cat
+				break
+			}
+		}
+		if funcs[i].Category == "" {
+			funcs[i].Category = "utility"
+		}
+	}
+
+	return funcs
 }
 
 // All returns a combined list of all CEL extension functions, including both

--- a/pkg/celexp/ext/ext_test.go
+++ b/pkg/celexp/ext/ext_test.go
@@ -298,6 +298,7 @@ func TestCustom(t *testing.T) {
 		"map":         {"map.add", "map.select", "map.omit", "map.merge"},
 		"marshalling": {"json.marshal", "json.unmarshal", "yaml.marshal", "yaml.unmarshal"},
 		"out":         {"out.nil"},
+		"regex":       {"regex.match", "regex.replace", "regex.findAll", "regex.split"},
 		"sort":        {"sort.objects"},
 		"strings":     {"strings.clean", "strings.title"},
 		"time":        {"time.now"},

--- a/pkg/celexp/ext/regex/regex.go
+++ b/pkg/celexp/ext/regex/regex.go
@@ -1,0 +1,251 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package regex
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+)
+
+// MatchFunc returns a CEL extension function that tests if a string matches a regular expression.
+// The function takes two string arguments: a regex pattern and an input string.
+// Returns true if the pattern matches anywhere in the input string.
+//
+// CEL usage:
+//
+//	regex.match("^test", "testing")    // true
+//	regex.match("[0-9]+", "abc")       // false
+func MatchFunc() celexp.ExtFunction {
+	funcName := "regex.match"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Description:   "Tests if a string matches a regular expression pattern (RE2 syntax). Returns true if the pattern matches anywhere in the input string",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Match a pattern at the start of a string",
+				Expression:  `regex.match("^Hello", "Hello World")`,
+			},
+			{
+				Description: "Match digits in a string",
+				Expression:  `regex.match("[0-9]+", "abc123")`,
+			},
+			{
+				Description: "No match returns false",
+				Expression:  `regex.match("^xyz", "Hello World")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType, cel.StringType},
+					cel.BoolType,
+					cel.BinaryBinding(func(patternRef, inputRef ref.Val) ref.Val {
+						pattern, ok := patternRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.match: expected string pattern, got %s", patternRef.Type())
+						}
+						input, ok := inputRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.match: expected string input, got %s", inputRef.Type())
+						}
+						re, err := regexp.Compile(pattern)
+						if err != nil {
+							return types.NewErr("regex.match: invalid regex pattern %q: %v", pattern, err)
+						}
+						return types.Bool(re.MatchString(input))
+					}),
+				),
+			),
+		},
+	}
+}
+
+// ReplaceFunc returns a CEL extension function that replaces all occurrences of a regex
+// pattern in a string with a replacement string.
+//
+// CEL usage:
+//
+//	regex.replace("Hello World", "[Ww]orld", "Go")     // "Hello Go"
+//	regex.replace("abc123def456", "[0-9]+", "#")        // "abc#def#"
+func ReplaceFunc() celexp.ExtFunction {
+	funcName := "regex.replace"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Description:   "Replaces all occurrences of a regular expression pattern (RE2 syntax) in a string with a replacement string",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Replace all digits with a hash",
+				Expression:  `regex.replace("abc123def456", "[0-9]+", "#")`,
+			},
+			{
+				Description: "Replace whitespace with dashes",
+				Expression:  `regex.replace("hello world foo", "\\s+", "-")`,
+			},
+			{
+				Description: "Remove all non-alphanumeric characters",
+				Expression:  `regex.replace("hello! @world#", "[^a-zA-Z0-9]", "")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+					cel.StringType,
+					cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+						if len(args) != 3 {
+							return types.NewErr("regex.replace: expected 3 arguments (input, pattern, replacement), got %d", len(args))
+						}
+						input, ok := args[0].Value().(string)
+						if !ok {
+							return types.NewErr("regex.replace: expected string input, got %s", args[0].Type())
+						}
+						pattern, ok := args[1].Value().(string)
+						if !ok {
+							return types.NewErr("regex.replace: expected string pattern, got %s", args[1].Type())
+						}
+						replacement, ok := args[2].Value().(string)
+						if !ok {
+							return types.NewErr("regex.replace: expected string replacement, got %s", args[2].Type())
+						}
+						re, err := regexp.Compile(pattern)
+						if err != nil {
+							return types.NewErr("regex.replace: invalid regex pattern %q: %v", pattern, err)
+						}
+						return types.String(re.ReplaceAllString(input, replacement))
+					}),
+				),
+			),
+		},
+	}
+}
+
+// FindAllFunc returns a CEL extension function that finds all matches of a regex pattern
+// in a string and returns them as a list of strings.
+//
+// CEL usage:
+//
+//	regex.findAll("[0-9]+", "abc123def456")    // ["123", "456"]
+//	regex.findAll("[a-z]+", "ABC")             // []
+func FindAllFunc() celexp.ExtFunction {
+	funcName := "regex.findAll"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Description:   "Finds all matches of a regular expression pattern (RE2 syntax) in a string and returns them as a list of strings",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Find all digit sequences",
+				Expression:  `regex.findAll("[0-9]+", "abc123def456")`,
+			},
+			{
+				Description: "Find all words",
+				Expression:  `regex.findAll("[a-zA-Z]+", "hello 123 world 456")`,
+			},
+			{
+				Description: "No matches returns empty list",
+				Expression:  `regex.findAll("[0-9]+", "no digits here")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType, cel.StringType},
+					cel.ListType(cel.StringType),
+					cel.BinaryBinding(func(patternRef, inputRef ref.Val) ref.Val {
+						pattern, ok := patternRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.findAll: expected string pattern, got %s", patternRef.Type())
+						}
+						input, ok := inputRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.findAll: expected string input, got %s", inputRef.Type())
+						}
+						re, err := regexp.Compile(pattern)
+						if err != nil {
+							return types.NewErr("regex.findAll: invalid regex pattern %q: %v", pattern, err)
+						}
+						matches := re.FindAllString(input, -1)
+						if matches == nil {
+							matches = []string{}
+						}
+						celList := make([]ref.Val, len(matches))
+						for i, m := range matches {
+							celList[i] = types.String(m)
+						}
+						return types.DefaultTypeAdapter.NativeToValue(celList)
+					}),
+				),
+			),
+		},
+	}
+}
+
+// SplitFunc returns a CEL extension function that splits a string by a regex pattern
+// and returns a list of strings.
+//
+// CEL usage:
+//
+//	regex.split("\\s+", "hello   world")   // ["hello", "world"]
+//	regex.split("[,;]+", "a,b;c,,d")       // ["a", "b", "c", "d"]
+func SplitFunc() celexp.ExtFunction {
+	funcName := "regex.split"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Description:   "Splits a string by a regular expression pattern (RE2 syntax) and returns a list of strings",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Split by whitespace",
+				Expression:  `regex.split("\\s+", "hello   world   foo")`,
+			},
+			{
+				Description: "Split by multiple delimiters",
+				Expression:  `regex.split("[,;]+", "a,b;c,,d")`,
+			},
+			{
+				Description: "Split by digits",
+				Expression:  `regex.split("[0-9]+", "abc123def456ghi")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType, cel.StringType},
+					cel.ListType(cel.StringType),
+					cel.BinaryBinding(func(patternRef, inputRef ref.Val) ref.Val {
+						pattern, ok := patternRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.split: expected string pattern, got %s", patternRef.Type())
+						}
+						input, ok := inputRef.Value().(string)
+						if !ok {
+							return types.NewErr("regex.split: expected string input, got %s", inputRef.Type())
+						}
+						re, err := regexp.Compile(pattern)
+						if err != nil {
+							return types.NewErr("regex.split: invalid regex pattern %q: %v", pattern, err)
+						}
+						parts := re.Split(input, -1)
+						celList := make([]ref.Val, len(parts))
+						for i, p := range parts {
+							celList[i] = types.String(p)
+						}
+						return types.DefaultTypeAdapter.NativeToValue(celList)
+					}),
+				),
+			),
+		},
+	}
+}

--- a/pkg/celexp/ext/regex/regex_test.go
+++ b/pkg/celexp/ext/regex/regex_test.go
@@ -1,0 +1,597 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package regex
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MatchFunc tests ---
+
+func TestMatchFunc_Metadata(t *testing.T) {
+	f := MatchFunc()
+	assert.Equal(t, "regex.match", f.Name)
+	assert.True(t, f.Custom)
+	assert.Contains(t, f.FunctionNames, "regex.match")
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.NotEmpty(t, f.EnvOptions)
+}
+
+func TestMatchFunc_CELIntegration(t *testing.T) {
+	matchFunc := MatchFunc()
+
+	env, err := cel.NewEnv(matchFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   bool
+	}{
+		{
+			name:       "match at start",
+			expression: `regex.match("^Hello", "Hello World")`,
+			expected:   true,
+		},
+		{
+			name:       "match digits",
+			expression: `regex.match("[0-9]+", "abc123")`,
+			expected:   true,
+		},
+		{
+			name:       "no match",
+			expression: `regex.match("^xyz", "Hello World")`,
+			expected:   false,
+		},
+		{
+			name:       "full match",
+			expression: `regex.match("^[a-z]+$", "hello")`,
+			expected:   true,
+		},
+		{
+			name:       "email-like pattern",
+			expression: `regex.match("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", "user@example.com")`,
+			expected:   true,
+		},
+		{
+			name:       "empty pattern matches empty string",
+			expression: `regex.match("", "")`,
+			expected:   true,
+		},
+		{
+			name:       "dot matches any char",
+			expression: `regex.match("h.llo", "hello")`,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compilation failed: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result.Value())
+		})
+	}
+}
+
+func TestMatchFunc_InvalidRegex(t *testing.T) {
+	matchFunc := MatchFunc()
+
+	env, err := cel.NewEnv(matchFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.match("(invalid[", "test")`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prog.Eval(map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex pattern")
+}
+
+func TestMatchFunc_TypeError(t *testing.T) {
+	matchFunc := MatchFunc()
+
+	env, err := cel.NewEnv(matchFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		expression       string
+		expectedErrorMsg string
+	}{
+		{
+			name:             "integer first arg",
+			expression:       `regex.match(123, "test")`,
+			expectedErrorMsg: "found no matching overload for 'regex.match' applied to '(int, string)'",
+		},
+		{
+			name:             "integer second arg",
+			expression:       `regex.match("pattern", 123)`,
+			expectedErrorMsg: "found no matching overload for 'regex.match' applied to '(string, int)'",
+		},
+		{
+			name:             "boolean args",
+			expression:       `regex.match(true, false)`,
+			expectedErrorMsg: "found no matching overload for 'regex.match' applied to '(bool, bool)'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, issues := env.Compile(tt.expression)
+			require.NotNil(t, issues, "expected compilation error for wrong type")
+			assert.Contains(t, issues.String(), tt.expectedErrorMsg)
+		})
+	}
+}
+
+func TestMatchFunc_WithVariables(t *testing.T) {
+	matchFunc := MatchFunc()
+
+	env, err := cel.NewEnv(
+		matchFunc.EnvOptions[0],
+		cel.Variable("pattern", cel.StringType),
+		cel.Variable("input", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.match(pattern, input)`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	result, _, err := prog.Eval(map[string]interface{}{
+		"pattern": "^test",
+		"input":   "testing",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, result.Value())
+}
+
+// --- ReplaceFunc tests ---
+
+func TestReplaceFunc_Metadata(t *testing.T) {
+	f := ReplaceFunc()
+	assert.Equal(t, "regex.replace", f.Name)
+	assert.True(t, f.Custom)
+	assert.Contains(t, f.FunctionNames, "regex.replace")
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.NotEmpty(t, f.EnvOptions)
+}
+
+func TestReplaceFunc_CELIntegration(t *testing.T) {
+	replaceFunc := ReplaceFunc()
+
+	env, err := cel.NewEnv(replaceFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   string
+	}{
+		{
+			name:       "replace digits with hash",
+			expression: `regex.replace("abc123def456", "[0-9]+", "#")`,
+			expected:   "abc#def#",
+		},
+		{
+			name:       "replace whitespace with dashes",
+			expression: `regex.replace("hello world foo", "\\s+", "-")`,
+			expected:   "hello-world-foo",
+		},
+		{
+			name:       "remove non-alphanumeric",
+			expression: `regex.replace("hello! @world#", "[^a-zA-Z0-9]", "")`,
+			expected:   "helloworld",
+		},
+		{
+			name:       "no match leaves string unchanged",
+			expression: `regex.replace("hello", "[0-9]+", "X")`,
+			expected:   "hello",
+		},
+		{
+			name:       "replace entire string",
+			expression: `regex.replace("test", ".*", "replaced")`,
+			expected:   "replaced",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compilation failed: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result.Value())
+		})
+	}
+}
+
+func TestReplaceFunc_InvalidRegex(t *testing.T) {
+	replaceFunc := ReplaceFunc()
+
+	env, err := cel.NewEnv(replaceFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.replace("test", "(invalid[", "x")`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prog.Eval(map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex pattern")
+}
+
+func TestReplaceFunc_TypeError(t *testing.T) {
+	replaceFunc := ReplaceFunc()
+
+	env, err := cel.NewEnv(replaceFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	_, issues := env.Compile(`regex.replace(123, "pattern", "replacement")`)
+	require.NotNil(t, issues, "expected compilation error for wrong type")
+}
+
+// --- FindAllFunc tests ---
+
+func TestFindAllFunc_Metadata(t *testing.T) {
+	f := FindAllFunc()
+	assert.Equal(t, "regex.findAll", f.Name)
+	assert.True(t, f.Custom)
+	assert.Contains(t, f.FunctionNames, "regex.findAll")
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.NotEmpty(t, f.EnvOptions)
+}
+
+func TestFindAllFunc_CELIntegration(t *testing.T) {
+	findAllFunc := FindAllFunc()
+
+	env, err := cel.NewEnv(findAllFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   []string
+	}{
+		{
+			name:       "find digit sequences",
+			expression: `regex.findAll("[0-9]+", "abc123def456")`,
+			expected:   []string{"123", "456"},
+		},
+		{
+			name:       "find words",
+			expression: `regex.findAll("[a-zA-Z]+", "hello 123 world 456")`,
+			expected:   []string{"hello", "world"},
+		},
+		{
+			name:       "no matches returns empty list",
+			expression: `regex.findAll("[0-9]+", "no digits here")`,
+			expected:   []string{},
+		},
+		{
+			name:       "single match",
+			expression: `regex.findAll("world", "hello world")`,
+			expected:   []string{"world"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compilation failed: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+
+			// Convert CEL list to Go slice for comparison
+			var actual []string
+			switch v := result.Value().(type) {
+			case []any:
+				for _, item := range v {
+					actual = append(actual, item.(string))
+				}
+			case []ref.Val:
+				for _, item := range v {
+					actual = append(actual, item.Value().(string))
+				}
+			default:
+				t.Fatalf("unexpected result type: %T", result.Value())
+			}
+			if actual == nil {
+				actual = []string{}
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestFindAllFunc_InvalidRegex(t *testing.T) {
+	findAllFunc := FindAllFunc()
+
+	env, err := cel.NewEnv(findAllFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.findAll("(invalid[", "test")`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prog.Eval(map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex pattern")
+}
+
+func TestFindAllFunc_TypeError(t *testing.T) {
+	findAllFunc := FindAllFunc()
+
+	env, err := cel.NewEnv(findAllFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	_, issues := env.Compile(`regex.findAll(123, "test")`)
+	require.NotNil(t, issues, "expected compilation error for wrong type")
+}
+
+// --- SplitFunc tests ---
+
+func TestSplitFunc_Metadata(t *testing.T) {
+	f := SplitFunc()
+	assert.Equal(t, "regex.split", f.Name)
+	assert.True(t, f.Custom)
+	assert.Contains(t, f.FunctionNames, "regex.split")
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.NotEmpty(t, f.EnvOptions)
+}
+
+func TestSplitFunc_CELIntegration(t *testing.T) {
+	splitFunc := SplitFunc()
+
+	env, err := cel.NewEnv(splitFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   []string
+	}{
+		{
+			name:       "split by whitespace",
+			expression: `regex.split("\\s+", "hello   world   foo")`,
+			expected:   []string{"hello", "world", "foo"},
+		},
+		{
+			name:       "split by comma",
+			expression: `regex.split(",", "a,b,c")`,
+			expected:   []string{"a", "b", "c"},
+		},
+		{
+			name:       "split by multiple delimiters",
+			expression: `regex.split("[,;]+", "a,b;c,,d")`,
+			expected:   []string{"a", "b", "c", "d"},
+		},
+		{
+			name:       "split by digits",
+			expression: `regex.split("[0-9]+", "abc123def456ghi")`,
+			expected:   []string{"abc", "def", "ghi"},
+		},
+		{
+			name:       "no match returns single element",
+			expression: `regex.split(",", "nosep")`,
+			expected:   []string{"nosep"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compilation failed: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+
+			var actual []string
+			switch v := result.Value().(type) {
+			case []any:
+				for _, item := range v {
+					actual = append(actual, item.(string))
+				}
+			case []ref.Val:
+				for _, item := range v {
+					actual = append(actual, item.Value().(string))
+				}
+			default:
+				t.Fatalf("unexpected result type: %T", result.Value())
+			}
+			if actual == nil {
+				actual = []string{}
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSplitFunc_InvalidRegex(t *testing.T) {
+	splitFunc := SplitFunc()
+
+	env, err := cel.NewEnv(splitFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.split("(invalid[", "test")`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prog.Eval(map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex pattern")
+}
+
+func TestSplitFunc_TypeError(t *testing.T) {
+	splitFunc := SplitFunc()
+
+	env, err := cel.NewEnv(splitFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	_, issues := env.Compile(`regex.split(123, "test")`)
+	require.NotNil(t, issues, "expected compilation error for wrong type")
+}
+
+// --- Cross-function tests ---
+
+func TestRegex_ChainedOperations(t *testing.T) {
+	matchFunc := MatchFunc()
+	replaceFunc := ReplaceFunc()
+	findAllFunc := FindAllFunc()
+	splitFunc := SplitFunc()
+
+	env, err := cel.NewEnv(
+		matchFunc.EnvOptions[0],
+		replaceFunc.EnvOptions[0],
+		findAllFunc.EnvOptions[0],
+		splitFunc.EnvOptions[0],
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   any
+	}{
+		{
+			name:       "replace then match",
+			expression: `regex.match("^[a-z]+$", regex.replace("Hello123", "[^a-z]", ""))`,
+			expected:   true,
+		},
+		{
+			name:       "findAll count via size",
+			expression: `size(regex.findAll("[0-9]+", "a1b2c3"))`,
+			expected:   int64(3),
+		},
+		{
+			name:       "split count via size",
+			expression: `size(regex.split(",", "a,b,c,d"))`,
+			expected:   int64(4),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compilation failed: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result.Value())
+		})
+	}
+}
+
+func TestRegex_WithDynVariables(t *testing.T) {
+	matchFunc := MatchFunc()
+
+	env, err := cel.NewEnv(
+		matchFunc.EnvOptions[0],
+		cel.Variable("_", cel.DynType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`regex.match("^[0-9]+$", _)`)
+	require.Nil(t, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	result, _, err := prog.Eval(map[string]interface{}{
+		"_": "12345",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, result.Value())
+}
+
+// --- Benchmarks ---
+
+func BenchmarkMatchFunc(b *testing.B) {
+	matchFunc := MatchFunc()
+	env, _ := cel.NewEnv(matchFunc.EnvOptions...)
+	ast, _ := env.Compile(`regex.match("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", "user@example.com")`)
+	prog, _ := env.Program(ast)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prog.Eval(map[string]interface{}{})
+	}
+}
+
+func BenchmarkReplaceFunc(b *testing.B) {
+	replaceFunc := ReplaceFunc()
+	env, _ := cel.NewEnv(replaceFunc.EnvOptions...)
+	ast, _ := env.Compile(`regex.replace("Hello World 123", "[^a-zA-Z]", "")`)
+	prog, _ := env.Program(ast)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prog.Eval(map[string]interface{}{})
+	}
+}
+
+func BenchmarkFindAllFunc(b *testing.B) {
+	findAllFunc := FindAllFunc()
+	env, _ := cel.NewEnv(findAllFunc.EnvOptions...)
+	ast, _ := env.Compile(`regex.findAll("[0-9]+", "abc123def456ghi789")`)
+	prog, _ := env.Program(ast)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prog.Eval(map[string]interface{}{})
+	}
+}
+
+func BenchmarkSplitFunc(b *testing.B) {
+	splitFunc := SplitFunc()
+	env, _ := cel.NewEnv(splitFunc.EnvOptions...)
+	ast, _ := env.Compile(`regex.split("\\s+", "hello world foo bar baz")`)
+	prog, _ := env.Program(ast)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prog.Eval(map[string]interface{}{})
+	}
+}

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -89,9 +90,11 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 	}
 
 	// Build scaffold input from the parsed solution
+	fileDeps := discoverFileDepsFromSolution(&sol, opts.File)
 	input := &soltesting.ScaffoldInput{
-		Resolvers: sol.Spec.Resolvers,
-		Workflow:  sol.Spec.Workflow,
+		Resolvers:        sol.Spec.Resolvers,
+		Workflow:         sol.Spec.Workflow,
+		FileDependencies: fileDeps,
 	}
 
 	// Generate scaffold
@@ -111,4 +114,20 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 	fmt.Fprint(opts.IOStreams.Out, string(out))
 
 	return nil
+}
+
+// discoverFileDepsFromSolution uses bundler.DiscoverFiles to extract file dependencies.
+// Returns nil on error (best-effort).
+func discoverFileDepsFromSolution(sol *solution.Solution, solutionPath string) []string {
+	bundleRoot := filepath.Dir(solutionPath)
+	result, err := bundler.DiscoverFiles(sol, bundleRoot)
+	if err != nil || result == nil {
+		return nil
+	}
+
+	var deps []string
+	for _, f := range result.LocalFiles {
+		deps = append(deps, f.RelPath)
+	}
+	return deps
 }

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -1,0 +1,279 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package concepts
+
+// builtinConcepts defines the canonical set of scafctl domain concepts.
+var builtinConcepts = []Concept{
+	// --- Resolvers ---
+	{
+		Name:     "resolver",
+		Title:    "Resolver",
+		Category: "resolvers",
+		Summary:  "A named unit that resolves a value through one or more provider steps (resolve → transform → validate).",
+		Explanation: `A resolver is the primary data-gathering primitive in scafctl. Each resolver has a name, an optional type hint, and a pipeline of phases:
+
+1. **resolve** — one or more provider steps that produce the initial value (e.g., prompt user, read file, call API).
+2. **transform** — optional steps that reshape or enrich the resolved value.
+3. **validate** — optional steps that enforce constraints on the final value.
+
+Resolvers can depend on each other via 'dependsOn' or implicit CEL references (_.otherResolver). The dependency graph must be a DAG — circular references are rejected at lint time.`,
+		Examples: []string{
+			"spec:\n  resolvers:\n    region:\n      type: string\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              name: region\n              default: us-east-1",
+		},
+		SeeAlso: []string{"provider", "cel-expression", "depends-on"},
+	},
+	{
+		Name:     "depends-on",
+		Title:    "dependsOn",
+		Category: "resolvers",
+		Summary:  "Declares explicit ordering between resolvers or actions.",
+		Explanation: `The 'dependsOn' field creates an explicit edge in the dependency graph. scafctl also infers implicit dependencies from CEL expressions (_.resolverName), but dependsOn is useful when:
+
+- A resolver has a side effect that another resolver needs (e.g., writing a temp file).
+- You want to force ordering without a data dependency.
+- The implicit detection doesn't cover your case (e.g., dynamic resolver references in templates).
+
+For actions, dependsOn controls execution order within the workflow DAG.`,
+		Examples: []string{
+			"resolvers:\n  setup:\n    resolve:\n      with:\n        - provider: exec\n          inputs:\n            command: setup.sh\n  main:\n    dependsOn: [setup]\n    resolve:\n      with:\n        - provider: file\n          inputs:\n            path: output.json",
+		},
+		SeeAlso: []string{"resolver", "action", "dag"},
+	},
+	// --- Providers ---
+	{
+		Name:     "provider",
+		Title:    "Provider",
+		Category: "providers",
+		Summary:  "A pluggable executor that performs a specific operation (e.g., read file, call API, prompt user).",
+		Explanation: `Providers are the execution engines in scafctl. Each provider has a name, a typed input schema, and produces output. Providers are referenced by name in resolver steps and action definitions.
+
+Built-in providers include: static, parameter, env, file, exec, http, cel, go-template, validation, directory, hcl, and solution. Custom providers can be added via the plugin system.
+
+Use 'list_providers' to see all available providers and 'get_provider_schema' to see a provider's input/output schema.`,
+		SeeAlso: []string{"resolver", "action", "go-template-provider"},
+	},
+	{
+		Name:     "go-template-provider",
+		Title:    "Go Template Provider",
+		Category: "providers",
+		Summary:  "Renders Go templates with access to resolver data and custom functions.",
+		Explanation: `The go-template provider evaluates Go templates using the standard text/template engine augmented with sprig functions and scafctl extensions.
+
+Template data is available as the root context '.', which contains all resolved values. Custom functions include: slugify, toDnsString, where, selectField, cel, toYaml, fromYaml, toHcl, and all sprig functions.
+
+Common pitfall: Go templates are strongly typed at render time. Passing a string where a map is expected (or vice versa) produces 'can't evaluate field X of type string' errors. Use the cel() function for complex data manipulation.`,
+		Examples: []string{
+			"resolve:\n  with:\n    - provider: go-template\n      inputs:\n        template: |\n          name: {{ .appName | slugify }}\n          replicas: {{ .replicas }}",
+		},
+		SeeAlso: []string{"provider", "cel-expression", "template-functions"},
+	},
+	{
+		Name:     "template-functions",
+		Title:    "Template Functions",
+		Category: "providers",
+		Summary:  "Custom functions available in Go templates beyond standard sprig.",
+		Explanation: `scafctl extends Go templates with these custom functions:
+
+- **slugify** / **toDnsString** — Convert a string to a DNS-safe label (RFC 1123). Lowercases, replaces non-alphanumeric chars with hyphens, trims, truncates to 63 chars.
+- **where** — Filter a list of maps: {{ where "status" "active" .items }}
+- **selectField** — Project a single field from a list: {{ selectField "name" .items }}  
+- **cel** — Evaluate a CEL expression inline: {{ cel "_.items.filter(x, x.active)" . }}
+- **toYaml** / **fromYaml** / **mustToYaml** / **mustFromYaml** — YAML serialization.
+- **toHcl** — Convert data to HCL format.
+
+Plus all sprig v3 functions (https://masterminds.github.io/sprig/).`,
+		SeeAlso: []string{"go-template-provider", "cel-expression"},
+	},
+	// --- Actions & Workflow ---
+	{
+		Name:     "action",
+		Title:    "Action",
+		Category: "actions",
+		Summary:  "A workflow step that performs a side effect using a provider (e.g., create file, deploy resource).",
+		Explanation: `Actions are defined under spec.workflow.actions and execute after all resolvers complete. Each action specifies a provider and inputs, and can optionally declare dependencies on other actions via 'dependsOn'.
+
+Actions support: conditional execution (when), retry policies, forEach iteration, timeouts, and result schemas. The workflow engine executes actions as a DAG, running independent actions in parallel.
+
+Cleanup actions go under spec.workflow.finally and always execute (even if earlier actions fail).`,
+		Examples: []string{
+			"spec:\n  workflow:\n    actions:\n      create-config:\n        provider: file\n        inputs:\n          path: output/config.yaml\n          content:\n            tmpl: |\n              region: {{ .region }}",
+		},
+		SeeAlso: []string{"provider", "depends-on", "workflow"},
+	},
+	{
+		Name:     "workflow",
+		Title:    "Workflow",
+		Category: "actions",
+		Summary:  "The action execution engine that runs actions as a DAG after resolver resolution.",
+		Explanation: `The workflow section (spec.workflow) defines actions that execute after all resolvers have been resolved. Actions form a DAG based on their dependsOn declarations and are executed with maximum parallelism.
+
+Key sections:
+- **actions** — The main action definitions, executed as a DAG.
+- **finally** — Cleanup actions that always run, even after failures.
+
+The workflow engine provides special variables: __actions (results of completed actions), __error (failure info), __item/__index (forEach iteration).`,
+		SeeAlso: []string{"action", "depends-on", "dag"},
+	},
+	// --- CEL ---
+	{
+		Name:     "cel-expression",
+		Title:    "CEL Expression",
+		Category: "expressions",
+		Summary:  "Common Expression Language expressions used for conditions, filtering, and dynamic values.",
+		Explanation: `CEL (Common Expression Language) is used throughout scafctl for:
+
+- **when** conditions on resolvers and actions
+- **expr** fields in ValueRef inputs (dynamic values)
+- **validation** expressions in the validation provider
+- **forEach** iteration sources
+
+The root variable '_' contains all resolved values. Special variables include __self (current resolver value in transform/validate), __actions (workflow results), __item/__index (forEach).
+
+Use list_cel_functions to see all available CEL functions and evaluate_cel to test expressions.`,
+		Examples: []string{
+			"when: \"_.environment == 'production'\"\n\n# In inputs:\ninputs:\n  value:\n    expr: \"_.items.filter(x, x.status == 'active')\"",
+		},
+		SeeAlso: []string{"resolver", "action", "template-functions"},
+	},
+	// --- Testing ---
+	{
+		Name:     "functional-testing",
+		Title:    "Functional Testing",
+		Category: "testing",
+		Summary:  "Built-in test framework for validating solutions via spec.testing.cases.",
+		Explanation: `scafctl includes a functional test framework that runs solution commands in isolated sandboxes and validates results with CEL assertions.
+
+Test cases are defined in spec.testing.cases (or composed from separate files). Each test specifies: command, args, expected exit code, assertions (CEL expressions over output), and file dependencies.
+
+Key features:
+- **Sandbox isolation** — each test runs in a temporary directory with only declared files.
+- **CEL assertions** — validate output structure and values.
+- **Tags** — organize and filter tests (e.g., --tag smoke).
+- **Templates** — share common config via extends and test templates (names starting with _).
+- **File dependencies** — declare which files the test needs via the files list (supports paths, globs, directories).`,
+		Examples: []string{
+			"spec:\n  testing:\n    cases:\n      smoke-test:\n        description: Verify basic rendering\n        command: [render, solution]\n        exitCode: 0\n        files: [templates/]\n        assertions:\n          - expression: \"size(__output) > 0\"\n            message: Output should not be empty",
+		},
+		SeeAlso: []string{"test-sandbox", "test-assertions", "test-scaffold"},
+	},
+	{
+		Name:     "test-sandbox",
+		Title:    "Test Sandbox",
+		Category: "testing",
+		Summary:  "Isolated temporary directory where each test case executes.",
+		Explanation: `Each test runs in its own sandbox — a temporary directory containing only:
+
+1. The solution file itself.
+2. Compose files referenced by the solution.
+3. Bundle files.
+4. Test-specific files declared in the test's 'files' list.
+
+The files list supports three entry types:
+- **Plain paths**: 'templates/main.yaml' — copies a single file.
+- **Globs**: 'templates/**/*.yaml' — copies all matching files (uses doublestar).
+- **Directories**: 'templates/' or 'templates' — recursively copies all files.
+
+Files not declared in the list are NOT available in the sandbox. If a test fails with "file not found", check that the file is listed in the test's files array.`,
+		SeeAlso: []string{"functional-testing", "test-scaffold"},
+	},
+	{
+		Name:     "test-scaffold",
+		Title:    "Test Scaffold",
+		Category: "testing",
+		Summary:  "Auto-generate starter test cases from a solution's structure.",
+		Explanation: `The scaffold generator analyzes a solution's resolvers, validation rules, and workflow actions to produce starter test cases. It generates:
+
+- A smoke test for resolver resolution with defaults.
+- A smoke test for solution rendering.
+- A lint test.
+- Per-resolver output tests with basic assertions.
+- Validation failure tests for resolvers with validation rules.
+- Per-action execution tests.
+
+The scaffold also auto-populates the 'files' list based on static analysis of provider inputs (e.g., file provider paths, template references).
+
+Use 'scafctl test init -f solution.yaml' (CLI) or 'generate_test_scaffold' (MCP) to generate.`,
+		SeeAlso: []string{"functional-testing", "test-sandbox"},
+	},
+	{
+		Name:     "test-assertions",
+		Title:    "Test Assertions",
+		Category: "testing",
+		Summary:  "CEL expressions that validate test output.",
+		Explanation: `Each test case can include assertions — CEL expressions evaluated against the test's output. The special variable __output contains the parsed command output (typically JSON or YAML).
+
+Assertions have two fields:
+- **expression** — a CEL expression that must evaluate to true.
+- **message** — a human-readable failure message.
+
+For commands that output JSON (e.g., -o json), __output is the parsed object. For plain text output, __output is the raw string.`,
+		Examples: []string{
+			"assertions:\n  - expression: \"__output.region == 'us-east-1'\"\n    message: Region should default to us-east-1\n  - expression: \"size(__output.items) > 0\"\n    message: Should have at least one item",
+		},
+		SeeAlso: []string{"functional-testing", "cel-expression"},
+	},
+	// --- Composition ---
+	{
+		Name:     "compose",
+		Title:    "Solution Composition",
+		Category: "structure",
+		Summary:  "Merge partial YAML files into a solution using the compose field.",
+		Explanation: `The top-level 'compose' field lists relative paths to partial YAML files that are deep-merged into the solution at load time. This enables splitting large solutions into logical modules:
+
+- Separate resolver definitions from workflow actions.
+- Keep test cases in their own file.
+- Share common configurations across solutions.
+
+Compose files are merged in order — later files override earlier ones for conflicting keys. Array fields are replaced, not concatenated.`,
+		Examples: []string{
+			"# solution.yaml\napiVersion: scafctl.io/v1\ncompose:\n  - resolvers.yaml\n  - actions.yaml\n  - tests.yaml\nmetadata:\n  name: my-solution",
+		},
+		SeeAlso: []string{"bundle"},
+	},
+	{
+		Name:     "bundle",
+		Title:    "Bundling",
+		Category: "structure",
+		Summary:  "Package a solution and its file dependencies for catalog publishing.",
+		Explanation: `Bundling creates a self-contained archive of a solution and all files it needs. The bundle.include field specifies which files to include (supports globs).
+
+scafctl automatically discovers file dependencies through static analysis of provider inputs (e.g., file paths in the file provider, template references). Use 'bundle.include' to explicitly add files that can't be detected statically.
+
+The lint rule 'unbundled-test-file' warns when test files aren't covered by bundle.include patterns.`,
+		Examples: []string{
+			"bundle:\n  include:\n    - templates/**\n    - configs/*.yaml\n    - tests/**",
+		},
+		SeeAlso: []string{"compose", "catalog"},
+	},
+	// --- DAG ---
+	{
+		Name:     "dag",
+		Title:    "Directed Acyclic Graph (DAG)",
+		Category: "architecture",
+		Summary:  "The dependency graph model used for resolver and action execution ordering.",
+		Explanation: `scafctl uses DAGs (Directed Acyclic Graphs) to determine execution order for both resolvers and actions:
+
+- **Resolver DAG** — built from dependsOn declarations and implicit CEL references (_.resolverName). Resolvers with no dependencies execute first, in parallel.
+- **Action DAG** — built from dependsOn declarations on actions. Independent actions execute in parallel.
+
+Circular dependencies are detected at lint time (workflow-validation rule) and rejected. Use 'render_solution' with graph_type 'resolver-deps' or 'action-deps' to visualize the DAG.`,
+		SeeAlso: []string{"depends-on", "resolver", "action"},
+	},
+	// --- Catalog ---
+	{
+		Name:     "catalog",
+		Title:    "Solution Catalog",
+		Category: "catalog",
+		Summary:  "A registry for publishing, discovering, and consuming reusable solutions.",
+		Explanation: `The catalog is a centralized registry of solutions that can be searched, installed, and referenced. Solutions are published as bundles with metadata (name, version, description, tags).
+
+Key operations:
+- **catalog search** — find solutions by name, tag, or description.
+- **catalog install** — install a solution locally.
+- **solution provider** — reference a catalog solution as a nested dependency (source: 'solution-name@version').
+
+The catalog supports versioning, visibility controls (public/private), and beta flags.`,
+		SeeAlso: []string{"bundle", "compose"},
+	},
+}

--- a/pkg/concepts/concepts.go
+++ b/pkg/concepts/concepts.go
@@ -1,0 +1,137 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package concepts provides a registry of scafctl domain concepts with
+// concise explanations, examples, and cross-references. It is used by
+// MCP tools, CLI help, and documentation generation.
+package concepts
+
+import "sort"
+
+// Concept describes a single scafctl domain concept.
+type Concept struct {
+	// Name is the canonical kebab-case concept identifier.
+	Name string `json:"name" yaml:"name"`
+
+	// Title is the human-readable display name.
+	Title string `json:"title" yaml:"title"`
+
+	// Category groups related concepts (e.g., "resolvers", "testing", "actions").
+	Category string `json:"category" yaml:"category"`
+
+	// Summary is a one-sentence description.
+	Summary string `json:"summary" yaml:"summary"`
+
+	// Explanation is a multi-paragraph detailed explanation.
+	Explanation string `json:"explanation" yaml:"explanation"`
+
+	// Examples provides short YAML or code examples.
+	Examples []string `json:"examples,omitempty" yaml:"examples,omitempty"`
+
+	// SeeAlso lists related concept names.
+	SeeAlso []string `json:"seeAlso,omitempty" yaml:"seeAlso,omitempty"`
+}
+
+// registry is the canonical map of all concepts keyed by name.
+//
+//nolint:gochecknoinits // Package-level registration of builtin concepts is the simplest approach.
+var registry = func() map[string]Concept {
+	m := make(map[string]Concept, len(builtinConcepts))
+	for _, c := range builtinConcepts {
+		m[c.Name] = c
+	}
+	return m
+}()
+
+// Get returns a concept by name. Returns false if not found.
+func Get(name string) (Concept, bool) {
+	c, ok := registry[name]
+	return c, ok
+}
+
+// List returns all registered concepts sorted by category then name.
+func List() []Concept {
+	result := make([]Concept, 0, len(registry))
+	for _, c := range registry {
+		result = append(result, c)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Category != result[j].Category {
+			return result[i].Category < result[j].Category
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// Categories returns a sorted list of unique category names.
+func Categories() []string {
+	seen := map[string]bool{}
+	for _, c := range registry {
+		seen[c.Category] = true
+	}
+	cats := make([]string, 0, len(seen))
+	for c := range seen {
+		cats = append(cats, c)
+	}
+	sort.Strings(cats)
+	return cats
+}
+
+// ByCategory returns all concepts in a given category, sorted by name.
+func ByCategory(category string) []Concept {
+	var result []Concept
+	for _, c := range registry {
+		if c.Category == category {
+			result = append(result, c)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// Search returns concepts whose name, title, or summary contain the query (case-insensitive).
+func Search(query string) []Concept {
+	if query == "" {
+		return List()
+	}
+	var result []Concept
+	lq := toLower(query)
+	for _, c := range registry {
+		if contains(c.Name, lq) || contains(c.Title, lq) || contains(c.Summary, lq) {
+			result = append(result, c)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func toLower(s string) string {
+	b := make([]byte, len(s))
+	for i := range s {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		indexOf(toLower(haystack), needle) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/concepts/concepts_test.go
+++ b/pkg/concepts/concepts_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package concepts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet_ExistingConcept(t *testing.T) {
+	c, ok := Get("resolver")
+	require.True(t, ok)
+	assert.Equal(t, "Resolver", c.Title)
+	assert.Equal(t, "resolvers", c.Category)
+	assert.NotEmpty(t, c.Summary)
+	assert.NotEmpty(t, c.Explanation)
+}
+
+func TestGet_NotFound(t *testing.T) {
+	_, ok := Get("nonexistent-concept")
+	assert.False(t, ok)
+}
+
+func TestList_ReturnsAll(t *testing.T) {
+	all := List()
+	assert.GreaterOrEqual(t, len(all), 10)
+	// Verify sorted by category then name
+	for i := 1; i < len(all); i++ {
+		prev := all[i-1]
+		cur := all[i]
+		if prev.Category == cur.Category {
+			assert.LessOrEqual(t, prev.Name, cur.Name)
+		} else {
+			assert.Less(t, prev.Category, cur.Category)
+		}
+	}
+}
+
+func TestCategories(t *testing.T) {
+	cats := Categories()
+	assert.NotEmpty(t, cats)
+	for i := 1; i < len(cats); i++ {
+		assert.Less(t, cats[i-1], cats[i])
+	}
+}
+
+func TestByCategory(t *testing.T) {
+	items := ByCategory("testing")
+	assert.NotEmpty(t, items)
+	for _, c := range items {
+		assert.Equal(t, "testing", c.Category)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	results := Search("template")
+	assert.NotEmpty(t, results)
+}
+
+func TestSearch_Empty(t *testing.T) {
+	results := Search("")
+	assert.Equal(t, len(List()), len(results))
+}
+
+func TestSearch_NoMatch(t *testing.T) {
+	results := Search("zzzznonexistentzzzz")
+	assert.Empty(t, results)
+}

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -218,17 +218,18 @@ func findExamplesDir() (string, error) {
 func DescriptionFromPath(path string) string {
 	descriptions := map[string]string{
 		// Solutions
-		"solutions/comprehensive/solution.yaml":   "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
-		"solutions/email-notifier/solution.yaml":  "Email notification solution with parameters, validation, and action workflow",
-		"solutions/terraform/solution.yaml":       "Terraform infrastructure scaffolding solution",
-		"solutions/k8s-clusters/solution.yaml":    "Kubernetes cluster provisioning solution",
-		"solutions/directory/solution.yaml":       "Directory provider examples (list, read, create, copy)",
-		"solutions/scaffold-demo/solution.yaml":   "Scaffold/template rendering demo solution",
-		"solutions/github-auth/solution.yaml":     "GitHub authentication and API access solution",
-		"solutions/composition/parent.yaml":       "Solution composition - parent that composes children",
-		"solutions/composition/child.yaml":        "Solution composition - child partial solution",
-		"solutions/taskfile/solution.yaml":        "Taskfile-based workflow solution",
-		"solutions/tested-solution/solution.yaml": "Solution with functional tests defined in spec.testing.cases",
+		"solutions/comprehensive/solution.yaml":      "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
+		"solutions/email-notifier/solution.yaml":     "Email notification solution with parameters, validation, and action workflow",
+		"solutions/terraform/solution.yaml":          "Terraform infrastructure scaffolding solution",
+		"solutions/k8s-clusters/solution.yaml":       "Kubernetes cluster provisioning solution",
+		"solutions/directory/solution.yaml":          "Directory provider examples (list, read, create, copy)",
+		"solutions/scaffold-demo/solution.yaml":      "Scaffold/template rendering demo solution",
+		"solutions/github-auth/solution.yaml":        "GitHub authentication and API access solution",
+		"solutions/composition/parent.yaml":          "Solution composition - parent that composes children",
+		"solutions/composition/child.yaml":           "Solution composition - child partial solution",
+		"solutions/taskfile/solution.yaml":           "Taskfile-based workflow solution",
+		"solutions/tested-solution/solution.yaml":    "Solution with functional tests defined in spec.testing.cases",
+		"solutions/template-functions/solution.yaml": "Demonstrates custom Go template functions: slugify, where, selectField, cel, toYaml, metadata provider",
 
 		// Actions
 		"actions/hello-world.yaml":              "Simple hello world action",
@@ -260,6 +261,10 @@ func DescriptionFromPath(path string) string {
 		"resolvers/feature-flags.yaml":       "Feature flag resolver pattern",
 		"resolvers/identity.yaml":            "Identity/auth resolver pattern",
 		"resolvers/secrets.yaml":             "Secrets resolver pattern",
+
+		// Providers
+		"providers/metadata-full.yaml":         "Metadata provider — expose all solution metadata as a map",
+		"providers/metadata-single-field.yaml": "Metadata provider — extract a single metadata field",
 	}
 
 	if desc, ok := descriptions[path]; ok {

--- a/pkg/gotmpl/ext/celeval/celeval.go
+++ b/pkg/gotmpl/ext/celeval/celeval.go
@@ -1,0 +1,85 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package celeval provides a Go template extension function for evaluating
+// CEL (Common Expression Language) expressions inline within Go templates.
+package celeval
+
+import (
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// CelFunc returns an ExtFunction that evaluates a CEL expression inline
+// within a Go template. The template's current context (.) is available
+// as the root variable (_) inside the CEL expression.
+//
+// Example usage in a Go template:
+//
+//	{{ cel "_.items.filter(x, x.active)" . }}
+//	{{ cel "'hello ' + _.name" . }}
+func CelFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "cel",
+		Description: "Evaluates a CEL (Common Expression Language) expression inline. " +
+			"The second argument is the data context, accessible as _ in the expression. " +
+			"Supports all standard CEL functions plus scafctl CEL extensions. " +
+			"For complex or repeated expressions, consider pre-computing values in CEL resolvers.",
+		Custom: true,
+		Links:  []string{"https://github.com/google/cel-spec"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Filter a list",
+				Template:    `{{ cel "_.items.filter(x, x.status == 'active')" . }}`,
+			},
+			{
+				Description: "String concatenation",
+				Template:    `{{ cel "'Hello, ' + _.name + '!'" . }}`,
+			},
+			{
+				Description: "Conditional expression",
+				Template:    `{{ cel "_.count > 10 ? 'many' : 'few'" . }}`,
+			},
+			{
+				Description: "Map access with default",
+				Template:    `{{ cel "has(_.config.timeout) ? _.config.timeout : '30s'" . }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"cel": Cel,
+		},
+	}
+}
+
+// Cel evaluates a CEL expression with the given data as root context.
+//
+// Parameters:
+//   - expr: The CEL expression string to evaluate
+//   - data: The data context, accessible as _ in the expression
+//
+// Returns the result of the CEL evaluation, which can be any Go type
+// (string, number, bool, list, map, etc.).
+//
+// For performance-sensitive templates, prefer pre-computing complex expressions
+// in CEL resolvers rather than using inline cel() calls in templates.
+func Cel(expr string, data any) (any, error) {
+	if expr == "" {
+		return nil, fmt.Errorf("cel: expression cannot be empty")
+	}
+
+	result, err := celexp.EvaluateExpression(
+		context.Background(),
+		expr,
+		data,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cel: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/gotmpl/ext/celeval/celeval_test.go
+++ b/pkg/gotmpl/ext/celeval/celeval_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package celeval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCel(t *testing.T) {
+	t.Run("simple string expression", func(t *testing.T) {
+		got, err := Cel("'hello world'", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", got)
+	})
+
+	t.Run("arithmetic expression", func(t *testing.T) {
+		got, err := Cel("2 + 3", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), got)
+	})
+
+	t.Run("boolean expression", func(t *testing.T) {
+		got, err := Cel("true && false", nil)
+		require.NoError(t, err)
+		assert.Equal(t, false, got)
+	})
+
+	t.Run("access root data via underscore", func(t *testing.T) {
+		data := map[string]any{"name": "world"}
+		got, err := Cel("'hello ' + _.name", data)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", got)
+	})
+
+	t.Run("conditional expression", func(t *testing.T) {
+		data := map[string]any{"count": int64(15)}
+		got, err := Cel("_.count > 10 ? 'many' : 'few'", data)
+		require.NoError(t, err)
+		assert.Equal(t, "many", got)
+	})
+
+	t.Run("list filtering", func(t *testing.T) {
+		data := map[string]any{
+			"items": []any{
+				map[string]any{"name": "a", "active": true},
+				map[string]any{"name": "b", "active": false},
+				map[string]any{"name": "c", "active": true},
+			},
+		}
+		got, err := Cel("_.items.filter(x, x.active)", data)
+		require.NoError(t, err)
+		result, ok := got.([]any)
+		require.True(t, ok, "expected []any, got %T", got)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("empty expression returns error", func(t *testing.T) {
+		_, err := Cel("", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expression cannot be empty")
+	})
+
+	t.Run("invalid expression returns error", func(t *testing.T) {
+		_, err := Cel("invalid syntax here!", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		got, err := Cel("42", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), got)
+	})
+
+	t.Run("nested map access", func(t *testing.T) {
+		data := map[string]any{
+			"config": map[string]any{
+				"server": map[string]any{
+					"port": int64(8080),
+				},
+			},
+		}
+		got, err := Cel("_.config.server.port", data)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8080), got)
+	})
+}
+
+func TestCelFunc(t *testing.T) {
+	f := CelFunc()
+	assert.Equal(t, "cel", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.Contains(t, f.Func, "cel")
+}

--- a/pkg/gotmpl/ext/collections/collections.go
+++ b/pkg/gotmpl/ext/collections/collections.go
@@ -1,0 +1,198 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package collections provides Go template extension functions for filtering
+// and projecting lists of maps, enabling common data transformation patterns
+// directly within Go templates.
+package collections
+
+import (
+	"fmt"
+	"reflect"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// WhereFunc returns an ExtFunction that filters a list of maps by a key/value match.
+//
+// Example usage in a Go template:
+//
+//	{{ .items | where "status" "active" }}
+func WhereFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "where",
+		Description: "Filters a list of maps, returning only entries where the given key " +
+			"equals the given value. Non-map entries and entries missing the key are excluded. " +
+			"Returns an empty list if no matches are found.",
+		Custom: true,
+		Examples: []gotmpl.Example{
+			{
+				Description: "Filter active items",
+				Template:    `{{ .items | where "status" "active" }}`,
+			},
+			{
+				Description: "Filter by type",
+				Template:    `{{ .resources | where "kind" "Deployment" }}`,
+			},
+			{
+				Description: "Chain with range",
+				Template:    `{{ range (.items | where "enabled" true) }}{{ .name }}{{ end }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"where": Where,
+		},
+	}
+}
+
+// SelectFunc returns an ExtFunction that projects a single field from a list of maps.
+//
+// Example usage in a Go template:
+//
+//	{{ .items | selectField "name" }}
+func SelectFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "selectField",
+		Description: "Extracts a single field from each map in a list, returning a flat list of values. " +
+			"Non-map entries are skipped. Entries missing the key produce nil in the output.",
+		Custom: true,
+		Examples: []gotmpl.Example{
+			{
+				Description: "Extract names from a list of items",
+				Template:    `{{ .items | selectField "name" }}`,
+			},
+			{
+				Description: "Get all IDs and join them",
+				Template:    `{{ .items | selectField "id" | join ", " }}`,
+			},
+			{
+				Description: "Extract nested field for further processing",
+				Template:    `{{ range (.items | selectField "email") }}{{ . }}{{ end }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"selectField": SelectField,
+		},
+	}
+}
+
+// Where filters a list, returning only entries where list[i][key] == value.
+//
+// The list can be []any, []map[string]any, or any slice type.
+// Non-map entries are silently skipped. The comparison uses reflect.DeepEqual
+// so it works with strings, numbers, booleans, and nested structures.
+//
+// Returns an empty []any if the input is nil, empty, or has no matches.
+func Where(key string, value, list any) ([]any, error) {
+	items, err := toSlice(list)
+	if err != nil {
+		return nil, fmt.Errorf("where: %w", err)
+	}
+
+	var result []any
+	for _, item := range items {
+		m, ok := toMap(item)
+		if !ok {
+			continue
+		}
+		v, exists := m[key]
+		if exists && reflect.DeepEqual(v, value) {
+			result = append(result, item)
+		}
+	}
+
+	if result == nil {
+		return []any{}, nil
+	}
+	return result, nil
+}
+
+// SelectField extracts a single field from each map in a list.
+//
+// The list can be []any, []map[string]any, or any slice type.
+// Non-map entries are silently skipped. If a map doesn't have the specified
+// key, nil is included in the output to preserve positional alignment.
+//
+// Returns an empty []any if the input is nil or empty.
+func SelectField(key string, list any) ([]any, error) {
+	items, err := toSlice(list)
+	if err != nil {
+		return nil, fmt.Errorf("selectField: %w", err)
+	}
+
+	var result []any
+	for _, item := range items {
+		m, ok := toMap(item)
+		if !ok {
+			continue
+		}
+		result = append(result, m[key])
+	}
+
+	if result == nil {
+		return []any{}, nil
+	}
+	return result, nil
+}
+
+// toSlice converts any slice or array to []any using reflection.
+// Returns nil, nil for nil input. Returns an error for non-slice/array types.
+func toSlice(v any) ([]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	// Fast path for common types
+	switch typed := v.(type) {
+	case []any:
+		return typed, nil
+	case []map[string]any:
+		result := make([]any, len(typed))
+		for i, m := range typed {
+			result[i] = m
+		}
+		return result, nil
+	}
+
+	// Reflection fallback for other slice/array types
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, fmt.Errorf("expected a list/array, got %T", v)
+	}
+
+	result := make([]any, rv.Len())
+	for i := range rv.Len() {
+		result[i] = rv.Index(i).Interface()
+	}
+	return result, nil
+}
+
+// toMap attempts to convert a value to map[string]any.
+// Returns the map and true if successful, nil and false otherwise.
+func toMap(v any) (map[string]any, bool) {
+	if v == nil {
+		return nil, false
+	}
+
+	// Fast path
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+
+	// Reflection fallback for map types with string keys
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Map {
+		return nil, false
+	}
+
+	if rv.Type().Key().Kind() != reflect.String {
+		return nil, false
+	}
+
+	result := make(map[string]any, rv.Len())
+	for _, key := range rv.MapKeys() {
+		result[key.String()] = rv.MapIndex(key).Interface()
+	}
+	return result, true
+}

--- a/pkg/gotmpl/ext/collections/collections_test.go
+++ b/pkg/gotmpl/ext/collections/collections_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhere(t *testing.T) {
+	items := []any{
+		map[string]any{"name": "alice", "status": "active"},
+		map[string]any{"name": "bob", "status": "inactive"},
+		map[string]any{"name": "carol", "status": "active"},
+	}
+
+	t.Run("filter by string value", func(t *testing.T) {
+		got, err := Where("status", "active", items)
+		require.NoError(t, err)
+		assert.Equal(t, []any{
+			map[string]any{"name": "alice", "status": "active"},
+			map[string]any{"name": "carol", "status": "active"},
+		}, got)
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		got, err := Where("status", "deleted", items)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("filter by boolean", func(t *testing.T) {
+		list := []any{
+			map[string]any{"name": "a", "enabled": true},
+			map[string]any{"name": "b", "enabled": false},
+		}
+		got, err := Where("enabled", true, list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{
+			map[string]any{"name": "a", "enabled": true},
+		}, got)
+	})
+
+	t.Run("nil list", func(t *testing.T) {
+		got, err := Where("key", "val", nil)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		got, err := Where("key", "val", []any{})
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("missing key in some entries", func(t *testing.T) {
+		list := []any{
+			map[string]any{"name": "alice", "status": "active"},
+			map[string]any{"name": "bob"},
+		}
+		got, err := Where("status", "active", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{
+			map[string]any{"name": "alice", "status": "active"},
+		}, got)
+	})
+
+	t.Run("non-map entries skipped", func(t *testing.T) {
+		list := []any{
+			map[string]any{"name": "alice", "status": "active"},
+			"not a map",
+			42,
+		}
+		got, err := Where("status", "active", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{
+			map[string]any{"name": "alice", "status": "active"},
+		}, got)
+	})
+
+	t.Run("non-list input", func(t *testing.T) {
+		_, err := Where("key", "val", "not a list")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected a list/array")
+	})
+
+	t.Run("typed slice input", func(t *testing.T) {
+		list := []map[string]any{
+			{"k": "v", "x": "1"},
+			{"k": "other", "x": "2"},
+		}
+		got, err := Where("k", "v", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{
+			map[string]any{"k": "v", "x": "1"},
+		}, got)
+	})
+}
+
+func TestSelectField(t *testing.T) {
+	items := []any{
+		map[string]any{"name": "alice", "age": 30},
+		map[string]any{"name": "bob", "age": 25},
+		map[string]any{"name": "carol", "age": 35},
+	}
+
+	t.Run("extract string field", func(t *testing.T) {
+		got, err := SelectField("name", items)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"alice", "bob", "carol"}, got)
+	})
+
+	t.Run("extract number field", func(t *testing.T) {
+		got, err := SelectField("age", items)
+		require.NoError(t, err)
+		assert.Equal(t, []any{30, 25, 35}, got)
+	})
+
+	t.Run("missing key produces nil", func(t *testing.T) {
+		got, err := SelectField("email", items)
+		require.NoError(t, err)
+		assert.Equal(t, []any{nil, nil, nil}, got)
+	})
+
+	t.Run("nil list", func(t *testing.T) {
+		got, err := SelectField("name", nil)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		got, err := SelectField("name", []any{})
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("non-map entries skipped", func(t *testing.T) {
+		list := []any{
+			map[string]any{"name": "alice"},
+			"not a map",
+		}
+		got, err := SelectField("name", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"alice"}, got)
+	})
+
+	t.Run("non-list input", func(t *testing.T) {
+		_, err := SelectField("name", 42)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected a list/array")
+	})
+
+	t.Run("typed slice input", func(t *testing.T) {
+		list := []map[string]any{
+			{"name": "alice"},
+			{"name": "bob"},
+		}
+		got, err := SelectField("name", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"alice", "bob"}, got)
+	})
+}
+
+func TestWhereFunc(t *testing.T) {
+	f := WhereFunc()
+	assert.Equal(t, "where", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.Contains(t, f.Func, "where")
+}
+
+func TestSelectFunc(t *testing.T) {
+	f := SelectFunc()
+	assert.Equal(t, "selectField", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.Contains(t, f.Func, "selectField")
+}

--- a/pkg/gotmpl/ext/dns/dns.go
+++ b/pkg/gotmpl/ext/dns/dns.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dns provides Go template extension functions for converting
+// arbitrary strings into DNS-safe label format (RFC 1123).
+package dns
+
+import (
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+const (
+	// maxDNSLabelLength is the maximum length of a DNS label per RFC 1123.
+	maxDNSLabelLength = 63
+)
+
+var (
+	// nonDNSChars matches any character that is not a lowercase letter, digit, or hyphen.
+	nonDNSChars = regexp.MustCompile(`[^a-z0-9-]`)
+	// multipleHyphens matches consecutive hyphens.
+	multipleHyphens = regexp.MustCompile(`-{2,}`)
+)
+
+// SlugifyFunc returns an ExtFunction that converts a string into a
+// DNS-safe label (RFC 1123). The output is lowercase, contains only
+// [a-z0-9-], has no leading/trailing/consecutive hyphens, and is
+// truncated to 63 characters.
+//
+// Example usage in a Go template:
+//
+//	{{ .name | slugify }}
+//	{{ slugify .orgName }}
+func SlugifyFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "slugify",
+		Description: "Converts a string into a DNS-safe label (RFC 1123). " +
+			"Lowercases the input, replaces non-alphanumeric characters with hyphens, " +
+			"collapses consecutive hyphens, strips leading/trailing hyphens, and " +
+			"truncates to 63 characters.",
+		Custom: true,
+		Links:  []string{"https://tools.ietf.org/html/rfc1123"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a name to a DNS-safe label",
+				Template:    `{{ "My Application Name" | slugify }}`,
+			},
+			{
+				Description: "Use with pipeline",
+				Template:    `{{ .githubOrg | slugify }}`,
+			},
+			{
+				Description: "Handle special characters",
+				Template:    `{{ "hello_world@2024!" | slugify }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"slugify": Slugify,
+		},
+	}
+}
+
+// ToDNSStringFunc returns an ExtFunction that is an alias for slugify,
+// providing backward compatibility for templates using the toDnsString name.
+//
+// Example usage in a Go template:
+//
+//	{{ .name | toDnsString }}
+func ToDNSStringFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "toDnsString",
+		Description: "Alias for slugify. Converts a string into a DNS-safe label (RFC 1123). " +
+			"Lowercases the input, replaces non-alphanumeric characters with hyphens, " +
+			"collapses consecutive hyphens, strips leading/trailing hyphens, and " +
+			"truncates to 63 characters.",
+		Custom: true,
+		Links:  []string{"https://tools.ietf.org/html/rfc1123"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a name to a DNS label",
+				Template:    `{{ .kubeNamespace | toDnsString }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"toDnsString": Slugify,
+		},
+	}
+}
+
+// Slugify converts an arbitrary string into a DNS-safe label (RFC 1123).
+//
+// The transformation:
+//  1. Converts to lowercase
+//  2. Replaces any character not in [a-z0-9-] with a hyphen
+//  3. Collapses consecutive hyphens into a single hyphen
+//  4. Strips leading and trailing hyphens
+//  5. Truncates to 63 characters (the DNS label limit)
+//  6. Strips any trailing hyphen introduced by truncation
+//
+// Returns an empty string if the input is empty or contains no valid characters.
+func Slugify(s string) string {
+	// 1. Lowercase
+	result := strings.ToLower(s)
+
+	// 2. Replace non-DNS characters with hyphens
+	result = nonDNSChars.ReplaceAllString(result, "-")
+
+	// 3. Collapse consecutive hyphens
+	result = multipleHyphens.ReplaceAllString(result, "-")
+
+	// 4. Strip leading/trailing hyphens
+	result = strings.Trim(result, "-")
+
+	// 5. Truncate to max DNS label length
+	if len(result) > maxDNSLabelLength {
+		result = result[:maxDNSLabelLength]
+	}
+
+	// 6. Strip trailing hyphen from truncation
+	result = strings.TrimRight(result, "-")
+
+	return result
+}

--- a/pkg/gotmpl/ext/dns/dns_test.go
+++ b/pkg/gotmpl/ext/dns/dns_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package dns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple lowercase",
+			input: "hello",
+			want:  "hello",
+		},
+		{
+			name:  "mixed case",
+			input: "Hello World",
+			want:  "hello-world",
+		},
+		{
+			name:  "underscores and special chars",
+			input: "hello_world@2024!",
+			want:  "hello-world-2024",
+		},
+		{
+			name:  "consecutive special characters",
+			input: "hello---world___test",
+			want:  "hello-world-test",
+		},
+		{
+			name:  "leading and trailing special chars",
+			input: "---hello---",
+			want:  "hello",
+		},
+		{
+			name:  "unicode characters",
+			input: "h\u00e9llo w\u00f6rld caf\u00e9",
+			want:  "h-llo-w-rld-caf",
+		},
+		{
+			name:  "all special characters",
+			input: "@#$%^&*()",
+			want:  "",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "already valid DNS label",
+			input: "my-valid-label",
+			want:  "my-valid-label",
+		},
+		{
+			name:  "digits only",
+			input: "12345",
+			want:  "12345",
+		},
+		{
+			name:  "leading digits",
+			input: "123-abc",
+			want:  "123-abc",
+		},
+		{
+			name:  "max length truncation",
+			input: strings.Repeat("a", 100),
+			want:  strings.Repeat("a", 63),
+		},
+		{
+			name:  "truncation at hyphen boundary",
+			input: strings.Repeat("a", 63) + "-extra",
+			want:  strings.Repeat("a", 63),
+		},
+		{
+			name:  "truncation creates trailing hyphen",
+			input: strings.Repeat("a", 62) + "--extra",
+			want:  strings.Repeat("a", 62),
+		},
+		{
+			name:  "dots replaced",
+			input: "my.service.name",
+			want:  "my-service-name",
+		},
+		{
+			name:  "slashes replaced",
+			input: "org/repo/name",
+			want:  "org-repo-name",
+		},
+		{
+			name:  "CamelCase",
+			input: "MyApplicationName",
+			want:  "myapplicationname",
+		},
+		{
+			name:  "kubernetes namespace style",
+			input: "My Kube_Namespace",
+			want:  "my-kube-namespace",
+		},
+		{
+			name:  "github org style",
+			input: "My-GitHub_Org.Name",
+			want:  "my-github-org-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Slugify(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSlugifyFunc(t *testing.T) {
+	f := SlugifyFunc()
+	assert.Equal(t, "slugify", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.Contains(t, f.Func, "slugify")
+}
+
+func TestToDNSStringFunc(t *testing.T) {
+	f := ToDNSStringFunc()
+	assert.Equal(t, "toDnsString", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.Contains(t, f.Func, "toDnsString")
+}

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -14,6 +14,9 @@ import (
 
 	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/celeval"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/collections"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/dns"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/hcl"
 	extyaml "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/yaml"
 )
@@ -69,6 +72,17 @@ func Custom() gotmpl.ExtFunctionList {
 	return gotmpl.ExtFunctionList{
 		// HCL functions
 		hcl.ToHclFunc(),
+
+		// DNS / slugify functions
+		dns.SlugifyFunc(),
+		dns.ToDNSStringFunc(),
+
+		// Collection / list-filtering functions
+		collections.WhereFunc(),
+		collections.SelectFunc(),
+
+		// Inline CEL evaluation
+		celeval.CelFunc(),
 
 		// YAML functions (removed from Sprig v3.3.0)
 		extyaml.ToYamlFunc(),

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -411,7 +412,7 @@ func (s *Service) executeTemplate(ctx context.Context, tmpl *template.Template, 
 		lgr.Error(err, "template execution failed",
 			"name", opts.Name,
 			"dataType", fmt.Sprintf("%T", opts.Data))
-		return "", fmt.Errorf("execution error: %w", err)
+		return "", fmt.Errorf("execution error: %w\n%s", err, diagnoseTemplateError(err, opts))
 	}
 
 	output := buf.String()
@@ -428,6 +429,66 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// diagnoseTemplateError inspects a template execution error and returns
+// actionable guidance for common failure modes.
+func diagnoseTemplateError(err error, opts TemplateOptions) string {
+	msg := err.Error()
+	var hints []string
+
+	// Nil pointer / interface conversion (usually accessing a field on nil data).
+	if strings.Contains(msg, "nil pointer") || strings.Contains(msg, "interface conversion") {
+		hints = append(hints, "A value used in the template is nil. Check that all referenced resolver fields have been resolved before this template runs.")
+	}
+
+	// Wrong type for range (e.g., ranging over a string).
+	if strings.Contains(msg, "range can't iterate over") {
+		hints = append(hints, "The 'range' action received a non-iterable value. Ensure the variable is a list/slice or map, not a string or number.")
+	}
+
+	// Method/field not found.
+	if strings.Contains(msg, "can't evaluate field") || strings.Contains(msg, "is not a field of struct") {
+		hints = append(hints, "A referenced field does not exist on the data object. Double-check field names and casing. Resolver data keys are case-sensitive.")
+	}
+
+	// Function not defined.
+	if strings.Contains(msg, "function") && strings.Contains(msg, "not defined") {
+		hints = append(hints, "A template function is not registered. Available custom functions: slugify, toDnsString, where, selectField, cel, toHcl, toYaml, fromYaml. Sprig functions are also available.")
+	}
+
+	// Wrong number of args.
+	if strings.Contains(msg, "wrong number of args") {
+		hints = append(hints, "A function or method was called with the wrong number of arguments. Check the function signature.")
+	}
+
+	// Map has no entry.
+	if strings.Contains(msg, "map has no entry for key") {
+		hints = append(hints, "A map key was not found. Use 'index' to safely access map keys, or set missingKey to 'zero' or 'default'.")
+	}
+
+	// Describe the data type passed.
+	if opts.Data != nil {
+		hints = append(hints, fmt.Sprintf("Template data type: %T", opts.Data))
+		if m, ok := opts.Data.(map[string]any); ok && len(m) > 0 {
+			keys := make([]string, 0, len(m))
+			for k := range m {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			if len(keys) > 20 {
+				keys = append(keys[:20], "...")
+			}
+			hints = append(hints, fmt.Sprintf("Available top-level keys: %s", strings.Join(keys, ", ")))
+		}
+	} else {
+		hints = append(hints, "Template data is nil — no resolver data was passed to this template.")
+	}
+
+	if len(hints) == 0 {
+		return ""
+	}
+	return "Hints: " + strings.Join(hints, " | ")
 }
 
 // Execute is a convenience function that creates a service and executes a template

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
@@ -88,7 +89,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintWorkflow(sol, result, registry)
-	lintTests(sol, result)
+	lintTests(sol, filePath, result)
 	lintProviderInputs(sol, result, registry)
 
 	for _, f := range result.Findings {
@@ -544,10 +545,12 @@ func scanExpressionForResolverRefs(expr string, pattern *regexp.Regexp, refs map
 	}
 }
 
-func lintTests(sol *solution.Solution, result *Result) {
+func lintTests(sol *solution.Solution, solutionPath string, result *Result) {
 	if !sol.Spec.HasTests() {
 		return
 	}
+
+	solutionDir := filepath.Dir(solutionPath)
 
 	// Test name validation regexes (same as soltesting package).
 	testNameRegex := soltesting.TestNamePattern()
@@ -596,6 +599,19 @@ func lintTests(sol *solution.Solution, result *Result) {
 			}
 		}
 
+		// Rule: unreachable-test-path — warn when a files entry doesn't resolve to anything on disk.
+		if solutionDir != "" && len(tc.Files) > 0 {
+			for i, file := range tc.Files {
+				fileLoc := fmt.Sprintf("%s.files[%d]", location, i)
+				if !testFileReachable(solutionDir, file) {
+					result.addFinding(SeverityWarning, "testing", fileLoc,
+						fmt.Sprintf("test file path %q does not match any existing file or directory", file),
+						"Check for typos, verify the file exists, or use a valid glob pattern (e.g., 'templates/**/*.yaml')",
+						"unreachable-test-path")
+				}
+			}
+		}
+
 		// Rule: unused-template — templates not referenced by any extends.
 		if isTemplate && !extendsRefs[name] {
 			result.addFinding(SeverityWarning, "usage", location,
@@ -616,6 +632,29 @@ func isCoveredByBundleInclude(file string, includes []string) bool {
 		}
 	}
 	return false
+}
+
+// testFileReachable returns true if a test file entry resolves to at least one
+// existing file or directory on disk. Supports plain paths, directories, and glob patterns.
+func testFileReachable(solutionDir, entry string) bool {
+	cleaned := filepath.Clean(entry)
+
+	// Reject path traversal and absolute paths — let other rules handle those.
+	if strings.HasPrefix(cleaned, "..") || filepath.IsAbs(cleaned) {
+		return true // don't double-flag, other rules will catch this
+	}
+
+	// Glob patterns: check if they expand to at least one match.
+	if strings.ContainsAny(entry, "*?[{") {
+		absPattern := filepath.Join(solutionDir, entry)
+		matches, err := doublestar.FilepathGlob(absPattern)
+		return err == nil && len(matches) > 0
+	}
+
+	// Plain path or directory: check if it exists on disk.
+	absPath := filepath.Join(solutionDir, cleaned)
+	_, err := os.Stat(absPath)
+	return err == nil
 }
 
 // lintSchema reads the solution file from disk, unmarshals it into a generic
@@ -708,6 +747,10 @@ func lintProviderInputsForStep(providerName string, inputs map[string]*spec.Valu
 		// Check for unknown input keys.
 		if allowedProps != nil {
 			if _, exists := allowedProps[key]; !exists {
+				// If the schema allows additional properties, skip the unknown-input check.
+				if desc.Schema.AdditionalProperties != nil {
+					continue
+				}
 				result.addFinding(SeverityError, "provider", inputLoc,
 					fmt.Sprintf("unknown input %q for provider %q", key, providerName),
 					fmt.Sprintf("Check the provider's accepted inputs. Run: scafctl explain provider %s", providerName),

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -234,6 +234,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Wrong (causes cycle):\nvalidate:\n  with:\n    - provider: validation\n      inputs:\n        expression: \"_.myResolver.statusCode == 200\"\n\n# Correct:\nvalidate:\n  with:\n    - provider: validation\n      inputs:\n        expression: \"__self.statusCode == 200\"",
 		},
 	},
+	"unreachable-test-path": {
+		Rule:        "unreachable-test-path",
+		Severity:    string(SeverityWarning),
+		Category:    "testing",
+		Description: "A test case references a file path in its 'files' list that does not exist on disk and does not match any file via glob expansion.",
+		Why:         "Tests that reference non-existent files will fail at sandbox setup time with a confusing error. This usually indicates a typo in the path, a deleted file, or a glob pattern that doesn't match anything.",
+		Fix:         "Check the file path for typos. Run 'ls' or glob expansion to verify the pattern matches files. Use directories (e.g., 'templates/') or globs (e.g., 'templates/**/*.yaml') for dynamic file sets.",
+		Examples: []string{
+			"# Correct patterns:\nfiles:\n  - templates/main.yaml      # exact file\n  - data/                     # entire directory\n  - configs/**/*.yaml          # recursive glob",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 24 rules — update this when new rules are added
-	assert.Equal(t, 24, len(KnownRules), "expected 24 known lint rules")
+	// We expect exactly 25 rules — update this when new rules are added
+	assert.Equal(t, 25, len(KnownRules), "expected 25 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/enhancements_test.go
+++ b/pkg/mcp/enhancements_test.go
@@ -53,7 +53,7 @@ func TestToolIcons(t *testing.T) {
 		"solution", "provider", "cel", "template", "schema",
 		"example", "catalog", "auth", "lint", "scaffold",
 		"action", "diff", "dryrun", "config", "refs",
-		"testing", "snapshot", "version",
+		"testing", "snapshot", "version", "help",
 	}
 
 	for _, cat := range expectedCategories {

--- a/pkg/mcp/icons.go
+++ b/pkg/mcp/icons.go
@@ -84,6 +84,10 @@ var toolIcons = map[string]mcp.Icon{
 		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2390A4AE' stroke-width='2'><circle cx='12' cy='12' r='10'/><line x1='12' y1='16' x2='12' y2='12'/><line x1='12' y1='8' x2='12.01' y2='8'/></svg>",
 		MIMEType: "image/svg+xml",
 	},
+	"help": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2329B6F6' stroke-width='2'><circle cx='12' cy='12' r='10'/><path d='M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3'/><line x1='12' y1='17' x2='12.01' y2='17'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
 }
 
 // promptIcons maps prompt categories to their icons.

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -342,8 +342,8 @@ func (s *Server) handleSolutionTestsResource(_ context.Context, request mcp.Read
 		if len(tc.Tags) > 0 {
 			caseData["tags"] = tc.Tags
 		}
-		if tc.Skip {
-			caseData["skip"] = true
+		if !tc.Skip.IsZero() {
+			caseData["skip"] = tc.Skip.String()
 			if tc.SkipReason != "" {
 				caseData["skipReason"] = tc.SkipReason
 			}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -521,6 +521,9 @@ func (s *Server) registerTools() {
 	// Lint explanation tools
 	s.registerLintTools()
 
+	// Error explanation tools
+	s.registerErrorTools()
+
 	// Scaffold tools
 	s.registerScaffoldTools()
 
@@ -544,6 +547,9 @@ func (s *Server) registerTools() {
 
 	// Snapshot inspection & diff tools
 	s.registerSnapshotTools()
+
+	// Concept explanation tools
+	s.registerConceptTools()
 
 	// Version tool
 	s.registerVersionTools()

--- a/pkg/mcp/tools_cel.go
+++ b/pkg/mcp/tools_cel.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -33,6 +34,9 @@ func (s *Server) registerCELTools() {
 		),
 		mcp.WithString("name",
 			mcp.Description("Get details for a specific function by name (substring match)"),
+		),
+		mcp.WithString("category",
+			mcp.Description("Filter by category: 'strings', 'collections', 'encoding', 'math', 'time', 'filepath', 'debug', 'utility', 'language'. Omit to list all."),
 		),
 	)
 	s.mcpServer.AddTool(listCELFunctionsTool, s.handleListCELFunctions)
@@ -69,12 +73,23 @@ func (s *Server) handleListCELFunctions(_ context.Context, request mcp.CallToolR
 	customOnly := request.GetBool("custom_only", false)
 	builtinOnly := request.GetBool("builtin_only", false)
 	name := request.GetString("name", "")
+	category := request.GetString("category", "")
 
 	functions := ext.All()
 	if customOnly {
 		functions = ext.Custom()
 	} else if builtinOnly {
 		functions = ext.BuiltIn()
+	}
+
+	if category != "" {
+		filtered := make(celexp.ExtFunctionList, 0, len(functions))
+		for _, f := range functions {
+			if strings.EqualFold(f.Category, category) {
+				filtered = append(filtered, f)
+			}
+		}
+		functions = filtered
 	}
 
 	return filterAndReturnNamedFunctions(

--- a/pkg/mcp/tools_concepts.go
+++ b/pkg/mcp/tools_concepts.go
@@ -1,0 +1,134 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/concepts"
+)
+
+// registerConceptTools registers concept explanation MCP tools.
+func (s *Server) registerConceptTools() {
+	tool := mcp.NewTool("explain_concepts",
+		mcp.WithDescription("Look up and explain scafctl concepts such as resolvers, providers, actions, testing, CEL expressions, composition, and more. Use without arguments to list all concepts, or provide a name or search query to get detailed explanations with examples."),
+		mcp.WithTitleAnnotation("Explain Concepts"),
+		mcp.WithToolIcons(toolIcons["help"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("name",
+			mcp.Description("Exact concept name to look up (e.g., 'resolver', 'cel-expression', 'test-sandbox')"),
+		),
+		mcp.WithString("query",
+			mcp.Description("Free-text search across concept names, titles, and summaries"),
+		),
+		mcp.WithString("category",
+			mcp.Description("Filter concepts by category (e.g., 'resolvers', 'testing', 'providers', 'actions')"),
+		),
+	)
+	s.mcpServer.AddTool(tool, s.handleExplainConcepts)
+}
+
+// handleExplainConcepts handles the explain_concepts MCP tool.
+func (s *Server) handleExplainConcepts(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name := request.GetString("name", "")
+	query := request.GetString("query", "")
+	category := request.GetString("category", "")
+
+	// Exact name lookup — return detailed single concept.
+	if name != "" {
+		c, ok := concepts.Get(name)
+		if !ok {
+			available := concepts.List()
+			names := make([]string, len(available))
+			for i, a := range available {
+				names[i] = a.Name
+			}
+			return newStructuredError(ErrCodeNotFound,
+				fmt.Sprintf("concept %q not found", name),
+				WithSuggestion("Use explain_concepts without arguments to list all concepts"),
+				WithField("name"),
+			), nil
+		}
+		return mcp.NewToolResultJSON(map[string]any{
+			"concept": c,
+		})
+	}
+
+	// Category filter.
+	if category != "" {
+		results := concepts.ByCategory(category)
+		if len(results) == 0 {
+			return mcp.NewToolResultJSON(map[string]any{
+				"concepts":   []any{},
+				"categories": concepts.Categories(),
+				"message":    fmt.Sprintf("No concepts in category %q. Available categories listed above.", category),
+			})
+		}
+		summaries := make([]map[string]string, len(results))
+		for i, c := range results {
+			summaries[i] = map[string]string{
+				"name":    c.Name,
+				"title":   c.Title,
+				"summary": c.Summary,
+			}
+		}
+		return mcp.NewToolResultJSON(map[string]any{
+			"category": category,
+			"concepts": summaries,
+			"hint":     "Use explain_concepts with name='<concept>' for full details",
+		})
+	}
+
+	// Free-text search.
+	if query != "" {
+		results := concepts.Search(query)
+		if len(results) == 0 {
+			return mcp.NewToolResultJSON(map[string]any{
+				"concepts":   []any{},
+				"categories": concepts.Categories(),
+				"message":    fmt.Sprintf("No concepts matching %q. Try a broader query or list all with no arguments.", query),
+			})
+		}
+		summaries := make([]map[string]string, len(results))
+		for i, c := range results {
+			summaries[i] = map[string]string{
+				"name":     c.Name,
+				"title":    c.Title,
+				"category": c.Category,
+				"summary":  c.Summary,
+			}
+		}
+		return mcp.NewToolResultJSON(map[string]any{
+			"query":    query,
+			"concepts": summaries,
+			"hint":     "Use explain_concepts with name='<concept>' for full details",
+		})
+	}
+
+	// No arguments — list all concepts grouped by category.
+	categories := concepts.Categories()
+	grouped := make(map[string][]map[string]string)
+	for _, cat := range categories {
+		items := concepts.ByCategory(cat)
+		summaries := make([]map[string]string, len(items))
+		for i, c := range items {
+			summaries[i] = map[string]string{
+				"name":    c.Name,
+				"summary": c.Summary,
+			}
+		}
+		grouped[cat] = summaries
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"categories": grouped,
+		"totalCount": len(concepts.List()),
+		"hint":       "Use explain_concepts with name='<concept>' for full explanation and examples",
+	})
+}

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -32,6 +32,9 @@ func (s *Server) registerDryRunTools() {
 		mcp.WithObject("params",
 			mcp.Description("Input parameters as key-value pairs for parameter-type resolvers"),
 		),
+		mcp.WithObject("mock_data",
+			mcp.Description("Override specific resolver values with mock data instead of executing them. Keys are resolver names, values are the mock output. Useful for testing action behavior with specific resolver outputs without requiring real provider execution. Example: {\"api_url\": \"https://mock.example.com\", \"config\": {\"env\": \"test\"}}"),
+		),
 	)
 	s.mcpServer.AddTool(dryRunTool, s.handleDryRunSolution)
 }
@@ -48,6 +51,7 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 
 	// Parse params
 	var params map[string]any
+	var mockData map[string]any
 	args := request.GetArguments()
 	if p, ok := args["params"]; ok && p != nil {
 		if pm, ok := p.(map[string]any); ok {
@@ -56,6 +60,16 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 			return newStructuredError(ErrCodeInvalidInput, "'params' must be an object (key-value pairs)",
 				WithField("params"),
 				WithSuggestion("Provide params as a JSON object, e.g. {\"key\": \"value\"}"),
+			), nil
+		}
+	}
+	if m, ok := args["mock_data"]; ok && m != nil {
+		if mm, ok := m.(map[string]any); ok {
+			mockData = mm
+		} else {
+			return newStructuredError(ErrCodeInvalidInput, "'mock_data' must be an object mapping resolver names to mock values",
+				WithField("mock_data"),
+				WithSuggestion("Provide mock_data as {\"resolver_name\": <value>}"),
 			), nil
 		}
 	}
@@ -102,6 +116,16 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 			resolverData = make(map[string]any)
 		} else {
 			resolverData = result.Data
+		}
+	}
+
+	// Apply mock_data overrides — these take precedence over dry-run results
+	if len(mockData) > 0 {
+		if resolverData == nil {
+			resolverData = make(map[string]any)
+		}
+		for name, val := range mockData {
+			resolverData[name] = val
 		}
 	}
 

--- a/pkg/mcp/tools_errors.go
+++ b/pkg/mcp/tools_errors.go
@@ -1,0 +1,306 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// registerErrorTools registers the explain_error MCP tool.
+func (s *Server) registerErrorTools() {
+	explainErrorTool := mcp.NewTool("explain_error",
+		mcp.WithDescription("Explain a scafctl error message. Parses the error text, identifies the error category, and returns a structured explanation with root cause analysis and actionable fix suggestions. Paste any error from resolver execution, validation, CEL evaluation, or provider failures."),
+		mcp.WithTitleAnnotation("Explain Error"),
+		mcp.WithToolIcons(toolIcons["lint"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("error",
+			mcp.Required(),
+			mcp.Description("The error message text to explain. Can be a full error string or snippet from resolver execution, validation, CEL evaluation, or any scafctl operation."),
+		),
+	)
+	s.mcpServer.AddTool(explainErrorTool, s.handleExplainError)
+}
+
+// errorExplanation is the structured response for explain_error.
+type errorExplanation struct {
+	Category    string   `json:"category"`
+	Summary     string   `json:"summary"`
+	RootCause   string   `json:"rootCause"`
+	Suggestions []string `json:"suggestions"`
+	RelatedDocs []string `json:"relatedDocs,omitempty"`
+	Example     string   `json:"example,omitempty"`
+}
+
+// errorPattern defines a pattern matcher for known error types.
+type errorPattern struct {
+	name    string
+	pattern *regexp.Regexp
+	build   func(matches []string, fullError string) errorExplanation
+}
+
+// knownPatterns returns all recognized error patterns.
+func knownPatterns() []errorPattern {
+	return []errorPattern{
+		{
+			name:    "execution-error",
+			pattern: regexp.MustCompile(`resolver "([^"]+)" failed in (\w+) phase \(step (\d+)(?:, provider (\w+))?\): (.+)`),
+			build: func(m []string, _ string) errorExplanation {
+				resolver := m[1]
+				phase := m[2]
+				provider := m[4]
+				cause := m[5]
+				exp := errorExplanation{
+					Category:  "resolver_execution",
+					Summary:   fmt.Sprintf("Resolver %q failed during the %s phase", resolver, phase),
+					RootCause: cause,
+					Suggestions: []string{
+						fmt.Sprintf("Check the %s phase configuration for resolver %q", phase, resolver),
+						"Use inspect_solution to view the full resolver definition",
+						"Use lint_solution to check for configuration issues",
+					},
+				}
+				if provider == "http" {
+					exp.Suggestions = append(exp.Suggestions,
+						"HTTP provider returns {statusCode, body, headers} — access response data via body.<field>",
+						"Check that the URL is reachable and returns the expected format",
+					)
+				}
+				if provider == "cel" {
+					exp.Suggestions = append(exp.Suggestions,
+						"Use evaluate_cel to test the expression independently",
+						"Use list_cel_functions to discover available functions",
+					)
+				}
+				return exp
+			},
+		},
+		{
+			name:    "type-coercion",
+			pattern: regexp.MustCompile(`resolver "([^"]+)": type coercion from (\w+) to (\w+) failed after (\w+) phase: (.+)`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "type_coercion",
+					Summary:   fmt.Sprintf("Cannot convert %s to %s for resolver %q", m[2], m[3], m[1]),
+					RootCause: m[5],
+					Suggestions: []string{
+						fmt.Sprintf("Add a transform step to convert %s → %s before the resolver returns", m[2], m[3]),
+						"Check that the provider output matches the declared resolver type",
+						"If using the CEL provider, ensure the expression returns the correct type",
+						fmt.Sprintf("Example transform: {\"provider\": \"cel\", \"inputs\": {\"expression\": \"%s(value)\"}}", m[3]),
+					},
+				}
+			},
+		},
+		{
+			name:    "validation-failed",
+			pattern: regexp.MustCompile(`resolver "([^"]+)" validation failed(?:: (.+)| with (\d+) errors?)`),
+			build: func(m []string, _ string) errorExplanation {
+				resolver := m[1]
+				exp := errorExplanation{
+					Category:  "validation",
+					Summary:   fmt.Sprintf("Resolver %q produced a value that failed validation", resolver),
+					RootCause: "The resolved value did not satisfy the validation rules defined in the validate phase",
+					Suggestions: []string{
+						fmt.Sprintf("Use inspect_solution to view the validation rules for resolver %q", resolver),
+						"Use preview_resolvers to see the actual resolved values",
+						"Add or adjust validation rules to match the expected value format",
+					},
+				}
+				if m[2] != "" {
+					exp.RootCause = m[2]
+				}
+				return exp
+			},
+		},
+		{
+			name:    "circular-dependency",
+			pattern: regexp.MustCompile(`circular dependency detected: (.+)`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "dependency",
+					Summary:   "Circular dependency in resolver graph",
+					RootCause: fmt.Sprintf("The following resolvers form a cycle: %s", m[1]),
+					Suggestions: []string{
+						"Break the cycle by removing one of the dependsOn entries",
+						"Consider merging the interdependent resolvers into one",
+						"Use a transform step to combine data instead of circular references",
+						"Use lint_solution to visualize the dependency graph",
+					},
+				}
+			},
+		},
+		{
+			name:    "cel-undeclared-ref",
+			pattern: regexp.MustCompile(`undeclared reference to '([^']+)'`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "cel_expression",
+					Summary:   fmt.Sprintf("CEL expression references undefined variable %q", m[1]),
+					RootCause: fmt.Sprintf("The variable %q is not available in the current CEL evaluation context", m[1]),
+					Suggestions: []string{
+						"Check that the referenced resolver exists and is declared as a dependency",
+						"Available variables in CEL expressions: resolvers (resolved values), params (input parameters), metadata (solution metadata)",
+						"Use evaluate_cel with the data parameter to test the expression with sample data",
+						"Use list_cel_functions to see available functions",
+					},
+				}
+			},
+		},
+		{
+			name:    "cel-no-overload",
+			pattern: regexp.MustCompile(`found no matching overload for '([^']+)'`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "cel_expression",
+					Summary:   fmt.Sprintf("CEL function %q called with wrong argument types", m[1]),
+					RootCause: "The function exists but the argument types don't match any known signature",
+					Suggestions: []string{
+						fmt.Sprintf("Use list_cel_functions to check the signature of %q", m[1]),
+						"Ensure input types match — e.g., string functions need string arguments",
+						"Use type() to inspect the actual type of a value in CEL",
+					},
+				}
+			},
+		},
+		{
+			name:    "no-such-key",
+			pattern: regexp.MustCompile(`no such key: (\w+)`),
+			build: func(m []string, full string) errorExplanation {
+				exp := errorExplanation{
+					Category:  "data_access",
+					Summary:   fmt.Sprintf("Attempted to access non-existent key %q", m[1]),
+					RootCause: "The data structure does not contain the referenced key",
+					Suggestions: []string{
+						"Use preview_resolvers to inspect the actual data shape returned by the provider",
+						"Check for typos in the key name",
+						"Use has() in CEL to safely check if a key exists before accessing it",
+					},
+				}
+				if strings.Contains(full, "http") || strings.Contains(full, "statusCode") {
+					exp.Suggestions = append(exp.Suggestions,
+						"HTTP provider returns {statusCode, body, headers} — access response fields via body.<field>",
+					)
+				}
+				return exp
+			},
+		},
+		{
+			name:    "phase-timeout",
+			pattern: regexp.MustCompile(`phase (\d+) timed out(?: with (\d+) resolvers? still waiting)?`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "timeout",
+					Summary:   fmt.Sprintf("Phase %s timed out", m[1]),
+					RootCause: "One or more resolvers in this execution phase took too long to complete",
+					Suggestions: []string{
+						"Increase the resolver timeout from the default 30s",
+						"Check if the provider target (API, command) is responsive",
+						"For HTTP providers, verify the endpoint is reachable",
+						"Consider breaking slow resolvers into smaller steps",
+					},
+				}
+			},
+		},
+		{
+			name:    "value-size",
+			pattern: regexp.MustCompile(`resolver "([^"]+)" value size (\d+) bytes exceeds maximum (\d+) bytes`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "value_size",
+					Summary:   fmt.Sprintf("Resolver %q produced a value exceeding the size limit", m[1]),
+					RootCause: fmt.Sprintf("Value is %s bytes but the maximum is %s bytes", m[2], m[3]),
+					Suggestions: []string{
+						"Add a transform step to filter or reduce the data before returning",
+						"Use CEL expressions like size(), filter(), or map() to trim results",
+						"Consider fetching only the fields you need from the source",
+					},
+				}
+			},
+		},
+		{
+			name:    "foreach-type",
+			pattern: regexp.MustCompile(`resolver "([^"]+)" transform step (\d+): forEach requires array input, got (\w+)`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "type_mismatch",
+					Summary:   fmt.Sprintf("forEach in resolver %q expected an array but got %s", m[1], m[3]),
+					RootCause: fmt.Sprintf("Transform step %s uses forEach which requires an array input, but the current value is type %s", m[2], m[3]),
+					Suggestions: []string{
+						"Add a transform step before forEach to convert the value to an array",
+						"Use [value] to wrap a single value into an array if needed",
+						"Check that the resolve phase returns an array for this resolver",
+					},
+				}
+			},
+		},
+		{
+			name:    "aggregated-execution",
+			pattern: regexp.MustCompile(`(\d+) resolver\(s\) failed`),
+			build: func(m []string, _ string) errorExplanation {
+				return errorExplanation{
+					Category:  "multiple_failures",
+					Summary:   fmt.Sprintf("%s resolvers failed during execution", m[1]),
+					RootCause: "Multiple resolvers encountered errors. Failures may cascade if resolvers depend on each other.",
+					Suggestions: []string{
+						"Fix the resolver errors starting from those with no dependencies (earliest phase)",
+						"Use preview_resolvers to see which resolvers succeeded and which failed",
+						"Skipped resolvers are typically caused by their dependencies failing — fix their dependencies first",
+						"Use lint_solution to check for configuration issues across all resolvers",
+					},
+				}
+			},
+		},
+	}
+}
+
+// handleExplainError parses an error message and returns a structured explanation.
+func (s *Server) handleExplainError(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	errText := request.GetString("error", "")
+	if errText == "" {
+		return newStructuredError(ErrCodeInvalidInput, "error parameter is required",
+			WithField("error"),
+			WithSuggestion("Paste the full error message from a failed operation"),
+		), nil
+	}
+
+	for _, p := range knownPatterns() {
+		matches := p.pattern.FindStringSubmatch(errText)
+		if matches != nil {
+			explanation := p.build(matches, errText)
+			return marshalExplanation(explanation)
+		}
+	}
+
+	// No pattern matched — return generic guidance
+	generic := errorExplanation{
+		Category:  "unknown",
+		Summary:   "Could not categorize this error automatically",
+		RootCause: errText,
+		Suggestions: []string{
+			"Use lint_solution to check for configuration issues",
+			"Use inspect_solution to review the solution structure",
+			"Use preview_resolvers with verbose=true to see detailed execution output",
+			"Check that all referenced providers and resolvers exist",
+		},
+	}
+	return marshalExplanation(generic)
+}
+
+func marshalExplanation(exp errorExplanation) (*mcp.CallToolResult, error) {
+	data, err := json.Marshal(exp)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal explanation: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/pkg/mcp/tools_errors_test.go
+++ b/pkg/mcp/tools_errors_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleExplainError(t *testing.T) {
+	s := &Server{}
+
+	tests := []struct {
+		name            string
+		errorText       string
+		wantCategory    string
+		wantSummaryPart string
+		wantSuggestions int // minimum number of suggestions
+		wantIsError     bool
+	}{
+		{
+			name:            "execution error with http provider",
+			errorText:       `resolver "api-data" failed in resolve phase (step 0, provider http): connection refused`,
+			wantCategory:    "resolver_execution",
+			wantSummaryPart: "api-data",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "execution error with cel provider",
+			errorText:       `resolver "transform-x" failed in transform phase (step 1, provider cel): found no matching overload`,
+			wantCategory:    "resolver_execution",
+			wantSummaryPart: "transform-x",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "type coercion error",
+			errorText:       `resolver "age-value": type coercion from string to int failed after resolve phase: invalid syntax`,
+			wantCategory:    "type_coercion",
+			wantSummaryPart: "string to int",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "validation failure",
+			errorText:       `resolver "email" validation failed: value must be a valid email address`,
+			wantCategory:    "validation",
+			wantSummaryPart: "email",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "circular dependency",
+			errorText:       `circular dependency detected: a → b → a`,
+			wantCategory:    "dependency",
+			wantSummaryPart: "Circular dependency",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "CEL undeclared reference",
+			errorText:       `undeclared reference to 'foobar' in expression`,
+			wantCategory:    "cel_expression",
+			wantSummaryPart: "foobar",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "CEL no matching overload",
+			errorText:       `found no matching overload for 'size'`,
+			wantCategory:    "cel_expression",
+			wantSummaryPart: "size",
+			wantSuggestions: 2,
+		},
+		{
+			name:            "no such key",
+			errorText:       `no such key: items`,
+			wantCategory:    "data_access",
+			wantSummaryPart: "items",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "no such key with http context",
+			errorText:       `no such key: data — http statusCode was 200`,
+			wantCategory:    "data_access",
+			wantSummaryPart: "data",
+			wantSuggestions: 4,
+		},
+		{
+			name:            "phase timeout",
+			errorText:       `phase 2 timed out with 3 resolvers still waiting`,
+			wantCategory:    "timeout",
+			wantSummaryPart: "Phase 2",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "value size exceeded",
+			errorText:       `resolver "big-data" value size 10485760 bytes exceeds maximum 1048576 bytes`,
+			wantCategory:    "value_size",
+			wantSummaryPart: "big-data",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "forEach type mismatch",
+			errorText:       `resolver "items" transform step 0: forEach requires array input, got string`,
+			wantCategory:    "type_mismatch",
+			wantSummaryPart: "items",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "aggregated failures",
+			errorText:       `3 resolver(s) failed, 2 skipped due to failed dependencies`,
+			wantCategory:    "multiple_failures",
+			wantSummaryPart: "3 resolvers",
+			wantSuggestions: 3,
+		},
+		{
+			name:            "unknown error",
+			errorText:       `something completely unexpected happened`,
+			wantCategory:    "unknown",
+			wantSummaryPart: "Could not categorize",
+			wantSuggestions: 3,
+		},
+		{
+			name:        "empty error",
+			errorText:   "",
+			wantIsError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := mcp.CallToolRequest{}
+			request.Params.Arguments = map[string]any{
+				"error": tt.errorText,
+			}
+
+			result, err := s.handleExplainError(context.TODO(), request)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			if tt.wantIsError {
+				assert.True(t, result.IsError)
+				return
+			}
+
+			assert.False(t, result.IsError)
+			require.Len(t, result.Content, 1)
+
+			text := result.Content[0].(mcp.TextContent).Text
+			var exp errorExplanation
+			require.NoError(t, json.Unmarshal([]byte(text), &exp))
+
+			assert.Equal(t, tt.wantCategory, exp.Category)
+			assert.Contains(t, exp.Summary, tt.wantSummaryPart)
+			assert.GreaterOrEqual(t, len(exp.Suggestions), tt.wantSuggestions, "expected at least %d suggestions, got %d", tt.wantSuggestions, len(exp.Suggestions))
+			assert.NotEmpty(t, exp.RootCause)
+		})
+	}
+}

--- a/pkg/mcp/tools_examples.go
+++ b/pkg/mcp/tools_examples.go
@@ -15,7 +15,7 @@ import (
 func (s *Server) registerExampleTools() {
 	// list_examples — list available example files
 	listExamplesTool := mcp.NewTool("list_examples",
-		mcp.WithDescription("List available scafctl example files. Examples demonstrate best practices for solutions, resolvers, actions, providers, and more. Filter by category (solutions, resolvers, actions, providers, exec, config, mcp, snapshots, catalog) or get all."),
+		mcp.WithDescription("List available scafctl example files. Examples demonstrate best practices for solutions, resolvers, actions, providers, and more. Filter by category or get all (grouped by category)."),
 		mcp.WithTitleAnnotation("List Examples"),
 		mcp.WithToolIcons(toolIcons["example"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -23,8 +23,8 @@ func (s *Server) registerExampleTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("category",
-			mcp.Description("Filter by category: solutions, resolvers, actions, providers, exec, config, mcp, snapshots, catalog. Omit to list all."),
-			mcp.Enum("solutions", "resolvers", "actions", "providers", "exec", "config", "mcp", "snapshots", "catalog"),
+			mcp.Description("Filter by category. Omit to list all examples grouped by category."),
+			mcp.Enum("solutions", "resolvers", "actions", "providers", "exec", "config", "mcp", "snapshots", "catalog", "auth", "eval", "plugins", "telemetry"),
 		),
 	)
 	s.mcpServer.AddTool(listExamplesTool, s.handleListExamples)
@@ -68,9 +68,54 @@ func (s *Server) handleListExamples(_ context.Context, request mcp.CallToolReque
 		})
 	}
 
+	// When listing all (no category filter), group by category for easier navigation.
+	if category == "" {
+		grouped := make(map[string][]examples.Example)
+		for _, item := range items {
+			cat := item.Category
+			if cat == "" {
+				cat = "(uncategorized)"
+			}
+			grouped[cat] = append(grouped[cat], item)
+		}
+
+		// Build summary per category.
+		type categorySummary struct {
+			Category string             `json:"category"`
+			Count    int                `json:"count"`
+			Examples []examples.Example `json:"examples"`
+		}
+
+		cats := examples.Categories()
+		summaries := make([]categorySummary, 0, len(cats))
+		for _, cat := range cats {
+			if g, ok := grouped[cat]; ok {
+				summaries = append(summaries, categorySummary{
+					Category: cat,
+					Count:    len(g),
+					Examples: g,
+				})
+			}
+		}
+		// Include uncategorized if present.
+		if g, ok := grouped["(uncategorized)"]; ok {
+			summaries = append(summaries, categorySummary{
+				Category: "(uncategorized)",
+				Count:    len(g),
+				Examples: g,
+			})
+		}
+
+		return mcp.NewToolResultJSON(map[string]any{
+			"categories": summaries,
+			"totalCount": len(items),
+		})
+	}
+
 	return mcp.NewToolResultJSON(map[string]any{
 		"examples": items,
 		"count":    len(items),
+		"category": category,
 	})
 }
 

--- a/pkg/mcp/tools_examples_test.go
+++ b/pkg/mcp/tools_examples_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHandleListExamples(t *testing.T) {
-	t.Run("lists all examples", func(t *testing.T) {
+	t.Run("lists all examples grouped by category", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)
 
@@ -32,13 +32,19 @@ func TestHandleListExamples(t *testing.T) {
 		var data map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &data))
 
-		exs, ok := data["examples"].([]any)
-		require.True(t, ok, "expected examples array")
-		assert.Greater(t, len(exs), 0, "should find at least one example")
+		cats, ok := data["categories"].([]any)
+		require.True(t, ok, "expected categories array")
+		assert.Greater(t, len(cats), 0, "should have at least one category")
 
-		count, ok := data["count"].(float64)
+		totalCount, ok := data["totalCount"].(float64)
 		require.True(t, ok)
-		assert.Equal(t, float64(len(exs)), count)
+		assert.Greater(t, totalCount, float64(0), "should find at least one example")
+
+		// Each category entry should have category, count, and examples
+		first := cats[0].(map[string]any)
+		assert.NotEmpty(t, first["category"])
+		assert.Greater(t, first["count"].(float64), float64(0))
+		assert.NotEmpty(t, first["examples"])
 	})
 
 	t.Run("filters by category", func(t *testing.T) {

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -49,6 +49,26 @@ func (s *Server) registerProviderTools() {
 		),
 	)
 	s.mcpServer.AddTool(getProviderSchemaTool, s.handleGetProviderSchema)
+
+	// get_provider_output_shape
+	getProviderOutputShapeTool := mcp.NewTool("get_provider_output_shape",
+		mcp.WithDescription("Get the output shape (field names, types) for a specific provider and capability. Use this to discover what fields a resolver produces after execution — essential for writing CEL expressions that reference resolver output. Returns the output schema for the requested capability, or all capabilities if none specified."),
+		mcp.WithTitleAnnotation("Get Provider Output Shape"),
+		mcp.WithToolIcons(toolIcons["provider"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("Provider name (e.g., http, static, file, cel, exec)"),
+		),
+		mcp.WithString("capability",
+			mcp.Description("Optional capability to filter output schema (from, transform, validation, authentication, action). Omit for all capabilities."),
+			mcp.Enum("from", "transform", "validation", "authentication", "action"),
+		),
+	)
+	s.mcpServer.AddTool(getProviderOutputShapeTool, s.handleGetProviderOutputShape)
 }
 
 // providerItem is a structured response for provider listings.
@@ -156,4 +176,72 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 	detail := provdetail.BuildProviderDetail(*desc)
 
 	return mcp.NewToolResultJSON(detail)
+}
+
+// handleGetProviderOutputShape returns the output schema for a provider, optionally
+// filtered by capability. This makes it easy for agents to discover what fields
+// resolver results contain after execution.
+func (s *Server) handleGetProviderOutputShape(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := request.RequireString("name")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("name"),
+			WithSuggestion("Use list_providers to see available provider names"),
+			WithRelatedTools("list_providers"),
+		), nil
+	}
+	capability := request.GetString("capability", "")
+
+	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
+	if err != nil {
+		availableNames := ""
+		if s.registry != nil {
+			names := s.registry.List()
+			if len(names) > 0 {
+				availableNames = fmt.Sprintf(". Available providers: %v", names)
+			}
+		}
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("provider %q not found%s", name, availableNames),
+			WithField("name"),
+			WithSuggestion("Use list_providers to see available provider names"),
+			WithRelatedTools("list_providers"),
+		), nil
+	}
+
+	if len(desc.OutputSchemas) == 0 {
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("provider %q has no output schemas defined", name),
+			WithSuggestion("Not all providers define output schemas. Use get_provider_schema for full details."),
+			WithRelatedTools("get_provider_schema"),
+		), nil
+	}
+
+	result := map[string]any{
+		"provider": name,
+	}
+
+	if capability != "" {
+		provCap := provider.Capability(capability)
+		schema, ok := desc.OutputSchemas[provCap]
+		if !ok {
+			availableCaps := make([]string, 0, len(desc.OutputSchemas))
+			for c := range desc.OutputSchemas {
+				availableCaps = append(availableCaps, string(c))
+			}
+			return newStructuredError(ErrCodeNotFound,
+				fmt.Sprintf("provider %q has no output schema for capability %q. Available: %v", name, capability, availableCaps),
+				WithField("capability"),
+				WithSuggestion("Check the capability name against the available capabilities"),
+			), nil
+		}
+		result["capability"] = capability
+		result["outputSchema"] = provdetail.BuildSchemaOutput(schema)
+	} else {
+		outputSchemas := make(map[string]any, len(desc.OutputSchemas))
+		for cap, schema := range desc.OutputSchemas {
+			outputSchemas[string(cap)] = provdetail.BuildSchemaOutput(schema)
+		}
+		result["outputSchemas"] = outputSchemas
+	}
+
+	return mcp.NewToolResultJSON(result)
 }

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -19,6 +20,7 @@ import (
 	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
@@ -700,10 +702,7 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	progress.report(s.ctx, 2, fmt.Sprintf("Executing %d resolvers", len(sol.Spec.Resolvers)))
 	result, err := execute.Resolvers(s.ctx, sol, params, reg, cfg)
 	if err != nil {
-		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
-			WithSuggestion("Check resolver configuration and dependencies"),
-			WithRelatedTools("lint_solution", "inspect_solution"),
-		), nil
+		return buildResolverExecutionError(err, sol), nil
 	}
 
 	progress.report(s.ctx, 3, "Building response")
@@ -715,17 +714,18 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 
 	type resolverPreview struct {
-		Value       any                 `json:"value"`
-		Type        string              `json:"type,omitempty"`
-		Description string              `json:"description,omitempty"`
-		Status      string              `json:"status"`
-		Provider    string              `json:"provider,omitempty"`
-		DependsOn   []string            `json:"dependsOn,omitempty"`
-		Resolve     []resolverPhaseInfo `json:"resolve,omitempty"`
-		Transform   []resolverPhaseInfo `json:"transform,omitempty"`
-		Validate    []resolverPhaseInfo `json:"validate,omitempty"`
-		When        string              `json:"when,omitempty"`
-		SourcePos   *sourcepos.Position `json:"sourcePos,omitempty"`
+		Value        any                 `json:"value"`
+		Type         string              `json:"type,omitempty"`
+		Description  string              `json:"description,omitempty"`
+		Status       string              `json:"status"`
+		Provider     string              `json:"provider,omitempty"`
+		OutputSchema any                 `json:"outputSchema,omitempty"`
+		DependsOn    []string            `json:"dependsOn,omitempty"`
+		Resolve      []resolverPhaseInfo `json:"resolve,omitempty"`
+		Transform    []resolverPhaseInfo `json:"transform,omitempty"`
+		Validate     []resolverPhaseInfo `json:"validate,omitempty"`
+		When         string              `json:"when,omitempty"`
+		SourcePos    *sourcepos.Position `json:"sourcePos,omitempty"`
 	}
 
 	resolvers := make(map[string]resolverPreview, len(sol.Spec.Resolvers))
@@ -753,6 +753,29 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		// Get the primary provider name
 		if rslvr.Resolve != nil && len(rslvr.Resolve.With) > 0 {
 			preview.Provider = rslvr.Resolve.With[0].Provider
+		}
+
+		// Determine output schema: last transform provider's transform schema,
+		// or first resolve provider's from schema if no transforms exist.
+		{
+			var outputProviderName string
+			var outputCap provider.Capability
+			if rslvr.Transform != nil && len(rslvr.Transform.With) > 0 {
+				last := rslvr.Transform.With[len(rslvr.Transform.With)-1]
+				outputProviderName = last.Provider
+				outputCap = provider.CapabilityTransform
+			} else if rslvr.Resolve != nil && len(rslvr.Resolve.With) > 0 {
+				outputProviderName = rslvr.Resolve.With[0].Provider
+				outputCap = provider.CapabilityFrom
+			}
+			if outputProviderName != "" && reg != nil {
+				if p, ok := reg.Get(outputProviderName); ok {
+					desc := p.Descriptor()
+					if schema, ok := desc.OutputSchemas[outputCap]; ok {
+						preview.OutputSchema = provdetail.BuildSchemaOutput(schema)
+					}
+				}
+			}
 		}
 
 		// Add pipeline details for single-resolver debugging
@@ -1106,6 +1129,122 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 	)
 
 	return result, nil
+}
+
+// buildResolverExecutionError converts resolver execution errors into rich structured
+// error responses with typed diagnostics and actionable suggestions.
+func buildResolverExecutionError(err error, sol *solution.Solution) *mcp.CallToolResult {
+	var suggestions []string
+	var details strings.Builder
+
+	switch {
+	case errors.As(err, new(*resolver.AggregatedExecutionError)):
+		var aggErr *resolver.AggregatedExecutionError
+		errors.As(err, &aggErr)
+
+		fmt.Fprintf(&details, "%d resolver(s) failed", len(aggErr.Errors))
+		if aggErr.SucceededCount > 0 {
+			fmt.Fprintf(&details, ", %d succeeded", aggErr.SucceededCount)
+		}
+		if aggErr.SkippedCount > 0 {
+			fmt.Fprintf(&details, ", %d skipped (failed dependencies: %s)",
+				aggErr.SkippedCount, strings.Join(aggErr.SkippedNames, ", "))
+		}
+		details.WriteString("\n\nFailures:\n")
+
+		for i, fr := range aggErr.Errors {
+			fmt.Fprintf(&details, "  %d. resolver %q (phase %d): %s\n", i+1, fr.ResolverName, fr.Phase, fr.ErrMessage)
+			appendResolverHints(&suggestions, fr.Err, fr.ResolverName, sol)
+		}
+
+	case errors.As(err, new(*resolver.ExecutionError)):
+		var execErr *resolver.ExecutionError
+		errors.As(err, &execErr)
+
+		fmt.Fprintf(&details, "Resolver %q failed in %s phase (step %d", execErr.ResolverName, execErr.Phase, execErr.Step)
+		if execErr.Provider != "" {
+			fmt.Fprintf(&details, ", provider: %s", execErr.Provider)
+		}
+		details.WriteString(")\n")
+		fmt.Fprintf(&details, "Error: %v", execErr.Cause)
+
+		appendResolverHints(&suggestions, execErr.Cause, execErr.ResolverName, sol)
+		if execErr.Provider == "http" {
+			suggestions = append(suggestions, "HTTP provider returns {statusCode, body, headers} — use body.field, not field directly")
+		}
+
+	case errors.As(err, new(*resolver.TypeCoercionError)):
+		var coercionErr *resolver.TypeCoercionError
+		errors.As(err, &coercionErr)
+
+		fmt.Fprintf(&details, "Resolver %q: cannot coerce %s → %s (after %s phase)\n",
+			coercionErr.ResolverName, coercionErr.SourceType, coercionErr.TargetType, coercionErr.Phase)
+		fmt.Fprintf(&details, "Error: %v", coercionErr.Cause)
+		suggestions = append(suggestions,
+			fmt.Sprintf("Add a transform step to convert %s to %s before the type coercion", coercionErr.SourceType, coercionErr.TargetType),
+			"Check if the provider output shape matches the expected resolver type",
+		)
+
+	case errors.As(err, new(*resolver.AggregatedValidationError)):
+		var valErr *resolver.AggregatedValidationError
+		errors.As(err, &valErr)
+
+		fmt.Fprintf(&details, "Resolver %q failed validation with %d error(s):\n", valErr.ResolverName, len(valErr.Failures))
+		for i, f := range valErr.Failures {
+			fmt.Fprintf(&details, "  %d. [rule %d] %s\n", i+1, f.Rule, f.Error())
+		}
+		suggestions = append(suggestions, "Review the validation rules in the resolver's validate section")
+
+	case errors.As(err, new(*resolver.CircularDependencyError)):
+		var circErr *resolver.CircularDependencyError
+		errors.As(err, &circErr)
+
+		fmt.Fprintf(&details, "Circular dependency detected: %s", strings.Join(circErr.Cycle, " → "))
+		suggestions = append(suggestions, "Break the cycle by restructuring resolver dependencies or using a transform to combine data")
+
+	default:
+		details.WriteString(err.Error())
+	}
+
+	if len(suggestions) == 0 {
+		suggestions = append(suggestions, "Check resolver configuration and dependencies")
+	}
+
+	opts := make([]ErrorOption, 0, 1+len(suggestions))
+	opts = append(opts, WithRelatedTools("lint_solution", "inspect_solution"))
+	for _, s := range suggestions {
+		opts = append(opts, WithSuggestion(s))
+	}
+
+	return newStructuredError(ErrCodeExecFailed,
+		fmt.Sprintf("resolver execution failed: %s", details.String()),
+		opts...,
+	)
+}
+
+// appendResolverHints inspects an error cause and adds provider-specific hints.
+func appendResolverHints(suggestions *[]string, cause error, resolverName string, sol *solution.Solution) {
+	if cause == nil {
+		return
+	}
+	msg := cause.Error()
+
+	// HTTP provider: hint about envelope structure
+	if strings.Contains(msg, "no such key") {
+		if res, ok := sol.Spec.Resolvers[resolverName]; ok && res.Resolve != nil {
+			for _, step := range res.Resolve.With {
+				if step.Provider == "http" {
+					*suggestions = append(*suggestions, fmt.Sprintf("Resolver %q uses the http provider which returns {statusCode, body, headers} — reference nested fields as body.<field>", resolverName))
+					break
+				}
+			}
+		}
+	}
+
+	// CEL expression errors
+	if strings.Contains(msg, "undeclared reference") || strings.Contains(msg, "found no matching overload") {
+		*suggestions = append(*suggestions, "Use list_cel_functions to see available CEL functions and their signatures")
+	}
 }
 
 // isResolverDependency checks if candidateName is a direct or transitive dependency

--- a/pkg/mcp/tools_testing.go
+++ b/pkg/mcp/tools_testing.go
@@ -6,8 +6,11 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 )
@@ -76,8 +79,9 @@ func (s *Server) handleGenerateTestScaffold(_ context.Context, request mcp.CallT
 	}
 
 	input := &soltesting.ScaffoldInput{
-		Resolvers: sol.Spec.Resolvers,
-		Workflow:  sol.Spec.Workflow,
+		Resolvers:        sol.Spec.Resolvers,
+		Workflow:         sol.Spec.Workflow,
+		FileDependencies: discoverFileDeps(sol, path),
 	}
 
 	result := soltesting.Scaffold(input)
@@ -131,6 +135,27 @@ func (s *Server) handleGenerateTestScaffold(_ context.Context, request mcp.CallT
 			"Add edge case tests for error conditions",
 			"Run run_solution_tests to verify tests pass",
 		},
+		"sandboxGuidance": map[string]any{
+			"overview": "Each test case runs in an isolated sandbox directory. The sandbox copies the solution file and any files listed in the test case 'files' field.",
+			"filesField": []string{
+				"Use relative paths from the solution directory (e.g., 'templates/main.tf')",
+				"Use glob patterns to match multiple files (e.g., 'templates/**')",
+				"Use directory paths to copy entire directories (e.g., 'configs/')",
+				"Files are deduplicated — overlapping globs and directories are safe",
+			},
+			"fileDependencies": func() string {
+				if len(input.FileDependencies) > 0 {
+					return fmt.Sprintf("Detected %d file dependencies from provider inputs. These have been auto-populated in each test case's 'files' field.", len(input.FileDependencies))
+				}
+				return "No file dependencies were detected. If your solution references external files (templates, configs, etc.), add them to each test case's 'files' field."
+			}(),
+			"commonPatterns": []string{
+				"Use 'expr' in assertions to write CEL expressions that check resolved values",
+				"Use 'contains' for partial string matching in resolver outputs",
+				"Use 'eq' for exact value comparison",
+				"Mock external providers (HTTP, exec) with static values for deterministic tests",
+			},
+		},
 	})
 }
 
@@ -167,7 +192,7 @@ func (s *Server) handleListTests(_ context.Context, request mcp.CallToolRequest)
 		Description    string   `json:"description,omitempty"`
 		Command        []string `json:"command,omitempty"`
 		Tags           []string `json:"tags,omitempty"`
-		Skip           bool     `json:"skip,omitempty"`
+		Skip           string   `json:"skip,omitempty"`
 		SkipReason     string   `json:"skipReason,omitempty"`
 		AssertionCount int      `json:"assertionCount"`
 	}
@@ -190,7 +215,7 @@ func (s *Server) handleListTests(_ context.Context, request mcp.CallToolRequest)
 				Description:    tc.Description,
 				Command:        tc.Command,
 				Tags:           tc.Tags,
-				Skip:           tc.Skip,
+				Skip:           tc.Skip.String(),
 				SkipReason:     tc.SkipReason,
 				AssertionCount: len(tc.Assertions),
 			}
@@ -210,4 +235,24 @@ func (s *Server) handleListTests(_ context.Context, request mcp.CallToolRequest)
 		"totalTests":     totalTests,
 		"totalSolutions": len(solutionResults),
 	})
+}
+
+// discoverFileDeps uses bundler.DiscoverFiles to extract local file dependencies
+// from a loaded solution. Returns nil on error (best-effort).
+func discoverFileDeps(sol *solution.Solution, solutionPath string) []string {
+	if sol == nil {
+		return nil
+	}
+
+	bundleRoot := filepath.Dir(solutionPath)
+	result, err := bundler.DiscoverFiles(sol, bundleRoot)
+	if err != nil || result == nil {
+		return nil
+	}
+
+	var deps []string
+	for _, f := range result.LocalFiles {
+		deps = append(deps, f.RelPath)
+	}
+	return deps
 }

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -15,11 +15,13 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/envprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/execprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/fileprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/githubprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/gitprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/gotmplprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/hclprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/httpprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/identityprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/metadataprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/parameterprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/secretprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/sleepprovider"
@@ -64,6 +66,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		validationprovider.NewValidationProvider(),
 		execprovider.NewExecProvider(),
 		gitprovider.NewGitProvider(),
+		githubprovider.NewGitHubProvider(),
 		debugprovider.NewDebugProvider(),
 		sleepprovider.NewSleepProvider(),
 		parameterprovider.NewParameterProvider(),
@@ -71,6 +74,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		gotmplprovider.NewGoTemplateProvider(),
 		identityprovider.NewIdentityProvider(),
 		hclprovider.NewHCLProvider(),
+		metadataprovider.New(),
 	}
 
 	// Initialize secrets store for the secret provider.
@@ -134,6 +138,8 @@ func ProviderNames() []string {
 		"secret",
 		"identity",
 		"hcl",
+		"github",
+		"metadata",
 	}
 }
 

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -74,7 +74,7 @@ func TestProviderNames(t *testing.T) {
 	names := ProviderNames()
 
 	// Should have all built-in providers
-	expectedCount := 16 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl
+	expectedCount := 18 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl, github, metadata
 	assert.Len(t, names, expectedCount, "should have %d built-in providers", expectedCount)
 
 	// Verify expected names are present
@@ -95,6 +95,8 @@ func TestProviderNames(t *testing.T) {
 		"secret",
 		"identity",
 		"hcl",
+		"github",
+		"metadata",
 	}
 
 	for _, expected := range expectedNames {
@@ -171,6 +173,8 @@ func TestAllProvidersRegistered(t *testing.T) {
 		{"secret", "secret"},
 		{"identity", "identity"},
 		{"hcl", "HCL"},
+		{"metadata", "metadata"},
+		{"github", "GitHub"},
 	}
 
 	for _, expected := range expectedProviders {

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -313,8 +313,8 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 		opts.Stdin = stdin
 	}
 
-	// Execute command
-	result, err := shellexec.Run(cmdCtx, opts)
+	// Execute command — uses RunWithContext so tests can inject a mock RunFunc
+	result, err := shellexec.RunWithContext(cmdCtx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute command: %w", err)
 	}

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -1,0 +1,349 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package githubprovider implements a provider for common GitHub API operations.
+//
+// It supports retrieving repository info, file content, releases, and pull requests
+// via the GitHub REST API. Authentication is handled automatically using the
+// configured GitHub auth handler.
+package githubprovider
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/oakwood-commons/scafctl/pkg/ptrs"
+)
+
+// ProviderName is the registered name for this provider.
+const ProviderName = "github"
+
+// GitHubProvider implements common GitHub API operations as a resolver provider.
+type GitHubProvider struct {
+	descriptor *provider.Descriptor
+	// httpClient can be overridden for testing
+	httpClient *http.Client
+}
+
+// Option configures a GitHubProvider.
+type Option func(*GitHubProvider)
+
+// WithHTTPClient sets a custom HTTP client (useful for testing).
+func WithHTTPClient(c *http.Client) Option {
+	return func(p *GitHubProvider) {
+		p.httpClient = c
+	}
+}
+
+// NewGitHubProvider creates a new GitHub API provider.
+func NewGitHubProvider(opts ...Option) *GitHubProvider {
+	version, _ := semver.NewVersion("1.0.0")
+
+	p := &GitHubProvider{
+		descriptor: &provider.Descriptor{
+			Name:        ProviderName,
+			DisplayName: "GitHub API",
+			APIVersion:  "v1",
+			Version:     version,
+			Description: "Retrieve data from the GitHub REST API. Supports repository info, file content, releases, and pull requests. " +
+				"Uses the configured GitHub auth handler automatically. " +
+				"For arbitrary HTTP requests to GitHub, use the 'http' provider with authProvider: github.",
+			Category:     "data",
+			MockBehavior: "Returns mock data for the requested operation without making real API calls",
+			Capabilities: []provider.Capability{
+				provider.CapabilityFrom,
+				provider.CapabilityTransform,
+			},
+			Schema: schemahelper.ObjectSchema(
+				[]string{"operation", "owner", "repo"},
+				map[string]*jsonschema.Schema{
+					"operation": schemahelper.StringProp("GitHub API operation to perform",
+						schemahelper.WithEnum(
+							"get_repo",
+							"get_file",
+							"list_releases",
+							"get_latest_release",
+							"list_pull_requests",
+							"get_pull_request",
+						),
+						schemahelper.WithExample("get_repo"),
+					),
+					"owner": schemahelper.StringProp("Repository owner (user or organization)",
+						schemahelper.WithExample("octocat"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+					),
+					"repo": schemahelper.StringProp("Repository name",
+						schemahelper.WithExample("hello-world"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+					),
+					"path": schemahelper.StringProp("File path within the repository (for get_file operation)",
+						schemahelper.WithExample("README.md"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(1000)),
+					),
+					"ref": schemahelper.StringProp("Git reference (branch, tag, or commit SHA). Defaults to the repo's default branch.",
+						schemahelper.WithExample("main"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+					),
+					"number": schemahelper.IntProp("Pull request number (for get_pull_request operation)",
+						schemahelper.WithMinimum(1),
+						schemahelper.WithExample(42),
+					),
+					"state": schemahelper.StringProp("Filter by state for list operations",
+						schemahelper.WithEnum("open", "closed", "all"),
+						schemahelper.WithDefault("open"),
+					),
+					"per_page": schemahelper.IntProp("Number of results per page (max 100)",
+						schemahelper.WithMinimum(1),
+						schemahelper.WithMaximum(100),
+						schemahelper.WithDefault(30),
+					),
+					"api_base": schemahelper.StringProp("GitHub API base URL. Defaults to https://api.github.com. Set for GitHub Enterprise.",
+						schemahelper.WithDefault("https://api.github.com"),
+						schemahelper.WithFormat("uri"),
+					),
+				},
+			),
+			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"result": schemahelper.AnyProp("The API response data — structure varies by operation"),
+				}),
+				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"result": schemahelper.AnyProp("The API response data — structure varies by operation"),
+				}),
+			},
+			Examples: []provider.Example{
+				{
+					Name:        "Get repository info",
+					Description: "Fetch metadata for a GitHub repository",
+					YAML: `operation: get_repo
+owner: octocat
+repo: hello-world`,
+				},
+				{
+					Name:        "Get file content",
+					Description: "Retrieve a file from a repository at a specific branch",
+					YAML: `operation: get_file
+owner: octocat
+repo: hello-world
+path: README.md
+ref: main`,
+				},
+				{
+					Name:        "Get latest release",
+					Description: "Fetch the latest release of a repository",
+					YAML: `operation: get_latest_release
+owner: cli
+repo: cli`,
+				},
+				{
+					Name:        "List open pull requests",
+					Description: "List open pull requests for a repository",
+					YAML: `operation: list_pull_requests
+owner: golang
+repo: go
+state: open
+per_page: 10`,
+				},
+			},
+			Links: []provider.Link{
+				{Name: "GitHub REST API", URL: "https://docs.github.com/en/rest"},
+			},
+			Tags: []string{"github", "api", "data"},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Descriptor returns the provider metadata, schema, and capabilities.
+func (p *GitHubProvider) Descriptor() *provider.Descriptor {
+	return p.descriptor
+}
+
+// Execute runs the requested GitHub API operation.
+func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected map input, got %T", ProviderName, input)
+	}
+
+	operation, _ := inputs["operation"].(string)
+	owner, _ := inputs["owner"].(string)
+	repo, _ := inputs["repo"].(string)
+	apiBase, _ := inputs["api_base"].(string)
+	if apiBase == "" {
+		apiBase = "https://api.github.com"
+	}
+	apiBase = strings.TrimRight(apiBase, "/")
+
+	// Build the API URL based on operation
+	var apiURL string
+	var queryParams []string
+
+	switch operation {
+	case "get_repo":
+		apiURL = fmt.Sprintf("%s/repos/%s/%s", apiBase, owner, repo)
+
+	case "get_file":
+		path, _ := inputs["path"].(string)
+		if path == "" {
+			return nil, fmt.Errorf("%s: 'path' is required for get_file operation", ProviderName)
+		}
+		apiURL = fmt.Sprintf("%s/repos/%s/%s/contents/%s", apiBase, owner, repo, path)
+		if ref, ok := inputs["ref"].(string); ok && ref != "" {
+			queryParams = append(queryParams, "ref="+ref)
+		}
+
+	case "list_releases":
+		apiURL = fmt.Sprintf("%s/repos/%s/%s/releases", apiBase, owner, repo)
+		addPaginationParams(inputs, &queryParams)
+
+	case "get_latest_release":
+		apiURL = fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, owner, repo)
+
+	case "list_pull_requests":
+		apiURL = fmt.Sprintf("%s/repos/%s/%s/pulls", apiBase, owner, repo)
+		if state, ok := inputs["state"].(string); ok && state != "" {
+			queryParams = append(queryParams, "state="+state)
+		}
+		addPaginationParams(inputs, &queryParams)
+
+	case "get_pull_request":
+		num, _ := getIntInput(inputs, "number")
+		if num == 0 {
+			return nil, fmt.Errorf("%s: 'number' is required for get_pull_request operation", ProviderName)
+		}
+		apiURL = fmt.Sprintf("%s/repos/%s/%s/pulls/%d", apiBase, owner, repo, num)
+
+	default:
+		return nil, fmt.Errorf("%s: unknown operation %q — supported: get_repo, get_file, list_releases, get_latest_release, list_pull_requests, get_pull_request", ProviderName, operation)
+	}
+
+	if len(queryParams) > 0 {
+		apiURL += "?" + strings.Join(queryParams, "&")
+	}
+
+	// Make the request
+	result, err := p.doRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	// For get_file, decode base64 content if present
+	if operation == "get_file" {
+		if m, ok := result.(map[string]any); ok {
+			if encoded, ok := m["content"].(string); ok {
+				decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(encoded, "\n", ""))
+				if err == nil {
+					m["decoded_content"] = string(decoded)
+				}
+			}
+		}
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"result": result,
+		},
+	}, nil
+}
+
+// doRequest performs an authenticated GitHub API request.
+func (p *GitHubProvider) doRequest(ctx context.Context, url string) (any, error) {
+	lgr := logger.FromContext(ctx)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	// Try to get GitHub auth token
+	handler, handlerErr := auth.GetHandler(ctx, "github")
+	if handlerErr == nil {
+		token, tokenErr := handler.GetToken(ctx, auth.TokenOptions{})
+		if tokenErr == nil {
+			req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+			lgr.V(2).Info("using GitHub auth token for API request")
+		} else {
+			lgr.V(1).Info("GitHub auth token unavailable, making unauthenticated request", "error", tokenErr)
+		}
+	} else {
+		lgr.V(1).Info("GitHub auth handler not available, making unauthenticated request", "error", handlerErr)
+	}
+
+	client := p.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req) //nolint:gosec // URL is intentionally user-provided via provider input
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		// Try to extract GitHub error message
+		var ghErr map[string]any
+		if json.Unmarshal(body, &ghErr) == nil {
+			if msg, ok := ghErr["message"].(string); ok {
+				return nil, fmt.Errorf("GitHub API error (HTTP %d): %s", resp.StatusCode, msg)
+			}
+		}
+		return nil, fmt.Errorf("GitHub API error (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing response JSON: %w", err)
+	}
+
+	return result, nil
+}
+
+// addPaginationParams adds per_page query parameter if provided.
+func addPaginationParams(inputs map[string]any, params *[]string) {
+	if perPage, _ := getIntInput(inputs, "per_page"); perPage > 0 {
+		*params = append(*params, fmt.Sprintf("per_page=%d", perPage))
+	}
+}
+
+// getIntInput extracts an integer from the input map, handling both float64 (from JSON) and int.
+func getIntInput(inputs map[string]any, key string) (int, bool) {
+	v, ok := inputs[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_test.go
+++ b/pkg/provider/builtin/githubprovider/github_test.go
@@ -1,0 +1,270 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGitHubProvider(t *testing.T) {
+	p := NewGitHubProvider()
+	desc := p.Descriptor()
+	assert.Equal(t, ProviderName, desc.Name)
+	assert.Equal(t, "GitHub API", desc.DisplayName)
+	assert.NotEmpty(t, desc.Examples)
+	assert.NotEmpty(t, desc.Links)
+}
+
+func TestGitHubProvider_Execute_GetRepo(t *testing.T) {
+	repoData := map[string]any{
+		"name":        "hello-world",
+		"full_name":   "octocat/hello-world",
+		"description": "My first repository on GitHub!",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/octocat/hello-world", r.URL.Path)
+		assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(repoData)
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_repo",
+		"owner":     "octocat",
+		"repo":      "hello-world",
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, "hello-world", result["name"])
+}
+
+func TestGitHubProvider_Execute_GetFile(t *testing.T) {
+	content := "# Hello World\nThis is a test."
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/octocat/hello-world/contents/README.md", r.URL.Path)
+		assert.Equal(t, "main", r.URL.Query().Get("ref"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"name":    "README.md",
+			"content": encoded,
+			"type":    "file",
+		})
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_file",
+		"owner":     "octocat",
+		"repo":      "hello-world",
+		"path":      "README.md",
+		"ref":       "main",
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, "README.md", result["name"])
+	assert.Equal(t, content, result["decoded_content"])
+}
+
+func TestGitHubProvider_Execute_GetFile_MissingPath(t *testing.T) {
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_file",
+		"owner":     "octocat",
+		"repo":      "hello-world",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "'path' is required")
+}
+
+func TestGitHubProvider_Execute_ListReleases(t *testing.T) {
+	releases := []map[string]any{
+		{"tag_name": "v1.0.0"},
+		{"tag_name": "v0.9.0"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/cli/cli/releases", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("per_page"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_releases",
+		"owner":     "cli",
+		"repo":      "cli",
+		"per_page":  float64(10),
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].([]any)
+	assert.Len(t, result, 2)
+}
+
+func TestGitHubProvider_Execute_GetLatestRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/cli/cli/releases/latest", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"tag_name": "v2.50.0"})
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_latest_release",
+		"owner":     "cli",
+		"repo":      "cli",
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, "v2.50.0", result["tag_name"])
+}
+
+func TestGitHubProvider_Execute_ListPullRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/golang/go/pulls", r.URL.Path)
+		assert.Equal(t, "open", r.URL.Query().Get("state"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"number": 1, "title": "Fix bug"},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_pull_requests",
+		"owner":     "golang",
+		"repo":      "go",
+		"state":     "open",
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].([]any)
+	assert.Len(t, result, 1)
+}
+
+func TestGitHubProvider_Execute_GetPullRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/golang/go/pulls/42", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"number": 42, "title": "Great PR"})
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_pull_request",
+		"owner":     "golang",
+		"repo":      "go",
+		"number":    float64(42),
+		"api_base":  server.URL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, float64(42), result["number"])
+}
+
+func TestGitHubProvider_Execute_GetPullRequest_MissingNumber(t *testing.T) {
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_pull_request",
+		"owner":     "golang",
+		"repo":      "go",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "'number' is required")
+}
+
+func TestGitHubProvider_Execute_UnknownOperation(t *testing.T) {
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "delete_everything",
+		"owner":     "test",
+		"repo":      "test",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown operation")
+}
+
+func TestGitHubProvider_Execute_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
+	}))
+	defer server.Close()
+
+	p := NewGitHubProvider(WithHTTPClient(server.Client()))
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "get_repo",
+		"owner":     "nonexistent",
+		"repo":      "repo",
+		"api_base":  server.URL,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+	assert.Contains(t, err.Error(), "Not Found")
+}
+
+func TestGitHubProvider_Execute_InvalidInput(t *testing.T) {
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), "not a map")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected map input")
+}
+
+func TestGetIntInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputs map[string]any
+		key    string
+		want   int
+		wantOK bool
+	}{
+		{"float64", map[string]any{"n": float64(42)}, "n", 42, true},
+		{"int", map[string]any{"n": 42}, "n", 42, true},
+		{"int64", map[string]any{"n": int64(42)}, "n", 42, true},
+		{"missing", map[string]any{}, "n", 0, false},
+		{"string", map[string]any{"n": "42"}, "n", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := getIntInput(tt.inputs, tt.key)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -69,6 +69,25 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 					schemahelper.WithExample("%>"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(10))),
 				"data": schemahelper.AnyProp("Additional data to merge with resolver context. These values are accessible alongside resolver data in the template."),
+				"ignoredBlocks": schemahelper.ArrayProp(
+					"List of literal blocks to preserve without template parsing. Each entry uses EITHER start/end markers (for multi-line blocks) OR a line marker (for single-line matches). Content is passed through unchanged. Useful for templates containing syntax like Terraform for_each or GitHub Actions expressions that conflict with Go template delimiters.",
+					schemahelper.WithItems(schemahelper.ObjectProp(
+						"A block to exclude from template parsing. Use 'start'+'end' for multi-line ranges, or 'line' for single-line matches. These modes are mutually exclusive.",
+						nil,
+						map[string]*jsonschema.Schema{
+							"start": schemahelper.StringProp("Start marker for a multi-line ignored block (e.g., '/*scafctl:ignore:start*/'). Must be paired with 'end'. Mutually exclusive with 'line'.",
+								schemahelper.WithExample("/*scafctl:ignore:start*/"),
+								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
+							"end": schemahelper.StringProp("End marker for a multi-line ignored block (e.g., '/*scafctl:ignore:end*/'). Must be paired with 'start'. Mutually exclusive with 'line'.",
+								schemahelper.WithExample("/*scafctl:ignore:end*/"),
+								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
+							"line": schemahelper.StringProp("Marker that identifies lines to ignore individually. Every line containing this substring is preserved literally. Mutually exclusive with 'start'/'end'.",
+								schemahelper.WithExample("# scafctl:ignore"),
+								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
+						},
+					)),
+					schemahelper.WithMaxItems(20),
+				),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -152,6 +171,43 @@ inputs:
   data:
     prefix: "*** "
     suffix: " ***"`,
+				},
+				{
+					Name:        "Ignored blocks for literal pass-through",
+					Description: "Preserve Terraform for_each expressions that conflict with Go template syntax",
+					YAML: `name: terraform-template
+provider: go-template
+inputs:
+  name: terraform-config
+  template: |
+    resource "azurerm_resource_group" "rg" {
+      name     = "{{.resourceGroupName}}"
+      location = "{{.location}}"
+      /*scafctl:ignore:start*/
+      for_each = { for k, v in var.items : k => v }
+      /*scafctl:ignore:end*/
+    }
+  ignoredBlocks:
+    - start: "/*scafctl:ignore:start*/"
+      end: "/*scafctl:ignore:end*/"`,
+				},
+				{
+					Name:        "Line-based ignore for single-line pass-through",
+					Description: "Preserve individual lines containing a marker without needing start/end wrappers",
+					YAML: `name: github-actions
+provider: go-template
+inputs:
+  name: workflow-config
+  template: |
+    name: Deploy {{.appName}}
+    on: [push]
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+  ignoredBlocks:
+    - line: "# scafctl:ignore"`,
 				},
 			},
 		},
@@ -250,14 +306,73 @@ func (p *GoTemplateProvider) Execute(ctx context.Context, input any) (*provider.
 		"leftDelim", leftDelim,
 		"rightDelim", rightDelim)
 
+	// Extract ignored blocks for literal pass-through
+	// Supports two modes:
+	//   1. start/end — multi-line block markers (content between markers is preserved)
+	//   2. line — every line containing the marker substring is preserved
+	var replacements []gotmpl.Replacement
+	if blocks, ok := inputs["ignoredBlocks"].([]any); ok {
+		for i, block := range blocks {
+			blockMap, ok := block.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			start, _ := blockMap["start"].(string)
+			end, _ := blockMap["end"].(string)
+			line, _ := blockMap["line"].(string)
+
+			// Mutual exclusion: line and start/end cannot be used together
+			hasStartEnd := start != "" || end != ""
+			hasLine := line != ""
+
+			if hasLine && hasStartEnd {
+				return nil, fmt.Errorf("%s: ignoredBlocks[%d]: 'line' and 'start'/'end' are mutually exclusive — use one mode per entry", ProviderName, i)
+			}
+
+			if hasLine {
+				// Line mode: find every line that contains the marker and preserve it
+				for _, templateLine := range strings.Split(templateStr, "\n") {
+					if strings.Contains(templateLine, line) {
+						replacements = append(replacements, gotmpl.Replacement{Find: templateLine})
+					}
+				}
+				continue
+			}
+
+			if start == "" || end == "" {
+				continue
+			}
+
+			// Start/end mode: find all occurrences of start...end and create a replacement for each full block
+			remaining := templateStr
+			for {
+				startIdx := strings.Index(remaining, start)
+				if startIdx < 0 {
+					break
+				}
+				afterStart := remaining[startIdx+len(start):]
+				endIdx := strings.Index(afterStart, end)
+				if endIdx < 0 {
+					break
+				}
+				// Extract the full block: start marker + content + end marker
+				fullBlock := remaining[startIdx : startIdx+len(start)+endIdx+len(end)]
+				replacements = append(replacements, gotmpl.Replacement{Find: fullBlock})
+				remaining = remaining[startIdx+len(start)+endIdx+len(end):]
+			}
+		}
+	}
+
 	// Execute the template
 	result, err := p.service.Execute(ctx, gotmpl.TemplateOptions{
-		Content:    templateStr,
-		Name:       templateName,
-		Data:       templateData,
-		MissingKey: missingKey,
-		LeftDelim:  leftDelim,
-		RightDelim: rightDelim,
+		Content:      templateStr,
+		Name:         templateName,
+		Data:         templateData,
+		MissingKey:   missingKey,
+		LeftDelim:    leftDelim,
+		RightDelim:   rightDelim,
+		Replacements: replacements,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -431,6 +431,7 @@ func TestGoTemplateProvider_Descriptor_Schema(t *testing.T) {
 	require.Contains(t, props, "leftDelim")
 	require.Contains(t, props, "rightDelim")
 	require.Contains(t, props, "data")
+	require.Contains(t, props, "ignoredBlocks")
 
 	// Check required fields
 	assert.Contains(t, desc.Schema.Required, "template")
@@ -439,4 +440,242 @@ func TestGoTemplateProvider_Descriptor_Schema(t *testing.T) {
 	// Check optional fields are not required
 	assert.NotContains(t, desc.Schema.Required, "missingKey")
 	assert.NotContains(t, desc.Schema.Required, "data")
+	assert.NotContains(t, desc.Schema.Required, "ignoredBlocks")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name":     "my-resource",
+		"location": "eastus",
+	})
+
+	inputs := map[string]any{
+		"name": "ignored-blocks-test",
+		"template": `resource "azurerm_resource_group" "rg" {
+  name     = "{{.name}}"
+  location = "{{.location}}"
+  /*scafctl:ignore:start*/
+  for_each = { for k, v in var.items : k => v }
+  /*scafctl:ignore:end*/
+}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"start": "/*scafctl:ignore:start*/",
+				"end":   "/*scafctl:ignore:end*/",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	// Verify template variables were rendered
+	assert.Contains(t, result, `name     = "my-resource"`)
+	assert.Contains(t, result, `location = "eastus"`)
+
+	// Verify ignored block markers and content were preserved literally
+	assert.Contains(t, result, "/*scafctl:ignore:start*/")
+	assert.Contains(t, result, "/*scafctl:ignore:end*/")
+	assert.Contains(t, result, "for_each = { for k, v in var.items : k => v }")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Multiple(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"value": "rendered",
+	})
+
+	inputs := map[string]any{
+		"name":     "multi-blocks-test",
+		"template": `before-{{.value}}-<!--preserve-->{{ .broken }}<!--/preserve-->-after-{{.value}}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"start": "<!--preserve-->",
+				"end":   "<!--/preserve-->",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	assert.Contains(t, result, "before-rendered-")
+	assert.Contains(t, result, "<!--preserve-->{{ .broken }}<!--/preserve-->")
+	assert.Contains(t, result, "-after-rendered")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Empty(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "test",
+	})
+
+	// Empty/invalid blocks should be silently skipped
+	inputs := map[string]any{
+		"name":     "empty-blocks-test",
+		"template": "Hello, {{.name}}!",
+		"ignoredBlocks": []any{
+			map[string]any{"start": "", "end": ""},
+			map[string]any{"start": "something", "end": ""},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, test!", output.Data)
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Line(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"appName": "my-app",
+	})
+
+	inputs := map[string]any{
+		"name": "line-ignore-test",
+		"template": `name: {{.appName}}
+steps:
+  - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+  - run: echo "deployed"`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"line": "# scafctl:ignore",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	// Template variable should be rendered
+	assert.Contains(t, result, "name: my-app")
+	// The ignored line should be preserved literally (including the ${{ }} syntax)
+	assert.Contains(t, result, "${{ secrets.TOKEN }}")
+	assert.Contains(t, result, "# scafctl:ignore")
+	// Non-ignored line should still be present
+	assert.Contains(t, result, `echo "deployed"`)
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Line_Multiple(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"env": "prod",
+	})
+
+	inputs := map[string]any{
+		"name": "multi-line-ignore-test",
+		"template": `env: {{.env}}
+line1: ${{ secrets.A }}  # scafctl:ignore
+line2: normal content
+line3: ${{ secrets.B }}  # scafctl:ignore`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"line": "# scafctl:ignore",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	assert.Contains(t, result, "env: prod")
+	assert.Contains(t, result, "${{ secrets.A }}")
+	assert.Contains(t, result, "${{ secrets.B }}")
+	assert.Contains(t, result, "normal content")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Line_MutualExclusion(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "test",
+	})
+
+	// Using both line and start/end should produce an error
+	inputs := map[string]any{
+		"name":     "mutual-exclusion-test",
+		"template": "Hello, {{.name}}!",
+		"ignoredBlocks": []any{
+			map[string]any{
+				"line":  "# scafctl:ignore",
+				"start": "/*start*/",
+				"end":   "/*end*/",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Line_MixedEntries(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "my-resource",
+	})
+
+	// Different entries can use different modes
+	inputs := map[string]any{
+		"name": "mixed-entries-test",
+		"template": `resource "aws_instance" "main" {
+  name = "{{.name}}"
+  secret = ${{ secrets.KEY }}  # scafctl:ignore
+  /*preserve:start*/
+  tags = { for k, v in var.x : k => v }
+  /*preserve:end*/
+}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"line": "# scafctl:ignore",
+			},
+			map[string]any{
+				"start": "/*preserve:start*/",
+				"end":   "/*preserve:end*/",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	// Template variable rendered
+	assert.Contains(t, result, `name = "my-resource"`)
+	// Line-ignored content preserved
+	assert.Contains(t, result, "${{ secrets.KEY }}")
+	// Block-ignored content preserved
+	assert.Contains(t, result, "for k, v in var.x : k => v")
 }

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -5,6 +5,7 @@ package httpprovider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -146,6 +147,21 @@ func NewHTTPProvider() *HTTPProvider {
 					schemahelper.WithExample(30),
 					schemahelper.WithMaximum(*ptrs.Float64Ptr(300.0))),
 				"retry": schemahelper.AnyProp("Retry configuration for transient failures"),
+				"poll": schemahelper.ObjectProp("Polling configuration for re-executing the request until a condition is met. Use this for waiting on async operations (e.g., deployment status). Different from retry: retry handles transient failures, poll re-executes until the response content matches a condition.", []string{"until"}, map[string]*jsonschema.Schema{
+					"until": schemahelper.StringProp("CEL expression evaluated against {statusCode, body, headers}. Polling stops when this returns true.",
+						schemahelper.WithExample("_.body.status == 'succeeded'"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+					"failWhen": schemahelper.StringProp("CEL expression for early exit with error. If true, polling stops immediately with a failure.",
+						schemahelper.WithExample("_.body.status == 'failed'"),
+						schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+					"interval": schemahelper.StringProp("Duration between poll attempts (Go duration format or integer seconds, default: 10s)",
+						schemahelper.WithDefault("10s"),
+						schemahelper.WithExample("5s")),
+					"maxAttempts": schemahelper.IntProp("Maximum number of poll attempts before giving up (default: 30)",
+						schemahelper.WithDefault(30),
+						schemahelper.WithExample(30),
+						schemahelper.WithMaximum(*ptrs.Float64Ptr(1000))),
+				}),
 				"pagination": schemahelper.ObjectProp("Pagination configuration for automatically following paginated API responses", []string{"strategy", "maxPages"}, map[string]*jsonschema.Schema{
 					"strategy": schemahelper.StringProp("Pagination strategy to use",
 						schemahelper.WithEnum("offset", "pageNumber", "cursor", "linkHeader", "custom"),
@@ -201,18 +217,19 @@ func NewHTTPProvider() *HTTPProvider {
 				"scope": schemahelper.StringProp("OAuth scope for authentication. Required for auth providers that support per-request scopes (e.g., Entra). Not used for providers with scopes fixed at login time (e.g., GitHub).",
 					schemahelper.WithExample("https://graph.microsoft.com/.default"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
+				"autoParseJson": schemahelper.BoolProp("When true and the response Content-Type is application/json, automatically parse the body into a structured object instead of returning it as a raw string. This allows direct field access in downstream CEL expressions (e.g., _.myApi.body.items) without manual parsing."),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"body":       schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
 					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"body":       schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
 					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
@@ -220,7 +237,7 @@ func NewHTTPProvider() *HTTPProvider {
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success":    schemahelper.BoolProp("Whether the HTTP request completed successfully (2xx status)"),
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					"body":       schemahelper.StringProp("Response body as string. When paginating with collectPath, contains the JSON array of all collected items"),
+					"body":       schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
 					"headers":    schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
@@ -376,6 +393,31 @@ inputs:
     collectPath: "body.results"
     stopWhen: "!has(body.links) || !has(body.links.next)"`,
 				},
+				{
+					Name:        "Auto-parse JSON response",
+					Description: "Automatically parse JSON response body for direct field access in downstream expressions",
+					YAML: `name: fetch-user-parsed
+provider: http
+inputs:
+  url: "https://api.example.com/users/1"
+  method: GET
+  autoParseJson: true`,
+				},
+				{
+					Name:        "Poll until condition is met",
+					Description: "Keep checking a deployment status API until the deployment succeeds or fails",
+					YAML: `name: wait-for-deployment
+provider: http
+inputs:
+  url: "https://api.example.com/deployments/123"
+  method: GET
+  autoParseJson: true
+  poll:
+    until: "_.body.status == 'succeeded'"
+    failWhen: "_.body.status == 'failed'"
+    interval: "10s"
+    maxAttempts: 30`,
+				},
 			},
 		},
 	}
@@ -515,14 +557,32 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)
 	}
 
+	// Parse poll configuration
+	pollCfg, err := parsePollConfig(inputs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
 	httpClient := httpc.NewClient(httpcCfg)
+
+	autoParseJSON, _ := inputs["autoParseJson"].(bool)
 
 	// If pagination is configured, use the paginated execution path
 	if pagCfg != nil {
 		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg)
 	}
 
-	return p.execute(ctx, httpClient, method, urlStr, bodyContent, headers)
+	// Build the execute function for potential polling
+	executeFunc := func() (*provider.Output, error) {
+		return p.execute(ctx, httpClient, method, urlStr, bodyContent, headers, autoParseJSON)
+	}
+
+	// If polling is configured, wrap execution in a poll loop
+	if pollCfg != nil {
+		return p.executePoll(ctx, nil, method, urlStr, bodyContent, headers, pollCfg, autoParseJSON, executeFunc)
+	}
+
+	return executeFunc()
 }
 
 // buildHTTPClientConfig translates provider timeout and retry config into an httpc.ClientConfig.
@@ -578,6 +638,7 @@ func (p *HTTPProvider) execute(
 	client *httpc.Client,
 	method, urlStr, bodyContent string,
 	headers map[string]any,
+	autoParseJSON bool,
 ) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
@@ -627,11 +688,28 @@ func (p *HTTPProvider) execute(
 
 	lgr.V(1).Info("provider execution completed", "provider", ProviderName, "statusCode", resp.StatusCode)
 
+	// Determine response body value
+	var bodyValue any = string(respBody)
+	if autoParseJSON && isJSONContentType(resp.Header.Get("Content-Type")) && len(respBody) > 0 {
+		var parsed any
+		if err := json.Unmarshal(respBody, &parsed); err == nil {
+			bodyValue = parsed
+		}
+		// If JSON parse fails, fall back to raw string silently
+	}
+
 	return &provider.Output{
 		Data: map[string]any{
 			"statusCode": resp.StatusCode,
-			"body":       string(respBody),
+			"body":       bodyValue,
 			"headers":    respHeaders,
 		},
 	}, nil
+}
+
+// isJSONContentType returns true if the Content-Type header indicates a JSON response.
+func isJSONContentType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	return strings.HasPrefix(ct, "application/json") ||
+		strings.HasSuffix(ct, "+json")
 }

--- a/pkg/provider/builtin/httpprovider/http_test.go
+++ b/pkg/provider/builtin/httpprovider/http_test.go
@@ -1074,3 +1074,95 @@ func TestHTTPProvider_Execute_HeadersCopy(t *testing.T) {
 	_, hasAuth := originalHeaders["Authorization"]
 	assert.False(t, hasAuth, "Original headers should not be modified")
 }
+
+func TestHTTPProvider_Execute_AutoParseJson(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"users":[{"name":"alice"},{"name":"bob"}],"count":2}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	t.Run("enabled", func(t *testing.T) {
+		inputs := map[string]any{
+			"url":           server.URL,
+			"method":        "GET",
+			"autoParseJson": true,
+		}
+
+		output, err := p.Execute(ctx, inputs)
+		require.NoError(t, err)
+		data := output.Data.(map[string]any)
+
+		// Body should be parsed into structured data
+		body, ok := data["body"].(map[string]any)
+		require.True(t, ok, "body should be a map when autoParseJson is true")
+		assert.Equal(t, float64(2), body["count"])
+
+		users, ok := body["users"].([]any)
+		require.True(t, ok)
+		assert.Len(t, users, 2)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		inputs := map[string]any{
+			"url":    server.URL,
+			"method": "GET",
+		}
+
+		output, err := p.Execute(ctx, inputs)
+		require.NoError(t, err)
+		data := output.Data.(map[string]any)
+
+		// Body should be a raw string when autoParseJson is not set
+		body, ok := data["body"].(string)
+		require.True(t, ok, "body should be a string when autoParseJson is false")
+		assert.Contains(t, body, `"users"`)
+	})
+
+	t.Run("non-json-content-type", func(t *testing.T) {
+		textServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not json`))
+		}))
+		defer textServer.Close()
+
+		inputs := map[string]any{
+			"url":           textServer.URL,
+			"method":        "GET",
+			"autoParseJson": true,
+		}
+
+		output, err := p.Execute(ctx, inputs)
+		require.NoError(t, err)
+		data := output.Data.(map[string]any)
+
+		// Body should remain a string for non-JSON content type
+		_, ok := data["body"].(string)
+		assert.True(t, ok, "body should remain string for non-JSON content type")
+	})
+}
+
+func TestIsJSONContentType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		expected    bool
+	}{
+		{"application/json", true},
+		{"application/json; charset=utf-8", true},
+		{"APPLICATION/JSON", true},
+		{"application/vnd.api+json", true},
+		{"text/plain", false},
+		{"text/html", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isJSONContentType(tt.contentType))
+		})
+	}
+}

--- a/pkg/provider/builtin/httpprovider/poll.go
+++ b/pkg/provider/builtin/httpprovider/poll.go
@@ -1,0 +1,166 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// pollConfig holds polling configuration for HTTP requests that need to
+// retry until a response condition is met (e.g., waiting for deployment status).
+type pollConfig struct {
+	Until       string        // CEL expression that must evaluate to true to stop polling (required)
+	FailWhen    string        // CEL expression — if true, stop with error (optional)
+	Interval    time.Duration // Duration between poll attempts (default: 10s)
+	MaxAttempts int           // Maximum poll attempts before giving up (default: 30)
+}
+
+// defaultPollConfig returns default polling configuration.
+func defaultPollConfig() pollConfig {
+	return pollConfig{
+		Interval:    10 * time.Second,
+		MaxAttempts: 30,
+	}
+}
+
+// parsePollConfig parses poll configuration from inputs.
+// Returns nil if no poll configuration is present.
+func parsePollConfig(inputs map[string]any) (*pollConfig, error) {
+	pollInput, ok := inputs["poll"]
+	if !ok || pollInput == nil {
+		return nil, nil
+	}
+
+	pollMap, ok := pollInput.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("poll must be an object")
+	}
+
+	cfg := defaultPollConfig()
+
+	until, _ := pollMap["until"].(string)
+	if until == "" {
+		return nil, fmt.Errorf("poll.until is required (CEL expression)")
+	}
+	cfg.Until = until
+
+	if failWhen, ok := pollMap["failWhen"].(string); ok {
+		cfg.FailWhen = failWhen
+	}
+
+	if interval, ok := pollMap["interval"].(string); ok {
+		d, err := time.ParseDuration(interval)
+		if err != nil {
+			return nil, fmt.Errorf("poll.interval: %w", err)
+		}
+		if d < 1*time.Second {
+			return nil, fmt.Errorf("poll.interval must be at least 1s")
+		}
+		cfg.Interval = d
+	}
+	// Handle numeric seconds from JSON/YAML
+	if intervalSec, ok := pollMap["interval"].(float64); ok && intervalSec > 0 {
+		cfg.Interval = time.Duration(intervalSec) * time.Second
+	}
+	if intervalSec, ok := pollMap["interval"].(int); ok && intervalSec > 0 {
+		cfg.Interval = time.Duration(intervalSec) * time.Second
+	}
+
+	if maxAttempts, ok := pollMap["maxAttempts"].(float64); ok && maxAttempts > 0 {
+		cfg.MaxAttempts = int(maxAttempts)
+	}
+	if maxAttempts, ok := pollMap["maxAttempts"].(int); ok && maxAttempts > 0 {
+		cfg.MaxAttempts = maxAttempts
+	}
+
+	return &cfg, nil
+}
+
+// executePoll wraps execute() in a polling loop, re-executing the HTTP request
+// until a CEL condition is met or max attempts are exhausted.
+func (p *HTTPProvider) executePoll(
+	ctx context.Context,
+	_ interface {
+		Do(req interface{}) (interface{}, error)
+	},
+	_, _, _ string,
+	_ map[string]any,
+	pollCfg *pollConfig,
+	_ bool,
+	executeFunc func() (*provider.Output, error),
+) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	var lastOutput *provider.Output
+	var lastErr error
+
+	for attempt := 1; attempt <= pollCfg.MaxAttempts; attempt++ {
+		lgr.V(1).Info("poll attempt", "attempt", attempt, "maxAttempts", pollCfg.MaxAttempts)
+
+		lastOutput, lastErr = executeFunc()
+		if lastErr != nil {
+			lgr.V(1).Info("poll attempt failed with error", "attempt", attempt, "error", lastErr)
+			// On error, continue polling unless context is done
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("%s: poll cancelled: %w", ProviderName, ctx.Err())
+			}
+			if attempt < pollCfg.MaxAttempts {
+				sleepWithContext(ctx, pollCfg.Interval)
+				continue
+			}
+			return nil, fmt.Errorf("%s: poll exhausted after %d attempts, last error: %w", ProviderName, pollCfg.MaxAttempts, lastErr)
+		}
+
+		// Build evaluation data from the response output
+		evalData := lastOutput.Data
+
+		// Check failWhen first (early exit with error)
+		if pollCfg.FailWhen != "" {
+			result, err := celexp.EvaluateExpression(ctx, pollCfg.FailWhen, evalData, nil)
+			if err != nil {
+				lgr.V(1).Info("poll failWhen expression error (ignored)", "error", err)
+			} else if boolResult, ok := result.(bool); ok && boolResult {
+				return nil, fmt.Errorf("%s: poll failWhen condition met on attempt %d", ProviderName, attempt)
+			}
+		}
+
+		// Check until condition (success — stop polling)
+		result, err := celexp.EvaluateExpression(ctx, pollCfg.Until, evalData, nil)
+		if err != nil {
+			lgr.V(1).Info("poll until expression error (continuing)", "error", err, "attempt", attempt)
+		} else if boolResult, ok := result.(bool); ok && boolResult {
+			lgr.V(1).Info("poll until condition met", "attempt", attempt)
+			return lastOutput, nil
+		}
+
+		// Not done yet — wait and retry
+		if attempt < pollCfg.MaxAttempts {
+			lgr.V(2).Info("poll condition not met, waiting", "interval", pollCfg.Interval)
+			if cancelled := sleepWithContext(ctx, pollCfg.Interval); cancelled {
+				return nil, fmt.Errorf("%s: poll cancelled: %w", ProviderName, ctx.Err())
+			}
+		}
+	}
+
+	// Max attempts exhausted — return the last output (not an error)
+	lgr.V(1).Info("poll max attempts exhausted, returning last response", "maxAttempts", pollCfg.MaxAttempts)
+	return lastOutput, nil
+}
+
+// sleepWithContext sleeps for the given duration but returns early if context is cancelled.
+// Returns true if the context was cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return false
+	case <-ctx.Done():
+		return true
+	}
+}

--- a/pkg/provider/builtin/httpprovider/poll_test.go
+++ b/pkg/provider/builtin/httpprovider/poll_test.go
@@ -1,0 +1,260 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePollConfig(t *testing.T) {
+	t.Run("no poll config", func(t *testing.T) {
+		cfg, err := parsePollConfig(map[string]any{})
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("nil poll", func(t *testing.T) {
+		cfg, err := parsePollConfig(map[string]any{"poll": nil})
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("missing until", func(t *testing.T) {
+		_, err := parsePollConfig(map[string]any{
+			"poll": map[string]any{
+				"interval": "5s",
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "until is required")
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		cfg, err := parsePollConfig(map[string]any{
+			"poll": map[string]any{
+				"until":       "_.body.status == 'done'",
+				"failWhen":    "_.body.status == 'failed'",
+				"interval":    "5s",
+				"maxAttempts": float64(10),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "_.body.status == 'done'", cfg.Until)
+		assert.Equal(t, "_.body.status == 'failed'", cfg.FailWhen)
+		assert.Equal(t, 5*time.Second, cfg.Interval)
+		assert.Equal(t, 10, cfg.MaxAttempts)
+	})
+
+	t.Run("defaults applied", func(t *testing.T) {
+		cfg, err := parsePollConfig(map[string]any{
+			"poll": map[string]any{
+				"until": "_.statusCode == 200",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 10*time.Second, cfg.Interval)
+		assert.Equal(t, 30, cfg.MaxAttempts)
+	})
+
+	t.Run("numeric interval seconds", func(t *testing.T) {
+		cfg, err := parsePollConfig(map[string]any{
+			"poll": map[string]any{
+				"until":    "true",
+				"interval": float64(15),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 15*time.Second, cfg.Interval)
+	})
+
+	t.Run("interval too short", func(t *testing.T) {
+		_, err := parsePollConfig(map[string]any{
+			"poll": map[string]any{
+				"until":    "true",
+				"interval": "500ms",
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least 1s")
+	})
+}
+
+func TestHTTPProvider_Execute_Poll_UntilConditionMet(t *testing.T) {
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if count >= 3 {
+			_, _ = w.Write([]byte(`{"status":"succeeded"}`))
+		} else {
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":           server.URL,
+		"method":        "GET",
+		"autoParseJson": true,
+		"poll": map[string]any{
+			"until":       "_.body.status == 'succeeded'",
+			"interval":    "1s",
+			"maxAttempts": float64(5),
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	body := data["body"].(map[string]any)
+	assert.Equal(t, "succeeded", body["status"])
+	assert.GreaterOrEqual(t, int(callCount.Load()), 3)
+}
+
+func TestHTTPProvider_Execute_Poll_FailWhen(t *testing.T) {
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if count >= 2 {
+			_, _ = w.Write([]byte(`{"status":"failed","error":"deployment crashed"}`))
+		} else {
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":           server.URL,
+		"method":        "GET",
+		"autoParseJson": true,
+		"poll": map[string]any{
+			"until":       "_.body.status == 'succeeded'",
+			"failWhen":    "_.body.status == 'failed'",
+			"interval":    "1s",
+			"maxAttempts": float64(10),
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failWhen condition met")
+}
+
+func TestHTTPProvider_Execute_Poll_MaxAttemptsExhausted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"running"}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":           server.URL,
+		"method":        "GET",
+		"autoParseJson": true,
+		"poll": map[string]any{
+			"until":       "_.body.status == 'succeeded'",
+			"interval":    "1s",
+			"maxAttempts": float64(2),
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	// Max attempts exhausted returns the last output, not an error
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	data := output.Data.(map[string]any)
+	body := data["body"].(map[string]any)
+	assert.Equal(t, "running", body["status"])
+}
+
+func TestHTTPProvider_Execute_Poll_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"running"}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	inputs := map[string]any{
+		"url":           server.URL,
+		"method":        "GET",
+		"autoParseJson": true,
+		"poll": map[string]any{
+			"until":       "_.body.status == 'succeeded'",
+			"interval":    "5s",
+			"maxAttempts": float64(100),
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
+func TestHTTPProvider_Execute_Poll_WithStringBody(t *testing.T) {
+	// Test polling with autoParseJson=false (body is a string)
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := callCount.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		if count >= 2 {
+			_, _ = fmt.Fprint(w, "READY")
+		} else {
+			_, _ = fmt.Fprint(w, "PENDING")
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		"poll": map[string]any{
+			"until":       "_.body == 'READY'",
+			"interval":    "1s",
+			"maxAttempts": float64(5),
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, "READY", data["body"])
+}

--- a/pkg/provider/builtin/metadataprovider/metadata.go
+++ b/pkg/provider/builtin/metadataprovider/metadata.go
@@ -1,0 +1,119 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package metadataprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+)
+
+// ProviderName is the name of this provider.
+const ProviderName = "metadata"
+
+// MetadataProvider returns solution metadata fields as resolved data.
+// This lets resolvers expose metadata (name, version, description, etc.)
+// for use in templates and downstream providers without hard-coding values.
+type MetadataProvider struct{}
+
+// New creates a new metadata provider instance.
+func New() *MetadataProvider {
+	return &MetadataProvider{}
+}
+
+// Descriptor returns the provider's metadata and schema.
+func (p *MetadataProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:        ProviderName,
+		DisplayName: "Metadata Provider",
+		APIVersion:  "v1",
+		Version:     semver.MustParse("1.0.0"),
+		Description: "Returns structured metadata about a solution. Accepts arbitrary key-value pairs and returns them as a map, optionally returning a single field by key. Useful for exposing solution name, version, description, tags, and custom attributes to templates and downstream resolvers.",
+		Schema: func() *jsonschema.Schema {
+			s := schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"field": schemahelper.StringProp("Optional: return only this single field from the metadata map instead of the full map", schemahelper.WithMaxLength(200), schemahelper.WithExample("name")),
+			})
+			s.AdditionalProperties = &jsonschema.Schema{} // allow arbitrary metadata keys
+			return s
+		}(),
+		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+			provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"metadata": schemahelper.AnyProp("The full metadata map or a single field value"),
+			}),
+		},
+		Capabilities: []provider.Capability{
+			provider.CapabilityFrom,
+		},
+		Category:     "Core",
+		Tags:         []string{"metadata", "solution", "introspection"},
+		MockBehavior: "Returns the provided metadata map unchanged",
+		Examples: []provider.Example{
+			{
+				Name:        "Full metadata",
+				Description: "Return all metadata fields as a map",
+				YAML: `name: sol-meta
+type: metadata
+from:
+  name: my-solution
+  version: 2.1.0
+  description: Scaffolds a GCP project
+  category: infrastructure
+  tags:
+    - gcp
+    - terraform`,
+			},
+			{
+				Name:        "Single field",
+				Description: "Return only the solution name",
+				YAML: `name: sol-name
+type: metadata
+from:
+  field: name
+  name: my-solution
+  version: 2.1.0`,
+			},
+		},
+	}
+}
+
+// Execute returns the metadata map or a single field from it.
+func (p *MetadataProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected map[string]any, got %T", ProviderName, input)
+	}
+
+	lgr.V(1).Info("executing provider", "provider", ProviderName)
+
+	// Check if a specific field was requested.
+	fieldName, _ := inputs["field"].(string)
+
+	if fieldName != "" {
+		value, exists := inputs[fieldName]
+		if !exists {
+			return nil, fmt.Errorf("%s: requested field %q not found in metadata inputs", ProviderName, fieldName)
+		}
+		lgr.V(1).Info("provider completed", "provider", ProviderName, "field", fieldName)
+		return &provider.Output{Data: value}, nil
+	}
+
+	// Return the full metadata map (excluding the "field" key itself).
+	result := make(map[string]any, len(inputs))
+	for k, v := range inputs {
+		if k == "field" {
+			continue
+		}
+		result[k] = v
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "keys", len(result))
+	return &provider.Output{Data: result}, nil
+}

--- a/pkg/provider/builtin/metadataprovider/metadata_test.go
+++ b/pkg/provider/builtin/metadataprovider/metadata_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package metadataprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptor(t *testing.T) {
+	p := New()
+	d := p.Descriptor()
+	assert.Equal(t, ProviderName, d.Name)
+	assert.Equal(t, "Metadata Provider", d.DisplayName)
+	assert.NotNil(t, d.Schema)
+	assert.Len(t, d.Capabilities, 1)
+	assert.Len(t, d.Examples, 2)
+}
+
+func TestExecute_FullMap(t *testing.T) {
+	p := New()
+	input := map[string]any{
+		"name":    "my-solution",
+		"version": "1.0.0",
+		"tags":    []string{"gcp", "terraform"},
+	}
+	out, err := p.Execute(context.Background(), input)
+	require.NoError(t, err)
+
+	result, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "my-solution", result["name"])
+	assert.Equal(t, "1.0.0", result["version"])
+	assert.Equal(t, []string{"gcp", "terraform"}, result["tags"])
+}
+
+func TestExecute_SingleField(t *testing.T) {
+	p := New()
+	input := map[string]any{
+		"field":   "name",
+		"name":    "my-solution",
+		"version": "2.0.0",
+	}
+	out, err := p.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.Equal(t, "my-solution", out.Data)
+}
+
+func TestExecute_SingleField_Missing(t *testing.T) {
+	p := New()
+	input := map[string]any{
+		"field": "missing-key",
+		"name":  "my-solution",
+	}
+	_, err := p.Execute(context.Background(), input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-key")
+}
+
+func TestExecute_FieldKeyExcluded(t *testing.T) {
+	p := New()
+	input := map[string]any{
+		"field":   "",
+		"name":    "test",
+		"version": "1.0.0",
+	}
+	out, err := p.Execute(context.Background(), input)
+	require.NoError(t, err)
+	result, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, result, "field")
+	assert.Equal(t, "test", result["name"])
+}
+
+func TestExecute_BadInputType(t *testing.T) {
+	p := New()
+	_, err := p.Execute(context.Background(), "not-a-map")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected map[string]any")
+}
+
+func TestExecute_EmptyMap(t *testing.T) {
+	p := New()
+	out, err := p.Execute(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	result, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, result)
+}

--- a/pkg/resolver/errors.go
+++ b/pkg/resolver/errors.go
@@ -12,15 +12,24 @@ import (
 // ExecutionError represents an error during resolver execution with context about
 // which resolver, phase, step, and provider were involved.
 type ExecutionError struct {
-	ResolverName string `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver that failed" example:"my-resolver"`
-	Phase        string `json:"phase" yaml:"phase" doc:"Execution phase where failure occurred" enum:"resolve,transform,validate" example:"resolve"`
-	Step         int    `json:"step" yaml:"step" doc:"Step number within the phase (0-indexed)" minimum:"0" example:"0"`
-	Provider     string `json:"provider" yaml:"provider" doc:"Provider name that failed" example:"http"`
-	Cause        error  `json:"-" yaml:"-" doc:"Underlying error that caused the failure"`
+	ResolverName  string `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver that failed" example:"my-resolver"`
+	Phase         string `json:"phase" yaml:"phase" doc:"Execution phase where failure occurred" enum:"resolve,transform,validate" example:"resolve"`
+	Step          int    `json:"step" yaml:"step" doc:"Step number within the phase (0-indexed)" minimum:"0" example:"0"`
+	Provider      string `json:"provider" yaml:"provider" doc:"Provider name that failed" example:"http"`
+	Cause         error  `json:"-" yaml:"-" doc:"Underlying error that caused the failure"`
+	CustomMessage string `json:"customMessage,omitempty" yaml:"customMessage,omitempty" doc:"User-defined error message from messages.error"`
 }
 
 // Error implements the error interface.
 func (e *ExecutionError) Error() string {
+	if e.CustomMessage != "" {
+		if e.Provider != "" {
+			return fmt.Sprintf("resolver %q failed in %s phase (step %d, provider %s): %s (detail: %v)",
+				e.ResolverName, e.Phase, e.Step, e.Provider, e.CustomMessage, e.Cause)
+		}
+		return fmt.Sprintf("resolver %q failed in %s phase (step %d): %s (detail: %v)",
+			e.ResolverName, e.Phase, e.Step, e.CustomMessage, e.Cause)
+	}
 	if e.Provider != "" {
 		return fmt.Sprintf("resolver %q failed in %s phase (step %d, provider %s): %v",
 			e.ResolverName, e.Phase, e.Step, e.Provider, e.Cause)
@@ -68,14 +77,19 @@ func (f *ValidationFailure) Error() string {
 // AggregatedValidationError represents validation failure with multiple messages.
 // This collects all validation failures from a resolver's validate phase.
 type AggregatedValidationError struct {
-	ResolverName string              `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver that failed validation" example:"user-email"`
-	Value        any                 `json:"-" yaml:"-" doc:"The value that failed validation"`
-	Failures     []ValidationFailure `json:"failures" yaml:"failures" doc:"List of validation failures" minItems:"1"`
-	Sensitive    bool                `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether the resolver value is sensitive"`
+	ResolverName  string              `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver that failed validation" example:"user-email"`
+	Value         any                 `json:"-" yaml:"-" doc:"The value that failed validation"`
+	Failures      []ValidationFailure `json:"failures" yaml:"failures" doc:"List of validation failures" minItems:"1"`
+	Sensitive     bool                `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether the resolver value is sensitive"`
+	CustomMessage string              `json:"customMessage,omitempty" yaml:"customMessage,omitempty" doc:"User-defined error message from messages.error"`
 }
 
 // Error implements the error interface.
 func (e *AggregatedValidationError) Error() string {
+	if e.CustomMessage != "" {
+		return fmt.Sprintf("resolver %q validation failed: %s", e.ResolverName, e.CustomMessage)
+	}
+
 	if len(e.Failures) == 0 {
 		return fmt.Sprintf("resolver %q validation failed (no details)", e.ResolverName)
 	}
@@ -156,15 +170,20 @@ func (e *ValueSizeError) Error() string {
 
 // TypeCoercionError represents a failure to coerce a value to the expected type.
 type TypeCoercionError struct {
-	ResolverName string `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver" example:"age-value"`
-	Phase        string `json:"phase" yaml:"phase" doc:"Phase where coercion was attempted" enum:"resolve,transform" example:"resolve"`
-	SourceType   string `json:"sourceType" yaml:"sourceType" doc:"Original type of the value" example:"string"`
-	TargetType   Type   `json:"targetType" yaml:"targetType" doc:"Target type for coercion" example:"int"`
-	Cause        error  `json:"-" yaml:"-" doc:"Underlying coercion error"`
+	ResolverName  string `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver" example:"age-value"`
+	Phase         string `json:"phase" yaml:"phase" doc:"Phase where coercion was attempted" enum:"resolve,transform" example:"resolve"`
+	SourceType    string `json:"sourceType" yaml:"sourceType" doc:"Original type of the value" example:"string"`
+	TargetType    Type   `json:"targetType" yaml:"targetType" doc:"Target type for coercion" example:"int"`
+	Cause         error  `json:"-" yaml:"-" doc:"Underlying coercion error"`
+	CustomMessage string `json:"customMessage,omitempty" yaml:"customMessage,omitempty" doc:"User-defined error message from messages.error"`
 }
 
 // Error implements the error interface.
 func (e *TypeCoercionError) Error() string {
+	if e.CustomMessage != "" {
+		return fmt.Sprintf("resolver %q: type coercion from %s to %s failed after %s phase: %s (detail: %v)",
+			e.ResolverName, e.SourceType, e.TargetType, e.Phase, e.CustomMessage, e.Cause)
+	}
 	return fmt.Sprintf("resolver %q: type coercion from %s to %s failed after %s phase: %v",
 		e.ResolverName, e.SourceType, e.TargetType, e.Phase, e.Cause)
 }

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -6,6 +6,7 @@ package resolver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -582,10 +583,11 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 		result.Value = nil
 		result.Status = ExecutionStatusFailed
 		result.Error = &ExecutionError{
-			ResolverName: r.Name,
-			Phase:        "resolve",
-			Step:         0,
-			Cause:        err,
+			ResolverName:  r.Name,
+			Phase:         "resolve",
+			Step:          0,
+			Cause:         err,
+			CustomMessage: resolveCustomErrorMessage(resolverContext, r, err),
 		}
 		return false, result.Error
 	}
@@ -610,10 +612,11 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 			result.Value = value
 			result.Status = ExecutionStatusFailed
 			result.Error = &ExecutionError{
-				ResolverName: r.Name,
-				Phase:        "transform",
-				Step:         0,
-				Cause:        err,
+				ResolverName:  r.Name,
+				Phase:         "transform",
+				Step:          0,
+				Cause:         err,
+				CustomMessage: resolveCustomErrorMessage(resolverContext, r, err),
 			}
 			return false, result.Error
 		}
@@ -630,11 +633,12 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 			result.Value = value
 			result.Status = ExecutionStatusFailed
 			result.Error = &TypeCoercionError{
-				ResolverName: r.Name,
-				Phase:        coercionPhase,
-				SourceType:   fmt.Sprintf("%T", value),
-				TargetType:   r.Type,
-				Cause:        err,
+				ResolverName:  r.Name,
+				Phase:         coercionPhase,
+				SourceType:    fmt.Sprintf("%T", value),
+				TargetType:    r.Type,
+				Cause:         err,
+				CustomMessage: resolveCustomErrorMessage(resolverContext, r, err),
 			}
 			return false, result.Error
 		}
@@ -658,6 +662,11 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 			// Emit transformed value even on validation failure (partial emission)
 			result.Value = value
 			result.Status = ExecutionStatusFailed
+			// Inject custom message from messages.error if configured
+			var aggErr *AggregatedValidationError
+			if errors.As(validationErr, &aggErr) {
+				aggErr.CustomMessage = resolveCustomErrorMessage(resolverContext, r, validationErr)
+			}
 			result.Error = validationErr
 			return false, result.Error
 		}
@@ -1463,4 +1472,34 @@ func RedactMapValues(m map[string]any, sensitive bool) map[string]any {
 		result[k] = "[REDACTED]"
 	}
 	return result
+}
+
+// resolveCustomErrorMessage evaluates a resolver's messages.error field and returns the
+// resolved string, or "" if no custom message is configured or evaluation fails.
+func resolveCustomErrorMessage(ctx context.Context, r *Resolver, originalErr error) string {
+	if r.Messages == nil || r.Messages.Error == nil {
+		return ""
+	}
+
+	resolverCtx, ok := FromContext(ctx)
+	if !ok {
+		return ""
+	}
+
+	resolverData := resolverCtx.ToMap()
+
+	// Pass __error as the self parameter so it's available as __self in CEL/templates,
+	// and also add it to resolverData so it's available as _.__error or _["__error"].
+	errorMsg := originalErr.Error()
+	resolverData["__error"] = errorMsg
+
+	resolved, err := r.Messages.Error.Resolve(ctx, resolverData, errorMsg)
+	if err != nil {
+		return ""
+	}
+
+	if msg, ok := resolved.(string); ok {
+		return msg
+	}
+	return fmt.Sprintf("%v", resolved)
 }

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -81,6 +81,17 @@ type Resolver struct {
 	Resolve   *ResolvePhase   `json:"resolve" yaml:"resolve" doc:"Value resolution phase"`
 	Transform *TransformPhase `json:"transform,omitempty" yaml:"transform,omitempty" doc:"Value transformation phase"`
 	Validate  *ValidatePhase  `json:"validate,omitempty" yaml:"validate,omitempty" doc:"Value validation phase"`
+
+	// Messages contains user-defined messages shown on resolver outcomes.
+	Messages *Messages `json:"messages,omitempty" yaml:"messages,omitempty" doc:"Custom messages for resolver outcomes"`
+}
+
+// Messages holds user-defined messages displayed on resolver outcomes.
+type Messages struct {
+	// Error is shown when the resolver fails (resolve, transform, or validate phase).
+	// Supports static strings, CEL expressions (expr:), and Go templates (tmpl:).
+	// The resolver data map is available as _ and the error message as __error.
+	Error *ValueRef `json:"error,omitempty" yaml:"error,omitempty" doc:"Custom message on resolver failure"`
 }
 
 // ResolvePhase defines how to obtain an initial value

--- a/pkg/schema/solution_schema.go
+++ b/pkg/schema/solution_schema.go
@@ -174,6 +174,7 @@ func patchSchema(doc map[string]any) {
 
 	patchValueRef(defs)
 	patchSkipBuiltinsValue(defs)
+	patchSkipValue(defs)
 	patchMapKeyNames(defs)
 	patchJSONSchemaType(defs)
 }
@@ -295,6 +296,24 @@ func patchSkipBuiltinsValue(defs map[string]any) {
 				"type":  "array",
 				"items": map[string]any{"type": "string"},
 			},
+		},
+	}
+}
+
+// patchSkipValue replaces the SkipValue $def with oneOf
+// since it supports both bool and string (CEL expression) via custom UnmarshalYAML
+// but Huma sees an empty object (all fields are json:"-").
+func patchSkipValue(defs map[string]any) {
+	key := findDefKey(defs, "SkipValue")
+	if key == "" {
+		return
+	}
+
+	defs[key] = map[string]any{
+		"description": "When true, unconditionally skips the test. When a string, evaluated as a CEL expression for conditional skipping.",
+		"oneOf": []any{
+			map[string]any{"type": "boolean"},
+			map[string]any{"type": "string"},
 		},
 	}
 }

--- a/pkg/shellexec/mockexec.go
+++ b/pkg/shellexec/mockexec.go
@@ -1,0 +1,32 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package shellexec
+
+import "context"
+
+// RunFunc is a function signature matching Run, allowing mock implementations.
+type RunFunc func(ctx context.Context, opts *RunOptions) (*RunResult, error)
+
+type contextKey struct{}
+
+// WithRunFunc returns a context with a custom RunFunc injected.
+// When present, RunWithContext will use this function instead of the real Run.
+func WithRunFunc(ctx context.Context, fn RunFunc) context.Context {
+	return context.WithValue(ctx, contextKey{}, fn)
+}
+
+// RunFuncFromContext returns a RunFunc from the context, if one was injected.
+func RunFuncFromContext(ctx context.Context) (RunFunc, bool) {
+	fn, ok := ctx.Value(contextKey{}).(RunFunc)
+	return fn, ok
+}
+
+// RunWithContext executes a command, but first checks if a mock RunFunc
+// was injected via WithRunFunc. This enables exec mocking in tests.
+func RunWithContext(ctx context.Context, opts *RunOptions) (*RunResult, error) {
+	if fn, ok := RunFuncFromContext(ctx); ok {
+		return fn(ctx, opts)
+	}
+	return Run(ctx, opts)
+}

--- a/pkg/solution/inspect/inspect.go
+++ b/pkg/solution/inspect/inspect.go
@@ -8,6 +8,7 @@ package inspect
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
@@ -18,6 +19,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 )
@@ -41,6 +43,9 @@ type SolutionExplanation struct {
 	Tags        []string         `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Solution tags"`
 	Links       []LinkInfo       `json:"links,omitempty" yaml:"links,omitempty" doc:"Related links"`
 	Maintainers []MaintainerInfo `json:"maintainers,omitempty" yaml:"maintainers,omitempty" doc:"Solution maintainers"`
+
+	// FileDependencies lists files discovered through static analysis of provider inputs.
+	FileDependencies []FileDependencyInfo `json:"fileDependencies,omitempty" yaml:"fileDependencies,omitempty" doc:"File dependencies discovered via static analysis"`
 }
 
 // CatalogInfo holds catalog metadata.
@@ -81,6 +86,12 @@ type LinkInfo struct {
 type MaintainerInfo struct {
 	Name  string `json:"name" yaml:"name" doc:"Maintainer name"`
 	Email string `json:"email,omitempty" yaml:"email,omitempty" doc:"Maintainer email"`
+}
+
+// FileDependencyInfo describes a file dependency discovered via static analysis.
+type FileDependencyInfo struct {
+	Path   string `json:"path" yaml:"path" doc:"Relative file path"`
+	Source string `json:"source" yaml:"source" doc:"How the dependency was discovered (static-analysis, explicit-include, test-include)"`
 }
 
 // LoadSolution loads a solution from a path using the standard loader with
@@ -172,6 +183,19 @@ func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation {
 			Name:  m.Name,
 			Email: m.Email,
 		})
+	}
+
+	// File dependencies via static analysis
+	if solPath := sol.GetPath(); solPath != "" {
+		bundleRoot := filepath.Dir(solPath)
+		if result, err := bundler.DiscoverFiles(sol, bundleRoot); err == nil && result != nil {
+			for _, f := range result.LocalFiles {
+				exp.FileDependencies = append(exp.FileDependencies, FileDependencyInfo{
+					Path:   f.RelPath,
+					Source: f.Source.String(),
+				})
+			}
+		}
 	}
 
 	return exp

--- a/pkg/solution/soltesting/inheritance.go
+++ b/pkg/solution/soltesting/inheritance.go
@@ -182,8 +182,8 @@ func mergeTestCase(dst, src *TestCase) {
 	if src.ExitCode != nil {
 		dst.ExitCode = src.ExitCode
 	}
-	if src.Skip {
-		dst.Skip = true
+	if !src.Skip.IsZero() {
+		dst.Skip = src.Skip
 	}
 	if src.SkipReason != "" {
 		dst.SkipReason = src.SkipReason
@@ -193,9 +193,6 @@ func mergeTestCase(dst, src *TestCase) {
 	}
 	if src.Snapshot != "" {
 		dst.Snapshot = src.Snapshot
-	}
-	if src.SkipExpression != "" {
-		dst.SkipExpression = src.SkipExpression
 	}
 	if src.Retries > 0 {
 		dst.Retries = src.Retries

--- a/pkg/solution/soltesting/inheritance_test.go
+++ b/pkg/solution/soltesting/inheritance_test.go
@@ -210,12 +210,12 @@ func TestResolveExtends_ScalarChildWins(t *testing.T) {
 
 	tests := map[string]*soltesting.TestCase{
 		"_base": {
-			Name:           "_base",
-			Description:    "base desc",
-			Timeout:        &baseTimeout,
-			ExpectFailure:  true,
-			SkipExpression: celexp.Expression("true"),
-			Retries:        2,
+			Name:          "_base",
+			Description:   "base desc",
+			Timeout:       &baseTimeout,
+			ExpectFailure: true,
+			Skip:          soltesting.SkipValue{Expression: celexp.Expression("true")},
+			Retries:       2,
 		},
 		"child": {
 			Name:        "child",
@@ -239,7 +239,7 @@ func TestResolveExtends_ScalarChildWins(t *testing.T) {
 	assert.True(t, child.ExpectFailure)
 	assert.Equal(t, 42, *child.ExitCode)
 	assert.Equal(t, 5, child.Retries)
-	assert.Equal(t, celexp.Expression("true"), child.SkipExpression)
+	assert.Equal(t, celexp.Expression("true"), child.Skip.Expression)
 }
 
 func TestResolveExtends_FilesMergeDedup(t *testing.T) {

--- a/pkg/solution/soltesting/mockexec/mockexec.go
+++ b/pkg/solution/soltesting/mockexec/mockexec.go
@@ -1,0 +1,179 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mockexec provides a configurable mock for shell command execution in
+// functional tests. It is designed to run as a test service alongside the mock HTTP
+// server — configure it via `spec.testing.config.services` with `type: exec`.
+//
+// Mock rules match commands by exact string or regex and return predefined
+// stdout, stderr, and exit codes. Unmatched commands can fall through to real
+// execution or fail with an error (configurable via Passthrough).
+package mockexec
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/oakwood-commons/scafctl/pkg/shellexec"
+)
+
+// Rule defines a single mock command response.
+type Rule struct {
+	// Command is an exact command string to match. Mutually exclusive with Pattern.
+	Command string `json:"command,omitempty" yaml:"command,omitempty" doc:"Exact command string to match" maxLength:"1000"`
+
+	// Pattern is a regex pattern to match against the command. Mutually exclusive with Command.
+	Pattern string `json:"pattern,omitempty" yaml:"pattern,omitempty" doc:"Regex pattern to match against command" maxLength:"500"`
+
+	// Stdout is the mock standard output to return.
+	Stdout string `json:"stdout,omitempty" yaml:"stdout,omitempty" doc:"Mock stdout response" maxLength:"100000"`
+
+	// Stderr is the mock standard error to return.
+	Stderr string `json:"stderr,omitempty" yaml:"stderr,omitempty" doc:"Mock stderr response" maxLength:"100000"`
+
+	// ExitCode is the mock exit code (default: 0).
+	ExitCode int `json:"exitCode,omitempty" yaml:"exitCode,omitempty" doc:"Mock exit code" maximum:"255"`
+
+	// compiled is the compiled regex pattern (populated by Compile).
+	compiled *regexp.Regexp
+}
+
+// Compile pre-compiles the regex pattern if set. Returns an error for invalid patterns.
+func (r *Rule) Compile() error {
+	if r.Pattern != "" {
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return fmt.Errorf("invalid mock exec pattern %q: %w", r.Pattern, err)
+		}
+		r.compiled = re
+	}
+	return nil
+}
+
+// Matches returns true if the rule matches the given command string.
+func (r *Rule) Matches(command string) bool {
+	if r.Command != "" {
+		return command == r.Command || strings.Contains(command, r.Command)
+	}
+	if r.compiled != nil {
+		return r.compiled.MatchString(command)
+	}
+	return false
+}
+
+// MockExec intercepts shell commands and returns predefined responses.
+type MockExec struct {
+	mu          sync.Mutex
+	rules       []Rule
+	calls       []CallRecord
+	passthrough bool
+}
+
+// CallRecord records a command that was intercepted.
+type CallRecord struct {
+	Command string
+	Args    []string
+	Matched bool
+	Rule    *Rule
+}
+
+// Option configures a MockExec.
+type Option func(*MockExec)
+
+// WithPassthrough allows unmatched commands to execute normally via the real shellexec.Run.
+// When false (default), unmatched commands return an error.
+func WithPassthrough(allow bool) Option {
+	return func(m *MockExec) {
+		m.passthrough = allow
+	}
+}
+
+// New creates a new MockExec with the given rules.
+// Rules are matched in order — the first matching rule wins.
+func New(rules []Rule, opts ...Option) (*MockExec, error) {
+	for i := range rules {
+		if err := rules[i].Compile(); err != nil {
+			return nil, err
+		}
+	}
+	m := &MockExec{
+		rules: rules,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m, nil
+}
+
+// RunFunc returns a shellexec.RunFunc that can be injected into context via
+// shellexec.WithRunFunc. Matched commands return mock responses; unmatched
+// commands either pass through to real execution or fail, depending on config.
+func (m *MockExec) RunFunc() shellexec.RunFunc {
+	return func(ctx context.Context, opts *shellexec.RunOptions) (*shellexec.RunResult, error) {
+		fullCmd := shellexec.BuildFullCommand(opts.Command, opts.Args)
+
+		m.mu.Lock()
+		for i := range m.rules {
+			if m.rules[i].Matches(fullCmd) {
+				rule := &m.rules[i]
+				m.calls = append(m.calls, CallRecord{
+					Command: fullCmd,
+					Args:    opts.Args,
+					Matched: true,
+					Rule:    rule,
+				})
+				m.mu.Unlock()
+
+				// Write mock output to the provided writers
+				if opts.Stdout != nil && rule.Stdout != "" {
+					_, _ = fmt.Fprint(opts.Stdout, rule.Stdout)
+				}
+				if opts.Stderr != nil && rule.Stderr != "" {
+					_, _ = fmt.Fprint(opts.Stderr, rule.Stderr)
+				}
+
+				return &shellexec.RunResult{
+					ExitCode: rule.ExitCode,
+					Shell:    opts.Shell,
+				}, nil
+			}
+		}
+
+		m.calls = append(m.calls, CallRecord{
+			Command: fullCmd,
+			Args:    opts.Args,
+			Matched: false,
+		})
+		m.mu.Unlock()
+
+		if m.passthrough {
+			return shellexec.Run(ctx, opts)
+		}
+
+		return nil, fmt.Errorf("mockexec: no matching rule for command %q (add a rule or enable passthrough)", fullCmd)
+	}
+}
+
+// Calls returns a copy of all recorded call records.
+func (m *MockExec) Calls() []CallRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]CallRecord, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// Reset clears recorded calls.
+func (m *MockExec) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = nil
+}
+
+// Rules returns the configured rules (read-only slice).
+func (m *MockExec) Rules() []Rule {
+	return m.rules
+}

--- a/pkg/solution/soltesting/mockexec/mockexec_test.go
+++ b/pkg/solution/soltesting/mockexec/mockexec_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mockexec
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/shellexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_CompileError(t *testing.T) {
+	_, err := New([]Rule{
+		{Pattern: "[invalid"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mock exec pattern")
+}
+
+func TestNew_ValidRules(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "echo hello"},
+		{Pattern: "^curl "},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, m)
+}
+
+func TestRule_Matches_ExactCommand(t *testing.T) {
+	r := Rule{Command: "echo hello"}
+	assert.True(t, r.Matches("echo hello"))
+	assert.True(t, r.Matches("echo hello world")) // contains
+	assert.False(t, r.Matches("echo goodbye"))
+}
+
+func TestRule_Matches_Pattern(t *testing.T) {
+	r := Rule{Pattern: `^curl\s+`}
+	require.NoError(t, r.Compile())
+	assert.True(t, r.Matches("curl https://example.com"))
+	assert.False(t, r.Matches("wget https://example.com"))
+}
+
+func TestMockExec_RunFunc_MatchedCommand(t *testing.T) {
+	m, err := New([]Rule{
+		{
+			Command:  "echo hello",
+			Stdout:   "mocked hello\n",
+			ExitCode: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	fn := m.RunFunc()
+	result, err := fn(context.Background(), &shellexec.RunOptions{
+		Command: "echo hello",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "mocked hello\n", stdout.String())
+	assert.Empty(t, stderr.String())
+
+	calls := m.Calls()
+	require.Len(t, calls, 1)
+	assert.True(t, calls[0].Matched)
+	assert.Equal(t, "echo hello", calls[0].Command)
+}
+
+func TestMockExec_RunFunc_MatchedPattern(t *testing.T) {
+	m, err := New([]Rule{
+		{
+			Pattern:  `^terraform\s+apply`,
+			Stdout:   "Apply complete!\n",
+			Stderr:   "Warning: something\n",
+			ExitCode: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	fn := m.RunFunc()
+	result, err := fn(context.Background(), &shellexec.RunOptions{
+		Command: "terraform apply -auto-approve",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "Apply complete!\n", stdout.String())
+	assert.Equal(t, "Warning: something\n", stderr.String())
+}
+
+func TestMockExec_RunFunc_NonZeroExitCode(t *testing.T) {
+	m, err := New([]Rule{
+		{
+			Command:  "failing-command",
+			Stderr:   "error: something went wrong\n",
+			ExitCode: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	fn := m.RunFunc()
+	result, err := fn(context.Background(), &shellexec.RunOptions{
+		Command: "failing-command",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	require.NoError(t, err) // error is in exit code, not returned
+	assert.Equal(t, 1, result.ExitCode)
+	assert.Equal(t, "error: something went wrong\n", stderr.String())
+}
+
+func TestMockExec_RunFunc_Unmatched_NoPassthrough(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "echo hello"},
+	})
+	require.NoError(t, err)
+
+	fn := m.RunFunc()
+	_, err = fn(context.Background(), &shellexec.RunOptions{
+		Command: "unknown-command",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no matching rule")
+	assert.Contains(t, err.Error(), "unknown-command")
+
+	calls := m.Calls()
+	require.Len(t, calls, 1)
+	assert.False(t, calls[0].Matched)
+}
+
+func TestMockExec_RunFunc_Unmatched_Passthrough(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "nonexistent-cmd"},
+	}, WithPassthrough(true))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	fn := m.RunFunc()
+	result, err := fn(context.Background(), &shellexec.RunOptions{
+		Command: "echo passthrough-test",
+		Stdout:  &stdout,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, stdout.String(), "passthrough-test")
+}
+
+func TestMockExec_RunFunc_FirstMatchWins(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "echo", Stdout: "first\n"},
+		{Command: "echo", Stdout: "second\n"},
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	fn := m.RunFunc()
+	_, err = fn(context.Background(), &shellexec.RunOptions{
+		Command: "echo test",
+		Stdout:  &stdout,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "first\n", stdout.String())
+}
+
+func TestMockExec_Reset(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "echo hello", Stdout: "hi\n"},
+	})
+	require.NoError(t, err)
+
+	fn := m.RunFunc()
+	_, _ = fn(context.Background(), &shellexec.RunOptions{
+		Command: "echo hello",
+	})
+
+	assert.Len(t, m.Calls(), 1)
+	m.Reset()
+	assert.Len(t, m.Calls(), 0)
+}
+
+func TestMockExec_ContextIntegration(t *testing.T) {
+	m, err := New([]Rule{
+		{Command: "echo ctx-test", Stdout: "from mock\n"},
+	})
+	require.NoError(t, err)
+
+	ctx := shellexec.WithRunFunc(context.Background(), m.RunFunc())
+
+	var stdout bytes.Buffer
+	result, err := shellexec.RunWithContext(ctx, &shellexec.RunOptions{
+		Command: "echo ctx-test",
+		Stdout:  &stdout,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "from mock\n", stdout.String())
+}

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -233,11 +233,8 @@ func ReportList(solutions []SolutionTests, opts *kvx.OutputOptions, includeBuilt
 			}
 
 			skip := "false"
-			if tc.Skip {
-				skip = "true"
-			}
-			if tc.SkipExpression != "" {
-				skip = string(tc.SkipExpression)
+			if !tc.Skip.IsZero() {
+				skip = tc.Skip.String()
 			}
 
 			entries = append(entries, listEntry{

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/shellexec"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockexec"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockserver"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -201,8 +202,9 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 		}
 	}()
 
-	// Start background services (e.g., mock HTTP servers)
+	// Start background services (e.g., mock HTTP servers, exec mocks)
 	var serviceEnv map[string]string
+	var execMocks []*mockexec.MockExec
 	if st.Config != nil && len(st.Config.Services) > 0 {
 		var servers []*mockserver.Server
 		serviceEnv = make(map[string]string)
@@ -215,7 +217,51 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 		}()
 
 		for _, svc := range st.Config.Services {
-			if svc.Type != "http" {
+			switch svc.Type {
+			case "http":
+				srv := mockserver.New(svc.Routes)
+				if err := srv.Start(); err != nil {
+					results := make([]TestResult, 0, len(testNames))
+					for _, name := range testNames {
+						result := TestResult{
+							Solution: st.SolutionName,
+							Test:     name,
+							Status:   StatusError,
+							Message:  fmt.Sprintf("service %q start failed: %s", svc.Name, err),
+						}
+						r.emitTestComplete(result)
+						results = append(results, result)
+					}
+					return results, nil
+				}
+				servers = append(servers, srv)
+
+				if svc.PortEnv != "" {
+					serviceEnv[svc.PortEnv] = fmt.Sprintf("%d", srv.Port())
+				}
+				if svc.BaseURLEnv != "" {
+					serviceEnv[svc.BaseURLEnv] = srv.BaseURL()
+				}
+
+			case "exec":
+				me, err := mockexec.New(svc.ExecRules, mockexec.WithPassthrough(svc.Passthrough))
+				if err != nil {
+					results := make([]TestResult, 0, len(testNames))
+					for _, name := range testNames {
+						result := TestResult{
+							Solution: st.SolutionName,
+							Test:     name,
+							Status:   StatusError,
+							Message:  fmt.Sprintf("exec service %q init failed: %s", svc.Name, err),
+						}
+						r.emitTestComplete(result)
+						results = append(results, result)
+					}
+					return results, nil
+				}
+				execMocks = append(execMocks, me)
+
+			default:
 				results := make([]TestResult, 0, len(testNames))
 				for _, name := range testNames {
 					result := TestResult{
@@ -229,30 +275,6 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 				}
 				return results, nil
 			}
-
-			srv := mockserver.New(svc.Routes)
-			if err := srv.Start(); err != nil {
-				results := make([]TestResult, 0, len(testNames))
-				for _, name := range testNames {
-					result := TestResult{
-						Solution: st.SolutionName,
-						Test:     name,
-						Status:   StatusError,
-						Message:  fmt.Sprintf("service %q start failed: %s", svc.Name, err),
-					}
-					r.emitTestComplete(result)
-					results = append(results, result)
-				}
-				return results, nil
-			}
-			servers = append(servers, srv)
-
-			if svc.PortEnv != "" {
-				serviceEnv[svc.PortEnv] = fmt.Sprintf("%d", srv.Port())
-			}
-			if svc.BaseURLEnv != "" {
-				serviceEnv[svc.BaseURLEnv] = srv.BaseURL()
-			}
 		}
 
 		// Inject service env vars into testConfig.Env so buildEnvMap picks them up automatically.
@@ -261,6 +283,15 @@ func (r *Runner) runSolution(ctx context.Context, st *SolutionTests, testNames [
 		}
 		for k, v := range serviceEnv {
 			st.Config.Env[k] = v
+		}
+
+		// Inject exec mock into context so the exec provider uses mock responses.
+		// This works for in-process test execution. For subprocess execution, exec
+		// mocks are not yet supported — unmatched commands run normally.
+		if len(execMocks) > 0 {
+			// Compose all exec mocks into a single RunFunc: try each in order.
+			composed := composeExecMocks(execMocks)
+			ctx = shellexec.WithRunFunc(ctx, composed)
 		}
 	}
 
@@ -413,7 +444,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 	}
 
 	// Check skip conditions
-	if tc.Skip {
+	if tc.Skip.ShouldSkip() {
 		result.Status = StatusSkip
 		result.Message = tc.SkipReason
 		if result.Message == "" {
@@ -423,8 +454,8 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 		return result
 	}
 
-	if tc.SkipExpression != "" {
-		skipped, err := r.evaluateSkipExpression(ctx, string(tc.SkipExpression))
+	if tc.Skip.HasExpression() {
+		skipped, err := r.evaluateSkipExpression(ctx, string(tc.Skip.Expression))
 		if err != nil {
 			result.Status = StatusError
 			result.Message = fmt.Sprintf("skip expression error: %s", err)
@@ -435,7 +466,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 			result.Status = StatusSkip
 			result.Message = tc.SkipReason
 			if result.Message == "" {
-				result.Message = fmt.Sprintf("skip expression: %s", tc.SkipExpression)
+				result.Message = fmt.Sprintf("skip expression: %s", tc.Skip.Expression)
 			}
 			result.Duration = time.Since(start)
 			return result
@@ -750,8 +781,9 @@ func (r *Runner) checkExitCode(tc *TestCase, output *CommandOutput) bool {
 // evaluateSkipExpression evaluates a CEL skip expression.
 func (r *Runner) evaluateSkipExpression(ctx context.Context, expr string) (bool, error) {
 	envVars := map[string]any{
-		"os":   os.Getenv("GOOS"),
-		"arch": os.Getenv("GOARCH"),
+		"os":         os.Getenv("GOOS"),
+		"arch":       os.Getenv("GOARCH"),
+		"subprocess": r.BinaryPath != "",
 	}
 
 	result, err := celexp.EvaluateExpression(ctx, expr, nil, envVars)
@@ -863,4 +895,42 @@ func mergeEnvForStep(envMap map[string]any, stepEnv map[string]string) []string 
 	}
 
 	return shellexec.MergeEnv(combined)
+}
+
+// composeExecMocks creates a single RunFunc that tries each MockExec in order.
+// The first mock that has a matching rule handles the command. If no mock matches
+// and a mock allows passthrough, the real shellexec.Run is called.
+func composeExecMocks(mocks []*mockexec.MockExec) shellexec.RunFunc {
+	fns := make([]shellexec.RunFunc, len(mocks))
+	for i, m := range mocks {
+		fns[i] = m.RunFunc()
+	}
+
+	return func(ctx context.Context, opts *shellexec.RunOptions) (*shellexec.RunResult, error) {
+		fullCmd := shellexec.BuildFullCommand(opts.Command, opts.Args)
+		var lastErr error
+
+		for i, m := range mocks {
+			// Check if any rule matches in this mock
+			for _, rule := range m.Rules() {
+				if rule.Matches(fullCmd) {
+					return fns[i](ctx, opts)
+				}
+			}
+		}
+
+		// No match found — try each mock's RunFunc (which will either passthrough or error)
+		for _, fn := range fns {
+			result, err := fn(ctx, opts)
+			if err == nil {
+				return result, nil
+			}
+			lastErr = err
+		}
+
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("mockexec: no matching rule for command %q", fullCmd)
+	}
 }

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -153,7 +153,7 @@ func TestRunnerSkipTest(t *testing.T) {
 				"skipped-test": {
 					Name:       "skipped-test",
 					Command:    []string{"run"},
-					Skip:       true,
+					Skip:       SkipValue{Static: true},
 					SkipReason: "not ready yet",
 					Assertions: []Assertion{
 						{Expression: "__exitCode == 0"},

--- a/pkg/solution/soltesting/sandbox.go
+++ b/pkg/solution/soltesting/sandbox.go
@@ -85,8 +85,13 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 		}
 	}
 
-	// Copy test files
-	for _, f := range testFiles {
+	// Copy test files (with glob and directory expansion)
+	expandedTestFiles, err := resolveFileEntries(solutionDir, testFiles)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("resolving test files: %w", err)
+	}
+	for _, f := range expandedTestFiles {
 		if err := s.copyFile(solutionDir, f); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying test file %q: %w", f, err)
@@ -122,8 +127,13 @@ func (s *Sandbox) CopyForTest(solutionDir string, testFiles []string) (*Sandbox,
 		solutionPath: filepath.Join(tmpDir, solutionBase),
 	}
 
-	// Copy test-specific files from the original solution directory
-	for _, f := range testFiles {
+	// Copy test-specific files from the original solution directory (with glob and directory expansion)
+	expandedTestFiles, err := resolveFileEntries(solutionDir, testFiles)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("resolving test files: %w", err)
+	}
+	for _, f := range expandedTestFiles {
 		if err := child.copyFile(solutionDir, f); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying test file %q: %w", f, err)
@@ -222,7 +232,11 @@ func (s *Sandbox) copyFile(sourceDir, relPath string) error {
 	// Reject path traversal
 	cleaned := filepath.Clean(relPath)
 	if strings.HasPrefix(cleaned, "..") || filepath.IsAbs(cleaned) {
-		return fmt.Errorf("path traversal rejected: %q", relPath)
+		return fmt.Errorf(
+			"path traversal rejected: %q — test files must be within the solution directory. "+
+				"Move or copy the file alongside solution.yaml, or use 'init' steps instead",
+			relPath,
+		)
 	}
 
 	srcPath := filepath.Join(sourceDir, cleaned)
@@ -234,6 +248,13 @@ func (s *Sandbox) copyFile(sourceDir, relPath string) error {
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("symlinks are not allowed: %q", relPath)
+	}
+	if info.IsDir() {
+		return fmt.Errorf(
+			"is a directory: %q — the 'files' property requires file paths or glob patterns "+
+				"(e.g., %q to copy the entire directory tree)",
+			relPath, relPath+"/**",
+		)
 	}
 
 	dstPath := filepath.Join(s.root, cleaned)
@@ -317,6 +338,135 @@ func copyDirRecursive(src, dst string) error {
 
 		return os.Chmod(dstPath, info.Mode())
 	})
+}
+
+// resolveFileEntries expands a list of file entries (which may include glob patterns
+// and directory paths) into a flat list of individual relative file paths.
+//
+// Supported entry types:
+//   - Plain file path: "config.yaml" — used as-is
+//   - Glob pattern: "templates/**/*.yaml" — expanded via doublestar
+//   - Directory path: "templates/" (trailing slash) or a path that resolves to a directory
+//     — recursively expanded to include all files in the tree
+//
+// All returned paths are relative to sourceDir.
+func resolveFileEntries(sourceDir string, entries []string) ([]string, error) {
+	var result []string
+	seen := make(map[string]bool)
+
+	for _, entry := range entries {
+		expanded, err := resolveOneFileEntry(sourceDir, entry)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range expanded {
+			if !seen[p] {
+				seen[p] = true
+				result = append(result, p)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// resolveOneFileEntry resolves a single file entry to one or more relative paths.
+func resolveOneFileEntry(sourceDir, entry string) ([]string, error) {
+	cleaned := filepath.Clean(entry)
+
+	// Reject path traversal early
+	if strings.HasPrefix(cleaned, "..") || filepath.IsAbs(cleaned) {
+		// Let copyFile produce the detailed error
+		return []string{entry}, nil
+	}
+
+	absPath := filepath.Join(sourceDir, cleaned)
+
+	// Check if it's a directory (either by trailing slash or by stat)
+	isDir := strings.HasSuffix(entry, "/") || strings.HasSuffix(entry, string(filepath.Separator))
+	if !isDir {
+		info, err := os.Stat(absPath)
+		if err == nil && info.IsDir() {
+			isDir = true
+		}
+	}
+
+	if isDir {
+		return expandDirectory(sourceDir, cleaned)
+	}
+
+	// Check if it contains glob characters
+	if strings.ContainsAny(entry, "*?[{") {
+		return expandGlob(sourceDir, entry)
+	}
+
+	// Plain file path — return as-is
+	return []string{cleaned}, nil
+}
+
+// expandDirectory recursively walks a directory and returns all files as relative paths.
+func expandDirectory(sourceDir, relDir string) ([]string, error) {
+	absDir := filepath.Join(sourceDir, relDir)
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("directory %q: %w", relDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("not a directory: %q", relDir)
+	}
+
+	var result []string
+	err = filepath.Walk(absDir, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		// Skip symlinks
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return fmt.Errorf("computing relative path for %q: %w", path, err)
+		}
+		result = append(result, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking directory %q: %w", relDir, err)
+	}
+
+	return result, nil
+}
+
+// expandGlob expands a glob pattern relative to sourceDir into matching file paths.
+func expandGlob(sourceDir, pattern string) ([]string, error) {
+	absPattern := filepath.Join(sourceDir, pattern)
+
+	matches, err := doublestar.FilepathGlob(absPattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob pattern %q: %w", pattern, err)
+	}
+
+	var result []string
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			continue // skip unstat-able entries
+		}
+		if info.IsDir() {
+			continue // skip directories, only include files
+		}
+		rel, err := filepath.Rel(sourceDir, match)
+		if err != nil {
+			return nil, fmt.Errorf("computing relative path for %q: %w", match, err)
+		}
+		result = append(result, rel)
+	}
+
+	return result, nil
 }
 
 // discoverComposeFiles reads a solution file and returns the relative paths

--- a/pkg/solution/soltesting/sandbox_test.go
+++ b/pkg/solution/soltesting/sandbox_test.go
@@ -235,6 +235,159 @@ func TestNewBaseSandbox_And_CopyForTest(t *testing.T) {
 	assert.Equal(t, "shared config", string(content))
 }
 
+func TestNewSandbox_GlobExpansion(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "templates/main.yaml", "main")
+	writeSandboxFile(t, dir, "templates/sub/nested.yaml", "nested")
+	writeSandboxFile(t, dir, "templates/other.txt", "other")
+
+	sb, err := soltesting.NewSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		nil,
+		[]string{"templates/**/*.yaml"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	// Both .yaml files should be copied
+	content, err := os.ReadFile(filepath.Join(sb.Path(), "templates/main.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "main", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "templates/sub/nested.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(content))
+
+	// .txt file should NOT be copied (doesn't match *.yaml glob)
+	_, err = os.Stat(filepath.Join(sb.Path(), "templates/other.txt"))
+	assert.True(t, os.IsNotExist(err), "non-matching file should not be copied")
+}
+
+func TestNewSandbox_DirectoryExpansion(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "testdata/a.json", "a")
+	writeSandboxFile(t, dir, "testdata/sub/b.yaml", "b")
+
+	sb, err := soltesting.NewSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		nil,
+		[]string{"testdata"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(sb.Path(), "testdata/a.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "a", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "testdata/sub/b.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "b", string(content))
+}
+
+func TestNewSandbox_DirectoryWithTrailingSlash(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "data/file1.txt", "f1")
+	writeSandboxFile(t, dir, "data/file2.txt", "f2")
+
+	sb, err := soltesting.NewSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		nil,
+		[]string{"data/"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(sb.Path(), "data/file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "f1", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "data/file2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "f2", string(content))
+}
+
+func TestNewSandbox_MixedFilesGlobsAndDirectories(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "single.txt", "single")
+	writeSandboxFile(t, dir, "templates/main.yaml", "main-tmpl")
+	writeSandboxFile(t, dir, "templates/other.yaml", "other-tmpl")
+	writeSandboxFile(t, dir, "data/input.json", "input")
+
+	sb, err := soltesting.NewSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		nil,
+		[]string{"single.txt", "templates/*.yaml", "data"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(sb.Path(), "single.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "single", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "templates/main.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "main-tmpl", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "templates/other.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "other-tmpl", string(content))
+
+	content, err = os.ReadFile(filepath.Join(sb.Path(), "data/input.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "input", string(content))
+}
+
+func TestNewSandbox_DeduplicatesGlobResults(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "templates/main.yaml", "content")
+
+	// Both entries resolve to the same file — should not error
+	sb, err := soltesting.NewSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		nil,
+		[]string{"templates/main.yaml", "templates/*.yaml"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(sb.Path(), "templates/main.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestCopyForTest_GlobAndDirectoryExpansion(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "shared/config.yaml", "shared")
+	writeSandboxFile(t, dir, "testdata/a.json", "a")
+	writeSandboxFile(t, dir, "testdata/b.json", "b")
+	writeSandboxFile(t, dir, "extra/deep/file.txt", "deep")
+
+	base, err := soltesting.NewBaseSandbox(
+		filepath.Join(dir, "solution.yaml"),
+		[]string{"shared/config.yaml"},
+	)
+	require.NoError(t, err)
+	defer base.Cleanup()
+
+	child, err := base.CopyForTest(dir, []string{"testdata/*.json", "extra"})
+	require.NoError(t, err)
+	defer child.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(child.Path(), "testdata/a.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "a", string(content))
+
+	content, err = os.ReadFile(filepath.Join(child.Path(), "testdata/b.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "b", string(content))
+
+	content, err = os.ReadFile(filepath.Join(child.Path(), "extra/deep/file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "deep", string(content))
+}
+
 func setupSandboxDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -27,6 +27,11 @@ type ScaffoldInput struct {
 
 	// Workflow is the action workflow from the solution spec (may be nil).
 	Workflow *action.Workflow
+
+	// FileDependencies is a list of file paths (relative to the solution dir)
+	// discovered through static analysis of provider inputs.
+	// These are automatically populated onto generated test cases.
+	FileDependencies []string
 }
 
 // Scaffold generates a skeleton test suite from the provided solution data.
@@ -49,6 +54,17 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 	// Generate action-specific tests
 	if input.Workflow != nil && input.Workflow.Actions != nil {
 		addActionTests(result, input.Workflow)
+	}
+
+	// Auto-populate discovered file dependencies on all generated test cases
+	if len(input.FileDependencies) > 0 {
+		sorted := make([]string, len(input.FileDependencies))
+		copy(sorted, input.FileDependencies)
+		sort.Strings(sorted)
+
+		for _, tc := range result.Cases {
+			tc.Files = sorted
+		}
 	}
 
 	return result

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -210,3 +210,35 @@ func exprPtr(s string) *celexp.Expression {
 	e := celexp.Expression(s)
 	return &e
 }
+
+func TestScaffold_FileDependenciesPopulatedOnAllCases(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"region": {
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "static"},
+					},
+				},
+			},
+		},
+		FileDependencies: []string{"templates/main.yaml", "data/config.json"},
+	}
+
+	result := Scaffold(input)
+
+	// Every generated case should have the file dependencies
+	for name, tc := range result.Cases {
+		assert.Equal(t, []string{"data/config.json", "templates/main.yaml"}, tc.Files,
+			"test case %q should have sorted file dependencies", name)
+	}
+}
+
+func TestScaffold_EmptyFileDependenciesOmitted(t *testing.T) {
+	result := Scaffold(&ScaffoldInput{})
+
+	for name, tc := range result.Cases {
+		assert.Nil(t, tc.Files,
+			"test case %q should have nil Files when no dependencies discovered", name)
+	}
+}

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockexec"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockserver"
 	"gopkg.in/yaml.v3"
 )
@@ -158,6 +159,111 @@ func (s SkipBuiltinsValue) IsSkipped() bool {
 	return s.All || len(s.Names) > 0
 }
 
+// SkipValue supports both bool and CEL expression string via custom UnmarshalYAML.
+// When bool: true skips unconditionally, false means no skip.
+// When string: the string is evaluated as a CEL expression at discovery time.
+// YAML usage:
+//
+//	skip: true              # unconditional skip
+//	skip: 'os == "windows"'  # conditional skip via CEL
+type SkipValue struct {
+	// Static when true means unconditionally skip.
+	Static bool `json:"-" yaml:"-"`
+	// Expression is a CEL expression for conditional skipping.
+	Expression celexp.Expression `json:"-" yaml:"-"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for SkipValue.
+func (s *SkipValue) UnmarshalYAML(value *yaml.Node) error {
+	// Try bool first
+	var b bool
+	if err := value.Decode(&b); err == nil {
+		s.Static = b
+		s.Expression = ""
+		return nil
+	}
+
+	// Try string (CEL expression)
+	var expr string
+	if err := value.Decode(&expr); err == nil {
+		s.Static = false
+		s.Expression = celexp.Expression(expr)
+		return nil
+	}
+
+	return fmt.Errorf("skip must be a bool or a CEL expression string")
+}
+
+// MarshalYAML implements yaml.Marshaler for SkipValue.
+func (s SkipValue) MarshalYAML() (any, error) {
+	if s.Expression != "" {
+		return string(s.Expression), nil
+	}
+	if s.Static {
+		return true, nil
+	}
+	return false, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for SkipValue.
+func (s *SkipValue) UnmarshalJSON(data []byte) error {
+	// Try bool first
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		s.Static = b
+		s.Expression = ""
+		return nil
+	}
+
+	// Try string (CEL expression)
+	var expr string
+	if err := json.Unmarshal(data, &expr); err == nil {
+		s.Static = false
+		s.Expression = celexp.Expression(expr)
+		return nil
+	}
+
+	return fmt.Errorf("skip must be a bool or a CEL expression string")
+}
+
+// MarshalJSON implements json.Marshaler for SkipValue.
+func (s SkipValue) MarshalJSON() ([]byte, error) {
+	if s.Expression != "" {
+		return json.Marshal(string(s.Expression))
+	}
+	if s.Static {
+		return json.Marshal(true)
+	}
+	return json.Marshal(false)
+}
+
+// IsZero returns true if the SkipValue is the zero value (no skip configured).
+func (s SkipValue) IsZero() bool {
+	return !s.Static && s.Expression == ""
+}
+
+// ShouldSkip returns true if the SkipValue indicates unconditional skip.
+// For expression-based skip, use the runner's evaluation logic.
+func (s SkipValue) ShouldSkip() bool {
+	return s.Static
+}
+
+// HasExpression returns true if the SkipValue has a CEL expression.
+func (s SkipValue) HasExpression() bool {
+	return s.Expression != ""
+}
+
+// String returns a human-readable string representation.
+func (s SkipValue) String() string {
+	if s.Expression != "" {
+		return string(s.Expression)
+	}
+	if s.Static {
+		return "true"
+	}
+	return "false"
+}
+
 // TestSuite groups all test-related configuration under a single top-level property.
 type TestSuite struct {
 	// Config holds solution-level test configuration.
@@ -203,19 +309,28 @@ type ServiceConfig struct {
 	// Name is a unique identifier for the service within this solution's tests.
 	Name string `json:"name" yaml:"name" doc:"Unique service identifier" maxLength:"100" pattern:"^[a-zA-Z0-9][a-zA-Z0-9_-]*$"`
 
-	// Type is the service type. Currently only "http" is supported.
-	Type string `json:"type" yaml:"type" doc:"Service type" pattern:"^http$" patternDescription:"Must be: http"`
+	// Type is the service type. Supported: "http" (mock HTTP server), "exec" (mock shell commands).
+	Type string `json:"type" yaml:"type" doc:"Service type" pattern:"^(http|exec)$" patternDescription:"Must be: http or exec"`
 
 	// PortEnv is the environment variable name where the assigned port is exposed.
 	// Tests can reference this via testConfig.env or in resolver inputs (e.g., $MOCK_HTTP_PORT).
-	PortEnv string `json:"portEnv" yaml:"portEnv" doc:"Env var name for assigned port" maxLength:"100" pattern:"^[A-Z][A-Z0-9_]*$"`
+	// Only used when Type is "http".
+	PortEnv string `json:"portEnv,omitempty" yaml:"portEnv,omitempty" doc:"Env var name for assigned port (http only)" maxLength:"100" pattern:"^[A-Z][A-Z0-9_]*$"`
 
 	// BaseURLEnv is the environment variable name where the base URL is exposed (e.g., http://127.0.0.1:PORT).
-	// Optional — if empty, only PortEnv is set.
-	BaseURLEnv string `json:"baseUrlEnv,omitempty" yaml:"baseUrlEnv,omitempty" doc:"Env var name for base URL" maxLength:"100"`
+	// Optional — if empty, only PortEnv is set. Only used when Type is "http".
+	BaseURLEnv string `json:"baseUrlEnv,omitempty" yaml:"baseUrlEnv,omitempty" doc:"Env var name for base URL (http only)" maxLength:"100"`
 
 	// Routes defines the mock HTTP routes (only used when Type is "http").
 	Routes []mockserver.Route `json:"routes,omitempty" yaml:"routes,omitempty" doc:"Mock HTTP routes" maxItems:"100"`
+
+	// ExecRules defines mock command rules (only used when Type is "exec").
+	// Rules are matched in order — the first matching rule wins.
+	ExecRules []mockexec.Rule `json:"execRules,omitempty" yaml:"execRules,omitempty" doc:"Mock command rules" maxItems:"100"`
+
+	// Passthrough allows unmatched exec commands to run normally (only used when Type is "exec").
+	// When false (default), unmatched commands fail with an error.
+	Passthrough bool `json:"passthrough,omitempty" yaml:"passthrough,omitempty" doc:"Allow unmatched exec commands to run (exec only)"`
 }
 
 // InitStep is a setup/cleanup command.
@@ -266,8 +381,10 @@ type TestCase struct {
 	// Env contains per-test environment variables.
 	Env map[string]string `json:"env,omitempty" yaml:"env,omitempty" doc:"Per-test environment variables"`
 
-	// Files lists relative paths or globs for files required by this test.
-	Files []string `json:"files,omitempty" yaml:"files,omitempty" doc:"Relative paths or globs for files required by this test" maxItems:"50"`
+	// Files lists relative paths, glob patterns, or directory paths for files required by this test.
+	// Globs (e.g., 'templates/**/*.yaml') are expanded using doublestar matching.
+	// Directories (e.g., 'templates/') are recursively expanded to include all files.
+	Files []string `json:"files,omitempty" yaml:"files,omitempty" doc:"Relative paths, glob patterns (e.g., 'templates/**'), or directory paths for files required by this test. Directories are recursively copied." maxItems:"50"`
 
 	// Init contains setup steps executed sequentially before the command.
 	Init []InitStep `json:"init,omitempty" yaml:"init,omitempty" doc:"Setup steps executed sequentially before the command" maxItems:"50"`
@@ -294,14 +411,11 @@ type TestCase struct {
 	// Timeout is the per-test timeout as a Go duration string.
 	Timeout *duration.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Per-test timeout as a Go duration string"`
 
-	// Skip skips this test when true.
-	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty" doc:"Skip this test"`
+	// Skip controls test skipping. Accepts true (unconditional) or a CEL expression string (conditional).
+	Skip SkipValue `json:"skip,omitempty" yaml:"skip,omitempty" doc:"Skip this test: true for unconditional, or a CEL expression string for conditional skip"`
 
 	// SkipReason is a human-readable reason for skipping.
 	SkipReason string `json:"skipReason,omitempty" yaml:"skipReason,omitempty" doc:"Human-readable reason for skipping" maxLength:"500"`
-
-	// SkipExpression is a CEL expression evaluated at discovery time for conditional skipping.
-	SkipExpression celexp.Expression `json:"skipExpression,omitempty" yaml:"skipExpression,omitempty" doc:"CEL expression for conditional skip evaluation"`
 
 	// Retries is the number of retry attempts for a failing test.
 	Retries int `json:"retries,omitempty" yaml:"retries,omitempty" doc:"Number of retry attempts for failing tests" maximum:"10"`

--- a/pkg/terminal/kvx/cel.go
+++ b/pkg/terminal/kvx/cel.go
@@ -87,10 +87,14 @@ func buildFunctionHints() map[string]string {
 			hints[extFunc.Name] = "e.g. urlDecode(_.encoded)"
 
 		// String functions
-		case "regexMatch":
-			hints[extFunc.Name] = "e.g. regexMatch('^test', _.name)"
-		case "regexReplace":
-			hints[extFunc.Name] = "e.g. regexReplace(_.text, 'old', 'new')"
+		case "regex.match":
+			hints[extFunc.Name] = "e.g. regex.match('^test', _.name)"
+		case "regex.replace":
+			hints[extFunc.Name] = "e.g. regex.replace(_.text, '[0-9]+', '#')"
+		case "regex.findAll":
+			hints[extFunc.Name] = "e.g. regex.findAll('[0-9]+', _.text)"
+		case "regex.split":
+			hints[extFunc.Name] = "e.g. regex.split('[,;]+', _.csv)"
 		case "split":
 			hints[extFunc.Name] = "e.g. split(_.csv, ',')"
 		case "join":

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -586,4 +586,4 @@ tasks:
     desc: "Integration tests"
     run: once
     cmds:
-      - '{{.DIST}}/{{.OUTPUT_FILE}} test functional --tests-path "{{.FIXED_ROOT}}/tests/integration/solutions" --no-color -q'
+      - '{{.DIST}}/{{.OUTPUT_FILE}} test functional --tests-path "{{.FIXED_ROOT}}/tests/integration/solutions" --no-color -q --concurrency 10'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4061,6 +4061,12 @@ func TestIntegration_MCPServeInfo(t *testing.T) {
 	assert.True(t, toolNames["preview_resolvers"], "expected preview_resolvers tool")
 	assert.True(t, toolNames["run_solution_tests"], "expected run_solution_tests tool")
 	assert.True(t, toolNames["get_run_command"], "expected get_run_command tool")
+
+	// New tools from recent enhancements
+	assert.True(t, toolNames["explain_error"], "expected explain_error tool")
+	assert.True(t, toolNames["get_provider_output_shape"], "expected get_provider_output_shape tool")
+	assert.True(t, toolNames["dry_run_solution"], "expected dry_run_solution tool")
+	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool")
 }
 
 func TestIntegration_MCPServeProtocol(t *testing.T) {
@@ -4600,4 +4606,235 @@ func TestIntegration_Plugins_Install_NoPlugins(t *testing.T) {
 	_ = stderr
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "No plugins declared")
+}
+
+// TestIntegration_RunResolver_MetadataProvider runs the metadata provider and verifies output.
+func TestIntegration_RunResolver_MetadataProvider(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: metadata-test
+  version: 1.0.0
+spec:
+  resolvers:
+    meta:
+      resolve:
+        with:
+          - provider: metadata
+            inputs:
+              name: my-solution
+              version: 2.1.0
+              category: infrastructure
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.meta.name", "-o", "json", "--hide-execution")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "my-solution")
+}
+
+// TestIntegration_RunResolver_TemplateFunctions_Slugify verifies slugify template function.
+func TestIntegration_RunResolver_TemplateFunctions_Slugify(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: slugify-test
+  version: 1.0.0
+spec:
+  resolvers:
+    input:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "My Cool Project!"
+    slugified:
+      dependsOn: [input]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ slugify .input }}'
+              name: slugify-test
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.slugified", "-o", "json", "--hide-execution")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "my-cool-project")
+}
+
+// TestIntegration_RunResolver_TemplateFunctions_CelInline verifies inline cel template function.
+func TestIntegration_RunResolver_TemplateFunctions_CelInline(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-inline-test
+  version: 1.0.0
+spec:
+  resolvers:
+    items:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: a
+                  active: true
+                - name: b
+                  active: false
+    count:
+      dependsOn: [items]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ cel "string(size(_.items.filter(x, x.active == true)))" . }}'
+              name: cel-inline-test
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.count", "-o", "json", "--hide-execution")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "1")
+}
+
+// TestIntegration_RunResolver_TemplateFunctions_WhereSelectField verifies where and selectField template functions.
+func TestIntegration_RunResolver_TemplateFunctions_WhereSelectField(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: where-select-test
+  version: 1.0.0
+spec:
+  resolvers:
+    services:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  active: true
+                - name: web
+                  active: true
+                - name: legacy
+                  active: false
+    names:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ selectField "name" .services | toYaml }}'
+              name: select-test
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.names", "-o", "json", "--hide-execution")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "api")
+	assert.Contains(t, stdout, "legacy")
+}
+
+// TestIntegration_Lint_UnreachableTestPath verifies unreachable-test-path lint rule detects bad test file references.
+func TestIntegration_Lint_UnreachableTestPath(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unreachable-path-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  testing:
+    cases:
+      bad-test:
+        description: This test references a non-existent file
+        command: [run, resolver]
+        files:
+          - testdata/does-not-exist.json
+        assertions:
+          - expression: __exitCode == 0
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", solutionFile, "-o", "json")
+
+	// Exit code 0 = no errors (warnings only), 2 = validation errors found
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
+	assert.Contains(t, stdout, "unreachable-test-path")
+}
+
+// TestIntegration_MCPServeInfo_ExplainConcepts verifies explain_concepts tool is registered.
+func TestIntegration_MCPServeInfo_ExplainConcepts(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "serve", "--info")
+	assert.Equal(t, 0, exitCode)
+
+	var info struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &info))
+
+	toolNames := make(map[string]bool)
+	for _, tool := range info.Tools {
+		toolNames[tool.Name] = true
+	}
+	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool to be registered")
 }

--- a/tests/integration/solutions/README.md
+++ b/tests/integration/solutions/README.md
@@ -40,7 +40,9 @@ tests/integration/solutions/
 │   ├── go-template-extensions/ # Go template extensions (Sprig + toHcl + toYaml/fromYaml)
 │   ├── validation/           # Match/notMatch/expression validation
 │   ├── sleep/                # Sleep/timing
-│   ├── http/                 # HTTP requests (via mock server)
+│   ├── http/                 # HTTP requests (via mock server), autoParseJson, polling
+│   ├── github/               # GitHub API provider (via mock server)
+│   ├── exec-mocking/         # Exec command mocking (mock service rules)
 │   ├── git/                  # Git operations (via local bare repo)
 │   ├── debug/                # Debug output formatting
 │   ├── parameter/            # CLI parameter passing (-r flag)
@@ -53,6 +55,7 @@ tests/integration/solutions/
 │   ├── conditional/          # When conditions
 │   ├── timeout/              # Per-resolver timeout
 │   ├── foreach-filter/       # ForEach filter tests
+│   ├── messages/             # Custom error messages (messages.error)
 │   └── sensitive/            # Sensitive value masking
 ├── actions/                  # Workflow action tests
 │   ├── exclusive/            # Mutual exclusion (exclusive field)
@@ -149,4 +152,4 @@ These providers are excluded from functional tests due to external dependencies:
 - **`secret`** — requires keyring/credential store
 - **`identity`** — requires authentication handlers
 
-They can be added later with conditional `skipExpression` guards.
+They can be added later with conditional `skip` expression guards.

--- a/tests/integration/solutions/actions/conditional-retry/solution.yaml
+++ b/tests/integration/solutions/actions/conditional-retry/solution.yaml
@@ -54,9 +54,6 @@ spec:
           command: "echo plain retry pass"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for conditional retry tests

--- a/tests/integration/solutions/actions/conditional/solution.yaml
+++ b/tests/integration/solutions/actions/conditional/solution.yaml
@@ -71,9 +71,6 @@ spec:
           command: "echo Always running"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for conditional action tests

--- a/tests/integration/solutions/actions/error-handling/solution.yaml
+++ b/tests/integration/solutions/actions/error-handling/solution.yaml
@@ -49,9 +49,6 @@ spec:
           command: "echo after-success"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for error handling tests

--- a/tests/integration/solutions/actions/exclusive/solution.yaml
+++ b/tests/integration/solutions/actions/exclusive/solution.yaml
@@ -66,9 +66,6 @@ spec:
             expr: "'echo Deployment to ' + _.environment + ' complete'"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
     # =========================================================================
     # Base templates

--- a/tests/integration/solutions/actions/finally/solution.yaml
+++ b/tests/integration/solutions/actions/finally/solution.yaml
@@ -50,9 +50,6 @@ spec:
           command: "echo Sending completion notification"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for finally tests

--- a/tests/integration/solutions/actions/foreach/solution.yaml
+++ b/tests/integration/solutions/actions/foreach/solution.yaml
@@ -57,9 +57,6 @@ spec:
             expr: "'echo Checking health of ' + server"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for forEach tests

--- a/tests/integration/solutions/actions/parallel/solution.yaml
+++ b/tests/integration/solutions/actions/parallel/solution.yaml
@@ -60,9 +60,6 @@ spec:
             expr: "'echo Publishing ' + _.appName"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for parallel tests

--- a/tests/integration/solutions/actions/result-schema/solution.yaml
+++ b/tests/integration/solutions/actions/result-schema/solution.yaml
@@ -64,9 +64,6 @@ spec:
           command: "echo no schema validation"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for result schema tests

--- a/tests/integration/solutions/actions/retry/solution.yaml
+++ b/tests/integration/solutions/actions/retry/solution.yaml
@@ -61,9 +61,6 @@ spec:
           command: "echo no retry"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for retry tests

--- a/tests/integration/solutions/actions/sequential/solution.yaml
+++ b/tests/integration/solutions/actions/sequential/solution.yaml
@@ -65,9 +65,6 @@ spec:
             expr: "'echo Deploying ' + _.project + ' v' + _.version"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for run tests

--- a/tests/integration/solutions/actions/timeout/solution.yaml
+++ b/tests/integration/solutions/actions/timeout/solution.yaml
@@ -44,9 +44,6 @@ spec:
           command: "echo no timeout action done"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       _run-base:
         description: Base template for timeout tests

--- a/tests/integration/solutions/composed/solution.yaml
+++ b/tests/integration/solutions/composed/solution.yaml
@@ -21,7 +21,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/composition/solution.yaml
+++ b/tests/integration/solutions/composition/solution.yaml
@@ -13,7 +13,8 @@ compose:
 spec:
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
@@ -33,7 +33,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # lint: solution has intentionally invalid exclusive declarations (self-ref and missing action refs)
+      # render-defaults: invalid exclusive references cause render to fail
+      skipBuiltins: [lint, render-defaults]
 
     cases:
       lint-rejects-self-reference:

--- a/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
@@ -20,7 +20,10 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # lint: solution uses non-existent provider (does-not-exist) that lint correctly rejects
+      # resolve-defaults: resolver uses non-existent provider that fails resolution
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
 
     cases:
       unknown-provider:

--- a/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
+++ b/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
@@ -23,7 +23,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: slowResolver deliberately exceeds its timeout
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       timeout-exceeded:

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -67,7 +67,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers have intentional validation failures by design
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       valid-passes:

--- a/tests/integration/solutions/hello-world/solution.yaml
+++ b/tests/integration/solutions/hello-world/solution.yaml
@@ -18,7 +18,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       render-basic:

--- a/tests/integration/solutions/lint-schema/solution.yaml
+++ b/tests/integration/solutions/lint-schema/solution.yaml
@@ -28,9 +28,6 @@ spec:
           command: "echo ok"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
       lint-passes:
         description: Valid solution should pass lint with zero errors

--- a/tests/integration/solutions/lint-schema/unknown-field/solution.yaml
+++ b/tests/integration/solutions/lint-schema/unknown-field/solution.yaml
@@ -23,7 +23,10 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # lint: solution intentionally has unknown top-level field (unknownField) that lint correctly rejects
+      # resolve-defaults: resolver uses parameter provider requiring external input
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
 
     cases:
       schema-violation-detected:

--- a/tests/integration/solutions/lint-schema/unknown-nested-field/solution.yaml
+++ b/tests/integration/solutions/lint-schema/unknown-nested-field/solution.yaml
@@ -33,7 +33,10 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # lint: solution intentionally has unknown nested field (spec.badNestedField) that lint correctly rejects
+      # resolve-defaults: resolver uses parameter provider requiring external input
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
 
     cases:
       nested-field-detected:

--- a/tests/integration/solutions/plugins/solution.yaml
+++ b/tests/integration/solutions/plugins/solution.yaml
@@ -18,7 +18,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       plugins-help:

--- a/tests/integration/solutions/providers/cel-regex/solution.yaml
+++ b/tests/integration/solutions/providers/cel-regex/solution.yaml
@@ -1,0 +1,205 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-cel-regex
+  version: 1.0.0
+  description: |
+    Functional tests for the regex CEL extension functions.
+    Verifies regex.match, regex.replace, regex.findAll, and regex.split
+    work correctly within the CEL provider.
+
+spec:
+  resolvers:
+    # Base values for regex tests
+    textWithNumbers:
+      description: A string containing mixed text and numbers
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello 123 World 456 Foo 789"
+
+    emailList:
+      description: A string containing email addresses
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Contact user@example.com or admin@server.org for help"
+
+    csvLine:
+      description: A CSV-like string with mixed delimiters
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "apple,banana;cherry,,date;elderberry"
+
+    dirtyString:
+      description: A string with special characters to clean
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello! @world# 123"
+
+    # Regex-computed resolvers
+    matchDigits:
+      description: Check if text contains digits
+      type: bool
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.match("[0-9]+", _.textWithNumbers)'
+
+    matchNoDigits:
+      description: Check if text without digits returns false
+      type: bool
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.match("[0-9]+", "no digits here")'
+
+    replaceDigits:
+      description: Replace all digit sequences with a hash
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.replace(_.textWithNumbers, "[0-9]+", "#")'
+
+    removeSpecialChars:
+      description: Remove non-alphanumeric characters
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.replace(_.dirtyString, "[^a-zA-Z0-9 ]", "")'
+
+    findAllDigits:
+      description: Find all digit sequences
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.findAll("[0-9]+", _.textWithNumbers)'
+
+    findAllDigitsCount:
+      description: Count of digit sequences found
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'size(regex.findAll("[0-9]+", _.textWithNumbers))'
+
+    splitByDelimiters:
+      description: Split CSV with mixed delimiters
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.split("[,;]+", _.csvLine)'
+
+    splitByWhitespace:
+      description: Split text by whitespace
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.split("\\s+", _.textWithNumbers)'
+
+    # Chained operations
+    cleanAndMatch:
+      description: Clean string then check if it matches a pattern
+      type: bool
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'regex.match("^hello", regex.replace(_.dirtyString, "[^a-zA-Z0-9 ]", ""))'
+
+  testing:
+    config:
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
+
+    cases:
+      _base:
+        description: Base template for regex CEL tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, cel, regex]
+        assertions:
+          - expression: __exitCode == 0
+
+      match-digits-true:
+        description: Verify regex.match returns true when digits present
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.matchDigits == true
+            message: "regex.match should find digits in text"
+
+      match-digits-false:
+        description: Verify regex.match returns false when no digits
+        extends: [_base]
+        assertions:
+          - expression: __output.matchNoDigits == false
+            message: "regex.match should not find digits in text without digits"
+
+      replace-digits:
+        description: Verify regex.replace replaces all digit sequences
+        extends: [_base]
+        assertions:
+          - expression: '__output.replaceDigits == "Hello # World # Foo #"'
+            message: "regex.replace should replace all digit sequences with #"
+
+      remove-special-chars:
+        description: Verify regex.replace can remove characters
+        extends: [_base]
+        assertions:
+          - expression: __output.removeSpecialChars == "hello world 123"
+            message: "regex.replace should remove non-alphanumeric chars"
+
+      find-all-digits:
+        description: Verify regex.findAll returns all matches
+        extends: [_base]
+        assertions:
+          - expression: size(__output.findAllDigits) == 3
+            message: "regex.findAll should find 3 digit sequences"
+          - expression: '"123" in __output.findAllDigits'
+          - expression: '"456" in __output.findAllDigits'
+          - expression: '"789" in __output.findAllDigits'
+
+      find-all-digits-count:
+        description: Verify size of findAll result
+        extends: [_base]
+        assertions:
+          - expression: __output.findAllDigitsCount == 3
+
+      split-by-delimiters:
+        description: Verify regex.split with mixed delimiters
+        extends: [_base]
+        assertions:
+          - expression: size(__output.splitByDelimiters) == 5
+            message: "regex.split should produce 5 parts from mixed delimiters"
+          - expression: __output.splitByDelimiters[0] == "apple"
+          - expression: __output.splitByDelimiters[1] == "banana"
+
+      split-by-whitespace:
+        description: Verify regex.split by whitespace
+        extends: [_base]
+        assertions:
+          - expression: size(__output.splitByWhitespace) == 6
+            message: "regex.split by whitespace should produce 6 tokens"
+
+      chained-clean-and-match:
+        description: Verify chained regex operations
+        extends: [_base]
+        assertions:
+          - expression: __output.cleanAndMatch == true
+            message: "Chained regex.replace then regex.match should work"

--- a/tests/integration/solutions/providers/cel/solution.yaml
+++ b/tests/integration/solutions/providers/cel/solution.yaml
@@ -146,7 +146,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/debug/solution.yaml
+++ b/tests/integration/solutions/providers/debug/solution.yaml
@@ -89,7 +89,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: debugToFile resolver depends on SCAFCTL_SANDBOX_DIR env var
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/directory/solution.yaml
+++ b/tests/integration/solutions/providers/directory/solution.yaml
@@ -29,7 +29,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers depend on files created by test init steps
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/env/solution.yaml
+++ b/tests/integration/solutions/providers/env/solution.yaml
@@ -38,7 +38,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: testInjected resolver reads SCAFCTL_FUNC_TEST_VAR only set by test harness
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
       env:
         SCAFCTL_FUNC_TEST_VAR: "global-test-value"
 

--- a/tests/integration/solutions/providers/exec-mocking/solution.yaml
+++ b/tests/integration/solutions/providers/exec-mocking/solution.yaml
@@ -1,0 +1,108 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-exec-mocking
+  version: 1.0.0
+  description: |
+    Functional tests for exec command mocking.
+    Verifies that exec provider calls can be intercepted by mock rules
+    defined in testing.config.services with type: exec.
+
+spec:
+  resolvers:
+    kubectlPods:
+      description: Simulated kubectl command via exec mock
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "kubectl get pods -n production"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.stdout.trim()"
+
+    terraformPlan:
+      description: Simulated terraform plan via pattern-matched mock
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "terraform plan -out=plan.tfplan"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.stdout.trim()"
+
+    failingCommand:
+      description: Simulated failing command returning non-zero exit code
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: "curl https://unreachable.example.com"
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "string(__self.exitCode)"
+
+  testing:
+    config:
+      # resolve-defaults: resolvers use exec provider with commands that require mock services
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: exec-mock
+          type: exec
+          execRules:
+            - command: "kubectl get pods -n production"
+              stdout: |
+                NAME       READY   STATUS
+                web-1      1/1     Running
+                api-2      1/1     Running
+              exitCode: 0
+            - pattern: "^terraform plan.*"
+              stdout: "No changes. Infrastructure is up-to-date."
+              exitCode: 0
+            - pattern: "^curl.*"
+              stderr: "curl: (7) Failed to connect"
+              exitCode: 7
+
+    cases:
+      _base:
+        description: Base template for exec mock tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, exec, mock]
+        skip: 'subprocess'
+        skipReason: "exec mocking requires in-process execution; subprocess mode does not support RunFunc injection"
+        assertions:
+          - expression: __exitCode == 0
+
+      exact-command-match:
+        description: Verify exact command matching returns mocked stdout
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.kubectlPods.contains("web-1")
+            message: "Mocked kubectl should return pod list"
+          - expression: __output.kubectlPods.contains("Running")
+            message: "Pod status should be Running"
+
+      pattern-command-match:
+        description: Verify regex pattern matching returns mocked output
+        extends: [_base]
+        assertions:
+          - expression: __output.terraformPlan.contains("No changes")
+            message: "Mocked terraform plan should return no changes"
+
+      failing-command-mock:
+        description: Verify mocked non-zero exit code is captured
+        extends: [_base]
+        assertions:
+          - expression: __output.failingCommand == "7"
+            message: "Exit code should be 7 from mocked curl failure"

--- a/tests/integration/solutions/providers/exec/solution.yaml
+++ b/tests/integration/solutions/providers/exec/solution.yaml
@@ -108,7 +108,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers use exec provider requiring shell command execution
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/file/solution.yaml
+++ b/tests/integration/solutions/providers/file/solution.yaml
@@ -46,7 +46,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers read fixture files that only exist via test init steps
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/git/solution.yaml
+++ b/tests/integration/solutions/providers/git/solution.yaml
@@ -62,7 +62,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers depend on SCAFCTL_SANDBOX_DIR env var and test-created git repo
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/github/solution.yaml
+++ b/tests/integration/solutions/providers/github/solution.yaml
@@ -1,0 +1,228 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-github-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the GitHub API provider.
+    Uses a mock HTTP server to simulate GitHub API endpoints.
+    Tests repository info, file content, releases, and pull requests.
+
+spec:
+  resolvers:
+    mockBaseUrl:
+      description: Base URL of mock GitHub API server from env
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_GITHUB_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+    repoInfo:
+      description: Get repository information
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_repo
+              owner: test-org
+              repo: test-repo
+              api_base:
+                expr: "_.mockBaseUrl"
+
+    fileContent:
+      description: Get file content from repository
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_file
+              owner: test-org
+              repo: test-repo
+              path: README.md
+              ref: main
+              api_base:
+                expr: "_.mockBaseUrl"
+
+    latestRelease:
+      description: Get latest release
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_latest_release
+              owner: test-org
+              repo: test-repo
+              api_base:
+                expr: "_.mockBaseUrl"
+
+    listPullRequests:
+      description: List open pull requests
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_pull_requests
+              owner: test-org
+              repo: test-repo
+              state: open
+              per_page: 10
+              api_base:
+                expr: "_.mockBaseUrl"
+
+    pullRequestDetail:
+      description: Get a single pull request
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_pull_request
+              owner: test-org
+              repo: test-repo
+              number: 42
+              api_base:
+                expr: "_.mockBaseUrl"
+
+    listReleases:
+      description: List releases
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_releases
+              owner: test-org
+              repo: test-repo
+              per_page: 5
+              api_base:
+                expr: "_.mockBaseUrl"
+
+  testing:
+    config:
+      # resolve-defaults: resolvers depend on MOCK_GITHUB_BASE_URL env var and mock HTTP service
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: github-mock
+          type: http
+          baseUrlEnv: MOCK_GITHUB_BASE_URL
+          routes:
+            - path: /repos/test-org/test-repo
+              method: GET
+              status: 200
+              body: '{"name":"test-repo","full_name":"test-org/test-repo","description":"A test repository","default_branch":"main","private":false,"html_url":"https://github.com/test-org/test-repo","stargazers_count":42}'
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/contents/README.md
+              method: GET
+              status: 200
+              body: '{"name":"README.md","path":"README.md","sha":"abc123","size":45,"type":"file","content":"IyBUZXN0IFJlcG8KClRoaXMgaXMgYSB0ZXN0Lg==","encoding":"base64"}'
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/releases/latest
+              method: GET
+              status: 200
+              body: '{"tag_name":"v1.2.3","name":"Release 1.2.3","body":"Bug fixes and improvements","published_at":"2025-01-15T00:00:00Z","prerelease":false}'
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/pulls
+              method: GET
+              status: 200
+              body: '[{"number":42,"title":"Add feature X","state":"open","user":{"login":"alice"},"created_at":"2025-06-01T00:00:00Z"},{"number":43,"title":"Fix bug Y","state":"open","user":{"login":"bob"},"created_at":"2025-06-02T00:00:00Z"}]'
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/pulls/42
+              method: GET
+              status: 200
+              body: '{"number":42,"title":"Add feature X","state":"open","body":"This PR adds feature X","user":{"login":"alice"},"mergeable":true,"created_at":"2025-06-01T00:00:00Z"}'
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/releases
+              method: GET
+              status: 200
+              body: '[{"tag_name":"v1.2.3","name":"Release 1.2.3","published_at":"2025-01-15T00:00:00Z","prerelease":false},{"tag_name":"v1.2.2","name":"Release 1.2.2","published_at":"2025-01-01T00:00:00Z","prerelease":false}]'
+              headers:
+                Content-Type: application/json
+
+    cases:
+      _base:
+        description: Base template for GitHub provider tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, github]
+        assertions:
+          - expression: __exitCode == 0
+
+      get-repo-info:
+        description: Verify get_repo returns repository metadata
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.repoInfo.result.name == "test-repo"
+            message: "Repository name should be test-repo"
+          - expression: __output.repoInfo.result.default_branch == "main"
+            message: "Default branch should be main"
+          - expression: __output.repoInfo.result.full_name == "test-org/test-repo"
+            message: "Full name should include org"
+
+      get-file-content:
+        description: Verify get_file returns decoded file content
+        extends: [_base]
+        assertions:
+          - expression: __output.fileContent.result.name == "README.md"
+            message: "File name should be README.md"
+          - expression: '__output.fileContent.result.decoded_content.contains("Test Repo")'
+            message: "Decoded content should contain the readme text"
+          - expression: __output.fileContent.result.sha == "abc123"
+            message: "SHA should match"
+
+      get-latest-release:
+        description: Verify get_latest_release returns release info
+        extends: [_base]
+        assertions:
+          - expression: __output.latestRelease.result.tag_name == "v1.2.3"
+            message: "Tag should be v1.2.3"
+          - expression: '__output.latestRelease.result.name == "Release 1.2.3"'
+            message: "Release name should match"
+
+      list-pull-requests:
+        description: Verify list_pull_requests returns array of PRs
+        extends: [_base]
+        assertions:
+          - expression: size(__output.listPullRequests.result) == 2
+            message: "Should return 2 pull requests"
+          - expression: __output.listPullRequests.result[0].number == 42.0
+            message: "First PR number should be 42"
+          - expression: __output.listPullRequests.result[0].title == "Add feature X"
+            message: "First PR title should match"
+
+      get-pull-request-detail:
+        description: Verify get_pull_request returns single PR with details
+        extends: [_base]
+        assertions:
+          - expression: __output.pullRequestDetail.result.number == 42.0
+            message: "PR number should be 42"
+          - expression: __output.pullRequestDetail.result.mergeable == true
+            message: "PR should be mergeable"
+          - expression: __output.pullRequestDetail.result.user.login == "alice"
+            message: "PR author should be alice"
+
+      list-releases:
+        description: Verify list_releases returns release array
+        extends: [_base]
+        assertions:
+          - expression: size(__output.listReleases.result) == 2
+            message: "Should return 2 releases"
+          - expression: __output.listReleases.result[0].tag_name == "v1.2.3"
+            message: "First release tag should be v1.2.3"

--- a/tests/integration/solutions/providers/go-template-extensions/solution.yaml
+++ b/tests/integration/solutions/providers/go-template-extensions/solution.yaml
@@ -434,7 +434,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -155,9 +155,55 @@ spec:
               name: tohcl-test
               template: '{{ toHcl .toHclData }}'
 
+    ignoredBlocksTemplate:
+      description: Template with ignored blocks for literal pass-through
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: ignored-blocks
+              template: |
+                name = "{{ .appName }}"
+                /*scafctl:ignore:start*/
+                tags = {
+                  Name = "${var.project}-${var.env}"
+                }
+                /*scafctl:ignore:end*/
+              ignoredBlocks:
+                - start: "/*scafctl:ignore:start*/"
+                  end: "/*scafctl:ignore:end*/"
+
+    ignoredBlocksLineTemplate:
+      description: Template with line-based ignore markers
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: ignored-blocks-line
+              template: |
+                name: {{ .appName }}
+                steps:
+                  - run: echo ${{ secrets.TOKEN }}  # scafctl:ignore
+                  - run: echo "deployed"
+              ignoredBlocks:
+                - line: "# scafctl:ignore"
+
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:
@@ -221,3 +267,27 @@ spec:
           - expression: '__output.toHclTemplate.contains("name")'
           - expression: '__output.toHclTemplate.contains("my-service")'
           - expression: '__output.toHclTemplate.contains("port")'
+
+      ignored-blocks:
+        description: Verify ignoredBlocks preserves content literally
+        extends: [_base]
+        tags: [ignoredBlocks]
+        assertions:
+          - expression: '__output.ignoredBlocksTemplate.contains("name = \"my-service\"")'
+            message: "Template variables outside ignored blocks should be rendered"
+          - expression: '__output.ignoredBlocksTemplate.contains("${var.project}")'
+            message: "Content inside ignored blocks should be preserved literally"
+          - expression: '__output.ignoredBlocksTemplate.contains("${var.env}")'
+            message: "Terraform interpolations should pass through unchanged"
+
+      ignored-blocks-line:
+        description: Verify line-based ignoredBlocks preserves single lines
+        extends: [_base]
+        tags: [ignoredBlocks]
+        assertions:
+          - expression: '__output.ignoredBlocksLineTemplate.contains("name: my-service")'
+            message: "Template variables should be rendered"
+          - expression: '__output.ignoredBlocksLineTemplate.contains("${{ secrets.TOKEN }}")'
+            message: "Line with ignore marker should be preserved literally"
+          - expression: '__output.ignoredBlocksLineTemplate.contains("echo \"deployed\"")'
+            message: "Non-ignored lines should render normally"

--- a/tests/integration/solutions/providers/hcl/solution.yaml
+++ b/tests/integration/solutions/providers/hcl/solution.yaml
@@ -219,7 +219,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/http/solution.yaml
+++ b/tests/integration/solutions/providers/http/solution.yaml
@@ -66,6 +66,32 @@ spec:
                 expr: "_.mockBaseUrl + '/__health'"
               method: GET
 
+    autoParsedGet:
+      description: GET with autoParseJson enabled
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/users'"
+              method: GET
+              autoParseJson: true
+
+    pollEndpoint:
+      description: Poll an endpoint until condition is met
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/__health'"
+              method: GET
+              autoParseJson: true
+              poll:
+                until: 'statusCode == 200'
+                interval: 1s
+                maxAttempts: 3
+
     mockBaseUrl:
       description: Base URL of mock server from env
       resolve:
@@ -82,7 +108,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers depend on MOCK_BASE_URL env var and moc  resolvers
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
       services:
         - name: mock-api
           type: http
@@ -169,3 +197,24 @@ spec:
         assertions:
           - expression: __output.healthCheck.statusCode == 200
             message: "Health endpoint should return 200"
+
+      autoparse-json:
+        description: Verify autoParseJson parses response body into structured data
+        extends: [_base]
+        tags: [autoParseJson]
+        assertions:
+          - expression: __output.autoParsedGet.statusCode == 200
+          - expression: type(__output.autoParsedGet.body) != type("")
+            message: "Body should be parsed object, not string"
+          - expression: size(__output.autoParsedGet.body.users) == 2
+            message: "Should have 2 users in parsed body"
+          - expression: __output.autoParsedGet.body.users[0].name == "alice"
+            message: "First user should be alice"
+
+      poll-until-success:
+        description: Verify poll executes until condition is met
+        extends: [_base]
+        tags: [poll]
+        assertions:
+          - expression: __output.pollEndpoint.statusCode == 200
+            message: "Poll should succeed with 200"

--- a/tests/integration/solutions/providers/metadata/solution.yaml
+++ b/tests/integration/solutions/providers/metadata/solution.yaml
@@ -1,0 +1,61 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: metadata-provider-test
+  version: 1.0.0
+  description: Integration test for the metadata provider
+  category: test
+
+spec:
+  resolvers:
+    # Full metadata map
+    full-meta:
+      resolve:
+        with:
+          - provider: metadata
+            inputs:
+              name: my-solution
+              version: 2.1.0
+              category: infrastructure
+              tags:
+                - gcp
+                - terraform
+
+    # Single field extraction
+    sol-name:
+      resolve:
+        with:
+          - provider: metadata
+            inputs:
+              field: name
+              name: my-solution
+              version: 2.1.0
+
+  testing:
+    config:
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
+    cases:
+      resolve-full-meta:
+        description: Verify full metadata map resolves correctly
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output["full-meta"].name == "my-solution"'
+            message: "name should be my-solution"
+          - expression: '__output["full-meta"].version == "2.1.0"'
+            message: "version should be 2.1.0"
+          - expression: '__output["full-meta"].category == "infrastructure"'
+            message: "category should be infrastructure"
+          - expression: 'size(__output["full-meta"].tags) == 2'
+            message: "should have 2 tags"
+
+      resolve-sol-name:
+        description: Verify single field extraction returns name
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output["sol-name"] == "my-solution"'
+            message: "should return my-solution"

--- a/tests/integration/solutions/providers/parameter/solution.yaml
+++ b/tests/integration/solutions/providers/parameter/solution.yaml
@@ -79,7 +79,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: resolvers use parameter provider requiring external -r flag input
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/sleep/solution.yaml
+++ b/tests/integration/solutions/providers/sleep/solution.yaml
@@ -20,7 +20,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/solution/solution.yaml
+++ b/tests/integration/solutions/providers/solution/solution.yaml
@@ -60,7 +60,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: child solution requires parameter inputs (message, number)
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/static/solution.yaml
+++ b/tests/integration/solutions/providers/static/solution.yaml
@@ -128,7 +128,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/template-functions/solution.yaml
+++ b/tests/integration/solutions/providers/template-functions/solution.yaml
@@ -1,0 +1,149 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-functions-test
+  version: 1.0.0
+  description: Integration test for custom Go template functions
+  category: test
+
+spec:
+  resolvers:
+    project-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "My Cool Project! (v2)"
+
+    services:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api-gateway
+                  port: 8080
+                  active: true
+                - name: auth-service
+                  port: 8081
+                  active: true
+                - name: legacy-proxy
+                  port: 9090
+                  active: false
+
+    # slugify test
+    slugified:
+      dependsOn: [project-name]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ slugify (index . "project-name") }}'
+              name: slugify-test
+
+    # toDnsString test
+    dns-label:
+      dependsOn: [project-name]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ toDnsString (index . "project-name") }}'
+              name: dns-test
+
+    # where test
+    active-services:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.services.filter(s, s.active == true)'
+
+    # selectField test
+    service-names:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ selectField "name" .services | toYaml }}'
+              name: select-test
+
+    # cel inline test
+    active-count:
+      dependsOn: [services]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ cel "string(size(_.services.filter(s, s.active == true)))" . }}'
+              name: cel-inline-test
+
+  testing:
+    config:
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
+    cases:
+      test-slugify:
+        description: Verify slugify produces correct slug
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.slugified == "my-cool-project-v2"
+            message: "slugify should produce correct slug"
+
+      test-dns-string:
+        description: Verify toDnsString produces correct DNS label
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output["dns-label"] == "my-cool-project-v2"
+            message: "toDnsString should produce correct DNS label"
+
+      test-active-count:
+        description: Verify cel inline counts active services
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output["active-count"] == "2"
+            message: "cel inline should count active services"
+
+      test-service-names:
+        description: Verify selectField extracts service names
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output["service-names"].contains("api-gateway")'
+            message: "selectField should extract api-gateway"
+          - expression: '__output["service-names"].contains("legacy-proxy")'
+            message: "selectField should extract legacy-proxy"

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -85,7 +85,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/rendering/solution.yaml
+++ b/tests/integration/solutions/rendering/solution.yaml
@@ -59,7 +59,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/conditional/solution.yaml
+++ b/tests/integration/solutions/resolvers/conditional/solution.yaml
@@ -78,7 +78,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/dag/solution.yaml
+++ b/tests/integration/solutions/resolvers/dag/solution.yaml
@@ -100,7 +100,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
+++ b/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
@@ -111,7 +111,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
     # =========================================================================

--- a/tests/integration/solutions/resolvers/messages/solution.yaml
+++ b/tests/integration/solutions/resolvers/messages/solution.yaml
@@ -1,0 +1,98 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-messages
+  version: 1.0.0
+  description: |
+    Functional tests for custom error messages on resolvers.
+    Verifies that messages.error overrides default error text
+    for validation failures, using static strings and CEL expressions.
+
+spec:
+  resolvers:
+    validPort:
+      description: Port that passes validation (no custom error expected)
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "8080"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "int(__self) >= 1024 && int(__self) <= 65535"
+              message: port out of range
+
+    invalidPortStatic:
+      description: Port that fails validation with a static custom error
+      messages:
+        error: "Port must be between 1024 and 65535. Please fix your configuration."
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "80"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "int(__self) >= 1024 && int(__self) <= 65535"
+              message: port out of range
+
+    invalidPortCel:
+      description: Port that fails validation with a CEL-based custom error
+      messages:
+        error:
+          expr: "'Custom CEL error: port validation failed with ' + __self"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "80"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "int(__self) >= 1024 && int(__self) <= 65535"
+              message: port out of range
+
+  testing:
+    config:
+      # resolve-defaults: invalidPortStatic and invalidPortCel have intentional validation failures
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+
+    cases:
+      valid-resolver-succeeds:
+        description: Resolver with valid data should resolve normally
+        command: [run, resolver, validPort]
+        args: ["-o", "json"]
+        tags: [resolver, messages]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.validPort == "8080"
+            message: "Valid port should resolve to 8080"
+
+      static-custom-error:
+        description: Verify static custom error message overrides default
+        command: [run, resolver, invalidPortStatic]
+        args: ["-o", "json"]
+        tags: [resolver, messages, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("Port must be between 1024 and 65535")'
+            message: "Custom static error message should appear in output"
+
+      cel-custom-error:
+        description: Verify CEL-based custom error message includes dynamic content
+        command: [run, resolver, invalidPortCel]
+        args: ["-o", "json"]
+        tags: [resolver, messages, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("Custom CEL error")'
+            message: "CEL-generated custom error should appear in output"

--- a/tests/integration/solutions/resolvers/sensitive/solution.yaml
+++ b/tests/integration/solutions/resolvers/sensitive/solution.yaml
@@ -30,7 +30,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       sensitive-in-json:

--- a/tests/integration/solutions/resolvers/timeout/solution.yaml
+++ b/tests/integration/solutions/resolvers/timeout/solution.yaml
@@ -36,7 +36,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/transform-chain/solution.yaml
+++ b/tests/integration/solutions/resolvers/transform-chain/solution.yaml
@@ -100,7 +100,9 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # resolve-defaults: execTransform resolver uses exec provider requiring shell execution
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/type-coercion/solution.yaml
+++ b/tests/integration/solutions/resolvers/type-coercion/solution.yaml
@@ -73,7 +73,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/until/solution.yaml
+++ b/tests/integration/solutions/resolvers/until/solution.yaml
@@ -48,7 +48,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/telemetry/solution.yaml
+++ b/tests/integration/solutions/telemetry/solution.yaml
@@ -29,7 +29,8 @@ spec:
 
   testing:
     config:
-      skipBuiltins: true
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
 
     cases:
       resolvers-succeed:

--- a/tests/integration/solutions/test-generation/solution.yaml
+++ b/tests/integration/solutions/test-generation/solution.yaml
@@ -51,9 +51,6 @@ spec:
             expr: "'echo Hello from ' + _.environment"
 
   testing:
-    config:
-      skipBuiltins: true
-
     cases:
     # =========================================================================
     # run resolver -o test


### PR DESCRIPTION
…late extensions, concepts package, and MCP tools

Add several major features across providers, CEL, templating, testing, and MCP:

Providers:
- Add GitHub provider (pkg/provider/builtin/githubprovider) for fetching GitHub resource data
- Add HTTP polling support (httpprovider/poll.go) with configurable retry and condition logic
- Add metadata provider (metadataprovider) for exposing solution/resolver metadata as resolver values

CEL Extensions:
- Add regex extension (pkg/celexp/ext/regex) with full regex match, find, replace, split, and named-group support
- Expand CEL context with additional built-in functions and improved expression evaluation

Go Template Extensions:
- Add celeval extension for evaluating CEL expressions inside Go templates
- Add collections extension with map/filter/groupBy/keys/values helpers
- Add dns extension for DNS lookups within templates
- Register all new extensions in pkg/gotmpl/ext/ext.go

Concepts:
- Introduce pkg/concepts package with built-in resolver/provider concept definitions
- Wire concepts into MCP via new tools_concepts.go tool

MCP Enhancements:
- Add tools_errors.go for structured error analysis and diagnosis
- Add tools_provider.go for provider introspection
- Expand tools_solution.go and tools_testing.go with additional capabilities
- Add MCP icons and resource updates

Solution Testing:
- Add mockexec package (soltesting/mockexec) for mocking exec provider calls in tests
- Expand sandbox, scaffold, types, and runner with snapshot, inheritance, and mock support

Linting:
- Add new lint rules and expand lint.go validation coverage

Integration Tests & Examples:
- Add integration tests for github, cel-regex, exec-mocking, metadata, http-poll, resolver messages providers
- Add example solutions: template-functions, cel-extensions, go-template-ignored-blocks, messages
- Add provider examples: github, http-autoparse, http-poll, metadata

Documentation:
- Add validation-patterns-tutorial.md and provider-output-shapes.md tutorials
- Expand provider-reference, go-templates, cel, resolver, linting, and functional-testing tutorials
- Update design docs for functional testing
