### PR TITLE
feat(identity-provider): add scope input for on-demand scoped token o…

### DIFF
--- a/docs/design/identity-provider.md
+++ b/docs/design/identity-provider.md
@@ -1,0 +1,142 @@
+---
+title: "Identity Provider"
+weight: 22
+---
+
+# Identity Provider
+
+The **identity** provider exposes authentication identity information from auth handlers. It returns non-sensitive identity data such as claims, authentication status, and identity type. It **never exposes tokens or other secrets**.
+
+## Operations
+
+| Operation | Description | Scope Support |
+|-----------|-------------|---------------|
+| `claims` | Returns identity claims (name, email, subject, etc.) | Yes — parse scoped access token JWT |
+| `status` | Returns authentication status, expiry, identity type | Yes — return scoped token metadata |
+| `groups` | Returns Entra group memberships (ObjectIDs) | No |
+| `list` | Lists all registered auth handlers | No |
+
+## Inputs
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `operation` | string | Yes | Operation to perform: `status`, `claims`, `groups`, `list` |
+| `handler` | string | No | Auth handler name (e.g., `entra`). Defaults to the first authenticated handler. |
+| `scope` | string | No | OAuth scope for scoped token operations. When set, `claims` and `status` operations mint a token with this scope and return its details instead of stored metadata. |
+
+## Default Behavior (without scope)
+
+When no `scope` is provided, the identity provider reads **stored metadata** from the auth handler's local session. This metadata was extracted from the OIDC ID token JWT at login time:
+
+- **`claims`** — returns claims (email, name, subject, tenantId, etc.) from the stored ID token
+- **`status`** — returns session status (authenticated, expiresAt, identityType) from stored metadata
+
+No network calls or token minting occurs.
+
+## Scoped Token Behavior
+
+When `scope` is provided, the identity provider calls `GetToken(scope)` on the auth handler to mint (or retrieve from cache) an **OAuth 2.0 access token** for the given scope. It then parses the access token JWT to extract claims and identity details.
+
+This is useful when you need identity information tied to a specific API audience/resource rather than the login session.
+
+### How it works
+
+1. The auth handler mints an access token for the requested scope (using a stored refresh token or other credential)
+2. Token caching is scope-aware — each scope gets its own cache slot, so repeated calls are efficient
+3. The access token JWT payload is decoded (base64url, no signature verification) to extract claims
+4. Claims and token metadata are returned in the same format as the default behavior
+5. The access token value itself is **never** included in the output
+
+### Scoped output fields
+
+When `scope` is provided, the output includes additional fields:
+
+| Field | Description |
+|-------|-------------|
+| `scopedToken` | `true` — indicates the response came from a scoped access token |
+| `tokenScope` | The OAuth scope that was requested |
+| `tokenType` | Token type (typically `Bearer`) — status operation only |
+| `flow` | Authentication flow that produced the token (e.g., `device_code`) — status operation only |
+| `sessionId` | Stable session identifier — status operation only |
+
+### Opaque tokens
+
+Some access tokens are not decodable JWTs (e.g., encrypted tokens for first-party Microsoft resources like Graph). When this happens:
+
+- Claims are returned as `null`
+- A warning is included explaining the token is opaque
+- Token metadata (expiry, scope) is still returned where available from the `Token` struct
+- The provider does **not** fail — it degrades gracefully
+
+### Scope restrictions
+
+- `scope` is only supported with `claims` and `status` operations
+- Passing `scope` with `groups` or `list` returns an error explaining the restriction
+
+## Examples
+
+### Get claims from stored metadata
+
+```yaml
+name: get-claims
+provider: identity
+inputs:
+  operation: claims
+```
+
+### Get claims from a scoped access token
+
+```yaml
+name: scoped-claims
+provider: identity
+inputs:
+  operation: claims
+  scope: api://my-app/.default
+```
+
+### Check scoped token status
+
+```yaml
+name: scoped-status
+provider: identity
+inputs:
+  operation: status
+  scope: https://management.azure.com/.default
+  handler: entra
+```
+
+### Check authentication status
+
+```yaml
+name: check-auth
+provider: identity
+inputs:
+  operation: status
+  handler: entra
+```
+
+### Get Entra group memberships
+
+```yaml
+name: user-groups
+provider: identity
+inputs:
+  operation: groups
+  handler: entra
+```
+
+### List available handlers
+
+```yaml
+name: list-handlers
+provider: identity
+inputs:
+  operation: list
+```
+
+## Architecture Notes
+
+- **JWT parsing** is handled by the shared `auth.ParseJWTClaims()` function in `pkg/auth/jwt.go`, which supports both ID tokens and access tokens with claim name fallbacks for Entra v1/v2 differences
+- **Token caching** is scope-aware in the auth layer — each `(flow, fingerprint, scope)` tuple gets a separate cache entry
+- **No secrets exposed** — the identity provider never returns the access token value, maintaining the security contract
+- **Identity type inference** — when parsing a scoped access token JWT, the provider infers whether the identity is a `user` or `service-principal` based on the presence of human-readable claims (name, email, username)

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -1393,6 +1393,48 @@ scafctl auth token entra --scope "https://management.azure.com/.default" --clip
 # Output: ✓ Token copied to clipboard (expires in 58m42s).
 ```
 
+### Inspecting Scoped Token Claims in Resolvers
+
+The `identity` provider's `scope` input lets you mint a fresh access token for a
+specific OAuth scope inside a resolver and inspect the claims or metadata parsed
+from its JWT — without ever exposing the token value. This is useful for
+preflight checks, per-API identity auditing, and debugging consent errors.
+
+```yaml
+# Mint a token for an API scope and surface the caller's identity claims
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: claims
+        scope: api://my-app/.default
+
+# Check token expiry and flow for a management-plane scope
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: status
+        scope: https://management.azure.com/.default
+        handler: entra
+```
+
+**Key differences from `auth token`:**
+
+| | `auth token` | `identity` provider (scoped) |
+|-|---|---|
+| Returns the raw token | ✅ | ❌ (token is never exposed) |
+| Parses JWT claims | ❌ | ✅ |
+| Usable inside a resolver pipeline | ❌ | ✅ |
+| Dry-run support | N/A | ✅ |
+
+When the access token is opaque (not a decodable JWT — common with Microsoft
+Graph tokens), `claims` will be `null` and a warning is emitted. Token metadata
+such as expiry and type is still returned.
+
+> **Scope restriction:** The `scope` input is only valid for `claims` and
+> `status` operations. Using it with `groups` or `list` returns an error.
+
 ### Using the Token Directly
 
 Get the full token for use with other tools:

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1173,7 +1173,9 @@ inputs:
 
 ## identity
 
-Get authentication identity information without exposing tokens.
+Get authentication identity information without exposing tokens. Supports
+reading stored session metadata or minting a fresh scoped access token to
+inspect its claims on demand.
 
 ### Capabilities
 
@@ -1183,19 +1185,43 @@ Get authentication identity information without exposing tokens.
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `operation` | string | ✅ | Operation: `status`, `claims`, `list` |
+| `operation` | string | ✅ | Operation: `status`, `claims`, `groups`, `list` |
 | `handler` | string | ❌ | Auth handler name (e.g., `entra`, `github`) |
+| `scope` | string | ❌ | OAuth scope for on-demand token minting. When set, `claims` and `status` mint a fresh access token for the scope and return its details instead of stored session metadata. Not supported for `groups` or `list`. |
+
+### Operations
+
+| Operation | Description |
+|-----------|-------------|
+| `status` | Returns authentication status, expiry, and identity type from stored session metadata (or scoped token when `scope` is set) |
+| `claims` | Returns identity claims (name, email, tenant, etc.) from stored session metadata (or scoped token JWT when `scope` is set) |
+| `groups` | Returns Entra group memberships for the authenticated user |
+| `list` | Lists all registered auth handler names |
 
 ### Output
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `operation` | string | The operation that was executed |
+| `handler` | string | The auth handler that was used |
 | `authenticated` | bool | Whether authenticated |
-| `identityType` | string | Type of identity |
-| `claims` | object | Token claims |
-| `tenantId` | string | Tenant ID |
-| `expiresAt` | string | Token expiration |
-| `handlers` | array | Available handlers (for `list`) |
+| `identityType` | string | Identity type: `user` or `service-principal` |
+| `claims` | object | Token claims (email, name, subject, tenantId, etc.) |
+| `tenantId` | string | Tenant ID (for Entra) |
+| `expiresAt` | string | Token expiration in RFC3339 format |
+| `expiresIn` | string | Human-readable duration until expiry |
+| `groups` | array | Group display names (for `groups` operation) |
+| `handlers` | array | Available handler names (for `list` operation) |
+| `scopedToken` | bool | `true` when the response was derived from a scoped access token |
+| `tokenScope` | string | The OAuth scope the token was minted for (when `scope` input was set) |
+| `tokenType` | string | Token type, typically `Bearer` (when `scope` input was set) |
+| `flow` | string | Auth flow that produced the token (when `scope` input was set) |
+| `sessionId` | string | Stable session identifier (when `scope` input was set) |
+
+> **Opaque tokens:** When `scope` is provided and the access token is not a
+> decodable JWT (e.g., encrypted Microsoft Graph tokens), claims will be `null`
+> and a warning is added to the output. Token metadata (expiry, type) is still
+> returned where available.
 
 ### Examples
 
@@ -1216,7 +1242,7 @@ resolve:
         operation: status
         handler: github
 
-# Get claims
+# Get claims from stored session metadata
 resolve:
   with:
     - provider: identity
@@ -1231,6 +1257,38 @@ resolve:
       inputs:
         operation: claims
         handler: github
+
+# Mint a scoped token and inspect its claims
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: claims
+        scope: api://my-app/.default
+
+# Check scoped token status (expiry, flow, tokenType)
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: status
+        scope: https://management.azure.com/.default
+        handler: entra
+
+# List all registered auth handlers
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: list
+
+# Get Entra group memberships
+resolve:
+  with:
+    - provider: identity
+      inputs:
+        operation: groups
+        handler: entra
 ```
 
 ---

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -15,6 +15,12 @@ Example input files for use with `scafctl run provider --input @<file>`.
 | [hcl-validate.yaml](hcl-validate.yaml) | `hcl` | Validate HCL syntax and return diagnostics |
 | [hcl-generate.yaml](hcl-generate.yaml) | `hcl` | Generate HCL from structured block data |
 | [hcl-generate-json.yaml](hcl-generate-json.yaml) | `hcl` | Generate Terraform JSON (`.tf.json`) from structured block data |
+| [identity-claims.yaml](identity-claims.yaml) | `identity` | Get identity claims from stored metadata |
+| [identity-status.yaml](identity-status.yaml) | `identity` | Check authentication status |
+| [identity-scoped-claims.yaml](identity-scoped-claims.yaml) | `identity` | Get claims from a scoped access token JWT |
+| [identity-scoped-status.yaml](identity-scoped-status.yaml) | `identity` | Check scoped token status and metadata |
+| [identity-groups.yaml](identity-groups.yaml) | `identity` | Get Entra group memberships |
+| [identity-list.yaml](identity-list.yaml) | `identity` | List available auth handlers |
 
 ## Usage
 

--- a/examples/providers/identity-claims.yaml
+++ b/examples/providers/identity-claims.yaml
@@ -1,0 +1,2 @@
+# Identity provider - get claims from stored metadata
+operation: claims

--- a/examples/providers/identity-groups.yaml
+++ b/examples/providers/identity-groups.yaml
@@ -1,0 +1,3 @@
+# Identity provider - get Entra group memberships
+operation: groups
+handler: entra

--- a/examples/providers/identity-list.yaml
+++ b/examples/providers/identity-list.yaml
@@ -1,0 +1,2 @@
+# Identity provider - list available auth handlers
+operation: list

--- a/examples/providers/identity-scoped-claims.yaml
+++ b/examples/providers/identity-scoped-claims.yaml
@@ -1,0 +1,5 @@
+# Identity provider - get claims from a scoped access token
+# Mints (or retrieves from cache) an access token for the given scope,
+# parses its JWT payload, and returns the claims.
+operation: claims
+scope: api://my-app/.default

--- a/examples/providers/identity-scoped-status.yaml
+++ b/examples/providers/identity-scoped-status.yaml
@@ -1,0 +1,7 @@
+# Identity provider - check scoped token status
+# Mints (or retrieves from cache) an access token for the given scope
+# and returns token metadata (expiry, flow, type) along with
+# identity details parsed from the JWT.
+operation: status
+scope: https://management.azure.com/.default
+handler: entra

--- a/examples/providers/identity-status.yaml
+++ b/examples/providers/identity-status.yaml
@@ -1,0 +1,3 @@
+# Identity provider - check auth status
+operation: status
+handler: entra

--- a/pkg/auth/entra/token.go
+++ b/pkg/auth/entra/token.go
@@ -5,7 +5,6 @@ package entra
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -241,55 +240,11 @@ func (h *Handler) loadMetadata(ctx context.Context) (*TokenMetadata, error) {
 }
 
 // extractClaims extracts normalized claims from the token response.
+// Delegates to the shared auth.ParseJWTClaims parser.
 func (h *Handler) extractClaims(tokenResp *TokenResponse) (*auth.Claims, error) {
 	if tokenResp.IDToken == "" {
 		return &auth.Claims{}, nil
 	}
 
-	// Parse ID token (JWT format: header.payload.signature)
-	parts := strings.SplitN(tokenResp.IDToken, ".", 3)
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid ID token format")
-	}
-
-	// Decode payload (base64url)
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ID token payload: %w", err)
-	}
-
-	var idTokenClaims struct {
-		Issuer            string `json:"iss"`
-		Subject           string `json:"sub"`
-		Audience          string `json:"aud"`
-		TenantID          string `json:"tid"`
-		ObjectID          string `json:"oid"`
-		Email             string `json:"email"`
-		PreferredUsername string `json:"preferred_username"`
-		Name              string `json:"name"`
-		IssuedAt          int64  `json:"iat"`
-		ExpiresAt         int64  `json:"exp"`
-	}
-
-	if err := json.Unmarshal(payload, &idTokenClaims); err != nil {
-		return nil, fmt.Errorf("failed to parse ID token claims: %w", err)
-	}
-
-	email := idTokenClaims.Email
-	if email == "" {
-		email = idTokenClaims.PreferredUsername
-	}
-
-	return &auth.Claims{
-		Issuer:    idTokenClaims.Issuer,
-		Subject:   idTokenClaims.Subject,
-		TenantID:  idTokenClaims.TenantID,
-		ObjectID:  idTokenClaims.ObjectID,
-		ClientID:  idTokenClaims.Audience,
-		Email:     email,
-		Name:      idTokenClaims.Name,
-		Username:  idTokenClaims.PreferredUsername,
-		IssuedAt:  time.Unix(idTokenClaims.IssuedAt, 0),
-		ExpiresAt: time.Unix(idTokenClaims.ExpiresAt, 0),
-	}, nil
+	return auth.ParseJWTClaims(tokenResp.IDToken)
 }

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -1,0 +1,111 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrOpaqueToken is returned when a token is not a decodable JWT (e.g., encrypted or opaque).
+var ErrOpaqueToken = fmt.Errorf("token is not a decodable JWT")
+
+// jwtClaims is the union of claim names found in both OIDC ID tokens and
+// OAuth 2.0 access tokens issued by Entra ID (and other common providers).
+type jwtClaims struct {
+	Issuer            string `json:"iss"`
+	Subject           string `json:"sub"`
+	Audience          string `json:"aud"`
+	TenantID          string `json:"tid"`
+	ObjectID          string `json:"oid"`
+	Email             string `json:"email"`
+	PreferredUsername string `json:"preferred_username"`
+	Name              string `json:"name"`
+	IssuedAt          int64  `json:"iat"`
+	ExpiresAt         int64  `json:"exp"`
+
+	// Access-token-specific claim names (Entra v1 tokens use appid, v2 use azp).
+	AppID            string `json:"appid"`
+	AuthorizedParty  string `json:"azp"`
+	UniqueName       string `json:"unique_name"`
+	UPN              string `json:"upn"`
+	ServicePrincipal string `json:"app_displayname"`
+}
+
+// ParseJWTClaims decodes a JWT token string (without signature verification)
+// and extracts normalized identity claims. This works for both ID tokens and
+// access tokens that are standard three-part JWTs.
+//
+// Returns ErrOpaqueToken if the token is not a decodable JWT (e.g., encrypted
+// or opaque tokens issued by some providers for first-party resources).
+func ParseJWTClaims(rawJWT string) (*Claims, error) {
+	parts := strings.SplitN(rawJWT, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: expected 3 parts, got %d", ErrOpaqueToken, len(parts))
+	}
+
+	// Decode payload (base64url, part index 1)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to decode payload: %v", ErrOpaqueToken, err)
+	}
+
+	var raw jwtClaims
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse claims: %v", ErrOpaqueToken, err)
+	}
+
+	// Resolve email: prefer email > preferred_username > upn > unique_name
+	email := raw.Email
+	if email == "" {
+		email = raw.PreferredUsername
+	}
+	if email == "" {
+		email = raw.UPN
+	}
+	if email == "" {
+		email = raw.UniqueName
+	}
+
+	// Resolve username: prefer preferred_username > upn > unique_name
+	username := raw.PreferredUsername
+	if username == "" {
+		username = raw.UPN
+	}
+	if username == "" {
+		username = raw.UniqueName
+	}
+
+	// Resolve client ID: prefer aud > azp > appid
+	clientID := raw.Audience
+	if clientID == "" {
+		clientID = raw.AuthorizedParty
+	}
+	if clientID == "" {
+		clientID = raw.AppID
+	}
+
+	claims := &Claims{
+		Issuer:   raw.Issuer,
+		Subject:  raw.Subject,
+		TenantID: raw.TenantID,
+		ObjectID: raw.ObjectID,
+		ClientID: clientID,
+		Email:    email,
+		Name:     raw.Name,
+		Username: username,
+	}
+
+	if raw.IssuedAt != 0 {
+		claims.IssuedAt = time.Unix(raw.IssuedAt, 0)
+	}
+	if raw.ExpiresAt != 0 {
+		claims.ExpiresAt = time.Unix(raw.ExpiresAt, 0)
+	}
+
+	return claims, nil
+}

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -1,0 +1,217 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildJWT constructs a minimal unsigned JWT from a claims payload for testing.
+func buildJWT(t *testing.T, payload any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	encodedBody := base64.RawURLEncoding.EncodeToString(body)
+	return header + "." + encodedBody + ".sig"
+}
+
+func TestParseJWTClaims_FullIDToken(t *testing.T) {
+	jwt := buildJWT(t, map[string]any{
+		"iss":                "https://login.microsoftonline.com/tenant-123/v2.0",
+		"sub":                "user-sub-abc",
+		"aud":                "app-client-id",
+		"tid":                "tenant-123",
+		"oid":                "obj-456",
+		"email":              "user@example.com",
+		"preferred_username": "user@example.com",
+		"name":               "Test User",
+		"iat":                1700000000,
+		"exp":                1700003600,
+	})
+
+	claims, err := ParseJWTClaims(jwt)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://login.microsoftonline.com/tenant-123/v2.0", claims.Issuer)
+	assert.Equal(t, "user-sub-abc", claims.Subject)
+	assert.Equal(t, "app-client-id", claims.ClientID)
+	assert.Equal(t, "tenant-123", claims.TenantID)
+	assert.Equal(t, "obj-456", claims.ObjectID)
+	assert.Equal(t, "user@example.com", claims.Email)
+	assert.Equal(t, "Test User", claims.Name)
+	assert.Equal(t, "user@example.com", claims.Username)
+	assert.False(t, claims.IssuedAt.IsZero())
+	assert.False(t, claims.ExpiresAt.IsZero())
+}
+
+func TestParseJWTClaims_AccessTokenV1Claims(t *testing.T) {
+	// Entra v1 access tokens use appid for client ID and upn for username
+	jwt := buildJWT(t, map[string]any{
+		"iss":         "https://sts.windows.net/tenant-123/",
+		"sub":         "v1-subject",
+		"tid":         "tenant-123",
+		"oid":         "obj-789",
+		"appid":       "v1-app-id",
+		"upn":         "upnuser@example.com",
+		"unique_name": "unique@example.com",
+		"iat":         1700000000,
+		"exp":         1700003600,
+	})
+
+	claims, err := ParseJWTClaims(jwt)
+	require.NoError(t, err)
+
+	// upn should populate both email and username since email & preferred_username are empty
+	assert.Equal(t, "upnuser@example.com", claims.Email)
+	assert.Equal(t, "upnuser@example.com", claims.Username)
+	// No aud, so clientID falls through to appid
+	assert.Equal(t, "v1-app-id", claims.ClientID)
+}
+
+func TestParseJWTClaims_AccessTokenV2Claims(t *testing.T) {
+	// Entra v2 access tokens use azp for authorized party
+	jwt := buildJWT(t, map[string]any{
+		"iss": "https://login.microsoftonline.com/tenant-123/v2.0",
+		"sub": "v2-subject",
+		"azp": "v2-azp-client",
+		"tid": "tenant-123",
+		"oid": "obj-012",
+		"iat": 1700000000,
+		"exp": 1700003600,
+	})
+
+	claims, err := ParseJWTClaims(jwt)
+	require.NoError(t, err)
+
+	// No aud, so clientID should fall through to azp
+	assert.Equal(t, "v2-azp-client", claims.ClientID)
+	assert.Equal(t, "v2-subject", claims.Subject)
+}
+
+func TestParseJWTClaims_MinimalClaims(t *testing.T) {
+	jwt := buildJWT(t, map[string]any{
+		"sub": "minimal-subject",
+	})
+
+	claims, err := ParseJWTClaims(jwt)
+	require.NoError(t, err)
+
+	assert.Equal(t, "minimal-subject", claims.Subject)
+	assert.Empty(t, claims.Email)
+	assert.Empty(t, claims.Name)
+	assert.Empty(t, claims.TenantID)
+	assert.True(t, claims.IssuedAt.IsZero())
+	assert.True(t, claims.ExpiresAt.IsZero())
+}
+
+func TestParseJWTClaims_EmailFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   map[string]any
+		wantEmail string
+		wantUser  string
+	}{
+		{
+			name:      "email present",
+			payload:   map[string]any{"email": "direct@test.com", "preferred_username": "pref@test.com"},
+			wantEmail: "direct@test.com",
+			wantUser:  "pref@test.com",
+		},
+		{
+			name:      "preferred_username fallback",
+			payload:   map[string]any{"preferred_username": "pref@test.com"},
+			wantEmail: "pref@test.com",
+			wantUser:  "pref@test.com",
+		},
+		{
+			name:      "upn fallback",
+			payload:   map[string]any{"upn": "upn@test.com"},
+			wantEmail: "upn@test.com",
+			wantUser:  "upn@test.com",
+		},
+		{
+			name:      "unique_name fallback",
+			payload:   map[string]any{"unique_name": "unique@test.com"},
+			wantEmail: "unique@test.com",
+			wantUser:  "unique@test.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt := buildJWT(t, tt.payload)
+			claims, err := ParseJWTClaims(jwt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEmail, claims.Email)
+			assert.Equal(t, tt.wantUser, claims.Username)
+		})
+	}
+}
+
+func TestParseJWTClaims_ClientIDPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  map[string]any
+		wantID   string
+	}{
+		{
+			name:    "aud takes precedence",
+			payload: map[string]any{"aud": "aud-val", "azp": "azp-val", "appid": "appid-val"},
+			wantID:  "aud-val",
+		},
+		{
+			name:    "azp fallback",
+			payload: map[string]any{"azp": "azp-val", "appid": "appid-val"},
+			wantID:  "azp-val",
+		},
+		{
+			name:    "appid fallback",
+			payload: map[string]any{"appid": "appid-val"},
+			wantID:  "appid-val",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt := buildJWT(t, tt.payload)
+			claims, err := ParseJWTClaims(jwt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, claims.ClientID)
+		})
+	}
+}
+
+func TestParseJWTClaims_NotAJWT(t *testing.T) {
+	_, err := ParseJWTClaims("not-a-jwt")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOpaqueToken))
+}
+
+func TestParseJWTClaims_InvalidBase64(t *testing.T) {
+	_, err := ParseJWTClaims("header.!!!invalid-base64!!!.sig")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOpaqueToken))
+}
+
+func TestParseJWTClaims_InvalidJSON(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	_, err := ParseJWTClaims("header." + payload + ".sig")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOpaqueToken))
+}
+
+func TestParseJWTClaims_EmptyPayload(t *testing.T) {
+	jwt := buildJWT(t, map[string]any{})
+	claims, err := ParseJWTClaims(jwt)
+	require.NoError(t, err)
+	assert.Empty(t, claims.Subject)
+	assert.Empty(t, claims.Email)
+}

--- a/pkg/provider/builtin/identityprovider/identity.go
+++ b/pkg/provider/builtin/identityprovider/identity.go
@@ -8,6 +8,7 @@ package identityprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -59,6 +60,9 @@ func NewIdentityProvider() *IdentityProvider {
 					schemahelper.WithMaxLength(*ptrs.IntPtr(50)),
 					schemahelper.WithPattern(`^[a-z][a-z0-9-]*$`),
 					schemahelper.WithExample("entra")),
+				"scope": schemahelper.StringProp("OAuth scope for scoped token operations. When set, 'claims' and 'status' operations mint a token with this scope and return its details instead of stored metadata. Not supported for 'groups' or 'list' operations.",
+					schemahelper.WithMaxLength(*ptrs.IntPtr(1024)),
+					schemahelper.WithExample("api://my-app/.default")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -73,6 +77,11 @@ func NewIdentityProvider() *IdentityProvider {
 					"expiresAt":     schemahelper.StringProp("Token expiration time in RFC3339 format", schemahelper.WithExample("2024-01-15T10:30:00Z")),
 					"expiresIn":     schemahelper.StringProp("Human-readable duration until token expires", schemahelper.WithExample("55m30s")),
 					"handlers":      schemahelper.ArrayProp("List of available auth handler names (for 'list' operation)"),
+					"scopedToken":   schemahelper.BoolProp("Whether the response was derived from a scoped access token (true when scope input was provided)"),
+					"tokenScope":    schemahelper.StringProp("The OAuth scope the token was minted for (present when scope input was provided)", schemahelper.WithExample("api://my-app/.default")),
+					"tokenType":     schemahelper.StringProp("Token type, typically Bearer (present when scope input was provided)", schemahelper.WithExample("Bearer")),
+					"flow":          schemahelper.StringProp("Authentication flow that produced the token (present when scope input was provided)", schemahelper.WithExample("device_code")),
+					"sessionId":     schemahelper.StringProp("Stable identifier of the authentication session (present when scope input was provided)"),
 				}),
 			},
 			Examples: []provider.Example{
@@ -110,6 +119,25 @@ provider: identity
 inputs:
   operation: list`,
 				},
+				{
+					Name:        "Get claims from a scoped token",
+					Description: "Mint a token for a specific OAuth scope and return the claims parsed from the access token JWT",
+					YAML: `name: scoped-claims
+provider: identity
+inputs:
+  operation: claims
+  scope: api://my-app/.default`,
+				},
+				{
+					Name:        "Check scoped token status",
+					Description: "Mint a token for a specific OAuth scope and return its metadata (expiry, flow, type)",
+					YAML: `name: scoped-status
+provider: identity
+inputs:
+  operation: status
+  scope: https://management.azure.com/.default
+  handler: entra`,
+				},
 			},
 		},
 	}
@@ -135,12 +163,18 @@ func (p *IdentityProvider) Execute(ctx context.Context, input any) (*provider.Ou
 	}
 
 	handlerName, _ := inputs["handler"].(string)
+	scope, _ := inputs["scope"].(string)
 
-	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation, "handler", handlerName)
+	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation, "handler", handlerName, "scope", scope)
+
+	// Validate scope is only used with supported operations
+	if scope != "" && (operation == "groups" || operation == "list") {
+		return nil, fmt.Errorf("%s: scope is not supported for the %q operation; it can only be used with 'claims' or 'status'", ProviderName, operation)
+	}
 
 	// Check for dry-run mode
 	if dryRun := provider.DryRunFromContext(ctx); dryRun {
-		return p.executeDryRun(operation, handlerName)
+		return p.executeDryRun(operation, handlerName, scope)
 	}
 
 	var result *provider.Output
@@ -148,9 +182,17 @@ func (p *IdentityProvider) Execute(ctx context.Context, input any) (*provider.Ou
 
 	switch operation {
 	case "status":
-		result, err = p.executeStatus(ctx, handlerName)
+		if scope != "" {
+			result, err = p.executeScopedStatus(ctx, handlerName, scope)
+		} else {
+			result, err = p.executeStatus(ctx, handlerName)
+		}
 	case "claims":
-		result, err = p.executeClaims(ctx, handlerName)
+		if scope != "" {
+			result, err = p.executeScopedClaims(ctx, handlerName, scope)
+		} else {
+			result, err = p.executeClaims(ctx, handlerName)
+		}
 	case "groups":
 		result, err = p.executeGroups(ctx, handlerName)
 	case "list":
@@ -273,47 +315,183 @@ func (p *IdentityProvider) executeClaims(ctx context.Context, handlerName string
 	}
 
 	// Build claims map from the Claims struct
-	claims := make(map[string]any)
-	if status.Claims != nil {
-		if status.Claims.Issuer != "" {
-			claims["issuer"] = status.Claims.Issuer
-		}
-		if status.Claims.Subject != "" {
-			claims["subject"] = status.Claims.Subject
-		}
-		if status.Claims.TenantID != "" {
-			claims["tenantId"] = status.Claims.TenantID
-		}
-		if status.Claims.ObjectID != "" {
-			claims["objectId"] = status.Claims.ObjectID
-		}
-		if status.Claims.ClientID != "" {
-			claims["clientId"] = status.Claims.ClientID
-		}
-		if status.Claims.Email != "" {
-			claims["email"] = status.Claims.Email
-		}
-		if status.Claims.Name != "" {
-			claims["name"] = status.Claims.Name
-		}
-		if status.Claims.Username != "" {
-			claims["username"] = status.Claims.Username
-		}
-		if !status.Claims.IssuedAt.IsZero() {
-			claims["issuedAt"] = status.Claims.IssuedAt.Format(time.RFC3339)
-		}
-		if !status.Claims.ExpiresAt.IsZero() {
-			claims["expiresAt"] = status.Claims.ExpiresAt.Format(time.RFC3339)
-		}
-
-		// Provide a display identity for convenience
-		claims["displayIdentity"] = status.Claims.DisplayIdentity()
-	}
+	claims := claimsToMap(status.Claims)
 
 	result["claims"] = claims
 	result["identityType"] = string(status.IdentityType)
 
 	return &provider.Output{Data: result}, nil
+}
+
+// executeScopedStatus mints a token for the given scope and returns status
+// derived from the token metadata rather than stored session metadata.
+func (p *IdentityProvider) executeScopedStatus(ctx context.Context, handlerName, scope string) (*provider.Output, error) {
+	handler, err := p.getHandler(ctx, handlerName)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: scope})
+	if err != nil {
+		return nil, fmt.Errorf("failed to mint scoped token from handler %q for scope %q: %w", handler.Name(), scope, err)
+	}
+
+	result := map[string]any{
+		"operation":     "status",
+		"handler":       handler.Name(),
+		"authenticated": true,
+		"scopedToken":   true,
+		"tokenScope":    scope,
+	}
+
+	if token.TokenType != "" {
+		result["tokenType"] = token.TokenType
+	}
+	if string(token.Flow) != "" {
+		result["flow"] = string(token.Flow)
+	}
+	if token.SessionID != "" {
+		result["sessionId"] = token.SessionID
+	}
+
+	if !token.ExpiresAt.IsZero() {
+		result["expiresAt"] = token.ExpiresAt.Format(time.RFC3339)
+		remaining := time.Until(token.ExpiresAt)
+		if remaining > 0 {
+			result["expiresIn"] = remaining.Truncate(time.Second).String()
+		} else {
+			result["expiresIn"] = "expired"
+		}
+	}
+
+	// Try to extract identity info from the access token JWT
+	var warnings []string
+	claims, parseErr := auth.ParseJWTClaims(token.AccessToken)
+	if parseErr != nil {
+		if errors.Is(parseErr, auth.ErrOpaqueToken) {
+			warnings = append(warnings, fmt.Sprintf("access token is not a decodable JWT — identity details unavailable: %v", parseErr))
+		} else {
+			warnings = append(warnings, fmt.Sprintf("failed to parse access token claims: %v", parseErr))
+		}
+	} else {
+		if claims.TenantID != "" {
+			result["tenantId"] = claims.TenantID
+		}
+		if string(identityTypeFromClaims(claims)) != "" {
+			result["identityType"] = string(identityTypeFromClaims(claims))
+		}
+	}
+
+	output := &provider.Output{Data: result}
+	if len(warnings) > 0 {
+		output.Warnings = warnings
+	}
+	return output, nil
+}
+
+// executeScopedClaims mints a token for the given scope and returns claims
+// parsed from the access token JWT.
+func (p *IdentityProvider) executeScopedClaims(ctx context.Context, handlerName, scope string) (*provider.Output, error) {
+	handler, err := p.getHandler(ctx, handlerName)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{Scope: scope})
+	if err != nil {
+		return nil, fmt.Errorf("failed to mint scoped token from handler %q for scope %q: %w", handler.Name(), scope, err)
+	}
+
+	result := map[string]any{
+		"operation":     "claims",
+		"handler":       handler.Name(),
+		"authenticated": true,
+		"scopedToken":   true,
+		"tokenScope":    scope,
+	}
+
+	var warnings []string
+	parsedClaims, parseErr := auth.ParseJWTClaims(token.AccessToken)
+	if parseErr != nil {
+		// Opaque/encrypted token — return token metadata without claims
+		if errors.Is(parseErr, auth.ErrOpaqueToken) {
+			warnings = append(warnings, fmt.Sprintf("access token is not a decodable JWT — claims unavailable: %v", parseErr))
+		} else {
+			warnings = append(warnings, fmt.Sprintf("failed to parse access token claims: %v", parseErr))
+		}
+		result["claims"] = nil
+
+		// Still include what we know from the token metadata
+		if !token.ExpiresAt.IsZero() {
+			result["expiresAt"] = token.ExpiresAt.Format(time.RFC3339)
+		}
+	} else {
+		// Build claims map from parsed JWT
+		claims := claimsToMap(parsedClaims)
+		result["claims"] = claims
+		result["identityType"] = string(identityTypeFromClaims(parsedClaims))
+	}
+
+	output := &provider.Output{Data: result}
+	if len(warnings) > 0 {
+		output.Warnings = warnings
+	}
+	return output, nil
+}
+
+// claimsToMap converts an auth.Claims struct to a map[string]any,
+// omitting zero-value fields.
+func claimsToMap(c *auth.Claims) map[string]any {
+	if c == nil {
+		return nil
+	}
+	claims := make(map[string]any)
+	if c.Issuer != "" {
+		claims["issuer"] = c.Issuer
+	}
+	if c.Subject != "" {
+		claims["subject"] = c.Subject
+	}
+	if c.TenantID != "" {
+		claims["tenantId"] = c.TenantID
+	}
+	if c.ObjectID != "" {
+		claims["objectId"] = c.ObjectID
+	}
+	if c.ClientID != "" {
+		claims["clientId"] = c.ClientID
+	}
+	if c.Email != "" {
+		claims["email"] = c.Email
+	}
+	if c.Name != "" {
+		claims["name"] = c.Name
+	}
+	if c.Username != "" {
+		claims["username"] = c.Username
+	}
+	if !c.IssuedAt.IsZero() {
+		claims["issuedAt"] = c.IssuedAt.Format(time.RFC3339)
+	}
+	if !c.ExpiresAt.IsZero() {
+		claims["expiresAt"] = c.ExpiresAt.Format(time.RFC3339)
+	}
+	claims["displayIdentity"] = c.DisplayIdentity()
+	return claims
+}
+
+// identityTypeFromClaims infers the identity type from JWT claims.
+// If ObjectID is present but no human-readable fields (Name, Email, Username),
+// this is likely a service principal. Otherwise, it's a user.
+func identityTypeFromClaims(c *auth.Claims) auth.IdentityType {
+	if c == nil {
+		return auth.IdentityTypeUser
+	}
+	// Service principals typically have no name/email/username in the access token
+	if c.Name == "" && c.Email == "" && c.Username == "" && c.ObjectID != "" {
+		return auth.IdentityTypeServicePrincipal
+	}
+	return auth.IdentityTypeUser
 }
 
 func (p *IdentityProvider) executeGroups(ctx context.Context, handlerName string) (*provider.Output, error) {
@@ -391,7 +569,7 @@ func (p *IdentityProvider) executeList(ctx context.Context) (*provider.Output, e
 	}, nil
 }
 
-func (p *IdentityProvider) executeDryRun(operation, handlerName string) (*provider.Output, error) {
+func (p *IdentityProvider) executeDryRun(operation, handlerName, scope string) (*provider.Output, error) {
 	result := map[string]any{
 		"operation": operation,
 	}
@@ -401,10 +579,18 @@ func (p *IdentityProvider) executeDryRun(operation, handlerName string) (*provid
 		result["handler"] = handlerName
 		result["authenticated"] = false
 		result["identityType"] = "[DRY-RUN] Not checked"
+		if scope != "" {
+			result["scopedToken"] = true
+			result["tokenScope"] = scope
+		}
 	case "claims":
 		result["handler"] = handlerName
 		result["authenticated"] = false
 		result["claims"] = nil
+		if scope != "" {
+			result["scopedToken"] = true
+			result["tokenScope"] = scope
+		}
 	case "groups":
 		result["handler"] = handlerName
 		result["groups"] = []string{}

--- a/pkg/provider/builtin/identityprovider/identity_test.go
+++ b/pkg/provider/builtin/identityprovider/identity_test.go
@@ -5,6 +5,8 @@ package identityprovider
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -530,4 +532,431 @@ func TestIdentityProvider_ExecuteGroups_DryRun(t *testing.T) {
 	assert.Equal(t, "groups", result["operation"])
 	assert.Equal(t, 0, result["count"])
 	assert.True(t, output.Metadata["dryRun"].(bool))
+}
+
+// --- Scope feature tests ---
+
+// testBuildJWT constructs a minimal unsigned JWT from a claims map for testing.
+func testBuildJWT(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	encodedBody := base64.RawURLEncoding.EncodeToString(body)
+	return header + "." + encodedBody + ".sig"
+}
+
+func TestIdentityProvider_ScopedClaims_Success(t *testing.T) {
+	p := NewIdentityProvider()
+
+	accessToken := testBuildJWT(t, map[string]any{
+		"iss":                "https://login.microsoftonline.com/tenant-123/v2.0",
+		"sub":                "scoped-subject",
+		"aud":                "api://my-app",
+		"tid":                "tenant-123",
+		"oid":                "obj-789",
+		"email":              "scoped@example.com",
+		"preferred_username": "scoped@example.com",
+		"name":               "Scoped User",
+		"iat":                1700000000,
+		"exp":                1700003600,
+	})
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       "api://my-app/.default",
+		Flow:        auth.FlowDeviceCode,
+		SessionID:   "session-123",
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "api://my-app/.default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "claims", result["operation"])
+	assert.Equal(t, "entra", result["handler"])
+	assert.True(t, result["authenticated"].(bool))
+	assert.True(t, result["scopedToken"].(bool))
+	assert.Equal(t, "api://my-app/.default", result["tokenScope"])
+
+	claims, ok := result["claims"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "scoped@example.com", claims["email"])
+	assert.Equal(t, "Scoped User", claims["name"])
+	assert.Equal(t, "tenant-123", claims["tenantId"])
+	assert.Equal(t, "scoped-subject", claims["subject"])
+	assert.Equal(t, "user", result["identityType"])
+	assert.NotEmpty(t, claims["displayIdentity"])
+
+	// Verify GetToken was called with the correct scope
+	require.Len(t, mockHandler.GetTokenCalls, 1)
+	assert.Equal(t, "api://my-app/.default", mockHandler.GetTokenCalls[0].Scope)
+
+	// No warnings for a valid JWT
+	assert.Empty(t, output.Warnings)
+}
+
+func TestIdentityProvider_ScopedClaims_OpaqueToken(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: "opaque-encrypted-token-not-a-jwt",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "https://graph.microsoft.com/.default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result := output.Data.(map[string]any)
+	assert.True(t, result["scopedToken"].(bool))
+	assert.Nil(t, result["claims"])
+
+	// Should have a warning about opaque token
+	require.NotEmpty(t, output.Warnings)
+	assert.Contains(t, output.Warnings[0], "not a decodable JWT")
+
+	// Should still include token expiry metadata
+	assert.NotEmpty(t, result["expiresAt"])
+}
+
+func TestIdentityProvider_ScopedClaims_TokenError(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetTokenError(fmt.Errorf("token acquisition failed: consent required"))
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "api://my-app/.default",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to mint scoped token")
+	assert.Contains(t, err.Error(), "consent required")
+}
+
+func TestIdentityProvider_ScopedStatus_Success(t *testing.T) {
+	p := NewIdentityProvider()
+
+	accessToken := testBuildJWT(t, map[string]any{
+		"iss":   "https://login.microsoftonline.com/tenant-abc/v2.0",
+		"sub":   "status-subject",
+		"tid":   "tenant-abc",
+		"email": "user@test.com",
+		"name":  "Status User",
+		"iat":   1700000000,
+		"exp":   1700003600,
+	})
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(30 * time.Minute),
+		Scope:       "https://management.azure.com/.default",
+		Flow:        auth.FlowDeviceCode,
+		SessionID:   "sess-456",
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "status",
+		"scope":     "https://management.azure.com/.default",
+		"handler":   "entra",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result := output.Data.(map[string]any)
+	assert.Equal(t, "status", result["operation"])
+	assert.Equal(t, "entra", result["handler"])
+	assert.True(t, result["authenticated"].(bool))
+	assert.True(t, result["scopedToken"].(bool))
+	assert.Equal(t, "https://management.azure.com/.default", result["tokenScope"])
+	assert.Equal(t, "Bearer", result["tokenType"])
+	assert.Equal(t, "device_code", result["flow"])
+	assert.Equal(t, "sess-456", result["sessionId"])
+	assert.NotEmpty(t, result["expiresAt"])
+	assert.NotEmpty(t, result["expiresIn"])
+	assert.Equal(t, "tenant-abc", result["tenantId"])
+	assert.Equal(t, "user", result["identityType"])
+
+	// No warnings for a valid JWT
+	assert.Empty(t, output.Warnings)
+}
+
+func TestIdentityProvider_ScopedStatus_OpaqueToken(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: "not.a.jwt.with.four.parts",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Flow:        auth.FlowServicePrincipal,
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "status",
+		"scope":     "api://my-app/.default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result := output.Data.(map[string]any)
+	assert.True(t, result["scopedToken"].(bool))
+	assert.True(t, result["authenticated"].(bool))
+
+	// Should have a warning about opaque token
+	require.NotEmpty(t, output.Warnings)
+	assert.Contains(t, output.Warnings[0], "not a decodable JWT")
+
+	// identityType and tenantId should NOT be present (couldn't parse JWT)
+	_, hasTenant := result["tenantId"]
+	assert.False(t, hasTenant)
+}
+
+func TestIdentityProvider_ScopedStatus_TokenError(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetTokenError(auth.ErrNotAuthenticated)
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "status",
+		"scope":     "api://my-app/.default",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to mint scoped token")
+}
+
+func TestIdentityProvider_ScopeNotSupportedForGroups(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "groups",
+		"scope":     "api://my-app/.default",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope is not supported for the \"groups\" operation")
+}
+
+func TestIdentityProvider_ScopeNotSupportedForList(t *testing.T) {
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"scope":     "api://my-app/.default",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope is not supported for the \"list\" operation")
+}
+
+func TestIdentityProvider_ScopedDryRun_Claims(t *testing.T) {
+	p := NewIdentityProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "api://my-app/.default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result := output.Data.(map[string]any)
+	assert.Equal(t, "claims", result["operation"])
+	assert.True(t, result["scopedToken"].(bool))
+	assert.Equal(t, "api://my-app/.default", result["tokenScope"])
+	assert.True(t, output.Metadata["dryRun"].(bool))
+}
+
+func TestIdentityProvider_ScopedDryRun_Status(t *testing.T) {
+	p := NewIdentityProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "status",
+		"scope":     "https://management.azure.com/.default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result := output.Data.(map[string]any)
+	assert.Equal(t, "status", result["operation"])
+	assert.True(t, result["scopedToken"].(bool))
+	assert.Equal(t, "https://management.azure.com/.default", result["tokenScope"])
+	assert.True(t, output.Metadata["dryRun"].(bool))
+}
+
+func TestIdentityProvider_ScopedClaims_ServicePrincipalDetection(t *testing.T) {
+	p := NewIdentityProvider()
+
+	// Service principal tokens typically have no name/email/username
+	accessToken := testBuildJWT(t, map[string]any{
+		"iss":   "https://login.microsoftonline.com/tenant-sp/v2.0",
+		"sub":   "sp-subject",
+		"aud":   "api://target-app",
+		"tid":   "tenant-sp",
+		"oid":   "sp-object-id",
+		"appid": "sp-app-id",
+		"iat":   1700000000,
+		"exp":   1700003600,
+	})
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.SetToken(&auth.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "api://target-app/.default",
+	})
+	require.NoError(t, err)
+
+	result := output.Data.(map[string]any)
+	assert.Equal(t, "service-principal", result["identityType"])
+}
+
+func TestIdentityProvider_WithoutScope_UsesStoredMetadata(t *testing.T) {
+	// Verify that claims without scope still uses Status() not GetToken()
+	p := NewIdentityProvider()
+
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.StatusResult = &auth.Status{
+		Authenticated: true,
+		IdentityType:  auth.IdentityTypeUser,
+		Claims: &auth.Claims{
+			Email: "stored@example.com",
+			Name:  "Stored User",
+		},
+	}
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mockHandler))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{"operation": "claims"})
+	require.NoError(t, err)
+
+	result := output.Data.(map[string]any)
+	// Should NOT have scopedToken
+	_, hasScopedToken := result["scopedToken"]
+	assert.False(t, hasScopedToken)
+
+	claims := result["claims"].(map[string]any)
+	assert.Equal(t, "stored@example.com", claims["email"])
+
+	// GetToken should NOT have been called
+	assert.Empty(t, mockHandler.GetTokenCalls)
+}
+
+func TestIdentityProvider_ScopedClaims_SpecificHandler(t *testing.T) {
+	p := NewIdentityProvider()
+
+	accessToken := testBuildJWT(t, map[string]any{
+		"sub":   "handler2-subject",
+		"email": "handler2@example.com",
+	})
+
+	handler1 := auth.NewMockHandler("handler1")
+	handler2 := auth.NewMockHandler("handler2")
+	handler2.SetToken(&auth.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(handler1))
+	require.NoError(t, registry.Register(handler2))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "claims",
+		"scope":     "api://my-app/.default",
+		"handler":   "handler2",
+	})
+	require.NoError(t, err)
+
+	result := output.Data.(map[string]any)
+	assert.Equal(t, "handler2", result["handler"])
+
+	claims := result["claims"].(map[string]any)
+	assert.Equal(t, "handler2@example.com", claims["email"])
+
+	// Verify handler2 received the call, handler1 didn't
+	assert.Len(t, handler2.GetTokenCalls, 1)
+	assert.Empty(t, handler1.GetTokenCalls)
+}
+
+func TestIdentityProvider_Descriptor_HasScopeField(t *testing.T) {
+	p := NewIdentityProvider()
+	desc := p.Descriptor()
+
+	// Verify scope is in the input schema
+	assert.Contains(t, desc.Schema.Properties, "scope")
+
+	// Verify new output fields exist
+	outputSchema, ok := desc.OutputSchemas[provider.CapabilityFrom]
+	require.True(t, ok)
+	assert.Contains(t, outputSchema.Properties, "scopedToken")
+	assert.Contains(t, outputSchema.Properties, "tokenScope")
+	assert.Contains(t, outputSchema.Properties, "tokenType")
+	assert.Contains(t, outputSchema.Properties, "flow")
+	assert.Contains(t, outputSchema.Properties, "sessionId")
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -446,6 +446,76 @@ func TestIntegration_RunProvider_HCL_DryRun(t *testing.T) {
 	assert.Contains(t, stdout, "dryRun")
 }
 
+func TestIntegration_RunProvider_Identity_DryRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation string
+		extra     []string // additional --input flags
+		wantInOut string   // substring expected in stdout
+	}{
+		{
+			name:      "claims",
+			operation: "claims",
+			wantInOut: "claims",
+		},
+		{
+			name:      "status",
+			operation: "status",
+			wantInOut: "status",
+		},
+		{
+			name:      "groups",
+			operation: "groups",
+			wantInOut: "groups",
+		},
+		{
+			name:      "list",
+			operation: "list",
+			wantInOut: "list",
+		},
+		{
+			name:      "scoped claims",
+			operation: "claims",
+			extra:     []string{"--input", "scope=api://my-app/.default"},
+			wantInOut: "scopedToken",
+		},
+		{
+			name:      "scoped status",
+			operation: "status",
+			extra:     []string{"--input", "scope=https://management.azure.com/.default"},
+			wantInOut: "scopedToken",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := []string{"run", "provider", "identity", "--input", "operation=" + tt.operation, "--dry-run", "-o", "json"}
+			args = append(args, tt.extra...)
+			stdout, _, exitCode := runScafctl(t, args...)
+
+			assert.Equal(t, 0, exitCode)
+			assert.Contains(t, stdout, "dryRun")
+			assert.Contains(t, stdout, tt.wantInOut)
+		})
+	}
+}
+
+func TestIntegration_RunProvider_Identity_ScopeRestriction(t *testing.T) {
+	t.Parallel()
+
+	// scope + groups should error (even with --dry-run, scope validation happens before dry-run check)
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "identity",
+		"--input", "operation=groups",
+		"--input", "scope=api://my-app/.default",
+		"-o", "json")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "scope is not supported")
+}
+
 func TestIntegration_RunProvider_HCL_Validate(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "run", "provider", "hcl",

--- a/tests/integration/solutions/providers/identity/solution.yaml
+++ b/tests/integration/solutions/providers/identity/solution.yaml
@@ -1,0 +1,113 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-identity-provider
+  version: 1.0.0
+  description: |
+    Functional tests for the identity provider using dry-run mode.
+    The identity provider requires active auth sessions for live tests;
+    each test case calls 'run provider identity' directly with --dry-run
+    so __output reflects the provider's own JSON output shape rather than
+    resolver keys (which would be empty under 'run resolver --dry-run').
+
+spec:
+  resolvers:
+    # Placeholder resolver so the solution parses correctly.
+    # Actual test cases below call 'run provider identity' directly.
+    _placeholder:
+      description: Placeholder — not used by any test case
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: identity-provider-tests
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      _base:
+        description: Base template for identity provider dry-run tests
+        # Each test case overrides command+args; this just sets shared tags.
+        tags: [provider, identity, dry-run]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.dryRun == true
+
+      status-dry-run:
+        description: Verify dry-run status output shape
+        extends: [_base]
+        tags: [smoke]
+        command: [run, provider, identity]
+        args: ["--input", "operation=status", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "status"
+          - expression: __output.data.authenticated == false
+          - expression: has(__output.data.identityType)
+
+      claims-dry-run:
+        description: Verify dry-run claims output shape
+        extends: [_base]
+        command: [run, provider, identity]
+        args: ["--input", "operation=claims", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "claims"
+          - expression: __output.data.authenticated == false
+
+      groups-dry-run:
+        description: Verify dry-run groups output shape
+        extends: [_base]
+        command: [run, provider, identity]
+        args: ["--input", "operation=groups", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "groups"
+          - expression: has(__output.data.groups)
+
+      list-dry-run:
+        description: Verify dry-run list output shape
+        extends: [_base]
+        command: [run, provider, identity]
+        args: ["--input", "operation=list", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "list"
+          - expression: has(__output.data.handlers)
+
+      scoped-claims-dry-run:
+        description: Verify scoped claims dry-run includes scopedToken and tokenScope
+        extends: [_base]
+        tags: [smoke]
+        command: [run, provider, identity]
+        args: ["--input", "operation=claims", "--input", "scope=api://my-app/.default", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "claims"
+          - expression: __output.data.scopedToken == true
+          - expression: __output.data.tokenScope == "api://my-app/.default"
+
+      scoped-status-dry-run:
+        description: Verify scoped status dry-run includes scopedToken and tokenScope
+        extends: [_base]
+        command: [run, provider, identity]
+        args: ["--input", "operation=status", "--input", "scope=https://management.azure.com/.default", "--input", "handler=entra", "--dry-run", "-o", "json"]
+        injectFile: false
+        assertions:
+          - expression: __output.data.operation == "status"
+          - expression: __output.data.scopedToken == true
+          - expression: __output.data.tokenScope == "https://management.azure.com/.default"
+          - expression: __output.data.handler == "entra"
+
+      scope-restriction-groups:
+        description: Verify scope is rejected for groups operation
+        command: [run, provider, identity]
+        args: ["--input", "operation=groups", "--input", "scope=api://my-app/.default", "-o", "json"]
+        injectFile: false
+        tags: [provider, identity]
+        assertions:
+          - expression: __exitCode != 0
+          - expression: __stderr.contains("scope is not supported")


### PR DESCRIPTION
…perations

Extend the identity provider with an optional 'scope' input that, when set, mints a fresh access token for the given OAuth scope and returns claims or status derived from that token's JWT rather than the stored session metadata. This enables per-resource token inspection without requiring a full re-authentication.

Key changes:
- Add 'scope' input field (string, max 1024 chars) to the identity provider schema; validate that it is unsupported for 'groups' and 'list' operations and return a descriptive error
- Add executeScopedClaims — calls handler.GetToken(scope), parses the access token JWT via auth.ParseJWTClaims, and returns claims plus identityType; gracefully handles opaque/encrypted tokens with a warning rather than an error
- Add executeScopedStatus — same token-minting path, returns expiry, flow, tokenType, sessionId, and any parseable JWT fields (tenantId, identityType) in the status output
- Add claimsToMap helper to eliminate duplicated claims-building logic shared between executeClaims and executeScopedClaims
- Add identityTypeFromClaims to infer service-principal vs user from access-token JWT claims (no name/email/username + objectId present)
- Extend executeDryRun to accept and reflect the scope parameter in dry-run output (scopedToken + tokenScope fields)
- Add output schema fields: scopedToken, tokenScope, tokenType, flow, sessionId
- Add two provider examples: identity-scoped-claims.yaml, identity-scoped-status.yaml; document them in examples/providers/README.md
- Refactor entra/token.go extractClaims to delegate JWT parsing to the shared auth.ParseJWTClaims, removing ~45 lines of duplicated decoding
- Add 11 unit tests covering success paths, opaque tokens, token errors, dry-run, scope restriction, service-principal detection, and handler selection
- Add integration tests: all-operation dry-run matrix including scoped variants, and scope-restriction enforcement for the 'groups' operation
