### PR TITLE
feat: make -f flag optional via auto-discovery across all commands

### DIFF
--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -49,6 +49,12 @@ Run the test:
 scafctl test functional -f solution.yaml
 ```
 
+If your solution file is named `solution.yaml` (or any other well-known name like `scafctl.yaml`) in the current directory or `scafctl/`/`.scafctl/` subdirectories, you can omit `-f` entirely:
+
+```bash
+scafctl test functional
+```
+
 Expected output:
 
 ```

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -31,6 +31,12 @@ scafctl includes a built-in linter that checks solution YAML files for:
 scafctl lint -f solution.yaml
 ```
 
+If your solution file is in a well-known location (`solution.yaml`, `scafctl.yaml`, etc. in the current directory or `scafctl/`/`.scafctl/` subdirectories), you can omit `-f`:
+
+```bash
+scafctl lint
+```
+
 Output shows findings in a table with severity, rule, message, and location.
 
 ### JSON Output

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -51,12 +51,12 @@ func ParseJWTClaims(rawJWT string) (*Claims, error) {
 	// Decode payload (base64url, part index 1)
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to decode payload: %v", ErrOpaqueToken, err)
+		return nil, fmt.Errorf("%w: failed to decode payload: %w", ErrOpaqueToken, err)
 	}
 
 	var raw jwtClaims
 	if err := json.Unmarshal(payload, &raw); err != nil {
-		return nil, fmt.Errorf("%w: failed to parse claims: %v", ErrOpaqueToken, err)
+		return nil, fmt.Errorf("%w: failed to parse claims: %w", ErrOpaqueToken, err)
 	}
 
 	// Resolve email: prefer email > preferred_username > upn > unique_name

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -158,9 +158,9 @@ func TestParseJWTClaims_EmailFallback(t *testing.T) {
 
 func TestParseJWTClaims_ClientIDPrecedence(t *testing.T) {
 	tests := []struct {
-		name     string
-		payload  map[string]any
-		wantID   string
+		name    string
+		payload map[string]any
+		wantID  string
 	}{
 		{
 			name:    "aud takes precedence",

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -127,7 +127,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (required for lint)")
+	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
 	cmd.Flags().StringVar(&options.Severity, "severity", "info", "Minimum severity to report: error, warning, info")
 
@@ -139,10 +139,6 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 }
 
 func runLint(ctx context.Context, opts *Options) error {
-	if opts.File == "" {
-		return fmt.Errorf("required flag \"file\" not set")
-	}
-
 	lgr := logger.FromContext(ctx)
 
 	// Set up getter with catalog resolver for bare name resolution

--- a/pkg/cmd/scafctl/plugins/install.go
+++ b/pkg/cmd/scafctl/plugins/install.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -79,10 +80,9 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to solution file (required)")
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to solution file (auto-discovered if not provided)")
 	cmd.Flags().StringVar(&opts.Platform, "platform", "", "Target platform (default: current, e.g., linux/amd64)")
 	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", "Plugin cache directory (default: $XDG_CACHE_HOME/scafctl/plugins/)")
-	_ = cmd.MarkFlagRequired("file")
 
 	return cmd
 }
@@ -91,8 +91,19 @@ func runInstall(ctx context.Context, opts *InstallOptions) error {
 	w := writer.MustFromContext(ctx)
 	lgr := logger.FromContext(ctx)
 
+	// Auto-discover solution file if not provided
+	filePath := opts.File
+	if filePath == "" {
+		filePath = get.NewGetter().FindSolution()
+	}
+	if filePath == "" {
+		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f)")
+		w.Errorf("%s", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
 	// Load the solution
-	sol, err := loadSolution(opts.File)
+	sol, err := loadSolution(filePath)
 	if err != nil {
 		w.Errorf("failed to load solution: %v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -104,7 +115,7 @@ func runInstall(ctx context.Context, opts *InstallOptions) error {
 	}
 
 	// Load lock file if available
-	lockFile, _ := bundler.LoadLockFile(filepath.Join(filepath.Dir(opts.File), bundler.DefaultLockFileName))
+	lockFile, _ := bundler.LoadLockFile(filepath.Join(filepath.Dir(filePath), bundler.DefaultLockFileName))
 	var lockPlugins []bundler.LockPlugin
 	if lockFile != nil {
 		lockPlugins = lockFile.Plugins

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -61,6 +62,9 @@ using CEL expressions, regex matching, substring checks, and golden-file
 snapshots.
 
 Examples:
+  # Auto-discover solution in current directory
+  scafctl test functional
+
   # Run all tests in a solution
   scafctl test functional -f ./solution.yaml
 
@@ -98,7 +102,7 @@ Examples:
 	}
 
 	// Register flags
-	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to the solution file")
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
 	cCmd.Flags().StringVar(&opts.TestsPath, "tests-path", "", "Path to directory containing solution files with tests")
 	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
 	cCmd.Flags().StringVar(&opts.ReportFile, "report-file", "", "Path to write JUnit XML report")
@@ -129,19 +133,21 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 		w = writer.New(opts.IOStreams, opts.CliParams)
 	}
 
-	// Validate input
-	if opts.File == "" && opts.TestsPath == "" {
-		err := fmt.Errorf("either --file (-f) or --tests-path must be specified")
+	// Determine the path to discover solutions from.
+	// Priority: --tests-path > -f > auto-discover
+	testsPath := opts.TestsPath
+	if testsPath == "" {
+		testsPath = opts.File
+	}
+	if testsPath == "" {
+		testsPath = get.NewGetter().FindSolution()
+	}
+	if testsPath == "" {
+		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f) or --tests-path")
 		if w != nil {
 			w.Errorf("%s", err)
 		}
 		return exitcode.WithCode(err, exitcode.InvalidInput)
-	}
-
-	// Determine the path to discover solutions from.
-	testsPath := opts.TestsPath
-	if testsPath == "" {
-		testsPath = opts.File
 	}
 
 	// Watch mode — delegate to the watcher loop.

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -63,8 +64,7 @@ Examples:
 		},
 	}
 
-	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to the solution file (required)")
-	_ = cCmd.MarkFlagRequired("file")
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to the solution file (auto-discovered if not provided)")
 
 	return cCmd
 }
@@ -76,8 +76,19 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 		w = writer.New(opts.IOStreams, opts.CliParams)
 	}
 
+	// Auto-discover solution file if not provided
+	filePath := opts.File
+	if filePath == "" {
+		filePath = get.NewGetter().FindSolution()
+	}
+	if filePath == "" {
+		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f)")
+		w.Errorf("%s", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
 	// Read and parse the solution
-	data, err := os.ReadFile(opts.File)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		w.Errorf("reading solution file: %s", err)
 		return exitcode.WithCode(fmt.Errorf("reading solution file: %w", err), exitcode.FileNotFound)
@@ -90,7 +101,7 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 	}
 
 	// Build scaffold input from the parsed solution
-	fileDeps := discoverFileDepsFromSolution(&sol, opts.File)
+	fileDeps := discoverFileDepsFromSolution(&sol, filePath)
 	input := &soltesting.ScaffoldInput{
 		Resolvers:        sol.Spec.Resolvers,
 		Workflow:         sol.Spec.Workflow,
@@ -108,7 +119,7 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 	}
 
 	// Write YAML header comment
-	fmt.Fprintf(opts.IOStreams.Out, "# Generated test scaffold for %s\n", opts.File)
+	fmt.Fprintf(opts.IOStreams.Out, "# Generated test scaffold for %s\n", filePath)
 	fmt.Fprintf(opts.IOStreams.Out, "# Paste this into your solution's spec section or a compose test file.\n")
 	fmt.Fprintf(opts.IOStreams.Out, "# Customize assertions and parameters to match your expected behavior.\n\n")
 	fmt.Fprint(opts.IOStreams.Out, string(out))

--- a/pkg/cmd/scafctl/test/list.go
+++ b/pkg/cmd/scafctl/test/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -44,6 +45,9 @@ Shows test names, commands, tags, and skip status without running any tests.
 Useful for discovering available tests and verifying test configuration.
 
 Examples:
+  # Auto-discover solution in current directory
+  scafctl test list
+
   # List all tests in a solution
   scafctl test list -f ./solution.yaml
 
@@ -71,7 +75,7 @@ Examples:
 	}
 
 	// Register flags
-	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to the solution file")
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
 	cCmd.Flags().StringVar(&opts.TestsPath, "tests-path", "", "Path to directory containing solution files with tests")
 	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
 	cCmd.Flags().BoolVar(&opts.IncludeBuiltins, "include-builtins", false, "Include builtin tests in the listing")
@@ -89,19 +93,21 @@ func runList(ctx context.Context, opts *ListOptions) error {
 		w = writer.New(opts.IOStreams, opts.CliParams)
 	}
 
-	// Validate input
-	if opts.File == "" && opts.TestsPath == "" {
-		err := fmt.Errorf("either --file (-f) or --tests-path must be specified")
+	// Determine the path to discover solutions from.
+	// Priority: --tests-path > -f > auto-discover
+	testsPath := opts.TestsPath
+	if testsPath == "" {
+		testsPath = opts.File
+	}
+	if testsPath == "" {
+		testsPath = get.NewGetter().FindSolution()
+	}
+	if testsPath == "" {
+		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f) or --tests-path")
 		if w != nil {
 			w.Errorf("%s", err)
 		}
 		return exitcode.WithCode(err, exitcode.InvalidInput)
-	}
-
-	// Discover solutions
-	testsPath := opts.TestsPath
-	if testsPath == "" {
-		testsPath = opts.File
 	}
 
 	solutions, err := soltesting.DiscoverSolutions(testsPath)

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -474,7 +474,7 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 func (o *Getter) FindSolution() string {
 	for _, folder := range settings.RootSolutionFolders {
 		for _, filename := range settings.SolutionFileNames {
-			fullPath := filepath.Join(folder, filename)
+			fullPath := filepath.NormalizeFilePath(pathlib.Join(folder, filename))
 			if filepath.PathExists(fullPath, o.statFunc) {
 				return fullPath
 			}
@@ -491,7 +491,7 @@ func PossibleSolutionPaths() []string {
 
 	for _, folder := range settings.RootSolutionFolders {
 		for _, filename := range settings.SolutionFileNames {
-			fullPath := filepath.Join(folder, filename)
+			fullPath := filepath.NormalizeFilePath(pathlib.Join(folder, filename))
 			paths = append(paths, fullPath)
 		}
 	}

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -561,14 +561,14 @@ func TestGetPossibleSolutionPaths(t *testing.T) {
 		paths := PossibleSolutionPaths()
 
 		// Check for some expected paths
-		// Note: empty folder creates paths like "/solution.yaml"
+		// Note: empty folder + filename produces bare "solution.yaml" (no leading slash)
 		expectedPaths := []string{
 			"scafctl/solution.yaml",
 			"scafctl/solution.yml",
 			".scafctl/solution.yaml",
-			"/solution.yaml", // Empty folder + filename
+			"solution.yaml", // Empty folder + filename
 			"scafctl/scafctl.yaml",
-			"/solution.json", // Empty folder + filename
+			"solution.json", // Empty folder + filename
 		}
 
 		for _, expected := range expectedPaths {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -69,11 +69,16 @@ func findProjectRoot() string {
 
 func runScafctl(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runScafctlInDir(t, findProjectRoot(), args...)
+}
+
+func runScafctlInDir(t *testing.T, dir string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binaryPath, args...)
-	cmd.Dir = findProjectRoot()
+	cmd.Dir = dir
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -492,7 +497,8 @@ func TestIntegration_RunProvider_Identity_DryRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := []string{"run", "provider", "identity", "--input", "operation=" + tt.operation, "--dry-run", "-o", "json"}
+			args := make([]string, 0, 8+len(tt.extra))
+			args = append(args, "run", "provider", "identity", "--input", "operation="+tt.operation, "--dry-run", "-o", "json")
 			args = append(args, tt.extra...)
 			stdout, _, exitCode := runScafctl(t, args...)
 
@@ -1734,10 +1740,12 @@ func TestIntegration_Lint_Help(t *testing.T) {
 
 func TestIntegration_Lint_RequiresFile(t *testing.T) {
 	t.Parallel()
-	_, stderr, exitCode := runScafctl(t, "lint")
+	// Run lint from an empty dir where no solution can be auto-discovered
+	emptyDir := t.TempDir()
+	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "lint")
 
 	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "required flag")
+	assert.Contains(t, stderr, "no solution path provided")
 }
 
 func TestIntegration_Lint_ValidSolution(t *testing.T) {
@@ -1886,6 +1894,32 @@ func TestIntegration_Lint_SchemaValid(t *testing.T) {
 	assert.NotContains(t, stdout, "schema-violation")
 	// May still have info-level findings (e.g., missing-description) but not schema errors
 	_ = exitCode
+}
+
+func TestIntegration_Lint_AutoDiscovery(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: auto-lint
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctlInDir(t, tmpDir, "lint", "-o", "json")
+	// Should auto-discover solution.yaml and lint it
+	assert.Contains(t, stdout, "findings")
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
 }
 
 // ============================================================================
@@ -3993,6 +4027,93 @@ spec:
 	assert.Contains(t, stdout, "composed-test", "composed test should appear in output")
 }
 
+func TestIntegration_Test_Functional_AutoDiscovery(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: auto-functional
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+  testing:
+    cases:
+      resolve-greeting:
+        description: Verify greeting resolver
+        command: [run, resolver]
+        assertions:
+          - expression: __exitCode == 0
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir,
+		"test", "functional", "--skip-builtins", "--no-color",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode, "expected auto-discovery to work\nstdout: %s\nstderr: %s", stdout, stderr)
+}
+
+func TestIntegration_Test_Functional_AutoDiscoveryNoFile(t *testing.T) {
+	t.Parallel()
+	emptyDir := t.TempDir()
+
+	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "test", "functional")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "no solution path provided")
+}
+
+func TestIntegration_Test_List_AutoDiscovery(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: auto-list
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+  testing:
+    cases:
+      resolve-greeting:
+        description: Verify greeting resolver
+        command: [run, resolver]
+        assertions:
+          - expression: __exitCode == 0
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "test", "list")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode, "expected test list to auto-discover solution.yaml")
+	assert.Contains(t, stdout, "resolve-greeting")
+}
+
+func TestIntegration_Test_List_AutoDiscoveryNoFile(t *testing.T) {
+	t.Parallel()
+	emptyDir := t.TempDir()
+
+	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "test", "list")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "no solution path provided")
+}
+
 func TestIntegration_Test_Init(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -4057,6 +4178,40 @@ func TestIntegration_Test_Init_MissingFile(t *testing.T) {
 
 	assert.NotEqual(t, 0, exitCode, "expected non-zero exit code")
 	assert.Contains(t, stderr, "reading solution file")
+}
+
+func TestIntegration_Test_Init_AutoDiscovery(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: auto-init
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctlInDir(t, tmpDir, "test", "init")
+	assert.Equal(t, 0, exitCode, "expected test init to auto-discover solution.yaml")
+	assert.Contains(t, stdout, "cases:")
+}
+
+func TestIntegration_Test_Init_AutoDiscoveryNoFile(t *testing.T) {
+	t.Parallel()
+	emptyDir := t.TempDir()
+
+	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "test", "init")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "no solution path provided")
 }
 
 // ─── MCP Server Integration Tests ────────────────────────────────────────────
@@ -4665,6 +4820,15 @@ func TestIntegration_Plugins_Install_MissingSolutionFile(t *testing.T) {
 	assert.NotEqual(t, 0, exitCode)
 }
 
+// TestIntegration_Plugins_Install_AutoDiscoveryNoFile verifies error when no solution is found.
+func TestIntegration_Plugins_Install_AutoDiscoveryNoFile(t *testing.T) {
+	t.Parallel()
+	emptyDir := t.TempDir()
+	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "plugins", "install")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "no solution path provided")
+}
+
 // TestIntegration_Plugins_Install_NoPlugins verifies install succeeds with a solution that has no plugins.
 func TestIntegration_Plugins_Install_NoPlugins(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -4675,6 +4839,33 @@ func TestIntegration_Plugins_Install_NoPlugins(t *testing.T) {
 	stdout, stderr, exitCode := runScafctl(t, "plugins", "install", "-f", "examples/resolver-demo.yaml")
 	_ = stderr
 	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "No plugins declared")
+}
+
+// TestIntegration_Plugins_Install_AutoDiscovery verifies auto-discovery of solution file.
+func TestIntegration_Plugins_Install_AutoDiscovery(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: auto-plugins
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctlInDir(t, tmpDir, "plugins", "install")
+	assert.Equal(t, 0, exitCode, "expected plugins install to auto-discover solution.yaml")
 	assert.Contains(t, stdout, "No plugins declared")
 }
 

--- a/tests/integration/solutions/auto-discovery/solution.yaml
+++ b/tests/integration/solutions/auto-discovery/solution.yaml
@@ -1,0 +1,43 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: auto-discovery-test
+  version: 1.0.0
+  description: Tests that commands auto-discover solution files when -f is not provided
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting for auto-discovery test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Discovered!
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      lint-auto-discovery:
+        description: Verify lint auto-discovers and succeeds
+        command: [lint]
+        assertions:
+          - expression: __exitCode == 0
+
+      resolve-auto-discovery:
+        description: Verify resolver resolves via auto-discovery
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "Discovered!"
+
+      test-list-auto-discovery:
+        description: Verify test list auto-discovers tests
+        command: [test, list]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: lint-auto-discovery


### PR DESCRIPTION
Add automatic solution file discovery to all commands that accept -f/--file, matching the existing behavior of \scafctl run resolver\. When -f is omitted, commands now call \get.Getter.FindSolution()\ to search for a solution file in default locations (scafctl/, .scafctl/, and the working directory) before returning an error.

Commands updated:
- scafctl lint
- scafctl test functional
- scafctl test list
- scafctl test init
- scafctl plugins install

fix: normalize auto-discovered paths using filepath.NormalizeFilePath

After switching FindSolution() and PossibleSolutionPaths() from the custom pkg/filepath.Join (which produced /solution.yaml for empty-folder entries) to the standard path/filepath.Join, restore the two normalization behaviors that pkg/filepath.NormalizeFilePath provides: stripping any colon-prefixed segment and converting backslashes to forward slashes for Windows compatibility.

fix: correct lint issues in jwt.go and jwt_test.go

- Use %w instead of %v for error wrapping (errorlint)
- Remove extraneous spaces in struct field alignment (gofumpt)

test: add auto-discovery integration tests and solution integration test

- Add runScafctlInDir helper to run commands from arbitrary directories
- Add 9 auto-discovery integration tests (positive + negative) for lint, test functional, test list, test init, and plugins install
- Add tests/integration/solutions/auto-discovery/solution.yaml solution integration test exercising auto-discovery across lint, resolver, and test list commands
- Fix TestGetPossibleSolutionPaths to expect bare filenames (e.g. solution.yaml) instead of the previously incorrect absolute paths (/solution.yaml)
