### PR TITLE
feat: add directory template rendering pipeline with render-tree and …

### DIFF
--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -1012,17 +1012,45 @@ resolve:
 
 ### file
 
-Reads data from the local filesystem.
+Filesystem operations: read, write, check existence, delete, and batch write-tree.
 
 > **Note:** Previously documented as `filesystem`.
 
 ~~~yaml
+# Read a file
 resolve:
   with:
     - provider: file
       inputs:
         operation: read
         path: ./config/name.txt
+~~~
+
+**Operations:**
+- `read` — Read file content
+- `write` — Write content to a file
+- `exists` — Check if a file exists
+- `delete` — Delete a file
+- `write-tree` — Batch-write an array of `{path, content}` entries under a base directory
+
+**`write-tree` inputs:**
+- `basePath` (required): Destination root directory
+- `entries` (required): Array of `{path, content}` objects
+- `outputPath`: Go template to transform each entry’s output path. Variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`
+
+~~~yaml
+# Batch-write rendered templates, stripping .tpl extensions
+workflow:
+  actions:
+    write-output:
+      provider: file
+      inputs:
+        operation: write-tree
+        basePath: ./output
+        entries:
+          rslvr: rendered
+        outputPath: >-
+          {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
 ~~~
 
 ---
@@ -1151,8 +1179,11 @@ resolve:
 ### go-template
 
 Renders Go text/template content with resolver data as the template context.
+Supports single-template rendering (`render`, the default) and batch directory
+rendering (`render-tree`).
 
 ~~~yaml
+# Single template render
 resolve:
   with:
     - provider: go-template
@@ -1161,12 +1192,29 @@ resolve:
         template: "Hello, {{.name}}!"
 ~~~
 
-**Inputs:**
-- `name` (required): Name for the template, used in error messages and logging
-- `template` (required): Go template content to render
+**Inputs (shared):**
+- `operation`: `render` (default) or `render-tree`
+- `name`: Name for the template (optional, defaults to `"render-tree"` for render-tree)
 - `missingKey`: Behavior when a map key is missing: `default`, `zero`, or `error`
 - `leftDelim`, `rightDelim`: Custom delimiters (default: `{{` and `}}`)
 - `data`: Additional data to merge with resolver context
+- `ignoredBlocks`: Blocks to pass through without template processing
+
+**`render-tree` inputs:**
+- `entries` (required): Array of `{path, content}` objects (typically from the directory provider with `includeContent: true`)
+
+~~~yaml
+# Batch-render a directory of templates
+resolve:
+  with:
+    - provider: go-template
+      inputs:
+        operation: render-tree
+        entries:
+          expr: '_.templateFiles.entries'
+        data:
+          rslvr: vars
+~~~
 
 ---
 

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -26,15 +26,16 @@ This tutorial walks you through using Go templates in scafctl to generate struct
 9. [Using Custom Delimiters](#using-custom-delimiters)
 10. [Using `tmpl` for Dynamic Inputs](#using-tmpl-for-dynamic-inputs)
 11. [Generating Multiple Files with ForEach](#generating-multiple-files-with-foreach)
-12. [Putting It All Together: README Generator](#putting-it-all-together-readme-generator)
-13. [Using Sprig Functions](#using-sprig-functions)
-14. [Converting Data to HCL with toHcl](#converting-data-to-hcl-with-tohcl)
-15. [Serializing and Parsing YAML with toYaml / fromYaml](#serializing-and-parsing-yaml-with-toyaml--fromyaml)
-16. [DNS-Safe Strings with slugify / toDnsString](#dns-safe-strings-with-slugify--todnsstring)
-17. [Filtering Lists with where / selectField](#filtering-lists-with-where--selectfield)
-18. [Inline CEL with cel](#inline-cel-with-cel)
-19. [Debugging Template Type Errors](#debugging-template-type-errors)
-20. [Discovering Available Functions](#discovering-available-functions)
+12. [Rendering Template Directories](#rendering-template-directories)
+13. [Putting It All Together: README Generator](#putting-it-all-together-readme-generator)
+14. [Using Sprig Functions](#using-sprig-functions)
+15. [Converting Data to HCL with toHcl](#converting-data-to-hcl-with-tohcl)
+16. [Serializing and Parsing YAML with toYaml / fromYaml](#serializing-and-parsing-yaml-with-toyaml--fromyaml)
+17. [DNS-Safe Strings with slugify / toDnsString](#dns-safe-strings-with-slugify--todnsstring)
+18. [Filtering Lists with where / selectField](#filtering-lists-with-where--selectfield)
+19. [Inline CEL with cel](#inline-cel-with-cel)
+20. [Debugging Template Type Errors](#debugging-template-type-errors)
+21. [Discovering Available Functions](#discovering-available-functions)
 
 ---
 
@@ -1217,6 +1218,121 @@ replicas: 3
 - Inside `tmpl`, the iteration variable is accessed as `{{ .svc.name }}`.
 - Both `path` and `content` can use `tmpl` — making it easy to generate unique filenames and content per item.
 - Other resolvers (like `team`) remain accessible alongside the iteration variable.
+
+---
+
+## Rendering Template Directories
+
+While `forEach` generates files from a list, the `render-tree` operation lets you
+render an **entire directory** of Go template files in one step. This is ideal
+for scaffolding complete projects where each template file retains its directory
+structure.
+
+The pattern uses three providers in sequence:
+
+1. **`directory`** — reads all template files and their content
+2. **`go-template` (render-tree)** — batch-renders every template
+3. **`file` (write-tree)** — writes the rendered files preserving structure
+
+### Step 1: Create Template Files
+
+Create a `templates/` directory with `.tpl` files:
+
+```
+templates/
+├── README.md.tpl
+└── k8s/
+    └── deployment.yaml.tpl
+```
+
+`templates/k8s/deployment.yaml.tpl`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .appName }}
+spec:
+  replicas: {{ .replicas }}
+```
+
+### Step 2: Create the Solution
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: render-tree-demo
+  version: 1.0.0
+
+spec:
+  resolvers:
+    vars:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: myapp
+                replicas: 3
+
+    templateFiles:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    rendered:
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: vars
+
+  workflow:
+    actions:
+      write-output:
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: ./output
+          entries:
+            rslvr: rendered
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+```
+
+### Step 3: Run It
+
+```bash
+scafctl run solution -f solution.yaml
+```
+
+Result:
+- `templates/k8s/deployment.yaml.tpl` → `output/k8s/deployment.yaml` (rendered, `.tpl` stripped)
+- `templates/README.md.tpl` → `output/README.md`
+
+### What You Learned
+
+- `render-tree` batch-renders an array of `{path, content}` entries
+- `write-tree` writes them to disk preserving directory structure
+- `outputPath` is a Go template for transforming output paths (variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`)
+- Use `expr: '_.resolver.entries'` to feed directory provider results into render-tree
+
+For a complete walkthrough with advanced patterns, see the
+[Template Directory Rendering]({{< relref "template-directory-rendering" >}}) tutorial.
 
 ---
 

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -161,13 +161,18 @@ transform:
 ```
 
 ### `file`
-Returns file content.
+Returns file content, or for `write-tree`, information about written files.
 
 | Capability | Fields | Type | Description |
 |-----------|--------|------|-------------|
 | from | `content` | string | Raw file content |
 | | `path` | string | Resolved file path |
 | | `size` | int | File size in bytes |
+| action (`write-tree`) | `success` | bool | Whether all files were written |
+| | `operation` | string | `"write-tree"` |
+| | `basePath` | string | Resolved base directory path |
+| | `filesWritten` | int | Number of files written |
+| | `paths` | array | Relative paths of written files |
 
 ### `directory`
 Returns directory listings.
@@ -209,11 +214,12 @@ transform:
 ```
 
 ### `go-template`
-Returns rendered template output.
+Returns rendered template output. For `render-tree`, returns an array of rendered entries.
 
 | Capability | Fields | Type | Description |
 |-----------|--------|------|-------------|
-| transform | `<rendered text>` | string | Template output as string |
+| transform (`render`) | `<rendered text>` | string | Template output as string |
+| transform (`render-tree`) | `[{path, content}]` | array | Array of rendered file entries. Each entry has `path` (string) and `content` (string). |
 
 ### `hcl`
 Varies by operation — parse returns structured data, format/validate return strings.

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -375,7 +375,8 @@ inputs:
 
 ## file
 
-Filesystem operations: read, write, check existence, delete.
+Filesystem operations: read, write, check existence, delete, and batch write
+a tree of files.
 
 ### Capabilities
 
@@ -385,11 +386,14 @@ Filesystem operations: read, write, check existence, delete.
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `operation` | string | ✅ | Operation: `read`, `write`, `exists`, `delete` |
-| `path` | string | ✅ | File path (absolute or relative) |
+| `operation` | string | ✅ | Operation: `read`, `write`, `exists`, `delete`, `write-tree` |
+| `path` | string | ❌ | File path — required for `read`, `write`, `exists`, `delete` |
 | `content` | string | ❌ | Content to write (required for `write`) |
-| `createDirs` | bool | ❌ | Create parent directories if missing |
+| `createDirs` | bool | ❌ | Create parent directories if missing (for `write`) |
 | `encoding` | string | ❌ | File encoding: `utf-8`, `binary` (default: `utf-8`) |
+| `basePath` | string | ❌ | Destination root directory (required for `write-tree`) |
+| `entries` | array | ❌ | Array of `{path, content}` objects (required for `write-tree`) |
+| `outputPath` | string | ❌ | Go template to transform each entry's path before writing (`write-tree` only). Available variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`. Sprig functions supported. |
 
 ### Output
 
@@ -399,6 +403,10 @@ Filesystem operations: read, write, check existence, delete.
 | `exists` | bool | Whether file exists |
 | `size` | int | File size in bytes |
 | `success` | bool | Operation success (action only) |
+| `operation` | string | Operation performed (`write-tree` only) |
+| `basePath` | string | Resolved base path (`write-tree` only) |
+| `filesWritten` | int | Number of files written (`write-tree` only) |
+| `paths` | array | Relative paths of files written (`write-tree` only) |
 
 ### Examples
 
@@ -427,6 +435,16 @@ resolve:
       inputs:
         operation: exists
         path: "./optional-config.yaml"
+
+# Write a tree of rendered files, stripping .tpl extensions
+provider: file
+inputs:
+  operation: write-tree
+  basePath: ./output
+  entries:
+    rslvr: rendered
+  outputPath: >-
+    {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
 ```
 
 ---
@@ -656,7 +674,8 @@ action:
 
 ## go-template
 
-Transform data using Go text/template syntax.
+Transform data using Go text/template syntax. Supports single-template rendering
+(`render`, the default) and batch directory rendering (`render-tree`).
 
 ### Capabilities
 
@@ -666,8 +685,10 @@ Transform data using Go text/template syntax.
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `template` | string | ✅ | Go template content |
-| `name` | string | ✅ | Template name (for error messages) |
+| `operation` | string | ❌ | Operation: `render` (default) or `render-tree` |
+| `template` | string | ❌ | Go template content (required for `render`) |
+| `name` | string | ❌ | Template name for error messages (defaults to `"render-tree"` for render-tree) |
+| `entries` | array | ❌ | Array of `{path, content}` objects to render (required for `render-tree`) |
 | `missingKey` | string | ❌ | Behavior for missing keys: `default`, `zero`, `error` |
 | `leftDelim` | string | ❌ | Left delimiter (default: `{{`) |
 | `rightDelim` | string | ❌ | Right delimiter (default: `}}`) |
@@ -676,7 +697,11 @@ Transform data using Go text/template syntax.
 
 ### Output
 
-Returns the rendered template as a string.
+**`render` operation:** Returns the rendered template as a string.
+
+**`render-tree` operation:** Returns an array of `{path, content}` objects where
+each `content` is the rendered result. Metadata includes `templateName` and
+`entryCount`.
 
 ### Ignored Blocks
 
@@ -733,7 +758,7 @@ The content between `start` and `end` markers (including the markers themselves)
 ### Examples
 
 ```yaml
-# Render template
+# Render a single template
 transform:
   with:
     - provider: go-template
@@ -744,6 +769,17 @@ transform:
             host: {{ .host }}
             port: {{ .port }}
             env: {{ .environment }}
+
+# Batch-render a directory of templates (render-tree)
+resolve:
+  with:
+    - provider: go-template
+      inputs:
+        operation: render-tree
+        entries:
+          expr: '_.templateFiles.entries'
+        data:
+          rslvr: vars
 ```
 
 ---

--- a/docs/tutorials/template-directory-rendering.md
+++ b/docs/tutorials/template-directory-rendering.md
@@ -1,0 +1,479 @@
+---
+title: "Template Directory Rendering"
+weight: 97
+---
+
+# Template Directory Rendering Tutorial
+
+This tutorial walks you through the recommended pattern for rendering a directory
+tree of Go templates into output files while preserving the directory structure.
+You'll learn how to combine three providers — `directory`, `go-template`, and
+`file` — in a single solution to scaffold entire projects from templates.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with solution files and Go template syntax
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Setting Up Templates](#setting-up-templates)
+3. [Reading Templates with the Directory Provider](#reading-templates-with-the-directory-provider)
+4. [Batch Rendering with render-tree](#batch-rendering-with-render-tree)
+5. [Writing Files with write-tree](#writing-files-with-write-tree)
+6. [Path Transformation with outputPath](#path-transformation-with-outputpath)
+7. [Putting It All Together](#putting-it-all-together)
+8. [Advanced Patterns](#advanced-patterns)
+
+---
+
+## Overview
+
+A common scaffolding task is:
+
+1. You have a directory of **template files** (`.tpl`, `.tmpl`, `.gotmpl`, etc.)
+2. You want to **render** each template with shared variables
+3. You want to **write** the rendered output preserving the directory structure
+
+scafctl solves this with three operations:
+
+| Step | Provider | Operation | Purpose |
+|------|----------|-----------|---------|
+| 1 | `directory` | `list` | Read template files with their content |
+| 2 | `go-template` | `render-tree` | Batch-render all templates at once |
+| 3 | `file` | `write-tree` | Write rendered files preserving structure |
+
+---
+
+## Setting Up Templates
+
+Create a `templates/` directory with your Go template files:
+
+```
+templates/
+├── README.md.tpl
+├── config/
+│   └── app.yaml.tpl
+└── k8s/
+    ├── deployment.yaml.tpl
+    └── service.yaml.tpl
+```
+
+Each `.tpl` file is a standard Go template. For example, `k8s/deployment.yaml.tpl`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .appName }}
+  namespace: {{ .namespace }}
+spec:
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      app: {{ .appName }}
+  template:
+    spec:
+      containers:
+        - name: {{ .appName }}
+          image: {{ .registry }}/{{ .appName }}:{{ .appVersion }}
+          ports:
+            - containerPort: {{ .containerPort }}
+```
+
+---
+
+## Reading Templates with the Directory Provider
+
+Use the `directory` provider with `includeContent: true` to read all templates recursively:
+
+```yaml
+resolvers:
+  templateFiles:
+    type: any
+    resolve:
+      with:
+        - provider: directory
+          inputs:
+            operation: list
+            path: ./templates
+            recursive: true
+            filterGlob: "*.tpl"
+            includeContent: true
+```
+
+This returns an object with an `entries` array. Each entry has:
+- `path` — the relative path (e.g. `k8s/deployment.yaml.tpl`)
+- `content` — the file's raw content (the unrendered template text)
+- Plus metadata like `name`, `size`, `extension`, etc.
+
+---
+
+## Batch Rendering with render-tree
+
+The `go-template` provider's `render-tree` operation takes an array of
+`{path, content}` entries and renders each `content` as a Go template:
+
+```yaml
+resolvers:
+  rendered:
+    type: any
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            operation: render-tree
+            entries:
+              expr: '_.templateFiles.entries'
+            data:
+              appName: myapp
+              namespace: production
+              replicas: 3
+              registry: ghcr.io/myorg
+              appVersion: "1.0.0"
+              containerPort: 8080
+```
+
+The output is an array of `{path, content}` where each `content` is now the
+**rendered** result. The `path` is passed through unchanged from the input.
+
+### Using a Separate Vars Resolver
+
+For cleaner solutions, define variables in their own resolver and reference them:
+
+```yaml
+resolvers:
+  vars:
+    type: any
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value:
+              appName: myapp
+              namespace: production
+              # ... more vars
+
+  rendered:
+    type: any
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            operation: render-tree
+            entries:
+              expr: '_.templateFiles.entries'
+            data:
+              rslvr: vars
+```
+
+---
+
+## Writing Files with write-tree
+
+The `file` provider's `write-tree` operation takes an array of `{path, content}`
+entries and writes them under a `basePath`:
+
+```yaml
+workflow:
+  actions:
+    write-output:
+      provider: file
+      inputs:
+        operation: write-tree
+        basePath: ./output
+        entries:
+          rslvr: rendered
+```
+
+This writes each entry as a file relative to `basePath`, automatically creating
+subdirectories as needed. Without `outputPath`, files keep their original paths:
+
+```
+./output/k8s/deployment.yaml.tpl    # Still has .tpl extension!
+./output/k8s/service.yaml.tpl
+./output/config/app.yaml.tpl
+./output/README.md.tpl
+```
+
+To strip the `.tpl` extension, use `outputPath`.
+
+---
+
+## Path Transformation with outputPath
+
+The `outputPath` field is a Go template that transforms each entry's path before
+writing. It receives these variables:
+
+| Variable | Description | Example for `k8s/deployment.yaml.tpl` |
+|----------|-------------|---------------------------------------|
+| `__filePath` | Original relative path | `k8s/deployment.yaml.tpl` |
+| `__fileName` | File name only | `deployment.yaml.tpl` |
+| `__fileStem` | File name without last extension | `deployment.yaml` |
+| `__fileExtension` | Last extension including dot | `.tpl` |
+| `__fileDir` | Directory part (empty for root files) | `k8s` |
+
+### Stripping the `.tpl` Extension
+
+The most common pattern — reconstruct the path using the stem (which drops `.tpl`):
+
+```yaml
+outputPath: >-
+  {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+```
+
+Result: `k8s/deployment.yaml.tpl` → `k8s/deployment.yaml`
+
+### Flattening All Files into One Directory
+
+Ignore the directory structure, keeping only file names:
+
+```yaml
+outputPath: "{{ .__fileName }}"
+```
+
+Result: `k8s/deployment.yaml.tpl` → `deployment.yaml.tpl`
+
+### Using Sprig Functions
+
+All [Sprig](http://masterminds.github.io/sprig/) template functions are available:
+
+```yaml
+outputPath: "{{ lower .__filePath }}"
+```
+
+Result: `SRC/MyFile.TXT` → `src/myfile.txt`
+
+### Replacing Extensions
+
+Change `.tpl` to `.generated.yaml`:
+
+```yaml
+outputPath: >-
+  {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ trimSuffix ".tpl" .__fileName }}.generated.yaml
+```
+
+---
+
+## Putting It All Together
+
+Here is a complete solution that reads templates, renders them, and writes the
+output:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-directory-rendering
+  version: 1.0.0
+  description: Render a directory of Go templates into output files
+
+spec:
+  resolvers:
+    # Variables shared across all templates
+    vars:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: myapp
+                appVersion: "1.2.0"
+                namespace: production
+                environment: prod
+                replicas: 3
+                registry: ghcr.io/myorg
+                containerPort: 8080
+                servicePort: 80
+                serviceType: ClusterIP
+                logLevel: info
+
+    # Read all template files
+    templateFiles:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: ./templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    # Render all templates with vars
+    rendered:
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: vars
+
+  workflow:
+    actions:
+      # Write rendered results, stripping .tpl extension
+      write-output:
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: ./output
+          entries:
+            rslvr: rendered
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+```
+
+Run it:
+
+```bash
+scafctl run solution -f solution.yaml
+```
+
+Inspect the output:
+
+```bash
+find ./output -type f
+# output/README.md
+# output/config/app.yaml
+# output/k8s/deployment.yaml
+# output/k8s/service.yaml
+
+cat ./output/k8s/deployment.yaml
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: myapp
+#   namespace: production
+# ...
+```
+
+---
+
+## Advanced Patterns
+
+### Combining with CEL Filtering
+
+Use a `cel` transform to filter entries before rendering — for instance, skip
+files larger than 10KB:
+
+```yaml
+resolvers:
+  small-templates:
+    type: any
+    resolve:
+      with:
+        - provider: directory
+          inputs:
+            operation: list
+            path: ./templates
+            recursive: true
+            filterGlob: "*.tpl"
+            includeContent: true
+      transforms:
+        - provider: cel
+          inputs:
+            expression: >-
+              {"entries": data.entries.filter(e, e.size < 10000)}
+```
+
+### Multiple Template Sets
+
+Render different template directories with different variables by defining
+separate resolver chains:
+
+```yaml
+resolvers:
+  frontendTemplates:
+    type: any
+    resolve:
+      with:
+        - provider: directory
+          inputs:
+            operation: list
+            path: ./templates/frontend
+            recursive: true
+            filterGlob: "*.tpl"
+            includeContent: true
+
+  backendTemplates:
+    type: any
+    resolve:
+      with:
+        - provider: directory
+          inputs:
+            operation: list
+            path: ./templates/backend
+            recursive: true
+            filterGlob: "*.tpl"
+            includeContent: true
+
+  renderedFrontend:
+    type: any
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            operation: render-tree
+            entries:
+              expr: '_.frontendTemplates.entries'
+            data:
+              framework: react
+              # ...
+
+  renderedBackend:
+    type: any
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            operation: render-tree
+            entries:
+              expr: '_.backendTemplates.entries'
+            data:
+              framework: gin
+              # ...
+```
+
+Then write each set to a different output directory:
+
+```yaml
+workflow:
+  actions:
+    write-frontend:
+      provider: file
+      inputs:
+        operation: write-tree
+        basePath: ./output/frontend
+        entries:
+          rslvr: renderedFrontend
+        outputPath: >-
+          {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+
+    write-backend:
+      provider: file
+      inputs:
+        operation: write-tree
+        basePath: ./output/backend
+        entries:
+          rslvr: renderedBackend
+        outputPath: >-
+          {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+```
+
+### Dry Run
+
+Use `--dry-run` to preview what would be written without touching the filesystem:
+
+```bash
+scafctl run solution -f solution.yaml --dry-run
+```
+
+The `write-tree` action will report all paths that *would* be written, including
+paths transformed by `outputPath`, without creating any files.

--- a/examples/solutions/template-directory/README.md
+++ b/examples/solutions/template-directory/README.md
@@ -1,0 +1,74 @@
+# Template Directory Rendering Example
+
+Demonstrates the recommended pattern for rendering a directory tree of Go
+templates into final output files, preserving the original directory structure.
+
+## What It Does
+
+1. **Reads** all `.tpl` files from `templates/` recursively using the `directory` provider
+2. **Renders** every template with shared variables using `go-template` `render-tree`
+3. **Writes** all rendered files under `./output/`, stripping the `.tpl` extension using `file` `write-tree` with `outputPath`
+
+## Directory Layout
+
+```
+template-directory/
+├── solution.yaml           # The solution definition
+├── README.md               # This file
+└── templates/
+    ├── README.md.tpl       # Project readme template
+    ├── config/
+    │   └── app.yaml.tpl    # Application config template
+    └── k8s/
+        ├── deployment.yaml.tpl
+        └── service.yaml.tpl
+```
+
+## Running
+
+```bash
+scafctl run solution -f examples/solutions/template-directory/solution.yaml
+```
+
+## Output
+
+After running, the `./output/` directory will contain:
+
+```
+output/
+├── README.md
+├── config/
+│   └── app.yaml
+└── k8s/
+    ├── deployment.yaml
+    └── service.yaml
+```
+
+Note how the `.tpl` extension is stripped automatically via the `outputPath` template.
+
+## Key Concepts
+
+### Provider Pipeline
+
+| Step | Provider | Operation | Purpose |
+|------|----------|-----------|---------|
+| 1 | `directory` | `list` | Read template files with content |
+| 2 | `go-template` | `render-tree` | Batch-render all templates |
+| 3 | `file` | `write-tree` | Write results preserving structure |
+
+### `outputPath` Template
+
+The `outputPath` field on the `file` provider's `write-tree` operation is a Go
+template that controls where each file is written (relative to `basePath`).
+Available variables:
+
+| Variable | Example for `k8s/deployment.yaml.tpl` |
+|----------|---------------------------------------|
+| `__filePath` | `k8s/deployment.yaml.tpl` |
+| `__fileName` | `deployment.yaml.tpl` |
+| `__fileStem` | `deployment.yaml` |
+| `__fileExtension` | `.tpl` |
+| `__fileDir` | `k8s` |
+
+The template `{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}`
+reconstructs the path without the `.tpl` extension.

--- a/examples/solutions/template-directory/solution.yaml
+++ b/examples/solutions/template-directory/solution.yaml
@@ -1,0 +1,117 @@
+# Template Directory Rendering Example
+#
+# Demonstrates the complete directory→render→write pipeline:
+# 1. Read a directory tree of .tpl template files (directory provider)
+# 2. Batch-render all templates with shared variables (go-template render-tree)
+# 3. Write all rendered files preserving structure, stripping .tpl extension
+#    (file provider write-tree with outputPath)
+#
+# This is the recommended pattern for scaffolding projects that use a directory
+# of templates spanning multiple subdirectories.
+#
+# Run:
+#   scafctl run solution -f examples/solutions/template-directory/solution.yaml
+#
+# After running, check the output:
+#   find ./output -type f
+#   cat ./output/k8s/deployment.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-directory-rendering
+  version: 1.0.0
+  description: |
+    Render a directory tree of Go templates into final files, preserving
+    directory structure and stripping the .tpl extension from output paths.
+
+spec:
+  resolvers:
+    # -------------------------------------------------------------------------
+    # Step 1: Define template variables
+    # -------------------------------------------------------------------------
+    vars:
+      description: Shared variables injected into every template
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: myapp
+                appVersion: "1.2.0"
+                namespace: production
+                environment: prod
+                replicas: 3
+                registry: ghcr.io/myorg
+                containerPort: 8080
+                servicePort: 80
+                serviceType: ClusterIP
+                cpuRequest: "100m"
+                cpuLimit: "500m"
+                memoryRequest: "128Mi"
+                memoryLimit: "512Mi"
+                logLevel: info
+                dbHost: postgres.svc.cluster.local
+                dbPort: 5432
+                dbName: myapp_prod
+                dbPoolSize: 20
+                cacheEnabled: true
+                cacheTTL: "300s"
+
+    # -------------------------------------------------------------------------
+    # Step 2: Read template files from the templates/ directory
+    # -------------------------------------------------------------------------
+    templateFiles:
+      description: Read all .tpl files recursively, including their content
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: examples/solutions/template-directory/templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    # -------------------------------------------------------------------------
+    # Step 3: Render all templates in one batch using render-tree
+    # -------------------------------------------------------------------------
+    rendered:
+      description: Batch-render every template file with the shared variables
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: vars
+
+  # ===========================================================================
+  # ACTIONS: Write rendered files to disk
+  # ===========================================================================
+  workflow:
+    actions:
+      # -----------------------------------------------------------------------
+      # Step 4: Write all rendered files, stripping the .tpl extension
+      # -----------------------------------------------------------------------
+      write-rendered-files:
+        description: >
+          Write the rendered templates under ./output, preserving the directory
+          structure and removing the .tpl suffix from each file name.
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: ./output
+          entries:
+            rslvr: rendered
+          # Strip the .tpl extension:
+          #   k8s/deployment.yaml.tpl → k8s/deployment.yaml
+          #   config/app.yaml.tpl     → config/app.yaml
+          #   README.md.tpl           → README.md
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}

--- a/examples/solutions/template-directory/templates/README.md.tpl
+++ b/examples/solutions/template-directory/templates/README.md.tpl
@@ -1,0 +1,25 @@
+# {{ .appName }}
+
+> Auto-generated documentation for **{{ .appName }}** ({{ .environment }})
+
+## Overview
+
+| Property     | Value                          |
+|-------------|--------------------------------|
+| Version     | {{ .appVersion }}              |
+| Namespace   | {{ .namespace }}               |
+| Environment | {{ .environment }}             |
+| Replicas    | {{ .replicas }}                |
+| Registry    | {{ .registry }}                |
+
+## Endpoints
+
+- **Service port**: {{ .servicePort }}
+- **Container port**: {{ .containerPort }}
+- **Service type**: {{ .serviceType }}
+
+## Database
+
+- **Host**: {{ .dbHost }}:{{ .dbPort }}
+- **Database**: {{ .dbName }}
+- **Pool size**: {{ .dbPoolSize }}

--- a/examples/solutions/template-directory/templates/config/app.yaml.tpl
+++ b/examples/solutions/template-directory/templates/config/app.yaml.tpl
@@ -1,0 +1,19 @@
+server:
+  host: 0.0.0.0
+  port: {{ .containerPort }}
+
+logging:
+  level: {{ .logLevel }}
+  format: json
+
+database:
+  host: {{ .dbHost }}
+  port: {{ .dbPort }}
+  name: {{ .dbName }}
+  pool:
+    maxOpen: {{ .dbPoolSize }}
+    maxIdle: 5
+
+cache:
+  enabled: {{ .cacheEnabled }}
+  ttl: {{ .cacheTTL }}

--- a/examples/solutions/template-directory/templates/k8s/deployment.yaml.tpl
+++ b/examples/solutions/template-directory/templates/k8s/deployment.yaml.tpl
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .appName }}
+  namespace: {{ .namespace }}
+  labels:
+    app: {{ .appName }}
+    version: {{ .appVersion }}
+    environment: {{ .environment }}
+spec:
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      app: {{ .appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .appName }}
+        version: {{ .appVersion }}
+    spec:
+      containers:
+        - name: {{ .appName }}
+          image: {{ .registry }}/{{ .appName }}:{{ .appVersion }}
+          ports:
+            - containerPort: {{ .containerPort }}
+          resources:
+            requests:
+              cpu: {{ .cpuRequest }}
+              memory: {{ .memoryRequest }}
+            limits:
+              cpu: {{ .cpuLimit }}
+              memory: {{ .memoryLimit }}
+          env:
+            - name: APP_ENV
+              value: {{ .environment }}
+            - name: LOG_LEVEL
+              value: {{ .logLevel }}

--- a/examples/solutions/template-directory/templates/k8s/service.yaml.tpl
+++ b/examples/solutions/template-directory/templates/k8s/service.yaml.tpl
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .appName }}
+  namespace: {{ .namespace }}
+  labels:
+    app: {{ .appName }}
+spec:
+  type: {{ .serviceType }}
+  ports:
+    - port: {{ .servicePort }}
+      targetPort: {{ .containerPort }}
+      protocol: TCP
+  selector:
+    app: {{ .appName }}

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -16,14 +16,17 @@ import (
 // that start with the specified prefix. The returned variable names do not include the prefix.
 // It returns a deduplicated, sorted list of variable names. If prefix is empty, it defaults to "_."
 //
+// Both dot notation (_.resolverName) and bracket notation (_["resolverName"]) are supported
+// for prefixes ending in "." (like "_.").
+//
 // Example:
 //
 //	expr := celexp.CelExpression("_.user.name + _.config.value")
-//	vars, err := expr.GetVariablesWithPrefix("_.")
+//	vars, err := expr.GetVariablesWithPrefix("\.")
 //	// Returns: []string{"config", "user"}, nil (sorted)
 //
-//	expr := celexp.CelExpression("ctx.user.name + ctx.config.value")
-//	vars, err := expr.GetVariablesWithPrefix("ctx.")
+//	expr := celexp.CelExpression(`_["user"].name + _["config"].value`)
+//	vars, err := expr.GetVariablesWithPrefix("_.")
 //	// Returns: []string{"config", "user"}, nil (sorted)
 func (e Expression) GetVariablesWithPrefix(prefix string) ([]string, error) {
 	// Default prefix to _. if empty
@@ -72,12 +75,17 @@ func (e Expression) GetVariablesWithPrefix(prefix string) ([]string, error) {
 }
 
 // GetUnderscoreVariables is a convenience method that calls GetVariablesWithPrefix with "_." prefix.
+// Supports both dot notation (_.name) and bracket notation (_["name"]).
 //
 // Example:
 //
 //	expr := celexp.CelExpression("_.user.name + _.config.value")
 //	vars, err := expr.GetUnderscoreVariables()
-//	// Returns: []string{"user", "config"}, nil
+//	// Returns: []string{"config", "user"}, nil
+//
+//	expr := celexp.CelExpression(`_["user"].name + _["config"].value`)
+//	vars, err := expr.GetUnderscoreVariables()
+//	// Returns: []string{"config", "user"}, nil
 func (e Expression) GetUnderscoreVariables() ([]string, error) {
 	return e.GetVariablesWithPrefix("_.")
 }
@@ -207,6 +215,20 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 	case *exprpb.Expr_CallExpr:
 		// Process function calls and their arguments
 		call := expr.GetCallExpr()
+
+		// Handle bracket/index access: _["resolverName"] is parsed as a CallExpr
+		// with function "_[_]", where args[0] is the map operand and args[1] is the key.
+		if useSelect && call.GetFunction() == "_[_]" && len(call.GetArgs()) == 2 {
+			operand := call.GetArgs()[0]
+			key := call.GetArgs()[1]
+			if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
+				// Check if the key is a string constant (e.g., _["resolverName"])
+				if key.GetConstExpr() != nil && key.GetConstExpr().GetStringValue() != "" {
+					vars[key.GetConstExpr().GetStringValue()] = struct{}{}
+				}
+			}
+		}
+
 		if call.GetTarget() != nil {
 			extractVariablesWithPrefix(call.GetTarget(), prefix, vars)
 		}

--- a/pkg/celexp/refs_test.go
+++ b/pkg/celexp/refs_test.go
@@ -235,6 +235,31 @@ func TestGetUnderscoreVariables_EdgeCases(t *testing.T) {
 			expected:   []string{"count", "minCount", "maxCount"},
 		},
 		{
+			name:       "bracket notation single",
+			expression: `_["resolverName"]`,
+			expected:   []string{"resolverName"},
+		},
+		{
+			name:       "bracket notation multiple",
+			expression: `_["first"] + _["second"]`,
+			expected:   []string{"first", "second"},
+		},
+		{
+			name:       "bracket notation mixed with dot notation",
+			expression: `_.dotAccess + _["bracketAccess"]`,
+			expected:   []string{"bracketAccess", "dotAccess"},
+		},
+		{
+			name:       "bracket notation with nested property",
+			expression: `_["config"].host`,
+			expected:   []string{"config"},
+		},
+		{
+			name:       "bracket notation duplicate with dot",
+			expression: `_.user + _["user"]`,
+			expected:   []string{"user"},
+		},
+		{
 			name:       "unclosed parenthesis",
 			expression: "_.value + (_.other",
 			wantError:  true,

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -209,6 +209,30 @@ Provider Schema Reference:
   types, which fields are required, and what outputs are available.
   The provider://reference resource gives a compact overview of all providers.
 
+Template Directory Rendering (directory → render-tree → write-tree pipeline):
+  Use this pattern to render a directory tree of Go templates with shared variables
+  and write the rendered files preserving the original directory structure.
+  
+  The pipeline uses three providers in sequence:
+  1. directory provider (operation: list): reads template files, returns entries array
+     - Use recursive: true, filterGlob: "*.tpl", includeContent: true
+  2. go-template provider (operation: render-tree): batch-renders all entries
+     - Takes entries (array of {path, content}) and data (shared template variables)
+     - entries is typically: expr: '_.templateFiles.entries' (CEL sub-key access)
+     - data is typically: rslvr: vars (references a resolver with shared variables)
+     - 'name' input is optional for render-tree (defaults to "render-tree")
+     - Returns array of {path, content} with rendered content
+  3. file provider (operation: write-tree): writes rendered entries to disk
+     - Takes basePath (output directory), entries (from render-tree), and optional outputPath
+     - outputPath is a Go template for renaming files. Available variables:
+       __filePath, __fileName, __fileStem, __fileExtension, __fileDir
+     - Example outputPath to strip .tpl extension:
+       '{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}'
+  
+  IMPORTANT: Use 'expr:' (CEL) syntax to access sub-keys of resolver outputs
+  (e.g., expr: '_.templateFiles.entries'). The 'rslvr:' syntax does not support
+  dotted sub-path access.
+
 CLI Usage Reference (use these exact flags when suggesting commands to users):
   Run a solution:       scafctl run solution -f ./solution.yaml -r key=value
   Run resolvers only:   scafctl run resolver -f ./solution.yaml -r key=value

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
@@ -42,11 +44,11 @@ func NewFileProvider() *FileProvider {
 				provider.CapabilityAction,    // write, delete operations
 				provider.CapabilityTransform, // transform operations on file content
 			},
-			Schema: schemahelper.ObjectSchema([]string{"operation", "path"}, map[string]*jsonschema.Schema{
+			Schema: schemahelper.ObjectSchema([]string{"operation"}, map[string]*jsonschema.Schema{
 				"operation": schemahelper.StringProp("Operation to perform",
 					schemahelper.WithExample("read"),
-					schemahelper.WithEnum("read", "write", "exists", "delete")),
-				"path": schemahelper.StringProp("File path (absolute or relative)",
+					schemahelper.WithEnum("read", "write", "exists", "delete", "write-tree")),
+				"path": schemahelper.StringProp("File path (absolute or relative). Required for read, write, exists, delete operations.",
 					schemahelper.WithExample("./config.yaml"),
 					schemahelper.WithMaxLength(4096)),
 				"content": schemahelper.StringProp("Content to write (required for write operation)",
@@ -59,6 +61,24 @@ func NewFileProvider() *FileProvider {
 					schemahelper.WithExample("utf-8"),
 					schemahelper.WithDefault("utf-8"),
 					schemahelper.WithEnum("utf-8", "binary")),
+				"basePath": schemahelper.StringProp("Destination root directory (required for write-tree operation). Entries are written relative to this path.",
+					schemahelper.WithExample("./output"),
+					schemahelper.WithMaxLength(4096)),
+				"entries": schemahelper.ArrayProp("Array of {path, content} objects to write (required for write-tree operation). Typically produced by the go-template provider's render-tree operation.",
+					schemahelper.WithItems(schemahelper.ObjectProp(
+						"A file entry with relative path and content to write",
+						[]string{"path", "content"},
+						map[string]*jsonschema.Schema{
+							"path":    schemahelper.StringProp("Relative file path within basePath"),
+							"content": schemahelper.StringProp("File content to write"),
+						},
+					))),
+				"outputPath": schemahelper.StringProp("Go template for transforming each entry's output path before writing (write-tree only). "+
+					"Available variables: __filePath (relative path), __fileName (base name), __fileStem (name without final extension), "+
+					"__fileExtension (final extension with dot), __fileDir (parent directory). "+
+					"Sprig functions are available. If omitted, the original entry path is used unchanged.",
+					schemahelper.WithExample("{{ .__fileDir }}/{{ .__fileStem }}"),
+					schemahelper.WithMaxLength(4096)),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -116,6 +136,29 @@ inputs:
   operation: delete
   path: /tmp/temporary-file.txt`,
 				},
+				{
+					Name:        "Write tree of rendered templates",
+					Description: "Write an array of rendered file entries to a destination directory, preserving directory structure. Typically used with the go-template provider's render-tree output.",
+					YAML: `name: write-rendered-templates
+provider: file
+inputs:
+  operation: write-tree
+  basePath: ./output
+  entries:
+    rslvr: rendered-templates`,
+				},
+				{
+					Name:        "Write tree with path transformation",
+					Description: "Write rendered templates while stripping the .tpl extension from output paths using outputPath Go template",
+					YAML: `name: write-with-path-transform
+provider: file
+inputs:
+  operation: write-tree
+  basePath: ./output
+  entries:
+    rslvr: rendered-templates
+  outputPath: "{{ .__fileDir }}/{{ .__fileStem }}"`,
+				},
 			},
 		},
 	}
@@ -139,12 +182,19 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 		return nil, fmt.Errorf("%s: operation is required and must be a string", ProviderName)
 	}
 
+	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation)
+
+	// write-tree uses basePath instead of path
+	if operation == "write-tree" {
+		return p.executeWriteTreeDispatch(ctx, inputs)
+	}
+
 	path, ok := inputs["path"].(string)
 	if !ok {
 		return nil, fmt.Errorf("%s: path is required and must be a string", ProviderName)
 	}
 
-	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation, "path", path)
+	lgr.V(1).Info("executing file operation", "provider", ProviderName, "operation", operation, "path", path)
 
 	// Convert to absolute path
 	absPath, err := filepath.Abs(path)
@@ -271,6 +321,223 @@ func (p *FileProvider) executeDelete(absPath string) (*provider.Output, error) {
 		Data: map[string]any{
 			"success": true,
 			"path":    absPath,
+		},
+	}, nil
+}
+
+// executeWriteTreeDispatch handles the write-tree operation routing (dry-run vs live).
+func (p *FileProvider) executeWriteTreeDispatch(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	basePath, ok := inputs["basePath"].(string)
+	if !ok || basePath == "" {
+		return nil, fmt.Errorf("%s: basePath is required for write-tree operation", ProviderName)
+	}
+
+	absBasePath, err := filepath.Abs(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid basePath: %w", ProviderName, err)
+	}
+
+	if provider.DryRunFromContext(ctx) {
+		return p.executeDryRunWriteTree(absBasePath, inputs)
+	}
+
+	result, err := p.executeWriteTree(absBasePath, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "operation", "write-tree")
+	return result, nil
+}
+
+// executeWriteTree writes an array of {path, content} entries to the filesystem under basePath.
+func (p *FileProvider) executeWriteTree(absBasePath string, inputs map[string]any) (*provider.Output, error) {
+	entries, err := p.parseWriteTreeEntries(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	outputPathTmpl, _ := inputs["outputPath"].(string)
+
+	var writtenPaths []string
+
+	for i, entry := range entries {
+		outputPath := entry.path
+		if outputPathTmpl != "" {
+			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, entry.path)
+			if tmplErr != nil {
+				return nil, fmt.Errorf("outputPath template failed for entries[%d] (%s): %w", i, entry.path, tmplErr)
+			}
+			outputPath = transformed
+		}
+
+		// Resolve absolute destination
+		absDest := filepath.Join(absBasePath, outputPath)
+
+		// Path traversal safety: ensure the destination is under basePath
+		if !isSubPath(absBasePath, absDest) {
+			return nil, fmt.Errorf("path traversal detected: entries[%d] path %q resolves outside basePath %q", i, outputPath, absBasePath)
+		}
+
+		// Create parent directories
+		dir := filepath.Dir(absDest)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create directories for %s: %w", outputPath, err)
+		}
+
+		// Write file
+		//nolint:gosec // 0644 is intentional for user-created files
+		if err := os.WriteFile(absDest, []byte(entry.content), 0o644); err != nil {
+			return nil, fmt.Errorf("failed to write %s: %w", outputPath, err)
+		}
+
+		writtenPaths = append(writtenPaths, outputPath)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":      true,
+			"operation":    "write-tree",
+			"basePath":     absBasePath,
+			"filesWritten": len(writtenPaths),
+			"paths":        writtenPaths,
+		},
+	}, nil
+}
+
+// writeTreeEntry holds a parsed entry for write-tree.
+type writeTreeEntry struct {
+	path    string
+	content string
+}
+
+// parseWriteTreeEntries parses and validates the entries input for write-tree.
+func (p *FileProvider) parseWriteTreeEntries(inputs map[string]any) ([]writeTreeEntry, error) {
+	entriesRaw, ok := inputs["entries"]
+	if !ok || entriesRaw == nil {
+		return nil, fmt.Errorf("entries is required for write-tree operation")
+	}
+
+	// Handle both []any and []map[string]any (the latter comes from JSON/resolver data)
+	var entryMaps []map[string]any
+	switch v := entriesRaw.(type) {
+	case []any:
+		entryMaps = make([]map[string]any, 0, len(v))
+		for i, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("entries[%d] must be a map, got %T", i, item)
+			}
+			entryMaps = append(entryMaps, m)
+		}
+	case []map[string]any:
+		entryMaps = v
+	default:
+		return nil, fmt.Errorf("entries must be an array, got %T", entriesRaw)
+	}
+
+	result := make([]writeTreeEntry, 0, len(entryMaps))
+	for i, entry := range entryMaps {
+		path, ok := entry["path"].(string)
+		if !ok || path == "" {
+			return nil, fmt.Errorf("entries[%d].path is required and must be a string", i)
+		}
+
+		content, ok := entry["content"].(string)
+		if !ok {
+			return nil, fmt.Errorf("entries[%d].content is required and must be a string", i)
+		}
+
+		result = append(result, writeTreeEntry{path: path, content: content})
+	}
+
+	return result, nil
+}
+
+// renderOutputPath renders the outputPath Go template for a given file path,
+// injecting __file* variables computed from the path.
+func (p *FileProvider) renderOutputPath(outputPathTmpl, filePath string) (string, error) {
+	// Compute __file* variables
+	fileName := filepath.Base(filePath)
+	fileExt := filepath.Ext(fileName)
+	fileStem := strings.TrimSuffix(fileName, fileExt)
+	fileDir := filepath.ToSlash(filepath.Dir(filePath))
+	if fileDir == "." {
+		fileDir = ""
+	}
+
+	data := map[string]any{
+		"__filePath":      filepath.ToSlash(filePath),
+		"__fileName":      fileName,
+		"__fileStem":      fileStem,
+		"__fileExtension": fileExt,
+		"__fileDir":       fileDir,
+	}
+
+	svc := gotmpl.NewService(nil)
+	result, err := svc.Execute(context.Background(), gotmpl.TemplateOptions{
+		Content: outputPathTmpl,
+		Name:    "outputPath",
+		Data:    data,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Clean up the result
+	output := strings.TrimSpace(result.Output)
+	// Normalize path separators
+	output = filepath.ToSlash(output)
+	// Remove leading slash if present (should be relative)
+	output = strings.TrimPrefix(output, "/")
+
+	return output, nil
+}
+
+// isSubPath checks that child is under parent (path traversal protection).
+func isSubPath(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	// If the relative path starts with "..", it's outside the parent
+	return !strings.HasPrefix(rel, "..") && rel != ".."
+}
+
+// executeDryRunWriteTree returns a dry-run preview for write-tree.
+func (p *FileProvider) executeDryRunWriteTree(absBasePath string, inputs map[string]any) (*provider.Output, error) {
+	entries, err := p.parseWriteTreeEntries(inputs)
+	if err != nil {
+		// In dry-run, still validate entries
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	outputPathTmpl, _ := inputs["outputPath"].(string)
+
+	var outputPaths []string
+	for i, entry := range entries {
+		outputPath := entry.path
+		if outputPathTmpl != "" {
+			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, entry.path)
+			if tmplErr != nil {
+				return nil, fmt.Errorf("%s: outputPath template failed for entries[%d] (%s): %w", ProviderName, i, entry.path, tmplErr)
+			}
+			outputPath = transformed
+		}
+		outputPaths = append(outputPaths, outputPath)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":      true,
+			"operation":    "write-tree",
+			"basePath":     absBasePath,
+			"filesWritten": len(outputPaths),
+			"paths":        outputPaths,
+			"_dryRun":      true,
+			"_message":     fmt.Sprintf("Would write %d files under %s", len(outputPaths), absBasePath),
 		},
 	}, nil
 }

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -444,4 +446,483 @@ func TestFileProvider_Execute_RelativePath(t *testing.T) {
 	data := result.Data.(map[string]any)
 	// Should convert to absolute path
 	assert.True(t, filepath.IsAbs(data["path"].(string)))
+}
+
+// --- write-tree tests ---
+
+func TestFileProvider_WriteTree_BasicNestedDirs(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "file1.txt", "content": "hello"},
+			map[string]any{"path": "sub/file2.txt", "content": "world"},
+			map[string]any{"path": "sub/deep/file3.txt", "content": "nested"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "write-tree", data["operation"])
+	assert.Equal(t, 3, data["filesWritten"])
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"file1.txt", "sub/file2.txt", "sub/deep/file3.txt"}, paths)
+
+	// Verify files actually exist
+	b1, err := os.ReadFile(filepath.Join(tmpDir, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(b1))
+
+	b2, err := os.ReadFile(filepath.Join(tmpDir, "sub", "file2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(b2))
+
+	b3, err := os.ReadFile(filepath.Join(tmpDir, "sub", "deep", "file3.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(b3))
+}
+
+func TestFileProvider_WriteTree_OutputPathStripExtension(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "deployment.yaml.tpl", "content": "apiVersion: apps/v1"},
+			map[string]any{"path": "configs/app.conf.tpl", "content": "key=value"},
+		},
+		"outputPath": `{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 2, data["filesWritten"])
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"deployment.yaml", "configs/app.conf"}, paths)
+
+	// Verify content
+	b, err := os.ReadFile(filepath.Join(tmpDir, "deployment.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "apiVersion: apps/v1", string(b))
+}
+
+func TestFileProvider_WriteTree_OutputPathReplaceExtension(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "app/main.go.tpl", "content": "package main"},
+		},
+		"outputPath": `{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"app/main.go"}, paths)
+}
+
+func TestFileProvider_WriteTree_OutputPathFlatten(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "a/b/file.txt", "content": "flat"},
+		},
+		// Flatten: ignore directory, just use the filename
+		"outputPath": `{{ .__fileName }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"file.txt"}, paths)
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "flat", string(b))
+}
+
+func TestFileProvider_WriteTree_NoOutputPath(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "keep/original/path.txt", "content": "preserved"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"keep/original/path.txt"}, paths)
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "keep", "original", "path.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "preserved", string(b))
+}
+
+func TestFileProvider_WriteTree_PathTraversalBlocked(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "../../etc/passwd", "content": "evil"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestFileProvider_WriteTree_OutputPathTraversalBlocked(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "safe.txt", "content": "evil"},
+		},
+		"outputPath": `../../escaped`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestFileProvider_WriteTree_EmptyEntries(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries":   []any{},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, 0, data["filesWritten"])
+}
+
+func TestFileProvider_WriteTree_MissingBasePath(t *testing.T) {
+	p := NewFileProvider()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"entries": []any{
+			map[string]any{"path": "x.txt", "content": "y"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "basePath is required")
+}
+
+func TestFileProvider_WriteTree_MissingEntries(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "entries is required")
+}
+
+func TestFileProvider_WriteTree_InvalidEntryType(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries":   []any{"not a map"},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "entries[0] must be a map")
+}
+
+func TestFileProvider_WriteTree_MissingEntryPath(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"content": "no path here"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "entries[0].path is required")
+}
+
+func TestFileProvider_WriteTree_MissingEntryContent(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "file.txt"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "entries[0].content is required")
+}
+
+func TestFileProvider_WriteTree_DryRun(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "a.txt", "content": "alpha"},
+			map[string]any{"path": "sub/b.txt", "content": "beta"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.True(t, data["_dryRun"].(bool))
+	assert.Equal(t, 2, data["filesWritten"])
+	assert.Contains(t, data["_message"], "Would write 2 files")
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"a.txt", "sub/b.txt"}, paths)
+
+	// Ensure no files were actually written
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestFileProvider_WriteTree_DryRunWithOutputPath(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation":  "write-tree",
+		"basePath":   tmpDir,
+		"outputPath": `{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}`,
+		"entries": []any{
+			map[string]any{"path": "app/main.go.tpl", "content": "package main"},
+			map[string]any{"path": "deploy.yaml.tpl", "content": "apiVersion: v1"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"app/main.go", "deploy.yaml"}, paths)
+}
+
+func TestFileProvider_WriteTree_Overwrite(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	// Pre-create a file
+	err := os.WriteFile(filepath.Join(tmpDir, "existing.txt"), []byte("old"), 0o644)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "existing.txt", "content": "new content"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "existing.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "new content", string(b))
+}
+
+func TestFileProvider_WriteTree_OutputPathWithSprigFunctions(t *testing.T) {
+	// Register extension functions (Sprig etc.) for this test
+	gotmpl.SetExtensionFuncMapFactory(gotmplext.AllFuncMap)
+
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "SRC/MyFile.txt", "content": "lowered"},
+		},
+		"outputPath": `{{ lower .__filePath }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"src/myfile.txt"}, paths)
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "src", "myfile.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "lowered", string(b))
+}
+
+func TestFileProvider_WriteTree_FileVarsComputed(t *testing.T) {
+	// Validate that all __file* variables are correctly populated
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{
+				"path":    "charts/templates/deployment.yaml.tpl",
+				"content": "test",
+			},
+		},
+		// Template that uses all __file* vars to build the output path
+		"outputPath": `{{ .__fileDir }}/{{ .__fileStem }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	// __fileDir = "charts/templates", __fileStem = "deployment.yaml" (stem of "deployment.yaml.tpl" is "deployment.yaml")
+	assert.Equal(t, []string{"charts/templates/deployment.yaml"}, paths)
+}
+
+func TestFileProvider_WriteTree_RootLevelFileDir(t *testing.T) {
+	// When a file is at the root level, __fileDir should be empty
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "readme.md.tpl", "content": "# Hello"},
+		},
+		// Should produce just the stem since __fileDir is empty
+		"outputPath": `{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"readme.md"}, paths)
+}
+
+func TestFileProvider_WriteTree_DoesNotRequirePath(t *testing.T) {
+	// write-tree should NOT require the "path" field (it uses basePath instead)
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries":   []any{},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -22,7 +22,12 @@ const (
 	// ProviderName is the name of the go-template provider
 	ProviderName = "go-template"
 	// Version is the version of the go-template provider
-	Version = "1.0.0"
+	Version = "2.0.0"
+
+	// OperationRender is the default single-template render operation.
+	OperationRender = "render"
+	// OperationRenderTree is the batch render operation for directory trees.
+	OperationRenderTree = "render-tree"
 )
 
 // GoTemplateProvider provides data transformation using Go templates
@@ -41,7 +46,7 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 			Name:         ProviderName,
 			DisplayName:  "Go Template Provider",
 			APIVersion:   "v1",
-			Description:  "Transform and render data using Go text/template syntax with resolver data from context",
+			Description:  "Transform and render data using Go text/template syntax with resolver data from context. Supports single template rendering (operation: render) and batch directory tree rendering (operation: render-tree).",
 			Version:      version,
 			Category:     "data",
 			MockBehavior: "Returns a placeholder indicating the template was not executed (same as CEL provider dry-run behavior)",
@@ -49,11 +54,14 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 				provider.CapabilityTransform,
 				provider.CapabilityAction,
 			},
-			Schema: schemahelper.ObjectSchema([]string{"template", "name"}, map[string]*jsonschema.Schema{
-				"template": schemahelper.StringProp("Go template content to render. Resolver data is available as the root context (e.g., .name, .config.host). Use {{.fieldName}} to access values.",
+			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"operation": schemahelper.StringProp("Operation to perform. 'render' (default) renders a single template. 'render-tree' renders an array of file entries (e.g. from the directory provider).",
+					schemahelper.WithDefault(OperationRender),
+					schemahelper.WithEnum(OperationRender, OperationRenderTree)),
+				"template": schemahelper.StringProp("Go template content to render (required for 'render' operation). Resolver data is available as the root context (e.g., .name, .config.host). Use {{.fieldName}} to access values.",
 					schemahelper.WithExample("Hello, {{.name}}!"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(65536))),
-				"name": schemahelper.StringProp("Name for the template, used in error messages and logging",
+				"name": schemahelper.StringProp("Name for the template, used in error messages and logging. Required for 'render', optional for 'render-tree' (defaults to 'render-tree').",
 					schemahelper.WithExample("greeting-template"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
 				"missingKey": schemahelper.StringProp("Behavior when a map key is missing: 'default' (prints <no value>), 'zero' (returns zero value), 'error' (stops with error)",
@@ -88,14 +96,41 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 					)),
 					schemahelper.WithMaxItems(20),
 				),
+				"entries": schemahelper.ArrayProp("Array of file entry objects to render (required for 'render-tree' operation). Each entry must have 'path' (string) and 'content' (string) fields. Typically produced by the directory provider with includeContent: true.",
+					schemahelper.WithItems(schemahelper.ObjectProp(
+						"A file entry with path and content to render as a Go template",
+						[]string{"path", "content"},
+						map[string]*jsonschema.Schema{
+							"path":    schemahelper.StringProp("Relative file path (preserved in output for downstream use)"),
+							"content": schemahelper.StringProp("File content to render as a Go template"),
+						},
+					))),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"result": schemahelper.StringProp("The rendered template output", schemahelper.WithExample("Hello, World!")),
+					"result": schemahelper.StringProp("The rendered template output (render operation)", schemahelper.WithExample("Hello, World!")),
+					"entries": schemahelper.ArrayProp("Array of rendered file entries (render-tree operation)",
+						schemahelper.WithItems(schemahelper.ObjectProp(
+							"A rendered file entry",
+							nil,
+							map[string]*jsonschema.Schema{
+								"path":    schemahelper.StringProp("Relative file path from the source directory"),
+								"content": schemahelper.StringProp("Rendered template content"),
+							},
+						))),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success": schemahelper.BoolProp("Whether the template rendered successfully"),
-					"result":  schemahelper.StringProp("The rendered template output", schemahelper.WithExample("Hello, World!")),
+					"result":  schemahelper.StringProp("The rendered template output (render operation)", schemahelper.WithExample("Hello, World!")),
+					"entries": schemahelper.ArrayProp("Array of rendered file entries (render-tree operation)",
+						schemahelper.WithItems(schemahelper.ObjectProp(
+							"A rendered file entry",
+							nil,
+							map[string]*jsonschema.Schema{
+								"path":    schemahelper.StringProp("Relative file path from the source directory"),
+								"content": schemahelper.StringProp("Rendered template content"),
+							},
+						))),
 				}),
 			},
 			Tags: []string{"template", "go-template", "text/template", "transform", "render"},
@@ -209,6 +244,21 @@ inputs:
   ignoredBlocks:
     - line: "# scafctl:ignore"`,
 				},
+				{
+					Name:        "Render directory tree of templates",
+					Description: "Batch-render an array of file entries from the directory provider. Combine with the file provider's write-tree operation to write rendered files preserving directory structure.",
+					YAML: `name: rendered-templates
+provider: go-template
+inputs:
+  operation: render-tree
+  name: project-templates
+  entries:
+    expr: '__self.entries.filter(e, e.type == "file")'
+  data:
+    appName: my-app
+    namespace: production
+    replicas: 3`,
+				},
 			},
 		},
 	}
@@ -228,14 +278,34 @@ func (p *GoTemplateProvider) Execute(ctx context.Context, input any) (*provider.
 		return nil, fmt.Errorf("%s: expected map[string]any, got %T", ProviderName, input)
 	}
 
-	lgr.V(1).Info("executing provider", "provider", ProviderName)
+	// Determine operation (default: render for backward compatibility)
+	operation := OperationRender
+	if op, ok := inputs["operation"].(string); ok && op != "" {
+		operation = op
+	}
+
+	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation)
+
+	switch operation {
+	case OperationRender:
+		return p.executeRender(ctx, inputs)
+	case OperationRenderTree:
+		return p.executeRenderTree(ctx, inputs)
+	default:
+		return nil, fmt.Errorf("%s: unsupported operation: %s (supported: render, render-tree)", ProviderName, operation)
+	}
+}
+
+// executeRender performs single-template rendering (the original behavior).
+func (p *GoTemplateProvider) executeRender(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
 
 	// Check for dry-run mode
 	if provider.DryRunFromContext(ctx) {
 		return p.executeDryRun(inputs)
 	}
 
-	// Extract template (required)
+	// Extract template (required for render)
 	templateStr, ok := inputs["template"].(string)
 	if !ok || templateStr == "" {
 		return nil, fmt.Errorf("%s: template is required and must be a string", ProviderName)
@@ -247,56 +317,14 @@ func (p *GoTemplateProvider) Execute(ctx context.Context, input any) (*provider.
 		return nil, fmt.Errorf("%s: name is required and must be a string", ProviderName)
 	}
 
-	// Extract missing key behavior
-	missingKey := gotmpl.MissingKeyDefault
-	if mk, ok := inputs["missingKey"].(string); ok && mk != "" {
-		switch mk {
-		case "default":
-			missingKey = gotmpl.MissingKeyDefault
-		case "zero":
-			missingKey = gotmpl.MissingKeyZero
-		case "error":
-			missingKey = gotmpl.MissingKeyError
-		default:
-			return nil, fmt.Errorf("%s: invalid missingKey value %q, must be 'default', 'zero', or 'error'", ProviderName, mk)
-		}
-	}
-
-	// Extract delimiters
-	leftDelim := gotmpl.DefaultLeftDelim
-	if ld, ok := inputs["leftDelim"].(string); ok && ld != "" {
-		leftDelim = ld
-	}
-	rightDelim := gotmpl.DefaultRightDelim
-	if rd, ok := inputs["rightDelim"].(string); ok && rd != "" {
-		rightDelim = rd
+	// Parse shared rendering options
+	missingKey, leftDelim, rightDelim, err := p.parseRenderingOptions(inputs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build template data from resolver context and additional data
-	templateData := make(map[string]any)
-
-	// Get resolver data from context
-	if resolverData, ok := provider.ResolverContextFromContext(ctx); ok && resolverData != nil {
-		maps.Copy(templateData, resolverData)
-	}
-
-	// Extract iteration context if present and merge iteration variables
-	if iterCtx, ok := provider.IterationContextFromContext(ctx); ok && iterCtx != nil {
-		if iterCtx.ItemAlias != "" {
-			templateData[iterCtx.ItemAlias] = iterCtx.Item
-		}
-		if iterCtx.IndexAlias != "" {
-			templateData[iterCtx.IndexAlias] = iterCtx.Index
-		}
-		// Also set __item and __index for standard access
-		templateData["__item"] = iterCtx.Item
-		templateData["__index"] = iterCtx.Index
-	}
-
-	// Merge additional data from inputs (overrides resolver data if same key)
-	if data, ok := inputs["data"].(map[string]any); ok {
-		maps.Copy(templateData, data)
-	}
+	templateData := p.buildTemplateData(ctx, inputs)
 
 	lgr.V(2).Info("executing template",
 		"name", templateName,
@@ -307,62 +335,27 @@ func (p *GoTemplateProvider) Execute(ctx context.Context, input any) (*provider.
 		"rightDelim", rightDelim)
 
 	// Extract ignored blocks for literal pass-through
-	// Supports two modes:
-	//   1. start/end — multi-line block markers (content between markers is preserved)
-	//   2. line — every line containing the marker substring is preserved
-	var replacements []gotmpl.Replacement
+	ignoredBlocksCfg := p.parseIgnoredBlocksConfig(inputs)
+
+	// Validate mutual exclusion for ignored blocks
 	if blocks, ok := inputs["ignoredBlocks"].([]any); ok {
 		for i, block := range blocks {
 			blockMap, ok := block.(map[string]any)
 			if !ok {
 				continue
 			}
-
 			start, _ := blockMap["start"].(string)
 			end, _ := blockMap["end"].(string)
 			line, _ := blockMap["line"].(string)
-
-			// Mutual exclusion: line and start/end cannot be used together
 			hasStartEnd := start != "" || end != ""
 			hasLine := line != ""
-
 			if hasLine && hasStartEnd {
 				return nil, fmt.Errorf("%s: ignoredBlocks[%d]: 'line' and 'start'/'end' are mutually exclusive — use one mode per entry", ProviderName, i)
 			}
-
-			if hasLine {
-				// Line mode: find every line that contains the marker and preserve it
-				for _, templateLine := range strings.Split(templateStr, "\n") {
-					if strings.Contains(templateLine, line) {
-						replacements = append(replacements, gotmpl.Replacement{Find: templateLine})
-					}
-				}
-				continue
-			}
-
-			if start == "" || end == "" {
-				continue
-			}
-
-			// Start/end mode: find all occurrences of start...end and create a replacement for each full block
-			remaining := templateStr
-			for {
-				startIdx := strings.Index(remaining, start)
-				if startIdx < 0 {
-					break
-				}
-				afterStart := remaining[startIdx+len(start):]
-				endIdx := strings.Index(afterStart, end)
-				if endIdx < 0 {
-					break
-				}
-				// Extract the full block: start marker + content + end marker
-				fullBlock := remaining[startIdx : startIdx+len(start)+endIdx+len(end)]
-				replacements = append(replacements, gotmpl.Replacement{Find: fullBlock})
-				remaining = remaining[startIdx+len(start)+endIdx+len(end):]
-			}
 		}
 	}
+
+	replacements := p.buildIgnoredBlockReplacements(templateStr, ignoredBlocksCfg)
 
 	// Execute the template
 	result, err := p.service.Execute(ctx, gotmpl.TemplateOptions{
@@ -390,6 +383,16 @@ func (p *GoTemplateProvider) Execute(ctx context.Context, input any) (*provider.
 }
 
 func (p *GoTemplateProvider) executeDryRun(inputs map[string]any) (*provider.Output, error) {
+	// Check if this is a render-tree dry-run
+	operation := OperationRender
+	if op, ok := inputs["operation"].(string); ok && op != "" {
+		operation = op
+	}
+
+	if operation == OperationRenderTree {
+		return p.executeDryRunRenderTree(inputs)
+	}
+
 	templateStr, _ := inputs["template"].(string)
 	templateName, _ := inputs["name"].(string)
 
@@ -409,13 +412,342 @@ func (p *GoTemplateProvider) executeDryRun(inputs map[string]any) (*provider.Out
 	}, nil
 }
 
-// extractDependencies extracts resolver references from the go-template provider inputs.
-// It respects custom delimiters specified in leftDelim/rightDelim if present.
-func extractDependencies(inputs map[string]any) []string {
-	// Get template content
-	templateContent, ok := inputs["template"].(string)
+// executeRenderTree batch-renders an array of file entries as Go templates.
+// Each entry must have "path" and "content" fields. The output is an array of
+// {path, content} objects with rendered content, suitable for the file provider's write-tree operation.
+func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Check for dry-run mode
+	if provider.DryRunFromContext(ctx) {
+		return p.executeDryRunRenderTree(inputs)
+	}
+
+	// Extract name (optional for render-tree, defaults to "render-tree")
+	templateName, _ := inputs["name"].(string)
+	if templateName == "" {
+		templateName = "render-tree"
+	}
+
+	// Extract entries (required for render-tree)
+	entriesRaw, ok := inputs["entries"]
+	if !ok || entriesRaw == nil {
+		return nil, fmt.Errorf("%s: entries is required for render-tree operation", ProviderName)
+	}
+
+	entries, ok := entriesRaw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: entries must be an array, got %T", ProviderName, entriesRaw)
+	}
+
+	// Parse shared rendering options
+	missingKey, leftDelim, rightDelim, err := p.parseRenderingOptions(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse ignored blocks configuration (shared with render)
+	ignoredBlocksCfg := p.parseIgnoredBlocksConfig(inputs)
+
+	// Build base template data from resolver context + additional data
+	baseData := p.buildTemplateData(ctx, inputs)
+
+	lgr.V(1).Info("executing render-tree",
+		"name", templateName,
+		"entryCount", len(entries),
+		"dataKeys", len(baseData),
+	)
+
+	// Handle empty entries
+	if len(entries) == 0 {
+		return &provider.Output{
+			Data: []map[string]any{},
+			Metadata: map[string]any{
+				"templateName": templateName,
+				"entryCount":   0,
+			},
+		}, nil
+	}
+
+	// Render each entry
+	var warnings []string
+	results := make([]map[string]any, 0, len(entries))
+
+	for i, entryRaw := range entries {
+		entry, ok := entryRaw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s: entries[%d] must be a map, got %T", ProviderName, i, entryRaw)
+		}
+
+		entryPath, ok := entry["path"].(string)
+		if !ok || entryPath == "" {
+			return nil, fmt.Errorf("%s: entries[%d].path is required and must be a string", ProviderName, i)
+		}
+
+		entryContent, ok := entry["content"].(string)
+		if !ok {
+			// Skip entries without content (e.g., binary files, directories)
+			warnings = append(warnings, fmt.Sprintf("skipped %s: no string content", entryPath))
+			continue
+		}
+
+		// Build per-entry template data: base data + entry content is the template
+		templateData := make(map[string]any, len(baseData))
+		maps.Copy(templateData, baseData)
+
+		// Build ignored block replacements for this entry's content
+		replacements := p.buildIgnoredBlockReplacements(entryContent, ignoredBlocksCfg)
+
+		// Render the entry content as a Go template
+		entryTemplateName := fmt.Sprintf("%s/%s", templateName, entryPath)
+		result, renderErr := p.service.Execute(ctx, gotmpl.TemplateOptions{
+			Content:      entryContent,
+			Name:         entryTemplateName,
+			Data:         templateData,
+			MissingKey:   missingKey,
+			LeftDelim:    leftDelim,
+			RightDelim:   rightDelim,
+			Replacements: replacements,
+		})
+		if renderErr != nil {
+			return nil, fmt.Errorf("%s: failed to render %s: %w", ProviderName, entryPath, renderErr)
+		}
+
+		results = append(results, map[string]any{
+			"path":    entryPath,
+			"content": result.Output,
+		})
+	}
+
+	lgr.V(1).Info("render-tree completed",
+		"name", templateName,
+		"renderedCount", len(results),
+		"warningCount", len(warnings),
+	)
+
+	output := &provider.Output{
+		Data: results,
+		Metadata: map[string]any{
+			"templateName": templateName,
+			"entryCount":   len(results),
+		},
+	}
+
+	if len(warnings) > 0 {
+		output.Warnings = warnings
+	}
+
+	return output, nil
+}
+
+// executeDryRunRenderTree returns a dry-run placeholder for render-tree.
+func (p *GoTemplateProvider) executeDryRunRenderTree(inputs map[string]any) (*provider.Output, error) {
+	templateName, _ := inputs["name"].(string)
+
+	entries, _ := inputs["entries"].([]any)
+	results := make([]map[string]any, 0, len(entries))
+
+	for _, entryRaw := range entries {
+		entry, ok := entryRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		entryPath, _ := entry["path"].(string)
+		if entryPath == "" {
+			continue
+		}
+		results = append(results, map[string]any{
+			"path":    entryPath,
+			"content": "[dry-run rendered]",
+		})
+	}
+
+	return &provider.Output{
+		Data: results,
+		Metadata: map[string]any{
+			"dryRun":       true,
+			"templateName": templateName,
+			"entryCount":   len(results),
+		},
+	}, nil
+}
+
+// parseRenderingOptions extracts missingKey, leftDelim, and rightDelim from inputs.
+func (p *GoTemplateProvider) parseRenderingOptions(inputs map[string]any) (gotmpl.MissingKeyOption, string, string, error) {
+	missingKey := gotmpl.MissingKeyDefault
+	if mk, ok := inputs["missingKey"].(string); ok && mk != "" {
+		switch mk {
+		case "default":
+			missingKey = gotmpl.MissingKeyDefault
+		case "zero":
+			missingKey = gotmpl.MissingKeyZero
+		case "error":
+			missingKey = gotmpl.MissingKeyError
+		default:
+			return "", "", "", fmt.Errorf("%s: invalid missingKey value %q, must be 'default', 'zero', or 'error'", ProviderName, mk)
+		}
+	}
+
+	leftDelim := gotmpl.DefaultLeftDelim
+	if ld, ok := inputs["leftDelim"].(string); ok && ld != "" {
+		leftDelim = ld
+	}
+	rightDelim := gotmpl.DefaultRightDelim
+	if rd, ok := inputs["rightDelim"].(string); ok && rd != "" {
+		rightDelim = rd
+	}
+
+	return missingKey, leftDelim, rightDelim, nil
+}
+
+// buildTemplateData constructs the template data map from resolver context, iteration context, and additional data.
+func (p *GoTemplateProvider) buildTemplateData(ctx context.Context, inputs map[string]any) map[string]any {
+	templateData := make(map[string]any)
+
+	// Get resolver data from context
+	if resolverData, ok := provider.ResolverContextFromContext(ctx); ok && resolverData != nil {
+		maps.Copy(templateData, resolverData)
+	}
+
+	// Extract iteration context if present and merge iteration variables
+	if iterCtx, ok := provider.IterationContextFromContext(ctx); ok && iterCtx != nil {
+		if iterCtx.ItemAlias != "" {
+			templateData[iterCtx.ItemAlias] = iterCtx.Item
+		}
+		if iterCtx.IndexAlias != "" {
+			templateData[iterCtx.IndexAlias] = iterCtx.Index
+		}
+		templateData["__item"] = iterCtx.Item
+		templateData["__index"] = iterCtx.Index
+	}
+
+	// Merge additional data from inputs (overrides resolver data if same key)
+	if data, ok := inputs["data"].(map[string]any); ok {
+		maps.Copy(templateData, data)
+	}
+
+	return templateData
+}
+
+// ignoredBlockConfig holds a parsed ignored block entry.
+type ignoredBlockConfig struct {
+	start string
+	end   string
+	line  string
+}
+
+// parseIgnoredBlocksConfig parses the ignoredBlocks input into a config slice without
+// applying it to a specific template string. The actual replacements are built per-entry.
+func (p *GoTemplateProvider) parseIgnoredBlocksConfig(inputs map[string]any) []ignoredBlockConfig {
+	blocks, ok := inputs["ignoredBlocks"].([]any)
 	if !ok {
 		return nil
+	}
+
+	var configs []ignoredBlockConfig
+	for _, block := range blocks {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		start, _ := blockMap["start"].(string)
+		end, _ := blockMap["end"].(string)
+		line, _ := blockMap["line"].(string)
+
+		configs = append(configs, ignoredBlockConfig{
+			start: start,
+			end:   end,
+			line:  line,
+		})
+	}
+
+	return configs
+}
+
+// buildIgnoredBlockReplacements builds gotmpl.Replacement entries for a specific template
+// string based on the parsed ignored block config.
+func (p *GoTemplateProvider) buildIgnoredBlockReplacements(templateStr string, configs []ignoredBlockConfig) []gotmpl.Replacement {
+	var replacements []gotmpl.Replacement
+
+	for _, cfg := range configs {
+		hasStartEnd := cfg.start != "" || cfg.end != ""
+		hasLine := cfg.line != ""
+
+		if hasLine {
+			for _, templateLine := range strings.Split(templateStr, "\n") {
+				if strings.Contains(templateLine, cfg.line) {
+					replacements = append(replacements, gotmpl.Replacement{Find: templateLine})
+				}
+			}
+			continue
+		}
+
+		if !hasStartEnd || cfg.start == "" || cfg.end == "" {
+			continue
+		}
+
+		remaining := templateStr
+		for {
+			startIdx := strings.Index(remaining, cfg.start)
+			if startIdx < 0 {
+				break
+			}
+			afterStart := remaining[startIdx+len(cfg.start):]
+			endIdx := strings.Index(afterStart, cfg.end)
+			if endIdx < 0 {
+				break
+			}
+			fullBlock := remaining[startIdx : startIdx+len(cfg.start)+endIdx+len(cfg.end)]
+			replacements = append(replacements, gotmpl.Replacement{Find: fullBlock})
+			remaining = remaining[startIdx+len(cfg.start)+endIdx+len(cfg.end):]
+		}
+	}
+
+	return replacements
+}
+
+// extractDependencies extracts resolver references from the go-template provider inputs.
+// Handles both the "render" operation (template input) and the "render-tree" operation
+// (entries/data inputs). It respects custom delimiters specified in leftDelim/rightDelim
+// if present.
+func extractDependencies(inputs map[string]any) []string {
+	seen := make(map[string]bool)
+	var deps []string
+
+	addDep := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			deps = append(deps, name)
+		}
+	}
+
+	// Extract rslvr/expr references from ValueRef-shaped inputs (entries, data, template, etc.)
+	for _, key := range []string{"entries", "data", "template"} {
+		raw, ok := inputs[key]
+		if !ok {
+			continue
+		}
+		if m, ok := raw.(map[string]any); ok {
+			if rslvr, ok := m["rslvr"].(string); ok {
+				// Extract base resolver name (strip dotted sub-path)
+				if idx := strings.Index(rslvr, "."); idx > 0 {
+					addDep(rslvr[:idx])
+				} else {
+					addDep(rslvr)
+				}
+			}
+			if expr, ok := m["expr"].(string); ok {
+				extractCELDeps(expr, addDep)
+			}
+		}
+	}
+
+	// For the "render" operation, also extract Go template references from
+	// the template content (if provided as a literal string).
+	templateContent, ok := inputs["template"].(string)
+	if !ok {
+		return deps
 	}
 
 	// Get delimiters (default to standard Go template delimiters)
@@ -433,14 +765,11 @@ func extractDependencies(inputs map[string]any) []string {
 	refs, err := gotmpl.GetGoTemplateReferences(templateContent, leftDelim, rightDelim)
 	if err != nil {
 		// On parse error, fall back to no dependencies - the error will be caught during execution
-		return nil
+		return deps
 	}
 
 	// Extract the first segment of each reference path as the dependency name
 	// e.g., ".config.host" -> "config", "._.name" -> "name"
-	seen := make(map[string]bool)
-	var deps []string
-
 	for _, ref := range refs {
 		path := ref.Path
 		// Strip leading dot if present
@@ -454,17 +783,28 @@ func extractDependencies(inputs map[string]any) []string {
 			path = path[:idx]
 		}
 
-		// Skip empty paths
-		if path == "" {
-			continue
-		}
-
-		// Deduplicate
-		if !seen[path] {
-			seen[path] = true
-			deps = append(deps, path)
-		}
+		addDep(path)
 	}
 
 	return deps
+}
+
+// extractCELDeps extracts resolver references from a CEL expression string.
+// It looks for _.resolverName patterns and calls addDep for each found.
+func extractCELDeps(expr string, addDep func(string)) {
+	// Simple pattern: find _.identifier patterns
+	// Full CEL parsing is done by the CEL provider; this is a lightweight check.
+	for i := 0; i < len(expr)-2; i++ {
+		if expr[i] == '_' && expr[i+1] == '.' {
+			// Extract identifier after _.
+			start := i + 2
+			end := start
+			for end < len(expr) && (expr[end] == '_' || (expr[end] >= 'a' && expr[end] <= 'z') || (expr[end] >= 'A' && expr[end] <= 'Z') || (expr[end] >= '0' && expr[end] <= '9')) {
+				end++
+			}
+			if end > start {
+				addDep(expr[start:end])
+			}
+		}
+	}
 }

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -425,6 +425,7 @@ func TestGoTemplateProvider_Descriptor_Schema(t *testing.T) {
 
 	// Check required properties exist
 	props := desc.Schema.Properties
+	require.Contains(t, props, "operation")
 	require.Contains(t, props, "template")
 	require.Contains(t, props, "name")
 	require.Contains(t, props, "missingKey")
@@ -432,10 +433,14 @@ func TestGoTemplateProvider_Descriptor_Schema(t *testing.T) {
 	require.Contains(t, props, "rightDelim")
 	require.Contains(t, props, "data")
 	require.Contains(t, props, "ignoredBlocks")
+	require.Contains(t, props, "entries")
 
-	// Check required fields
-	assert.Contains(t, desc.Schema.Required, "template")
-	assert.Contains(t, desc.Schema.Required, "name")
+	// Check required fields - name is no longer globally required (optional for render-tree)
+	// No fields are globally required (template or entries depend on operation, name defaults for render-tree)
+	assert.Empty(t, desc.Schema.Required)
+
+	// template is no longer globally required (only for render operation)
+	assert.NotContains(t, desc.Schema.Required, "template")
 
 	// Check optional fields are not required
 	assert.NotContains(t, desc.Schema.Required, "missingKey")
@@ -678,4 +683,337 @@ func TestGoTemplateProvider_Execute_IgnoredBlocks_Line_MixedEntries(t *testing.T
 	assert.Contains(t, result, "${{ secrets.KEY }}")
 	// Block-ignored content preserved
 	assert.Contains(t, result, "for k, v in var.x : k => v")
+}
+
+// --- render-tree tests ---
+
+func TestGoTemplateProvider_RenderTree_BasicMultipleEntries(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{})
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "test-tree",
+		"entries": []any{
+			map[string]any{
+				"path":    "app/deployment.yaml.tpl",
+				"content": "name: {{ .appName }}\nreplicas: {{ .replicas }}",
+			},
+			map[string]any{
+				"path":    "app/service.yaml.tpl",
+				"content": "service: {{ .appName }}-svc\nport: {{ .port }}",
+			},
+		},
+		"data": map[string]any{
+			"appName":  "my-app",
+			"replicas": 3,
+			"port":     8080,
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 2)
+
+	// First entry
+	assert.Equal(t, "app/deployment.yaml.tpl", results[0]["path"])
+	assert.Equal(t, "name: my-app\nreplicas: 3", results[0]["content"])
+
+	// Second entry
+	assert.Equal(t, "app/service.yaml.tpl", results[1]["path"])
+	assert.Equal(t, "service: my-app-svc\nport: 8080", results[1]["content"])
+
+	// Metadata
+	assert.Equal(t, "test-tree", output.Metadata["templateName"])
+	assert.Equal(t, 2, output.Metadata["entryCount"])
+}
+
+func TestGoTemplateProvider_RenderTree_EmptyEntries(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "empty-tree",
+		"entries":   []any{},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, results)
+	assert.Equal(t, 0, output.Metadata["entryCount"])
+}
+
+func TestGoTemplateProvider_RenderTree_MissingEntries(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "missing-entries",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entries is required")
+}
+
+func TestGoTemplateProvider_RenderTree_InvalidEntryType(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "invalid-entries",
+		"entries":   []any{"not-a-map"},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entries[0] must be a map")
+}
+
+func TestGoTemplateProvider_RenderTree_MissingEntryPath(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "no-path",
+		"entries": []any{
+			map[string]any{
+				"content": "hello",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entries[0].path is required")
+}
+
+func TestGoTemplateProvider_RenderTree_SkipsEntriesWithoutContent(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "skip-no-content",
+		"entries": []any{
+			map[string]any{
+				"path":    "good.txt",
+				"content": "Hello {{ .name }}",
+			},
+			map[string]any{
+				"path": "no-content.bin",
+				// no content field
+			},
+		},
+		"data": map[string]any{"name": "World"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "good.txt", results[0]["path"])
+	assert.Equal(t, "Hello World", results[0]["content"])
+
+	// Should have a warning for the skipped entry
+	assert.Len(t, output.Warnings, 1)
+	assert.Contains(t, output.Warnings[0], "no-content.bin")
+}
+
+func TestGoTemplateProvider_RenderTree_ErrorIncludesPath(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation":  "render-tree",
+		"name":       "error-path",
+		"missingKey": "error",
+		"entries": []any{
+			map[string]any{
+				"path":    "broken/template.tpl",
+				"content": "{{ .nonExistentVar }}",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken/template.tpl")
+}
+
+func TestGoTemplateProvider_RenderTree_WithResolverContext(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"env": "production",
+	})
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "resolver-ctx",
+		"entries": []any{
+			map[string]any{
+				"path":    "config.yaml",
+				"content": "environment: {{ .env }}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	assert.Equal(t, "environment: production", results[0]["content"])
+}
+
+func TestGoTemplateProvider_RenderTree_DataOverridesResolverContext(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"env": "staging",
+	})
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "data-override",
+		"entries": []any{
+			map[string]any{
+				"path":    "config.yaml",
+				"content": "environment: {{ .env }}",
+			},
+		},
+		"data": map[string]any{
+			"env": "production",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	assert.Equal(t, "environment: production", results[0]["content"])
+}
+
+func TestGoTemplateProvider_RenderTree_DryRun(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+	ctx = provider.WithDryRun(ctx, true)
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "dry-run-tree",
+		"entries": []any{
+			map[string]any{
+				"path":    "a.tpl",
+				"content": "{{ .val }}",
+			},
+			map[string]any{
+				"path":    "b/c.tpl",
+				"content": "{{ .val }}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	assert.Len(t, results, 2)
+	assert.Equal(t, "a.tpl", results[0]["path"])
+	assert.Equal(t, "[dry-run rendered]", results[0]["content"])
+	assert.Equal(t, "b/c.tpl", results[1]["path"])
+	assert.Equal(t, "[dry-run rendered]", results[1]["content"])
+
+	assert.True(t, output.Metadata["dryRun"].(bool))
+}
+
+func TestGoTemplateProvider_RenderTree_PathsPassThrough(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "path-passthrough",
+		"entries": []any{
+			map[string]any{
+				"path":    "child1/grandchild1/app.deployment.tpl",
+				"content": "name: {{ .appName }}",
+			},
+			map[string]any{
+				"path":    "child2/service.yaml.tpl",
+				"content": "svc: {{ .appName }}",
+			},
+		},
+		"data": map[string]any{
+			"appName": "test",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 2)
+
+	// Paths are preserved exactly as provided
+	assert.Equal(t, "child1/grandchild1/app.deployment.tpl", results[0]["path"])
+	assert.Equal(t, "child2/service.yaml.tpl", results[1]["path"])
+}
+
+func TestGoTemplateProvider_RenderTree_DefaultOperationIsRender(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "World",
+	})
+
+	// No operation specified - should default to render
+	inputs := map[string]any{
+		"name":     "default-op",
+		"template": "Hello, {{.name}}!",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!", output.Data)
+}
+
+func TestGoTemplateProvider_RenderTree_UnsupportedOperation(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "invalid-op",
+		"name":      "bad-op",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported operation")
 }

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -92,7 +92,7 @@ func extractDepsFromExpression(expr string, deps map[string]bool) {
 	// Use existing CEL expression parsing functionality
 	celExpr := celexp.Expression(expr)
 
-	// Extract all _.resolverName references
+	// Extract all _.resolverName and _["resolverName"] references
 	vars, err := celExpr.GetUnderscoreVariables()
 	if err != nil {
 		// If parsing fails, skip dependency extraction for this expression
@@ -142,8 +142,8 @@ func extractDepsFromValueRef(ref *ValueRef, deps map[string]bool) {
 func extractDepsFromLiteral(literal any, deps map[string]bool) {
 	switch v := literal.(type) {
 	case string:
-		// Check if the string contains CEL-like expressions (_.something patterns)
-		if strings.Contains(v, "_.") {
+		// Check if the string contains CEL-like expressions (_.something or _["something"] patterns)
+		if strings.Contains(v, "_.") || strings.Contains(v, "_[") {
 			extractDepsFromExpression(v, deps)
 		}
 		// Check if the string contains Go template syntax ({{ and }})

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -497,6 +497,40 @@ func TestExtractDependencies(t *testing.T) {
 			// _.checker is self-ref (filtered), _.otherResolver is a real dep
 			want: []string{"otherResolver"},
 		},
+		{
+			name: "bracket notation CEL expression dependency",
+			resolver: &Resolver{
+				Name: "bracketTest",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "cel",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr(`_["base"] + "-suffix"`)},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"base"},
+		},
+		{
+			name: "bracket notation mixed with dot notation dependency",
+			resolver: &Resolver{
+				Name: "mixedNotation",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "cel",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr(`_.dotRef + _["bracketRef"]`)},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"dotRef", "bracketRef"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -544,6 +578,21 @@ func TestExtractDepsFromExpression(t *testing.T) {
 			name: "nested expressions",
 			expr: "(_.enabled == true) && (_.region != '') && (_.account != '')",
 			want: []string{"enabled", "region", "account"},
+		},
+		{
+			name: "bracket notation single",
+			expr: `_["environment"]`,
+			want: []string{"environment"},
+		},
+		{
+			name: "bracket notation multiple",
+			expr: `_["env"] + '-' + _["region"]`,
+			want: []string{"env", "region"},
+		},
+		{
+			name: "bracket notation mixed with dot",
+			expr: `_.env + _["region"]`,
+			want: []string{"env", "region"},
 		},
 		{
 			name: "invalid expression (should not panic)",

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -67,6 +67,28 @@ func findProjectRoot() string {
 	}
 }
 
+// copyDir recursively copies a directory tree from src to dst.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
 func runScafctl(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
 	return runScafctlInDir(t, findProjectRoot(), args...)
@@ -1130,6 +1152,83 @@ func TestIntegration_RunSolution_K8sClusters(t *testing.T) {
 			assert.Contains(t, string(content), "kind: ResourceQuota", "manifest should contain ResourceQuota")
 		}
 	}
+}
+
+func TestIntegration_RunSolution_TemplateDirectory(t *testing.T) {
+	// Tests the directory → render-tree → write-tree pipeline end-to-end.
+	// Reads .tpl templates, renders them with shared vars, writes output
+	// stripping the .tpl extension and preserving directory structure.
+	projectRoot := findProjectRoot()
+	outputDir := t.TempDir()
+	solutionDir := t.TempDir()
+
+	// The solution references $OUTPUT_DIR as basePath — we inject it via env
+	// by rewriting the solution to use a concrete path.
+	solutionSrc, err := os.ReadFile(filepath.Join(projectRoot,
+		"tests/integration/solutions/template-directory/solution.yaml"))
+	require.NoError(t, err)
+
+	solutionContent := strings.ReplaceAll(string(solutionSrc), "$OUTPUT_DIR", outputDir)
+	tmpSolution := filepath.Join(solutionDir, "solution.yaml")
+	err = os.WriteFile(tmpSolution, []byte(solutionContent), 0o644)
+	require.NoError(t, err)
+
+	// Copy the templates directory next to the solution so relative path "templates" works
+	srcTemplates := filepath.Join(projectRoot, "tests/integration/solutions/template-directory/templates")
+	dstTemplates := filepath.Join(solutionDir, "templates")
+	err = copyDir(srcTemplates, dstTemplates)
+	require.NoError(t, err)
+
+	stdout, stderr, exitCode := runScafctlInDir(t, solutionDir,
+		"run", "solution",
+		"-f", tmpSolution,
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstderr: %s", exitCode, stderr)
+
+	// Verify output files exist with correct content
+	type expectedFile struct {
+		path     string
+		contains []string
+	}
+	expected := []expectedFile{
+		{
+			path:     "k8s/deployment.yaml",
+			contains: []string{"name: test-app", "namespace: test-ns", "replicas: 2"},
+		},
+		{
+			path:     "k8s/service.yaml",
+			contains: []string{"name: test-app-svc", "namespace: test-ns", "port: 8080"},
+		},
+		{
+			path:     "config/app.yaml",
+			contains: []string{"port: 8080", "level: debug"},
+		},
+		{
+			path:     "README.md",
+			contains: []string{"# test-app", "Version: 2.0.0"},
+		},
+	}
+
+	for _, ef := range expected {
+		fullPath := filepath.Join(outputDir, ef.path)
+		assert.FileExists(t, fullPath, "expected file %s", ef.path)
+
+		content, readErr := os.ReadFile(fullPath)
+		if assert.NoError(t, readErr, "reading %s", ef.path) {
+			for _, substr := range ef.contains {
+				assert.Contains(t, string(content), substr,
+					"file %s should contain %q", ef.path, substr)
+			}
+		}
+	}
+
+	// Ensure .tpl files do NOT exist — extension should be stripped
+	assert.NoFileExists(t, filepath.Join(outputDir, "k8s/deployment.yaml.tpl"))
+	assert.NoFileExists(t, filepath.Join(outputDir, "README.md.tpl"))
 }
 
 func TestIntegration_RunSolution_RetryIfWithCommandNotFound(t *testing.T) {

--- a/tests/integration/solutions/providers/file-write-tree/solution.yaml
+++ b/tests/integration/solutions/providers/file-write-tree/solution.yaml
@@ -1,0 +1,116 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-file-write-tree
+  version: 1.0.0
+  description: Tests for the file provider write-tree operation
+
+spec:
+  resolvers:
+    entries:
+      description: Static entries for write-tree tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - path: "hello.txt"
+                  content: "Hello, world!"
+                - path: "sub/nested.yaml"
+                  content: "key: value"
+                - path: "deep/dir/file.md"
+                  content: "# Title"
+
+    tplEntries:
+      description: Entries with .tpl extensions for outputPath tests
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - path: "config.yaml.tpl"
+                  content: "setting: true"
+                - path: "k8s/deploy.yaml.tpl"
+                  content: "kind: Deployment"
+                - path: "README.md.tpl"
+                  content: "# Docs"
+
+  workflow:
+    actions:
+      write-basic:
+        description: Write entries preserving paths
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: ./write-tree-output
+          entries:
+            rslvr: entries
+
+      write-with-output-path:
+        description: Write entries with outputPath stripping .tpl extension
+        provider: file
+        dependsOn: [write-basic]
+        inputs:
+          operation: write-tree
+          basePath: ./write-tree-transformed
+          entries:
+            rslvr: tplEntries
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+
+  testing:
+
+
+    cases:
+      _base:
+        description: Base template for write-tree tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [provider, file, write-tree]
+        cleanup:
+          - command: "rm -rf write-tree-output write-tree-transformed"
+        assertions:
+          - expression: __exitCode == 0
+
+      write-tree-basic:
+        description: Verify write-tree writes files and creates subdirectories
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Solution should succeed"
+          - expression: __output.actions["write-basic"].status == "succeeded"
+            message: "write-basic action should succeed"
+          - expression: __output.actions["write-basic"].results.success == true
+            message: "write-tree should report success"
+          - expression: '__output.actions["write-basic"].results.operation == "write-tree"'
+            message: "Should report write-tree operation"
+          - expression: __output.actions["write-basic"].results.filesWritten == 3
+            message: "Should write 3 files"
+
+      write-tree-paths:
+        description: Verify write-tree reports correct output paths
+        extends: [_base]
+        assertions:
+          - expression: __output.actions["write-basic"].results.paths.exists(p, p == "hello.txt")
+            message: "Should include hello.txt in paths"
+          - expression: __output.actions["write-basic"].results.paths.exists(p, p == "sub/nested.yaml")
+            message: "Should include sub/nested.yaml in paths"
+          - expression: __output.actions["write-basic"].results.paths.exists(p, p == "deep/dir/file.md")
+            message: "Should include deep/dir/file.md in paths"
+
+      write-tree-output-path:
+        description: Verify write-tree outputPath strips .tpl extensions
+        extends: [_base]
+        assertions:
+          - expression: __output.actions["write-with-output-path"].status == "succeeded"
+            message: "write-with-output-path action should succeed"
+          - expression: __output.actions["write-with-output-path"].results.filesWritten == 3
+            message: "Should write 3 transformed files"
+          - expression: '__output.actions["write-with-output-path"].results.paths.exists(p, p == "config.yaml")'
+            message: "Should strip .tpl from config.yaml.tpl"
+          - expression: '__output.actions["write-with-output-path"].results.paths.exists(p, p == "k8s/deploy.yaml")'
+            message: "Should strip .tpl from k8s/deploy.yaml.tpl preserving directory"
+          - expression: '__output.actions["write-with-output-path"].results.paths.exists(p, p == "README.md")'
+            message: "Should strip .tpl from README.md.tpl"

--- a/tests/integration/solutions/template-directory/solution.yaml
+++ b/tests/integration/solutions/template-directory/solution.yaml
@@ -1,0 +1,90 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-directory-integration
+  version: 1.0.0
+  description: Integration test for directory → render-tree → write-tree pipeline
+
+spec:
+  resolvers:
+    vars:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: test-app
+                appVersion: "2.0.0"
+                namespace: test-ns
+                replicas: 2
+                servicePort: 8080
+                logLevel: debug
+
+    templateFiles:
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    rendered:
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: vars
+
+  workflow:
+    actions:
+      write-output:
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: $OUTPUT_DIR
+          entries:
+            rslvr: rendered
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      _base:
+        description: Base for template-directory tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        files: ["templates/**"]
+        tags: [template-directory]
+        assertions:
+          - expression: __exitCode == 0
+
+      templates-loaded:
+        description: Verify template files were read
+        extends: [_base]
+        command: [run, resolver, templateFiles]
+        assertions:
+          - expression: size(__output.templateFiles.entries) == 4
+            message: "Expected 4 template files"
+
+      templates-rendered:
+        description: Verify all templates were rendered with vars
+        extends: [_base]
+        command: [run, resolver, rendered]
+        assertions:
+          - expression: size(__output.rendered) == 4
+            message: "Expected 4 rendered entries"
+          - expression: '__output.rendered.exists(e, e.content.contains("test-app"))'
+            message: "Rendered content should contain the appName variable"

--- a/tests/integration/solutions/template-directory/templates/README.md.tpl
+++ b/tests/integration/solutions/template-directory/templates/README.md.tpl
@@ -1,0 +1,3 @@
+# {{ .appName }}
+
+Version: {{ .appVersion }}

--- a/tests/integration/solutions/template-directory/templates/config/app.yaml.tpl
+++ b/tests/integration/solutions/template-directory/templates/config/app.yaml.tpl
@@ -1,0 +1,4 @@
+server:
+  port: {{ .servicePort }}
+logging:
+  level: {{ .logLevel }}

--- a/tests/integration/solutions/template-directory/templates/k8s/deployment.yaml.tpl
+++ b/tests/integration/solutions/template-directory/templates/k8s/deployment.yaml.tpl
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .appName }}
+  namespace: {{ .namespace }}
+spec:
+  replicas: {{ .replicas }}

--- a/tests/integration/solutions/template-directory/templates/k8s/service.yaml.tpl
+++ b/tests/integration/solutions/template-directory/templates/k8s/service.yaml.tpl
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .appName }}-svc
+  namespace: {{ .namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .servicePort }}


### PR DESCRIPTION
…write-tree operations

Add support for batch rendering a directory of Go templates and writing the rendered output while preserving directory structure. This introduces a three-stage pipeline: directory list → go-template render-tree → file write-tree.

Changes:
- pkg/provider/builtin/gotmplprovider: add render-tree operation to batch-render an array of {path, content} template entries with shared data variables, returning rendered {path, content} pairs
- pkg/provider/builtin/fileprovider: add write-tree operation that writes an array of {path, content} entries under a basePath, with optional outputPath Go template support for renaming files (strip extensions, etc.) using variables: __filePath, __fileName, __fileStem, __fileExtension, __fileDir
- pkg/celexp/refs: support bracket notation (_["name"]) in addition to dot notation (_.name) when extracting prefixed variables from CEL expressions
- pkg/mcp/server: document the directory → render-tree → write-tree pipeline pattern for MCP tool guidance
- pkg/resolver/graph: minor fixes
- tests/integration: add CLI integration tests for render-tree and write-tree
- docs/tutorials: add template-directory-rendering tutorial and update provider reference and go-templates tutorial
- examples/solutions/template-directory: add end-to-end example solution
