### PR TITLE
fix(resolver,lint,hcl,soltesting): address migration report issues B1…

### DIFF
--- a/examples/solutions/entra-groups/solution.yaml
+++ b/examples/solutions/entra-groups/solution.yaml
@@ -1,0 +1,71 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: entra-groups
+  version: 1.0.0
+  displayName: Entra Group Membership Check
+  description: >
+    Resolves the current user's Entra group memberships via the Microsoft Graph API.
+    Bypasses the 200-group JWT overage limit by calling /me/memberOf directly.
+  tags:
+    - entra
+    - identity
+    - groups
+
+spec:
+  resolvers:
+    # Get identity claims (name, email, objectId, etc.)
+    userClaims:
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: claims
+              handler: entra
+
+    # Get ALL group ObjectIDs via Graph API (not the JWT claim)
+    userGroups:
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: groups
+              handler: entra
+
+    # Extract just the group ID list
+    groupIds:
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: groups
+              handler: entra
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.groups"
+
+    # Group count
+    groupCount:
+      resolve:
+        with:
+          - provider: identity
+            inputs:
+              operation: groups
+              handler: entra
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.count"
+
+    # Check membership in a specific group (replace with your group ObjectID)
+    # isInTargetGroup:
+    #   dependsOn: [userGroups]
+    #   resolve:
+    #     with:
+    #       - provider: cel
+    #         inputs:
+    #           expression: |
+    #             _.userGroups.groups.exists(g, g == "YOUR-GROUP-OBJECT-ID-HERE")

--- a/pkg/gotmpl/ext/hcl/hcl.go
+++ b/pkg/gotmpl/ext/hcl/hcl.go
@@ -111,8 +111,9 @@ func writeHcl(buf *strings.Builder, value any, indent int) error {
 	case []any:
 		return writeHclList(buf, v, indent)
 	default:
-		// Primitive at top level — not valid HCL on its own
-		return fmt.Errorf("top-level value must be a map/object, got %T", value)
+		// Scalar at top level — emit as a bare HCL literal
+		buf.WriteString(formatHclValue(v))
+		return nil
 	}
 }
 

--- a/pkg/gotmpl/ext/hcl/hcl_test.go
+++ b/pkg/gotmpl/ext/hcl/hcl_test.go
@@ -187,9 +187,25 @@ func TestToHcl_EmptyMap(t *testing.T) {
 }
 
 func TestToHcl_TopLevelPrimitive(t *testing.T) {
-	_, err := ToHcl("hello")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "top-level value must be a map/object")
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"string", "hello", `"hello"`},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"integer", float64(42), "42"},
+		{"float", 3.14, "3.14"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToHcl(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestToHcl_ComplexExample(t *testing.T) {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -185,7 +185,36 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 					}
 				}
 
+				lintNilInputs(step.Inputs, stepLocation, result)
 				lintExpressions(step.Inputs, stepLocation, result)
+			}
+		}
+
+		// Check for empty transform.with / validate.with arrays.
+		if res.Transform != nil && len(res.Transform.With) == 0 {
+			result.addFinding(SeverityWarning, "structure", location+".transform",
+				"transform phase has empty 'with' array; no transformations will be applied",
+				"Add transform steps or remove the transform section entirely",
+				"empty-transform-with")
+		}
+		if res.Validate != nil && len(res.Validate.With) == 0 {
+			result.addFinding(SeverityWarning, "structure", location+".validate",
+				"validate phase has empty 'with' array; no validations will be applied",
+				"Add validation rules or remove the validate section entirely",
+				"empty-validate-with")
+		}
+
+		// Check for nil inputs in transform/validate phases.
+		if res.Transform != nil {
+			for i, step := range res.Transform.With {
+				stepLocation := fmt.Sprintf("%s.transform.with[%d]", location, i)
+				lintNilInputs(step.Inputs, stepLocation, result)
+			}
+		}
+		if res.Validate != nil {
+			for i, step := range res.Validate.With {
+				stepLocation := fmt.Sprintf("%s.validate.with[%d]", location, i)
+				lintNilInputs(step.Inputs, stepLocation, result)
 			}
 		}
 
@@ -421,6 +450,20 @@ func lintResultSchema(schema *jsonschema.Schema, location string, result *Result
 	// Lint array items schema
 	if schema.Items != nil {
 		lintResultSchema(schema.Items, location+".items", result)
+	}
+}
+
+// lintNilInputs checks for nil ValueRef entries in provider inputs, which
+// typically result from dangling YAML keys with no value.
+func lintNilInputs(inputs map[string]*spec.ValueRef, location string, result *Result) {
+	for key, val := range inputs {
+		if val == nil {
+			inputLoc := fmt.Sprintf("%s.inputs.%s", location, key)
+			result.addFinding(SeverityError, "provider", inputLoc,
+				fmt.Sprintf("input '%s' has no value (dangling YAML key)", key),
+				"Provide a value for the input or remove the key entirely",
+				"nil-provider-input")
+		}
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -537,3 +537,103 @@ func filterFindingsByRule(result *Result, rule string) []*Finding {
 	}
 	return out
 }
+
+func TestLintNilProviderInput(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"has-nil-input": {
+					Type: "string",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs: map[string]*spec.ValueRef{
+								"value":        {Literal: "ok"},
+								"dangling-key": nil,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "nil-provider-input")
+	require.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "dangling-key")
+	assert.Contains(t, findings[0].Message, "no value")
+}
+
+func TestLintEmptyTransformWith(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"empty-transform": {
+					Type: "string",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "ok"}},
+						}},
+					},
+					Transform: &resolver.TransformPhase{
+						With: []resolver.ProviderTransform{},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "empty-transform-with")
+	require.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "empty")
+}
+
+func TestLintEmptyValidateWith(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"empty-validate": {
+					Type: "string",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "ok"}},
+						}},
+					},
+					Validate: &resolver.ValidatePhase{
+						With: []resolver.ProviderValidation{},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "empty-validate-with")
+	require.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "empty")
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -245,6 +245,33 @@ var KnownRules = map[string]RuleMeta{
 			"# Correct patterns:\nfiles:\n  - templates/main.yaml      # exact file\n  - data/                     # entire directory\n  - configs/**/*.yaml          # recursive glob",
 		},
 	},
+	"nil-provider-input": {
+		Rule:        "nil-provider-input",
+		Severity:    string(SeverityError),
+		Category:    "provider",
+		Description: "A provider input key has no value (dangling YAML key). This will cause resolver execution to fail at runtime with an error.",
+		Why:         "A YAML key with no value (e.g., 'my-input:' on its own line) results in a nil entry. When the resolver engine evaluates provider inputs, a nil value causes resolution to fail with a descriptive runtime error.",
+		Fix:         "Either provide a value for the input key or remove the dangling key entirely.",
+		Examples: []string{
+			"# Wrong (dangling key):\ninputs:\n  my-input:\n\n# Correct:\ninputs:\n  my-input: 'some-value'",
+		},
+	},
+	"empty-transform-with": {
+		Rule:        "empty-transform-with",
+		Severity:    string(SeverityWarning),
+		Category:    "structure",
+		Description: "A resolver has a transform phase with an empty 'with' array. No transformations will be applied.",
+		Why:         "An empty transform.with array is almost certainly unintentional. The transform phase will be silently skipped, which may cause unexpected resolver output.",
+		Fix:         "Either add transform steps to the with array or remove the transform section entirely.",
+	},
+	"empty-validate-with": {
+		Rule:        "empty-validate-with",
+		Severity:    string(SeverityWarning),
+		Category:    "structure",
+		Description: "A resolver has a validate phase with an empty 'with' array. No validations will be applied.",
+		Why:         "An empty validate.with array is almost certainly unintentional. The validate phase will be silently skipped, which may cause unexpected behavior.",
+		Fix:         "Either add validation rules to the with array or remove the validate section entirely.",
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 25 rules — update this when new rules are added
-	assert.Equal(t, 25, len(KnownRules), "expected 25 known lint rules")
+	// We expect exactly 28 rules — update this when new rules are added
+	assert.Equal(t, 28, len(KnownRules), "expected 28 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -1359,6 +1359,9 @@ func (e *Executor) executeProviderWithSelf(ctx context.Context, providerName str
 	resolverData := resolverCtx.ToMap()
 
 	for key, valueRef := range inputRefs {
+		if valueRef == nil {
+			return nil, fmt.Errorf("input %q has no value (nil); check for dangling YAML keys with no value", key)
+		}
 		resolved, err := valueRef.Resolve(ctx, resolverData, self)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve input %q: %w", key, err)

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -1591,3 +1591,39 @@ func TestExecutor_Execute_ConcurrentStress(t *testing.T) {
 		}
 	})
 }
+
+func TestExecutor_Execute_NilValueRefInput(t *testing.T) {
+	registry := newMockRegistry()
+	registry.Register(&mockProvider{name: "mock"})
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "dangling-key",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "mock",
+						Inputs: map[string]*ValueRef{
+							"valid-key": {Literal: "hello"},
+							"nil-key":   nil, // dangling YAML key
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx, err := executor.Execute(ctx, resolvers, nil)
+
+	require.Error(t, err)
+	result, _ := FromContext(ctx)
+	require.NotNil(t, result)
+
+	execResult, ok := result.GetResult("dangling-key")
+	require.True(t, ok)
+	assert.Equal(t, ExecutionStatusFailed, execResult.Status)
+	require.Error(t, execResult.Error)
+	assert.Contains(t, execResult.Error.Error(), "no value (nil)")
+}

--- a/pkg/solution/soltesting/discovery.go
+++ b/pkg/solution/soltesting/discovery.go
@@ -24,6 +24,9 @@ type SolutionTests struct {
 	Config *TestConfig `json:"config,omitempty"`
 	// FilePath is the absolute path to the solution file.
 	FilePath string `json:"filePath"`
+	// DetectedFiles contains file patterns auto-detected from resolver specs
+	// (e.g., directory provider paths). Used to populate builtin test files.
+	DetectedFiles []string `json:"detectedFiles,omitempty"`
 }
 
 // FilterOptions specifies how to filter discovered tests.
@@ -108,12 +111,20 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 		} `yaml:"metadata"`
 		Compose []string `yaml:"compose"`
 		Spec    struct {
-			Testing *TestSuite `yaml:"testing"`
+			Testing   *TestSuite `yaml:"testing"`
+			Resolvers yaml.Node  `yaml:"resolvers"`
 		} `yaml:"spec"`
 	}
 
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing %q: %w", filePath, err)
+	}
+
+	// Best-effort parse of resolvers for file dependency detection.
+	// Only map-shaped resolvers are supported — arrays or other forms are silently ignored.
+	var resolverSpecs map[string]minimalResolver
+	if doc.Spec.Resolvers.Kind == yaml.MappingNode {
+		_ = doc.Spec.Resolvers.Decode(&resolverSpecs) // ignore errors — best-effort
 	}
 
 	// Process compose files — merge tests from referenced files
@@ -135,12 +146,26 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 				}
 				var composePart struct {
 					Spec struct {
-						Testing *TestSuite `yaml:"testing"`
+						Testing   *TestSuite `yaml:"testing"`
+						Resolvers yaml.Node  `yaml:"resolvers"`
 					} `yaml:"spec"`
 				}
 				if unmarshalErr := yaml.Unmarshal(composeData, &composePart); unmarshalErr != nil {
 					return nil, fmt.Errorf("parsing compose file %q: %w", match, unmarshalErr)
 				}
+				// Merge resolvers from compose file for dependency detection
+				if composePart.Spec.Resolvers.Kind == yaml.MappingNode {
+					var composeResolvers map[string]minimalResolver
+					if decErr := composePart.Spec.Resolvers.Decode(&composeResolvers); decErr == nil {
+						if resolverSpecs == nil {
+							resolverSpecs = make(map[string]minimalResolver)
+						}
+						for k, v := range composeResolvers {
+							resolverSpecs[k] = v
+						}
+					}
+				}
+
 				// Initialize doc testing if nil
 				if doc.Spec.Testing == nil {
 					doc.Spec.Testing = &TestSuite{}
@@ -184,10 +209,11 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 	}
 
 	return &SolutionTests{
-		SolutionName: doc.Metadata.Name,
-		Cases:        doc.Spec.Testing.Cases,
-		Config:       doc.Spec.Testing.Config,
-		FilePath:     absPath,
+		SolutionName:  doc.Metadata.Name,
+		Cases:         doc.Spec.Testing.Cases,
+		Config:        doc.Spec.Testing.Config,
+		FilePath:      absPath,
+		DetectedFiles: detectFileDependencies(resolverSpecs),
 	}, nil
 }
 
@@ -346,4 +372,59 @@ func matchesTagFilter(testTags, filterTags []string) bool {
 		}
 	}
 	return false
+}
+
+// minimalResolver is a lightweight struct for extracting directory provider
+// paths without importing the full resolver package.
+type minimalResolver struct {
+	Resolve *struct {
+		With []struct {
+			Provider string         `yaml:"provider"`
+			Inputs   map[string]any `yaml:"inputs"`
+		} `yaml:"with"`
+	} `yaml:"resolve"`
+}
+
+// detectFileDependencies scans minimally-parsed resolver specs for directory
+// provider path inputs and returns glob patterns covering those paths.
+// This enables builtin tests to auto-detect file dependencies.
+func detectFileDependencies(resolvers map[string]minimalResolver) []string {
+	seen := make(map[string]bool)
+	var patterns []string
+
+	for _, res := range resolvers {
+		if res.Resolve == nil {
+			continue
+		}
+		for _, step := range res.Resolve.With {
+			if step.Provider != "directory" {
+				continue
+			}
+			pathVal, ok := step.Inputs["path"]
+			if !ok {
+				continue
+			}
+			pathStr, ok := pathVal.(string)
+			if !ok || pathStr == "" {
+				continue
+			}
+			// Skip absolute paths and dynamic references
+			if filepath.IsAbs(pathStr) ||
+				strings.Contains(pathStr, "{{") ||
+				strings.HasPrefix(pathStr, "expr:") ||
+				strings.HasPrefix(pathStr, "rslvr:") ||
+				strings.HasPrefix(pathStr, "tmpl:") {
+				continue
+			}
+			// Convert directory path to a recursive glob
+			pattern := strings.TrimSuffix(pathStr, "/") + "/**"
+			if !seen[pattern] {
+				seen[pattern] = true
+				patterns = append(patterns, pattern)
+			}
+		}
+	}
+
+	sort.Strings(patterns)
+	return patterns
 }

--- a/pkg/solution/soltesting/discovery_test.go
+++ b/pkg/solution/soltesting/discovery_test.go
@@ -288,3 +288,134 @@ func TestSortedTestNames(t *testing.T) {
 	assert.Equal(t, "m-test", names[3])
 	assert.Equal(t, "z-test", names[4])
 }
+
+func TestDiscoverFromFile_DetectsDirectoryProviderFiles(t *testing.T) {
+	solutionYAML := `apiVersion: scafctl/v1
+kind: Solution
+metadata:
+  name: detect-files-test
+spec:
+  resolvers:
+    my-template:
+      type: object
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              path: templates/app
+              operation: list
+    my-data:
+      type: object
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              path: data/configs
+              operation: list
+    no-directory:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  testing:
+    cases:
+      basic:
+        command: [run, resolver]
+        assertions:
+          - expression: '__exitCode == 0'
+`
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(solutionYAML), 0o644))
+
+	// Create the referenced directories so the solution is valid
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "templates", "app"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "data", "configs"), 0o755))
+
+	st, err := soltesting.DiscoverFromFile(solPath)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	assert.Equal(t, []string{"data/configs/**", "templates/app/**"}, st.DetectedFiles)
+}
+
+func TestDiscoverFromFile_NoDetectedFilesWithoutDirectoryProvider(t *testing.T) {
+	solutionYAML := `apiVersion: scafctl/v1
+kind: Solution
+metadata:
+  name: no-files-test
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  testing:
+    cases:
+      basic:
+        command: [run, resolver]
+        assertions:
+          - expression: '__exitCode == 0'
+`
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(solutionYAML), 0o644))
+
+	st, err := soltesting.DiscoverFromFile(solPath)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	assert.Empty(t, st.DetectedFiles)
+}
+
+func TestDiscoverFromFile_DetectsFileDepsFromComposeResolvers(t *testing.T) {
+	solutionYAML := `apiVersion: scafctl/v1
+kind: Solution
+metadata:
+  name: compose-file-deps-test
+compose:
+  - resolvers.yaml
+spec:
+  testing:
+    cases:
+      basic:
+        command: [run, resolver]
+        assertions:
+          - expression: '__exitCode == 0'
+`
+	resolversYAML := `apiVersion: scafctl/v1
+kind: Solution
+spec:
+  resolvers:
+    my-files:
+      type: object
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              path: templates/app
+              operation: list
+    my-data:
+      type: object
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              path: data/configs
+              operation: list
+`
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resolvers.yaml"), []byte(resolversYAML), 0o644))
+
+	st, err := soltesting.DiscoverFromFile(filepath.Join(dir, "solution.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	assert.Equal(t, []string{"data/configs/**", "templates/app/**"}, st.DetectedFiles)
+}

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -97,6 +97,11 @@ func (r *Runner) Run(ctx context.Context, solutions []SolutionTests) ([]TestResu
 		// Generate builtins
 		builtins := BuiltinTests(st.Config)
 		for _, b := range builtins {
+			// Auto-populate builtin test files from detected dependencies
+			// so directory provider paths are available in the sandbox.
+			if len(b.Files) == 0 && len(st.DetectedFiles) > 0 {
+				b.Files = append(b.Files, st.DetectedFiles...)
+			}
 			st.Cases[b.Name] = b
 		}
 


### PR DESCRIPTION
…, B2, C1, C3

- Add nil guard in executeProviderWithSelf() to return descriptive error instead of panicking on dangling YAML keys (B2)
- Add lint rules: nil-provider-input, empty-transform-with, empty-validate-with to catch common YAML authoring mistakes (B2, C3)
- Support scalar values (string, bool, int, float) in toHcl template function for cldctl template compatibility (C1)
- Auto-detect file dependencies for builtin tests by scanning directory provider paths, fixing sandbox isolation failures (B1)

BREAKING CHANGE: toHcl now emits scalar literals instead of erroring
