### PR TITLE
feat(catalog): add multi-platform plugin support via OCI image index

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,8 +51,6 @@ See `pkg/httpc/README.md`
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
 - **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
 - **Testing**: Use `testify/assert`, mocks in `mock.go` files
-- **Linting**: Run `golangci-lint run` before committing
-- **Build**: Include LDFLAGS for version injection (see `taskfile.yaml`)
 - **Breaking changes**: Allowed—this app is not in production. Note when doing so.
 - **Backward compatibility**: Do not do it, see Breaking changes above.
 
@@ -93,3 +91,7 @@ golangci-lint run --fix          # Run Linter and auto-fix issues
 **IMPORTANT**: Never include business logic in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`) or API packages (future) instead, put it into proper shared domain packages (`pkg/...`)
 
 **Note**: The project uses `task` (go-task/task) as a convenience wrapper, but AI agents should use raw Go commands for clarity and portability.
+
+**IMPORTANT**: Always update documentation, tutorials, examples, mcp server tools (if applicable) when features, providers or commands change or added.
+**IMPORTANT**: Add benchmark tests for any new features or providers in `*_test.go` files using Go's `testing` package.
+**IMPORTANT**: After any change, run `task test:e2e` to ensure everything passes.

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -161,6 +161,9 @@ There is no MCP library in `go.mod` today. We would add one:
 | `list_providers` | `scafctl get provider` | List available providers |
 | `run_provider` | `scafctl run provider` | Execute a single provider |
 | `catalog_list` | `scafctl catalog list` | List catalog entries |
+| `catalog_inspect` | `scafctl catalog inspect` | Inspect artifact metadata (includes multi-platform info) |
+| `catalog_list_platforms` | — | List platforms for a multi-platform plugin artifact |
+| `build_plugin` | `scafctl build plugin` | Build multi-platform plugin into local catalog |
 | `catalog_pull` | `scafctl catalog pull` | Pull a solution from registry |
 | `test_solution` | `scafctl test functional` | Run functional tests |
 | `explain_solution` | `scafctl explain` | Explain a configuration |

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -395,6 +395,77 @@ See the [Plugin Auto-Fetching Tutorial](../tutorials/plugin-auto-fetch-tutorial.
 
 ---
 
+## Multi-Platform Support via OCI Image Index
+
+Plugin binaries are platform-specific — a Linux x86-64 binary cannot run on
+macOS ARM64. To distribute a single plugin that works across OS/architecture
+combinations, scafctl supports **OCI image indexes** (fat manifests).
+
+### Architecture
+
+| Component | Package | Responsibility |
+|-----------|---------|----------------|
+| **MultiPlatform helpers** | `pkg/catalog/multiplatform.go` | Platform↔OCI conversion, index matching |
+| **StoreMultiPlatform** | `pkg/catalog/local_multiplatform.go` | Store multi-platform artifact as image index |
+| **FetchByPlatform** | `pkg/catalog/local_multiplatform.go` | Fetch correct platform binary from image index |
+| **PlatformAwareCatalog** | `pkg/catalog/plugin_fetcher.go` | Interface for catalogs with image index support |
+| **build plugin** | `pkg/cmd/scafctl/build/plugin.go` | CLI for building multi-platform artifacts |
+
+### OCI Image Index Structure
+
+A multi-platform plugin is stored as an OCI image index referencing
+per-platform image manifests:
+
+```
+image index (application/vnd.oci.image.index.v1+json)
+├── platform: linux/amd64
+│   └── manifest → config + binary layer
+├── platform: darwin/arm64
+│   └── manifest → config + binary layer
+└── platform: windows/amd64
+    └── manifest → config + binary layer
+```
+
+### Platform Resolution Strategy
+
+When `PluginFetcher.FetchPlugin()` is called:
+
+1. **OCI image index** — If the catalog implements `PlatformAwareCatalog`,
+   try `FetchByPlatform()` which resolves the platform from the image index.
+   If the artifact IS an image index but the platform is missing, return
+   `PlatformNotFoundError` (no fallback — the artifact is explicitly
+   multi-platform).
+
+2. **Annotation matching** (legacy) — Fall back to listing artifacts and
+   matching the `dev.scafctl.plugin.platform` annotation on individual
+   manifests.
+
+3. **Direct fetch** — Fall back to fetching the artifact directly
+   (single-platform artifacts without platform metadata).
+
+### Supported Platforms
+
+- `linux/amd64`
+- `linux/arm64`
+- `darwin/amd64`
+- `darwin/arm64`
+- `windows/amd64`
+
+### Building Multi-Platform Artifacts
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=./dist/linux-amd64/my-provider \
+  --platform darwin/arm64=./dist/darwin-arm64/my-provider
+```
+
+See the [Multi-Platform Plugin Build Tutorial](../tutorials/multi-platform-plugin-build.md) for a complete walkthrough.
+
+---
+
 ## Summary
 
 Plugins are the extensibility layer of scafctl. They exist to supply providers in an isolated, versioned, and scalable way using go-plugin. Plugins are not a new execution model or abstraction. They are the mechanism by which providers are distributed and invoked, keeping the core system small, stable, and extensible.

--- a/docs/tutorials/multi-platform-plugin-build.md
+++ b/docs/tutorials/multi-platform-plugin-build.md
@@ -1,0 +1,204 @@
+---
+title: "Multi-Platform Plugin Build Tutorial"
+weight: 14
+---
+
+# Multi-Platform Plugin Build Tutorial
+
+This tutorial walks through building and distributing multi-platform plugin
+artifacts using OCI image indexes.
+
+## Overview
+
+Plugin artifacts (providers, auth handlers) are platform-specific binaries.
+To distribute a single plugin that works on multiple OS/architecture
+combinations, scafctl stores them as an **OCI image index** (also called a
+"fat manifest"). At runtime, scafctl automatically selects the correct
+binary for the current platform.
+
+### Supported Platforms
+
+| Platform | Description |
+|----------|-------------|
+| `linux/amd64` | Linux x86-64 |
+| `linux/arm64` | Linux ARM64 (e.g. AWS Graviton) |
+| `darwin/amd64` | macOS Intel |
+| `darwin/arm64` | macOS Apple Silicon |
+| `windows/amd64` | Windows x86-64 |
+
+## Prerequisites
+
+- scafctl CLI installed
+- Go toolchain (for cross-compilation)
+- Plugin source code that builds for multiple platforms
+
+## Step 1: Cross-Compile the Plugin
+
+Use Go's cross-compilation to build binaries for each target platform:
+
+```bash
+# Set the plugin name and version
+PLUGIN_NAME=my-provider
+VERSION=1.0.0
+
+# Build for all supported platforms
+GOOS=linux   GOARCH=amd64 go build -o dist/${PLUGIN_NAME}-linux-amd64   ./cmd/plugin
+GOOS=linux   GOARCH=arm64 go build -o dist/${PLUGIN_NAME}-linux-arm64   ./cmd/plugin
+GOOS=darwin  GOARCH=amd64 go build -o dist/${PLUGIN_NAME}-darwin-amd64  ./cmd/plugin
+GOOS=darwin  GOARCH=arm64 go build -o dist/${PLUGIN_NAME}-darwin-arm64  ./cmd/plugin
+GOOS=windows GOARCH=amd64 go build -o dist/${PLUGIN_NAME}-windows-amd64.exe ./cmd/plugin
+```
+
+## Step 2: Build Multi-Platform Artifact
+
+Use `scafctl build plugin` to package all binaries into a single
+multi-platform artifact:
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=./dist/my-provider-linux-amd64 \
+  --platform linux/arm64=./dist/my-provider-linux-arm64 \
+  --platform darwin/amd64=./dist/my-provider-darwin-amd64 \
+  --platform darwin/arm64=./dist/my-provider-darwin-arm64 \
+  --platform windows/amd64=./dist/my-provider-windows-amd64.exe
+```
+
+This creates an OCI image index in the local catalog with one manifest per
+platform.
+
+### Output
+
+```
+  linux/amd64 → ./dist/my-provider-linux-amd64 (12.3 MB)
+  linux/arm64 → ./dist/my-provider-linux-arm64 (11.8 MB)
+  darwin/amd64 → ./dist/my-provider-darwin-amd64 (13.1 MB)
+  darwin/arm64 → ./dist/my-provider-darwin-arm64 (12.5 MB)
+  windows/amd64 → ./dist/my-provider-windows-amd64.exe (14.2 MB)
+✓ Built my-provider@1.0.0 (5 platform(s))
+  Digest: sha256:abc123...
+  Catalog: ~/.local/share/scafctl/catalog/
+  Platform: linux/amd64
+  Platform: linux/arm64
+  Platform: darwin/amd64
+  Platform: darwin/arm64
+  Platform: windows/amd64
+```
+
+## Step 3: Push to Remote Registry
+
+Push the multi-platform artifact to an OCI registry:
+
+```bash
+scafctl catalog push my-provider@1.0.0 --catalog ghcr.io/myorg/scafctl
+```
+
+The image index and all platform manifests are pushed together.
+
+## Step 4: Runtime Platform Selection
+
+When a solution references this plugin, scafctl automatically selects
+the correct platform binary:
+
+```yaml
+# solution.yaml
+metadata:
+  name: my-solution
+  version: 1.0.0
+
+bundle:
+  plugins:
+    - name: my-provider
+      kind: provider
+      version: "^1.0.0"
+```
+
+On `darwin/arm64` (Apple Silicon), scafctl will:
+1. Resolve `my-provider@^1.0.0` from the catalog chain
+2. Detect the artifact is an OCI image index
+3. Select the `darwin/arm64` manifest from the index
+4. Fetch and cache the correct binary
+
+## Building for a Subset of Platforms
+
+You don't need to build for all platforms. For example, if your plugin
+only supports Linux:
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=./dist/linux-amd64/my-provider \
+  --platform linux/arm64=./dist/linux-arm64/my-provider
+```
+
+If a user on an unsupported platform tries to use this plugin, they'll get a
+clear error:
+
+```
+Error: platform "darwin/arm64" not found in image index (available: [linux/amd64 linux/arm64])
+```
+
+## Auth Handler Example
+
+The same workflow works for auth handler plugins:
+
+```bash
+scafctl build plugin \
+  --name github-auth \
+  --kind auth-handler \
+  --version 2.0.0 \
+  --platform linux/amd64=./dist/github-auth-linux-amd64 \
+  --platform darwin/arm64=./dist/github-auth-darwin-arm64
+```
+
+## Overwriting Existing Versions
+
+Use `--force` to overwrite an existing version:
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=./dist/my-provider-linux-amd64 \
+  --force
+```
+
+## How It Works Internally
+
+### OCI Image Index Structure
+
+A multi-platform plugin is stored as an OCI image index:
+
+```
+index.json (image index)
+├── manifest-linux-amd64 (image manifest)
+│   ├── config.json
+│   └── layer: linux-amd64 binary
+├── manifest-darwin-arm64 (image manifest)
+│   ├── config.json
+│   └── layer: darwin-arm64 binary
+└── manifest-windows-amd64 (image manifest)
+    ├── config.json
+    └── layer: windows-amd64 binary
+```
+
+### Platform Resolution Order
+
+When fetching a plugin, scafctl uses this resolution strategy:
+
+1. **OCI image index** — If the artifact is an image index, select the manifest
+   matching the current platform's OS and architecture
+2. **Annotation matching** — Fall back to matching the
+   `dev.scafctl.plugin.platform` annotation on individual artifacts (legacy)
+3. **Direct fetch** — Fall back to fetching the single artifact directly
+   (single-platform artifacts without annotations)
+
+### Content-Addressed Storage
+
+Binary content is stored with content-addressable digests. If two platforms
+share the same binary (e.g., a script), the blob is stored only once.

--- a/examples/plugins/multi-platform-build/README.md
+++ b/examples/plugins/multi-platform-build/README.md
@@ -1,0 +1,72 @@
+# Multi-Platform Plugin Build Example
+
+This example demonstrates building a multi-platform plugin artifact.
+
+## Prerequisites
+
+Create mock binaries (in real usage, these would be cross-compiled Go binaries):
+
+```bash
+mkdir -p dist
+echo "linux-amd64-binary" > dist/my-provider-linux-amd64
+echo "darwin-arm64-binary" > dist/my-provider-darwin-arm64
+```
+
+## Build Multi-Platform Artifact
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=dist/my-provider-linux-amd64 \
+  --platform darwin/arm64=dist/my-provider-darwin-arm64
+```
+
+## Build All Supported Platforms
+
+```bash
+scafctl build plugin \
+  --name my-provider \
+  --kind provider \
+  --version 1.0.0 \
+  --platform linux/amd64=dist/my-provider-linux-amd64 \
+  --platform linux/arm64=dist/my-provider-linux-arm64 \
+  --platform darwin/amd64=dist/my-provider-darwin-amd64 \
+  --platform darwin/arm64=dist/my-provider-darwin-arm64 \
+  --platform windows/amd64=dist/my-provider-windows-amd64.exe
+```
+
+## Auth Handler Example
+
+```bash
+scafctl build plugin \
+  --name github-auth \
+  --kind auth-handler \
+  --version 2.0.0 \
+  --platform linux/amd64=dist/github-auth-linux-amd64 \
+  --platform darwin/arm64=dist/github-auth-darwin-arm64
+```
+
+## Push to Remote Registry
+
+```bash
+scafctl catalog push my-provider@1.0.0 --catalog ghcr.io/myorg/scafctl
+```
+
+## Reference in a Solution
+
+```yaml
+metadata:
+  name: my-solution
+  version: 1.0.0
+
+bundle:
+  plugins:
+    - name: my-provider
+      kind: provider
+      version: "^1.0.0"
+```
+
+At runtime, scafctl detects the current platform and selects the correct
+binary from the OCI image index automatically.

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -78,6 +78,33 @@ func IsArtifactNotFoundError(err error) bool {
 	return IsNotFound(err)
 }
 
+// ErrPlatformNotFound is returned when no matching platform is found in an image index.
+var ErrPlatformNotFound = errors.New("platform not found")
+
+// PlatformNotFoundError provides details about a missing platform in an image index.
+type PlatformNotFoundError struct {
+	Platform  string   // The requested platform (e.g. "linux/amd64")
+	Available []string // Available platforms in the index
+}
+
+// Error implements the error interface.
+func (e *PlatformNotFoundError) Error() string {
+	if len(e.Available) > 0 {
+		return fmt.Sprintf("platform %q not found in image index (available: %v)", e.Platform, e.Available)
+	}
+	return fmt.Sprintf("platform %q not found in image index", e.Platform)
+}
+
+// Unwrap returns the base error for errors.Is support.
+func (e *PlatformNotFoundError) Unwrap() error {
+	return ErrPlatformNotFound
+}
+
+// IsPlatformNotFound returns true if the error indicates a missing platform.
+func IsPlatformNotFound(err error) bool {
+	return errors.Is(err, ErrPlatformNotFound)
+}
+
 // IsExists returns true if the error indicates an artifact already exists.
 func IsExists(err error) bool {
 	return errors.Is(err, ErrArtifactExists)

--- a/pkg/catalog/local.go
+++ b/pkg/catalog/local.go
@@ -925,10 +925,31 @@ func (c *LocalCatalog) Save(ctx context.Context, name, version, outputPath strin
 	}, nil
 }
 
-// collectBlobsForExport recursively collects all blobs referenced by a manifest.
+// collectBlobsForExport recursively collects all blobs referenced by a
+// manifest or image index.
 func (c *LocalCatalog) collectBlobsForExport(ctx context.Context, desc ocispec.Descriptor, blobs map[string]ocispec.Descriptor) error {
 	// Add this blob
 	blobs[desc.Digest.String()] = desc
+
+	// If it's an image index, recursively collect all referenced manifests
+	if IsImageIndex(desc) {
+		data, err := c.fetchBlob(ctx, desc)
+		if err != nil {
+			return err
+		}
+
+		var index ocispec.Index
+		if err := json.Unmarshal(data, &index); err != nil {
+			return err
+		}
+
+		for _, manifestDesc := range index.Manifests {
+			if err := c.collectBlobsForExport(ctx, manifestDesc, blobs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 
 	// If it's a manifest, also collect config and layers
 	if desc.MediaType == ocispec.MediaTypeImageManifest {
@@ -1066,9 +1087,10 @@ func (c *LocalCatalog) Load(ctx context.Context, inputPath string, force bool) (
 	}, nil
 }
 
-// markReferencedBlobs recursively marks all blobs referenced by a manifest.
+// markReferencedBlobs recursively marks all blobs referenced by a manifest
+// or image index.
 func (c *LocalCatalog) markReferencedBlobs(ctx context.Context, desc ocispec.Descriptor, refs map[string]bool) error {
-	// Fetch the manifest content
+	// Fetch the manifest/index content
 	rc, err := c.store.Fetch(ctx, desc)
 	if err != nil {
 		return err
@@ -1080,8 +1102,24 @@ func (c *LocalCatalog) markReferencedBlobs(ctx context.Context, desc ocispec.Des
 		return err
 	}
 
-	// Mark the manifest blob itself
+	// Mark the blob itself
 	refs[desc.Digest.String()] = true
+
+	// Check if this is an image index (multi-platform artifact)
+	if IsImageIndex(desc) {
+		var index ocispec.Index
+		if err := json.Unmarshal(manifestData, &index); err != nil {
+			return nil // not a valid index, just mark the blob
+		}
+		// Recursively mark all referenced manifests in the index
+		for _, manifestDesc := range index.Manifests {
+			if err := c.markReferencedBlobs(ctx, manifestDesc, refs); err != nil {
+				c.logger.V(2).Info("failed to mark blobs for index manifest",
+					"digest", manifestDesc.Digest.String(), "error", err)
+			}
+		}
+		return nil
+	}
 
 	// Parse as OCI manifest to get config and layers
 	var manifest ocispec.Manifest

--- a/pkg/catalog/local_multiplatform.go
+++ b/pkg/catalog/local_multiplatform.go
@@ -1,0 +1,298 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+)
+
+// StoreMultiPlatform stores a set of platform-specific plugin binaries as an
+// OCI image index (fat manifest). Each entry in platformBinaries maps a
+// platform string (e.g. "linux/amd64") to the raw binary data. The resulting
+// image index is tagged under the normal kind/name:version scheme.
+//
+// This replaces any existing single-platform artifact at the same reference.
+func (c *LocalCatalog) StoreMultiPlatform(ctx context.Context, ref Reference, platformBinaries []PlatformBinary, annotations map[string]string, force bool) (ArtifactInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(platformBinaries) == 0 {
+		return ArtifactInfo{}, fmt.Errorf("at least one platform binary is required")
+	}
+
+	// Check existence (unless force)
+	if !force && c.existsLocked(ctx, ref) {
+		return ArtifactInfo{}, &ArtifactExistsError{Reference: ref, Catalog: LocalCatalogName}
+	}
+
+	now := time.Now().UTC()
+
+	// Merge annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationArtifactType] = ref.Kind.String()
+	annotations[AnnotationArtifactName] = ref.Name
+	if ref.Version != nil {
+		annotations[AnnotationVersion] = ref.Version.String()
+	}
+	annotations[AnnotationCreated] = now.Format(time.RFC3339)
+
+	// Build a per-platform manifest for each binary and collect descriptors.
+	var manifestDescs []ocispec.Descriptor
+
+	for _, pb := range platformBinaries {
+		ociPlatform, err := PlatformToOCI(pb.Platform)
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("invalid platform %q: %w", pb.Platform, err)
+		}
+
+		// Push content layer
+		contentDesc, err := c.pushBlobLocked(ctx, MediaTypeForKind(ref.Kind), pb.Data)
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("pushing content for %s: %w", pb.Platform, err)
+		}
+
+		// Push config blob
+		configData, err := json.Marshal(map[string]any{
+			"kind":      ref.Kind.String(),
+			"name":      ref.Name,
+			"version":   ref.Version.String(),
+			"platform":  pb.Platform,
+			"createdAt": now.Format(time.RFC3339),
+		})
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("marshalling config for %s: %w", pb.Platform, err)
+		}
+
+		configDesc, err := c.pushBlobLocked(ctx, ConfigMediaTypeForKind(ref.Kind), configData)
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("pushing config for %s: %w", pb.Platform, err)
+		}
+
+		// Build per-platform manifest
+		platAnnotations := copyAnnotations(annotations)
+		platAnnotations[AnnotationPlatform] = pb.Platform
+
+		manifest := ocispec.Manifest{
+			Versioned:   specs.Versioned{SchemaVersion: 2},
+			MediaType:   ocispec.MediaTypeImageManifest,
+			Config:      configDesc,
+			Layers:      []ocispec.Descriptor{contentDesc},
+			Annotations: platAnnotations,
+		}
+
+		manifestData, err := json.Marshal(manifest)
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("marshalling manifest for %s: %w", pb.Platform, err)
+		}
+
+		manifestDesc, err := c.pushBlobLocked(ctx, ocispec.MediaTypeImageManifest, manifestData)
+		if err != nil {
+			return ArtifactInfo{}, fmt.Errorf("pushing manifest for %s: %w", pb.Platform, err)
+		}
+
+		manifestDesc.Platform = ociPlatform
+		manifestDesc.Annotations = platAnnotations
+		manifestDescs = append(manifestDescs, manifestDesc)
+	}
+
+	// Build the image index
+	index := ocispec.Index{
+		Versioned:   specs.Versioned{SchemaVersion: 2},
+		MediaType:   ocispec.MediaTypeImageIndex,
+		Manifests:   manifestDescs,
+		Annotations: annotations,
+	}
+
+	indexData, err := json.Marshal(index)
+	if err != nil {
+		return ArtifactInfo{}, fmt.Errorf("marshalling image index: %w", err)
+	}
+
+	indexDesc, err := c.pushBlobLocked(ctx, ocispec.MediaTypeImageIndex, indexData)
+	if err != nil {
+		return ArtifactInfo{}, fmt.Errorf("pushing image index: %w", err)
+	}
+
+	// Tag the index under the standard schema
+	tag := c.tagForRef(ref)
+	indexDesc.Annotations = annotations
+	if err := c.store.Tag(ctx, indexDesc, tag); err != nil {
+		return ArtifactInfo{}, fmt.Errorf("tagging image index: %w", err)
+	}
+
+	c.logger.V(1).Info("stored multi-platform artifact",
+		"name", ref.Name,
+		"version", ref.Version.String(),
+		"platforms", len(platformBinaries),
+		"digest", indexDesc.Digest.String())
+
+	return ArtifactInfo{
+		Reference:   ref,
+		Digest:      indexDesc.Digest.String(),
+		CreatedAt:   now,
+		Size:        indexDesc.Size,
+		Annotations: annotations,
+		Catalog:     LocalCatalogName,
+	}, nil
+}
+
+// FetchByPlatform fetches a plugin binary for the given platform from an
+// artifact that may be stored as either a single-platform manifest or a
+// multi-platform image index. It transparently handles both cases.
+func (c *LocalCatalog) FetchByPlatform(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	info, err := c.resolveLocked(ctx, ref)
+	if err != nil {
+		return nil, ArtifactInfo{}, err
+	}
+
+	tag := c.tagForRef(info.Reference)
+	desc, err := c.store.Resolve(ctx, tag)
+	if err != nil {
+		return nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: LocalCatalogName}
+	}
+
+	// If it's an image index, resolve the platform-specific manifest.
+	if IsImageIndex(desc) {
+		return c.fetchFromIndex(ctx, desc, platform, info)
+	}
+
+	// Single-platform manifest — return the content directly.
+	return c.fetchFromManifest(ctx, desc, info)
+}
+
+// fetchFromIndex resolves a platform-specific manifest from an image index
+// and returns the binary content.
+func (c *LocalCatalog) fetchFromIndex(ctx context.Context, indexDesc ocispec.Descriptor, platform string, info ArtifactInfo) ([]byte, ArtifactInfo, error) {
+	indexData, err := c.fetchBlob(ctx, indexDesc)
+	if err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("fetching image index: %w", err)
+	}
+
+	var index ocispec.Index
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("unmarshalling image index: %w", err)
+	}
+
+	platDesc, err := MatchPlatform(&index, platform)
+	if err != nil {
+		return nil, ArtifactInfo{}, err
+	}
+
+	content, _, err := c.fetchFromManifest(ctx, *platDesc, info)
+	if err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("fetching platform %s manifest: %w", platform, err)
+	}
+
+	// Enrich info with platform annotation
+	if info.Annotations == nil {
+		info.Annotations = make(map[string]string)
+	}
+	info.Annotations[AnnotationPlatform] = platform
+
+	return content, info, nil
+}
+
+// fetchFromManifest fetches the first layer content from a manifest descriptor.
+func (c *LocalCatalog) fetchFromManifest(ctx context.Context, manifestDesc ocispec.Descriptor, info ArtifactInfo) ([]byte, ArtifactInfo, error) {
+	manifestData, err := c.fetchBlob(ctx, manifestDesc)
+	if err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("fetching manifest: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("unmarshalling manifest: %w", err)
+	}
+
+	if len(manifest.Layers) == 0 {
+		return nil, ArtifactInfo{}, fmt.Errorf("manifest has no content layers")
+	}
+
+	content, err := c.fetchBlob(ctx, manifest.Layers[0])
+	if err != nil {
+		return nil, ArtifactInfo{}, fmt.Errorf("fetching content layer: %w", err)
+	}
+
+	return content, info, nil
+}
+
+// ListPlatforms returns the platforms available for a multi-platform artifact.
+// If the artifact is single-platform, returns nil.
+func (c *LocalCatalog) ListPlatforms(ctx context.Context, ref Reference) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	info, err := c.resolveLocked(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	tag := c.tagForRef(info.Reference)
+	desc, err := c.store.Resolve(ctx, tag)
+	if err != nil {
+		return nil, &ArtifactNotFoundError{Reference: ref, Catalog: LocalCatalogName}
+	}
+
+	if !IsImageIndex(desc) {
+		return nil, nil
+	}
+
+	indexData, err := c.fetchBlob(ctx, desc)
+	if err != nil {
+		return nil, fmt.Errorf("fetching image index: %w", err)
+	}
+
+	var index ocispec.Index
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil, fmt.Errorf("unmarshalling image index: %w", err)
+	}
+
+	return IndexPlatforms(&index), nil
+}
+
+// pushBlobLocked pushes a blob to the OCI store (caller must hold the lock).
+func (c *LocalCatalog) pushBlobLocked(ctx context.Context, mediaType string, content []byte) (ocispec.Descriptor, error) {
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+	}
+
+	if err := c.store.Push(ctx, desc, bytes.NewReader(content)); err != nil {
+		if !isAlreadyExists(err) {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	return desc, nil
+}
+
+// isAlreadyExists checks if the error is an "already exists" error from the oras store.
+func isAlreadyExists(err error) bool {
+	return err != nil && errors.Is(err, errdef.ErrAlreadyExists)
+}
+
+// copyAnnotations creates a shallow copy of an annotations map.
+func copyAnnotations(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/pkg/catalog/local_multiplatform_test.go
+++ b/pkg/catalog/local_multiplatform_test.go
@@ -1,0 +1,270 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLocalCatalog(t *testing.T) *LocalCatalog {
+	t.Helper()
+	dir := t.TempDir()
+	cat, err := NewLocalCatalogAt(dir, logr.Discard())
+	require.NoError(t, err)
+	return cat
+}
+
+func testPluginRef(name, version string) Reference {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		panic("bad test version: " + err.Error())
+	}
+	return Reference{
+		Kind:    ArtifactKindProvider,
+		Name:    name,
+		Version: v,
+	}
+}
+
+func TestLocalCatalog_StoreMultiPlatform_RoundTrip(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("multi-provider", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("linux-amd64-binary")},
+		{Platform: "darwin/arm64", Data: []byte("darwin-arm64-binary")},
+	}
+
+	info, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, "multi-provider", info.Reference.Name)
+	assert.Equal(t, "1.0.0", info.Reference.Version.String())
+	assert.NotEmpty(t, info.Digest)
+
+	// Fetch linux/amd64
+	data, fetchInfo, err := cat.FetchByPlatform(ctx, ref, "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("linux-amd64-binary"), data)
+	assert.Equal(t, "linux/amd64", fetchInfo.Annotations[AnnotationPlatform])
+
+	// Fetch darwin/arm64
+	data, fetchInfo, err = cat.FetchByPlatform(ctx, ref, "darwin/arm64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("darwin-arm64-binary"), data)
+	assert.Equal(t, "darwin/arm64", fetchInfo.Annotations[AnnotationPlatform])
+}
+
+func TestLocalCatalog_StoreMultiPlatform_PlatformNotFound(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("single-plat", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("linux-binary")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	// Try to fetch a platform that doesn't exist
+	_, _, err = cat.FetchByPlatform(ctx, ref, "windows/amd64")
+	require.Error(t, err)
+	assert.True(t, IsPlatformNotFound(err))
+}
+
+func TestLocalCatalog_StoreMultiPlatform_AlreadyExists(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("dup-provider", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("binary")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	// Second store should fail (no force)
+	_, err = cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.Error(t, err)
+	assert.True(t, IsExists(err))
+}
+
+func TestLocalCatalog_StoreMultiPlatform_Force(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("force-provider", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("binary-v1")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	// Force overwrite
+	binaries[0].Data = []byte("binary-v2")
+	_, err = cat.StoreMultiPlatform(ctx, ref, binaries, nil, true)
+	require.NoError(t, err)
+
+	// Verify v2 data
+	data, _, err := cat.FetchByPlatform(ctx, ref, "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("binary-v2"), data)
+}
+
+func TestLocalCatalog_StoreMultiPlatform_EmptyBinaries(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("empty-provider", "1.0.0")
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, nil, nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one platform binary")
+}
+
+func TestLocalCatalog_StoreMultiPlatform_InvalidPlatform(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("bad-plat-provider", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "invalid", Data: []byte("binary")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid platform")
+}
+
+func TestLocalCatalog_StoreMultiPlatform_FiveplatformRoundTrip(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("all-plats-provider", "2.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("linux-amd64")},
+		{Platform: "linux/arm64", Data: []byte("linux-arm64")},
+		{Platform: "darwin/amd64", Data: []byte("darwin-amd64")},
+		{Platform: "darwin/arm64", Data: []byte("darwin-arm64")},
+		{Platform: "windows/amd64", Data: []byte("windows-amd64")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	// Verify each platform
+	for _, pb := range binaries {
+		data, info, err := cat.FetchByPlatform(ctx, ref, pb.Platform)
+		require.NoError(t, err, "platform %s", pb.Platform)
+		assert.Equal(t, pb.Data, data, "platform %s", pb.Platform)
+		assert.Equal(t, pb.Platform, info.Annotations[AnnotationPlatform])
+	}
+}
+
+func TestLocalCatalog_ListPlatforms(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("list-plats", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("linux")},
+		{Platform: "darwin/arm64", Data: []byte("darwin")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	platforms, err := cat.ListPlatforms(ctx, ref)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"linux/amd64", "darwin/arm64"}, platforms)
+}
+
+func TestLocalCatalog_ListPlatforms_SinglePlatform(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := Reference{
+		Kind:    ArtifactKindProvider,
+		Name:    "single-provider",
+		Version: mustVersion("1.0.0"),
+	}
+
+	// Store a normal single-platform artifact
+	_, err := cat.Store(ctx, ref, []byte("binary"), nil, nil, false)
+	require.NoError(t, err)
+
+	// ListPlatforms should return nil for single-platform
+	platforms, err := cat.ListPlatforms(ctx, ref)
+	require.NoError(t, err)
+	assert.Nil(t, platforms)
+}
+
+func TestLocalCatalog_FetchByPlatform_SinglePlatformFallback(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := Reference{
+		Kind:    ArtifactKindProvider,
+		Name:    "single-provider",
+		Version: mustVersion("1.0.0"),
+	}
+
+	// Store a normal single-platform artifact
+	_, err := cat.Store(ctx, ref, []byte("single-binary"), nil, nil, false)
+	require.NoError(t, err)
+
+	// FetchByPlatform should return the content for any platform since
+	// it's a single-platform manifest (no image index)
+	data, _, err := cat.FetchByPlatform(ctx, ref, "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("single-binary"), data)
+}
+
+func TestLocalCatalog_StoreMultiPlatform_WithAnnotations(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := testPluginRef("annotated-provider", "1.0.0")
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("binary")},
+	}
+
+	annotations := map[string]string{
+		AnnotationDescription: "A test provider",
+		AnnotationAuthors:     "test-author",
+	}
+
+	info, err := cat.StoreMultiPlatform(ctx, ref, binaries, annotations, false)
+	require.NoError(t, err)
+	assert.Equal(t, "A test provider", info.Annotations[AnnotationDescription])
+	assert.Equal(t, "test-author", info.Annotations[AnnotationAuthors])
+}
+
+func TestLocalCatalog_StoreMultiPlatform_AuthHandler(t *testing.T) {
+	cat := newTestLocalCatalog(t)
+	ctx := context.Background()
+	ref := Reference{
+		Kind:    ArtifactKindAuthHandler,
+		Name:    "multi-auth",
+		Version: mustVersion("1.0.0"),
+	}
+
+	binaries := []PlatformBinary{
+		{Platform: "linux/amd64", Data: []byte("auth-linux")},
+		{Platform: "darwin/arm64", Data: []byte("auth-darwin")},
+	}
+
+	_, err := cat.StoreMultiPlatform(ctx, ref, binaries, nil, false)
+	require.NoError(t, err)
+
+	data, _, err := cat.FetchByPlatform(ctx, ref, "darwin/arm64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("auth-darwin"), data)
+}

--- a/pkg/catalog/multiplatform.go
+++ b/pkg/catalog/multiplatform.go
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// SupportedPluginPlatforms is the list of platforms supported for plugin artifacts.
+var SupportedPluginPlatforms = []string{
+	"linux/amd64",
+	"linux/arm64",
+	"darwin/amd64",
+	"darwin/arm64",
+	"windows/amd64",
+}
+
+// PlatformBinary pairs a platform string (e.g. "linux/amd64") with the
+// raw plugin binary for that platform.
+type PlatformBinary struct {
+	// Platform in OCI format, e.g. "linux/amd64".
+	Platform string `json:"platform" yaml:"platform" doc:"Target platform in os/arch format"`
+
+	// Data is the raw binary content.
+	Data []byte `json:"-" yaml:"-"`
+}
+
+// PlatformToOCI converts a platform string like "linux/amd64" to an OCI Platform struct.
+func PlatformToOCI(platform string) (*ocispec.Platform, error) {
+	os, arch, err := parsePlatformParts(platform)
+	if err != nil {
+		return nil, err
+	}
+	return &ocispec.Platform{
+		Architecture: arch,
+		OS:           os,
+	}, nil
+}
+
+// OCIPlatformString converts an OCI Platform struct to a "os/arch" string.
+func OCIPlatformString(p *ocispec.Platform) string {
+	if p == nil {
+		return ""
+	}
+	return p.OS + "/" + p.Architecture
+}
+
+// MatchPlatform selects the manifest descriptor from an OCI image index
+// that matches the requested platform. Returns an error if no match is found.
+func MatchPlatform(index *ocispec.Index, platform string) (*ocispec.Descriptor, error) {
+	if index == nil {
+		return nil, fmt.Errorf("nil index")
+	}
+
+	targetOS, targetArch, err := parsePlatformParts(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range index.Manifests {
+		desc := &index.Manifests[i]
+		if desc.Platform == nil {
+			continue
+		}
+		if desc.Platform.OS == targetOS && desc.Platform.Architecture == targetArch {
+			return desc, nil
+		}
+	}
+
+	available := make([]string, 0, len(index.Manifests))
+	for _, desc := range index.Manifests {
+		if desc.Platform != nil {
+			available = append(available, OCIPlatformString(desc.Platform))
+		}
+	}
+
+	return nil, &PlatformNotFoundError{
+		Platform:  platform,
+		Available: available,
+	}
+}
+
+// IndexPlatforms returns the list of platforms in an OCI image index.
+func IndexPlatforms(index *ocispec.Index) []string {
+	if index == nil {
+		return nil
+	}
+	platforms := make([]string, 0, len(index.Manifests))
+	for _, desc := range index.Manifests {
+		if desc.Platform != nil {
+			platforms = append(platforms, OCIPlatformString(desc.Platform))
+		}
+	}
+	return platforms
+}
+
+// IsImageIndex returns true if the descriptor has image index media type.
+func IsImageIndex(desc ocispec.Descriptor) bool {
+	return desc.MediaType == ocispec.MediaTypeImageIndex
+}
+
+// parsePlatformParts splits "os/arch" and validates the format.
+func parsePlatformParts(platform string) (os, arch string, err error) {
+	// Reuse the same logic as plugin.ParsePlatform, but keep catalog
+	// package self-contained to avoid circular imports.
+	parts := splitPlatform(platform)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid platform format %q: expected os/arch (e.g., linux/amd64)", platform)
+	}
+	return parts[0], parts[1], nil
+}
+
+func splitPlatform(platform string) []string {
+	parts := make([]string, 0, 2)
+	idx := -1
+	for i, c := range platform {
+		if c == '/' {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return []string{platform}
+	}
+	parts = append(parts, platform[:idx], platform[idx+1:])
+	return parts
+}
+
+// IsSupportedPlatform returns true if the platform string is in the supported list.
+func IsSupportedPlatform(platform string) bool {
+	for _, p := range SupportedPluginPlatforms {
+		if p == platform {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/catalog/multiplatform_test.go
+++ b/pkg/catalog/multiplatform_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformToOCI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOS   string
+		wantArch string
+		wantErr  bool
+	}{
+		{name: "linux/amd64", input: "linux/amd64", wantOS: "linux", wantArch: "amd64"},
+		{name: "darwin/arm64", input: "darwin/arm64", wantOS: "darwin", wantArch: "arm64"},
+		{name: "windows/amd64", input: "windows/amd64", wantOS: "windows", wantArch: "amd64"},
+		{name: "invalid empty", input: "", wantErr: true},
+		{name: "invalid no slash", input: "linux", wantErr: true},
+		{name: "invalid trailing slash", input: "linux/", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := PlatformToOCI(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOS, p.OS)
+			assert.Equal(t, tt.wantArch, p.Architecture)
+		})
+	}
+}
+
+func TestOCIPlatformString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *ocispec.Platform
+		want  string
+	}{
+		{
+			name:  "linux/amd64",
+			input: &ocispec.Platform{OS: "linux", Architecture: "amd64"},
+			want:  "linux/amd64",
+		},
+		{
+			name:  "darwin/arm64",
+			input: &ocispec.Platform{OS: "darwin", Architecture: "arm64"},
+			want:  "darwin/arm64",
+		},
+		{
+			name:  "nil platform",
+			input: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, OCIPlatformString(tt.input))
+		})
+	}
+}
+
+func TestMatchPlatform(t *testing.T) {
+	index := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Platform:  &ocispec.Platform{OS: "linux", Architecture: "amd64"},
+			},
+			{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Platform:  &ocispec.Platform{OS: "darwin", Architecture: "arm64"},
+			},
+			{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Platform:  &ocispec.Platform{OS: "windows", Architecture: "amd64"},
+			},
+		},
+	}
+
+	t.Run("match linux/amd64", func(t *testing.T) {
+		desc, err := MatchPlatform(index, "linux/amd64")
+		require.NoError(t, err)
+		assert.Equal(t, "linux", desc.Platform.OS)
+		assert.Equal(t, "amd64", desc.Platform.Architecture)
+	})
+
+	t.Run("match darwin/arm64", func(t *testing.T) {
+		desc, err := MatchPlatform(index, "darwin/arm64")
+		require.NoError(t, err)
+		assert.Equal(t, "darwin", desc.Platform.OS)
+		assert.Equal(t, "arm64", desc.Platform.Architecture)
+	})
+
+	t.Run("no match linux/arm64", func(t *testing.T) {
+		_, err := MatchPlatform(index, "linux/arm64")
+		require.Error(t, err)
+		assert.True(t, IsPlatformNotFound(err))
+		var pnf *PlatformNotFoundError
+		require.ErrorAs(t, err, &pnf)
+		assert.Equal(t, "linux/arm64", pnf.Platform)
+		assert.ElementsMatch(t, []string{"linux/amd64", "darwin/arm64", "windows/amd64"}, pnf.Available)
+	})
+
+	t.Run("nil index", func(t *testing.T) {
+		_, err := MatchPlatform(nil, "linux/amd64")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid platform format", func(t *testing.T) {
+		_, err := MatchPlatform(index, "invalid")
+		require.Error(t, err)
+	})
+}
+
+func TestIndexPlatforms(t *testing.T) {
+	index := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{Platform: &ocispec.Platform{OS: "linux", Architecture: "amd64"}},
+			{Platform: &ocispec.Platform{OS: "darwin", Architecture: "arm64"}},
+			{Platform: nil}, // no platform
+		},
+	}
+
+	platforms := IndexPlatforms(index)
+	assert.ElementsMatch(t, []string{"linux/amd64", "darwin/arm64"}, platforms)
+}
+
+func TestIndexPlatforms_Nil(t *testing.T) {
+	assert.Nil(t, IndexPlatforms(nil))
+}
+
+func TestIsImageIndex(t *testing.T) {
+	assert.True(t, IsImageIndex(ocispec.Descriptor{MediaType: ocispec.MediaTypeImageIndex}))
+	assert.False(t, IsImageIndex(ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}))
+	assert.False(t, IsImageIndex(ocispec.Descriptor{MediaType: ""}))
+}
+
+func TestIsSupportedPlatform(t *testing.T) {
+	assert.True(t, IsSupportedPlatform("linux/amd64"))
+	assert.True(t, IsSupportedPlatform("darwin/arm64"))
+	assert.True(t, IsSupportedPlatform("windows/amd64"))
+	assert.False(t, IsSupportedPlatform("freebsd/amd64"))
+	assert.False(t, IsSupportedPlatform(""))
+}
+
+func TestSupportedPluginPlatforms(t *testing.T) {
+	assert.Contains(t, SupportedPluginPlatforms, "linux/amd64")
+	assert.Contains(t, SupportedPluginPlatforms, "linux/arm64")
+	assert.Contains(t, SupportedPluginPlatforms, "darwin/amd64")
+	assert.Contains(t, SupportedPluginPlatforms, "darwin/arm64")
+	assert.Contains(t, SupportedPluginPlatforms, "windows/amd64")
+	assert.Len(t, SupportedPluginPlatforms, 5)
+}

--- a/pkg/catalog/plugin_fetcher.go
+++ b/pkg/catalog/plugin_fetcher.go
@@ -10,9 +10,26 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// PlatformAwareCatalog extends Catalog with multi-platform image index support.
+// Catalogs that store multi-platform artifacts (e.g. LocalCatalog) implement
+// this interface to allow transparent platform-specific fetching.
+type PlatformAwareCatalog interface {
+	Catalog
+
+	// FetchByPlatform fetches a plugin binary for the given platform,
+	// transparently handling both single-platform manifests and
+	// multi-platform image indexes.
+	FetchByPlatform(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error)
+
+	// ListPlatforms returns the platforms available for a multi-platform artifact.
+	// Returns nil if the artifact is single-platform.
+	ListPlatforms(ctx context.Context, ref Reference) ([]string, error)
+}
+
 // PluginFetcher fetches plugin binaries from a catalog with platform awareness.
 // It resolves plugin references, selects the appropriate platform variant via
-// the AnnotationPlatform annotation, and returns the raw binary data.
+// the OCI image index (preferred) or AnnotationPlatform annotation (fallback),
+// and returns the raw binary data.
 type PluginFetcher struct {
 	catalog Catalog
 	logger  logr.Logger
@@ -55,11 +72,38 @@ func (f *PluginFetcher) ResolvePlugin(ctx context.Context, name string, kind Art
 }
 
 // FetchPlugin fetches a plugin binary for the given platform.
-// It first tries to find a platform-specific artifact by listing all versions
-// and matching the AnnotationPlatform annotation. If no platform-specific
-// artifact is found, it falls back to the default (un-annotated) artifact.
+// It uses the following resolution strategy:
+//  1. If the catalog implements PlatformAwareCatalog, use FetchByPlatform
+//     which handles OCI image indexes (fat manifests) transparently.
+//  2. Otherwise, fall back to listing artifacts and matching the
+//     AnnotationPlatform annotation on individual manifests.
+//  3. If no platform-specific artifact is found, attempt a direct fetch
+//     (single-platform fallback).
 func (f *PluginFetcher) FetchPlugin(ctx context.Context, name string, kind ArtifactKind, version, platform string) ([]byte, ArtifactInfo, error) {
-	// List all artifacts for this plugin to find platform-specific variants
+	// Strategy 1: Use OCI image index via PlatformAwareCatalog
+	if pac, ok := f.catalog.(PlatformAwareCatalog); ok {
+		ref, err := f.buildRef(name, kind, version)
+		if err == nil {
+			data, info, err := pac.FetchByPlatform(ctx, ref, platform)
+			if err == nil {
+				f.logger.V(1).Info("fetched plugin via image index",
+					"name", name,
+					"version", version,
+					"platform", platform)
+				return data, info, nil
+			}
+			// If platform not found in an image index, don't fall back — the
+			// artifact is explicitly multi-platform and the requested platform
+			// is unavailable.
+			if IsPlatformNotFound(err) {
+				return nil, ArtifactInfo{}, err
+			}
+			f.logger.V(1).Info("image index fetch failed, trying annotation-based fallback",
+				"name", name, "error", err)
+		}
+	}
+
+	// Strategy 2: Annotation-based matching (legacy)
 	artifacts, err := f.catalog.List(ctx, kind, name)
 	if err != nil {
 		f.logger.V(1).Info("could not list plugin artifacts for platform selection, falling back to direct fetch",
@@ -86,7 +130,7 @@ func (f *PluginFetcher) FetchPlugin(ctx context.Context, name string, kind Artif
 		}
 	}
 
-	// No platform-specific artifact found — try direct fetch (single-platform fallback)
+	// Strategy 3: Direct fetch fallback (single-platform)
 	f.logger.V(1).Info("no platform-specific artifact found, falling back to direct fetch",
 		"name", name,
 		"version", version,
@@ -121,4 +165,13 @@ func (f *PluginFetcher) fetchByInfo(ctx context.Context, info ArtifactInfo) ([]b
 		return nil, ArtifactInfo{}, fmt.Errorf("fetching plugin %s: %w", info.Reference.String(), err)
 	}
 	return content, fetchedInfo, nil
+}
+
+// buildRef constructs a Reference from name, kind, and version string.
+func (f *PluginFetcher) buildRef(name string, kind ArtifactKind, version string) (Reference, error) {
+	refStr := name
+	if version != "" {
+		refStr = name + "@" + version
+	}
+	return ParseReference(kind, refStr)
 }

--- a/pkg/catalog/plugin_fetcher_multiplatform_test.go
+++ b/pkg/catalog/plugin_fetcher_multiplatform_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPlatformAwareCatalog extends mockCatalog with PlatformAwareCatalog support.
+type mockPlatformAwareCatalog struct {
+	mockCatalog
+	fetchByPlatformFunc func(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error)
+	listPlatformsFunc   func(ctx context.Context, ref Reference) ([]string, error)
+}
+
+func newMockPlatformAwareCatalog(name string) *mockPlatformAwareCatalog {
+	return &mockPlatformAwareCatalog{
+		mockCatalog: *newMockCatalog(name),
+	}
+}
+
+func (m *mockPlatformAwareCatalog) FetchByPlatform(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error) {
+	if m.fetchByPlatformFunc != nil {
+		return m.fetchByPlatformFunc(ctx, ref, platform)
+	}
+	return nil, ArtifactInfo{}, ErrArtifactNotFound
+}
+
+func (m *mockPlatformAwareCatalog) ListPlatforms(ctx context.Context, ref Reference) ([]string, error) {
+	if m.listPlatformsFunc != nil {
+		return m.listPlatformsFunc(ctx, ref)
+	}
+	return nil, nil
+}
+
+func TestPluginFetcher_FetchPlugin_ImageIndex(t *testing.T) {
+	cat := newMockPlatformAwareCatalog("test")
+
+	ref := testPluginRef("indexed-plugin", "3.0.0")
+	cat.addArtifact(ref, nil, nil)
+
+	cat.fetchByPlatformFunc = func(_ context.Context, r Reference, platform string) ([]byte, ArtifactInfo, error) {
+		if r.Name == "indexed-plugin" && platform == "linux/amd64" {
+			return []byte("linux-binary"), ArtifactInfo{
+				Reference: r,
+				Catalog:   "test",
+				Annotations: map[string]string{
+					AnnotationPlatform: "linux/amd64",
+				},
+			}, nil
+		}
+		return nil, ArtifactInfo{}, &PlatformNotFoundError{
+			Platform:  platform,
+			Available: []string{"linux/amd64"},
+		}
+	}
+
+	pf := NewPluginFetcher(cat, logr.Discard())
+
+	// Should use image index path
+	data, info, err := pf.FetchPlugin(context.Background(), "indexed-plugin", ArtifactKindProvider, "3.0.0", "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("linux-binary"), data)
+	assert.Equal(t, "linux/amd64", info.Annotations[AnnotationPlatform])
+}
+
+func TestPluginFetcher_FetchPlugin_ImageIndex_PlatformNotFound(t *testing.T) {
+	cat := newMockPlatformAwareCatalog("test")
+
+	ref := testPluginRef("indexed-plugin", "3.0.0")
+	cat.addArtifact(ref, nil, nil)
+
+	cat.fetchByPlatformFunc = func(_ context.Context, _ Reference, platform string) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, &PlatformNotFoundError{
+			Platform:  platform,
+			Available: []string{"linux/amd64"},
+		}
+	}
+
+	pf := NewPluginFetcher(cat, logr.Discard())
+
+	// PlatformNotFoundError should NOT fall back — it's an explicit multi-platform artifact
+	_, _, err := pf.FetchPlugin(context.Background(), "indexed-plugin", ArtifactKindProvider, "3.0.0", "darwin/arm64")
+	require.Error(t, err)
+	assert.True(t, IsPlatformNotFound(err))
+}
+
+func TestPluginFetcher_FetchPlugin_ImageIndex_FallsBackToAnnotation(t *testing.T) {
+	cat := newMockPlatformAwareCatalog("test")
+
+	ref := testPluginRef("fallback-plugin", "1.0.0")
+	cat.addArtifact(ref, []byte("fallback-binary"), map[string]string{
+		AnnotationPlatform: "linux/amd64",
+	})
+
+	// FetchByPlatform returns a non-platform error (artifact is single-platform)
+	cat.fetchByPlatformFunc = func(_ context.Context, _ Reference, _ string) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, ErrArtifactNotFound
+	}
+
+	// List returns the artifact with annotation matching
+	cat.listFunc = func(_ context.Context, _ ArtifactKind, _ string) ([]ArtifactInfo, error) {
+		return []ArtifactInfo{
+			{
+				Reference: ref,
+				Catalog:   "test",
+				Annotations: map[string]string{
+					AnnotationPlatform: "linux/amd64",
+				},
+			},
+		}, nil
+	}
+
+	pf := NewPluginFetcher(cat, logr.Discard())
+
+	data, _, err := pf.FetchPlugin(context.Background(), "fallback-plugin", ArtifactKindProvider, "1.0.0", "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("fallback-binary"), data)
+}
+
+func TestPluginFetcher_FetchPlugin_NonPlatformAwareCatalog(t *testing.T) {
+	// Use a regular mockCatalog (not PlatformAwareCatalog)
+	cat := newMockCatalog("test")
+
+	ref := testPluginRef("basic-plugin", "1.0.0")
+	cat.addArtifact(ref, []byte("basic-binary"), nil)
+
+	pf := NewPluginFetcher(cat, logr.Discard())
+
+	// Should fall through to direct fetch (no image index support)
+	data, _, err := pf.FetchPlugin(context.Background(), "basic-plugin", ArtifactKindProvider, "1.0.0", "linux/amd64")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("basic-binary"), data)
+}
+
+// Verify that LocalCatalog implements PlatformAwareCatalog.
+func TestLocalCatalog_ImplementsPlatformAwareCatalog(t *testing.T) {
+	var _ PlatformAwareCatalog = (*LocalCatalog)(nil)
+}

--- a/pkg/cmd/scafctl/build/build.go
+++ b/pkg/cmd/scafctl/build/build.go
@@ -32,6 +32,7 @@ func CommandBuild(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 	}
 
 	cmd.AddCommand(CommandBuildSolution(cliParams, ioStreams, path))
+	cmd.AddCommand(CommandBuildPlugin(cliParams, ioStreams, path))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/build/plugin.go
+++ b/pkg/cmd/scafctl/build/plugin.go
@@ -1,0 +1,259 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// PluginOptions holds options for the build plugin command.
+type PluginOptions struct {
+	Name      string
+	Kind      string // "provider" or "auth-handler"
+	Version   string
+	Platforms []string // e.g. ["linux/amd64=./bin/linux-amd64/my-plugin", "darwin/arm64=./bin/darwin-arm64/my-plugin"]
+	Force     bool
+	CliParams *settings.Run
+	IOStreams *terminal.IOStreams
+}
+
+// CommandBuildPlugin creates the build plugin command.
+func CommandBuildPlugin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	options := &PluginOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:          "plugin",
+		Aliases:      []string{"plug", "p"},
+		Short:        "Build a multi-platform plugin into the local catalog",
+		SilenceUsage: true,
+		Long: heredoc.Doc(`
+			Build one or more platform-specific plugin binaries into the local catalog
+			as an OCI image index (multi-platform artifact).
+
+			Each --platform flag maps a target platform to the local path of the pre-built
+			binary for that platform. The format is:
+
+			  --platform <os/arch>=<path>
+
+			Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
+
+			The resulting artifact is stored as an OCI image index (fat manifest) with one
+			manifest per platform. At runtime, scafctl automatically selects the correct
+			binary for the current OS and architecture.
+
+			If only a single --platform is specified, the artifact is still stored as an
+			image index for forward compatibility.
+
+			Examples:
+			  # Build a provider plugin for two platforms
+			  scafctl build plugin --name aws-provider --kind provider --version 1.0.0 \
+			    --platform linux/amd64=./dist/aws-provider-linux-amd64 \
+			    --platform darwin/arm64=./dist/aws-provider-darwin-arm64
+
+			  # Build an auth handler for all supported platforms
+			  scafctl build plugin --name github-auth --kind auth-handler --version 2.1.0 \
+			    --platform linux/amd64=./dist/github-auth-linux-amd64 \
+			    --platform linux/arm64=./dist/github-auth-linux-arm64 \
+			    --platform darwin/amd64=./dist/github-auth-darwin-amd64 \
+			    --platform darwin/arm64=./dist/github-auth-darwin-arm64 \
+			    --platform windows/amd64=./dist/github-auth-windows-amd64.exe
+
+			  # Overwrite existing version
+			  scafctl build plugin --name aws-provider --kind provider --version 1.0.0 \
+			    --platform linux/amd64=./dist/aws-provider --force
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBuildPlugin(cmd.Context(), options)
+		},
+	}
+
+	cmd.Flags().StringVar(&options.Name, "name", "", "Plugin artifact name (required)")
+	cmd.Flags().StringVar(&options.Kind, "kind", "provider", "Plugin kind: 'provider' or 'auth-handler'")
+	cmd.Flags().StringVar(&options.Version, "version", "", "Semantic version (required)")
+	cmd.Flags().StringArrayVar(&options.Platforms, "platform", nil,
+		"Platform-to-binary mapping in os/arch=path format (can be specified multiple times)")
+	cmd.Flags().BoolVar(&options.Force, "force", false, "Overwrite existing version")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("platform")
+
+	return cmd
+}
+
+func runBuildPlugin(ctx context.Context, opts *PluginOptions) error {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
+	// Validate name
+	if !catalog.IsValidName(opts.Name) {
+		w.Errorf("invalid name %q: must be lowercase alphanumeric with hyphens", opts.Name)
+		return exitcode.Errorf("invalid name")
+	}
+
+	// Validate kind
+	kind, ok := catalog.ParseArtifactKind(opts.Kind)
+	if !ok || (kind != catalog.ArtifactKindProvider && kind != catalog.ArtifactKindAuthHandler) {
+		w.Errorf("invalid kind %q: must be 'provider' or 'auth-handler'", opts.Kind)
+		return exitcode.Errorf("invalid kind")
+	}
+
+	// Parse version
+	version, err := semver.NewVersion(opts.Version)
+	if err != nil {
+		w.Errorf("invalid version %q: %v", opts.Version, err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Parse platform mappings
+	binaries, err := parsePlatformFlags(opts.Platforms)
+	if err != nil {
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Read binary files
+	platformBinaries := make([]catalog.PlatformBinary, 0, len(binaries))
+	for platform, path := range binaries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			w.Errorf("failed to read binary for %s at %s: %v", platform, path, err)
+			return exitcode.WithCode(err, exitcode.FileNotFound)
+		}
+
+		if len(data) == 0 {
+			w.Errorf("binary for %s at %s is empty", platform, path)
+			return exitcode.Errorf("empty binary")
+		}
+
+		platformBinaries = append(platformBinaries, catalog.PlatformBinary{
+			Platform: platform,
+			Data:     data,
+		})
+
+		w.Infof("  %s → %s (%s)", platform, path, formatBytes(int64(len(data))))
+	}
+
+	// Build reference
+	ref := catalog.Reference{
+		Kind:    kind,
+		Name:    opts.Name,
+		Version: version,
+	}
+
+	// Open local catalog
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err != nil {
+		w.Errorf("failed to open catalog: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	// Build annotations
+	annotations := catalog.NewAnnotationBuilder().Build()
+
+	// Store as multi-platform image index
+	info, err := localCatalog.StoreMultiPlatform(ctx, ref, platformBinaries, annotations, opts.Force)
+	if err != nil {
+		if catalog.IsExists(err) {
+			w.Errorf("%v\nUse --force to overwrite", err)
+			return exitcode.WithCode(err, exitcode.CatalogError)
+		}
+		w.Errorf("failed to store plugin: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	lgr.V(1).Info("built multi-platform plugin",
+		"name", info.Reference.Name,
+		"version", info.Reference.Version.String(),
+		"platforms", len(platformBinaries),
+		"digest", info.Digest)
+
+	w.Successf("Built %s@%s (%d platform(s))", info.Reference.Name, info.Reference.Version.String(), len(platformBinaries))
+	w.Infof("  Digest: %s", info.Digest)
+	w.Infof("  Catalog: %s", localCatalog.Path())
+	for _, pb := range platformBinaries {
+		w.Infof("  Platform: %s", pb.Platform)
+	}
+
+	return nil
+}
+
+// parsePlatformFlags parses --platform flags of the form "os/arch=path" into a
+// map[platform]path. Validates that each platform is supported and the path exists.
+func parsePlatformFlags(flags []string) (map[string]string, error) {
+	result := make(map[string]string, len(flags))
+
+	for _, flag := range flags {
+		parts := strings.SplitN(flag, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid --platform format %q: expected os/arch=path (e.g., linux/amd64=./bin/my-plugin)", flag)
+		}
+
+		platform := parts[0]
+		path := parts[1]
+
+		if !catalog.IsSupportedPlatform(platform) {
+			return nil, fmt.Errorf("unsupported platform %q: supported platforms are %v", platform, catalog.SupportedPluginPlatforms)
+		}
+
+		if _, exists := result[platform]; exists {
+			return nil, fmt.Errorf("duplicate platform %q", platform)
+		}
+
+		// Resolve and validate path
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid path %q for platform %s: %w", path, platform, err)
+		}
+
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("binary not found for platform %s at %q: %w", platform, path, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("path for platform %s is a directory, expected a file: %s", platform, path)
+		}
+
+		result[platform] = absPath
+	}
+
+	return result, nil
+}
+
+// formatBytes formats bytes as a human-readable string (local copy to avoid
+// pulling in the catalog cmd package).
+func formatBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/pkg/cmd/scafctl/build/plugin_test.go
+++ b/pkg/cmd/scafctl/build/plugin_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePlatformFlags(t *testing.T) {
+	t.Run("valid single platform", func(t *testing.T) {
+		// Create a temp binary
+		dir := t.TempDir()
+		bin := filepath.Join(dir, "my-plugin")
+		require.NoError(t, os.WriteFile(bin, []byte("binary"), 0o755))
+
+		result, err := parsePlatformFlags([]string{"linux/amd64=" + bin})
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, bin, result["linux/amd64"])
+	})
+
+	t.Run("valid multiple platforms", func(t *testing.T) {
+		dir := t.TempDir()
+		linBin := filepath.Join(dir, "linux-bin")
+		darBin := filepath.Join(dir, "darwin-bin")
+		require.NoError(t, os.WriteFile(linBin, []byte("linux"), 0o755))
+		require.NoError(t, os.WriteFile(darBin, []byte("darwin"), 0o755))
+
+		result, err := parsePlatformFlags([]string{
+			"linux/amd64=" + linBin,
+			"darwin/arm64=" + darBin,
+		})
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("missing equals sign", func(t *testing.T) {
+		_, err := parsePlatformFlags([]string{"linux/amd64"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --platform format")
+	})
+
+	t.Run("empty platform", func(t *testing.T) {
+		_, err := parsePlatformFlags([]string{"=./bin"})
+		require.Error(t, err)
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		_, err := parsePlatformFlags([]string{"linux/amd64="})
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported platform", func(t *testing.T) {
+		dir := t.TempDir()
+		bin := filepath.Join(dir, "bin")
+		require.NoError(t, os.WriteFile(bin, []byte("binary"), 0o755))
+
+		_, err := parsePlatformFlags([]string{"freebsd/amd64=" + bin})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported platform")
+	})
+
+	t.Run("duplicate platform", func(t *testing.T) {
+		dir := t.TempDir()
+		bin := filepath.Join(dir, "bin")
+		require.NoError(t, os.WriteFile(bin, []byte("binary"), 0o755))
+
+		_, err := parsePlatformFlags([]string{
+			"linux/amd64=" + bin,
+			"linux/amd64=" + bin,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate platform")
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := parsePlatformFlags([]string{"linux/amd64=/nonexistent/path"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "binary not found")
+	})
+
+	t.Run("path is directory", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := parsePlatformFlags([]string{"linux/amd64=" + dir})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is a directory")
+	})
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{100, "100 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, formatBytes(tt.input))
+	}
+}

--- a/pkg/mcp/icons.go
+++ b/pkg/mcp/icons.go
@@ -88,6 +88,10 @@ var toolIcons = map[string]mcp.Icon{
 		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2329B6F6' stroke-width='2'><circle cx='12' cy='12' r='10'/><path d='M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3'/><line x1='12' y1='17' x2='12.01' y2='17'/></svg>",
 		MIMEType: "image/svg+xml",
 	},
+	"plugin": {
+		Src:      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2300ACC1' stroke-width='2'><path d='M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83'/><circle cx='12' cy='12' r='3'/></svg>",
+		MIMEType: "image/svg+xml",
+	},
 }
 
 // promptIcons maps prompt categories to their icons.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -575,6 +575,9 @@ func (s *Server) registerTools() {
 	// Concept explanation tools
 	s.registerConceptTools()
 
+	// Catalog multi-platform tools (list platforms, build plugin)
+	s.registerCatalogMultiPlatformTools()
+
 	// Version tool
 	s.registerVersionTools()
 }

--- a/pkg/mcp/tools_catalog.go
+++ b/pkg/mcp/tools_catalog.go
@@ -192,5 +192,17 @@ func (s *Server) handleCatalogInspect(_ context.Context, request mcp.CallToolReq
 		result["annotations"] = info.Annotations
 	}
 
+	// Surface multi-platform info for plugin artifacts
+	if artifactKind == catalog.ArtifactKindProvider || artifactKind == catalog.ArtifactKindAuthHandler {
+		platforms, err := localCatalog.ListPlatforms(s.ctx, ref)
+		if err == nil {
+			result["isMultiPlatform"] = len(platforms) > 0
+			if len(platforms) > 0 {
+				result["platforms"] = platforms
+				result["platformCount"] = len(platforms)
+			}
+		}
+	}
+
 	return mcp.NewToolResultJSON(result)
 }

--- a/pkg/mcp/tools_catalog_multiplatform.go
+++ b/pkg/mcp/tools_catalog_multiplatform.go
@@ -1,0 +1,288 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+)
+
+// registerCatalogMultiPlatformTools registers multi-platform catalog MCP tools.
+func (s *Server) registerCatalogMultiPlatformTools() {
+	listPlatformsTool := mcp.NewTool("catalog_list_platforms",
+		mcp.WithDescription("List available platforms for a multi-platform plugin artifact in the local catalog. Returns the platform list (e.g., linux/amd64, darwin/arm64) for OCI image index artifacts, or indicates the artifact is single-platform. Use 'catalog_list' first to find plugin names, then inspect platforms."),
+		mcp.WithTitleAnnotation("Catalog List Platforms"),
+		mcp.WithToolIcons(toolIcons["plugin"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("reference",
+			mcp.Required(),
+			mcp.Description("Artifact reference in the format 'name' or 'name@version' (e.g., 'my-provider', 'my-provider@1.2.3')"),
+		),
+		mcp.WithString("kind",
+			mcp.Required(),
+			mcp.Description("Artifact kind: provider, auth-handler"),
+			mcp.Enum("provider", "auth-handler"),
+		),
+	)
+	s.mcpServer.AddTool(listPlatformsTool, s.handleCatalogListPlatforms)
+
+	buildPluginTool := mcp.NewTool("build_plugin",
+		mcp.WithDescription("Build a multi-platform plugin artifact into the local catalog as an OCI image index. Each platform entry maps an OS/architecture pair to a local binary path. Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64. Use this to package cross-compiled plugin binaries for distribution."),
+		mcp.WithTitleAnnotation("Build Plugin"),
+		mcp.WithToolIcons(toolIcons["plugin"]),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("Plugin name (e.g., 'my-provider')"),
+		),
+		mcp.WithString("kind",
+			mcp.Required(),
+			mcp.Description("Plugin kind: provider or auth-handler"),
+			mcp.Enum("provider", "auth-handler"),
+		),
+		mcp.WithString("version",
+			mcp.Required(),
+			mcp.Description("Semantic version for the plugin (e.g., '1.0.0')"),
+		),
+		mcp.WithObject("platforms",
+			mcp.Required(),
+			mcp.Description("Map of platform to binary path. Keys are 'os/arch' (e.g., 'linux/amd64'), values are absolute file paths to the compiled binary."),
+		),
+		mcp.WithBoolean("force",
+			mcp.Description("Overwrite an existing artifact with the same name and version (default: false)"),
+		),
+	)
+	s.mcpServer.AddTool(buildPluginTool, s.handleBuildPlugin)
+}
+
+// handleCatalogListPlatforms lists platforms for a multi-platform catalog artifact.
+func (s *Server) handleCatalogListPlatforms(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	reference, err := request.RequireString("reference")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("reference"),
+			WithSuggestion("Provide a catalog reference (e.g., 'my-provider@1.0.0')"),
+			WithRelatedTools("catalog_list"),
+		), nil
+	}
+
+	kindStr, err := request.RequireString("kind")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("kind"),
+			WithSuggestion("Provide an artifact kind: 'provider' or 'auth-handler'"),
+		), nil
+	}
+
+	artifactKind, ok := catalog.ParseArtifactKind(kindStr)
+	if !ok {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid kind %q", kindStr),
+			WithField("kind"),
+			WithSuggestion("Valid kinds for plugins: provider, auth-handler"),
+			WithRelatedTools("catalog_list"),
+		), nil
+	}
+
+	ref, err := catalog.ParseReference(artifactKind, reference)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid reference %q: %v", reference, err),
+			WithField("reference"),
+			WithSuggestion("Use format 'name@version' or just 'name' for latest"),
+			WithRelatedTools("catalog_list"),
+		), nil
+	}
+
+	localCatalog, err := catalog.NewLocalCatalog(s.logger)
+	if err != nil {
+		return newStructuredError(ErrCodeConfigError, fmt.Sprintf("failed to initialize local catalog: %v", err),
+			WithSuggestion("Ensure the catalog directory exists and is accessible"),
+		), nil
+	}
+
+	platforms, err := localCatalog.ListPlatforms(s.ctx, ref)
+	if err != nil {
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("artifact not found: %v", err),
+			WithField("reference"),
+			WithSuggestion("Use catalog_list to see available artifacts"),
+			WithRelatedTools("catalog_list"),
+		), nil
+	}
+
+	result := map[string]any{
+		"reference":       reference,
+		"kind":            kindStr,
+		"isMultiPlatform": len(platforms) > 0,
+	}
+	if len(platforms) > 0 {
+		result["platforms"] = platforms
+		result["platformCount"] = len(platforms)
+	}
+
+	return mcp.NewToolResultJSON(result)
+}
+
+// handleBuildPlugin builds a multi-platform plugin into the local catalog.
+func (s *Server) handleBuildPlugin(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := request.RequireString("name")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("name"),
+			WithSuggestion("Provide a plugin name"),
+		), nil
+	}
+
+	kindStr, err := request.RequireString("kind")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("kind"),
+			WithSuggestion("Provide a plugin kind: 'provider' or 'auth-handler'"),
+		), nil
+	}
+
+	artifactKind, ok := catalog.ParseArtifactKind(kindStr)
+	if !ok || (artifactKind != catalog.ArtifactKindProvider && artifactKind != catalog.ArtifactKindAuthHandler) {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid kind %q for plugin build; must be 'provider' or 'auth-handler'", kindStr),
+			WithField("kind"),
+			WithSuggestion("Use 'provider' or 'auth-handler'"),
+		), nil
+	}
+
+	versionStr, err := request.RequireString("version")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("version"),
+			WithSuggestion("Provide a semantic version (e.g., '1.0.0')"),
+		), nil
+	}
+
+	ver, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid semantic version %q: %v", versionStr, err),
+			WithField("version"),
+			WithSuggestion("Use semantic versioning (e.g., '1.0.0', '2.1.0-beta.1')"),
+		), nil
+	}
+
+	// Extract platforms map
+	args := request.GetArguments()
+	platformsRaw, ok := args["platforms"]
+	if !ok {
+		return newStructuredError(ErrCodeInvalidInput, "missing required parameter 'platforms'",
+			WithField("platforms"),
+			WithSuggestion("Provide a map of platform to binary path, e.g., {\"linux/amd64\": \"/path/to/binary\"}"),
+		), nil
+	}
+
+	platformsMap, ok := platformsRaw.(map[string]any)
+	if !ok || len(platformsMap) == 0 {
+		return newStructuredError(ErrCodeInvalidInput, "platforms must be a non-empty object mapping platform strings to file paths",
+			WithField("platforms"),
+			WithSuggestion("Example: {\"linux/amd64\": \"/path/to/binary\", \"darwin/arm64\": \"/path/to/binary\"}"),
+		), nil
+	}
+
+	force := request.GetBool("force", false)
+
+	// Validate platforms and read binaries
+	var platformBinaries []catalog.PlatformBinary
+	var platformList []string
+	for platform, pathRaw := range platformsMap {
+		binPath, ok := pathRaw.(string)
+		if !ok || binPath == "" {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("platform %q: binary path must be a non-empty string", platform),
+				WithField("platforms"),
+			), nil
+		}
+
+		if !catalog.IsSupportedPlatform(platform) {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unsupported platform %q; supported: %s", platform, strings.Join(catalog.SupportedPluginPlatforms, ", ")),
+				WithField("platforms"),
+				WithSuggestion(fmt.Sprintf("Supported platforms: %s", strings.Join(catalog.SupportedPluginPlatforms, ", "))),
+			), nil
+		}
+
+		// Resolve and validate path
+		absPath, err := filepath.Abs(binPath)
+		if err != nil {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("platform %q: invalid path %q: %v", platform, binPath, err),
+				WithField("platforms"),
+			), nil
+		}
+
+		fi, err := os.Stat(absPath)
+		if err != nil {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("platform %q: binary not found at %q: %v", platform, absPath, err),
+				WithField("platforms"),
+				WithSuggestion("Ensure the binary has been compiled and the path is correct"),
+			), nil //nolint:nilerr // returning structured MCP error, not propagating err
+		}
+		if fi.IsDir() {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("platform %q: path %q is a directory, not a binary", platform, absPath),
+				WithField("platforms"),
+			), nil
+		}
+
+		data, err := os.ReadFile(absPath)
+		if err != nil {
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("platform %q: failed to read binary: %v", platform, err),
+				WithField("platforms"),
+			), nil
+		}
+
+		platformBinaries = append(platformBinaries, catalog.PlatformBinary{
+			Platform: platform,
+			Data:     data,
+		})
+		platformList = append(platformList, platform)
+	}
+
+	ref := catalog.Reference{
+		Kind:    artifactKind,
+		Name:    name,
+		Version: ver,
+	}
+
+	localCatalog, err := catalog.NewLocalCatalog(s.logger)
+	if err != nil {
+		return newStructuredError(ErrCodeConfigError, fmt.Sprintf("failed to initialize local catalog: %v", err),
+			WithSuggestion("Ensure the catalog directory exists and is accessible"),
+		), nil
+	}
+
+	info, err := localCatalog.StoreMultiPlatform(s.ctx, ref, platformBinaries, nil, force)
+	if err != nil {
+		if catalog.IsExists(err) {
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("artifact %s@%s already exists", name, versionStr),
+				WithSuggestion("Use force: true to overwrite, or choose a different version"),
+				WithRelatedTools("catalog_list_platforms"),
+			), nil
+		}
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build plugin: %v", err),
+			WithSuggestion("Check file paths and catalog permissions"),
+		), nil
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"name":          name,
+		"kind":          kindStr,
+		"version":       versionStr,
+		"platforms":     platformList,
+		"platformCount": len(platformList),
+		"digest":        info.Digest,
+		"catalog":       info.Catalog,
+	})
+}

--- a/pkg/mcp/tools_catalog_multiplatform_test.go
+++ b/pkg/mcp/tools_catalog_multiplatform_test.go
@@ -1,0 +1,505 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setTestXDG sets XDG_DATA_HOME and XDG_CACHE_HOME to tmpDir and reloads xdg
+// so that NewLocalCatalog() picks up the override. Also restores xdg on cleanup.
+func setTestXDG(t *testing.T, tmpDir string) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+	xdg.Reload()
+	t.Cleanup(func() { xdg.Reload() })
+}
+
+func TestHandleCatalogListPlatforms(t *testing.T) {
+	t.Run("missing reference returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "catalog_list_platforms"
+		request.Params.Arguments = map[string]any{
+			"kind": "provider",
+		}
+
+		result, err := srv.handleCatalogListPlatforms(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing kind returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "catalog_list_platforms"
+		request.Params.Arguments = map[string]any{
+			"reference": "my-provider@1.0.0",
+		}
+
+		result, err := srv.handleCatalogListPlatforms(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("invalid kind returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "catalog_list_platforms"
+		request.Params.Arguments = map[string]any{
+			"reference": "my-provider@1.0.0",
+			"kind":      "invalid",
+		}
+
+		result, err := srv.handleCatalogListPlatforms(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "invalid kind")
+	})
+
+	t.Run("nonexistent artifact returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "catalog_list_platforms"
+		request.Params.Arguments = map[string]any{
+			"reference": "nonexistent@1.0.0",
+			"kind":      "provider",
+		}
+
+		result, err := srv.handleCatalogListPlatforms(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleBuildPlugin(t *testing.T) {
+	t.Run("missing name returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"kind":    "provider",
+			"version": "1.0.0",
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("invalid kind returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-plugin",
+			"kind":    "solution",
+			"version": "1.0.0",
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "invalid kind")
+	})
+
+	t.Run("invalid version returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-plugin",
+			"kind":    "provider",
+			"version": "not-a-version",
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "invalid semantic version")
+	})
+
+	t.Run("missing platforms returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-plugin",
+			"kind":    "provider",
+			"version": "1.0.0",
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "platforms")
+	})
+
+	t.Run("unsupported platform returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binPath := filepath.Join(tmpDir, "binary")
+		require.NoError(t, os.WriteFile(binPath, []byte("data"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-plugin",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"freebsd/amd64": binPath,
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "unsupported platform")
+	})
+
+	t.Run("binary not found returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-plugin",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64": "/nonexistent/binary",
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "binary not found")
+	})
+
+	t.Run("successful single-platform build", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		binPath := filepath.Join(tmpDir, "my-binary")
+		require.NoError(t, os.WriteFile(binPath, []byte("fake-plugin-binary"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "mcp-test-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64": binPath,
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "expected success, got: %+v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, "mcp-test-provider", parsed["name"])
+		assert.Equal(t, "provider", parsed["kind"])
+		assert.Equal(t, "1.0.0", parsed["version"])
+		assert.Equal(t, float64(1), parsed["platformCount"])
+	})
+
+	t.Run("successful multi-platform build", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		linuxBin := filepath.Join(tmpDir, "linux-bin")
+		darwinBin := filepath.Join(tmpDir, "darwin-bin")
+		require.NoError(t, os.WriteFile(linuxBin, []byte("linux-binary"), 0o755))
+		require.NoError(t, os.WriteFile(darwinBin, []byte("darwin-binary"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "mcp-multi-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64":  linuxBin,
+				"darwin/arm64": darwinBin,
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "expected success, got: %+v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, "mcp-multi-provider", parsed["name"])
+		assert.Equal(t, float64(2), parsed["platformCount"])
+	})
+
+	t.Run("duplicate version without force returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		binPath := filepath.Join(tmpDir, "binary")
+		require.NoError(t, os.WriteFile(binPath, []byte("binary-data"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		buildReq := mcp.CallToolRequest{}
+		buildReq.Params.Name = "build_plugin"
+		buildReq.Params.Arguments = map[string]any{
+			"name":    "dup-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64": binPath,
+			},
+		}
+
+		// First build
+		result, err := srv.handleBuildPlugin(context.Background(), buildReq)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		// Second build without force
+		result, err = srv.handleBuildPlugin(context.Background(), buildReq)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "already exists")
+	})
+
+	t.Run("force overwrite succeeds", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		binPath := filepath.Join(tmpDir, "binary")
+		require.NoError(t, os.WriteFile(binPath, []byte("binary-data"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		buildReq := mcp.CallToolRequest{}
+		buildReq.Params.Name = "build_plugin"
+		buildReq.Params.Arguments = map[string]any{
+			"name":    "force-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64": binPath,
+			},
+		}
+
+		// First build
+		result, err := srv.handleBuildPlugin(context.Background(), buildReq)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		// Force overwrite — create new request with force=true
+		forceReq := mcp.CallToolRequest{}
+		forceReq.Params.Name = "build_plugin"
+		forceReq.Params.Arguments = map[string]any{
+			"name":    "force-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64": binPath,
+			},
+			"force": true,
+		}
+		result, err = srv.handleBuildPlugin(context.Background(), forceReq)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("build then list platforms round-trip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		linuxBin := filepath.Join(tmpDir, "linux-bin")
+		darwinBin := filepath.Join(tmpDir, "darwin-bin")
+		require.NoError(t, os.WriteFile(linuxBin, []byte("linux-binary"), 0o755))
+		require.NoError(t, os.WriteFile(darwinBin, []byte("darwin-binary"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Build multi-platform plugin
+		buildReq := mcp.CallToolRequest{}
+		buildReq.Params.Name = "build_plugin"
+		buildReq.Params.Arguments = map[string]any{
+			"name":    "round-trip-provider",
+			"kind":    "provider",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"linux/amd64":  linuxBin,
+				"darwin/arm64": darwinBin,
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), buildReq)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "build failed: %+v", result.Content)
+
+		// List platforms
+		listReq := mcp.CallToolRequest{}
+		listReq.Params.Name = "catalog_list_platforms"
+		listReq.Params.Arguments = map[string]any{
+			"reference": "round-trip-provider@1.0.0",
+			"kind":      "provider",
+		}
+
+		result, err = srv.handleCatalogListPlatforms(context.Background(), listReq)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "list platforms failed: %+v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, true, parsed["isMultiPlatform"])
+		assert.Equal(t, float64(2), parsed["platformCount"])
+
+		platforms := parsed["platforms"].([]any)
+		platformStrs := make([]string, len(platforms))
+		for i, p := range platforms {
+			platformStrs[i] = p.(string)
+		}
+		assert.Contains(t, platformStrs, "linux/amd64")
+		assert.Contains(t, platformStrs, "darwin/arm64")
+	})
+
+	t.Run("auth-handler kind works", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		binPath := filepath.Join(tmpDir, "auth-handler")
+		require.NoError(t, os.WriteFile(binPath, []byte("auth-binary"), 0o755))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "build_plugin"
+		request.Params.Arguments = map[string]any{
+			"name":    "test-auth",
+			"kind":    "auth-handler",
+			"version": "1.0.0",
+			"platforms": map[string]any{
+				"darwin/arm64": binPath,
+			},
+		}
+
+		result, err := srv.handleBuildPlugin(context.Background(), request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "expected success, got: %+v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, "test-auth", parsed["name"])
+		assert.Equal(t, "auth-handler", parsed["kind"])
+	})
+}
+
+func TestCatalogInspect_MultiPlatformInfo(t *testing.T) {
+	t.Run("inspect multi-platform artifact shows platforms", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestXDG(t, tmpDir)
+
+		// Build a multi-platform artifact directly via catalog
+		localCatalog, err := catalog.NewLocalCatalog(logr.Discard())
+		require.NoError(t, err)
+
+		ref, err := catalog.ParseReference(catalog.ArtifactKindProvider, "inspect-mp-test@1.0.0")
+		require.NoError(t, err)
+
+		_, err = localCatalog.StoreMultiPlatform(context.Background(), ref, []catalog.PlatformBinary{
+			{Platform: "linux/amd64", Data: []byte("linux-binary")},
+			{Platform: "darwin/arm64", Data: []byte("darwin-binary")},
+		}, nil, false)
+		require.NoError(t, err)
+
+		// Now inspect via MCP
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "catalog_inspect"
+		request.Params.Arguments = map[string]any{
+			"reference": "inspect-mp-test@1.0.0",
+			"kind":      "provider",
+		}
+
+		result, err := srv.handleCatalogInspect(context.Background(), request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "expected success, got: %+v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		assert.Equal(t, true, parsed["isMultiPlatform"])
+		assert.Equal(t, float64(2), parsed["platformCount"])
+
+		platforms := parsed["platforms"].([]any)
+		platformStrs := make([]string, len(platforms))
+		for i, p := range platforms {
+			platformStrs[i] = p.(string)
+		}
+		assert.Contains(t, platformStrs, "linux/amd64")
+		assert.Contains(t, platformStrs, "darwin/arm64")
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3699,6 +3699,192 @@ func TestIntegration_BuildSolution_DryRunShowsDetails(t *testing.T) {
 }
 
 // ============================================================================
+// Build Plugin Integration Tests
+// ============================================================================
+
+func TestIntegration_BuildPluginHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "build", "plugin", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "multi-platform")
+	assert.Contains(t, stdout, "--name")
+	assert.Contains(t, stdout, "--kind")
+	assert.Contains(t, stdout, "--version")
+	assert.Contains(t, stdout, "--platform")
+	assert.Contains(t, stdout, "--force")
+}
+
+func TestIntegration_BuildPlugin_HelpShownInBuildParent(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "build", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "plugin")
+}
+
+func TestIntegration_BuildPlugin_MissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "build", "plugin")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_BuildPlugin_SinglePlatform(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	// Create a mock binary
+	binPath := filepath.Join(tmpDir, "my-provider")
+	require.NoError(t, os.WriteFile(binPath, []byte("fake-plugin-binary"), 0o755))
+
+	stdout, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "test-provider",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath)
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Built test-provider@1.0.0")
+	assert.Contains(t, stdout, "1 platform(s)")
+	assert.Contains(t, stdout, "linux/amd64")
+}
+
+func TestIntegration_BuildPlugin_MultiPlatform(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	// Create mock binaries for two platforms
+	linuxBin := filepath.Join(tmpDir, "provider-linux")
+	darwinBin := filepath.Join(tmpDir, "provider-darwin")
+	require.NoError(t, os.WriteFile(linuxBin, []byte("linux-binary"), 0o755))
+	require.NoError(t, os.WriteFile(darwinBin, []byte("darwin-binary"), 0o755))
+
+	stdout, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "multi-provider",
+		"--kind", "provider",
+		"--version", "2.0.0",
+		"--platform", "linux/amd64="+linuxBin,
+		"--platform", "darwin/arm64="+darwinBin)
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Built multi-provider@2.0.0")
+	assert.Contains(t, stdout, "2 platform(s)")
+}
+
+func TestIntegration_BuildPlugin_AuthHandler(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	binPath := filepath.Join(tmpDir, "auth-handler")
+	require.NoError(t, os.WriteFile(binPath, []byte("auth-binary"), 0o755))
+
+	stdout, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "test-auth",
+		"--kind", "auth-handler",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath)
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Built test-auth@1.0.0")
+}
+
+func TestIntegration_BuildPlugin_ForceOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	binPath := filepath.Join(tmpDir, "provider")
+	require.NoError(t, os.WriteFile(binPath, []byte("binary-v1"), 0o755))
+
+	// First build
+	_, _, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "force-test",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath)
+	assert.Equal(t, 0, exitCode)
+
+	// Second build without --force should fail
+	_, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "force-test",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "already exists")
+
+	// Third build with --force should succeed
+	stdout, _, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "force-test",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath,
+		"--force")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Built force-test@1.0.0")
+}
+
+func TestIntegration_BuildPlugin_InvalidPlatform(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	binPath := filepath.Join(tmpDir, "provider")
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+
+	_, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "bad-plat",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "freebsd/amd64="+binPath)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "unsupported platform")
+}
+
+func TestIntegration_BuildPlugin_InvalidKind(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	binPath := filepath.Join(tmpDir, "provider")
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+
+	_, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "bad-kind",
+		"--kind", "solution",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64="+binPath)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "invalid kind")
+}
+
+func TestIntegration_BuildPlugin_BinaryNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	_, stderr, exitCode := runScafctl(t, "build", "plugin",
+		"--name", "missing",
+		"--kind", "provider",
+		"--version", "1.0.0",
+		"--platform", "linux/amd64=/nonexistent/path")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "binary not found")
+}
+
+// ============================================================================
 // Directory Provider Integration Tests
 // ============================================================================
 

--- a/tests/integration/solutions/README.md
+++ b/tests/integration/solutions/README.md
@@ -72,6 +72,8 @@ tests/integration/solutions/
 ├── rendering/                # Template rendering tests
 ├── composition/              # Multi-file compose tests
 │   └── parts/                # Composed YAML fragments
+├── plugins/                  # Plugin CLI command tests
+│                             #   build plugin help, missing flags, subcommand discovery
 ├── test-generation/          # Test generation tests
 └── edge-cases/               # Negative/error tests
     ├── validation-failures/  # Intentional validation errors
@@ -100,6 +102,7 @@ tests/integration/solutions/
 | `dag`, `until`, `type-coercion`, `transform`, `conditional`, `timeout`, `sensitive` | Individual resolver feature tests |
 | `rendering` | Template rendering tests |
 | `composition` | Multi-file compose tests |
+| `plugin` | Plugin CLI command tests (build plugin, list, help) |
 | `edge-case` | Error handling and boundary tests |
 | `negative` | Tests expecting failures |
 

--- a/tests/integration/solutions/plugins/solution.yaml
+++ b/tests/integration/solutions/plugins/solution.yaml
@@ -38,6 +38,35 @@ spec:
         assertions:
           - expression: __exitCode == 0
 
+      build-plugin-help:
+        description: Verify build plugin help works
+        command: [build, plugin, --help]
+        injectFile: false
+        assertions:
+          - expression: __exitCode == 0
+          - contains: multi-platform
+          - contains: --name
+          - contains: --kind
+          - contains: --version
+          - contains: --platform
+          - contains: --force
+
+      build-plugin-missing-flags:
+        description: Build plugin without required flags should fail
+        command: [build, plugin]
+        injectFile: false
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+
+      build-help-shows-plugin:
+        description: Build parent shows plugin subcommand
+        command: [build, --help]
+        injectFile: false
+        assertions:
+          - expression: __exitCode == 0
+          - contains: plugin
+
       render-greeting:
         description: Verify resolver renders
         command: [run, resolver]


### PR DESCRIPTION
Implements #27. Providers and auth-handlers can now be packaged as OCI image index artifacts containing per-platform binaries (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64). At runtime, scafctl automatically selects the correct binary for the current platform.

## Core catalog changes (pkg/catalog/)

- Add multiplatform.go with helpers: PlatformToOCI, MatchPlatform, IndexPlatforms, IsImageIndex, IsSupportedPlatform, SupportedPluginPlatforms
- Add PlatformNotFoundError to errors.go for explicit platform-not-found signalling (no fallback when a multi-platform artifact lacks the requested platform)
- Add local_multiplatform.go with LocalCatalog methods: StoreMultiPlatform, FetchByPlatform, ListPlatforms
- Extend plugin_fetcher.go with PlatformAwareCatalog interface and 3-strategy resolution: OCI image index → annotation match → direct fetch
- Fix local.go markReferencedBlobs/collectBlobsForExport to recurse into image index manifests so GC and export include all platform blobs

## CLI (pkg/cmd/scafctl/build/)

- Add 'scafctl build plugin' command (--name, --kind, --version, --platform os/arch=path, --force); register as subcommand of 'build'

## MCP server (pkg/mcp/)

- Add tools_catalog_multiplatform.go with two new MCP tools: catalog_list_platforms and build_plugin
- Enrich catalog_inspect to include isMultiPlatform, platforms, and platformCount fields for provider/auth-handler artifacts
- Add 'plugin' icon to toolIcons map

## Tests

- Unit tests: multiplatform_test.go, local_multiplatform_test.go, plugin_fetcher_multiplatform_test.go, plugin_test.go, tools_catalog_multiplatform_test.go (65+ new test cases)
- CLI integration tests: 10 new TestIntegration_BuildPlugin_* cases
- Solution integration tests: build-plugin-help, build-plugin-missing-flags, build-help-shows-plugin added to plugins/solution.yaml

## Docs & examples

- Add docs/tutorials/multi-platform-plugin-build.md
- Add examples/plugins/multi-platform-build/README.md
- Update docs/design/plugins.md with OCI index architecture section
- Update docs/design/mcp-server.md with new catalog/build tools table


Closes #27