### PR TITLE
feat(cache): add TTL-based artifact cache for catalog solutions

### DIFF
--- a/pkg/cache/artifact.go
+++ b/pkg/cache/artifact.go
@@ -1,0 +1,186 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// ArtifactCache is a disk-based TTL cache for catalog artifacts.
+// It stores artifact content (and optional bundle data) in a structured
+// directory layout: {dir}/{kind}/{safe(name@version)}/
+//
+// Each cache entry contains:
+//   - content      - the primary artifact bytes (e.g., solution YAML)
+//   - bundle.tar.gz - the bundle tar (if any)
+//   - meta.json     - creation timestamp and content digest
+type ArtifactCache struct {
+	dir string
+	ttl time.Duration
+}
+
+// artifactCacheMeta holds metadata written alongside cached artifact files.
+type artifactCacheMeta struct {
+	CreatedAt time.Time `json:"createdAt"`
+	Digest    string    `json:"digest,omitempty"`
+}
+
+// NewArtifactCache creates a new ArtifactCache rooted at dir with the given TTL.
+// A zero TTL means entries never expire.
+func NewArtifactCache(dir string, ttl time.Duration) *ArtifactCache {
+	return &ArtifactCache{dir: dir, ttl: ttl}
+}
+
+// Dir returns the root directory of the cache.
+func (c *ArtifactCache) Dir() string {
+	return c.dir
+}
+
+// TTL returns the configured TTL for cache entries.
+func (c *ArtifactCache) TTL() time.Duration {
+	return c.ttl
+}
+
+// Get retrieves cached content and bundle data for the given artifact.
+// Returns (nil, nil, false, nil) on cache miss or expiry.
+// Returns (nil, nil, false, err) on read errors.
+func (c *ArtifactCache) Get(kind, name, version string) (content, bundleData []byte, ok bool, err error) {
+	dir := c.entryDir(kind, name, version)
+
+	// Read and validate meta
+	meta, found, err := c.readMeta(dir)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if !found {
+		return nil, nil, false, nil
+	}
+
+	// Check TTL
+	if c.ttl > 0 && time.Since(meta.CreatedAt) > c.ttl {
+		_ = os.RemoveAll(dir) // remove stale entry
+		return nil, nil, false, nil
+	}
+
+	// Read content
+	contentBytes, err := os.ReadFile(filepath.Join(dir, "content"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, fmt.Errorf("artifact cache: reading content: %w", err)
+	}
+
+	// Read bundle (optional — missing is not an error)
+	bundleBytes, err := os.ReadFile(filepath.Join(dir, "bundle.tar.gz"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, false, fmt.Errorf("artifact cache: reading bundle: %w", err)
+	}
+
+	return contentBytes, bundleBytes, true, nil
+}
+
+// Put stores artifact content and optional bundle data in the cache.
+// digest is the content digest returned by the catalog (e.g., "sha256:abc123...").
+// bundleData may be nil when the artifact has no bundle layer.
+func (c *ArtifactCache) Put(kind, name, version, digest string, content, bundleData []byte) error {
+	dir := c.entryDir(kind, name, version)
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("artifact cache: creating entry directory: %w", err)
+	}
+
+	// Write content
+	if err := os.WriteFile(filepath.Join(dir, "content"), content, 0o600); err != nil {
+		return fmt.Errorf("artifact cache: writing content: %w", err)
+	}
+
+	// Write bundle (skip if no bundle)
+	bundlePath := filepath.Join(dir, "bundle.tar.gz")
+	if len(bundleData) > 0 {
+		if err := os.WriteFile(bundlePath, bundleData, 0o600); err != nil {
+			return fmt.Errorf("artifact cache: writing bundle: %w", err)
+		}
+	} else {
+		// Remove stale bundle from a previous put, if any
+		_ = os.Remove(bundlePath)
+	}
+
+	// Write meta
+	meta := artifactCacheMeta{
+		CreatedAt: time.Now(),
+		Digest:    digest,
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("artifact cache: marshaling meta: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), metaBytes, 0o600); err != nil {
+		return fmt.Errorf("artifact cache: writing meta: %w", err)
+	}
+
+	return nil
+}
+
+// Invalidate removes a cached entry for the given artifact.
+// Returns nil if the entry does not exist.
+func (c *ArtifactCache) Invalidate(kind, name, version string) error {
+	dir := c.entryDir(kind, name, version)
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("artifact cache: invalidating entry: %w", err)
+	}
+	return nil
+}
+
+// entryDir returns the directory path for a given cache entry.
+// Path: {c.dir}/{safeKind}/{safeNameVersion}
+func (c *ArtifactCache) entryDir(kind, name, version string) string {
+	safeKind := sanitizeArtifactCacheKey(kind)
+	nameVersion := name
+	if version != "" {
+		nameVersion = name + "@" + version
+	}
+	safeNameVersion := sanitizeArtifactCacheKey(nameVersion)
+	return filepath.Join(c.dir, safeKind, safeNameVersion)
+}
+
+// readMeta reads and parses meta.json from a cache entry directory.
+// Returns (meta, true, nil) on success, (zero, false, nil) if not found,
+// (zero, false, err) on other errors.
+func (c *ArtifactCache) readMeta(dir string) (artifactCacheMeta, bool, error) {
+	metaPath := filepath.Join(dir, "meta.json")
+	data, err := os.ReadFile(metaPath)
+	if os.IsNotExist(err) {
+		return artifactCacheMeta{}, false, nil
+	}
+	if err != nil {
+		return artifactCacheMeta{}, false, fmt.Errorf("artifact cache: reading meta: %w", err)
+	}
+
+	var meta artifactCacheMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		// Corrupt meta — treat as cache miss and clean up
+		_ = os.RemoveAll(dir)
+		return artifactCacheMeta{}, false, nil //nolint:nilerr // Intentionally ignoring unmarshal error for corrupt meta
+	}
+
+	return meta, true, nil
+}
+
+// sanitizeArtifactCacheKey replaces characters unsafe for directory names.
+// Preserves letters, digits, '-', '.', '_', and '@'.
+func sanitizeArtifactCacheKey(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '.' || r == '_' || r == '@' {
+			return r
+		}
+		return '_'
+	}, s)
+}

--- a/pkg/cache/artifact_test.go
+++ b/pkg/cache/artifact_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cache_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactCache_PutAndGet(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	content := []byte("solution: {}")
+	bundle := []byte("bundle data")
+
+	err := c.Put("solution", "my-solution", "1.0.0", "sha256:abc123", content, bundle)
+	require.NoError(t, err)
+
+	got, gotBundle, ok, err := c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, content, got)
+	assert.Equal(t, bundle, gotBundle)
+}
+
+func TestArtifactCache_GetMiss(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	got, gotBundle, ok, err := c.Get("solution", "missing", "1.0.0")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+	assert.Nil(t, gotBundle)
+}
+
+func TestArtifactCache_TTLExpiry(t *testing.T) {
+	dir := t.TempDir()
+	// Use a 1ms TTL so the entry expires almost immediately
+	c := cache.NewArtifactCache(dir, 1*time.Millisecond)
+
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my-solution", "1.0.0", "sha256:abc123", content, nil)
+	require.NoError(t, err)
+
+	// Wait for the TTL to expire
+	time.Sleep(10 * time.Millisecond)
+
+	got, _, ok, err := c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestArtifactCache_ZeroTTL_NeverExpires(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, 0) // zero TTL = never expire
+
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my-solution", "2.0.0", "sha256:def456", content, nil)
+	require.NoError(t, err)
+
+	got, _, ok, err := c.Get("solution", "my-solution", "2.0.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, content, got)
+}
+
+func TestArtifactCache_NoBundle(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my-solution", "1.0.0", "sha256:abc123", content, nil)
+	require.NoError(t, err)
+
+	got, gotBundle, ok, err := c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, content, got)
+	assert.Nil(t, gotBundle)
+}
+
+func TestArtifactCache_Invalidate(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my-solution", "1.0.0", "sha256:abc123", content, nil)
+	require.NoError(t, err)
+
+	// Verify it's there
+	_, _, ok, err := c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	// Invalidate
+	err = c.Invalidate("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+
+	// Should be gone
+	_, _, ok, err = c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestArtifactCache_Invalidate_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	// Should not error on non-existent entry
+	err := c.Invalidate("solution", "nonexistent", "1.0.0")
+	assert.NoError(t, err)
+}
+
+func TestArtifactCache_CorruptMeta(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	// Store valid entry first
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my-solution", "1.0.0", "sha256:abc123", content, nil)
+	require.NoError(t, err)
+
+	// Corrupt the meta file to trigger corrupt-meta handling
+	entryDir := dir + "/solution/my-solution@1.0.0"
+	err = os.WriteFile(entryDir+"/meta.json", []byte("not-valid-json"), 0o600)
+	require.NoError(t, err)
+
+	// Should be treated as a cache miss
+	_, _, ok, err := c.Get("solution", "my-solution", "1.0.0")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestArtifactCache_SpecialCharsInName(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	// Names with special characters should be sanitized
+	content := []byte("solution: {}")
+	err := c.Put("solution", "my/solution:v2", "1.0.0", "sha256:abc123", content, nil)
+	require.NoError(t, err)
+
+	got, _, ok, err := c.Get("solution", "my/solution:v2", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, content, got)
+}
+
+func TestArtifactCache_DirAndTTL(t *testing.T) {
+	dir := t.TempDir()
+	ttl := 5 * time.Minute
+	c := cache.NewArtifactCache(dir, ttl)
+
+	assert.Equal(t, dir, c.Dir())
+	assert.Equal(t, ttl, c.TTL())
+}
+
+func BenchmarkArtifactCache_PutGet(b *testing.B) {
+	dir := b.TempDir()
+	c := cache.NewArtifactCache(dir, time.Hour)
+
+	content := []byte("solution: {name: bench}")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = c.Put("solution", "bench-solution", "1.0.0", "sha256:bench", content, nil)
+		_, _, _, _ = c.Get("solution", "bench-solution", "1.0.0")
+	}
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,10 +23,12 @@ const (
 	KindHTTP Kind = "http"
 	// KindBuild clears the build cache (incremental build fingerprints).
 	KindBuild Kind = "build"
+	// KindArtifact clears the artifact cache (downloaded catalog artifacts with TTL).
+	KindArtifact Kind = "artifact"
 )
 
 // ValidKinds lists all valid cache kinds.
-var ValidKinds = []string{string(KindAll), string(KindHTTP), string(KindBuild)}
+var ValidKinds = []string{string(KindAll), string(KindHTTP), string(KindBuild), string(KindArtifact)}
 
 // ClearOutput represents the result of a cache clear operation.
 type ClearOutput struct {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -125,5 +125,6 @@ func TestValidKinds(t *testing.T) {
 	assert.Contains(t, ValidKinds, "all")
 	assert.Contains(t, ValidKinds, "http")
 	assert.Contains(t, ValidKinds, "build")
-	assert.Len(t, ValidKinds, 3)
+	assert.Contains(t, ValidKinds, "artifact")
+	assert.Len(t, ValidKinds, 4)
 }

--- a/pkg/catalog/resolver.go
+++ b/pkg/catalog/resolver.go
@@ -11,27 +11,79 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// ArtifactCacher defines the interface for an artifact cache used by SolutionResolver.
+// This interface allows caching downloaded catalog artifacts to reduce repeated fetches.
+type ArtifactCacher interface {
+	// Get retrieves cached content and bundle data.
+	// Returns (nil, nil, false, nil) on cache miss. Returns an error on read failure.
+	Get(kind, name, version string) (content, bundleData []byte, ok bool, err error)
+	// Put stores artifact content and bundle data in the cache.
+	Put(kind, name, version, digest string, content, bundleData []byte) error
+}
+
+// SolutionResolverOption configures a SolutionResolver.
+type SolutionResolverOption func(*SolutionResolver)
+
+// WithResolverArtifactCache sets the artifact cache for the resolver.
+// When set, fetched artifacts are stored in and served from this cache.
+func WithResolverArtifactCache(c ArtifactCacher) SolutionResolverOption {
+	return func(r *SolutionResolver) {
+		r.artifactCache = c
+	}
+}
+
+// WithResolverNoCache disables artifact caching for this resolver.
+// When true, the cache is neither read nor written, ensuring fresh catalog fetches.
+func WithResolverNoCache(noCache bool) SolutionResolverOption {
+	return func(r *SolutionResolver) {
+		r.noCache = noCache
+	}
+}
+
 // SolutionResolver wraps a Catalog to provide solution fetching by name[@version].
 // It implements the CatalogResolver interface from pkg/solution/get.
 type SolutionResolver struct {
-	catalog Catalog
-	logger  logr.Logger
+	catalog       Catalog
+	logger        logr.Logger
+	artifactCache ArtifactCacher
+	noCache       bool
 }
 
 // NewSolutionResolver creates a resolver that fetches solutions from the given catalog.
-func NewSolutionResolver(catalog Catalog, logger logr.Logger) *SolutionResolver {
-	return &SolutionResolver{
+// Optional SolutionResolverOption values may be provided to configure artifact caching
+// and cache bypass behavior.
+func NewSolutionResolver(catalog Catalog, logger logr.Logger, opts ...SolutionResolverOption) *SolutionResolver {
+	r := &SolutionResolver{
 		catalog: catalog,
 		logger:  logger.WithName("solution-resolver"),
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // FetchSolution retrieves a solution from the catalog by name[@version].
 // The input format is "name" or "name@version" (e.g., "my-solution" or "my-solution@1.2.3").
 // Returns the solution content as bytes.
+//
+// When an artifact cache is configured and noCache is false, the result is served
+// from cache on a hit (within TTL), otherwise the catalog is fetched and the
+// result is stored for future use.
 func (r *SolutionResolver) FetchSolution(ctx context.Context, nameWithVersion string) ([]byte, error) {
 	// Parse the name[@version] format
 	name, version := parseNameVersion(nameWithVersion)
+
+	// Check artifact cache (skip when --no-cache or no cache configured)
+	if !r.noCache && r.artifactCache != nil {
+		cached, _, ok, err := r.artifactCache.Get(string(ArtifactKindSolution), name, version)
+		if err != nil {
+			r.logger.V(1).Info("artifact cache get error (ignoring)", "error", err)
+		} else if ok {
+			r.logger.V(1).Info("artifact cache hit", "name", name, "version", version)
+			return cached, nil
+		}
+	}
 
 	// Build the reference string for parsing
 	refStr := name
@@ -60,15 +112,40 @@ func (r *SolutionResolver) FetchSolution(ctx context.Context, nameWithVersion st
 		"digest", info.Digest,
 		"catalog", r.catalog.Name())
 
+	// Store in artifact cache using the resolved version as the cache key version.
+	if !r.noCache && r.artifactCache != nil {
+		resolvedVersion := version
+		if info.Reference.Version != nil {
+			resolvedVersion = info.Reference.Version.String()
+		}
+		if err := r.artifactCache.Put(string(ArtifactKindSolution), name, resolvedVersion, info.Digest, content, nil); err != nil {
+			r.logger.V(1).Info("artifact cache put error (ignoring)", "error", err)
+		}
+	}
+
 	return content, nil
 }
 
 // FetchSolutionWithBundle retrieves a solution and its bundle from the catalog by name[@version].
 // The input format is "name" or "name@version" (e.g., "my-solution" or "my-solution@1.2.3").
 // Returns the solution content bytes, bundle tar bytes (nil if no bundle), and any error.
+//
+// When an artifact cache is configured and noCache is false, both content and bundle
+// are cached together for TTL-based reuse.
 func (r *SolutionResolver) FetchSolutionWithBundle(ctx context.Context, nameWithVersion string) ([]byte, []byte, error) {
 	// Parse the name[@version] format
 	name, version := parseNameVersion(nameWithVersion)
+
+	// Check artifact cache (skip when --no-cache or no cache configured)
+	if !r.noCache && r.artifactCache != nil {
+		cachedContent, cachedBundle, ok, err := r.artifactCache.Get(string(ArtifactKindSolution), name, version)
+		if err != nil {
+			r.logger.V(1).Info("artifact cache get error (ignoring)", "error", err)
+		} else if ok {
+			r.logger.V(1).Info("artifact cache hit (with bundle)", "name", name, "version", version, "hasBundle", len(cachedBundle) > 0)
+			return cachedContent, cachedBundle, nil
+		}
+	}
 
 	// Build the reference string for parsing
 	refStr := name
@@ -97,6 +174,17 @@ func (r *SolutionResolver) FetchSolutionWithBundle(ctx context.Context, nameWith
 		"digest", info.Digest,
 		"hasBundle", len(bundleData) > 0,
 		"catalog", r.catalog.Name())
+
+	// Store in artifact cache using the resolved version as the cache key version.
+	if !r.noCache && r.artifactCache != nil {
+		resolvedVersion := version
+		if info.Reference.Version != nil {
+			resolvedVersion = info.Reference.Version.String()
+		}
+		if err := r.artifactCache.Put(string(ArtifactKindSolution), name, resolvedVersion, info.Digest, content, bundleData); err != nil {
+			r.logger.V(1).Info("artifact cache put error (ignoring)", "error", err)
+		}
+	}
 
 	return content, bundleData, nil
 }

--- a/pkg/cmd/scafctl/cache/clear.go
+++ b/pkg/cmd/scafctl/cache/clear.go
@@ -38,6 +38,8 @@ const (
 	KindHTTP cachelib.Kind = cachelib.KindHTTP
 	// KindBuild clears the build cache (incremental build fingerprints).
 	KindBuild cachelib.Kind = cachelib.KindBuild
+	// KindArtifact clears the artifact cache (downloaded catalog artifacts with TTL).
+	KindArtifact cachelib.Kind = cachelib.KindArtifact
 )
 
 // ValidKinds lists all valid cache kinds.
@@ -62,9 +64,10 @@ func CommandClear(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			type of cache, or --name to clear cache entries matching a pattern.
 
 			Cache kinds:
-			  all   - Clear all caches (default)
-			  http  - Clear HTTP response cache
-			  build - Clear build cache (incremental build fingerprints)
+		  all      - Clear all caches (default)
+		  http     - Clear HTTP response cache
+		  build    - Clear build cache (incremental build fingerprints)
+		  artifact - Clear artifact cache (downloaded catalog artifacts)
 
 			Examples:
 			  # Clear all caches
@@ -72,7 +75,8 @@ func CommandClear(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Clear only HTTP cache
 			  scafctl cache clear --kind http
-
+		  # Clear only artifact cache
+		  scafctl cache clear --kind artifact
 			  # Clear cache entries matching a pattern
 			  scafctl cache clear --name "api.github.com*"
 
@@ -110,6 +114,8 @@ func runClear(ctx context.Context, options *ClearOptions, outputOpts *kvx.Output
 			kind = KindHTTP
 		case string(KindBuild):
 			kind = KindBuild
+		case string(KindArtifact):
+			kind = KindArtifact
 		default:
 			err := fmt.Errorf("invalid cache kind %q; valid kinds: %s", options.Kind, strings.Join(ValidKinds, ", "))
 			w.Errorf("%v", err)
@@ -172,6 +178,15 @@ func runClear(ctx context.Context, options *ClearOptions, outputOpts *kvx.Output
 		files, bytes, err := cachelib.ClearDirectory(paths.BuildCacheDir(), options.Name)
 		if err != nil {
 			w.Errorf("failed to clear build cache: %v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+		totalFiles += files
+		totalBytes += bytes
+
+	case KindArtifact:
+		files, bytes, err := cachelib.ClearDirectory(paths.ArtifactCacheDir(), options.Name)
+		if err != nil {
+			w.Errorf("failed to clear artifact cache: %v", err)
 			return exitcode.WithCode(err, exitcode.GeneralError)
 		}
 		totalFiles += files

--- a/pkg/cmd/scafctl/cache/info.go
+++ b/pkg/cmd/scafctl/cache/info.go
@@ -66,6 +66,7 @@ func runInfo(ctx context.Context, _ *InfoOptions, outputOpts *kvx.OutputOptions)
 	caches := []cachelib.Info{
 		cachelib.GetCacheInfo("HTTP Cache", paths.HTTPCacheDir(), "HTTP response cache"),
 		cachelib.GetCacheInfo("Build Cache", paths.BuildCacheDir(), "Incremental build fingerprints"),
+		cachelib.GetCacheInfo("Artifact Cache", paths.ArtifactCacheDir(), "Downloaded catalog artifacts (TTL-based)"),
 	}
 
 	// Calculate totals

--- a/pkg/cmd/scafctl/catalog/pull.go
+++ b/pkg/cmd/scafctl/catalog/pull.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -26,6 +28,7 @@ type PullOptions struct {
 	Kind       string // Artifact kind override (--kind)
 	Force      bool   // Overwrite existing (--force)
 	Insecure   bool   // Allow HTTP (--insecure)
+	NoCache    bool   // Invalidate artifact cache after pull (--no-cache)
 	CliParams  *settings.Run
 	IOStreams  *terminal.IOStreams
 }
@@ -78,6 +81,7 @@ func CommandPull(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	cmd.Flags().StringVar(&options.Kind, "kind", "", "Artifact kind override (solution, provider, auth-handler)")
 	cmd.Flags().BoolVarP(&options.Force, "force", "f", false, "Overwrite existing local artifact")
 	cmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Allow insecure HTTP connections")
+	cmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Invalidate the artifact cache for this artifact after pulling")
 
 	return cmd
 }
@@ -188,6 +192,26 @@ func runPull(ctx context.Context, opts *PullOptions) error {
 		displayName,
 		ref.Version.String(),
 		formatBytes(result.Size))
+
+	// When --no-cache is set, invalidate any stale artifact cache entry so that
+	// subsequent run/render/get commands fetch the freshly pulled artifact from
+	// the local catalog rather than a cached copy.
+	if opts.NoCache {
+		artifactCache := cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+		targetName := ref.Name
+		if opts.TargetName != "" {
+			targetName = opts.TargetName
+		}
+		version := ""
+		if ref.Version != nil {
+			version = ref.Version.String()
+		}
+		if err := artifactCache.Invalidate(string(ref.Kind), targetName, version); err != nil {
+			lgr.V(1).Info("failed to invalidate artifact cache (ignoring)", "error", err)
+		} else {
+			lgr.V(1).Info("artifact cache invalidated", "kind", ref.Kind, "name", targetName, "version", version)
+		}
+	}
 
 	return nil
 }

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -9,9 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -28,6 +30,7 @@ type CmdOptionsVersion struct {
 	CliParams *settings.Run
 	Output    string
 	Path      string
+	NoCache   bool
 }
 
 func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
@@ -75,6 +78,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	}
 	cCmd.PersistentFlags().StringVarP(&options.Output, "output", "o", "", fmt.Sprintf("Output format. One of: (%s)", strings.Join(ValidOutputTypes, ", ")))
 	cCmd.PersistentFlags().StringVarP(&options.Path, "path", "p", "", "Path to the solution. This can be a local file path or a URL. If not provided, the command will attempt to locate a solution file in default locations.")
+	cCmd.PersistentFlags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
 	return cCmd
 }
 
@@ -85,7 +89,14 @@ func (o *CmdOptionsVersion) GetSolution(ctx context.Context) error {
 	var getterOpts []get.Option
 	localCatalog, err := catalog.NewLocalCatalog(*lgr)
 	if err == nil {
-		resolver := catalog.NewSolutionResolver(localCatalog, *lgr)
+		resolverOpts := []catalog.SolutionResolverOption{
+			catalog.WithResolverNoCache(o.NoCache),
+		}
+		if !o.NoCache {
+			artifactCache := cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+			resolverOpts = append(resolverOpts, catalog.WithResolverArtifactCache(artifactCache))
+		}
+		resolver := catalog.NewSolutionResolver(localCatalog, *lgr, resolverOpts...)
 		getterOpts = append(getterOpts, get.WithCatalogResolver(resolver))
 	} else {
 		lgr.V(1).Info("catalog not available for solution resolution", "error", err)

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -15,11 +15,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -55,6 +57,7 @@ type SolutionOptions struct {
 	PhaseTimeout    time.Duration
 	Compact         bool
 	NoTimestamp     bool
+	NoCache         bool
 
 	// Mode flags (mutually exclusive)
 	Graph        bool   // --graph: Show resolver dependency graph
@@ -222,6 +225,7 @@ Examples:
 	cCmd.Flags().BoolVar(&options.NoTimestamp, "no-timestamp", false, "Omit generation timestamp from output")
 	cCmd.Flags().DurationVar(&options.ResolverTimeout, "resolver-timeout", settings.DefaultResolverTimeout, "Timeout per resolver")
 	cCmd.Flags().DurationVar(&options.PhaseTimeout, "phase-timeout", settings.DefaultPhaseTimeout, "Timeout per phase")
+	cCmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
 
 	// Graph mode flags
 	cCmd.Flags().BoolVar(&options.Graph, "graph", false, "Show resolver dependency graph instead of action graph")
@@ -542,7 +546,14 @@ func (o *SolutionOptions) loadSolution(ctx context.Context) (*solution.Solution,
 		// Try to set up catalog resolver for bare name resolution
 		localCatalog, err := catalog.NewLocalCatalog(*lgr)
 		if err == nil {
-			resolver := catalog.NewSolutionResolver(localCatalog, *lgr)
+			resolverOpts := []catalog.SolutionResolverOption{
+				catalog.WithResolverNoCache(o.NoCache),
+			}
+			if !o.NoCache {
+				artifactCache := cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+				resolverOpts = append(resolverOpts, catalog.WithResolverArtifactCache(artifactCache))
+			}
+			resolver := catalog.NewSolutionResolver(localCatalog, *lgr, resolverOpts...)
 			getterOpts = append(getterOpts, get.WithCatalogResolver(resolver))
 		} else {
 			lgr.V(1).Info("catalog not available for solution resolution", "error", err)

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -114,6 +114,7 @@ type sharedResolverOptions struct {
 	SkipTransform   bool
 	ShowMetrics     bool
 	ShowSensitive   bool
+	NoCache         bool
 	WarnValueSize   int64
 	MaxValueSize    int64
 	ResolverTimeout time.Duration
@@ -456,6 +457,9 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 	if o.getter != nil {
 		opts = append(opts, prepare.WithGetter(o.getter))
 	}
+	if o.NoCache {
+		opts = append(opts, prepare.WithNoCache())
+	}
 	if o.registry != nil {
 		opts = append(opts, prepare.WithRegistry(o.registry))
 	}
@@ -486,6 +490,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().BoolVar(&o.SkipValidation, "skip-validation", false, "Skip the validation phase of all resolvers")
 	cCmd.Flags().BoolVar(&o.ShowMetrics, "show-metrics", false, "Show provider execution metrics after completion (output to stderr)")
 	cCmd.Flags().BoolVar(&o.ShowSensitive, "show-sensitive", false, "Reveal sensitive values in all output formats (by default, sensitive values are redacted in table output but shown in json/yaml)")
+	cCmd.Flags().BoolVar(&o.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
 	cCmd.Flags().Int64Var(&o.WarnValueSize, "warn-value-size", settings.DefaultWarnValueSize, "Warn when value exceeds this size in bytes (default: 1MB)")
 	cCmd.Flags().Int64Var(&o.MaxValueSize, "max-value-size", settings.DefaultMaxValueSize, "Fail when value exceeds this size in bytes (default: 10MB)")
 	cCmd.Flags().DurationVar(&o.ResolverTimeout, "resolver-timeout", settings.DefaultResolverTimeout, "Timeout per resolver")

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -30,6 +30,9 @@ const (
 
 	// PluginCacheDirName is the name of the plugin cache subdirectory.
 	PluginCacheDirName = "plugins"
+
+	// ArtifactCacheDirName is the name of the artifact cache subdirectory.
+	ArtifactCacheDirName = "artifact"
 )
 
 // ConfigFile returns the path to the config file.
@@ -165,6 +168,20 @@ func BuildCacheDir() string {
 //   - Windows: %LOCALAPPDATA%\cache\scafctl\plugins\
 func PluginCacheDir() string {
 	return filepath.Join(xdg.CacheHome, AppName, PluginCacheDirName)
+}
+
+// ArtifactCacheDir returns the default path to the artifact cache directory.
+// Used for caching downloaded catalog artifacts (solutions, providers, auth-handlers)
+// with configurable TTL-based expiration.
+//
+// Returns: $XDG_CACHE_HOME/scafctl/artifact/
+//
+// Platform defaults:
+//   - Linux: ~/.cache/scafctl/artifact/
+//   - macOS: ~/.cache/scafctl/artifact/
+//   - Windows: %LOCALAPPDATA%\cache\scafctl\artifact\
+func ArtifactCacheDir() string {
+	return filepath.Join(xdg.CacheHome, AppName, ArtifactCacheDirName)
 }
 
 // RuntimeDir returns the path to the runtime directory.

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -49,6 +49,10 @@ const (
 
 	// DefaultHTTPCacheKeyPrefix is the default prefix for HTTP cache keys.
 	DefaultHTTPCacheKeyPrefix = "scafctl:"
+
+	// DefaultArtifactCacheTTL is the default TTL for the artifact cache.
+	// Catalog artifacts are cached for 24 hours by default.
+	DefaultArtifactCacheTTL = 24 * time.Hour
 )
 
 // DefaultHTTPCacheDir returns the default directory for HTTP cache.

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -17,12 +17,15 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
@@ -40,6 +43,7 @@ type prepareConfig struct {
 	metricsOut    io.Writer
 	pluginFetcher *plugin.Fetcher
 	lockPlugins   []bundler.LockPlugin
+	noCache       bool
 }
 
 // WithGetter provides a custom solution getter. If not set, one is created
@@ -99,6 +103,14 @@ func WithLockPlugins(plugins []bundler.LockPlugin) Option {
 	}
 }
 
+// WithNoCache disables artifact caching when loading solutions from the catalog.
+// When set, the catalog is always queried directly, bypassing the filesystem cache.
+func WithNoCache() Option {
+	return func(c *prepareConfig) {
+		c.noCache = true
+	}
+}
+
 // Result holds the output of PrepareSolution.
 type Result struct {
 	// Solution is the loaded and prepared solution.
@@ -134,7 +146,7 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	// Get or create the solution getter
 	getter := cfg.getter
 	if getter == nil {
-		getter = newDefaultGetter(ctx)
+		getter = newDefaultGetter(ctx, cfg.noCache)
 	}
 
 	// Load the solution (with bundle if available)
@@ -279,7 +291,8 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 }
 
 // newDefaultGetter creates a default solution getter with catalog resolution support.
-func newDefaultGetter(ctx context.Context) get.Interface {
+// When noCache is true, the artifact cache is disabled so the catalog is always queried directly.
+func newDefaultGetter(ctx context.Context, noCache bool) get.Interface {
 	lgr := logger.FromContext(ctx)
 
 	var getterOpts []get.Option
@@ -288,7 +301,15 @@ func newDefaultGetter(ctx context.Context) get.Interface {
 
 		localCatalog, err := catalog.NewLocalCatalog(*lgr)
 		if err == nil {
-			catResolver := catalog.NewSolutionResolver(localCatalog, *lgr)
+			// Build SolutionResolverOptions with optional artifact cache
+			resolverOpts := []catalog.SolutionResolverOption{
+				catalog.WithResolverNoCache(noCache),
+			}
+			if !noCache {
+				artifactCache := cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+				resolverOpts = append(resolverOpts, catalog.WithResolverArtifactCache(artifactCache))
+			}
+			catResolver := catalog.NewSolutionResolver(localCatalog, *lgr, resolverOpts...)
 			getterOpts = append(getterOpts, get.WithCatalogResolver(catResolver))
 		} else {
 			lgr.V(1).Info("catalog not available for solution resolution", "error", err)


### PR DESCRIPTION
Introduce a new artifact cache layer that stores downloaded catalog solutions (and their bundles) on disk with a 24-hour TTL, reducing repeated OCI/catalog fetches across run, render, and get operations.

Changes:
- Add KindArtifact cache kind to pkg/cache and update ValidKinds
- Add ArtifactCacher interface and functional-options pattern (WithResolverArtifactCache, WithResolverNoCache) to SolutionResolver; FetchSolution and FetchSolutionWithBundle now read/write the cache
- Add ArtifactCacheDir() XDG path helper and ArtifactCacheDirName constant
- Add DefaultArtifactCacheTTL = 24h to settings
- Expose --no-cache flag on catalog pull, get solution, render solution, and all shared run commands to bypass or invalidate the artifact cache
- Wire artifact cache into solution prepare (WithNoCache option) and newDefaultGetter
- Add artifact cache entry to cache info output
- Add artifact cache clear support to cache clear command

Closes #28
