### PR TITLE
feat(actions): implement action alias for readable expression references

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,10 @@ linters:
         linters:
           - revive
         text: "var-naming: avoid package names"
+      - path: pkg/cmd/scafctl/build/plugin\.go
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
 formatters:
   enable:
     - gofumpt

--- a/docs/design/actions.md
+++ b/docs/design/actions.md
@@ -122,6 +122,7 @@ spec:
         description: "Human-readable description of what this action does"
         displayName: "Deploy Application"
         sensitive: false  # Whether results should be redacted in table output
+        alias: deploy     # Short alias for expression references (optional)
 
         # Provider
         provider: api
@@ -1259,7 +1260,8 @@ actions:
 
 ### Action Alias
 
-Actions could declare an alias for shorter, more readable references in expressions:
+Actions can declare an `alias` for shorter, more readable references in expressions.
+When set, the action's result data is available as a top-level CEL variable under the alias name, in addition to the standard `__actions.<actionName>` reference.
 
 ~~~yaml
 spec:
@@ -1281,6 +1283,10 @@ spec:
             expr: config.results.endpoint
           version:
             expr: config.results.version
+
+          # The original __actions form still works:
+          status:
+            expr: __actions.fetchConfiguration.status
 ~~~
 
 **Benefits:**
@@ -1291,10 +1297,13 @@ spec:
 
 **Rules:**
 
-- Alias must be unique across all actions (including other aliases)
-- Alias cannot conflict with reserved names (`_`, `__actions`, `__item`, `__index`, `__error`, etc.)
+- Alias must be unique across all actions and aliases (both `actions` and `finally` sections)
+- Alias cannot conflict with any action name
+- Alias cannot conflict with reserved names (`_`, `__actions`, `__item`, `__index`, `__error`, `__self`, `true`, `false`, `null`)
+- Alias cannot start with `__` (reserved prefix)
 - Alias follows the same naming pattern as action names: `^[a-zA-Z_][a-zA-Z0-9_-]*$`
 - The original `__actions.<actionName>` reference remains valid alongside the alias
+- Alias references in inputs are deferred (resolved at runtime) just like `__actions` references
 
 ---
 

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -483,6 +483,44 @@ The `fetch-user` action uses the `cel` provider to return structured data. The `
 | `inputs` | Resolved input values |
 | `error` | Error message (if failed) |
 
+### Action Aliases
+
+Referencing actions via `__actions['my-long-action-name'].results.field` can be verbose. You can declare an `alias` on an action to create a shorter top-level variable in CEL expressions.
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: alias-demo
+  version: 1.0.0
+
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      fetch-configuration:
+        alias: config
+        provider: cel
+        inputs:
+          expression: |
+            {"region": "us-east-1", "env": "production"}
+
+      deploy:
+        provider: exec
+        dependsOn: [fetch-configuration]
+        inputs:
+          command:
+            expr: "'echo Deploying to ' + config.results.region"
+```
+
+With the alias `config`, you can write `config.results.region` instead of `__actions['fetch-configuration'].results.region`. The `__actions` form still works alongside aliases.
+
+**Alias Rules:**
+- Must match `^[a-zA-Z_][a-zA-Z0-9_-]*$`
+- Cannot start with `__` (reserved prefix)
+- Cannot conflict with action names or reserved names (`true`, `false`, `null`, etc.)
+- Must be unique across all actions in the workflow
+
 ---
 
 ## Retry
@@ -996,6 +1034,7 @@ See the [examples/actions/](../examples/actions/) directory for complete working
 - `conditional-retry.yaml` - Conditional retry with retryIf
 - `conditional-execution.yaml` - When conditions
 - `finally-cleanup.yaml` - Cleanup actions
+- `action-alias.yaml` - Action aliases for shorter expression references
 - `complex-workflow.yaml` - Full CI/CD example
 
 ## Troubleshooting

--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -9,6 +9,7 @@ This directory contains example action configurations demonstrating the Actions 
 | [hello-world.yaml](hello-world.yaml) | Simplest possible action workflow |
 | [sequential-chain.yaml](sequential-chain.yaml) | Linear action dependency chain (A → B → C) |
 | [parallel-with-deps.yaml](parallel-with-deps.yaml) | Diamond pattern with parallel execution |
+| [action-alias.yaml](action-alias.yaml) | Action aliases for shorter expression references |
 | [foreach-deploy.yaml](foreach-deploy.yaml) | ForEach expansion for deploying to multiple targets |
 | [exclusive-actions.yaml](exclusive-actions.yaml) | Mutual exclusion for actions that share a resource |
 | [error-handling.yaml](error-handling.yaml) | Error handling with onError: continue |

--- a/examples/actions/action-alias.yaml
+++ b/examples/actions/action-alias.yaml
@@ -1,0 +1,57 @@
+# Action Alias Example
+# Demonstrates using action aliases for shorter, more readable expression references.
+# Instead of verbose __actions.fetchConfiguration.results.endpoint, use config.results.endpoint.
+#
+# Run: scafctl run solution -f examples/actions/action-alias.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: action-alias-demo
+  version: 1.0.0
+  description: Action alias for readable expression references
+
+spec:
+  resolvers:
+    environment:
+      description: Target environment
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "production"
+
+  workflow:
+    actions:
+      # Step 1: Fetch configuration
+      fetchConfiguration:
+        description: Load configuration from a static provider
+        displayName: Fetch Config
+        alias: config  # Short alias for expression references
+        provider: exec
+        inputs:
+          command: "echo '{\"endpoint\": \"https://api.example.com/deploy\", \"version\": \"2.1.0\"}'"
+
+      # Step 2: Validate (uses alias for readable expressions)
+      validateConfig:
+        description: Validate the fetched configuration
+        displayName: Validate
+        alias: validation
+        provider: exec
+        dependsOn: [fetchConfiguration]
+        inputs:
+          # Use short alias instead of __actions.fetchConfiguration.results.endpoint
+          command:
+            expr: "'echo Validating endpoint: ' + config.results.stdout"
+
+      # Step 3: Deploy (uses both alias and traditional __actions references)
+      deploy:
+        description: Deploy with validated configuration
+        displayName: Deploy
+        provider: exec
+        dependsOn: [fetchConfiguration, validateConfig]
+        inputs:
+          # Alias reference (short form)
+          command:
+            expr: "'echo Deploying v' + config.results.stdout + ' with validation status: ' + string(validation.status)"

--- a/pkg/action/alias_test.go
+++ b/pkg/action/alias_test.go
@@ -1,0 +1,581 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlias_Validation(t *testing.T) {
+	t.Run("valid alias", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alias with hyphen", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "my-config",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alias with underscore", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "my_config",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alias conflicts with action name", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "deploy",
+				},
+				"deploy": {
+					Provider:  "shell",
+					DependsOn: []string{"fetchConfiguration"},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "alias \"deploy\" conflicts with action name")
+	})
+
+	t.Run("alias conflicts with reserved name _", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "_",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserved name")
+	})
+
+	t.Run("alias conflicts with reserved name __actions", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "__actions",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		// Should fail on both reserved prefix and reserved name
+		assert.Contains(t, err.Error(), "reserved")
+	})
+
+	t.Run("alias conflicts with reserved name __item", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "__item",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserved")
+	})
+
+	t.Run("alias with __ prefix is reserved", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "__myalias",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserved prefix")
+	})
+
+	t.Run("duplicate alias across actions", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+				"loadConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "alias \"config\" already used")
+	})
+
+	t.Run("duplicate alias across sections", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+			},
+			Finally: map[string]*Action{
+				"cleanup": {
+					Provider: "shell",
+					Alias:    "config",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "alias \"config\" already used")
+	})
+
+	t.Run("invalid alias pattern", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "123invalid",
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must match pattern")
+	})
+
+	t.Run("empty alias is allowed (no alias)", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					// No alias set
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unique aliases across actions are valid", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+				"buildApp": {
+					Provider:  "shell",
+					Alias:     "build",
+					DependsOn: []string{"fetchConfiguration"},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAlias_BuildGraph(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("alias map is populated", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+				"deploy": {
+					Provider:  "shell",
+					DependsOn: []string{"fetchConfiguration"},
+				},
+			},
+		}
+
+		graph, err := BuildGraph(ctx, w, nil, &BuildGraphOptions{SkipInputMaterialization: true})
+		require.NoError(t, err)
+		require.NotNil(t, graph.AliasMap)
+		assert.Equal(t, "fetchConfiguration", graph.AliasMap["config"])
+		assert.Len(t, graph.AliasMap, 1)
+	})
+
+	t.Run("alias map from both sections", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+				},
+			},
+			Finally: map[string]*Action{
+				"cleanup": {
+					Provider: "shell",
+					Alias:    "clean",
+				},
+			},
+		}
+
+		graph, err := BuildGraph(ctx, w, nil, &BuildGraphOptions{SkipInputMaterialization: true})
+		require.NoError(t, err)
+		assert.Equal(t, "fetchConfiguration", graph.AliasMap["config"])
+		assert.Equal(t, "cleanup", graph.AliasMap["clean"])
+	})
+
+	t.Run("alias reference defers input", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+					Inputs: map[string]*spec.ValueRef{
+						"endpoint": {Literal: "https://api.example.com/config"},
+					},
+				},
+				"deploy": {
+					Provider:  "shell",
+					DependsOn: []string{"fetchConfiguration"},
+					Inputs: map[string]*spec.ValueRef{
+						"endpoint": {Expr: celExpr("config.results.endpoint")},
+						"name":     {Literal: "my-app"},
+					},
+				},
+			},
+		}
+
+		resolverData := map[string]any{}
+		graph, err := BuildGraph(ctx, w, resolverData, nil)
+		require.NoError(t, err)
+
+		deployAction := graph.Actions["deploy"]
+		require.NotNil(t, deployAction)
+
+		// The alias reference should be deferred
+		assert.Contains(t, deployAction.DeferredInputs, "endpoint")
+		assert.Equal(t, "config.results.endpoint", deployAction.DeferredInputs["endpoint"].OriginalExpr)
+
+		// The literal should be materialized
+		assert.Equal(t, "my-app", deployAction.MaterializedInputs["name"])
+	})
+
+	t.Run("__actions reference still works alongside alias", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"fetchConfiguration": {
+					Provider: "api",
+					Alias:    "config",
+					Inputs: map[string]*spec.ValueRef{
+						"endpoint": {Literal: "https://api.example.com/config"},
+					},
+				},
+				"deploy": {
+					Provider:  "shell",
+					DependsOn: []string{"fetchConfiguration"},
+					Inputs: map[string]*spec.ValueRef{
+						"endpoint": {Expr: celExpr("__actions.fetchConfiguration.results.endpoint")},
+					},
+				},
+			},
+		}
+
+		resolverData := map[string]any{}
+		graph, err := BuildGraph(ctx, w, resolverData, nil)
+		require.NoError(t, err)
+
+		deployAction := graph.Actions["deploy"]
+		require.NotNil(t, deployAction)
+
+		// The __actions reference should still be deferred
+		assert.Contains(t, deployAction.DeferredInputs, "endpoint")
+	})
+}
+
+func TestAlias_DeferredValueEvaluate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("evaluate with alias", func(t *testing.T) {
+		dv := &DeferredValue{
+			OriginalExpr: "config.results.endpoint",
+			Deferred:     true,
+		}
+
+		additionalVars := map[string]any{
+			"__actions": map[string]any{
+				"fetchConfiguration": map[string]any{
+					"results": map[string]any{
+						"endpoint": "https://api.example.com",
+					},
+				},
+			},
+			"config": map[string]any{
+				"results": map[string]any{
+					"endpoint": "https://api.example.com",
+				},
+			},
+		}
+
+		result, err := dv.Evaluate(ctx, nil, additionalVars)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com", result)
+	})
+
+	t.Run("evaluate with alias and resolver data", func(t *testing.T) {
+		dv := &DeferredValue{
+			OriginalExpr: `_.env + ":" + config.results.port`,
+			Deferred:     true,
+		}
+
+		resolverData := map[string]any{"env": "production"}
+		additionalVars := map[string]any{
+			"__actions": map[string]any{
+				"fetchConfiguration": map[string]any{
+					"results": map[string]any{
+						"port": "8080",
+					},
+				},
+			},
+			"config": map[string]any{
+				"results": map[string]any{
+					"port": "8080",
+				},
+			},
+		}
+
+		result, err := dv.Evaluate(ctx, resolverData, additionalVars)
+		require.NoError(t, err)
+		assert.Equal(t, "production:8080", result)
+	})
+}
+
+func TestAlias_BuildAdditionalVars(t *testing.T) {
+	t.Run("builds vars with aliases", func(t *testing.T) {
+		executor := NewExecutor()
+
+		// Set up action context with results
+		executor.actionContext.MarkRunning("fetchConfiguration", map[string]any{"endpoint": "https://api.example.com"})
+		executor.actionContext.MarkSucceeded("fetchConfiguration", map[string]any{
+			"endpoint": "https://api.example.com",
+			"version":  "1.2.3",
+		})
+
+		aliasMap := map[string]string{
+			"config": "fetchConfiguration",
+		}
+
+		vars := executor.buildAdditionalVars(aliasMap)
+
+		// Should have __actions namespace
+		actionsNs, ok := vars["__actions"].(map[string]any)
+		require.True(t, ok)
+		assert.Contains(t, actionsNs, "fetchConfiguration")
+
+		// Should have alias as top-level var pointing to the same data
+		configAlias, ok := vars["config"]
+		require.True(t, ok)
+		assert.NotNil(t, configAlias)
+
+		// Alias data should match __actions data
+		configMap, ok := configAlias.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, actionsNs["fetchConfiguration"], configMap)
+	})
+
+	t.Run("alias for non-existent action omitted", func(t *testing.T) {
+		executor := NewExecutor()
+
+		aliasMap := map[string]string{
+			"config": "nonExistent",
+		}
+
+		vars := executor.buildAdditionalVars(aliasMap)
+
+		// __actions should be present
+		assert.Contains(t, vars, "__actions")
+		// Alias should not be present since action doesn't exist
+		_, hasConfig := vars["config"]
+		assert.False(t, hasConfig)
+	})
+
+	t.Run("empty alias map", func(t *testing.T) {
+		executor := NewExecutor()
+
+		vars := executor.buildAdditionalVars(nil)
+
+		assert.Contains(t, vars, "__actions")
+		assert.Len(t, vars, 1)
+	})
+}
+
+func TestAlias_BuildAliasNames(t *testing.T) {
+	t.Run("collects aliases from actions", func(t *testing.T) {
+		actions := map[string]*Action{
+			"fetchConfig": {Alias: "config"},
+			"buildApp":    {Alias: "build"},
+			"deploy":      {},
+		}
+
+		names := buildAliasNames(actions)
+		assert.Len(t, names, 2)
+		assert.Contains(t, names, "config")
+		assert.Contains(t, names, "build")
+	})
+
+	t.Run("collects aliases from multiple sections", func(t *testing.T) {
+		actions := map[string]*Action{
+			"fetchConfig": {Alias: "config"},
+		}
+		finally := map[string]*Action{
+			"cleanup": {Alias: "clean"},
+		}
+
+		names := buildAliasNames(actions, finally)
+		assert.Len(t, names, 2)
+		assert.Contains(t, names, "config")
+		assert.Contains(t, names, "clean")
+	})
+
+	t.Run("handles empty sections", func(t *testing.T) {
+		names := buildAliasNames(nil, nil)
+		assert.Len(t, names, 0)
+	})
+
+	t.Run("handles nil actions", func(t *testing.T) {
+		actions := map[string]*Action{
+			"fetchConfig": nil,
+			"buildApp":    {Alias: "build"},
+		}
+
+		names := buildAliasNames(actions)
+		assert.Len(t, names, 1)
+		assert.Contains(t, names, "build")
+	})
+}
+
+func TestAlias_ReferencesActionsOrAlias(t *testing.T) {
+	t.Run("detects __actions reference", func(t *testing.T) {
+		v := &spec.ValueRef{Expr: celExpr("__actions.build.results.exitCode")}
+		assert.True(t, referencesActionsOrAlias(v, nil))
+	})
+
+	t.Run("detects alias reference", func(t *testing.T) {
+		v := &spec.ValueRef{Expr: celExpr("config.results.endpoint")}
+		assert.True(t, referencesActionsOrAlias(v, []string{"config"}))
+	})
+
+	t.Run("no match without alias", func(t *testing.T) {
+		v := &spec.ValueRef{Expr: celExpr("config.results.endpoint")}
+		assert.False(t, referencesActionsOrAlias(v, nil))
+	})
+
+	t.Run("no match for resolver reference", func(t *testing.T) {
+		v := &spec.ValueRef{Expr: celExpr("_.env")}
+		assert.False(t, referencesActionsOrAlias(v, []string{"config"}))
+	})
+
+	t.Run("literal value", func(t *testing.T) {
+		v := &spec.ValueRef{Literal: "hello"}
+		assert.False(t, referencesActionsOrAlias(v, []string{"config"}))
+	})
+}
+
+// Benchmarks
+
+func BenchmarkBuildAliasNames(b *testing.B) {
+	actions := make(map[string]*Action, 100)
+	for i := 0; i < 100; i++ {
+		actions[fmt.Sprintf("action%d", i)] = &Action{
+			Alias: fmt.Sprintf("alias%d", i),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buildAliasNames(actions)
+	}
+}
+
+func BenchmarkReferencesActionsOrAlias(b *testing.B) {
+	v := &spec.ValueRef{Expr: celExpr("config.results.endpoint")}
+	aliases := []string{"config", "build", "deploy", "test", "validate"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		referencesActionsOrAlias(v, aliases)
+	}
+}
+
+func BenchmarkBuildAdditionalVars(b *testing.B) {
+	executor := NewExecutor()
+	executor.actionContext.MarkRunning("fetchConfiguration", map[string]any{"endpoint": "https://api.example.com"})
+	executor.actionContext.MarkSucceeded("fetchConfiguration", map[string]any{
+		"endpoint": "https://api.example.com",
+		"version":  "1.2.3",
+	})
+
+	aliasMap := map[string]string{
+		"config": "fetchConfiguration",
+		"build":  "buildApp",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		executor.buildAdditionalVars(aliasMap)
+	}
+}
+
+func BenchmarkValidateAlias(b *testing.B) {
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"fetchConfiguration": {
+				Provider: "api",
+				Alias:    "config",
+			},
+			"buildApp": {
+				Provider:  "shell",
+				Alias:     "build",
+				DependsOn: []string{"fetchConfiguration"},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ValidateWorkflow(w, nil)
+	}
+}

--- a/pkg/action/deferred.go
+++ b/pkg/action/deferred.go
@@ -31,16 +31,12 @@ func (d *DeferredValue) IsDeferred() bool {
 	return d != nil && d.Deferred
 }
 
-// Evaluate resolves the deferred value using the provided resolver data and action results.
-// The actionsData should contain the __actions namespace with completed action results.
-func (d *DeferredValue) Evaluate(ctx context.Context, resolverData, actionsData map[string]any) (any, error) {
+// Evaluate resolves the deferred value using the provided resolver data and additional variables.
+// The additionalVars should contain both the __actions namespace (keyed by celexp.VarActions)
+// and any alias top-level variables pointing to individual action result data.
+func (d *DeferredValue) Evaluate(ctx context.Context, resolverData, additionalVars map[string]any) (any, error) {
 	if d == nil || !d.Deferred {
 		return nil, fmt.Errorf("cannot evaluate non-deferred value")
-	}
-
-	// Build additional vars with __actions namespace
-	additionalVars := map[string]any{
-		celexp.VarActions: actionsData,
 	}
 
 	if d.OriginalExpr != "" {
@@ -52,10 +48,12 @@ func (d *DeferredValue) Evaluate(ctx context.Context, resolverData, actionsData 
 	}
 
 	if d.OriginalTmpl != "" {
-		// For templates, merge resolver data with __actions at the template data level
+		// For templates, merge resolver data with additional vars at the template data level
 		templateData := map[string]any{
-			"_":         resolverData,
-			"__actions": actionsData,
+			"_": resolverData,
+		}
+		for k, v := range additionalVars {
+			templateData[k] = v
 		}
 		result, err := gotmpl.Execute(ctx, gotmpl.TemplateOptions{
 			Content: d.OriginalTmpl,
@@ -143,9 +141,10 @@ func HasDeferredValues(values map[string]any) bool {
 	return false
 }
 
-// ResolveDeferredValues evaluates all deferred values in the map using the provided action results.
+// ResolveDeferredValues evaluates all deferred values in the map using the provided additional variables.
+// additionalVars should contain __actions namespace and any alias variables.
 // Non-deferred values are passed through unchanged.
-func ResolveDeferredValues(ctx context.Context, values, resolverData, actionsData map[string]any) (map[string]any, error) {
+func ResolveDeferredValues(ctx context.Context, values, resolverData, additionalVars map[string]any) (map[string]any, error) {
 	if values == nil {
 		return nil, nil
 	}
@@ -154,7 +153,7 @@ func ResolveDeferredValues(ctx context.Context, values, resolverData, actionsDat
 
 	for name, v := range values {
 		if dv, ok := v.(*DeferredValue); ok && dv.IsDeferred() {
-			resolved, err := dv.Evaluate(ctx, resolverData, actionsData)
+			resolved, err := dv.Evaluate(ctx, resolverData, additionalVars)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve deferred value %q: %w", name, err)
 			}

--- a/pkg/action/deferred_test.go
+++ b/pkg/action/deferred_test.go
@@ -37,12 +37,12 @@ func TestDeferredValue_Evaluate(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name         string
-		value        *DeferredValue
-		resolverData map[string]any
-		actionsData  map[string]any
-		expected     any
-		expectError  bool
+		name           string
+		value          *DeferredValue
+		resolverData   map[string]any
+		additionalVars map[string]any
+		expected       any
+		expectError    bool
 	}{
 		{
 			name:        "nil value",
@@ -61,10 +61,12 @@ func TestDeferredValue_Evaluate(t *testing.T) {
 				Deferred:     true,
 			},
 			resolverData: map[string]any{"env": "prod"},
-			actionsData: map[string]any{
-				"build": map[string]any{
-					"results": map[string]any{
-						"exitCode": int64(0),
+			additionalVars: map[string]any{
+				"__actions": map[string]any{
+					"build": map[string]any{
+						"results": map[string]any{
+							"exitCode": int64(0),
+						},
 					},
 				},
 			},
@@ -77,10 +79,12 @@ func TestDeferredValue_Evaluate(t *testing.T) {
 				Deferred:     true,
 			},
 			resolverData: map[string]any{"env": "prod"},
-			actionsData: map[string]any{
-				"build": map[string]any{
-					"results": map[string]any{
-						"output": "success",
+			additionalVars: map[string]any{
+				"__actions": map[string]any{
+					"build": map[string]any{
+						"results": map[string]any{
+							"output": "success",
+						},
 					},
 				},
 			},
@@ -92,14 +96,39 @@ func TestDeferredValue_Evaluate(t *testing.T) {
 				OriginalTmpl: "Exit: {{ .__actions.build.results.exitCode }}",
 				Deferred:     true,
 			},
-			actionsData: map[string]any{
-				"build": map[string]any{
-					"results": map[string]any{
-						"exitCode": 0,
+			additionalVars: map[string]any{
+				"__actions": map[string]any{
+					"build": map[string]any{
+						"results": map[string]any{
+							"exitCode": 0,
+						},
 					},
 				},
 			},
 			expected: "Exit: 0",
+		},
+		{
+			name: "evaluate expr with alias",
+			value: &DeferredValue{
+				OriginalExpr: "config.results.endpoint",
+				Deferred:     true,
+			},
+			resolverData: map[string]any{"env": "prod"},
+			additionalVars: map[string]any{
+				"__actions": map[string]any{
+					"fetchConfiguration": map[string]any{
+						"results": map[string]any{
+							"endpoint": "https://api.example.com",
+						},
+					},
+				},
+				"config": map[string]any{
+					"results": map[string]any{
+						"endpoint": "https://api.example.com",
+					},
+				},
+			},
+			expected: "https://api.example.com",
 		},
 		{
 			name: "empty deferred value",
@@ -112,7 +141,7 @@ func TestDeferredValue_Evaluate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.value.Evaluate(ctx, tt.resolverData, tt.actionsData)
+			result, err := tt.value.Evaluate(ctx, tt.resolverData, tt.additionalVars)
 			if tt.expectError {
 				require.Error(t, err)
 				return
@@ -284,11 +313,13 @@ func TestResolveDeferredValues(t *testing.T) {
 	ctx := context.Background()
 
 	resolverData := map[string]any{"env": "prod"}
-	actionsData := map[string]any{
-		"build": map[string]any{
-			"results": map[string]any{
-				"exitCode": int64(0),
-				"output":   "success",
+	additionalVars := map[string]any{
+		"__actions": map[string]any{
+			"build": map[string]any{
+				"results": map[string]any{
+					"exitCode": int64(0),
+					"output":   "success",
+				},
 			},
 		},
 	}
@@ -302,7 +333,7 @@ func TestResolveDeferredValues(t *testing.T) {
 		},
 	}
 
-	result, err := ResolveDeferredValues(ctx, values, resolverData, actionsData)
+	result, err := ResolveDeferredValues(ctx, values, resolverData, additionalVars)
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello", result["literal"])

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -527,9 +527,7 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 
 	// Evaluate condition if present
 	if action.When != nil {
-		additionalVars := map[string]any{
-			"__actions": e.actionContext.GetNamespace(),
-		}
+		additionalVars := e.buildAdditionalVars(graph.AliasMap)
 		shouldRun, err := action.When.EvaluateWithAdditionalVars(ctx, e.resolverData, additionalVars)
 		if err != nil {
 			e.actionContext.MarkFailed(actionName, fmt.Sprintf("condition evaluation failed: %v", err))
@@ -549,7 +547,7 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 	}
 
 	// Resolve inputs (including deferred values)
-	resolvedInputs, err := e.resolveInputs(ctx, action)
+	resolvedInputs, err := e.resolveInputs(ctx, action, graph.AliasMap)
 	if err != nil {
 		e.actionContext.MarkFailed(actionName, fmt.Sprintf("input resolution failed: %v", err))
 		if e.progressCallback != nil {
@@ -672,7 +670,7 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 }
 
 // resolveInputs resolves all inputs including deferred values.
-func (e *Executor) resolveInputs(ctx context.Context, action *ExpandedAction) (map[string]any, error) {
+func (e *Executor) resolveInputs(ctx context.Context, action *ExpandedAction, aliasMap map[string]string) (map[string]any, error) {
 	// Start with materialized inputs
 	inputs := make(map[string]any)
 	for k, v := range action.MaterializedInputs {
@@ -681,14 +679,14 @@ func (e *Executor) resolveInputs(ctx context.Context, action *ExpandedAction) (m
 
 	// Resolve deferred inputs using current action results
 	if len(action.DeferredInputs) > 0 {
-		actionsNamespace := e.actionContext.GetNamespace()
+		additionalVars := e.buildAdditionalVars(aliasMap)
 
 		for name, deferredVal := range action.DeferredInputs {
 			if deferredVal == nil || !deferredVal.IsDeferred() {
 				continue
 			}
 
-			resolved, err := deferredVal.Evaluate(ctx, e.resolverData, actionsNamespace)
+			resolved, err := deferredVal.Evaluate(ctx, e.resolverData, additionalVars)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve deferred input %q: %w", name, err)
 			}
@@ -697,6 +695,26 @@ func (e *Executor) resolveInputs(ctx context.Context, action *ExpandedAction) (m
 	}
 
 	return inputs, nil
+}
+
+// buildAdditionalVars creates the additional variables map for CEL evaluation.
+// It includes the __actions namespace and any alias top-level variables.
+// Each alias points to the same data as __actions.<actionName> for the aliased action.
+func (e *Executor) buildAdditionalVars(aliasMap map[string]string) map[string]any {
+	namespace := e.actionContext.GetNamespace()
+
+	additionalVars := map[string]any{
+		"__actions": namespace,
+	}
+
+	// Add aliases as top-level variables
+	for alias, actionName := range aliasMap {
+		if actionData, ok := namespace[actionName]; ok {
+			additionalVars[alias] = actionData
+		}
+	}
+
+	return additionalVars
 }
 
 // callProvider executes the provider for an action.

--- a/pkg/action/graph.go
+++ b/pkg/action/graph.go
@@ -28,6 +28,11 @@ type Graph struct {
 	// FinallyOrder contains phases for the finally section.
 	// Finally actions have an implicit dependency on all main actions completing.
 	FinallyOrder [][]string `json:"finallyOrder,omitempty" yaml:"finallyOrder,omitempty" doc:"Parallel execution phases for finally actions"`
+
+	// AliasMap maps action aliases to their original action names.
+	// This enables shorter, more readable references in CEL expressions.
+	// For example, alias "config" → action name "fetchConfiguration".
+	AliasMap map[string]string `json:"aliasMap,omitempty" yaml:"aliasMap,omitempty" doc:"Alias-to-action-name mapping"`
 }
 
 // ExpandedAction is an action with materialized inputs ready for execution.
@@ -95,11 +100,15 @@ func BuildGraph(ctx context.Context, w *Workflow, resolverData map[string]any, o
 	}
 
 	graph := &Graph{
-		Actions: make(map[string]*ExpandedAction),
+		Actions:  make(map[string]*ExpandedAction),
+		AliasMap: make(map[string]string),
 	}
 
+	// Build alias map from all sections
+	aliasNames := buildAliasNames(w.Actions, w.Finally)
+
 	// Process main actions section
-	mainExpanded, mainDeps, err := expandSection(ctx, w.Actions, "actions", resolverData, opts)
+	mainExpanded, mainDeps, err := expandSection(ctx, w.Actions, "actions", resolverData, aliasNames, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand actions section: %w", err)
 	}
@@ -109,7 +118,7 @@ func BuildGraph(ctx context.Context, w *Workflow, resolverData map[string]any, o
 	}
 
 	// Process finally section
-	finallyExpanded, finallyDeps, err := expandSection(ctx, w.Finally, "finally", resolverData, opts)
+	finallyExpanded, finallyDeps, err := expandSection(ctx, w.Finally, "finally", resolverData, aliasNames, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand finally section: %w", err)
 	}
@@ -134,6 +143,15 @@ func BuildGraph(ctx context.Context, w *Workflow, resolverData map[string]any, o
 		graph.FinallyOrder = splitPhasesForExclusive(finallyOrder, finallyExpanded)
 	}
 
+	// Populate alias map from action definitions
+	for _, actions := range []map[string]*Action{w.Actions, w.Finally} {
+		for name, action := range actions {
+			if action != nil && action.Alias != "" {
+				graph.AliasMap[action.Alias] = name
+			}
+		}
+	}
+
 	return graph, nil
 }
 
@@ -144,6 +162,7 @@ func expandSection(
 	actions map[string]*Action,
 	section string,
 	resolverData map[string]any,
+	aliasNames []string,
 	opts *BuildGraphOptions,
 ) (map[string]*ExpandedAction, map[string][]string, error) {
 	expanded := make(map[string]*ExpandedAction)
@@ -180,7 +199,7 @@ func expandSection(
 				expandedName := fmt.Sprintf("%s[%d]", originalName, i)
 				expandedNames = append(expandedNames, expandedName)
 
-				expandedAction, err := createExpandedAction(ctx, action, section, i, item, originalName, resolverData, opts)
+				expandedAction, err := createExpandedAction(ctx, action, section, i, item, originalName, resolverData, aliasNames, opts)
 				if err != nil {
 					return nil, nil, fmt.Errorf("action %q iteration %d: %w", originalName, i, err)
 				}
@@ -193,7 +212,7 @@ func expandSection(
 			forEachExpansions[originalName] = expandedNames
 		} else {
 			// Non-forEach action - create single expanded action
-			expandedAction, err := createExpandedAction(ctx, action, section, -1, nil, name, resolverData, opts)
+			expandedAction, err := createExpandedAction(ctx, action, section, -1, nil, name, resolverData, aliasNames, opts)
 			if err != nil {
 				return nil, nil, fmt.Errorf("action %q: %w", name, err)
 			}
@@ -272,6 +291,7 @@ func createExpandedAction(
 	item any,
 	originalName string,
 	resolverData map[string]any,
+	aliasNames []string,
 	opts *BuildGraphOptions,
 ) (*ExpandedAction, error) {
 	expanded := &ExpandedAction{
@@ -311,8 +331,8 @@ func createExpandedAction(
 				continue
 			}
 
-			// Check if the value references __actions (needs deferral)
-			if valueRef.ReferencesVariable(celexp.VarActions) {
+			// Check if the value references __actions or an alias (needs deferral)
+			if referencesActionsOrAlias(valueRef, aliasNames) {
 				dv, err := materializeDeferred(valueRef)
 				if err != nil {
 					return nil, fmt.Errorf("failed to defer input %q: %w", inputName, err)
@@ -725,4 +745,39 @@ func parseActionsRefsForGraph(s string) []string {
 		result = append(result, name)
 	}
 	return result
+}
+
+// buildAliasNames collects all alias names from all workflow sections.
+// Returns a deduplicated slice of alias strings used during graph building
+// to detect which ValueRefs need deferral (because they reference an alias).
+func buildAliasNames(sections ...map[string]*Action) []string {
+	aliases := make([]string, 0)
+	seen := make(map[string]bool)
+
+	for _, actions := range sections {
+		for _, action := range actions {
+			if action != nil && action.Alias != "" && !seen[action.Alias] {
+				aliases = append(aliases, action.Alias)
+				seen[action.Alias] = true
+			}
+		}
+	}
+
+	return aliases
+}
+
+// referencesActionsOrAlias checks if a ValueRef references __actions or any action alias.
+// If either is true, the value must be deferred until runtime when action results are available.
+func referencesActionsOrAlias(v *spec.ValueRef, aliasNames []string) bool {
+	if v.ReferencesVariable(celexp.VarActions) {
+		return true
+	}
+
+	for _, alias := range aliasNames {
+		if v.ReferencesVariable(alias) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -40,6 +40,13 @@ type Action struct {
 	// Cannot start with "__" (reserved) or contain "[" or "]".
 	Name string `json:"name" yaml:"name" doc:"Action identifier (set from map key)" maxLength:"100" pattern:"^[a-zA-Z_][a-zA-Z0-9_-]*$" patternDescription:"Must start with letter/underscore, followed by alphanumerics, underscores, or hyphens"`
 
+	// Alias provides a short name for use in CEL/template expressions.
+	// When set, the action's result data is available as a top-level variable
+	// under this alias, in addition to the standard __actions.<name> reference.
+	// For example, alias: config allows using config.results.endpoint instead of
+	// __actions.fetchConfiguration.results.endpoint.
+	Alias string `json:"alias,omitempty" yaml:"alias,omitempty" doc:"Short alias for expression references" maxLength:"100" pattern:"^[a-zA-Z_][a-zA-Z0-9_-]*$" patternDescription:"Must start with letter/underscore, followed by alphanumerics, underscores, or hyphens"`
+
 	// Description provides documentation for the action.
 	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Human-readable description of what the action does" maxLength:"500"`
 

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -20,6 +20,20 @@ import (
 // Names must start with a letter or underscore, followed by alphanumerics, underscores, or hyphens.
 var actionNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
 
+// reservedNames are variable names that cannot be used as action aliases.
+// These are reserved for the CEL expression context.
+var reservedNames = map[string]bool{
+	"_":         true,
+	"__actions": true,
+	"__item":    true,
+	"__index":   true,
+	"__error":   true,
+	"__self":    true,
+	"true":      true,
+	"false":     true,
+	"null":      true,
+}
+
 // ValidationError provides detailed validation failure information.
 // It contains context about where the validation error occurred.
 type ValidationError struct {
@@ -132,11 +146,28 @@ func ValidateWorkflow(w *Workflow, registry RegistryInterface) error {
 	// Collect all action names across sections for uniqueness check
 	allNames := make(map[string]string) // name -> section
 
+	// Pre-collect all action names from both sections for alias conflict detection.
+	// This is separate from allNames because allNames is populated incrementally
+	// during validation to detect duplicate action names, while allActionNames
+	// needs all names upfront to catch alias-vs-action-name conflicts.
+	allActionNames := make(map[string]string) // name -> section
+	for name := range w.Actions {
+		allActionNames[name] = "actions"
+	}
+	for name := range w.Finally {
+		if _, exists := allActionNames[name]; !exists {
+			allActionNames[name] = "finally"
+		}
+	}
+
+	// Collect all aliases for uniqueness check (alias -> section.actionName)
+	allAliases := make(map[string]string)
+
 	// Validate actions section
-	validateSection(w.Actions, "actions", allNames, w, registry, errs)
+	validateSection(w.Actions, "actions", allNames, allActionNames, allAliases, w, registry, errs)
 
 	// Validate finally section
-	validateSection(w.Finally, "finally", allNames, w, registry, errs)
+	validateSection(w.Finally, "finally", allNames, allActionNames, allAliases, w, registry, errs)
 
 	return errs.ToError()
 }
@@ -146,6 +177,8 @@ func validateSection(
 	actions map[string]*Action,
 	section string,
 	allNames map[string]string,
+	allActionNames map[string]string,
+	allAliases map[string]string,
 	workflow *Workflow,
 	registry RegistryInterface,
 	errs *AggregatedValidationError,
@@ -171,6 +204,11 @@ func validateSection(
 				Message:    "action definition cannot be nil",
 			})
 			continue
+		}
+
+		// Validate alias if present
+		if action.Alias != "" {
+			validateAlias(action, section, allActionNames, allAliases, errs)
 		}
 
 		// Validate individual action
@@ -222,6 +260,70 @@ func validateActionName(name, section string, allNames map[string]string, errs *
 			Message:    fmt.Sprintf("action name %q already defined in %s section", name, existingSection),
 		})
 	}
+}
+
+// validateAlias validates an action's alias.
+func validateAlias(
+	action *Action,
+	section string,
+	allNames map[string]string,
+	allAliases map[string]string,
+	errs *AggregatedValidationError,
+) {
+	alias := action.Alias
+
+	// Rule: Alias must match the action name regex
+	if !actionNameRegex.MatchString(alias) {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "alias",
+			Message:    fmt.Sprintf("alias must match pattern ^[a-zA-Z_][a-zA-Z0-9_-]*$, got %q", alias),
+		})
+	}
+
+	// Rule: Alias cannot start with "__" (reserved prefix)
+	if strings.HasPrefix(alias, "__") {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "alias",
+			Message:    fmt.Sprintf("alias %q cannot start with '__' (reserved prefix)", alias),
+		})
+	}
+
+	// Rule: Alias cannot be a reserved name
+	if reservedNames[alias] {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "alias",
+			Message:    fmt.Sprintf("alias %q is a reserved name", alias),
+		})
+	}
+
+	// Rule: Alias cannot conflict with any action name
+	if existingSection, exists := allNames[alias]; exists {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "alias",
+			Message:    fmt.Sprintf("alias %q conflicts with action name in %s section", alias, existingSection),
+		})
+	}
+
+	// Rule: Alias must be unique across all aliases
+	if existingAction, exists := allAliases[alias]; exists {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "alias",
+			Message:    fmt.Sprintf("alias %q already used by action %s", alias, existingAction),
+		})
+	}
+
+	// Register alias for uniqueness tracking
+	allAliases[alias] = section + "." + action.Name
 }
 
 // validateAction validates an individual action definition.

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -93,7 +93,9 @@ Plus all sprig v3 functions (https://masterminds.github.io/sprig/).`,
 		Summary:  "A workflow step that performs a side effect using a provider (e.g., create file, deploy resource).",
 		Explanation: `Actions are defined under spec.workflow.actions and execute after all resolvers complete. Each action specifies a provider and inputs, and can optionally declare dependencies on other actions via 'dependsOn'.
 
-Actions support: conditional execution (when), retry policies, forEach iteration, timeouts, and result schemas. The workflow engine executes actions as a DAG, running independent actions in parallel.
+Actions support: conditional execution (when), retry policies, forEach iteration, timeouts, result schemas, and aliases. The workflow engine executes actions as a DAG, running independent actions in parallel.
+
+Actions can declare an 'alias' field for shorter expression references. For example, alias: config allows using config.results.endpoint instead of the verbose __actions.fetchConfiguration.results.endpoint.
 
 Cleanup actions go under spec.workflow.finally and always execute (even if earlier actions fail).`,
 		Examples: []string{

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -118,6 +118,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 	type actionPreview struct {
 		Name               string              `json:"name"`
+		Alias              string              `json:"alias,omitempty"`
 		Description        string              `json:"description,omitempty"`
 		Provider           string              `json:"provider"`
 		MaterializedInputs map[string]any      `json:"materializedInputs,omitempty"`
@@ -187,6 +188,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 
 		// Use fields from the embedded Action
 		preview.Description = ea.Description
+		preview.Alias = ea.Alias
 		if ea.When != nil && ea.When.Expr != nil {
 			preview.When = string(*ea.When.Expr)
 		}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -195,7 +195,7 @@ tasks:
       - .golangci.yml
     cmds:
       - |
-        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
         golangci-lint run --timeout 10m0s
 
   lint:solutions:

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1781,6 +1781,22 @@ func TestIntegration_ParallelWithDeps(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 }
 
+func TestIntegration_ActionAlias(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/actions/action-alias.yaml",
+		"-o", "json",
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "action alias example should succeed")
+	assert.Contains(t, stdout, "fetchConfiguration")
+	assert.Contains(t, stdout, "deploy")
+}
+
 // ============================================================================
 // Quiet Mode Tests
 // ============================================================================

--- a/tests/integration/solutions/actions/alias/solution.yaml
+++ b/tests/integration/solutions/actions/alias/solution.yaml
@@ -1,0 +1,140 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-alias
+  version: 1.0.0
+  description: |
+    Functional tests for action alias feature.
+    Verifies that aliases create shorter top-level variables
+    for referencing action results in CEL expressions.
+
+spec:
+  resolvers:
+    region:
+      description: Deployment region
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "us-east-1"
+
+  workflow:
+    actions:
+      fetchConfiguration:
+        alias: config
+        description: Fetch deployment configuration
+        provider: cel
+        inputs:
+          expression: |
+            {"region": "us-east-1", "env": "production", "replicas": 3}
+
+      validateConfig:
+        alias: validation
+        description: Validate the fetched configuration using config alias
+        provider: cel
+        dependsOn: [fetchConfiguration]
+        inputs:
+          expression: |
+            configData.env == "production" ? {"valid": true, "message": "Config OK"} : {"valid": false, "message": "Not production"}
+          variables:
+            expr: |
+              {"configData": config.results}
+
+      deploy:
+        alias: deployment
+        description: Deploy using config and validation alias references
+        provider: cel
+        dependsOn: [validateConfig]
+        inputs:
+          expression: |
+            validData.valid ? {"deployed": true, "region": configData.region, "replicas": configData.replicas} : {"deployed": false}
+          variables:
+            expr: |
+              {"configData": config.results, "validData": validation.results}
+
+      verifyWithFullRef:
+        description: Verify alias and __actions references return the same values
+        provider: cel
+        dependsOn: [fetchConfiguration]
+        inputs:
+          expression: |
+            {"aliasRegion": cfgAlias.region, "fullRefRegion": cfgFull.region}
+          variables:
+            expr: |
+              {"cfgAlias": config.results, "cfgFull": __actions["fetchConfiguration"].results}
+
+    finally:
+      cleanup:
+        description: Finally action using deployment alias reference
+        provider: cel
+        inputs:
+          expression: |
+            {"cleanedUp": true, "wasDeployed": deployData.deployed}
+          variables:
+            expr: |
+              {"deployData": deployment.results}
+
+  testing:
+    cases:
+      _run-base:
+        description: Base template for alias action tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, alias]
+        assertions:
+          - expression: __exitCode == 0
+
+      workflow-succeeds:
+        description: Verify entire workflow succeeds with aliases
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+
+      alias-resolves-results:
+        description: Verify alias references resolve action results correctly
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["fetchConfiguration"].status == "succeeded"
+          - expression: __output.actions["fetchConfiguration"].results.region == "us-east-1"
+            message: "fetchConfiguration should return region"
+
+      alias-in-dependent-action:
+        description: Verify alias works in dependent action expressions
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["validateConfig"].status == "succeeded"
+          - expression: __output.actions["validateConfig"].results.valid == true
+            message: "Validation should pass using alias reference to config"
+
+      chained-alias-references:
+        description: Verify chaining multiple alias references in one expression
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["deploy"].status == "succeeded"
+          - expression: __output.actions["deploy"].results.deployed == true
+            message: "Deploy should use both config and validation aliases"
+          - expression: __output.actions["deploy"].results.region == "us-east-1"
+            message: "Deploy should resolve config.results.region via alias"
+          - expression: __output.actions["deploy"].results.replicas == 3
+            message: "Deploy should resolve config.results.replicas via alias"
+
+      alias-and-full-ref-equivalent:
+        description: Verify alias and __actions form return the same values
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["verifyWithFullRef"].status == "succeeded"
+          - expression: __output.actions["verifyWithFullRef"].results.aliasRegion == __output.actions["verifyWithFullRef"].results.fullRefRegion
+            message: "Alias and __actions references should return identical values"
+
+      alias-in-finally:
+        description: Verify aliases work in finally section
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["cleanup"].status == "succeeded"
+          - expression: __output.actions["cleanup"].results.cleanedUp == true
+            message: "Finally action should resolve alias references"
+          - expression: __output.actions["cleanup"].results.wasDeployed == true
+            message: "Finally action should see deployment alias results"


### PR DESCRIPTION
Actions can now declare an optional 'alias' field that creates a short top-level variable in CEL expressions, replacing the verbose __actions['my-long-action-name'].results.field form.

Changes:
- Add 'alias' field to Action struct (types.go) with JSON/YAML tags and Huma validation (pattern, maxLength)
- Build AliasMap during graph construction (graph.go); detect alias references for input deferral alongside __actions
- Add validateAlias() in validation.go: enforces regex format, blocks '__' prefix and reserved names (_,__actions,__item, etc.), prevents conflicts with action names, and enforces uniqueness
- Add buildAdditionalVars() to executor (executor.go): injects alias keys alongside __actions into CEL/template evaluation context
- Update DeferredValue.Evaluate() and ResolveDeferredValues() to accept additionalVars map[string]any instead of a bare actionsData map, enabling alias resolution at runtime (deferred.go)
- Add Alias field to MCP actionPreview struct so aliases are visible when previewing actions via the MCP server (tools_action.go)

Tests:
- alias_test.go: 20+ unit tests covering validation, graph build, deferred eval, buildAdditionalVars, buildAliasNames, and referencesActionsOrAlias; includes four benchmarks
- deferred_test.go: updated for new Evaluate/ResolveDeferredValues signatures; added alias evaluation test case
- tests/integration/solutions/actions/alias/solution.yaml: e2e solution with 7 test cases covering alias resolution, chaining, __actions parity, and finally-section aliases
- tests/integration/cli_test.go: TestIntegration_ActionAlias added

Docs & examples:
- docs/design/actions.md: alias section moved from future enhancements to implemented; full rules and schema updated
- docs/tutorials/actions-tutorial.md: Action Aliases subsection added
- examples/actions/action-alias.yaml: new working example
- examples/actions/README.md: alias example listed
- pkg/concepts/builtin.go: action concept updated to mention aliases

Closes #51
