### PR TITLE
feat: add --cwd / -C global flag and MCP cwd parameter for working di…

### DIFF
--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -1580,6 +1580,7 @@ These flags should be available on the root command and inherited by all subcomm
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
+| `--cwd` | `-C` | string | `""` | Change the working directory before executing the command (similar to `git -C`) |
 | `--catalog` | | string | `""` | Target a specific configured catalog |
 | `--output` | `-o` | string | `table` | Output format: `table`, `json`, `yaml`, `quiet` |
 | `--quiet` | `-q` | bool | `false` | Suppress non-essential output |

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -582,6 +582,7 @@ These flags are available on most commands:
 
 | Flag | Short | Description | Status |
 |------|-------|-------------|--------|
+| `--cwd` | `-C` | Change the working directory before executing the command (similar to `git -C`) | ✅ Implemented |
 | `--quiet` | `-q` | Suppress non-essential output | ✅ Implemented |
 | `--no-color` | | Disable colored output | ✅ Implemented |
 | `--config` | | Path to config file (default: `~/.scafctl/config.yaml`) | ✅ Implemented |

--- a/docs/design/cwd.md
+++ b/docs/design/cwd.md
@@ -1,0 +1,138 @@
+---
+title: "Working Directory (--cwd)"
+weight: 16
+---
+
+# Working Directory (`--cwd`)
+
+## Overview
+
+The `--cwd` (short: `-C`) global flag changes the logical working directory for all path resolution without mutating the process CWD. It behaves similarly to `git -C`:
+
+```bash
+scafctl --cwd /path/to/project run solution -f solution.yaml
+scafctl -C /path/to/project run resolver -f demo.yaml -o json
+```
+
+When `--cwd` is set, **all** relative paths—including `-f`, `--output-dir`, snapshot paths, and auto-discovery—resolve against the specified directory instead of the process CWD.
+
+---
+
+## Architecture
+
+### Context-Based Resolution
+
+The `--cwd` flag is injected into the Go `context.Context` via `provider.WithWorkingDirectory()`, avoiding global state mutation. This design:
+
+- Is safe for concurrent use (MCP server handles multiple requests)
+- Does not affect other goroutines or the process environment
+- Composes cleanly with `--output-dir` (which operates on a separate context key)
+
+### Resolution Flow
+
+```
+CLI:  --cwd flag → root PersistentPreRunE → provider.WithWorkingDirectory(ctx)
+MCP:  cwd param  → s.contextWithCwd()     → provider.WithWorkingDirectory(ctx)
+                                                    ↓
+                                          provider.AbsFromContext(ctx, path)
+                                                    ↓
+                                          filepath.Join(cwd, relativePath)
+```
+
+### Key Functions
+
+| Function | Package | Purpose |
+|----------|---------|---------|
+| `WithWorkingDirectory` | `pkg/provider` | Stores the working directory in context |
+| `WorkingDirectoryFromContext` | `pkg/provider` | Retrieves the working directory from context |
+| `AbsFromContext` | `pkg/provider` | Resolves a relative path against the context working directory |
+| `GetWorkingDirectory` | `pkg/provider` | Returns the effective working directory (context → `os.Getwd()` fallback) |
+| `ResolvePath` | `pkg/provider` | Full path resolution including output-dir and cwd support |
+
+---
+
+## Interaction with `--output-dir`
+
+The `--cwd` and `--output-dir` flags serve different purposes and compose together:
+
+| Flag | Scope | Affects |
+|------|-------|---------|
+| `--cwd` | All phases (resolvers + actions) | Where relative paths are resolved from |
+| `--output-dir` | Action phase only | Where action outputs are written to |
+
+When both are set:
+- **Resolvers** resolve paths against `--cwd`
+- **Actions** resolve output paths against `--output-dir`
+- A relative `--output-dir` itself is resolved against `--cwd`
+
+```bash
+# Resolvers read from /project, actions write to /project/out
+scafctl --cwd /project run solution -f sol.yaml --output-dir out
+```
+
+---
+
+## MCP Server
+
+All MCP tools that accept file paths support an optional `cwd` parameter. When provided, it behaves identically to the CLI `--cwd` flag:
+
+```json
+{
+  "tool": "render_solution",
+  "arguments": {
+    "path": "solution.yaml",
+    "cwd": "/path/to/project"
+  }
+}
+```
+
+### Tools with `cwd` Support
+
+| Tool | File |
+|------|------|
+| `inspect_solution` | `tools_solution.go` |
+| `lint_solution` | `tools_solution.go` |
+| `render_solution` | `tools_solution.go` |
+| `preview_resolvers` | `tools_solution.go` |
+| `run_solution_tests` | `tools_solution.go` |
+| `get_run_command` | `tools_solution.go` |
+| `preview_action` | `tools_action.go` |
+| `dryrun_solution` | `tools_dryrun.go` |
+| `show_snapshot` | `tools_snapshot.go` |
+| `diff_snapshots` | `tools_snapshot.go` |
+| `generate_test_scaffold` | `tools_testing.go` |
+| `list_tests` | `tools_testing.go` |
+| `diff_solution` | `tools_diff.go` |
+| `build_plugin` | `tools_catalog_multiplatform.go` |
+| `extract_resolver_refs` | `tools_refs.go` |
+
+### Tools without `cwd` (not applicable)
+
+| Tool | Reason |
+|------|--------|
+| `list_examples` / `get_example` | Paths reference embedded resources, not the filesystem |
+| `catalog_list` / `catalog_list_platforms` | Catalog references, not filesystem paths |
+| `list_providers` / `get_provider_schema` | In-memory registry lookups |
+| `list_cel_functions` / `evaluate_cel` | No filesystem paths |
+| `auth_status` | No filesystem paths |
+
+---
+
+## Fallback Behavior
+
+When `--cwd` is **not** set:
+1. `WorkingDirectoryFromContext` returns `("", false)`
+2. `AbsFromContext` falls through to `filepath.Abs()` which uses `os.Getwd()`
+3. Behavior is identical to running without `--cwd`—fully backward compatible
+
+---
+
+## Validation
+
+The `--cwd` value is validated at entry point (CLI root or MCP `contextWithCwd`):
+
+1. Resolved to absolute path via `filepath.Abs`
+2. Checked for existence via `os.Stat`
+3. Verified to be a directory (not a file)
+
+Invalid values produce a clear error before any command logic executes.

--- a/docs/design/mcp-server-implementation-guide.md
+++ b/docs/design/mcp-server-implementation-guide.md
@@ -1727,6 +1727,52 @@ Examples:
 
 ---
 
+## Working Directory (`cwd`) Parameter
+
+All MCP tools that accept file paths support an optional `cwd` string parameter. When provided, relative paths resolve against the specified directory instead of the server's process CWD.
+
+### Pattern
+
+```go
+func (s *Server) handleMyTool(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    path := request.GetString("path", "")
+    cwd := request.GetString("cwd", "")
+
+    ctx, err := s.contextWithCwd(cwd)
+    if err != nil {
+        return newStructuredError(ErrCodeInvalidInput, err.Error(),
+            WithField("cwd"),
+            WithSuggestion("Provide a valid existing directory path"),
+        ), nil
+    }
+
+    // For tools that load solutions via prepare.Solution or inspect.LoadSolution,
+    // the path is resolved automatically by the getter:
+    sol, err := prepare.Solution(ctx, path, ...)
+
+    // For tools that use raw file I/O (e.g., snapshot loading),
+    // resolve the path explicitly first:
+    path, err = provider.AbsFromContext(ctx, path)
+    data, err := os.ReadFile(path)
+}
+```
+
+### Tool Registration
+
+```go
+mcp.WithString("cwd",
+    mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
+),
+```
+
+### Design Rationale
+
+- Uses `context.Context` instead of `os.Chdir` — safe for concurrent MCP requests
+- Mirrors the CLI `--cwd` / `-C` flag behavior
+- See [cwd design doc](cwd.md) for full architecture details
+
+---
+
 ## Implementation Order & Dependencies
 
 ```

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -134,6 +134,10 @@ The MCP server runs **locally on the user's machine**, in the same security cont
 
 The AI client (VS Code, Claude Desktop, etc.) connects to this local server process — it does not expose anything to the network (when using stdio transport).
 
+### Working Directory Override
+
+All MCP tools that accept file paths support an optional `cwd` parameter. This allows AI agents to specify the project directory for path resolution without requiring the MCP server process to be started from that directory. See the [cwd design doc](cwd.md) for details.
+
 ## What Is Required
 
 ### 1. New Go Dependency

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -919,6 +919,18 @@ scafctl render solution -f hello-world.yaml -o yaml
 scafctl render solution -f hello-world.yaml -o json > graph.json
 ```
 
+### Working Directory Override
+
+Use `--cwd` (`-C`) to run solutions from a different directory. All file paths in actions (reads, writes, exec commands) resolve against the specified directory:
+
+```bash
+# Run a solution in a different project directory
+scafctl --cwd /path/to/project run solution -f solution.yaml
+
+# Combine with --output-dir: resolvers read from --cwd, actions write to --output-dir
+scafctl -C /path/to/project run solution -f solution.yaml --output-dir /tmp/output
+```
+
 The rendered output includes:
 - Expanded actions (ForEach iterations)
 - Materialized inputs

--- a/docs/tutorials/dryrun-tutorial.md
+++ b/docs/tutorials/dryrun-tutorial.md
@@ -161,6 +161,20 @@ if [ "$warnings" -gt 0 ]; then
 fi
 ```
 
+## Working Directory Override
+
+Use `--cwd` (`-C`) to run a dry-run against a solution in a different directory:
+
+```bash
+# Dry-run a solution from another directory
+scafctl --cwd /path/to/project dryrun -f solution.yaml
+
+# Short form
+scafctl -C /path/to/project dryrun -f solution.yaml -o json
+```
+
+All relative paths in the solution (file references, templates, etc.) resolve against the `--cwd` directory.
+
 ## See Also
 
 - [Snapshots Tutorial]({{< relref "snapshots-tutorial" >}}) — Capture and compare runtime execution state

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -1020,6 +1020,20 @@ scafctl test functional -f solution.yaml --dry-run
 This resolves `extends` chains, validates test names, and reports discovery results.
 Exits 0 if valid, exit code 3 if invalid.
 
+### Working Directory Override
+
+Use `--cwd` (`-C`) to run tests against solutions in a different directory:
+
+```bash
+# Run tests from a project in another directory
+scafctl --cwd /path/to/project test functional -f solution.yaml
+
+# Short form
+scafctl -C /path/to/project test functional
+```
+
+The sandbox copies files relative to the working directory, so test `files` entries resolve correctly against `--cwd`.
+
 ---
 
 ## Builtin Tests

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -960,6 +960,22 @@ The server can stream structured log messages to connected clients in real-time 
 
 For clients that support the MCP roots capability, the server can discover workspace root directories, enabling workspace-aware file operations.
 
+### Working Directory (`cwd`) Parameter
+
+All tools that accept file paths support an optional `cwd` parameter. This sets the working directory for path resolution without changing the server process's CWD:
+
+```json
+{
+  "tool": "render_solution",
+  "arguments": {
+    "path": "solution.yaml",
+    "cwd": "/Users/me/projects/my-app"
+  }
+}
+```
+
+This is the MCP equivalent of the CLI `--cwd` (`-C`) flag. It allows AI agents to specify the project context when the MCP server runs from a different directory. See the [cwd design doc](../../design/cwd.md) for which tools support it and design details.
+
 ### Sampling and Elicitation
 
 The server supports two client interaction capabilities:

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -649,6 +649,25 @@ scafctl run resolver -f demo.yaml -e '_.environment'
 
 ---
 
+## Working Directory Override
+
+Use the `--cwd` (or `-C`) global flag to run commands as if you were in a different directory. This is useful when scripting or when your solution files live in a different location:
+
+```bash
+# Run resolvers from a solution in another directory
+scafctl --cwd /path/to/project run resolver -f solution.yaml
+
+# Short form (similar to git -C)
+scafctl -C /path/to/project run resolver -f solution.yaml
+
+# Combine with other flags
+scafctl -C /path/to/project run resolver -f solution.yaml -o json
+```
+
+All relative paths (including `-f`, `--output-dir`, etc.) are resolved against the specified working directory instead of the current directory.
+
+---
+
 ## Debugging Dependencies
 
 A common debugging workflow is to inspect how resolver dependencies cascade.

--- a/examples/solutions/cwd/README.md
+++ b/examples/solutions/cwd/README.md
@@ -1,0 +1,48 @@
+# Working Directory (`--cwd`) Example
+
+Demonstrates the `--cwd` (`-C`) global flag for running commands from a different working directory without `cd`-ing into it.
+
+## Concept
+
+The `--cwd` flag changes where scafctl resolves relative paths. This is useful for:
+
+- **Scripting**: Run commands against projects in different directories
+- **CI/CD**: Execute from a checkout root while targeting a subdirectory
+- **MCP agents**: Specify the project context when the server runs elsewhere
+
+## Solution
+
+The solution reads a local file (`data.txt`) using the `file` provider, demonstrating that relative paths resolve against the `--cwd` directory.
+
+## Running
+
+```bash
+# From the repository root — this would fail without --cwd because
+# data.txt is not in the repo root:
+scafctl --cwd examples/solutions/cwd run resolver -f solution.yaml -o json
+
+# Short-form flag (same as git -C):
+scafctl -C examples/solutions/cwd run resolver -f solution.yaml -o json
+
+# Combine with --output-dir (output-dir resolves against --cwd too):
+scafctl -C examples/solutions/cwd run solution -f solution.yaml --output-dir /tmp/cwd-demo
+
+# Equivalent to cd-ing into the directory first:
+cd examples/solutions/cwd && scafctl run resolver -f solution.yaml -o json
+```
+
+## MCP Usage
+
+```json
+{
+  "tool": "preview_resolvers",
+  "arguments": {
+    "path": "solution.yaml",
+    "cwd": "/path/to/examples/solutions/cwd"
+  }
+}
+```
+
+## Key Takeaway
+
+`--cwd` affects **all** relative paths — the solution file (`-f`), files read by resolvers, files written by actions, and `--output-dir` itself.

--- a/examples/solutions/cwd/data.txt
+++ b/examples/solutions/cwd/data.txt
@@ -1,0 +1,1 @@
+content from data.txt

--- a/examples/solutions/cwd/solution.yaml
+++ b/examples/solutions/cwd/solution.yaml
@@ -1,0 +1,39 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: cwd-example
+  version: 1.0.0
+  description: |
+    Demonstrates the --cwd flag for working directory override.
+    All relative paths resolve against the --cwd directory instead of the process CWD.
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting to verify basic resolver execution
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello from cwd example
+
+    local-data:
+      description: Read data.txt from the working directory
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data.txt
+
+  workflow:
+    actions:
+      write-result:
+        description: Write resolver results to a file
+        provider: file
+        inputs:
+          operation: write
+          path: result.txt
+          content:
+            expr: '"greeting=" + _.greeting + "\ndata=" + _["local-data"]'

--- a/pkg/catalog/multiplatform_build.go
+++ b/pkg/catalog/multiplatform_build.go
@@ -4,10 +4,12 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 // ValidatePluginKind validates that the given kind string is a valid plugin kind
@@ -27,7 +29,7 @@ func ValidatePluginKind(kindStr string) (ArtifactKind, error) {
 // platformPaths maps platform strings (e.g., "linux/amd64") to file paths.
 // Returns an error if any platform is unsupported, path doesn't exist,
 // path is a directory, or file data is empty or unreadable.
-func ReadPlatformBinaries(platformPaths map[string]string) ([]PlatformBinary, error) {
+func ReadPlatformBinaries(ctx context.Context, platformPaths map[string]string) ([]PlatformBinary, error) {
 	if len(platformPaths) == 0 {
 		return nil, fmt.Errorf("no platform binaries provided")
 	}
@@ -43,7 +45,7 @@ func ReadPlatformBinaries(platformPaths map[string]string) ([]PlatformBinary, er
 			return nil, fmt.Errorf("unsupported platform %q; supported: %s", platform, strings.Join(SupportedPluginPlatforms, ", "))
 		}
 
-		absPath, err := filepath.Abs(binPath)
+		absPath, err := provider.AbsFromContext(ctx, binPath)
 		if err != nil {
 			return nil, fmt.Errorf("platform %q: invalid path %q: %w", platform, binPath, err)
 		}

--- a/pkg/catalog/multiplatform_build_test.go
+++ b/pkg/catalog/multiplatform_build_test.go
@@ -4,6 +4,7 @@
 package catalog
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,7 +49,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	require.NoError(t, os.WriteFile(darwinBin, []byte("darwin-binary-data"), 0o755))
 
 	t.Run("valid platforms", func(t *testing.T) {
-		result, err := ReadPlatformBinaries(map[string]string{
+		result, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"linux/amd64":  linuxBin,
 			"darwin/arm64": darwinBin,
 		})
@@ -63,7 +64,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	})
 
 	t.Run("unsupported platform", func(t *testing.T) {
-		_, err := ReadPlatformBinaries(map[string]string{
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"solaris/sparc": linuxBin,
 		})
 		require.Error(t, err)
@@ -71,7 +72,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	})
 
 	t.Run("missing file", func(t *testing.T) {
-		_, err := ReadPlatformBinaries(map[string]string{
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"linux/amd64": filepath.Join(dir, "nonexistent"),
 		})
 		require.Error(t, err)
@@ -79,7 +80,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	})
 
 	t.Run("directory instead of file", func(t *testing.T) {
-		_, err := ReadPlatformBinaries(map[string]string{
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"linux/amd64": dir,
 		})
 		require.Error(t, err)
@@ -87,7 +88,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	})
 
 	t.Run("empty path", func(t *testing.T) {
-		_, err := ReadPlatformBinaries(map[string]string{
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"linux/amd64": "",
 		})
 		require.Error(t, err)
@@ -95,7 +96,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 	})
 
 	t.Run("empty map", func(t *testing.T) {
-		_, err := ReadPlatformBinaries(map[string]string{})
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no platform binaries")
 	})
@@ -104,7 +105,7 @@ func TestReadPlatformBinaries(t *testing.T) {
 		emptyFile := filepath.Join(dir, "empty")
 		require.NoError(t, os.WriteFile(emptyFile, nil, 0o755))
 
-		_, err := ReadPlatformBinaries(map[string]string{
+		_, err := ReadPlatformBinaries(context.Background(), map[string]string{
 			"linux/amd64": emptyFile,
 		})
 		require.Error(t, err)
@@ -120,7 +121,7 @@ func BenchmarkReadPlatformBinaries(b *testing.B) {
 	paths := map[string]string{"linux/amd64": binFile}
 
 	for b.Loop() {
-		_, _ = ReadPlatformBinaries(paths)
+		_, _ = ReadPlatformBinaries(context.Background(), paths)
 	}
 }
 

--- a/pkg/cmd/scafctl/build/plugin.go
+++ b/pkg/cmd/scafctl/build/plugin.go
@@ -130,7 +130,7 @@ func runBuildPlugin(ctx context.Context, opts *PluginOptions) error {
 	}
 
 	// Validate and read platform binaries
-	platformBinaries, err := catalog.ReadPlatformBinaries(platformPaths)
+	platformBinaries, err := catalog.ReadPlatformBinaries(ctx, platformPaths)
 	if err != nil {
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
@@ -136,7 +137,7 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 	}
 
 	// Determine bundle root (directory containing the solution file)
-	absFile, err := filepath.Abs(opts.File)
+	absFile, err := provider.AbsFromContext(ctx, opts.File)
 	if err != nil {
 		w.Errorf("failed to resolve path: %v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -5,6 +5,7 @@ package scafctl
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/profiler"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/telemetry"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -92,6 +94,7 @@ func Root(opts *RootOptions) *cobra.Command {
 	cliParams := settings.NewCliParams()
 	var (
 		configPath   = opts.ConfigPath
+		cwdFlag      string
 		debugFlag    bool
 		logFormat    = "console"
 		logFile      string
@@ -249,6 +252,18 @@ func Root(opts *RootOptions) *cobra.Command {
 			ctx = input.WithInput(ctx, in)
 			ctx = config.WithConfig(ctx, cfg)
 
+			// ── Resolve --cwd flag and inject into context ──
+			// This must happen before any path resolution so that downstream
+			// commands see the correct logical working directory.
+			if cwdFlag != "" {
+				absCwd, cwdErr := provider.ValidateDirectory(cwdFlag)
+				if cwdErr != nil {
+					w.ErrorWithExit(fmt.Sprintf("--cwd: %v", cwdErr))
+					return
+				}
+				ctx = provider.WithWorkingDirectory(ctx, absCwd)
+			}
+
 			// ── Initialize CEL subsystem from config ──
 			celValues := cfg.CEL.ToCELValues()
 			celexp.InitFromAppConfig(ctx, celexp.CELConfigInput{
@@ -388,6 +403,7 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write logs to a file instead of stderr")
 	cCmd.PersistentFlags().BoolVarP(&cliParams.IsQuiet, "quiet", "q", false, "Do not print additional information")
 	cCmd.PersistentFlags().BoolVar(&cliParams.NoColor, "no-color", false, "Disable color output")
+	cCmd.PersistentFlags().StringVarP(&cwdFlag, "cwd", "C", "", "Change the working directory before executing the command (similar to git -C)")
 	cCmd.PersistentFlags().StringVar(&configPath, "config", "", "Path to config file (default: ~/.scafctl/config.yaml)")
 	cCmd.PersistentFlags().String("pprof", "", "Enable profiling (options: memory, cpu)")
 	cCmd.PersistentFlags().String("pprof-output-dir", "./", "directory path to save the profiler.prof file (default: current working directory)")

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -47,6 +47,9 @@ func TestRoot_PersistentFlags(t *testing.T) {
 	if flags.Lookup("pprof-output-dir") == nil {
 		t.Error("Expected 'pprof-output-dir' persistent flag to be defined")
 	}
+	if flags.Lookup("cwd") == nil {
+		t.Error("Expected 'cwd' persistent flag to be defined")
+	}
 }
 
 func TestRoot_HiddenFlags(t *testing.T) {

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -252,7 +251,7 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	// Set output directory for action capabilities.
 	// In dry-run mode, resolve the path without creating the directory.
 	if o.OutputDir != "" && capability == provider.CapabilityAction {
-		absDir, err := filepath.Abs(o.OutputDir)
+		absDir, err := provider.AbsFromContext(ctx, o.OutputDir)
 		if err != nil {
 			w.Errorf("failed to resolve output directory %q: %v", o.OutputDir, err)
 			return exitcode.WithCode(err, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -252,7 +252,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	// Validate and prepare output directory before execution (fail-fast).
 	// In dry-run mode, resolve the path without creating the directory.
-	absOutputDir, err := o.resolveOutputDir(o.DryRun)
+	absOutputDir, err := o.resolveOutputDir(ctx, o.DryRun)
 	if err != nil {
 		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
@@ -260,7 +260,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Capture the original working directory before prepareSolutionForExecution,
 	// which may os.Chdir into a bundle extraction directory. This ensures __cwd
 	// in action expressions reflects the user's actual working directory.
-	originalCwd, err := os.Getwd()
+	originalCwd, err := provider.GetWorkingDirectory(ctx)
 	if err != nil {
 		return o.exitWithCode(ctx, fmt.Errorf("failed to get working directory: %w", err), exitcode.GeneralError)
 	}
@@ -532,12 +532,12 @@ func (o *SolutionOptions) getActionIOStreams() *provider.IOStreams {
 // Returns the absolute path if --output-dir was set, or empty string if not.
 // When dryRun is false, creates the directory if it doesn't exist.
 // When dryRun is true, only resolves to an absolute path without creating it.
-func (o *SolutionOptions) resolveOutputDir(dryRun bool) (string, error) {
+func (o *SolutionOptions) resolveOutputDir(ctx context.Context, dryRun bool) (string, error) {
 	if o.OutputDir == "" {
 		return "", nil
 	}
 
-	absDir, err := filepath.Abs(o.OutputDir)
+	absDir, err := provider.AbsFromContext(ctx, o.OutputDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve output directory %q: %w", o.OutputDir, err)
 	}

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -871,7 +871,7 @@ func TestSolutionOptions_resolveOutputDir(t *testing.T) {
 	t.Run("empty output dir returns empty string", func(t *testing.T) {
 		t.Parallel()
 		opts := &SolutionOptions{}
-		result, err := opts.resolveOutputDir(false)
+		result, err := opts.resolveOutputDir(context.Background(), false)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -883,7 +883,7 @@ func TestSolutionOptions_resolveOutputDir(t *testing.T) {
 
 		opts := &SolutionOptions{}
 		opts.OutputDir = target
-		result, err := opts.resolveOutputDir(false)
+		result, err := opts.resolveOutputDir(context.Background(), false)
 		require.NoError(t, err)
 		assert.Equal(t, target, result)
 
@@ -899,7 +899,7 @@ func TestSolutionOptions_resolveOutputDir(t *testing.T) {
 
 		opts := &SolutionOptions{}
 		opts.OutputDir = target
-		result, err := opts.resolveOutputDir(true)
+		result, err := opts.resolveOutputDir(context.Background(), true)
 		require.NoError(t, err)
 		assert.Equal(t, target, result)
 
@@ -918,6 +918,6 @@ func BenchmarkSolutionOptions_resolveOutputDir(b *testing.B) {
 	_ = os.MkdirAll(target, 0o755)
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = opts.resolveOutputDir(false)
+		_, _ = opts.resolveOutputDir(context.Background(), false)
 	}
 }

--- a/pkg/cmd/scafctl/vendor/update.go
+++ b/pkg/cmd/scafctl/vendor/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
@@ -105,7 +106,7 @@ func runVendorUpdate(ctx context.Context, opts *UpdateOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	absPath, err := filepath.Abs(opts.SolutionPath)
+	absPath, err := provider.AbsFromContext(ctx, opts.SolutionPath)
 	if err != nil {
 		w.Errorf("failed to resolve path: %v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)

--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -125,4 +126,19 @@ func NewContext(opts ...ContextOption) context.Context {
 	ctx = writer.WithWriter(ctx, w)
 
 	return ctx
+}
+
+// contextWithCwd returns the server context with a working directory override.
+// If cwd is empty, the original context is returned unchanged. If cwd is
+// non-empty, it is resolved to an absolute path and validated as an existing
+// directory before being injected into the context.
+func (s *Server) contextWithCwd(cwd string) (context.Context, error) {
+	if cwd == "" {
+		return s.ctx, nil
+	}
+	absCwd, err := provider.ValidateDirectory(cwd)
+	if err != nil {
+		return nil, err
+	}
+	return provider.WithWorkingDirectory(s.ctx, absCwd), nil
 }

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -35,6 +35,9 @@ func (s *Server) registerActionTools() {
 		mcp.WithString("action",
 			mcp.Description("Preview a specific action by name. If omitted, previews all actions."),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(previewActionTool, s.handlePreviewAction)
 }
@@ -50,6 +53,15 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	actionFilter := request.GetString("action", "")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
 
 	// Parse params
 	var params map[string]any
@@ -65,7 +77,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(s.ctx, path,
+	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
@@ -89,7 +101,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	// Execute resolvers to get data for action inputs
-	resolverData, err := s.executeResolversForRender(sol, params)
+	resolverData, err := s.executeResolversForRender(ctx, sol, params)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
 			WithSuggestion("Check resolver configurations with preview_resolvers. Missing parameters can be passed via the params field."),
@@ -98,7 +110,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	// Build the action graph (this materializes inputs)
-	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action definitions and dependencies. Use lint_solution to find structural issues."),

--- a/pkg/mcp/tools_catalog_multiplatform.go
+++ b/pkg/mcp/tools_catalog_multiplatform.go
@@ -62,6 +62,9 @@ func (s *Server) registerCatalogMultiPlatformTools() {
 		mcp.WithBoolean("force",
 			mcp.Description("Overwrite an existing artifact with the same name and version (default: false)"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative platform binary paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(buildPluginTool, s.handleBuildPlugin)
 }
@@ -193,6 +196,15 @@ func (s *Server) handleBuildPlugin(_ context.Context, request mcp.CallToolReques
 	}
 
 	force := request.GetBool("force", false)
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
 
 	// Convert platforms map to string paths and validate/read binaries
 	platformPaths := make(map[string]string, len(platformsMap))
@@ -206,7 +218,7 @@ func (s *Server) handleBuildPlugin(_ context.Context, request mcp.CallToolReques
 		platformPaths[platform] = binPath
 	}
 
-	platformBinaries, err := catalog.ReadPlatformBinaries(platformPaths)
+	platformBinaries, err := catalog.ReadPlatformBinaries(ctx, platformPaths)
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
 			WithField("platforms"),
@@ -232,7 +244,7 @@ func (s *Server) handleBuildPlugin(_ context.Context, request mcp.CallToolReques
 		), nil
 	}
 
-	info, err := localCatalog.StoreMultiPlatform(s.ctx, ref, platformBinaries, nil, force)
+	info, err := localCatalog.StoreMultiPlatform(ctx, ref, platformBinaries, nil, force)
 	if err != nil {
 		if catalog.IsExists(err) {
 			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("artifact %s@%s already exists", name, versionStr),

--- a/pkg/mcp/tools_diff.go
+++ b/pkg/mcp/tools_diff.go
@@ -31,6 +31,9 @@ func (s *Server) registerDiffTools() {
 			mcp.Required(),
 			mcp.Description("Path to the second solution file (e.g., the modified version)"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(diffSolutionTool, s.handleDiffSolution)
 }
@@ -51,8 +54,17 @@ func (s *Server) handleDiffSolution(_ context.Context, request mcp.CallToolReque
 			WithSuggestion("Provide two solution file paths to compare"),
 		), nil
 	}
+	cwd := request.GetString("cwd", "")
 
-	result, err := soldiff.CompareFiles(s.ctx, pathA, pathB)
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	result, err := soldiff.CompareFiles(ctx, pathA, pathB)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("diff failed: %v", err),
 			WithSuggestion("Check that both file paths exist and contain valid solution YAML"),

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -35,6 +35,9 @@ func (s *Server) registerDryRunTools() {
 		mcp.WithObject("mock_data",
 			mcp.Description("Override specific resolver values with mock data instead of executing them. Keys are resolver names, values are the mock output. Useful for testing action behavior with specific resolver outputs without requiring real provider execution. Example: {\"api_url\": \"https://mock.example.com\", \"config\": {\"env\": \"test\"}}"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(dryRunTool, s.handleDryRunSolution)
 }
@@ -46,6 +49,15 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
 			WithField("path"),
 			WithSuggestion("Provide the path to a solution file, catalog name, or URL"),
+		), nil
+	}
+
+	cwd := request.GetString("cwd", "")
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
 		), nil
 	}
 
@@ -75,7 +87,7 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(s.ctx, path,
+	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {

--- a/pkg/mcp/tools_refs.go
+++ b/pkg/mcp/tools_refs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 // registerRefsTools registers resolver reference extraction tools.
@@ -35,6 +36,9 @@ func (s *Server) registerRefsTools() {
 		mcp.WithString("type",
 			mcp.Description("Expression type: 'go-template' (default) or 'cel'"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative file paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(extractRefssTool, s.handleExtractResolverRefs)
 }
@@ -44,6 +48,7 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 	text := request.GetString("text", "")
 	filePath := request.GetString("file", "")
 	exprType := request.GetString("type", "go-template")
+	cwd := request.GetString("cwd", "")
 
 	if text == "" && filePath == "" {
 		return newStructuredError(ErrCodeInvalidInput, "either 'text' or 'file' must be provided",
@@ -51,11 +56,26 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 		), nil
 	}
 
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
 	source := "inline"
 	content := text
 	if filePath != "" {
+		// Resolve relative file path against the working directory
+		resolved, resolveErr := provider.AbsFromContext(ctx, filePath)
+		if resolveErr != nil {
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve path: %v", resolveErr),
+				WithField("file"),
+			), nil
+		}
 		source = "file"
-		data, err := os.ReadFile(filePath)
+		data, err := os.ReadFile(resolved)
 		if err != nil {
 			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("failed to read file %q: %v", filePath, err),
 				WithField("file"),
@@ -66,7 +86,6 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 	}
 
 	var resolverNames []string
-	var err error
 
 	switch exprType {
 	case "go-template":

--- a/pkg/mcp/tools_snapshot.go
+++ b/pkg/mcp/tools_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 )
 
@@ -28,6 +29,9 @@ func (s *Server) registerSnapshotTools() {
 		),
 		mcp.WithString("format",
 			mcp.Description("Output detail level: 'summary' (default), 'resolvers' (include per-resolver data), 'full' (everything including raw values)"),
+		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
 	s.mcpServer.AddTool(showSnapshotTool, s.handleShowSnapshot)
@@ -52,6 +56,9 @@ func (s *Server) registerSnapshotTools() {
 		mcp.WithBoolean("ignore_unchanged",
 			mcp.Description("Omit unchanged resolvers from the response. Default: true"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(diffSnapshotsTool, s.handleDiffSnapshots)
 }
@@ -66,6 +73,23 @@ func (s *Server) handleShowSnapshot(_ context.Context, request mcp.CallToolReque
 		), nil
 	}
 	format := request.GetString("format", "summary")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	// Resolve relative snapshot path against the working directory
+	path, err = provider.AbsFromContext(ctx, path)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve path: %v", err),
+			WithField("path"),
+		), nil
+	}
 
 	snapshot, err := resolver.LoadSnapshot(path)
 	if err != nil {
@@ -157,6 +181,29 @@ func (s *Server) handleDiffSnapshots(_ context.Context, request mcp.CallToolRequ
 	}
 
 	ignoreUnchanged := request.GetBool("ignore_unchanged", true)
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	// Resolve relative snapshot paths against the working directory
+	beforePath, err = provider.AbsFromContext(ctx, beforePath)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve before path: %v", err),
+			WithField("before"),
+		), nil
+	}
+	afterPath, err = provider.AbsFromContext(ctx, afterPath)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve after path: %v", err),
+			WithField("after"),
+		), nil
+	}
 
 	beforeSnap, err := resolver.LoadSnapshot(beforePath)
 	if err != nil {

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -62,6 +62,9 @@ func (s *Server) registerSolutionTools() {
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(inspectSolutionTool, s.handleInspectSolution)
 
@@ -82,6 +85,9 @@ func (s *Server) registerSolutionTools() {
 		mcp.WithString("severity",
 			mcp.Description("Minimum severity to return: error, warning, info (default: info)"),
 			mcp.Enum("error", "warning", "info"),
+		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
 	s.mcpServer.AddTool(lintSolutionTool, s.handleLintSolution)
@@ -110,6 +116,9 @@ func (s *Server) registerSolutionTools() {
 		mcp.WithString("output_dir",
 			mcp.Description("Target directory for action output. When set, actions resolve relative paths against this directory instead of CWD. Resolvers always use CWD regardless of this setting."),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(renderSolutionTool, s.handleRenderSolution)
 
@@ -135,6 +144,9 @@ func (s *Server) registerSolutionTools() {
 		),
 		mcp.WithString("output_dir",
 			mcp.Description("Target directory for action output. Included for path preview purposes — resolvers always use CWD regardless of this setting."),
+		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
 		),
 	)
 	s.mcpServer.AddTool(previewResolversTool, s.handlePreviewResolvers)
@@ -167,6 +179,9 @@ func (s *Server) registerSolutionTools() {
 		mcp.WithString("output_dir",
 			mcp.Description("Target directory for action output during test execution. When set, actions resolve relative paths against this directory instead of CWD."),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(runSolutionTestsTool, s.handleRunSolutionTests)
 
@@ -182,6 +197,9 @@ func (s *Server) registerSolutionTools() {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
 	s.mcpServer.AddTool(getRunCommandTool, s.handleGetRunCommand)
@@ -247,8 +265,17 @@ func (s *Server) handleInspectSolution(_ context.Context, request mcp.CallToolRe
 			WithSuggestion("Provide a solution file path, catalog name, or URL"),
 		), nil
 	}
+	cwd := request.GetString("cwd", "")
 
-	sol, err := inspect.LoadSolution(s.ctx, path)
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	sol, err := inspect.LoadSolution(ctx, path)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
 			WithField("path"),
@@ -281,9 +308,18 @@ func (s *Server) handleLintSolution(_ context.Context, request mcp.CallToolReque
 		), nil
 	}
 	severity := request.GetString("severity", "info")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
 
 	// Use prepare.Solution which handles catalog resolution and registry setup
-	prepResult, err := prepare.Solution(s.ctx, file,
+	prepResult, err := prepare.Solution(ctx, file,
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
@@ -347,6 +383,15 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 
 	graphType := request.GetString("graph_type", "action")
 	outputDir := request.GetString("output_dir", "")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
 
 	// Parse params from arguments
 	var params map[string]any
@@ -363,7 +408,7 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 	}
 
 	// Load solution via prepare.Solution
-	prepResult, err := prepare.Solution(s.ctx, path,
+	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
@@ -416,9 +461,9 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 	case "resolver":
 		return s.renderResolverGraph(sol, reg)
 	case "action-deps":
-		return s.renderActionDepsGraph(sol, params, outputDir)
+		return s.renderActionDepsGraph(ctx, sol, params, outputDir)
 	default:
-		return s.renderActionGraph(sol, params, outputDir)
+		return s.renderActionGraph(ctx, sol, params, outputDir)
 	}
 }
 
@@ -462,7 +507,7 @@ func (s *Server) renderResolverGraph(sol *solution.Solution, reg *provider.Regis
 }
 
 // renderActionGraph executes resolvers, builds, and renders the action graph.
-func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) { //nolint:unparam // error is always nil per MCP pattern
+func (s *Server) renderActionGraph(ctx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) { //nolint:unparam // error is always nil per MCP pattern
 	if !sol.Spec.HasWorkflow() {
 		suggestion := "Add a spec.workflow section with actions to the solution"
 		if sol.Spec.HasResolvers() {
@@ -475,7 +520,7 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 	}
 
 	// Execute resolvers to get data for action inputs
-	resolverData, err := s.executeResolversForRender(sol, params)
+	resolverData, err := s.executeResolversForRender(ctx, sol, params)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
 			WithSuggestion("Check resolver configuration with preview_resolvers"),
@@ -484,7 +529,7 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 	}
 
 	// Build the action graph
-	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action dependencies and provider configurations"),
@@ -524,7 +569,7 @@ func (s *Server) renderActionGraph(sol *solution.Solution, params map[string]any
 }
 
 // renderActionDepsGraph builds and returns the action dependency visualization.
-func (s *Server) renderActionDepsGraph(sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) {
+func (s *Server) renderActionDepsGraph(ctx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) {
 	if !sol.Spec.HasWorkflow() {
 		return newStructuredError(ErrCodeValidationError, "solution does not define a workflow",
 			WithSuggestion("Add a spec.workflow section with actions to the solution"),
@@ -533,7 +578,7 @@ func (s *Server) renderActionDepsGraph(sol *solution.Solution, params map[string
 	}
 
 	// Execute resolvers to get data for action inputs
-	resolverData, err := s.executeResolversForRender(sol, params)
+	resolverData, err := s.executeResolversForRender(ctx, sol, params)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
 			WithSuggestion("Check resolver configuration with preview_resolvers"),
@@ -542,7 +587,7 @@ func (s *Server) renderActionDepsGraph(sol *solution.Solution, params map[string
 	}
 
 	// Build the action graph
-	graph, err := action.BuildGraph(s.ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action dependencies and provider configurations"),
@@ -576,8 +621,8 @@ func (s *Server) renderActionDepsGraph(sol *solution.Solution, params map[string
 }
 
 // executeResolversForRender runs resolver execution for render operations.
-func (s *Server) executeResolversForRender(sol *solution.Solution, params map[string]any) (map[string]any, error) {
-	return execute.ResolversForPreview(s.ctx, sol, params, s.registry)
+func (s *Server) executeResolversForRender(ctx context.Context, sol *solution.Solution, params map[string]any) (map[string]any, error) {
+	return execute.ResolversForPreview(ctx, sol, params, s.registry)
 }
 
 // handlePreviewResolvers executes a solution's resolver chain and returns each resolver's value.
@@ -591,6 +636,15 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 
 	outputDir := request.GetString("output_dir", "")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
 
 	// Parse params
 	var params map[string]any
@@ -607,7 +661,7 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(s.ctx, path,
+	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
 	)
 	if err != nil {
@@ -675,13 +729,13 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 	if len(missingParamNames) > 0 {
 		sort.Strings(missingParamNames)
-		for k, v := range s.elicitMissingParams(s.ctx, missingParamNames, missingDescriptions) {
+		for k, v := range s.elicitMissingParams(ctx, missingParamNames, missingDescriptions) {
 			params[k] = v
 		}
 	}
 
 	if reg == nil {
-		reg, err = builtin.DefaultRegistry(s.ctx)
+		reg, err = builtin.DefaultRegistry(ctx)
 		if err != nil {
 			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to create provider registry: %v", err),
 				WithSuggestion("Check provider configurations"),
@@ -690,22 +744,22 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		}
 	}
 
-	cfg := execute.ResolverExecutionConfigFromContext(s.ctx)
+	cfg := execute.ResolverExecutionConfigFromContext(ctx)
 	// Check if we're debugging a single resolver
 	resolverFilter := request.GetString("resolver", "")
 
 	// Send progress notifications during execution
 	progress := newProgressReporter(s, request)
 	progress.setTotal(3)
-	progress.report(s.ctx, 1, "Loading and validating solution")
+	progress.report(ctx, 1, "Loading and validating solution")
 
-	progress.report(s.ctx, 2, fmt.Sprintf("Executing %d resolvers", len(sol.Spec.Resolvers)))
-	result, err := execute.Resolvers(s.ctx, sol, params, reg, cfg)
+	progress.report(ctx, 2, fmt.Sprintf("Executing %d resolvers", len(sol.Spec.Resolvers)))
+	result, err := execute.Resolvers(ctx, sol, params, reg, cfg)
 	if err != nil {
 		return buildResolverExecutionError(err, sol), nil
 	}
 
-	progress.report(s.ctx, 3, "Building response")
+	progress.report(ctx, 3, "Building response")
 
 	// Build structured response with per-resolver details
 	type resolverPhaseInfo struct {
@@ -877,11 +931,28 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 	filter := request.GetString("filter", "")
 	tag := request.GetString("tag", "")
 	outputDir := request.GetString("output_dir", "")
+	cwd := request.GetString("cwd", "")
 	skipBuiltins := false
 	if sb, ok := request.GetArguments()["skip_builtins"]; ok {
 		if b, ok := sb.(bool); ok {
 			skipBuiltins = b
 		}
+	}
+
+	ctx, cwdErr := s.contextWithCwd(cwd)
+	if cwdErr != nil {
+		return newStructuredError(ErrCodeInvalidInput, cwdErr.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	// Resolve relative path against the working directory
+	path, err = provider.AbsFromContext(ctx, path)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve path: %v", err),
+			WithField("path"),
+		), nil
 	}
 
 	// Verify the path exists
@@ -949,12 +1020,12 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 	// Send progress notifications during test execution
 	progress := newProgressReporter(s, request)
 	progress.setTotal(float64(len(solutions) + 2))
-	progress.report(s.ctx, 1, fmt.Sprintf("Discovered %d solution(s) with tests", len(solutions)))
+	progress.report(ctx, 1, fmt.Sprintf("Discovered %d solution(s) with tests", len(solutions)))
 
 	// Execute tests
 	start := time.Now()
-	progress.report(s.ctx, 2, "Running tests...")
-	results, err := runner.Run(s.ctx, solutions)
+	progress.report(ctx, 2, "Running tests...")
+	results, err := runner.Run(ctx, solutions)
 	elapsed := time.Since(start)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("test execution failed: %v", err),
@@ -962,7 +1033,7 @@ func (s *Server) handleRunSolutionTests(_ context.Context, request mcp.CallToolR
 			WithRelatedTools("lint_solution", "inspect_solution"),
 		), nil
 	}
-	progress.report(s.ctx, float64(len(solutions)+2), fmt.Sprintf("Tests complete (%s)", elapsed.String()))
+	progress.report(ctx, float64(len(solutions)+2), fmt.Sprintf("Tests complete (%s)", elapsed.String()))
 
 	// Build structured response
 	summary := soltesting.Summarize(results)
@@ -1021,8 +1092,17 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 			WithSuggestion("Provide the path to a solution file"),
 		), nil
 	}
+	cwd := request.GetString("cwd", "")
 
-	sol, err := inspect.LoadSolution(s.ctx, path)
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	sol, err := inspect.LoadSolution(ctx, path)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
 			WithField("path"),

--- a/pkg/mcp/tools_testing.go
+++ b/pkg/mcp/tools_testing.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
@@ -29,6 +30,9 @@ func (s *Server) registerTestingTools() {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the solution file to generate tests for"),
+		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
 	s.mcpServer.AddTool(genTestTool, s.handleGenerateTestScaffold)
@@ -54,6 +58,9 @@ func (s *Server) registerTestingTools() {
 		mcp.WithBoolean("include_builtins",
 			mcp.Description("Include built-in tests (lint, parse). Default: false"),
 		),
+		mcp.WithString("cwd",
+			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
+		),
 	)
 	s.mcpServer.AddTool(listTestsTool, s.handleListTests)
 }
@@ -68,8 +75,17 @@ func (s *Server) handleGenerateTestScaffold(_ context.Context, request mcp.CallT
 			WithRelatedTools("inspect_solution"),
 		), nil
 	}
+	cwd := request.GetString("cwd", "")
 
-	sol, err := inspect.LoadSolution(s.ctx, path)
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	sol, err := inspect.LoadSolution(ctx, path)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load solution: %v", err),
 			WithField("path"),
@@ -164,6 +180,23 @@ func (s *Server) handleListTests(_ context.Context, request mcp.CallToolRequest)
 	path := request.GetString("path", ".")
 	filter := request.GetString("filter", "")
 	tag := request.GetString("tag", "")
+	cwd := request.GetString("cwd", "")
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	// Resolve relative path against the working directory
+	path, err = provider.AbsFromContext(ctx, path)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve path: %v", err),
+			WithField("path"),
+		), nil
+	}
 
 	solutions, err := soltesting.DiscoverSolutions(path)
 	if err != nil {

--- a/pkg/provider/builtin/metadataprovider/metadata.go
+++ b/pkg/provider/builtin/metadataprovider/metadata.go
@@ -96,8 +96,8 @@ func (p *MetadataProvider) Execute(ctx context.Context, _ any) (*provider.Output
 	// CLI arguments.
 	args := os.Args
 
-	// Current working directory.
-	cwd, _ := os.Getwd()
+	// Current working directory (context-aware).
+	cwd, _ := provider.GetWorkingDirectory(ctx)
 
 	// Entrypoint and command path from settings context.
 	entrypoint := "unknown"

--- a/pkg/provider/builtin/solutionprovider/context.go
+++ b/pkg/provider/builtin/solutionprovider/context.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 type ancestorStackKey struct{}
@@ -58,7 +60,7 @@ func CheckDepth(ctx context.Context, maxDepth int) error {
 
 // Canonicalize normalizes a source reference into a canonical name for ancestor tracking.
 // File paths are resolved to absolute paths, catalog references and URLs are used as-is.
-func Canonicalize(source string) string {
+func Canonicalize(ctx context.Context, source string) string {
 	// URLs - use as-is
 	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
 		return source
@@ -66,7 +68,7 @@ func Canonicalize(source string) string {
 
 	// Relative or absolute file paths - resolve to absolute
 	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") || strings.Contains(source, string(filepath.Separator)) {
-		abs, err := filepath.Abs(source)
+		abs, err := provider.AbsFromContext(ctx, source)
 		if err != nil {
 			return source // fallback to raw value
 		}

--- a/pkg/provider/builtin/solutionprovider/context_test.go
+++ b/pkg/provider/builtin/solutionprovider/context_test.go
@@ -137,7 +137,7 @@ func TestCanonicalize_URL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := Canonicalize(tt.input)
+			got := Canonicalize(context.Background(), tt.input)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -155,19 +155,19 @@ func TestCanonicalize_CatalogReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := Canonicalize(tt.input)
+			got := Canonicalize(context.Background(), tt.input)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func TestCanonicalize_AbsolutePath(t *testing.T) {
-	got := Canonicalize("/home/user/infra.yaml")
+	got := Canonicalize(context.Background(), "/home/user/infra.yaml")
 	assert.Equal(t, "/home/user/infra.yaml", got)
 }
 
 func TestCanonicalize_RelativePath(t *testing.T) {
-	got := Canonicalize("./child.yaml")
+	got := Canonicalize(context.Background(), "./child.yaml")
 	// Should be resolved to an absolute path
 	assert.True(t, len(got) > len("./child.yaml"), "expected absolute path, got: %s", got)
 	assert.NotEqual(t, "./child.yaml", got)

--- a/pkg/provider/builtin/solutionprovider/solution.go
+++ b/pkg/provider/builtin/solutionprovider/solution.go
@@ -97,7 +97,7 @@ func (p *SolutionProvider) Execute(ctx context.Context, input any) (*provider.Ou
 	lgr := logger.FromContext(ctx)
 
 	// Resolve canonical name for ancestor tracking.
-	canonicalName := Canonicalize(in.Source)
+	canonicalName := Canonicalize(ctx, in.Source)
 
 	// Check circular references — always a hard error regardless of propagateErrors.
 	ctx, err := PushAncestor(ctx, canonicalName)

--- a/pkg/provider/builtin/solutionprovider/solution_test.go
+++ b/pkg/provider/builtin/solutionprovider/solution_test.go
@@ -514,7 +514,7 @@ func TestExecute_CircularDetection(t *testing.T) {
 	// Simulate already being inside a.yaml by pushing it as an ancestor
 	ctx = WithAncestorStack(ctx, []string{})
 	var err error
-	ctx, err = PushAncestor(ctx, Canonicalize("./a.yaml"))
+	ctx, err = PushAncestor(ctx, Canonicalize(ctx, "./a.yaml"))
 	require.NoError(t, err)
 
 	// Now try to execute a.yaml again — should detect circular reference

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -20,6 +20,7 @@ const (
 	ioStreamsKey        contextKey = "scafctl.provider.ioStreams"
 	solutionMetadataKey contextKey = "scafctl.provider.solutionMetadata"
 	outputDirectoryKey  contextKey = "scafctl.provider.outputDirectory"
+	workingDirectoryKey contextKey = "scafctl.provider.workingDirectory"
 )
 
 // SolutionMeta holds solution metadata fields made available to providers via context.
@@ -62,6 +63,22 @@ func WithOutputDirectory(ctx context.Context, dir string) context.Context {
 // Returns the directory path and true if found, empty string and false otherwise.
 func OutputDirectoryFromContext(ctx context.Context) (string, bool) {
 	dir, ok := ctx.Value(outputDirectoryKey).(string)
+	return dir, ok
+}
+
+// WithWorkingDirectory returns a new context with the logical working directory attached.
+// When set, path resolution helpers use this directory instead of the process CWD
+// (os.Getwd). This allows callers—such as the MCP server or a --cwd CLI flag—to
+// control path resolution without mutating global process state.
+func WithWorkingDirectory(ctx context.Context, dir string) context.Context {
+	return context.WithValue(ctx, workingDirectoryKey, dir)
+}
+
+// WorkingDirectoryFromContext retrieves the logical working directory from the context.
+// Returns the directory path and true if found, empty string and false otherwise.
+// When not set, callers should fall back to os.Getwd().
+func WorkingDirectoryFromContext(ctx context.Context) (string, bool) {
+	dir, ok := ctx.Value(workingDirectoryKey).(string)
 	return dir, ok
 }
 

--- a/pkg/provider/path.go
+++ b/pkg/provider/path.go
@@ -18,7 +18,9 @@ import (
 //   - The execution mode is CapabilityAction
 //   - An output directory is set in the context
 //
-// Otherwise, the path is resolved against the current working directory via filepath.Abs.
+// Otherwise, the path is resolved against the context working directory (set via
+// WithWorkingDirectory), falling back to the process CWD when no context directory
+// is set.
 //
 // When resolving against an output directory, the result is validated to ensure it
 // does not escape the output directory via parent traversal (e.g., "../../../etc/passwd").
@@ -38,6 +40,51 @@ func ResolvePath(ctx context.Context, path string) (string, error) {
 		}
 	}
 
+	return AbsFromContext(ctx, path)
+}
+
+// GetWorkingDirectory returns the effective working directory from the context.
+// It checks the context for a logical working directory first (set via
+// WithWorkingDirectory), then falls back to the process CWD via os.Getwd().
+func GetWorkingDirectory(ctx context.Context) (string, error) {
+	if cwd, ok := WorkingDirectoryFromContext(ctx); ok && cwd != "" {
+		return cwd, nil
+	}
+	return os.Getwd()
+}
+
+// ValidateDirectory resolves a directory path to an absolute path and validates
+// that it exists and is a directory. Returns the resolved absolute path or an error.
+func ValidateDirectory(dir string) (string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving path %q: %w", dir, err)
+	}
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return "", fmt.Errorf("directory %q does not exist: %w", absDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path %q is not a directory", absDir)
+	}
+	return absDir, nil
+}
+
+// AbsFromContext resolves a relative path to an absolute path using the context
+// working directory. If no working directory is set in the context, it falls back
+// to filepath.Abs (which uses os.Getwd()).
+//
+// Note: this function does NOT perform path containment/traversal validation.
+// If the caller needs to restrict resolved paths within a specific directory,
+// use ResolvePath (which validates containment for output directories) or
+// perform additional checks after calling this function.
+func AbsFromContext(ctx context.Context, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	if cwd, ok := WorkingDirectoryFromContext(ctx); ok && cwd != "" {
+		return filepath.Join(cwd, path), nil
+	}
 	return filepath.Abs(path)
 }
 

--- a/pkg/provider/path_test.go
+++ b/pkg/provider/path_test.go
@@ -281,3 +281,169 @@ func BenchmarkResolvePath_TraversalRejection(b *testing.B) {
 		_, _ = ResolvePath(ctx, "../../../etc/passwd")
 	}
 }
+
+// ── AbsFromContext tests ──
+
+func TestAbsFromContext_NoContextCWD(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := AbsFromContext(ctx, "relative/path.txt")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(cwd, "relative/path.txt"), result)
+}
+
+func TestAbsFromContext_WithContextCWD(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/custom/cwd")
+
+	result, err := AbsFromContext(ctx, "relative/path.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/cwd/relative/path.txt", result)
+}
+
+func TestAbsFromContext_AbsolutePathIgnoresContextCWD(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/custom/cwd")
+
+	result, err := AbsFromContext(ctx, "/absolute/path.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/absolute/path.txt", result)
+}
+
+func TestAbsFromContext_EmptyContextCWDFallsBack(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "")
+
+	result, err := AbsFromContext(ctx, "relative/path.txt")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(cwd, "relative/path.txt"), result)
+}
+
+// ── GetWorkingDirectory tests ──
+
+func TestGetWorkingDirectory_NoContext(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := GetWorkingDirectory(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, cwd, result)
+}
+
+func TestGetWorkingDirectory_WithContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/custom/cwd")
+
+	result, err := GetWorkingDirectory(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/cwd", result)
+}
+
+// ── ResolvePath with context CWD tests ──
+
+func TestResolvePath_WithContextCWD(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/custom/cwd")
+
+	result, err := ResolvePath(ctx, "subdir/file.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/cwd/subdir/file.txt", result)
+}
+
+func TestResolvePath_ActionModeOutputDirTakesPrecedenceOverContextCWD(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/custom/cwd")
+	ctx = WithExecutionMode(ctx, CapabilityAction)
+	ctx = WithOutputDirectory(ctx, "/output/dir")
+
+	result, err := ResolvePath(ctx, "subdir/file.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/output/dir/subdir/file.txt", result)
+}
+
+// ── WorkingDirectory context round-trip tests ──
+
+func TestWorkingDirectoryFromContext_NotSet(t *testing.T) {
+	ctx := context.Background()
+	dir, ok := WorkingDirectoryFromContext(ctx)
+	assert.False(t, ok)
+	assert.Empty(t, dir)
+}
+
+func TestWorkingDirectoryFromContext_Set(t *testing.T) {
+	ctx := WithWorkingDirectory(context.Background(), "/my/dir")
+	dir, ok := WorkingDirectoryFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "/my/dir", dir)
+}
+
+// ── Benchmarks for context CWD ──
+
+func BenchmarkAbsFromContext_WithCWD(b *testing.B) {
+	ctx := WithWorkingDirectory(context.Background(), "/custom/cwd")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = AbsFromContext(ctx, "relative/path.txt")
+	}
+}
+
+func BenchmarkAbsFromContext_NoCWD(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = AbsFromContext(ctx, "relative/path.txt")
+	}
+}
+
+func BenchmarkGetWorkingDirectory_WithCWD(b *testing.B) {
+	ctx := WithWorkingDirectory(context.Background(), "/custom/cwd")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = GetWorkingDirectory(ctx)
+	}
+}
+
+// ── ValidateDirectory tests ──
+
+func TestValidateDirectory_Valid(t *testing.T) {
+	dir := t.TempDir()
+	result, err := ValidateDirectory(dir)
+	require.NoError(t, err)
+	assert.Equal(t, dir, result)
+}
+
+func TestValidateDirectory_NonExistent(t *testing.T) {
+	_, err := ValidateDirectory("/nonexistent-dir-12345")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestValidateDirectory_FileNotDir(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+
+	_, err := ValidateDirectory(f)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestValidateDirectory_RelativePath(t *testing.T) {
+	// A relative path should be resolved to absolute
+	result, err := ValidateDirectory(".")
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(result))
+}
+
+func BenchmarkValidateDirectory(b *testing.B) {
+	dir := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ValidateDirectory(dir)
+	}
+}

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
@@ -336,7 +335,7 @@ func Actions(
 	// the context for action-mode providers. Only create the directory when
 	// not in dry-run mode to avoid filesystem side effects.
 	if cfg.OutputDir != "" {
-		absDir, err := filepath.Abs(cfg.OutputDir)
+		absDir, err := provider.AbsFromContext(ctx, cfg.OutputDir)
 		if err != nil {
 			return nil, fmt.Errorf("resolving output directory: %w", err)
 		}
@@ -360,6 +359,8 @@ func Actions(
 	}
 	if cfg.Cwd != "" {
 		executorOpts = append(executorOpts, action.WithCwd(cfg.Cwd))
+	} else if cwd, ok := provider.WorkingDirectoryFromContext(ctx); ok && cwd != "" {
+		executorOpts = append(executorOpts, action.WithCwd(cwd))
 	}
 
 	executor := action.NewExecutor(executorOpts...)

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/fs"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
@@ -363,6 +364,16 @@ func (o *Getter) fromCatalog(ctx context.Context, nameWithVersion string) (*solu
 func (o *Getter) FromLocalFileSystem(ctx context.Context, path string) (*solution.Solution, error) {
 	if o.readFile == nil {
 		o.readFile = os.ReadFile
+	}
+
+	// Resolve relative paths against the context working directory (--cwd flag)
+	// so that callers don't need to resolve paths before calling this method.
+	if !pathlib.IsAbs(path) {
+		resolved, err := provider.AbsFromContext(ctx, path)
+		if err != nil {
+			return &solution.Solution{}, fmt.Errorf("resolving solution path %q: %w", path, err)
+		}
+		path = resolved
 	}
 
 	_, span := telemetry.Tracer(telemetry.TracerSolution).Start(ctx, "solution.FromLocalFileSystem",

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6006,3 +6006,64 @@ func TestIntegration_Snapshot_Help(t *testing.T) {
 	assert.Contains(t, stdout, "show")
 	assert.Contains(t, stdout, "diff")
 }
+
+// ============================================================================
+// CWD Flag Tests
+// ============================================================================
+
+func TestIntegration_CwdFlag_ResolvesRelativePath(t *testing.T) {
+	t.Parallel()
+	// Run from a different directory with --cwd pointing to project root,
+	// using a relative solution path that only makes sense from the project root.
+	projectRoot := findProjectRoot()
+
+	// Use --cwd to set the working directory to the project root,
+	// while the process CWD is a temp directory
+	tmpDir := t.TempDir()
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir,
+		"--cwd", projectRoot,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode, "stderr: %s\nstdout: %s", stderr, stdout)
+	// The JSON output should contain resolver results
+	assert.Contains(t, stdout, "environment")
+}
+
+func TestIntegration_CwdFlag_NonExistentDir(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "--cwd", "/nonexistent-dir-12345", "version")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not exist")
+}
+
+func TestIntegration_CwdFlag_FileNotDir(t *testing.T) {
+	t.Parallel()
+	// Create a temp file (not directory)
+	tmpFile := filepath.Join(t.TempDir(), "notadir.txt")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("hello"), 0o644))
+
+	_, stderr, exitCode := runScafctl(t, "--cwd", tmpFile, "version")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "not a directory")
+}
+
+func TestIntegration_CwdFlag_ShortFlag(t *testing.T) {
+	t.Parallel()
+	// The -C short flag should work the same as --cwd
+	projectRoot := findProjectRoot()
+	tmpDir := t.TempDir()
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir,
+		"-C", projectRoot,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode, "stderr: %s\nstdout: %s", stderr, stdout)
+	assert.Contains(t, stdout, "environment")
+}

--- a/tests/integration/solutions/cwd/local-data.txt
+++ b/tests/integration/solutions/cwd/local-data.txt
@@ -1,0 +1,1 @@
+content from local-data.txt

--- a/tests/integration/solutions/cwd/solution.yaml
+++ b/tests/integration/solutions/cwd/solution.yaml
@@ -1,0 +1,59 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: cwd-integration
+  version: 1.0.0
+  description: |
+    Integration test for the --cwd flag.
+    Verifies that relative paths resolve against the --cwd directory
+    instead of the process CWD.
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting for basic resolver verification
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello from cwd test
+
+    local-file:
+      description: Read a file relative to the working directory
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: local-data.txt
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      resolver-basic:
+        description: Verify resolvers execute correctly
+        command: [run, resolver]
+        args: ["-o", "json"]
+        files: ["local-data.txt"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "Hello from cwd test"
+
+      resolver-reads-local-file:
+        description: Verify file provider reads from the working directory
+        command: [run, resolver]
+        args: ["-o", "json"]
+        files: ["local-data.txt"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "content from local-data.txt"
+
+      lint-passes:
+        description: Verify solution passes lint
+        command: [lint]
+        files: ["local-data.txt"]
+        assertions:
+          - expression: __exitCode == 0


### PR DESCRIPTION
…rectory override

Introduces a context-safe working directory override that allows callers to control path resolution without mutating global process state via os.Chdir. This is safe for concurrent MCP requests and mirrors the familiar 'git -C' flag interface.

### Core infrastructure (pkg/provider)
- Add WithWorkingDirectory / WorkingDirectoryFromContext context helpers
- Add GetWorkingDirectory(ctx) — falls back to os.Getwd when not set
- Add AbsFromContext(ctx, path) — resolves relative paths against context CWD, falling back to filepath.Abs
- Add ValidateDirectory(dir) — resolves and validates a directory exists
- Update ResolvePath to use AbsFromContext instead of filepath.Abs
- Add tests and benchmarks for all new helpers

### CLI (--cwd / -C flag)
- Register persistent --cwd / -C flag on the root command (similar to git -C)
- Validate the flag value with ValidateDirectory and inject into context via WithWorkingDirectory before any command executes
- Update run solution, run provider, build solution, build plugin, and vendor update to use AbsFromContext for all path resolution

### MCP server (cwd parameter)
- Add contextWithCwd helper on Server for per-request CWD injection
- Add optional 'cwd' parameter to all path-accepting tools: preview_action, dry_run_solution, render_solution, preview_resolvers, run_solution_tests, generate_test_scaffold, list_tests, build_plugin, show_snapshot, diff_snapshots, inspect_solution, lint_solution, get_run_command, diff_solution, extract_resolver_refs
- Propagate cwd-enriched context through all downstream calls, replacing s.ctx with the per-request ctx

### Path resolution consistency
- catalog.ReadPlatformBinaries now accepts ctx for CWD-aware path resolution
- solution/get.Getter.FromLocalFileSystem resolves relative paths via AbsFromContext before stat/load
- solution/execute.Actions uses AbsFromContext for output directory resolution and propagates context CWD to the action executor
- solutionprovider.Canonicalize accepts ctx for CWD-aware ancestor tracking
- metadataprovider uses GetWorkingDirectory(ctx) instead of os.Getwd

### Tests and examples
- CLI integration tests: cwd flag resolves relative paths, rejects non-existent dirs and files, short -C flag works
- Integration test solution at tests/integration/solutions/cwd/ validates file provider reads from the --cwd directory
- Example solution at examples/solutions/cwd/ demonstrates the feature

### Documentation
- New design doc: docs/design/cwd.md
- Updated tutorials: actions, dryrun, functional-testing, mcp-server, run-resolver all include --cwd usage examples
- Updated mcp-server.md and mcp-server-implementation-guide.md
