### PR TITLE
feat(run): positional key=value inputs, input validation, and dynamic…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ All notable changes to this project will be documented in this file.
 - *(deps)* Bump github.com/oakwood-commons/kvx from 0.4.0 to 0.6.0 (#92)
 - *(deps)* Bump goreleaser/goreleaser-action from 6 to 7 (#91)
 
+### 🚜 Refactor
+
+- [**breaking**] Remove all deprecated wrappers, aliases, and dead code (#117)
+  - Delete `pkg/cmd/scafctl/resolver/` package; use `run resolver` instead
+  - Delete forwarding wrappers in `pkg/cmd/scafctl/run/common.go`; callers use `pkg/solution/execute` directly
+  - Delete `pkg/cmd/scafctl/secrets/validation.go`; callers use `pkg/secrets` and `pkg/secrets/crypto` directly
+  - Delete type aliases from `cache/info.go`, `cache/clear.go`, `config/paths.go`, `get/resolver/refs.go`; callers use domain packages (`pkg/cache`, `pkg/paths`, `pkg/resolver/refs`)
+  - Remove deprecated wrappers from `get/celfunction/celfunction.go`; callers use `pkg/provider/detail` directly
+  - Delete dead `fallbackKeyring` struct from `pkg/secrets/keyring.go`
+  - Rename `ProviderDescriptor.Deprecated` → `ProviderDescriptor.IsDeprecated` (JSON tag `deprecated` preserved for wire compatibility)
+
 ### 🧪 Testing
 
 - Add solution integration tests for exclusive actions, forEach f… (#83)

--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -658,6 +658,25 @@ Supported formats:
 - `@file.yaml` - Load from file
 - `"key=value with spaces"` - Quoted values
 
+### Validating Input Keys Against a Schema
+
+When a command accepts dynamic `key=value` inputs and has a known set of valid keys
+(e.g. from a provider's JSON Schema or a solution's parameter resolvers), use
+`flags.ValidateInputKeys` for early detection of typos:
+
+```go
+import "github.com/oakwood-commons/scafctl/pkg/flags"
+
+// After parsing inputs and looking up valid keys
+validKeys := []string{"url", "method", "headers", "body", "timeout"}
+if err := flags.ValidateInputKeys(inputs, validKeys, `provider "http"`); err != nil {
+    // Error: provider "http" does not accept input "urll" — did you mean "url"?
+    return err
+}
+```
+
+This uses Levenshtein distance to suggest the closest valid key when a typo is detected.
+
 ### Hidden Flags
 
 ```go

--- a/docs/tutorials/auto-discovery-tutorial.md
+++ b/docs/tutorials/auto-discovery-tutorial.md
@@ -1,0 +1,209 @@
+---
+title: "Auto-Discovery Tutorial"
+weight: 88
+---
+
+# Auto-Discovery Tutorial
+
+This tutorial explains how scafctl automatically discovers solution files, making the `-f` flag optional for most commands.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with YAML syntax and solution files
+- Completion of the [Getting Started](../getting-started/) tutorial
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [How Auto-Discovery Works](#how-auto-discovery-works)
+3. [Search Order](#search-order)
+4. [Supported Commands](#supported-commands)
+5. [Examples](#examples)
+6. [Interaction with `--cwd`](#interaction-with---cwd)
+7. [When Auto-Discovery Fails](#when-auto-discovery-fails)
+8. [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+Many scafctl commands accept a `-f` / `--file` flag to specify the solution file path. When this flag is omitted, scafctl searches the current directory (or the `--cwd` target) for a solution file using a well-defined search order.
+
+This means you can simply `cd` into a project directory and run commands without specifying the file:
+
+```bash
+# Instead of:
+scafctl run solution -f solution.yaml
+
+# Just run:
+scafctl run solution
+```
+
+## How Auto-Discovery Works
+
+When no `-f` flag is provided, scafctl calls `FindSolution()`, which iterates over a set of **folder prefixes** and **file names** in order, returning the first match.
+
+### Search Order
+
+The search combines these folder prefixes with these file names:
+
+**Folder prefixes** (checked in order):
+1. `scafctl/` — conventional project subfolder
+2. `.scafctl/` — hidden project subfolder
+3. *(current directory)* — no subfolder prefix
+
+**File names** (checked in order for each folder):
+1. `solution.yaml`
+2. `solution.yml`
+3. `scafctl.yaml`
+4. `scafctl.yml`
+5. `solution.json`
+6. `scafctl.json`
+
+This produces 18 candidate paths checked in this exact order:
+
+| Priority | Path |
+|----------|------|
+| 1 | `scafctl/solution.yaml` |
+| 2 | `scafctl/solution.yml` |
+| 3 | `scafctl/scafctl.yaml` |
+| 4 | `scafctl/scafctl.yml` |
+| 5 | `scafctl/solution.json` |
+| 6 | `scafctl/scafctl.json` |
+| 7 | `.scafctl/solution.yaml` |
+| 8 | `.scafctl/solution.yml` |
+| 9 | `.scafctl/scafctl.yaml` |
+| 10 | `.scafctl/scafctl.yml` |
+| 11 | `.scafctl/solution.json` |
+| 12 | `.scafctl/scafctl.json` |
+| 13 | `solution.yaml` |
+| 14 | `solution.yml` |
+| 15 | `scafctl.yaml` |
+| 16 | `scafctl.yml` |
+| 17 | `solution.json` |
+| 18 | `scafctl.json` |
+
+The first file that exists on disk is used.
+
+## Supported Commands
+
+Auto-discovery works with every command that accepts `-f`:
+
+| Command | Auto-Discovery | Notes |
+|---------|:--------------:|-------|
+| `scafctl run solution` | ✅ | Also supports catalog bare names and URLs |
+| `scafctl run resolver` | ✅ | Falls back to auto-discovery when `-f` is omitted |
+| `scafctl lint` | ✅ | Discovers and lints the local solution |
+| `scafctl render solution` | ✅ | Discovers solution for rendering |
+| `scafctl test functional` | ✅ | Discovers solution to run functional tests |
+| `scafctl test list` | ✅ | Discovers solution to list test cases |
+| `scafctl test init` | ✅ | Discovers solution to generate test scaffold |
+| `scafctl plugins install` | ✅ | Discovers solution to install referenced plugins |
+
+## Examples
+
+### Basic Usage — Run in Project Directory
+
+```bash
+# Given this project structure:
+# my-project/
+# ├── solution.yaml
+# └── templates/
+#     └── config.yaml.tpl
+
+cd my-project
+scafctl run solution          # discovers ./solution.yaml
+scafctl lint                  # discovers ./solution.yaml
+scafctl test functional       # discovers ./solution.yaml
+```
+
+### Conventional Subfolder
+
+```bash
+# Given this project structure:
+# my-project/
+# ├── scafctl/
+# │   └── solution.yaml
+# └── src/
+#     └── main.go
+
+cd my-project
+scafctl run solution          # discovers ./scafctl/solution.yaml
+```
+
+### Hidden Subfolder
+
+```bash
+# Given this project structure:
+# my-project/
+# ├── .scafctl/
+# │   └── solution.yaml
+# └── README.md
+
+cd my-project
+scafctl lint                  # discovers ./.scafctl/solution.yaml
+```
+
+### Explicit `-f` Overrides Discovery
+
+When you specify `-f`, auto-discovery is skipped entirely:
+
+```bash
+# Use a specific file regardless of what's in the current directory
+scafctl run solution -f path/to/other-solution.yaml
+
+# Use stdin
+cat solution.yaml | scafctl lint -f -
+
+# Use a URL
+scafctl run solution -f https://example.com/solution.yaml
+
+# Use a catalog name
+scafctl run solution -f my-solution@1.0.0
+```
+
+## Interaction with `--cwd`
+
+When `--cwd` is set, auto-discovery searches relative to the specified directory instead of the process working directory:
+
+```bash
+# Discover solution inside another directory
+scafctl run solution --cwd /path/to/project
+
+# This is equivalent to:
+cd /path/to/project && scafctl run solution
+```
+
+All 18 candidate paths are resolved against the `--cwd` target.
+
+## When Auto-Discovery Fails
+
+If no solution file is found, scafctl returns a clear error:
+
+```
+Error: no solution path provided and no solution file found in default locations
+```
+
+Common causes:
+- You're not in the correct directory
+- The solution file has a non-standard name (use `-f` to specify it)
+- The `--cwd` flag points to the wrong directory
+
+You can see the candidate paths scafctl checks with:
+
+```bash
+scafctl config paths
+```
+
+## Best Practices
+
+1. **Use `solution.yaml` at the project root** — this is the most common convention and is discovered without any subfolder prefix.
+
+2. **Use `scafctl/` subfolder for multi-tool repos** — keeps scafctl configuration separate from other tools.
+
+3. **Use `.scafctl/` for hidden configuration** — useful when the solution is infrastructure that shouldn't be front-and-center.
+
+4. **Always use `-f` in CI/CD** — explicit paths prevent surprises when the working directory changes.
+
+5. **Combine with `--cwd` for monorepos** — target a specific project without changing directories.

--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -287,6 +287,61 @@ scafctl config set build.enableCache false
 scafctl config set build.autoCacheRemoteArtifacts false
 ```
 
+## Artifact Cache TTL
+
+The artifact cache supports a time-to-live (TTL) setting that controls how long cached catalog artifacts remain valid. When an artifact's age exceeds the configured TTL, it is treated as a cache miss and is re-fetched from the catalog.
+
+### How TTL Works
+
+1. When a catalog artifact is fetched, scafctl stores it on disk along with creation-time metadata
+2. On subsequent requests, scafctl checks the artifact's age against the configured TTL
+3. If the artifact is older than the TTL, it is considered expired and re-fetched
+4. A TTL of zero (the default) means artifacts never expire
+
+### Configuring TTL
+
+Set the artifact cache TTL in the scafctl config file:
+
+```yaml
+catalog:
+  cacheTTL: 10m    # Artifacts expire after 10 minutes
+```
+
+Common TTL values:
+
+| Value | Meaning |
+|-------|---------|
+| `0` | Never expire (default) |
+| `5m` | 5 minutes |
+| `1h` | 1 hour |
+| `24h` | 1 day |
+| `168h` | 1 week |
+
+Set via CLI:
+
+```bash
+# Set a 1-hour TTL for artifact cache
+scafctl config set catalog.cacheTTL 1h
+
+# Disable TTL (never expire)
+scafctl config set catalog.cacheTTL 0
+```
+
+### When to Use TTL
+
+- **Active development**: Use a short TTL (e.g., `5m`) to pick up frequent catalog updates
+- **CI/CD pipelines**: Use a moderate TTL (e.g., `1h`) to balance freshness with performance
+- **Stable environments**: Use zero TTL or a long TTL (e.g., `168h`) for maximum cache benefit
+- **Offline use**: Use zero TTL so previously fetched artifacts remain available indefinitely
+
+### Manually Clearing Expired Artifacts
+
+Even with a TTL configured, expired artifacts remain on disk until replaced. To reclaim disk space:
+
+```bash
+scafctl cache clear --kind build --force
+```
+
 ## Next Steps
 
 - [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/docs/tutorials/hcl-provider-tutorial.md
+++ b/docs/tutorials/hcl-provider-tutorial.md
@@ -960,25 +960,25 @@ You can also run the HCL provider directly from the command line:
 
 ```bash
 # Parse a file
-scafctl run provider hcl --input path=./main.tf -o json
+scafctl run provider hcl path=./main.tf -o json
 
 # Parse a directory
-scafctl run provider hcl --input dir=./terraform -o json
+scafctl run provider hcl dir=./terraform -o json
 
 # Format inline HCL
-scafctl run provider hcl --input operation=format --input 'content=variable "x" { type=string }' -o json
+scafctl run provider hcl operation=format 'content=variable "x" { type=string }' -o json
 
 # Format a file
-scafctl run provider hcl --input operation=format --input path=./main.tf -o json
+scafctl run provider hcl operation=format path=./main.tf -o json
 
 # Format all files in a directory
-scafctl run provider hcl --input operation=format --input dir=./terraform -o json
+scafctl run provider hcl operation=format dir=./terraform -o json
 
 # Validate a file
-scafctl run provider hcl --input operation=validate --input path=./main.tf -o json
+scafctl run provider hcl operation=validate path=./main.tf -o json
 
 # Validate a directory
-scafctl run provider hcl --input operation=validate --input dir=./terraform -o json
+scafctl run provider hcl operation=validate dir=./terraform -o json
 ```
 
 {{< tabs "hcl-file-input" >}}
@@ -997,13 +997,13 @@ scafctl run provider hcl --input '@examples/providers/hcl-format.yaml' -o json
 {{< /tabs >}}
 
 ```bash
-scafctl run provider hcl --input path=./main.tf --dry-run
+scafctl run provider hcl path=./main.tf --dry-run
 
 # Dry run (format)
-scafctl run provider hcl --input operation=format --input path=./main.tf --dry-run
+scafctl run provider hcl operation=format path=./main.tf --dry-run
 
 # Dry run (validate)
-scafctl run provider hcl --input operation=validate --input path=./main.tf --dry-run
+scafctl run provider hcl operation=validate path=./main.tf --dry-run
 ```
 
 Dry-run returns an empty structure without reading or modifying anything. For `parse`:

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -28,18 +28,24 @@ This tutorial covers the `scafctl run provider` command — a tool for executing
 
 ## Basic Usage
 
-The `scafctl run provider` command takes a provider name as its only positional argument and provider inputs via `--input` flags.
+The `scafctl run provider` command takes a provider name as its first argument. Provider inputs can be passed as positional `key=value` arguments or via the traditional `--input` flag:
 
 ```bash
+# Positional key=value (recommended)
+scafctl run provider <provider-name> <key>=<value>
+
+# Explicit --input flag
 scafctl run provider <provider-name> --input <key>=<value>
 ```
+
+Both forms can be mixed freely. When the same key appears multiple times, later values override earlier ones.
 
 ### Your First Provider Execution
 
 Run the `static` provider to return a simple value:
 
 ```bash
-scafctl run provider static --input value=hello
+scafctl run provider static value=hello
 ```
 
 Output:
@@ -56,11 +62,15 @@ The output always contains a `data` field with the provider's return value. Addi
 
 ## Passing Inputs
 
-Inputs are passed using `--input` flags. Multiple inputs can be specified by repeating the flag.
+Inputs can be passed as positional `key=value` arguments or via the `--input` flag. Both forms can be combined.
 
 ### Simple Key-Value Pairs
 
 ```bash
+# Positional key=value (recommended)
+scafctl run provider http url=https://httpbin.org/get method=GET
+
+# Explicit --input flag
 scafctl run provider http --input url=https://httpbin.org/get --input method=GET
 ```
 
@@ -84,7 +94,7 @@ Output:
 Comma-separated values are automatically converted to arrays:
 
 ```bash
-scafctl run provider exec --input command=echo --input args=hello,world
+scafctl run provider exec command=echo args=hello,world
 ```
 
 ### Values Containing Commas
@@ -94,7 +104,7 @@ quotes inside the flag value. Use single quotes around the entire flag to preven
 shell interpretation:
 
 ```bash
-scafctl run provider cel --input 'expression="[1,2,3].map(x, x * 2)"'
+scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
 ```
 
 ### Multiple Values for the Same Key
@@ -102,7 +112,7 @@ scafctl run provider cel --input 'expression="[1,2,3].map(x, x * 2)"'
 Repeating the same key creates an array:
 
 ```bash
-scafctl run provider exec --input command=echo --input args=hello --input args=world
+scafctl run provider exec command=echo args=hello args=world
 ```
 
 ---
@@ -160,17 +170,43 @@ that key from the file:
 {{< tabs "runprov-mixed-input" >}}
 {{< tab "Bash" >}}
 ```bash
-scafctl run provider http --input @inputs.yaml --input timeout=30
+scafctl run provider http --input @inputs.yaml timeout=30
 ```
 {{< /tab >}}
 {{< tab "PowerShell" >}}
 ```powershell
-scafctl run provider http --input '@inputs.yaml' --input timeout=30
+scafctl run provider http --input '@inputs.yaml' timeout=30
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
 This loads all values from `inputs.yaml` and adds `timeout=30`.
+
+---
+
+## Input Key Validation
+
+When you pass inputs, scafctl validates the input keys against the provider's
+schema. Unknown keys are rejected early with a helpful error message. If the
+key is close to a valid one (a likely typo), a suggestion is included:
+
+```bash
+# Typo in key name
+scafctl run provider http urll=https://example.com
+# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: body, headers, method, timeout, url)
+
+# Completely unknown key
+scafctl run provider http unknown=value
+# Error: provider "http" does not accept input "unknown" (valid inputs: body, headers, method, timeout, url)
+```
+
+This validation also applies to resolver and solution parameters:
+
+```bash
+# Typo in parameter name
+scafctl run resolver -f solution.yaml envrionment=prod
+# Error: solution does not accept input "envrionment" — did you mean "environment"? (valid inputs: environment, region)
+```
 
 ---
 
@@ -190,7 +226,7 @@ By default, `scafctl run provider` uses the provider's first declared capability
 
 ```bash
 # Run a provider with a specific capability
-scafctl run provider cel --input expression="1 + 2" --capability transform
+scafctl run provider cel expression="1 + 2" --capability transform
 ```
 
 ### Viewing Available Capabilities
@@ -208,7 +244,7 @@ scafctl get provider cel
 Use `--dry-run` to see what would be executed without actually running the provider:
 
 ```bash
-scafctl run provider http --input url=https://example.com --dry-run
+scafctl run provider http url=https://example.com --dry-run
 ```
 
 The provider will return simulated output without performing any side effects (no HTTP request, no command execution, etc.).
@@ -221,16 +257,16 @@ The default output format is JSON. Use `-o` to change it:
 
 ```bash
 # JSON output (default)
-scafctl run provider static --input value=hello -o json
+scafctl run provider static value=hello -o json
 
 # YAML output
-scafctl run provider static --input value=hello -o yaml
+scafctl run provider static value=hello -o yaml
 
 # Table output
-scafctl run provider static --input value=hello -o table
+scafctl run provider static value=hello -o table
 
 # Quiet mode (exit code only)
-scafctl run provider static --input value=hello -o quiet
+scafctl run provider static value=hello -o quiet
 ```
 
 ### Interactive Mode
@@ -257,12 +293,12 @@ Filter or transform output using CEL expressions:
 {{< tabs "runprov-cel-expr" >}}
 {{< tab "Bash" >}}
 ```bash
-scafctl run provider http --input url=https://httpbin.org/get -e "_.data"
+scafctl run provider http url=https://httpbin.org/get -e "_.data"
 ```
 {{< /tab >}}
 {{< tab "PowerShell" >}}
 ```powershell
-scafctl run provider http --input url=https://httpbin.org/get -e '_.data'
+scafctl run provider http url=https://httpbin.org/get -e '_.data'
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -272,7 +308,7 @@ scafctl run provider http --input url=https://httpbin.org/get -e '_.data'
 Use `--show-metrics` to display timing information:
 
 ```bash
-scafctl run provider http --input url=https://httpbin.org/get --show-metrics
+scafctl run provider http url=https://httpbin.org/get --show-metrics
 ```
 
 ---
@@ -283,10 +319,10 @@ Load providers from plugin executables using `--plugin-dir`:
 
 ```bash
 # Load plugins from a directory
-scafctl run provider echo --input message=hello --plugin-dir ./plugins
+scafctl run provider echo message=hello --plugin-dir ./plugins
 
 # Multiple plugin directories
-scafctl run provider my-plugin --input key=value --plugin-dir ./plugins --plugin-dir /opt/plugins
+scafctl run provider my-plugin key=value --plugin-dir ./plugins --plugin-dir /opt/plugins
 ```
 
 See the [Provider Development Guide](provider-development.md) for creating custom providers (including [plugin delivery](provider-development.md#delivering-as-a-plugin)).
@@ -309,6 +345,33 @@ scafctl get provider http
 
 This shows the provider's schema, capabilities, examples, and auto-generated CLI usage examples.
 
+### Dynamic Help for Provider Inputs
+
+When you run `--help` with a specific provider name, the help output automatically includes the provider's input parameters with types, required/optional status, defaults, and descriptions:
+
+```bash
+scafctl run provider http --help
+```
+
+At the end of the standard help text, you'll see a section like:
+
+```
+Provider Inputs (http):
+  body     string               Request body for POST/PUT/PATCH requests
+  headers  any                  HTTP headers as key-value pairs
+  method   string               HTTP method
+  timeout  integer              Request timeout in seconds
+  url      string   (required)  The URL to request
+```
+
+This works for any provider — just include the provider name before `--help`:
+
+```bash
+scafctl run provider env --help
+scafctl run provider static --help
+scafctl run provider file --help
+```
+
 ### Filter by Capability
 
 ```bash
@@ -328,53 +391,53 @@ scafctl get providers -i
 ### Read an Environment Variable
 
 ```bash
-scafctl run provider env --input operation=get --input name=HOME
+scafctl run provider env operation=get name=HOME
 ```
 
 ### Execute a Shell Command
 
 ```bash
-scafctl run provider exec --input command=date
+scafctl run provider exec command=date
 ```
 
 ### Read a File
 
 ```bash
-scafctl run provider file --input operation=read --input path=README.md
+scafctl run provider file operation=read path=README.md
 ```
 
 ### List a Directory
 
 ```bash
-scafctl run provider directory --input operation=list --input path=./pkg
+scafctl run provider directory operation=list path=./pkg
 ```
 
 ### Evaluate a CEL Expression
 
 ```bash
 # Simple expression (no commas)
-scafctl run provider cel --input expression="1 + 2"
+scafctl run provider cel expression="1 + 2"
 
 # Expressions with commas must be quoted to avoid CSV splitting
-scafctl run provider cel --input 'expression="[1,2,3].map(x, x * 2)"'
+scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
 ```
 
 ### Make an HTTP Request
 
 ```bash
-scafctl run provider http --input url=https://httpbin.org/get --input method=GET
+scafctl run provider http url=https://httpbin.org/get method=GET
 ```
 
 ### Get Git Repository Status
 
 ```bash
-scafctl run provider git --input operation=status --input path=.
+scafctl run provider git operation=status path=.
 ```
 
 ### Render a Go Template
 
 ```bash
-scafctl run provider go-template --input name=greeting --input 'template=Hello World'
+scafctl run provider go-template name=greeting 'template=Hello World'
 ```
 
 ### Redact Sensitive Output
@@ -383,7 +446,7 @@ Use `--redact` to mask sensitive values in the output. This example retrieves
 a secret (which must already exist in the scafctl secrets store):
 
 ```bash
-scafctl run provider secret --input operation=get --input name=my-secret --redact
+scafctl run provider secret operation=get name=my-secret --redact
 ```
 
 ---

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -705,33 +705,76 @@ This lets you progressively narrow down which resolver is producing unexpected o
 
 ## Working with Parameters
 
-Pass parameters using `-r` flags, just like with `run solution`:
+Parameters can be passed in two equivalent ways:
+
+1. **Positional `key=value`** (recommended) — after resolver names or on their own
+2. **Explicit `-r` flag** — repeatable flag for each parameter
+
+Both forms can be mixed freely.
 
 {{< tabs "runres-params" >}}
 {{< tab "Bash" >}}
 ```bash
-# Key-value parameter
+# Positional key=value syntax (recommended)
+scafctl run resolver -f parameterized.yaml env=staging
+
+# Load parameters from file (positional)
+scafctl run resolver -f parameterized.yaml @params.yaml
+
+# Multiple positional parameters
+scafctl run resolver -f parameterized.yaml env=prod region=us-east1
+
+# Mix resolver names and parameters — bare words are names, key=value are params
+scafctl run resolver db auth -f parameterized.yaml env=prod
+
+# Explicit -r flag (still supported)
 scafctl run resolver -f parameterized.yaml -r env=staging
 
-# Load parameters from file
+# Load parameters from file with -r
 scafctl run resolver -f parameterized.yaml -r @params.yaml
 
-# Multiple parameters
-scafctl run resolver -f parameterized.yaml -r env=prod -r region=us-east1
+# Mix both forms (-r values and positional values are combined)
+scafctl run resolver -f parameterized.yaml -r env=prod region=us-east1
 ```
 {{< /tab >}}
 {{< tab "PowerShell" >}}
 ```powershell
-scafctl run resolver -f parameterized.yaml -r env=staging
+# Positional key=value syntax (recommended)
+scafctl run resolver -f parameterized.yaml env=staging
 
 # Load parameters from file — wrap @file in single quotes to avoid splatting operator
+scafctl run resolver -f parameterized.yaml '@params.yaml'
+
+# Multiple positional parameters
+scafctl run resolver -f parameterized.yaml env=prod region=us-east1
+
+# Mix resolver names and parameters
+scafctl run resolver db auth -f parameterized.yaml env=prod
+
+# Explicit -r flag (still supported)
+scafctl run resolver -f parameterized.yaml -r env=staging
+
+# Load parameters from file with -r
 scafctl run resolver -f parameterized.yaml -r '@params.yaml'
 
-# Multiple parameters
-scafctl run resolver -f parameterized.yaml -r env=prod -r region=us-east1
+# Mix both forms
+scafctl run resolver -f parameterized.yaml -r env=prod region=us-east1
 ```
 {{< /tab >}}
 {{< /tabs >}}
+
+### Dynamic Help Text
+
+When you specify a solution file with `--help`, the command shows the solution's
+resolver parameters alongside the standard help text:
+
+```bash
+scafctl run resolver -f param-demo.yaml --help
+```
+
+This appends a table showing which resolvers accept CLI parameters, their types,
+and descriptions — making it easy to discover what inputs a solution expects
+without reading the YAML file.
 
 ### Example with Parameter Provider
 
@@ -768,7 +811,7 @@ spec:
 ```
 
 ```bash
-scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution
+scafctl run resolver -f param-demo.yaml environment=staging -o json --hide-execution
 ```
 
 Output:
@@ -778,6 +821,22 @@ Output:
   "config_url": "https://config.staging.example.com",
   "env": "staging"
 }
+```
+
+### Parameter Key Validation
+
+Parameter keys are validated against the solution's parameter-type resolver names.
+Unknown keys are rejected early with a helpful error message that suggests the
+closest valid key when a typo is detected:
+
+```bash
+# Typo: "envronment" instead of "environment"
+scafctl run resolver -f param-demo.yaml envronment=staging
+# Error: solution does not accept input "envronment" — did you mean "environment"?
+
+# Completely unknown key
+scafctl run resolver -f param-demo.yaml unknown=value
+# Error: solution does not accept input "unknown" (valid inputs: environment)
 ```
 
 ---

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -2,7 +2,9 @@
 # Demonstrates using CLI parameters with default values and type coercion.
 #
 # Run: scafctl run resolver -f parameters.yaml
+# Run: scafctl run resolver -f parameters.yaml name=Alice count=5
 # Run: scafctl run resolver -f parameters.yaml -r name=Alice -r count=5
+# Help: scafctl run resolver -f parameters.yaml --help
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -556,3 +556,31 @@ func solutionMetaFromSolution(sol *solution.Solution) *provider.SolutionMeta {
 	}
 	return meta
 }
+
+// extractParameterKeys collects the CLI parameter keys accepted by a set of resolvers.
+// It scans all resolve-phase provider sources for the "parameter" provider and
+// extracts the literal "key" input value, which is the actual name the user
+// must pass via -r key=value.
+func extractParameterKeys(resolvers []*resolver.Resolver) []string {
+	seen := make(map[string]bool)
+	var keys []string
+	for _, r := range resolvers {
+		if r.Resolve == nil {
+			continue
+		}
+		for _, src := range r.Resolve.With {
+			if src.Provider != "parameter" {
+				continue
+			}
+			keyRef, ok := src.Inputs["key"]
+			if !ok || keyRef == nil || keyRef.Literal == nil {
+				continue
+			}
+			if s, ok := keyRef.Literal.(string); ok && s != "" && !seen[s] {
+				seen[s] = true
+				keys = append(keys, s)
+			}
+		}
+	}
+	return keys
+}

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/detail"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -37,6 +38,10 @@ type ProviderOptions struct {
 
 	// InputParams are the provider input parameters (--input key=value or --input @file.yaml).
 	InputParams []string
+
+	// DynamicArgs are provider inputs from positional or dynamic-flag syntax
+	// (e.g. key=value or --key=value, captured after the provider name).
+	DynamicArgs []string
 
 	// Capability specifies which capability to execute.
 	// Defaults to the first capability declared by the provider.
@@ -89,14 +94,20 @@ providers in isolation. It accepts the provider name as a positional
 argument and provider inputs via --input flags.
 
 PROVIDER INPUTS:
-  Inputs are passed using --input flags in several formats:
-    --input key=value         Simple key-value pair
-    --input key=val1,val2     Multiple values become an array
-    --input @file.yaml        Load inputs from a YAML file
-    --input @file.json        Load inputs from a JSON file
+  Inputs can be passed in two equivalent ways:
 
-  Multiple --input flags can be combined. When the same key appears
-  in both a file and a flag, the flag value takes precedence.
+  1. Positional key=value (recommended):
+       key=value                After the provider name
+       @file.yaml               Load inputs from a file
+
+  2. Explicit --input flag:
+       --input key=value        Repeatable flag
+       --input key=val1,val2    Multiple values become an array
+       --input @file.yaml       Load inputs from a YAML file
+       --input @file.json       Load inputs from a JSON file
+
+  Both forms can be mixed. When the same key appears multiple
+  times, later values override earlier ones (last-wins).
 
 CAPABILITIES:
   Providers declare capabilities (from, transform, validation, action,
@@ -119,38 +130,40 @@ EXIT CODES:
   2  Validation failed (invalid inputs)
 
 Examples:
-  # Run the static provider with a simple value
+  # Positional key=value syntax (recommended)
+  scafctl run provider static value=hello
+  scafctl run provider http url=https://api.example.com method=GET
+  scafctl run provider env name=HOME -o json
+
+  # Explicit --input flag syntax
   scafctl run provider static --input value=hello
-
-  # Run the env provider to read an environment variable
-  scafctl run provider env --input name=HOME -o json
-
-  # Run the http provider with multiple inputs
   scafctl run provider http --input url=https://api.example.com --input method=GET
 
-  # Run the exec provider to execute a command
-  scafctl run provider exec --input command=echo --input args=hello
+  # Mix both forms freely
+  scafctl run provider http --input method=GET url=https://example.com timeout=30
 
   # Load inputs from a YAML file
   scafctl run provider http --input @inputs.yaml
+  scafctl run provider http @inputs.yaml
 
   # Run with a specific capability
   scafctl run provider validation --input value=test --capability validation
 
   # Dry-run to see what would be executed
-  scafctl run provider http --input url=https://example.com --dry-run
+  scafctl run provider http url=https://example.com --dry-run
 
   # Load plugin providers from a directory
-  scafctl run provider echo --input message=hello --plugin-dir ./plugins
+  scafctl run provider echo message=hello --plugin-dir ./plugins
 
   # Show execution metrics
-  scafctl run provider http --input url=https://example.com --show-metrics
+  scafctl run provider http url=https://example.com --show-metrics
 
   # Explore results interactively
-  scafctl run provider http --input url=https://api.example.com -i`,
-		Args: cobra.ExactArgs(1),
+  scafctl run provider http url=https://api.example.com -i`,
+		Args: cobra.MinimumNArgs(1),
 		PreRun: func(_ *cobra.Command, args []string) {
 			options.ProviderName = args[0]
+			options.DynamicArgs = args[1:]
 		},
 		RunE:         makeRunEFunc(cfg, "provider"),
 		SilenceUsage: true,
@@ -174,7 +187,86 @@ Examples:
 	cCmd.Flags().StringVarP(&options.Expression, "expression", "e", "",
 		"CEL expression to filter/transform output data (e.g., '_.data')")
 
+	setProviderHelpFunc(cCmd)
+
 	return cCmd
+}
+
+// setProviderHelpFunc installs a custom help function that appends dynamic
+// provider input documentation when a provider name is given.
+// For example, `scafctl run provider http --help` will show the standard
+// command help plus the HTTP provider's input parameters with types and descriptions.
+func setProviderHelpFunc(cmd *cobra.Command) {
+	defaultHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		// Render the default help first
+		defaultHelp(c, args)
+
+		// Try to find the provider name from multiple sources.
+		// Cobra does not always pass positional args to the help function
+		// depending on how flags are parsed, so we check:
+		// 1. The remaining non-flag arguments after cobra parsing (most reliable)
+		// 2. os.Args as a fallback (scanning after "provider" subcommand)
+		providerName := extractProviderName(c.Flags().Args())
+		if providerName == "" {
+			providerName = extractProviderNameFromOSArgs()
+		}
+
+		// Look up the provider in the registry (best effort — don't fail help on errors)
+		reg, err := builtin.DefaultRegistry(c.Context())
+		if err != nil {
+			return
+		}
+
+		prov, ok := reg.Get(providerName)
+		if !ok {
+			return
+		}
+
+		helpText := detail.FormatProviderInputHelp(prov.Descriptor())
+		if helpText != "" {
+			fmt.Fprintln(c.OutOrStdout())
+			fmt.Fprint(c.OutOrStdout(), helpText)
+		}
+	})
+}
+
+// extractProviderName finds the provider name from command-line arguments,
+// skipping flags and the "help" argument itself.
+func extractProviderName(args []string) string {
+	for _, arg := range args {
+		// Skip flags
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		// Skip the "help" argument that cobra sometimes includes
+		if arg == "help" {
+			continue
+		}
+		return arg
+	}
+	return ""
+}
+
+// extractProviderNameFromOSArgs scans os.Args for a provider name following
+// the "provider" (or alias "prov"/"p") subcommand token. This is used as a
+// fallback when cobra's help function doesn't pass positional args.
+func extractProviderNameFromOSArgs() string {
+	args := os.Args
+	found := false
+	for _, arg := range args {
+		if found {
+			// Skip flags after "provider"
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			return arg
+		}
+		if arg == "provider" || arg == "prov" || arg == "p" {
+			found = true
+		}
+	}
+	return ""
 }
 
 // Run executes a single provider directly
@@ -225,8 +317,21 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 
 	desc := prov.Descriptor()
 
+	// Parse dynamic arguments (--key=value and key=value from argv)
+	extraParsed, err := flags.ParseDynamicInputArgs(o.DynamicArgs)
+	if err != nil {
+		err := fmt.Errorf("failed to parse input arguments: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Merge: --input values first, then dynamic args (last-wins on conflict)
+	allParams := make([]string, 0, len(o.InputParams)+len(extraParsed))
+	allParams = append(allParams, o.InputParams...)
+	allParams = append(allParams, extraParsed...)
+
 	// Parse input parameters
-	inputs, err := flags.ParseResolverFlags(o.InputParams)
+	inputs, err := flags.ParseResolverFlags(allParams)
 	if err != nil {
 		err := fmt.Errorf("failed to parse input parameters: %w", err)
 		w.Errorf("%v", err)
@@ -234,6 +339,18 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	}
 
 	lgr.V(1).Info("parsed inputs", "count", len(inputs))
+
+	// Validate input keys against provider schema (early typo detection)
+	if desc.Schema != nil && len(desc.Schema.Properties) > 0 {
+		validKeys := make([]string, 0, len(desc.Schema.Properties))
+		for k := range desc.Schema.Properties {
+			validKeys = append(validKeys, k)
+		}
+		if err := flags.ValidateInputKeys(inputs, validKeys, fmt.Sprintf("provider %q", desc.Name)); err != nil {
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	}
 
 	// Resolve capability
 	capability, err := o.resolveCapability(desc)

--- a/pkg/cmd/scafctl/run/provider_test.go
+++ b/pkg/cmd/scafctl/run/provider_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandProvider(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandProvider(cliParams, streams, "")
+
+	assert.Equal(t, "provider <name>", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.Contains(t, cmd.Aliases, "prov")
+	assert.Contains(t, cmd.Aliases, "p")
+}
+
+func TestExtractProviderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{"empty args", nil, ""},
+		{"single provider name", []string{"http"}, "http"},
+		{"skips flags", []string{"--dry-run", "http"}, "http"},
+		{"skips help", []string{"help", "http"}, "http"},
+		{"first non-flag wins", []string{"http", "extra"}, "http"},
+		{"flags only", []string{"--help", "--dry-run"}, ""},
+		{"mixed flags and name", []string{"-i", "static", "--dry-run"}, "static"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractProviderName(tt.args)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractProviderNameFromOSArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		osArgs   []string
+		expected string
+	}{
+		{
+			"standard invocation",
+			[]string{"scafctl", "run", "provider", "http", "--help"},
+			"http",
+		},
+		{
+			"prov alias",
+			[]string{"scafctl", "run", "prov", "static", "--help"},
+			"static",
+		},
+		{
+			"p alias",
+			[]string{"scafctl", "run", "p", "env", "--help"},
+			"env",
+		},
+		{
+			"no provider name",
+			[]string{"scafctl", "run", "provider", "--help"},
+			"",
+		},
+		{
+			"provider not in args",
+			[]string{"scafctl", "run", "resolver", "--help"},
+			"",
+		},
+		{
+			"flag before name",
+			[]string{"scafctl", "run", "provider", "--dry-run", "http"},
+			"http",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore os.Args
+			originalArgs := os.Args
+			t.Cleanup(func() { os.Args = originalArgs })
+			os.Args = tt.osArgs
+
+			result := extractProviderNameFromOSArgs()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func BenchmarkExtractProviderName(b *testing.B) {
+	args := []string{"--dry-run", "-i", "http", "--capability", "from"}
+	for b.Loop() {
+		extractProviderName(args)
+	}
+}
+
+func BenchmarkExtractProviderNameFromOSArgs(b *testing.B) {
+	originalArgs := os.Args
+	b.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"scafctl", "run", "provider", "http", "--help"}
+
+	b.ResetTimer()
+	for b.Loop() {
+		extractProviderNameFromOSArgs()
+	}
+}

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,9 +16,12 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	resolverdetail "github.com/oakwood-commons/scafctl/pkg/resolver/detail"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -56,6 +60,10 @@ type ResolverOptions struct {
 
 	// HideExecution suppresses the __execution metadata from output.
 	HideExecution bool
+
+	// DynamicArgs are resolver parameters from positional key=value syntax
+	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
+	DynamicArgs []string
 }
 
 // CommandResolver creates the 'run resolver' subcommand
@@ -77,7 +85,7 @@ func CommandResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	}
 
 	cCmd := &cobra.Command{
-		Use:     "resolver [name...]",
+		Use:     "resolver [name...] [key=value...]",
 		Aliases: []string{"res", "resolvers"},
 		Short:   "Execute resolvers for debugging and inspection",
 		Long: `Execute resolvers from a solution without running actions.
@@ -129,11 +137,23 @@ SNAPSHOT MODE:
   debugging, testing, comparison, and audit trails.
 
 RESOLVER PARAMETERS:
-  Parameters can be passed using -r/--resolver flag in several formats:
-    key=value         Simple key-value pair
-    @file.yaml        Load parameters from YAML file
-    @file.json        Load parameters from JSON file
-    key=val1,val2     Multiple values become an array
+  Parameters can be passed in two equivalent ways:
+
+  1. Positional key=value (recommended):
+       key=value         After resolver names or on its own
+       @file.yaml        Load parameters from a file
+
+  2. Explicit -r/--resolver flag:
+       -r key=value      Repeatable flag
+       -r key=val1,val2  Multiple values become an array
+       -r @file.yaml     Load parameters from a YAML file
+       -r @file.json     Load parameters from a JSON file
+
+  Both forms can be mixed. When the same key appears multiple
+  times, later values override earlier ones (last-wins).
+
+  Bare words (without '=') are treated as resolver names.
+  Words containing '=' or starting with '@' are treated as parameters.
 
 OUTPUT FORMATS:
   table    Bordered table view (default when terminal)
@@ -155,8 +175,17 @@ Examples:
   # Run specific resolvers (with their dependencies)
   scafctl run resolver db config -f ./my-solution.yaml
 
-  # Run with parameters
+  # Run with parameters (positional key=value — recommended)
+  scafctl run resolver -f ./my-solution.yaml env=prod region=us-east1
+
+  # Run with parameters (explicit flag)
   scafctl run resolver -r env=prod -r region=us-east1
+
+  # Mix positional and flag parameters
+  scafctl run resolver -f ./my-solution.yaml -r env=prod region=us-east1
+
+  # Load parameters from a file (positional)
+  scafctl run resolver -f ./my-solution.yaml @params.yaml
 
   # JSON output for scripting
   scafctl run resolver -f ./my-solution.yaml -o json | jq .
@@ -197,8 +226,15 @@ Examples:
 			cCmd.Flags().Visit(func(f *pflag.Flag) {
 				options.flagsChanged[f.Name] = true
 			})
-			// Store positional args as resolver names
-			options.Names = args
+			// Split positional args: bare words are resolver names,
+			// args containing '=' or starting with '@' are dynamic parameters.
+			for _, arg := range args {
+				if strings.Contains(arg, "=") || strings.HasPrefix(arg, "@") {
+					options.DynamicArgs = append(options.DynamicArgs, arg)
+				} else {
+					options.Names = append(options.Names, arg)
+				}
+			}
 		},
 		RunE:         makeRunEFunc(cfg, "resolver"),
 		SilenceUsage: true,
@@ -216,6 +252,8 @@ Examples:
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
 	cCmd.Flags().BoolVar(&options.HideExecution, "hide-execution", false, "Suppress __execution metadata from output")
+
+	setResolverHelpFunc(cCmd)
 
 	return cCmd
 }
@@ -266,8 +304,19 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	}
 	defer cleanup()
 
+	// Parse dynamic positional arguments (key=value and @file.yaml from argv)
+	extraParsed, err := flags.ParseDynamicInputArgs(o.DynamicArgs)
+	if err != nil {
+		return o.exitWithCode(ctx, fmt.Errorf("failed to parse positional parameters: %w", err), exitcode.ValidationFailed)
+	}
+
+	// Merge: -r flag values first, then positional args (last-wins on conflict)
+	allParams := make([]string, 0, len(o.ResolverParams)+len(extraParsed))
+	allParams = append(allParams, o.ResolverParams...)
+	allParams = append(allParams, extraParsed...)
+
 	// Parse resolver parameters
-	params, err := flags.ParseResolverFlags(o.ResolverParams)
+	params, err := flags.ParseResolverFlags(allParams)
 	if err != nil {
 		return o.exitWithCode(ctx, fmt.Errorf("failed to parse resolver parameters: %w", err), exitcode.ValidationFailed)
 	}
@@ -276,6 +325,17 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 
 	// Get all resolvers, then filter by names if specified
 	allResolvers := sol.Spec.ResolversToSlice()
+
+	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
+	if len(params) > 0 {
+		paramKeys := extractParameterKeys(allResolvers)
+		if len(paramKeys) > 0 {
+			if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
+				return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+			}
+		}
+	}
+
 	var lookup resolver.DescriptorLookup
 	if reg != nil {
 		lookup = reg.DescriptorLookup()
@@ -575,3 +635,61 @@ type resolverAdapter struct {
 
 func (a *resolverAdapter) GetName() string    { return a.name }
 func (a *resolverAdapter) GetSensitive() bool { return a.sensitive }
+
+// setResolverHelpFunc installs a custom help function that appends dynamic
+// resolver input documentation when a solution file is available.
+// For example, `scafctl run resolver -f solution.yaml --help` will show the
+// standard command help plus the solution's resolver parameter table.
+func setResolverHelpFunc(cmd *cobra.Command) {
+	defaultHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		// Render the default help first
+		defaultHelp(c, args)
+
+		// Try to determine the solution file path from the -f flag or auto-discovery
+		solutionPath := extractSolutionPath(c)
+		if solutionPath == "" {
+			return
+		}
+
+		// Load the solution (best effort — don't fail help on errors)
+		sol, err := inspect.LoadSolution(c.Context(), solutionPath)
+		if err != nil {
+			return
+		}
+
+		helpText := resolverdetail.FormatResolverInputHelp(sol)
+		if helpText != "" {
+			fmt.Fprintln(c.OutOrStdout())
+			fmt.Fprint(c.OutOrStdout(), helpText)
+		}
+	})
+}
+
+// extractSolutionPath determines the solution file path from:
+// 1. The -f/--file flag value (most reliable)
+// 2. os.Args as a fallback (scanning for -f flag)
+// 3. Auto-discovery in the current directory
+func extractSolutionPath(c *cobra.Command) string {
+	// Try the parsed flag value
+	if f := c.Flags().Lookup("file"); f != nil && f.Value.String() != "" {
+		return f.Value.String()
+	}
+
+	// Fallback: scan os.Args for -f or --file
+	osArgs := os.Args
+	for i, arg := range osArgs {
+		if (arg == "-f" || arg == "--file") && i+1 < len(osArgs) {
+			return osArgs[i+1]
+		}
+		if strings.HasPrefix(arg, "-f=") {
+			return strings.TrimPrefix(arg, "-f=")
+		}
+		if strings.HasPrefix(arg, "--file=") {
+			return strings.TrimPrefix(arg, "--file=")
+		}
+	}
+
+	// Final fallback: auto-discover solution file in the current directory
+	return get.NewGetter().FindSolution()
+}

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -33,7 +33,7 @@ func TestCommandResolver(t *testing.T) {
 
 	cmd := CommandResolver(cliParams, streams, "")
 
-	assert.Equal(t, "resolver [name...]", cmd.Use)
+	assert.Equal(t, "resolver [name...] [key=value...]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.Contains(t, cmd.Aliases, "res")
 	assert.Contains(t, cmd.Aliases, "resolvers")
@@ -1916,4 +1916,245 @@ func TestResolverAdapter(t *testing.T) {
 	b := &resolverAdapter{name: "other", sensitive: false}
 	assert.Equal(t, "other", b.GetName())
 	assert.False(t, b.GetSensitive())
+}
+
+func TestResolverOptions_PositionalKeyValue_SeparatesNamesFromParams(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandResolver(cliParams, streams, "")
+
+	// Simulate cobra passing args: "db env=prod region=us-east-1"
+	args := []string{"db", "env=prod", "region=us-east-1"}
+	cmd.PreRun(cmd, args)
+
+	// Access the options through the PreRun closure
+	// The PreRun function closed over `options`, which is local to CommandResolver.
+	// Instead, test the logic directly by simulating arg splitting.
+	var names, dynamicArgs []string
+	for _, arg := range args {
+		if containsEqualsOrAtPrefix(arg) {
+			dynamicArgs = append(dynamicArgs, arg)
+		} else {
+			names = append(names, arg)
+		}
+	}
+
+	assert.Equal(t, []string{"db"}, names)
+	assert.Equal(t, []string{"env=prod", "region=us-east-1"}, dynamicArgs)
+}
+
+func TestResolverOptions_PositionalKeyValue_FileReference(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"myresolver", "@params.yaml", "key=value"}
+	var names, dynamicArgs []string
+	for _, arg := range args {
+		if containsEqualsOrAtPrefix(arg) {
+			dynamicArgs = append(dynamicArgs, arg)
+		} else {
+			names = append(names, arg)
+		}
+	}
+
+	assert.Equal(t, []string{"myresolver"}, names)
+	assert.Equal(t, []string{"@params.yaml", "key=value"}, dynamicArgs)
+}
+
+func TestResolverOptions_PositionalKeyValue_OnlyParams(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"env=prod", "region=us-east-1"}
+	var names, dynamicArgs []string
+	for _, arg := range args {
+		if containsEqualsOrAtPrefix(arg) {
+			dynamicArgs = append(dynamicArgs, arg)
+		} else {
+			names = append(names, arg)
+		}
+	}
+
+	assert.Empty(t, names)
+	assert.Equal(t, []string{"env=prod", "region=us-east-1"}, dynamicArgs)
+}
+
+func TestResolverOptions_PositionalKeyValue_OnlyNames(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"db", "config", "auth"}
+	var names, dynamicArgs []string
+	for _, arg := range args {
+		if containsEqualsOrAtPrefix(arg) {
+			dynamicArgs = append(dynamicArgs, arg)
+		} else {
+			names = append(names, arg)
+		}
+	}
+
+	assert.Equal(t, []string{"db", "config", "auth"}, names)
+	assert.Empty(t, dynamicArgs)
+}
+
+func TestResolverOptions_Run_PositionalParams(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: positional-params-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: greeting
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithParameters(),
+		},
+		// Simulate positional dynamic args (what PreRun would set)
+		DynamicArgs: []string{"greeting=hello"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "hello")
+}
+
+func TestResolverOptions_Run_PositionalParamsMergeWithFlags(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: merge-test
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithParameters(),
+			// -r flag provides one param
+			ResolverParams: []string{"env=prod"},
+		},
+		// Positional arg provides a different param
+		DynamicArgs: []string{"region=us-east-1"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	// Both sources should be merged
+	assert.Contains(t, output, "prod")
+	assert.Contains(t, output, "us-east-1")
+}
+
+func TestExtractSolutionPath_FromFlag(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandResolver(cliParams, streams, "")
+	err := cmd.Flags().Set("file", "/tmp/my-solution.yaml")
+	require.NoError(t, err)
+
+	path := extractSolutionPath(cmd)
+	assert.Equal(t, "/tmp/my-solution.yaml", path)
+}
+
+func TestExtractSolutionPath_EmptyFlag(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandResolver(cliParams, streams, "")
+	path := extractSolutionPath(cmd)
+	assert.Empty(t, path)
+}
+
+// containsEqualsOrAtPrefix mirrors the logic used in PreRun to split args.
+func containsEqualsOrAtPrefix(arg string) bool {
+	return len(arg) > 0 && (arg[0] == '@' || containsEquals(arg))
+}
+
+func containsEquals(s string) bool {
+	for _, c := range s {
+		if c == '=' {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -295,6 +295,16 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	lgr.V(1).Info("parsed parameters", "count", len(params))
 
+	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
+	if len(params) > 0 {
+		paramKeys := extractParameterKeys(sol.Spec.ResolversToSlice())
+		if len(paramKeys) > 0 {
+			if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
+				return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+			}
+		}
+	}
+
 	// Dry run — execute resolvers in dry-run mode and show structured report
 	if o.DryRun {
 		return o.executeDryRun(ctx, sol, reg, params)

--- a/pkg/flags/README.md
+++ b/pkg/flags/README.md
@@ -272,3 +272,17 @@ cmd := &cobra.Command{
 cmd.Flags().StringArrayVarP(&resolverPairs, "resolver", "r", []string{},
     "Resolver parameters in key=value format (repeatable)")
 ```
+
+## Input Key Validation
+
+Use `ValidateInputKeys` to check user-provided input keys against a known set of
+valid keys. Unknown keys produce an error with a "did you mean?" suggestion based
+on Levenshtein distance:
+
+```go
+inputs := map[string]any{"urll": "https://example.com", "method": "GET"}
+validKeys := []string{"url", "method", "headers", "body", "timeout"}
+
+err := flags.ValidateInputKeys(inputs, validKeys, `provider "http"`)
+// Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: body, headers, method, timeout, url)
+```

--- a/pkg/flags/params.go
+++ b/pkg/flags/params.go
@@ -98,6 +98,50 @@ func ParseResolverFlags(values []string) (map[string]any, error) {
 	return result, nil
 }
 
+// ParseDynamicInputArgs normalises raw CLI arguments into key=value strings
+// suitable for ParseResolverFlags.
+//
+// Three forms are recognised:
+//
+//	--key=value    → strip the leading "--" → "key=value"
+//	key=value      → passed through unchanged
+//	@file.yaml     → passed through unchanged (file reference)
+//
+// A bare "--key" (no "=") is rejected because we cannot distinguish a
+// boolean flag from a flag that expects the next token as a value.
+// Single-dash forms ("-k=v") are also rejected to avoid collisions with
+// existing short flags.
+func ParseDynamicInputArgs(args []string) ([]string, error) {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		switch {
+		case strings.HasPrefix(a, "--") && strings.Contains(a, "="):
+			// --key=value → key=value
+			out = append(out, strings.TrimPrefix(a, "--"))
+
+		case strings.HasPrefix(a, "--"):
+			// --key without "=" — ambiguous
+			return nil, fmt.Errorf("dynamic flag %q must use --key=value syntax (= is required)", a)
+
+		case strings.HasPrefix(a, "-"):
+			// -k or -k=v — reject to avoid short-flag collisions
+			return nil, fmt.Errorf("single-dash flag %q is not supported for dynamic inputs; use --key=value or key=value", a)
+
+		case strings.HasPrefix(a, "@"):
+			// @file.yaml — file reference, pass through
+			out = append(out, a)
+
+		case strings.Contains(a, "="):
+			// key=value positional — pass through
+			out = append(out, a)
+
+		default:
+			return nil, fmt.Errorf("unexpected argument %q: use key=value or --key=value for provider inputs", a)
+		}
+	}
+	return out, nil
+}
+
 // MergeValue merges a new value with an existing value, creating arrays as needed.
 // If existing is nil, returns newVal. If both are slices, concatenates them.
 // If existing is a scalar and newVal is provided, creates a slice.

--- a/pkg/flags/params_test.go
+++ b/pkg/flags/params_test.go
@@ -292,3 +292,91 @@ func BenchmarkMergeValue(b *testing.B) {
 		_ = MergeValue(existing, newVal)
 	}
 }
+
+func TestParseDynamicInputArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+		wantErr  string
+	}{
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: []string{},
+		},
+		{
+			name:     "double-dash key=value stripped",
+			args:     []string{"--url=https://example.com", "--method=GET"},
+			expected: []string{"url=https://example.com", "method=GET"},
+		},
+		{
+			name:     "positional key=value passed through",
+			args:     []string{"url=https://example.com", "method=GET"},
+			expected: []string{"url=https://example.com", "method=GET"},
+		},
+		{
+			name:     "file reference passed through",
+			args:     []string{"@inputs.yaml"},
+			expected: []string{"@inputs.yaml"},
+		},
+		{
+			name:     "mixed forms",
+			args:     []string{"--url=https://example.com", "method=GET", "@extra.yaml"},
+			expected: []string{"url=https://example.com", "method=GET", "@extra.yaml"},
+		},
+		{
+			name:    "bare double-dash flag rejected",
+			args:    []string{"--verbose"},
+			wantErr: "must use --key=value syntax",
+		},
+		{
+			name:    "single-dash flag rejected",
+			args:    []string{"-k=v"},
+			wantErr: "single-dash flag",
+		},
+		{
+			name:    "single-dash bare flag rejected",
+			args:    []string{"-v"},
+			wantErr: "single-dash flag",
+		},
+		{
+			name:    "bare word rejected",
+			args:    []string{"something"},
+			wantErr: "unexpected argument",
+		},
+		{
+			name:     "value with equals sign preserved",
+			args:     []string{"--expr=a==b"},
+			expected: []string{"expr=a==b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ParseDynamicInputArgs(tt.args)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func BenchmarkParseDynamicInputArgs(b *testing.B) {
+	args := []string{"--url=https://example.com", "--method=GET", "timeout=30", "@extra.yaml"}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = ParseDynamicInputArgs(args)
+	}
+}

--- a/pkg/flags/validate.go
+++ b/pkg/flags/validate.go
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agext/levenshtein"
+)
+
+// maxSuggestionDistance is the maximum Levenshtein distance for a key to be
+// considered a plausible typo of a known key.
+const maxSuggestionDistance = 3
+
+// ValidateInputKeys checks that every key in inputs exists in validKeys.
+// Unknown keys produce an error with a "did you mean?" suggestion when a
+// close match (Levenshtein distance ≤ maxSuggestionDistance) is found.
+//
+// contextName is used in error messages (e.g. "provider \"http\"" or "solution").
+func ValidateInputKeys(inputs map[string]any, validKeys []string, contextName string) error {
+	if len(inputs) == 0 || len(validKeys) == 0 {
+		return nil
+	}
+
+	validSet := make(map[string]bool, len(validKeys))
+	for _, k := range validKeys {
+		validSet[k] = true
+	}
+
+	// Collect unknown keys in deterministic order for stable error messages.
+	unknown := make([]string, 0)
+	for k := range inputs {
+		if !validSet[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+
+	var errs []string
+	for _, key := range unknown {
+		if suggestion := closestKey(key, validKeys); suggestion != "" {
+			errs = append(errs, fmt.Sprintf("%s does not accept input %q — did you mean %q?", contextName, key, suggestion))
+		} else {
+			errs = append(errs, fmt.Sprintf("%s does not accept input %q", contextName, key))
+		}
+	}
+
+	sortedValid := make([]string, len(validKeys))
+	copy(sortedValid, validKeys)
+	sort.Strings(sortedValid)
+	if len(errs) == 1 {
+		return fmt.Errorf("%s (valid inputs: %s)", errs[0], strings.Join(sortedValid, ", "))
+	}
+	return fmt.Errorf("unknown inputs for %s:\n  - %s\nvalid inputs: %s",
+		contextName, strings.Join(errs, "\n  - "), strings.Join(sortedValid, ", "))
+}
+
+// closestKey returns the validKey with the smallest Levenshtein distance to
+// key, provided it is within maxSuggestionDistance. Returns "" if no match
+// is close enough.
+func closestKey(key string, validKeys []string) string {
+	best := ""
+	bestDist := maxSuggestionDistance + 1
+	for _, candidate := range validKeys {
+		d := levenshtein.Distance(key, candidate, nil)
+		if d < bestDist {
+			bestDist = d
+			best = candidate
+		}
+	}
+	return best
+}

--- a/pkg/flags/validate_test.go
+++ b/pkg/flags/validate_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateInputKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		inputs      map[string]any
+		validKeys   []string
+		contextName string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "all keys valid",
+			inputs:      map[string]any{"url": "https://example.com", "method": "GET"},
+			validKeys:   []string{"url", "method", "headers", "body", "timeout"},
+			contextName: `provider "http"`,
+		},
+		{
+			name:        "empty inputs",
+			inputs:      map[string]any{},
+			validKeys:   []string{"url", "method"},
+			contextName: `provider "http"`,
+		},
+		{
+			name:        "nil inputs",
+			inputs:      nil,
+			validKeys:   []string{"url", "method"},
+			contextName: `provider "http"`,
+		},
+		{
+			name:        "empty valid keys",
+			inputs:      map[string]any{"url": "https://example.com"},
+			validKeys:   []string{},
+			contextName: `provider "http"`,
+		},
+		{
+			name:        "single unknown key with suggestion",
+			inputs:      map[string]any{"urll": "https://example.com"},
+			validKeys:   []string{"url", "method", "headers", "body", "timeout"},
+			contextName: `provider "http"`,
+			wantErr:     true,
+			errContains: `did you mean "url"`,
+		},
+		{
+			name:        "single unknown key no suggestion",
+			inputs:      map[string]any{"zzzzzzzzz": "value"},
+			validKeys:   []string{"url", "method"},
+			contextName: `provider "http"`,
+			wantErr:     true,
+			errContains: `does not accept input "zzzzzzzzz"`,
+		},
+		{
+			name:        "multiple unknown keys",
+			inputs:      map[string]any{"urll": "v", "mehod": "GET"},
+			validKeys:   []string{"url", "method", "headers"},
+			contextName: `provider "http"`,
+			wantErr:     true,
+			errContains: "unknown inputs",
+		},
+		{
+			name:        "mixed valid and unknown keys",
+			inputs:      map[string]any{"url": "https://example.com", "boddy": "data"},
+			validKeys:   []string{"url", "method", "headers", "body", "timeout"},
+			contextName: `provider "http"`,
+			wantErr:     true,
+			errContains: `did you mean "body"`,
+		},
+		{
+			name:        "suggestion for resolver parameter typo",
+			inputs:      map[string]any{"envrionment": "prod"}, //nolint:misspell // intentional typo for testing
+			validKeys:   []string{"environment", "region", "cluster"},
+			contextName: "solution",
+			wantErr:     true,
+			errContains: `did you mean "environment"`,
+		},
+		{
+			name:        "exact match is not flagged",
+			inputs:      map[string]any{"environment": "prod"},
+			validKeys:   []string{"environment", "region"},
+			contextName: "solution",
+		},
+		{
+			name:        "error message includes valid inputs list",
+			inputs:      map[string]any{"unknown": "x"},
+			validKeys:   []string{"alpha", "beta"},
+			contextName: "solution",
+			wantErr:     true,
+			errContains: "valid inputs: alpha, beta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateInputKeys(tt.inputs, tt.validKeys, tt.contextName)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestClosestKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		key       string
+		validKeys []string
+		want      string
+	}{
+		{
+			name:      "single character typo",
+			key:       "urll",
+			validKeys: []string{"url", "method", "headers"},
+			want:      "url",
+		},
+		{
+			name:      "transposition",
+			key:       "mehod",
+			validKeys: []string{"url", "method", "headers"},
+			want:      "method",
+		},
+		{
+			name:      "missing character",
+			key:       "headrs",
+			validKeys: []string{"url", "method", "headers"},
+			want:      "headers",
+		},
+		{
+			name:      "extra character",
+			key:       "bodyy",
+			validKeys: []string{"url", "method", "body"},
+			want:      "body",
+		},
+		{
+			name:      "too distant - no suggestion",
+			key:       "zzzzzzz",
+			validKeys: []string{"url", "method", "headers"},
+			want:      "",
+		},
+		{
+			name:      "empty valid keys",
+			key:       "url",
+			validKeys: []string{},
+			want:      "",
+		},
+		{
+			name:      "exact match returns it",
+			key:       "url",
+			validKeys: []string{"url", "method"},
+			want:      "url",
+		},
+		{
+			name:      "picks closest among multiple candidates",
+			key:       "timeot",
+			validKeys: []string{"timeout", "time", "timer"},
+			want:      "timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := closestKey(tt.key, tt.validKeys)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func BenchmarkValidateInputKeys(b *testing.B) {
+	inputs := map[string]any{
+		"urll":    "https://example.com",
+		"method":  "GET",
+		"boddy":   "data",
+		"timeout": 30,
+	}
+	validKeys := []string{"url", "method", "headers", "body", "timeout", "retries", "follow_redirects"}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_ = ValidateInputKeys(inputs, validKeys, `provider "http"`)
+	}
+}
+
+func BenchmarkClosestKey(b *testing.B) {
+	validKeys := []string{"url", "method", "headers", "body", "timeout", "retries", "follow_redirects", "max_redirects", "verify_ssl", "proxy"}
+
+	b.ResetTimer()
+	for b.Loop() {
+		closestKey("headrs", validKeys)
+	}
+}
+
+func BenchmarkClosestKeyLargeKeySet(b *testing.B) {
+	// Simulate a provider with many input keys
+	validKeys := make([]string, 50)
+	for i := range validKeys {
+		validKeys[i] = "property_" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		closestKey("property_z9", validKeys)
+	}
+}

--- a/pkg/logger/multisink.go
+++ b/pkg/logger/multisink.go
@@ -19,6 +19,7 @@ func newMultiSink(sinks ...logr.LogSink) *multiSink {
 }
 
 func (m *multiSink) Init(info logr.RuntimeInfo) {
+	info.CallDepth++ // account for the extra frame added by multiSink.Info/Error
 	for _, s := range m.sinks {
 		s.Init(info)
 	}

--- a/pkg/logger/multisink_test.go
+++ b/pkg/logger/multisink_test.go
@@ -102,10 +102,11 @@ func TestMultiSink_Init_DelegatesToAllSinks(t *testing.T) {
 	info := logr.RuntimeInfo{CallDepth: 2}
 	ms.Init(info)
 
+	expected := logr.RuntimeInfo{CallDepth: 3} // multiSink increments CallDepth by 1
 	require.Len(t, a.initCalls, 1)
 	require.Len(t, b.initCalls, 1)
-	assert.Equal(t, info, a.initCalls[0])
-	assert.Equal(t, info, b.initCalls[0])
+	assert.Equal(t, expected, a.initCalls[0])
+	assert.Equal(t, expected, b.initCalls[0])
 }
 
 // ── Enabled ───────────────────────────────────────────────────────────────────

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -302,10 +302,10 @@ IMPORTANT: Choose the correct run command based on whether the solution has a wo
   • If the solution has spec.workflow.actions (i.e. it performs side-effects/actions):
       scafctl run solution -f ./<filename>.yaml -r key=value
   • If the solution has ONLY resolvers and NO spec.workflow section:
-      scafctl run resolver -f ./<filename>.yaml -r key=value
+      scafctl run resolver -f ./<filename>.yaml key=value
     'scafctl run solution' will FAIL if there is no workflow defined.
-Parameters are passed with -r/--resolver (NOT -p). Example:
-  scafctl run resolver -f ./%s.yaml -r param1=value1 -r param2=value2
+Parameters are passed with -r/--resolver or positional key=value (NOT -p). Example:
+  scafctl run resolver -f ./%s.yaml param1=value1 param2=value2
   scafctl run solution -f ./%s.yaml -r param1=value1 -r param2=value2
 
 After creating the solution file:

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -235,7 +235,7 @@ Template Directory Rendering (directory → render-tree → write-tree pipeline)
 
 CLI Usage Reference (use these exact flags when suggesting commands to users):
   Run a solution:       scafctl run solution -f ./solution.yaml -r key=value
-  Run resolvers only:   scafctl run resolver -f ./solution.yaml -r key=value
+  Run resolvers only:   scafctl run resolver -f ./solution.yaml key=value
   Lint a solution:      scafctl lint -f ./solution.yaml
   Inspect a solution:   scafctl explain -f ./solution.yaml
   Run tests:            scafctl test functional -f ./solution.yaml
@@ -254,10 +254,11 @@ IMPORTANT — choosing between 'run solution' and 'run resolver':
   • Rule of thumb: if the solution YAML contains spec.workflow.actions → use 'run solution'.
     If it does NOT have spec.workflow → use 'run resolver'.
 
-IMPORTANT: Resolver parameters are passed with -r/--resolver, NOT -p. There is no -p flag.
+IMPORTANT: Resolver parameters are passed with -r/--resolver or positional key=value, NOT -p. There is no -p flag.
 Examples:
   scafctl run solution -f ./my-solution.yaml -r env=prod -r region=us-east1
   scafctl run solution my-catalog-solution -r inputText="Hello World" -r operation=uppercase
+  scafctl run resolver -f ./my-solution.yaml env=prod region=us-east1
   scafctl run resolver -f ./my-solution.yaml -r name=value
 
 IMPORTANT — file path references:

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -726,10 +726,12 @@ spec:
 		params := parsed["parameters"].([]any)
 		assert.Len(t, params, 2)
 
-		// Check command includes -r flags
+		// Check command includes positional key=value (resolver-only uses positional syntax)
 		cmd := parsed["command"].(string)
-		assert.Contains(t, cmd, "-r env=")
-		assert.Contains(t, cmd, "-r region=us-east-1")
+		assert.Contains(t, cmd, "env=")
+		assert.Contains(t, cmd, "region=us-east-1")
+		assert.NotContains(t, cmd, "-r env=")
+		assert.NotContains(t, cmd, "-r region=")
 	})
 
 	t.Run("empty solution returns error", func(t *testing.T) {

--- a/pkg/provider/detail/detail.go
+++ b/pkg/provider/detail/detail.go
@@ -132,7 +132,7 @@ func GenerateCLIExamples(desc *provider.Descriptor) []string {
 	for _, name := range requiredNames {
 		prop := desc.Schema.Properties[name]
 		placeholder := SchemaPlaceholder(name, prop)
-		inputFlags = append(inputFlags, fmt.Sprintf("--input %s=%s", name, placeholder))
+		inputFlags = append(inputFlags, fmt.Sprintf("%s=%s", name, placeholder))
 	}
 
 	var examples []string
@@ -159,7 +159,7 @@ func GenerateCLIExamples(desc *provider.Descriptor) []string {
 	}
 
 	// Add file-based input example
-	examples = append(examples, fmt.Sprintf("scafctl run provider %s --input @inputs.yaml", desc.Name))
+	examples = append(examples, fmt.Sprintf("scafctl run provider %s @inputs.yaml", desc.Name))
 
 	return examples
 }

--- a/pkg/provider/detail/help.go
+++ b/pkg/provider/detail/help.go
@@ -1,0 +1,115 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package detail
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// FormatProviderInputHelp generates a human-readable help section describing
+// a provider's input parameters from its JSON Schema. The output is formatted
+// for inclusion in CLI help text.
+//
+// Example output:
+//
+//	Provider Inputs (http):
+//	  url        string   (required)  The URL to request
+//	  method     string               HTTP method (default: GET)
+//	  headers    object               Request headers
+func FormatProviderInputHelp(desc *provider.Descriptor) string {
+	if desc == nil || desc.Schema == nil || len(desc.Schema.Properties) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "Provider Inputs (%s):\n", desc.Name)
+
+	// Build required set
+	requiredSet := make(map[string]bool, len(desc.Schema.Required))
+	for _, name := range desc.Schema.Required {
+		requiredSet[name] = true
+	}
+
+	// Collect and sort property names for deterministic output
+	propNames := make([]string, 0, len(desc.Schema.Properties))
+	for name := range desc.Schema.Properties {
+		propNames = append(propNames, name)
+	}
+	slices.Sort(propNames)
+
+	// Calculate column widths for alignment
+	maxNameLen := 0
+	maxTypeLen := 0
+	for _, name := range propNames {
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+		typeStr := formatSchemaType(desc.Schema.Properties[name])
+		if len(typeStr) > maxTypeLen {
+			maxTypeLen = len(typeStr)
+		}
+	}
+
+	// Render each property
+	for _, name := range propNames {
+		prop := desc.Schema.Properties[name]
+		typeStr := formatSchemaType(prop)
+
+		// Build the required/default annotation
+		annotation := ""
+		if requiredSet[name] {
+			annotation = "(required)"
+		} else if prop.Default != nil {
+			var def any
+			if err := json.Unmarshal(prop.Default, &def); err == nil {
+				annotation = fmt.Sprintf("(default: %v)", def)
+			}
+		}
+
+		// Build the description suffix
+		descStr := ""
+		if prop.Description != "" {
+			descStr = prop.Description
+		}
+
+		// Format: "  name    type   annotation  description"
+		line := fmt.Sprintf("  %-*s  %-*s  %-12s %s",
+			maxNameLen, name,
+			maxTypeLen, typeStr,
+			annotation, descStr)
+
+		sb.WriteString(strings.TrimRight(line, " ") + "\n")
+	}
+
+	return sb.String()
+}
+
+// formatSchemaType returns a compact type representation for a schema property.
+func formatSchemaType(prop *jsonschema.Schema) string {
+	if prop == nil {
+		return "any"
+	}
+
+	typeStr := prop.Type
+	if typeStr == "" {
+		typeStr = "any"
+	}
+
+	if len(prop.Enum) > 0 {
+		enumStrs := make([]string, len(prop.Enum))
+		for i, e := range prop.Enum {
+			enumStrs[i] = fmt.Sprint(e)
+		}
+		typeStr = fmt.Sprintf("%s[%s]", typeStr, strings.Join(enumStrs, "|"))
+	}
+
+	return typeStr
+}

--- a/pkg/provider/detail/help_test.go
+++ b/pkg/provider/detail/help_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package detail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatProviderInputHelp(t *testing.T) {
+	version := semver.MustParse("1.0.0")
+
+	t.Run("returns empty for nil descriptor", func(t *testing.T) {
+		result := FormatProviderInputHelp(nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty for nil schema", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "test",
+			Version: version,
+			Schema:  nil,
+		}
+		result := FormatProviderInputHelp(desc)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty for schema with no properties", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "test",
+			Version: version,
+			Schema:  &jsonschema.Schema{},
+		}
+		result := FormatProviderInputHelp(desc)
+		assert.Empty(t, result)
+	})
+
+	t.Run("formats single required property", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "static",
+			Version: version,
+			Schema: schemahelper.ObjectSchema([]string{"value"}, map[string]*jsonschema.Schema{
+				"value": schemahelper.AnyProp("The static value to return"),
+			}),
+		}
+		result := FormatProviderInputHelp(desc)
+		assert.Contains(t, result, "Provider Inputs (static):")
+		assert.Contains(t, result, "value")
+		assert.Contains(t, result, "(required)")
+		assert.Contains(t, result, "The static value to return")
+	})
+
+	t.Run("formats multiple properties with types", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "http",
+			Version: version,
+			Schema: schemahelper.ObjectSchema([]string{"url"}, map[string]*jsonschema.Schema{
+				"url":    schemahelper.StringProp("The URL to request"),
+				"method": schemahelper.StringProp("HTTP method"),
+				"timeout": schemahelper.IntProp("Request timeout in seconds",
+					schemahelper.WithDefault(30)),
+			}),
+		}
+		result := FormatProviderInputHelp(desc)
+		assert.Contains(t, result, "Provider Inputs (http):")
+		assert.Contains(t, result, "url")
+		assert.Contains(t, result, "string")
+		assert.Contains(t, result, "(required)")
+		assert.Contains(t, result, "method")
+		assert.Contains(t, result, "timeout")
+		assert.Contains(t, result, "integer")
+		assert.Contains(t, result, "(default: 30)")
+	})
+
+	t.Run("formats enum properties", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "test",
+			Version: version,
+			Schema: schemahelper.ObjectSchema([]string{"op"}, map[string]*jsonschema.Schema{
+				"op": schemahelper.StringProp("Operation to perform",
+					schemahelper.WithEnum("get", "set", "list")),
+			}),
+		}
+		result := FormatProviderInputHelp(desc)
+		assert.Contains(t, result, "string[get|set|list]")
+		assert.Contains(t, result, "(required)")
+	})
+
+	t.Run("sorts properties alphabetically", func(t *testing.T) {
+		desc := &provider.Descriptor{
+			Name:    "test",
+			Version: version,
+			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"zebra": schemahelper.StringProp("Last"),
+				"alpha": schemahelper.StringProp("First"),
+				"mid":   schemahelper.StringProp("Middle"),
+			}),
+		}
+		result := FormatProviderInputHelp(desc)
+		alphaIdx := strings.Index(result, "alpha")
+		midIdx := strings.Index(result, "mid")
+		zebraIdx := strings.Index(result, "zebra")
+		assert.Less(t, alphaIdx, midIdx)
+		assert.Less(t, midIdx, zebraIdx)
+	})
+}
+
+func TestFormatSchemaType(t *testing.T) {
+	t.Run("returns any for nil prop", func(t *testing.T) {
+		assert.Equal(t, "any", formatSchemaType(nil))
+	})
+
+	t.Run("returns type for simple property", func(t *testing.T) {
+		prop := schemahelper.StringProp("test")
+		assert.Equal(t, "string", formatSchemaType(prop))
+	})
+
+	t.Run("returns type with enum", func(t *testing.T) {
+		prop := schemahelper.StringProp("test", schemahelper.WithEnum("a", "b"))
+		assert.Equal(t, "string[a|b]", formatSchemaType(prop))
+	})
+
+	t.Run("returns any for empty type", func(t *testing.T) {
+		prop := &jsonschema.Schema{}
+		assert.Equal(t, "any", formatSchemaType(prop))
+	})
+}
+
+func BenchmarkFormatProviderInputHelp(b *testing.B) {
+	version := semver.MustParse("1.0.0")
+	desc := &provider.Descriptor{
+		Name:    "http",
+		Version: version,
+		Schema: schemahelper.ObjectSchema([]string{"url"}, map[string]*jsonschema.Schema{
+			"url":     schemahelper.StringProp("The URL to request"),
+			"method":  schemahelper.StringProp("HTTP method"),
+			"timeout": schemahelper.IntProp("Request timeout in seconds", schemahelper.WithDefault(30)),
+			"headers": schemahelper.AnyProp("HTTP headers as key-value pairs"),
+			"body":    schemahelper.StringProp("Request body"),
+		}),
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		FormatProviderInputHelp(desc)
+	}
+}

--- a/pkg/resolver/detail/help.go
+++ b/pkg/resolver/detail/help.go
@@ -1,0 +1,187 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package detail
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// ResolverInfo describes a single resolver for help text rendering.
+type ResolverInfo struct {
+	Name         string
+	Type         string
+	Description  string
+	HasDefault   bool
+	ParameterKey string // The parameter key if this resolver uses the "parameter" provider.
+}
+
+// ExtractResolverInfo builds a list of ResolverInfo from a solution's resolvers.
+// It inspects each resolver's resolve phase to determine which ones accept
+// CLI parameters (via the "parameter" provider) and whether they have fallback
+// defaults (additional sources after the parameter provider).
+func ExtractResolverInfo(sol *solution.Solution) []ResolverInfo {
+	if sol == nil || sol.Spec.Resolvers == nil {
+		return nil
+	}
+
+	resolvers := sol.Spec.ResolversToSlice()
+	infos := make([]ResolverInfo, 0, len(resolvers))
+
+	for _, r := range resolvers {
+		info := ResolverInfo{
+			Name:        r.Name,
+			Type:        string(r.Type),
+			Description: r.Description,
+		}
+
+		if r.Resolve != nil {
+			for i, src := range r.Resolve.With {
+				if src.Provider == "parameter" {
+					// Extract the key input (literal string value)
+					if keyRef, ok := src.Inputs["key"]; ok && keyRef != nil {
+						if s, ok := keyRef.Literal.(string); ok {
+							info.ParameterKey = s
+						}
+					}
+					// If there are more sources after this one, the resolver
+					// has a fallback default.
+					if i < len(r.Resolve.With)-1 {
+						info.HasDefault = true
+					}
+				}
+			}
+		}
+
+		infos = append(infos, info)
+	}
+
+	return infos
+}
+
+// FormatResolverInputHelp generates a human-readable help section describing
+// the resolvers in a solution. It shows resolver names, types, descriptions,
+// and which resolvers accept CLI parameters.
+//
+// Example output:
+//
+//	Solution Resolvers (my-solution):
+//	  PARAMETER     TYPE     RESOLVER     DESCRIPTION
+//	  name          string   name         User name from CLI or default (has default)
+//	  count         int      count        Repetition count (has default)
+//	  -             string   greeting     Final greeting message (computed)
+func FormatResolverInputHelp(sol *solution.Solution) string {
+	infos := ExtractResolverInfo(sol)
+	if len(infos) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	solutionName := sol.Metadata.Name
+	if solutionName == "" {
+		solutionName = "unknown"
+	}
+
+	fmt.Fprintf(&sb, "Solution Resolvers (%s):\n", solutionName)
+
+	// Separate into parameter resolvers and computed resolvers
+	var paramResolvers []ResolverInfo
+	var computedResolvers []ResolverInfo
+	for _, info := range infos {
+		if info.ParameterKey != "" {
+			paramResolvers = append(paramResolvers, info)
+		} else {
+			computedResolvers = append(computedResolvers, info)
+		}
+	}
+
+	// Sort each group by name for deterministic output
+	slices.SortFunc(paramResolvers, func(a, b ResolverInfo) int {
+		return strings.Compare(a.ParameterKey, b.ParameterKey)
+	})
+	slices.SortFunc(computedResolvers, func(a, b ResolverInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Calculate column widths across all resolvers
+	maxParamLen := len("PARAMETER")
+	maxTypeLen := len("TYPE")
+	maxNameLen := len("RESOLVER")
+
+	for _, info := range infos {
+		paramKey := info.ParameterKey
+		if paramKey == "" {
+			paramKey = "-"
+		}
+		if len(paramKey) > maxParamLen {
+			maxParamLen = len(paramKey)
+		}
+		typeStr := info.Type
+		if typeStr == "" {
+			typeStr = "any"
+		}
+		if len(typeStr) > maxTypeLen {
+			maxTypeLen = len(typeStr)
+		}
+		if len(info.Name) > maxNameLen {
+			maxNameLen = len(info.Name)
+		}
+	}
+
+	// Print header
+	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %s",
+		maxParamLen, "PARAMETER",
+		maxTypeLen, "TYPE",
+		maxNameLen, "RESOLVER",
+		"DESCRIPTION")
+	sb.WriteString(header + "\n")
+
+	// Print parameter resolvers first (these accept CLI input)
+	for _, info := range paramResolvers {
+		typeStr := info.Type
+		if typeStr == "" {
+			typeStr = "any"
+		}
+
+		desc := info.Description
+		if info.HasDefault {
+			desc += " (has default)"
+		}
+
+		line := fmt.Sprintf("  %-*s  %-*s  %-*s  %s",
+			maxParamLen, info.ParameterKey,
+			maxTypeLen, typeStr,
+			maxNameLen, info.Name,
+			desc)
+		sb.WriteString(strings.TrimRight(line, " ") + "\n")
+	}
+
+	// Print computed resolvers (no CLI parameter)
+	for _, info := range computedResolvers {
+		typeStr := info.Type
+		if typeStr == "" {
+			typeStr = "any"
+		}
+
+		desc := info.Description
+		if desc == "" {
+			desc = "(computed)"
+		} else {
+			desc += " (computed)"
+		}
+
+		line := fmt.Sprintf("  %-*s  %-*s  %-*s  %s",
+			maxParamLen, "-",
+			maxTypeLen, typeStr,
+			maxNameLen, info.Name,
+			desc)
+		sb.WriteString(strings.TrimRight(line, " ") + "\n")
+	}
+
+	return sb.String()
+}

--- a/pkg/resolver/detail/help_test.go
+++ b/pkg/resolver/detail/help_test.go
@@ -1,0 +1,319 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package detail
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractResolverInfo_NilSolution(t *testing.T) {
+	t.Parallel()
+	infos := ExtractResolverInfo(nil)
+	assert.Nil(t, infos)
+}
+
+func TestExtractResolverInfo_NoResolvers(t *testing.T) {
+	t.Parallel()
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: nil,
+		},
+	}
+	infos := ExtractResolverInfo(sol)
+	assert.Nil(t, infos)
+}
+
+func TestExtractResolverInfo_ParameterResolver(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"environment": {
+			Name:        "environment",
+			Type:        spec.TypeString,
+			Description: "Target deployment environment",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "env"},
+						},
+					},
+					{
+						Provider: "static",
+						Inputs: map[string]*spec.ValueRef{
+							"value": {Literal: "dev"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "environment", infos[0].Name)
+	assert.Equal(t, "string", infos[0].Type)
+	assert.Equal(t, "Target deployment environment", infos[0].Description)
+	assert.Equal(t, "env", infos[0].ParameterKey)
+	assert.True(t, infos[0].HasDefault)
+}
+
+func TestExtractResolverInfo_ParameterNoDefault(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"token": {
+			Name:        "token",
+			Type:        spec.TypeString,
+			Description: "Auth token",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "token"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "token", infos[0].ParameterKey)
+	assert.False(t, infos[0].HasDefault)
+}
+
+func TestExtractResolverInfo_ComputedResolver(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"greeting": {
+			Name:        "greeting",
+			Type:        spec.TypeString,
+			Description: "Final greeting",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "cel",
+						Inputs: map[string]*spec.ValueRef{
+							"expression": {Literal: "'hello'"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "greeting", infos[0].Name)
+	assert.Empty(t, infos[0].ParameterKey)
+	assert.False(t, infos[0].HasDefault)
+}
+
+func TestFormatResolverInputHelp_EmptyResolvers(t *testing.T) {
+	t.Parallel()
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: nil,
+		},
+	}
+	result := FormatResolverInputHelp(sol)
+	assert.Empty(t, result)
+}
+
+func TestFormatResolverInputHelp_MixedResolvers(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"environment": {
+			Name:        "environment",
+			Type:        spec.TypeString,
+			Description: "Target environment",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "env"},
+						},
+					},
+					{
+						Provider: "static",
+						Inputs: map[string]*spec.ValueRef{
+							"value": {Literal: "dev"},
+						},
+					},
+				},
+			},
+		},
+		"greeting": {
+			Name:        "greeting",
+			Type:        spec.TypeString,
+			Description: "Final greeting",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "cel",
+						Inputs: map[string]*spec.ValueRef{
+							"expression": {Literal: "'hello'"},
+						},
+					},
+				},
+			},
+		},
+	})
+	sol.Metadata.Name = "test-solution"
+
+	result := FormatResolverInputHelp(sol)
+	assert.Contains(t, result, "Solution Resolvers (test-solution):")
+	assert.Contains(t, result, "PARAMETER")
+	assert.Contains(t, result, "TYPE")
+	assert.Contains(t, result, "RESOLVER")
+	assert.Contains(t, result, "DESCRIPTION")
+	assert.Contains(t, result, "env")
+	assert.Contains(t, result, "environment")
+	assert.Contains(t, result, "has default")
+	assert.Contains(t, result, "greeting")
+	assert.Contains(t, result, "computed")
+}
+
+func TestFormatResolverInputHelp_OnlyParameters(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"name": {
+			Name:        "name",
+			Type:        spec.TypeString,
+			Description: "User name",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "name"},
+						},
+					},
+				},
+			},
+		},
+	})
+	sol.Metadata.Name = "param-only"
+
+	result := FormatResolverInputHelp(sol)
+	assert.Contains(t, result, "Solution Resolvers (param-only):")
+	assert.Contains(t, result, "name")
+	assert.NotContains(t, result, "computed")
+}
+
+func TestFormatResolverInputHelp_NoType(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"data": {
+			Name:        "data",
+			Description: "Some data",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "data"},
+						},
+					},
+				},
+			},
+		},
+	})
+	sol.Metadata.Name = "test"
+
+	result := FormatResolverInputHelp(sol)
+	assert.Contains(t, result, "any")
+}
+
+func BenchmarkFormatResolverInputHelp(b *testing.B) {
+	resolvers := make(map[string]*resolver.Resolver, 50)
+	for i := range 50 {
+		name := fmt.Sprintf("resolver_%02d", i)
+		r := &resolver.Resolver{
+			Name:        name,
+			Type:        spec.TypeString,
+			Description: "Test resolver",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: name},
+						},
+					},
+					{
+						Provider: "static",
+						Inputs: map[string]*spec.ValueRef{
+							"value": {Literal: "default"},
+						},
+					},
+				},
+			},
+		}
+		resolvers[name] = r
+	}
+	sol := buildTestSolution(resolvers)
+	sol.Metadata.Name = "benchmark-solution"
+
+	b.ResetTimer()
+	for range b.N {
+		FormatResolverInputHelp(sol)
+	}
+}
+
+func BenchmarkExtractResolverInfo(b *testing.B) {
+	resolvers := make(map[string]*resolver.Resolver, 50)
+	for i := range 50 {
+		name := fmt.Sprintf("resolver_%02d", i)
+		r := &resolver.Resolver{
+			Name:        name,
+			Type:        spec.TypeString,
+			Description: "Test resolver",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: name},
+						},
+					},
+				},
+			},
+		}
+		resolvers[name] = r
+	}
+	sol := buildTestSolution(resolvers)
+
+	b.ResetTimer()
+	for range b.N {
+		ExtractResolverInfo(sol)
+	}
+}
+
+func buildTestSolution(resolvers map[string]*resolver.Resolver) *solution.Solution {
+	return &solution.Solution{
+		Metadata: solution.Metadata{
+			Name: "test",
+		},
+		Spec: solution.Spec{
+			Resolvers: resolvers,
+		},
+	}
+}

--- a/pkg/solution/inspect/run_command.go
+++ b/pkg/solution/inspect/run_command.go
@@ -99,7 +99,13 @@ func BuildRunCommand(sol *solution.Solution, path string) (*RunCommandInfo, erro
 		if p.Example != nil {
 			exampleVal = fmt.Sprintf("%v", p.Example)
 		}
-		fullCommand += fmt.Sprintf(" -r %s=%s", p.Name, exampleVal)
+		if hasWorkflow {
+			// run solution uses -r flags
+			fullCommand += fmt.Sprintf(" -r %s=%s", p.Name, exampleVal)
+		} else {
+			// run resolver uses positional key=value
+			fullCommand += fmt.Sprintf(" %s=%s", p.Name, exampleVal)
+		}
 	}
 
 	return &RunCommandInfo{

--- a/pkg/solution/inspect/run_command_test.go
+++ b/pkg/solution/inspect/run_command_test.go
@@ -60,9 +60,12 @@ func TestBuildRunCommand_ResolverOnlySolution(t *testing.T) {
 	assert.False(t, info.HasWorkflow)
 	// Only parameter-type resolvers listed
 	assert.Len(t, info.Parameters, 2)
-	// Command includes parameter flags
-	assert.Contains(t, info.Command, "-r env=prod")
-	assert.Contains(t, info.Command, "-r region=<value>")
+	// Command includes positional parameter values (resolver-only uses positional syntax)
+	assert.Contains(t, info.Command, "env=prod")
+	assert.Contains(t, info.Command, "region=<value>")
+	// Should NOT use -r flags for resolver-only solutions
+	assert.NotContains(t, info.Command, "-r env=")
+	assert.NotContains(t, info.Command, "-r region=")
 	// Non-parameter resolver not included
 	for _, p := range info.Parameters {
 		assert.NotEqual(t, "config", p.Name)

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -211,7 +211,7 @@ tasks:
         SKIPPED=0
 
         # Directories/files that are intentionally invalid and should be skipped
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -357,6 +357,41 @@ func TestIntegration_RunProvider_Help(t *testing.T) {
 	assert.Contains(t, stdout, "--plugin-dir")
 }
 
+func TestIntegration_RunProvider_DynamicHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "http", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	// Standard help sections should still appear
+	assert.Contains(t, stdout, "--input")
+	// Dynamic provider inputs section should appear
+	assert.Contains(t, stdout, "Provider Inputs (http):")
+	assert.Contains(t, stdout, "url")
+	assert.Contains(t, stdout, "(required)")
+	assert.Contains(t, stdout, "method")
+}
+
+func TestIntegration_RunProvider_DynamicHelpStatic(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Provider Inputs (static):")
+	assert.Contains(t, stdout, "value")
+	assert.Contains(t, stdout, "(required)")
+}
+
+func TestIntegration_RunProvider_DynamicHelpUnknownProvider(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "nonexistent", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	// Standard help should still show
+	assert.Contains(t, stdout, "--input")
+	// No dynamic section for unknown provider
+	assert.NotContains(t, stdout, "Provider Inputs")
+}
+
 func TestIntegration_RunProvider_Static(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "--input", "value=hello")
@@ -447,6 +482,81 @@ func TestIntegration_RunProvider_ShowMetrics(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "metrics-test")
 	assert.Contains(t, stderr, "Provider Execution Metrics")
+}
+
+// ============================================================================
+// Run Provider — Positional Input Syntax Tests
+// ============================================================================
+
+func TestIntegration_RunProvider_PositionalKeyValue(t *testing.T) {
+	t.Parallel()
+	// value=hello  (positional key=value after provider name)
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "value=hello-positional")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hello-positional")
+}
+
+func TestIntegration_RunProvider_MixedInputSyntax(t *testing.T) {
+	t.Parallel()
+	// Mix --input and positional key=value
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "env",
+		"--input", "operation=get",
+		"name=PATH",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "data")
+}
+
+func TestIntegration_RunProvider_PositionalWithBuiltinFlag(t *testing.T) {
+	t.Parallel()
+	// Ensure built-in flags (-o) still work alongside positional args
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "value=flagtest", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "flagtest")
+	assert.Contains(t, stdout, "\"data\"")
+}
+
+func TestIntegration_RunProvider_PositionalFileRef(t *testing.T) {
+	t.Parallel()
+	// @file.yaml as positional arg
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "static", "@tests/files/provider-inputs/static-hello.yaml")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "data")
+}
+
+func TestIntegration_RunProvider_PositionalMultipleInputs(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "env", "operation=get", "name=PATH", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"data\"")
+}
+
+// ============================================================================
+// Run Provider — Unknown Input Key Validation Tests
+// ============================================================================
+
+func TestIntegration_RunProvider_UnknownInputKey(t *testing.T) {
+	t.Parallel()
+	// "valuee" is not a valid input for the static provider (should suggest "value")
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "static", "valuee=hello")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not accept input")
+	assert.Contains(t, stderr, `did you mean "value"`)
+}
+
+func TestIntegration_RunProvider_UnknownInputKeyNoSuggestion(t *testing.T) {
+	t.Parallel()
+	// "zzzzz" is too far from any valid key
+	_, stderr, exitCode := runScafctl(t, "run", "provider", "static", "zzzzz=hello")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not accept input")
 }
 
 func TestIntegration_RunProvider_HCL(t *testing.T) {
@@ -600,7 +710,7 @@ func TestIntegration_GetProvider_CLIUsage(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "CLI Usage:")
 	assert.Contains(t, stdout, "scafctl run provider http")
-	assert.Contains(t, stdout, "--input")
+	assert.Contains(t, stdout, "@inputs.yaml")
 }
 
 func TestIntegration_GetProvider_CLIUsageJSON(t *testing.T) {
@@ -680,6 +790,30 @@ func TestIntegration_RunSolution_BadSolutionYAML(t *testing.T) {
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "expected exactly one of rslvr, expr, or tmpl, but found")
 	assert.Contains(t, stderr, "line")
+}
+
+func TestIntegration_RunSolution_NullResolver(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "tests/integration/solutions/edge-cases/null-resolver/solution.yaml",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "null value")
+}
+
+func TestIntegration_Lint_NullResolver(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"lint",
+		"-f", "tests/integration/solutions/edge-cases/null-resolver/solution.yaml",
+		"-o", "json",
+	)
+
+	// Lint returns exit code 1 because spec validation rejects the null resolver
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "null value")
 }
 
 func TestIntegration_RunSolution_DryRun(t *testing.T) {
@@ -5578,6 +5712,107 @@ spec:
 	assert.Contains(t, stdout, "legacy")
 }
 
+func TestIntegration_RunResolver_PositionalParams(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"-o", "json",
+		"--hide-execution",
+		"name=Alice",
+		"count=5",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "Alice")
+}
+
+func TestIntegration_RunResolver_PositionalMixedWithFlags(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"-o", "json",
+		"--hide-execution",
+		"-r", "name=Bob",
+		"count=3",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "Bob")
+}
+
+func TestIntegration_RunResolver_PositionalWithResolverNames(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"name",
+		"-f", "examples/resolvers/parameters.yaml",
+		"-o", "json",
+		"--hide-execution",
+		"name=Charlie",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, "Charlie")
+	// Should NOT contain "count" or "uppercase" since we only asked for "name"
+	assert.NotContains(t, stdout, "\"count\"")
+}
+
+func TestIntegration_RunResolver_DynamicHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"--help",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	// Should show standard help
+	assert.Contains(t, stdout, "Execute resolvers from a solution without running actions")
+	// Should show dynamic resolver help from the solution
+	assert.Contains(t, stdout, "Solution Resolvers")
+	assert.Contains(t, stdout, "PARAMETER")
+	assert.Contains(t, stdout, "name")
+}
+
+// ============================================================================
+// Run Resolver — Unknown Parameter Key Validation Tests
+// ============================================================================
+
+func TestIntegration_RunResolver_UnknownParamKey(t *testing.T) {
+	t.Parallel()
+	// "namee" is not a valid parameter (should suggest "name")
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"namee=Alice",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not accept input")
+	assert.Contains(t, stderr, `did you mean "name"`)
+}
+
+func TestIntegration_RunResolver_UnknownParamKeyNoSuggestion(t *testing.T) {
+	t.Parallel()
+	// "zzzzz" is too far from any valid parameter key
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"zzzzz=value",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not accept input")
+}
+
 // TestIntegration_Lint_UnreachableTestPath verifies unreachable-test-path lint rule detects bad test file references.
 func TestIntegration_Lint_UnreachableTestPath(t *testing.T) {
 	t.Parallel()
@@ -6112,6 +6347,22 @@ func TestIntegration_SolutionDiff_YAML(t *testing.T) {
 	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
 	assert.Contains(t, stdout, "pathA:")
 	assert.Contains(t, stdout, "changes:")
+}
+
+func TestIntegration_CacheInfo_ShowsArtifactCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	// Build a solution to populate the artifact cache
+	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	require.Equal(t, 0, exitCode)
+
+	// Cache info should report artifact data
+	stdout, _, exitCode2 := runScafctl(t, "cache", "info")
+	assert.Equal(t, 0, exitCode2)
+	// Verify the cache info output contains expected sections
+	assert.Contains(t, stdout, "Cache")
 }
 
 func TestIntegration_SolutionDiff_MissingFile(t *testing.T) {

--- a/tests/integration/solutions/edge-cases/null-resolver/solution.yaml
+++ b/tests/integration/solutions/edge-cases/null-resolver/solution.yaml
@@ -1,0 +1,23 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-null-resolver
+  version: 1.0.0
+  description: |
+    Tests that null resolver values produce clear validation
+    errors instead of nil pointer panics. Covers the case
+    where a YAML key exists but has no body (e.g., migrated
+    solutions with placeholder resolver types).
+
+spec:
+  resolvers:
+    validValue:
+      description: A resolver with a valid resolve block
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+
+    nullValue:

--- a/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
@@ -1,0 +1,78 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-param-key-validation
+  version: 1.0.0
+  description: |
+    Functional tests for parameter key validation.
+    Verifies that unknown parameter keys are rejected with helpful error
+    messages and "did you mean?" suggestions.
+
+spec:
+  resolvers:
+    greeting:
+      description: A greeting message
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
+          - provider: static
+            inputs:
+              value: world
+
+    region:
+      description: Deployment region
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-east-1
+
+  testing:
+    config:
+      skipBuiltins: [resolve-defaults, render-defaults]
+
+    cases:
+      _base:
+        description: Base template
+        command: [run, resolver]
+        args: ["-o", "json", "--hide-execution"]
+        tags: [validation, parameter]
+        assertions:
+          - expression: __exitCode == 0
+
+      valid-params:
+        description: Valid parameter keys are accepted
+        extends: [_base]
+        args: ["-o", "json", "--hide-execution", "-r", "name=Alice", "-r", "region=eu-west-1"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.greeting == "Alice"
+          - expression: __output.region == "eu-west-1"
+
+      unknown-param-with-suggestion:
+        description: Unknown parameter key close to a valid one produces did-you-mean error
+        command: [run, resolver]
+        args: ["-o", "json", "--hide-execution", "-r", "namee=Alice"]
+        tags: [validation, parameter]
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("does not accept input")'
+            message: "Should report unknown input key"
+          - expression: '__stderr.contains("did you mean")'
+            message: "Should suggest closest valid key"
+
+      unknown-param-no-suggestion:
+        description: Completely unknown parameter key produces error without suggestion
+        command: [run, resolver]
+        args: ["-o", "json", "--hide-execution", "-r", "zzzzz=value"]
+        tags: [validation, parameter]
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("does not accept input")'
+            message: "Should report unknown input key"


### PR DESCRIPTION
… help

Add positional key=value input syntax as the recommended way to pass inputs to 'run provider' and resolver parameters to 'run resolver', alongside the existing --input/-r flags. Both forms can be freely mixed; later values win on conflict.

Key changes:

- flags: add ParseDynamicInputArgs() to normalise positional key=value, --key=value, and @file.yaml forms from argv
- flags: add ValidateInputKeys() with Levenshtein-based 'did you mean?' suggestions for unknown input keys (max distance 3)
- run provider: accept positional args after provider name; validate input keys against provider schema; install custom help function that appends provider input table for 'scafctl run provider <name> --help'
- run resolver: split positional args into resolver names (bare words) vs parameters (key=value / @file); validate param keys against parameter-provider 'key' inputs; install custom help function that appends solution resolver parameter table when -f is set
- provider/detail: add FormatProviderInputHelp() to render a provider's input schema as a formatted table for help output
- resolver/detail: add FormatResolverInputHelp() to render a solution's resolver parameters as a formatted table for help output
- solution/inspect: BuildRunCommand() now emits positional key=value for resolver-only solutions and -r flags for workflow solutions
- MCP: update server system prompt, prompts.go, and get_run_command test to recommend positional syntax for resolver commands

Tests:
- Unit tests for ParseDynamicInputArgs and ValidateInputKeys
- Unit tests for FormatProviderInputHelp and FormatResolverInputHelp
- Integration tests for positional inputs, mixed syntax, unknown-key validation (with/without suggestions), and dynamic help output
- New solution fixtures: null-resolver edge case and param-key-validation functional test solution

Docs:
- New auto-discovery tutorial
- run-provider-tutorial and run-resolver-tutorial updated to recommend positional syntax and document dynamic help
- hcl-provider-tutorial and cache-tutorial CLI examples updated