### PR TITLE
feat(cli): improve help UX with options command, command groups, and …

### DIFF
--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -1595,7 +1595,12 @@ if o.File == "" && name != "" {
 
 ## Global Flags
 
-These flags should be available on the root command and inherited by all subcommands:
+Global flags are available on all commands. Users can view them via `scafctl options`.
+They are defined as persistent flags on the root command in `root.go` and are **hidden from `--help` output** — instead, every command's help footer says:
+
+```
+Use "scafctl options" for a list of global command-line options (applies to all commands).
+```
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
@@ -1612,7 +1617,8 @@ These flags should be available on the root command and inherited by all subcomm
 
 ### Adding Global Flags
 
-Global flags are defined in `root.go`:
+Global flags are defined as persistent flags in `root.go`. The custom usage template ensures
+they are hidden from all `--help` output and only shown via `scafctl options`:
 
 ```go
 func Root() *cobra.Command {
@@ -1622,4 +1628,25 @@ func Root() *cobra.Command {
         "Path to config file (default: ~/.scafctl/config.yaml)")
     // ... existing flags
 }
+```
+
+### Command Groups
+
+Top-level commands are organized into named groups using Cobra's `AddGroup()` API.
+Groups are defined in `root.go` and each command is assigned via the `withGroup()` helper:
+
+| Group ID | Title | Commands |
+|----------|-------|----------|
+| `core` | Core Commands | run, render, lint, test |
+| `inspect` | Inspection Commands | eval, explain, get, snapshot, solution |
+| `scaffold` | Scaffolding Commands | new, build, bundle, catalog, vendor |
+| `config` | Configuration & Security Commands | auth, cache, config, secrets |
+| `plugin` | Plugin Commands | mcp, plugins |
+
+Commands without a group (e.g., completion, examples, help, options, version) appear under **Additional Commands**.
+
+When adding a new top-level command, assign it to the appropriate group:
+
+```go
+cCmd.AddCommand(withGroup(groupCore, myCmd.CommandMyCmd(cliParams, ioStreams, settings.CliBinaryName)))
 ```

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -579,7 +579,7 @@ Outputs:
 
 ## Global Flags
 
-These flags are available on most commands:
+These flags are available on all commands. Run `scafctl options` to see them:
 
 | Flag | Short | Description | Status |
 |------|-------|-------------|--------|

--- a/pkg/cmd/scafctl/bundle/bundle.go
+++ b/pkg/cmd/scafctl/bundle/bundle.go
@@ -16,6 +16,7 @@ import (
 func CommandBundle(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "bundle",
+		Aliases:      []string{"bun"},
 		Short:        "Inspect and manage solution bundles",
 		SilenceUsage: true,
 		Long: heredoc.Doc(`

--- a/pkg/cmd/scafctl/eval/eval.go
+++ b/pkg/cmd/scafctl/eval/eval.go
@@ -15,8 +15,9 @@ import (
 // CommandEval creates the 'eval' command group.
 func CommandEval(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cCmd := &cobra.Command{
-		Use:   "eval",
-		Short: "Evaluate CEL expressions and Go templates",
+		Use:     "eval",
+		Aliases: []string{"e"},
+		Short:   "Evaluate CEL expressions and Go templates",
 		Long: `Evaluate and validate CEL expressions and Go templates in isolation.
 
 Useful for testing expressions and templates before using them in solutions.`,

--- a/pkg/cmd/scafctl/examples/examples.go
+++ b/pkg/cmd/scafctl/examples/examples.go
@@ -16,6 +16,7 @@ import (
 func CommandExamples(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cCmd := &cobra.Command{
 		Use:          "examples",
+		Aliases:      []string{"ex"},
 		Short:        "Browse and retrieve scafctl example configurations",
 		SilenceUsage: true,
 	}

--- a/pkg/cmd/scafctl/options/options.go
+++ b/pkg/cmd/scafctl/options/options.go
@@ -1,0 +1,50 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandOptions returns a cobra.Command that prints global (persistent) flags
+// applicable to all commands, similar to kubectl options.
+func CommandOptions(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	return &cobra.Command{
+		Use:          "options",
+		Short:        "List global command-line options (applies to all commands)",
+		Long:         "List global command-line options that are applicable to all commands.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+			cmd.SetContext(ctx)
+
+			root := cmd.Root()
+			if root == nil {
+				return fmt.Errorf("unable to determine root command")
+			}
+
+			flags := root.PersistentFlags()
+			w.Plainf("The following options can be passed to any command:\n\n")
+			w.Plainf("%s", flags.FlagUsages())
+			return nil
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+}

--- a/pkg/cmd/scafctl/options/options_test.go
+++ b/pkg/cmd/scafctl/options/options_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandOptions_Properties(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandOptions(cliParams, ioStreams, "scafctl")
+
+	assert.Equal(t, "options", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+}
+
+func TestCommandOptions_PrintsGlobalFlags(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	var stdout bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &bytes.Buffer{}, false)
+
+	root := &cobra.Command{Use: "scafctl"}
+	root.PersistentFlags().String("log-level", "none", "Set the log level")
+	root.PersistentFlags().BoolP("quiet", "q", false, "Do not print additional information")
+	root.PersistentFlags().Bool("no-color", false, "Disable color output")
+	root.PersistentFlags().String("config", "", "Path to config file")
+
+	optCmd := CommandOptions(cliParams, ioStreams, "scafctl")
+	root.AddCommand(optCmd)
+
+	root.SetArgs([]string{"options"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "The following options can be passed to any command:")
+	assert.Contains(t, output, "--log-level")
+	assert.Contains(t, output, "--quiet")
+	assert.Contains(t, output, "--no-color")
+	assert.Contains(t, output, "--config")
+}
+
+func TestCommandOptions_HiddenFlagsNotShown(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	var stdout bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &bytes.Buffer{}, false)
+
+	root := &cobra.Command{Use: "scafctl"}
+	root.PersistentFlags().String("pprof", "", "Enable profiling")
+	require.NoError(t, root.PersistentFlags().MarkHidden("pprof"))
+	root.PersistentFlags().BoolP("quiet", "q", false, "Do not print additional information")
+
+	optCmd := CommandOptions(cliParams, ioStreams, "scafctl")
+	root.AddCommand(optCmd)
+
+	root.SetArgs([]string{"options"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.NotContains(t, output, "--pprof")
+	assert.Contains(t, output, "--quiet")
+}
+
+func BenchmarkCommandOptions(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	var stdout bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &bytes.Buffer{}, false)
+
+	root := &cobra.Command{Use: "scafctl"}
+	root.PersistentFlags().String("log-level", "none", "Set the log level")
+	root.PersistentFlags().BoolP("quiet", "q", false, "Suppress output")
+
+	optCmd := CommandOptions(cliParams, ioStreams, "scafctl")
+	root.AddCommand(optCmd)
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		root.SetArgs([]string{"options"})
+		_ = root.Execute()
+	}
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
 	mcpcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/mcp"
 	newcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/new"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/options"
 	pluginscmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/plugins"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/render"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
@@ -51,6 +52,49 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
+)
+
+// rootUsageTemplate is a custom usage template that hides global (persistent)
+// flags from all commands and instead directs users to "scafctl options".
+// This is based on Cobra's default usage template with the inherited-flags
+// section replaced by a one-line pointer, matching kubectl's UX pattern.
+// Local flags (command-specific) are still shown on subcommands.
+const rootUsageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasParent}}{{if .NonInheritedFlags.HasAvailableFlags}}
+
+Flags:
+{{.NonInheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+Use "{{.Root.Name}} options" for a list of global command-line options (applies to all commands).
+`
+
+// Command group IDs for organizing subcommands in help output.
+const (
+	groupCore     = "core"
+	groupInspect  = "inspect"
+	groupScaffold = "scaffold"
+	groupConfig   = "config"
+	groupPlugin   = "plugin"
 )
 
 // RootOptions configures a Root() invocation. All fields are optional;
@@ -419,6 +463,18 @@ func Root(opts *RootOptions) *cobra.Command {
 		},
 	}
 
+	cCmd.SetUsageTemplate(rootUsageTemplate)
+
+	// Command groups — organizes subcommands into logical categories
+	// in the help output, similar to kubectl's grouped help display.
+	cCmd.AddGroup(
+		&cobra.Group{ID: groupCore, Title: "Core Commands:"},
+		&cobra.Group{ID: groupInspect, Title: "Inspection Commands:"},
+		&cobra.Group{ID: groupScaffold, Title: "Scaffolding Commands:"},
+		&cobra.Group{ID: groupConfig, Title: "Configuration & Security Commands:"},
+		&cobra.Group{ID: groupPlugin, Title: "Plugin Commands:"},
+	)
+
 	cCmd.PersistentFlags().StringVar(&cliParams.MinLogLevel, "log-level", "none", "Set the log level (none, error, warn, info, debug, trace, or a numeric V-level)")
 	cCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debug logging (shorthand for --log-level debug)")
 	cCmd.PersistentFlags().StringVar(&logFormat, "log-format", "console", "Set the log output format (console, json)")
@@ -438,27 +494,45 @@ func Root(opts *RootOptions) *cobra.Command {
 	if err := cCmd.PersistentFlags().MarkHidden("pprof-output-dir"); err != nil {
 		return nil
 	}
+	// Core Commands — primary workflows
+	cCmd.AddCommand(withGroup(groupCore, run.CommandRun(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupCore, render.CommandRender(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupCore, lint.CommandLint(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupCore, testcmd.CommandTest(cliParams, ioStreams, settings.CliBinaryName)))
+
+	// Inspection Commands — explore and understand solutions
+	cCmd.AddCommand(withGroup(groupInspect, get.CommandGet(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupInspect, explain.CommandExplain(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupInspect, eval.CommandEval(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupInspect, solutioncmd.CommandSolution(cliParams, *ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupInspect, snapshot.CommandSnapshot(cliParams, *ioStreams, settings.CliBinaryName)))
+
+	// Scaffolding Commands — create and package artifacts
+	cCmd.AddCommand(withGroup(groupScaffold, newcmd.CommandNew(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupScaffold, build.CommandBuild(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupScaffold, bundlecmd.CommandBundle(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupScaffold, vendorcmd.CommandVendor(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupScaffold, catalogcmd.CommandCatalog(cliParams, ioStreams, settings.CliBinaryName)))
+
+	// Configuration & Security Commands
+	cCmd.AddCommand(withGroup(groupConfig, configcmd.CommandConfig(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupConfig, secretscmd.CommandSecrets(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupConfig, authcmd.CommandAuth(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupConfig, cachecmd.CommandCache(cliParams, ioStreams, settings.CliBinaryName)))
+
+	// Plugin Commands
+	cCmd.AddCommand(withGroup(groupPlugin, pluginscmd.CommandPlugins(cliParams, ioStreams, settings.CliBinaryName)))
+	cCmd.AddCommand(withGroup(groupPlugin, mcpcmd.CommandMCP(cliParams, ioStreams, settings.CliBinaryName)))
+
+	// Other Commands (no group — shown under "Additional Commands:")
 	cCmd.AddCommand(version.CommandVersion(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(get.CommandGet(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(run.CommandRun(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(render.CommandRender(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(explain.CommandExplain(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(snapshot.CommandSnapshot(cliParams, *ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(configcmd.CommandConfig(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(secretscmd.CommandSecrets(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(authcmd.CommandAuth(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(lint.CommandLint(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(eval.CommandEval(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(newcmd.CommandNew(cliParams, ioStreams, settings.CliBinaryName))
 	cCmd.AddCommand(examplescmd.CommandExamples(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(build.CommandBuild(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(catalogcmd.CommandCatalog(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(cachecmd.CommandCache(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(bundlecmd.CommandBundle(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(vendorcmd.CommandVendor(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(testcmd.CommandTest(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(mcpcmd.CommandMCP(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(pluginscmd.CommandPlugins(cliParams, ioStreams, settings.CliBinaryName))
-	cCmd.AddCommand(solutioncmd.CommandSolution(cliParams, *ioStreams, settings.CliBinaryName))
+	cCmd.AddCommand(options.CommandOptions(cliParams, ioStreams, settings.CliBinaryName))
 	return cCmd
+}
+
+// withGroup sets the GroupID on a command and returns it for chaining.
+func withGroup(group string, cmd *cobra.Command) *cobra.Command {
+	cmd.GroupID = group
+	return cmd
 }

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -4,11 +4,13 @@
 package scafctl
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoot_CommandProperties(t *testing.T) {
@@ -83,6 +85,85 @@ func TestRoot_HasVersionSubcommand(t *testing.T) {
 	}
 	if !found {
 		t.Error("Expected 'version' subcommand to be added")
+	}
+}
+
+func TestRoot_HasOptionsSubcommand(t *testing.T) {
+	t.Parallel()
+	cmd := Root(nil)
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "options" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected 'options' subcommand to be added")
+	}
+}
+
+func TestRoot_CommandGroups(t *testing.T) {
+	t.Parallel()
+	cmd := Root(nil)
+
+	groups := cmd.Groups()
+	if len(groups) == 0 {
+		t.Fatal("Expected command groups to be defined")
+	}
+
+	wantGroups := []string{"core", "inspect", "scaffold", "config", "plugin"}
+	gotIDs := make(map[string]bool)
+	for _, g := range groups {
+		gotIDs[g.ID] = true
+	}
+	for _, id := range wantGroups {
+		if !gotIDs[id] {
+			t.Errorf("Expected group %q to be defined", id)
+		}
+	}
+
+	// Verify key commands have group assignments.
+	subCmds := make(map[string]string)
+	for _, sub := range cmd.Commands() {
+		subCmds[sub.Name()] = sub.GroupID
+	}
+	wantAssignments := map[string]string{
+		"run":     "core",
+		"lint":    "core",
+		"get":     "inspect",
+		"explain": "inspect",
+		"new":     "scaffold",
+		"build":   "scaffold",
+		"config":  "config",
+		"auth":    "config",
+		"plugins": "plugin",
+		"mcp":     "plugin",
+	}
+	for name, wantGroup := range wantAssignments {
+		if got := subCmds[name]; got != wantGroup {
+			t.Errorf("command %q: GroupID = %q, want %q", name, got, wantGroup)
+		}
+	}
+}
+
+func TestRoot_UsageTemplateHidesGlobalFlags(t *testing.T) {
+	t.Parallel()
+	cmd := Root(nil)
+
+	// Verify the rendered root help omits flags and references "options".
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	output := buf.String()
+
+	if strings.Contains(output, "Global Flags:") {
+		t.Error("Root help output should not contain 'Global Flags:' section")
+	}
+	if !strings.Contains(output, `Use "scafctl options"`) {
+		t.Error("Root help output should reference 'scafctl options' command")
 	}
 }
 

--- a/pkg/cmd/scafctl/snapshot/snapshot.go
+++ b/pkg/cmd/scafctl/snapshot/snapshot.go
@@ -14,6 +14,7 @@ import (
 func CommandSnapshot(cliParams *settings.Run, ioStreams terminal.IOStreams, binaryName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "snapshot",
+		Aliases:      []string{"snap"},
 		Short:        "Manage resolver execution snapshots",
 		SilenceUsage: true,
 		Long: heredoc.Doc(`

--- a/pkg/cmd/scafctl/vendor/vendor.go
+++ b/pkg/cmd/scafctl/vendor/vendor.go
@@ -15,6 +15,7 @@ import (
 func CommandVendor(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "vendor",
+		Aliases:      []string{"vend"},
 		Short:        "Manage vendored solution dependencies",
 		SilenceUsage: true,
 		Long: heredoc.Doc(`

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -155,6 +155,29 @@ func TestIntegration_Help(t *testing.T) {
 	assert.Contains(t, stdout, "run")
 	assert.Contains(t, stdout, "render")
 	assert.Contains(t, stdout, "get")
+	assert.Contains(t, stdout, `Use "scafctl options" for a list of global command-line options (applies to all commands).`)
+	assert.NotContains(t, stdout, "Global Flags:")
+
+	// Command groups
+	assert.Contains(t, stdout, "Core Commands:")
+	assert.Contains(t, stdout, "Inspection Commands:")
+	assert.Contains(t, stdout, "Scaffolding Commands:")
+	assert.Contains(t, stdout, "Configuration & Security Commands:")
+	assert.Contains(t, stdout, "Plugin Commands:")
+	assert.Contains(t, stdout, "Additional Commands:")
+}
+
+func TestIntegration_Options(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "options")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "The following options can be passed to any command:")
+	assert.Contains(t, stdout, "--log-level")
+	assert.Contains(t, stdout, "--quiet")
+	assert.Contains(t, stdout, "--no-color")
+	assert.Contains(t, stdout, "--config")
+	assert.Contains(t, stdout, "--cwd")
 }
 
 func TestIntegration_RunHelp(t *testing.T) {
@@ -5416,19 +5439,19 @@ func TestIntegration_LogLevel_Numeric(t *testing.T) {
 }
 
 // TestIntegration_OtelEndpoint_FlagRegistered confirms that --otel-endpoint is
-// listed in the root --help output.
+// listed in the options output.
 func TestIntegration_OtelEndpoint_FlagRegistered(t *testing.T) {
 	t.Parallel()
-	stdout, _, exitCode := runScafctl(t, "--help")
+	stdout, _, exitCode := runScafctl(t, "options")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "otel-endpoint")
 }
 
 // TestIntegration_OtelInsecure_FlagRegistered confirms that --otel-insecure is
-// listed in the root --help output.
+// listed in the options output.
 func TestIntegration_OtelInsecure_FlagRegistered(t *testing.T) {
 	t.Parallel()
-	stdout, _, exitCode := runScafctl(t, "--help")
+	stdout, _, exitCode := runScafctl(t, "options")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "otel-insecure")
 }


### PR DESCRIPTION
…aliases

Add kubectl-inspired improvements to the scafctl CLI help experience:

- Add 'scafctl options' command that lists all global persistent flags, replacing the cluttered 'Global Flags:' section in the default help output
- Set a custom Cobra usage template on the root command that hides global flags from all command help output and appends a footer: 'Use "scafctl options" for a list of global command-line options'
- Organize the 25+ root subcommands into five named command groups for improved discoverability:
    Core Commands:                 run, render, lint, test
    Inspection Commands:           eval, explain, get, snapshot, solution
    Scaffolding Commands:          new, build, bundle, catalog, vendor
    Configuration & Security:      auth, cache, config, secrets
    Plugin Commands:               mcp, plugins
- Add short aliases to commands that were missing them:
    eval → e, snapshot → snap, bundle → bun, vendor → vend, examples → ex
- Update root_test.go with tests for the options subcommand, command groups,
  and usage template behavior
- Update integration tests to assert group headings and options command output
- Update docs/design/cli.md to reference 'scafctl options' for global flags
