### PR TITLE
ci: integrate Codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,9 @@ jobs:
           SCAFCTL_SECRET_KEY: dGVzdC1zZWNyZXQta2V5LWZvci1jaS0xMjM0NTY3ODk=
       
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
           fail_ci_if_error: false

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -375,10 +375,10 @@ tasks:
       - go.sum
 
   test-cover:
-    desc: "Run unit tests"
+    desc: "Run unit tests with coverage"
     cmds:
       - |
-        go test ./... -cover
+        go test ./... -coverprofile=coverage.txt -covermode=atomic
     sources:
       - "**/*.go"
       - go.mod


### PR DESCRIPTION
Update the test-cover task to generate a coverage report file using -coverprofile=coverage.txt and -covermode=atomic, as required by Codecov for accurate coverage analysis.

Upgrade the Codecov GitHub Actions step from v4 to v5 and explicitly reference the generated coverage.txt file via the files input, ensuring reports are correctly uploaded to Codecov on every CI run.
