### PR TITLE
docs: improve tutorials and remove deprecated render --graph flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ scafctl snapshot show --name baseline
 scafctl snapshot diff --from baseline --to current
 
 # Resolver dependency graph
-scafctl render solution -f solution.yaml --graph
+scafctl run resolver -f solution.yaml --graph
 
 # Configuration and secrets
 scafctl config show

--- a/docs/design/actions.md
+++ b/docs/design/actions.md
@@ -291,8 +291,9 @@ inputs:
 
 ### Rules
 
-- `__actions.<name>` may only reference declared dependencies
-- Referencing a non-dependency is a validation error
+- `__actions.<name>` must reference existing actions in the workflow
+- Dependencies are automatically inferred from `__actions` references during graph building. If your inputs or `when` condition reference `__actions.<name>`, an explicit `dependsOn: [<name>]` is not required for same-section ordering—the scheduler adds it automatically. Use `dependsOn` explicitly only for ordering without a data dependency.
+- `dependsOn` in `workflow.finally` cannot cross sections. To read results from a regular action inside a `finally` action, use `__actions.<name>` in inputs or `when`. The reference is **not** added to `dependencies` (which drives `FinallyOrder` phase computation) because cross-section ordering is guaranteed structurally—all main actions complete before any finally action starts. The reference is instead recorded in `crossSectionRefs` on the rendered graph for traceability.
 - In render mode, expressions referencing `__actions` are preserved as deferred expressions
 - External executors must be CEL-capable to evaluate deferred expressions
 
@@ -837,7 +838,7 @@ spec:
 
 ### Cross-Section References
 
-Finally actions can read from regular actions but cannot depend on them:
+Finally actions can read from regular actions but cannot declare a scheduling `dependsOn` on them.
 
 ~~~yaml
 spec:
@@ -850,7 +851,10 @@ spec:
 
     finally:
       report:
-        # ✅ Valid: Reference results/status via expressions
+        # ✅ Valid: Reference results/status via expressions.
+        # "deploy" appears in crossSectionRefs on the rendered graph (informational).
+        # It does NOT appear in dependencies because cross-section ordering is
+        # guaranteed structurally — all main actions complete first.
         provider: slack
         inputs:
           message:
@@ -859,12 +863,23 @@ spec:
             expr: __actions.deploy.error  # Available if deploy failed
 
       cleanup:
-        # ❌ Invalid: Cannot dependsOn regular actions
-        # dependsOn: [deploy]  # This would be a validation error
+        # ❌ Invalid: Cannot use dependsOn to reference regular actions from finally.
+        # dependsOn: [deploy]  # Validation error: dep not found in finally section
         provider: exec
         inputs:
           command: "rm -rf /tmp/build"
 ~~~
+
+#### `dependencies` vs `crossSectionRefs` in the rendered graph
+
+The rendered `ActionGraph` distinguishes two categories of relationships for a `finally` action:
+
+| Field | Content | Used for scheduling? |
+|---|---|---|
+| `dependencies` | Same-section `__actions` refs + explicit `dependsOn` | ✅ Yes — drives `FinallyOrder` phase ordering |
+| `crossSectionRefs` | `__actions` refs pointing at actions in `workflow.actions` | ❌ No — informational only |
+
+Cross-section ordering does not need to appear in `FinallyOrder` because the executor already guarantees all main actions finish before the finally section begins. Recording them in `crossSectionRefs` preserves traceability (e.g. for graph visualisation and audit) without introducing phantom in-degrees into the phase scheduler.
 
 ### Execution Order
 
@@ -963,6 +978,7 @@ After rendering, scafctl emits a graph that contains only concrete inputs and ex
     "cleanup": {
       "provider": "shell",
       "section": "finally",
+      "crossSectionRefs": ["deploy"],
       "inputs": {
         "command": "rm -rf /tmp/build"
       }
@@ -1030,6 +1046,7 @@ actions:
   cleanup:
     provider: exec
     section: finally
+    crossSectionRefs: [deploy]
     inputs:
       command: rm -rf /tmp/build
 
@@ -1066,6 +1083,7 @@ actions:
 - `executionOrder` is an array of phases, where each phase is an array of action names that can execute concurrently
 - `finallyOrder` is a separate array of phases for finally actions
 - Finally actions include `"section": "finally"` in the rendered output
+- Finally actions that read from `workflow.actions` via `__actions` references include `crossSectionRefs` listing those action names (informational — does not affect `FinallyOrder` phase computation)
 
 ---
 
@@ -1094,12 +1112,13 @@ The following are validated at parse/load time:
 3. Action names containing `[` or `]` are reserved (used for forEach expansion)
 4. Action names must be unique across both `workflow.actions` and `workflow.finally` sections
 5. `dependsOn` in `workflow.actions` must reference existing actions in `workflow.actions`
-6. `dependsOn` in `workflow.finally` must reference existing actions in `workflow.finally` only (cannot depend on regular actions)
+6. `dependsOn` in `workflow.finally` must reference existing actions in `workflow.finally` only (cannot depend on regular actions via `dependsOn`). To read results from a regular action inside a `finally` action, reference it via `__actions.<name>` in inputs or `when` — the reference is recorded in `crossSectionRefs` on the rendered graph for traceability; cross-section ordering is guaranteed structurally.
 7. `dependsOn` must not create cycles (within each section)
 8. Provider must exist and have `CapabilityAction`
-9. `__actions.<name>` references in expressions/templates must reference:
-   - In `workflow.actions`: actions in `dependsOn` (same section)
-   - In `workflow.finally`: any regular action OR finally actions in `dependsOn`
+9. `__actions.<name>` references in expressions/templates must reference existing actions:
+   - In `workflow.actions`: must reference actions defined in `workflow.actions`
+   - In `workflow.finally`: must reference actions defined in `workflow.actions` or `workflow.finally`
+   - Same-section `__actions` references are automatically added to `dependencies` during graph building (`dependsOn` is optional for those). Cross-section references (a `finally` action reading from `workflow.actions`) are recorded in `crossSectionRefs` only — they do not appear in `dependencies`. Use `dependsOn` explicitly only for same-section ordering without a data dependency.
 10. `forEach` is only allowed in `workflow.actions`, not in `workflow.finally`
 11. `retry.maxAttempts` must be >= 1
 12. `timeout` must be a valid duration

--- a/docs/design/cel.md
+++ b/docs/design/cel.md
@@ -196,7 +196,7 @@ actions:
 
 **Implementation Details:**
 - Constant: `VarActions = "__actions"` in `pkg/celexp/context.go`
-- Validation ensures `__actions` references only appear in actions with proper `dependsOn` declarations
+- Dependencies are automatically inferred from `__actions` references during workflow graph building
 - See `pkg/action/` for workflow execution implementation
 
 ---

--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -119,7 +119,7 @@ pkg/cmd/scafctl/
 │   └── progress.go      # Progress reporting
 ├── render/              # 'render' verb
 │   ├── render.go
-│   ├── solution.go      # 'render solution' (dry-run, --graph, --snapshot)
+│   ├── solution.go      # 'render solution' (dry-run, --action-graph, --snapshot)
 │   └── graph.go         # Graph rendering logic
 ├── build/               # 'build' verb (analogous to docker build)
 │   ├── build.go
@@ -1162,7 +1162,7 @@ This section tracks which commands from the design are implemented and what work
 | `get celfunction` | ✅ | Show CEL function details |
 | `run solution` | ✅ | Executes resolvers AND actions |
 | `run resolver` | ✅ | Executes resolvers only (for debugging and inspection) |
-| `render solution` | ✅ | Includes `--graph`, `--action-graph`, `--snapshot`, `--redact` flags |
+| `render solution` | ✅ | Includes `--action-graph`, `--snapshot`, `--redact` flags |
 | `build solution` | ✅ | Build solution into local catalog |
 | `catalog push` | ✅ | Push artifacts to remote catalog |
 | `catalog pull` | ✅ | Pull artifacts from remote catalog |
@@ -1225,7 +1225,7 @@ This section tracks which commands from the design are implemented and what work
 |---------|--------|--------|
 | `run workflow` | ✅ **Removed** | Merged into `run solution` (solution now runs resolvers + actions) |
 | `snapshot save` | ✅ **Removed** | Replaced with `render solution --snapshot` |
-| `resolver graph` | ✅ **Removed** | Replaced with `render solution --graph` |
+| `resolver graph` | ✅ **Removed** | Replaced with `run resolver --graph` |
 
 ### Code Changes Required
 
@@ -1280,10 +1280,10 @@ type RenderOptions struct {
 # Normal render (resolvers + action preview)
 scafctl render solution -f solution.yaml
 
-# Show dependency graph
-scafctl render solution -f solution.yaml --graph
-scafctl render solution -f solution.yaml --graph --graph-format dot | dot -Tpng > graph.png
-scafctl render solution -f solution.yaml --graph --graph-format mermaid
+# Show resolver dependency graph
+scafctl run resolver -f solution.yaml --graph
+scafctl run resolver -f solution.yaml --graph --graph-format dot | dot -Tpng > graph.png
+scafctl run resolver -f solution.yaml --graph --graph-format mermaid
 
 # Save snapshot
 scafctl render solution -f solution.yaml --snapshot output.json

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -26,7 +26,7 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 |---------|--------|-------|
 | `run solution` | ✅ Implemented | Requires workflow (errors if no workflow defined; use `run resolver` for resolver-only) |
 | `run resolver` | ✅ Implemented | Resolver-only execution for debugging and inspection |
-| `render solution` | ✅ Implemented | Includes graph and snapshot modes |
+| `render solution` | ✅ Implemented | Includes action-graph and snapshot modes |
 | `get solution/provider/resolver` | ✅ Implemented | |
 | `explain solution/provider` | ✅ Implemented | |
 | `config *` | ✅ Implemented | view, get, set, unset, add-catalog, remove-catalog, use-catalog, init, schema, validate |
@@ -34,7 +34,7 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 | `solution diff` | ✅ Implemented | Structural comparison of two solution files |
 | `secrets *` | ✅ Implemented | list, get, set, delete, exists, export, import, rotate |
 | `auth *` | ✅ Implemented | login, logout, status, token |
-| `resolver graph` | ❌ Removed | Use `render solution --graph` or `run resolver --graph` instead |
+| `resolver graph` | ❌ Removed | Use `run resolver --graph` instead |
 | `build solution` | ✅ Implemented | Catalog feature |
 | `catalog list/inspect/delete/prune` | ✅ Implemented | Catalog management |
 | `catalog save/load` | ✅ Implemented | Offline distribution |
@@ -337,24 +337,6 @@ scafctl render solution example \
 ### Render Options
 
 The `render` command supports additional modes for debugging and testing:
-
-#### Dependency Graph
-
-Visualize resolver dependencies without executing:
-
-~~~bash
-# ASCII art (default)
-scafctl render solution -f solution.yaml --graph
-
-# Graphviz DOT format (pipe to dot command)
-scafctl render solution -f solution.yaml --graph --graph-format dot | dot -Tpng > graph.png
-
-# Mermaid diagram syntax
-scafctl render solution -f solution.yaml --graph --graph-format mermaid
-
-# JSON for automation
-scafctl render solution -f solution.yaml --graph --graph-format json
-~~~
 
 #### Execution Snapshots
 
@@ -749,7 +731,7 @@ scafctl auth logout entra
 ## Resolver Commands
 
 > **Note**: The standalone `scafctl resolver graph` command has been removed.
-> Use `scafctl render solution --graph` or `scafctl run resolver --graph` instead.
+> Use `scafctl run resolver --graph` instead.
 
 ### Running Resolvers
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -583,7 +583,7 @@ The primary use case is AI-assisted solution authoring — helping users create 
 | `lint_solution` | Validate a solution file | Yes |
 | `list_providers` | List available providers and their schemas | Yes |
 | `get_provider_schema` | Get JSON Schema for a provider's inputs | Yes |
-| `render_solution` | Render action graph without executing | Yes |
+| `render_solution` | Render action graph without executing (includes `crossSectionRefs` for finally→main references) | Yes |
 | `list_cel_functions` | List all available CEL functions (built-in + scafctl custom) | Yes |
 | `list_go_template_functions` | List all available Go template extension functions (Sprig + custom) | Yes |
 | `evaluate_cel` | Test a CEL expression against sample data | Yes |

--- a/docs/design/misc.md
+++ b/docs/design/misc.md
@@ -240,12 +240,9 @@ Visualization operates on rendered graphs, not runtime execution.
 
 ```bash
 # Resolver graph visualization
-scafctl render solution -f solution.yaml --graph
-scafctl render solution -f solution.yaml --graph --graph-format=dot
-scafctl render solution -f solution.yaml --graph --graph-format=mermaid
-
-# Standalone resolver graph
-scafctl resolver graph -f solution.yaml --format=mermaid
+scafctl run resolver -f solution.yaml --graph
+scafctl run resolver -f solution.yaml --graph --graph-format=dot
+scafctl run resolver -f solution.yaml --graph --graph-format=mermaid
 ```
 
 ---

--- a/docs/design/solutions.md
+++ b/docs/design/solutions.md
@@ -352,8 +352,10 @@ All dependencies are inferred and validated.
 ### Action Dependencies
 
 - Declared explicitly with `dependsOn`
-- Must form a DAG
+- Inferred automatically from `__actions.<name>` references in inputs and `when` conditions
+- Must form a DAG (within each section)
 - Cycles are rejected
+- `dependsOn` in `workflow.finally` can only reference other finally actions — to read results from a main action, use `__actions.<name>` in inputs or `when` (the reference appears in `crossSectionRefs` on the rendered graph, not in `dependencies`)
 
 Resolvers never depend on actions.
 
@@ -548,8 +550,10 @@ spec:
       actionName:
         # Same fields as actions, except:
         # - No forEach allowed
-        # - Cannot dependsOn regular actions
-        # - Has implicit dependency on all regular actions
+        # - dependsOn can only reference other finally actions
+        # - To read main action results, use __actions.<name> in inputs/when
+        #   (appears in crossSectionRefs on rendered graph, not dependencies)
+        # - All main actions complete before any finally action starts
 ~~~
 
 ### Metadata Fields

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -11,6 +11,7 @@ Step-by-step guides for learning scafctl features.
 ## Getting Started
 
 - [Getting Started](getting-started.md) — Install scafctl and run your first solution
+- [Solution Scaffolding Tutorial](scaffolding-tutorial.md) — Create new solutions with `scafctl new solution`
 
 ## Core Tutorials
 
@@ -19,21 +20,23 @@ Step-by-step guides for learning scafctl features.
 - [Run Provider Tutorial](run-provider-tutorial.md) — Test providers in isolation
 - [Actions Tutorial](actions-tutorial.md) — Learn how to use actions for workflow automation
 - [Authentication Tutorial](auth-tutorial.md) — Set up authentication for your workflows
+- [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
+- [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
 - [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
+- [MCP Server Tutorial](mcp-server-tutorial.md) — Set up AI agent integration with VS Code Copilot, Claude, Cursor, and Windsurf
+- [Security Hardening](security-hardening.md) — Secure your solutions and workflows
+- [Validation Patterns Tutorial](validation-patterns-tutorial.md) — Input constraints, runtime validation, and common regex/CEL patterns
 - [Snapshots Tutorial](snapshots-tutorial.md) — Capture and compare execution snapshots
 - [Functional Testing Tutorial](functional-testing.md) — Write and run automated tests for your solutions
+
+## Operations & Configuration
+
 - [Configuration Tutorial](config-tutorial.md) — Manage application configuration
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
+- [Telemetry Tutorial](telemetry-tutorial.md) — Ship traces and metrics to Jaeger / Prometheus
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
-
-## Developer Tools
-
-- [Solution Scaffolding Tutorial](scaffolding-tutorial.md) — Create new solutions with `scafctl new solution`
-- [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
-- [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
-- [Validation Patterns Tutorial](validation-patterns-tutorial.md) — Input constraints, runtime validation, and common regex/CEL patterns
 
 ## Reference
 
@@ -50,7 +53,4 @@ Step-by-step guides for learning scafctl features.
 - [Auth Handler Development Guide](auth-handler-development.md) — Build custom auth handlers (builtin and plugin)
 - [Plugin Development Guide](plugin-development.md) — Plugin overview and discovery
 - [Plugin Auto-Fetching Tutorial](plugin-auto-fetch-tutorial.md) — Automatically fetch plugins from catalogs at runtime
-
-## AI Integration
-
-- [MCP Server Tutorial](mcp-server-tutorial.md) — Set up AI agent integration with VS Code Copilot, Claude, Cursor, and Windsurf
+- [Multi-Platform Plugin Build Tutorial](multi-platform-plugin-build.md) — Build plugins for multiple platforms

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -11,11 +11,9 @@ This tutorial introduces the Actions feature in scafctl, which enables executing
 
 Actions are the execution phase of a scafctl solution. While **resolvers** compute and gather data, **actions** perform work based on that data.
 
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  Resolvers  │ ──► │   Actions   │ ──► │   Results   │
-│ (compute)   │     │  (execute)  │     │  (outputs)  │
-└─────────────┘     └─────────────┘     └─────────────┘
+```mermaid
+flowchart LR
+  A["Resolvers<br/>(compute)"] --> B["Actions<br/>(execute)"] --> C["Results<br/>(outputs)"]
 ```
 
 **Key Principles:**
@@ -60,9 +58,18 @@ spec:
 ```
 
 Run it:
+{{< tabs "actions-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f hello-actions.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f hello-actions.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -107,9 +114,18 @@ This creates a linear chain: `build → test → deploy`
 
 Run it:
 
+{{< tabs "actions-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f build-pipeline.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f build-pipeline.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -169,9 +185,18 @@ This creates a diamond pattern:
 
 Run it:
 
+{{< tabs "actions-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f parallel.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f parallel.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output (build and test may appear in either order since they run in parallel):
 
@@ -182,6 +207,7 @@ Initializing...
 Deploying...
 ```
 
+> [!NOTE]
 > **Note**: When actions run in parallel, their output is prefixed with `[action-name]` to distinguish which action produced each line. Actions running alone (like `init` and `deploy`) don't get a prefix.
 
 ## Conditions (`when`)
@@ -245,9 +271,18 @@ spec:
 
 ### Run with Default (staging)
 
+{{< tabs "actions-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f conditional-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f conditional-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -261,9 +296,18 @@ The `prod-deploy` action is skipped because the condition `_.environment == 'pro
 
 ### Run with Production
 
+{{< tabs "actions-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f conditional-demo.yaml -r environment=prod
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f conditional-demo.yaml -r environment=prod
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -340,9 +384,18 @@ spec:
             expr: "'echo Verifying ' + string(size(_.targets)) + ' deployments...'"
 ```
 
+{{< tabs "actions-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f foreach-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f foreach-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -405,9 +458,18 @@ spec:
           command: "echo 'Doing main work...'"
 ```
 
+{{< tabs "actions-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f error-handling-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f error-handling-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -462,9 +524,18 @@ spec:
             expr: "'echo Hello, ' + __actions['fetch-user'].results.name + '!'"
 ```
 
+{{< tabs "actions-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f results-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f results-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -589,9 +660,18 @@ spec:
           command: "echo 'Retry + timeout succeeded'"
 ```
 
+{{< tabs "actions-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f retry-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f retry-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -713,9 +793,18 @@ Both database actions are eligible to run at the same time (neither depends on t
 
 Run it:
 
+{{< tabs "actions-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f exclusive-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f exclusive-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Key Rules
 
@@ -733,6 +822,7 @@ scafctl run solution -f exclusive-demo.yaml
 - **Rate-limited APIs**: Prevent overwhelming an external service with concurrent requests
 - **File operations**: Two actions that read/write the same file or directory
 
+> [!NOTE]
 > **Tip:** Prefer `dependsOn` when there is a true data dependency (one action needs the output of another). Use `exclusive` when the dependency is only about shared resource access and the execution order does not matter.
 
 ---
@@ -794,9 +884,18 @@ spec:
           command: "echo Workflow complete, cleanup finished"
 ```
 
+{{< tabs "actions-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f finally-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f finally-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -813,8 +912,31 @@ The finally actions run after all main actions complete. If `run-tests` failed, 
 ### Finally Rules
 
 - Finally actions run **after all main actions** (whether they succeeded or failed)
-- Finally actions can only depend on **other finally actions** (not main actions)
+- Finally actions can only use `dependsOn` to reference **other finally actions** — not main actions. Using `dependsOn: [main-action]` inside `finally` is a validation error.
+- To **read results from a main action** inside a finally action, use `__actions.<name>` in `inputs` or `when`. The scheduler does not need a dependency entry because structural ordering already guarantees all main actions finish first. The reference appears in `crossSectionRefs` on the rendered graph for traceability.
 - ForEach is **not allowed** in the finally section
+
+```yaml
+# ✅ Valid: read a main action result from finally via __actions
+finally:
+  upload-logs:
+    provider: exec
+    inputs:
+      command:
+        expr: "'echo upload: test outcome=' + string(__actions.run-tests.status)"
+
+# ✅ Valid: order two finally actions with dependsOn
+  notify:
+    provider: exec
+    dependsOn: [upload-logs]
+    inputs:
+      command: "echo done"
+
+# ❌ Invalid: dependsOn cannot cross sections
+  bad-action:
+    provider: exec
+    dependsOn: [run-tests]   # validation error: run-tests is in workflow.actions
+```
 
 ---
 
@@ -878,6 +1000,8 @@ See [Provider Reference](provider-reference.md) for complete provider documentat
 
 Run a solution (resolvers + actions):
 
+{{< tabs "actions-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # Basic execution
 scafctl run solution -f hello-world.yaml
@@ -903,11 +1027,42 @@ scafctl run resolver -f conditional-demo.yaml -r environment=staging --hide-exec
 # Run specific resolvers for inspection
 scafctl run resolver config -f conditional-demo.yaml -r environment=staging --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Basic execution
+scafctl run solution -f hello-world.yaml
+
+# Run with progress output
+scafctl run solution -f hello-world.yaml --progress
+
+# JSON output (for scripts/pipelines)
+scafctl run solution -f hello-world.yaml -o json
+
+# Override resolver values
+scafctl run solution -f conditional-demo.yaml -r environment=prod
+
+# Limit parallel actions
+scafctl run solution -f foreach-demo.yaml --max-action-concurrency=2
+
+# Dry-run (show plan without executing)
+scafctl run solution -f hello-world.yaml --dry-run
+
+# Run resolvers only (skip actions, for debugging)
+scafctl run resolver -f conditional-demo.yaml -r environment=staging --hide-execution
+
+# Run specific resolvers for inspection
+scafctl run resolver config -f conditional-demo.yaml -r environment=staging --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Render Mode
 
 Generate an executor-ready artifact:
 
+{{< tabs "actions-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 # Render to JSON (default)
 scafctl render solution -f hello-world.yaml
@@ -918,11 +1073,27 @@ scafctl render solution -f hello-world.yaml -o yaml
 # Write to file
 scafctl render solution -f hello-world.yaml -o json > graph.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Render to JSON (default)
+scafctl render solution -f hello-world.yaml
+
+# Render to YAML
+scafctl render solution -f hello-world.yaml -o yaml
+
+# Write to file
+scafctl render solution -f hello-world.yaml -o json > graph.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Working Directory Override
 
 Use `--cwd` (`-C`) to run solutions from a different directory. All file paths in actions (reads, writes, exec commands) resolve against the specified directory:
 
+{{< tabs "actions-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run a solution in a different project directory
 scafctl --cwd /path/to/project run solution -f solution.yaml
@@ -930,6 +1101,17 @@ scafctl --cwd /path/to/project run solution -f solution.yaml
 # Combine with --output-dir: resolvers read from --cwd, actions write to --output-dir
 scafctl -C /path/to/project run solution -f solution.yaml --output-dir /tmp/output
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run a solution in a different project directory
+scafctl --cwd /path/to/project run solution -f solution.yaml
+
+# Combine with --output-dir: resolvers read from --cwd, actions write to --output-dir
+scafctl -C /path/to/project run solution -f solution.yaml --output-dir /tmp/output
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The rendered output includes:
 - Expanded actions (ForEach iterations)

--- a/docs/tutorials/auth-handler-development.md
+++ b/docs/tutorials/auth-handler-development.md
@@ -18,6 +18,7 @@ Auth handlers can be delivered in two ways:
 | **Distribution** | Ships with scafctl releases | OCI catalog artifact (`kind: auth-handler`) or standalone binary |
 | **Interface** | `auth.Handler` (8 methods) | `plugin.AuthHandlerPlugin` (7 methods) |
 
+> [!WARNING]
 > **Prerequisite**: Read the [Extension Concepts](extension-concepts.md) page for terminology (provider vs auth handler vs plugin).
 
 ## Auth Handler Architecture
@@ -329,6 +330,7 @@ func (h *Handler) InjectAuth(ctx context.Context, req *http.Request, opts auth.T
 }
 ```
 
+> [!CAUTION]
 > **Convention**: All builtin auth handlers export a `HandlerName` constant, use functional options, defer secret store errors, and name the constructor `New(opts ...Option)`.
 
 ## Registering as a Builtin Auth Handler
@@ -360,6 +362,7 @@ if err != nil {
 ctx = auth.WithRegistry(ctx, authRegistry)
 ```
 
+> [!WARNING]
 > **Important**: Registration failures are logged at V(1), not fatal — the CLI still works for non-auth commands.
 
 ## Testing Your Auth Handler
@@ -461,6 +464,8 @@ func (m *MockSecretStore) Delete(key string) error {
 
 See `tests/integration/cli_test.go`. Auth-specific tests use the CLI:
 
+{{< tabs "auth-handler-development-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login
 scafctl auth login --handler my-idp --flow device_code
@@ -474,6 +479,23 @@ scafctl auth token --handler my-idp
 # Logout
 scafctl auth logout --handler my-idp
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login
+scafctl auth login --handler my-idp --flow device_code
+
+# Check status
+scafctl auth status --handler my-idp -o json
+
+# Get token
+scafctl auth token --handler my-idp
+
+# Logout
+scafctl auth logout --handler my-idp
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Best Practices
 
@@ -605,16 +627,12 @@ Instead of compiling your auth handler into scafctl, you can ship it as a **plug
 
 ### Architecture
 
-```
-┌─────────────────────┐        gRPC        ┌──────────────────────┐
-│      scafctl        │◄──────────────────►│   Auth Handler       │
-│                     │                     │   Plugin             │
-│  - Discovers plugin │                     │  - Implements gRPC   │
-│  - Calls handler    │                     │  - Manages creds     │
-│  - Manages lifecycle│                     │  - Returns tokens    │
-└─────────────────────┘                     └──────────────────────┘
+```mermaid
+flowchart LR
+  A["scafctl<br/>- Discovers plugin<br/>- Calls handler<br/>- Manages lifecycle"] <-- "gRPC" --> B["Auth Handler Plugin<br/>- Implements gRPC<br/>- Manages creds<br/>- Returns tokens"]
 ```
 
+> [!NOTE]
 > **Key difference from provider plugins**: Auth handler plugins manage their own credential storage. The host calls `GetToken()` over gRPC and injects the returned token into `http.Request` headers locally.
 
 ### Plugin Interface
@@ -731,6 +749,8 @@ func main() {
 
 ### Build and Install
 
+{{< tabs "auth-handler-development-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 go build -o scafctl-auth-okta .
 
@@ -738,6 +758,18 @@ go build -o scafctl-auth-okta .
 mkdir -p "$(scafctl paths cache)/plugins"
 cp scafctl-auth-okta "$(scafctl paths cache)/plugins/"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+go build -o scafctl-auth-okta .
+
+# Install to plugin cache
+$pluginDir = "$(scafctl paths cache)/plugins"
+New-Item -ItemType Directory -Force -Path $pluginDir
+Copy-Item scafctl-auth-okta $pluginDir
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Use in Solutions
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -62,6 +62,8 @@ scafctl currently supports the following auth handlers:
 
 You can always discover registered handlers and their capabilities at runtime:
 
+{{< tabs "auth-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # List all handlers with flows and capabilities
 scafctl auth list
@@ -69,6 +71,17 @@ scafctl auth list
 # Output as JSON for scripting
 scafctl auth list -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# List all handlers with flows and capabilities
+scafctl auth list
+
+# Output as JSON for scripting
+scafctl auth list -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -76,9 +89,18 @@ scafctl auth list -o json
 
 To authenticate with Microsoft Entra ID, use the `auth login` command:
 
+{{< tabs "auth-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 By default, this opens your browser for an OAuth authorization code flow with PKCE — the same approach used by `az login`, `gh auth login`, and `gcloud auth login`:
 
@@ -102,9 +124,18 @@ By default, this opens your browser for an OAuth authorization code flow with PK
 
 If you are in a headless environment, over SSH, or the browser cannot open, use the device code flow:
 
+{{< tabs "auth-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra --flow device-code
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra --flow device-code
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This displays a code and URL for you to enter manually:
 
@@ -122,12 +153,24 @@ Waiting for authentication...
 
 Use `--skip-if-authenticated` to skip re-authentication if you're already logged in. The command exits `0` without prompting, making it safe to call at the start of scripts or CI jobs without disrupting an active session:
 
+{{< tabs "auth-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Only login if not already authenticated
 scafctl auth login entra --skip-if-authenticated
 scafctl auth login github --skip-if-authenticated
 scafctl auth login gcp --skip-if-authenticated
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Only login if not already authenticated
+scafctl auth login entra --skip-if-authenticated
+scafctl auth login github --skip-if-authenticated
+scafctl auth login gcp --skip-if-authenticated
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 When already authenticated this prints a message and exits `0`. Without the flag, the command prompts for re-authentication (or warns if already authenticated but continues).
 
@@ -137,6 +180,8 @@ When already authenticated this prints a message and exits `0`. Without the flag
 
 By default, scafctl uses the "organizations" tenant (any work/school account). To authenticate with a specific tenant:
 
+{{< tabs "auth-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # Use a specific tenant ID
 scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
@@ -144,30 +189,51 @@ scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
 # Use a tenant domain
 scafctl auth login entra --tenant contoso.onmicrosoft.com
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Use a specific tenant ID
+scafctl auth login entra --tenant 08e70e8e-d05c-4449-a2c2-67bd0a9c4e79
+
+# Use a tenant domain
+scafctl auth login entra --tenant contoso.onmicrosoft.com
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Custom Client ID
 
 By default, scafctl uses the Azure CLI's public client ID (`04b07795-8ddb-461a-bbee-02f9e1bf7b46`). If your organization requires a custom app registration (e.g., for specific permissions or conditional access policies), use the `--client-id` flag:
 
+{{< tabs "auth-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The client ID used during login is persisted in your credential metadata so that subsequent token refreshes use the same client ID, even if your configuration file specifies a different one. This prevents token minting failures caused by a mismatch between the login client ID and the refresh client ID.
 
 You can also set a default client ID via the scafctl configuration file under `auth.entra.clientId`. Note that the `--client-id` flag at login time always takes precedence, and the stored client ID from login will be used for all future token refreshes.
 
+> [!WARNING]
 > **Important — Redirect URI registration:** When using a custom client ID with the
 > interactive (browser) login flow, the app registration must have `http://localhost`
 > registered as a redirect URI. Without it, Entra returns AADSTS500113 and the CLI
 > times out. In the Azure portal, go to **App registrations → your app →
 > Authentication → Add a platform → Mobile and desktop applications** and add
 > `http://localhost`.
->
+> 
 > If you cannot modify the app registration, use `--flow device-code` instead
 > (device code does not require a redirect URI), or use `--callback-port` to bind
 > the callback server to a specific port that matches a registered redirect URI:
->
+> 
 > ```bash
 > # If the app registration has http://localhost:8400 as a redirect URI
 > scafctl auth login entra --client-id 12345678-abcd-1234-abcd-123456789abc --callback-port 8400
@@ -179,9 +245,18 @@ By default, the interactive login flow starts a local HTTP server on a random
 (ephemeral) port. Some app registrations only allow specific redirect URIs. Use
 `--callback-port` to bind to a predictable port:
 
+{{< tabs "auth-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra --callback-port 8400
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra --callback-port 8400
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This makes the redirect URI `http://localhost:8400`, which must be registered in
 the app registration's **Authentication** settings.
@@ -190,14 +265,25 @@ the app registration's **Authentication** settings.
 
 The interactive login flow has a 5-minute default timeout. To extend it:
 
+{{< tabs "auth-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra --timeout 10m
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra --timeout 10m
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Requesting Specific Scopes
 
 By default, login requests only basic scopes (`openid`, `profile`, `offline_access`). If your resolvers need access to specific APIs (e.g., Microsoft Graph), include the required scope during login to establish consent:
 
+{{< tabs "auth-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with Microsoft Graph scope
 scafctl auth login entra --scope https://graph.microsoft.com/.default
@@ -205,9 +291,21 @@ scafctl auth login entra --scope https://graph.microsoft.com/.default
 # Login with Azure Resource Manager scope
 scafctl auth login entra --scope https://management.azure.com/.default
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with Microsoft Graph scope
+scafctl auth login entra --scope https://graph.microsoft.com/.default
+
+# Login with Azure Resource Manager scope
+scafctl auth login entra --scope https://management.azure.com/.default
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This ensures your authentication session has consent for that API resource, preventing "consent required" errors when resolvers run. The refresh token obtained at login can then be used to mint access tokens for the consented resource.
 
+> [!NOTE]
 > **Note:** Login should target a single API resource at a time. If you need
 > tokens for multiple API resources, use separate `scafctl auth login` calls,
 > or rely on the refresh token to mint tokens for additional resources at
@@ -217,6 +315,8 @@ This ensures your authentication session has consent for that API resource, prev
 
 For non-interactive scenarios like CI/CD pipelines, use service principal authentication:
 
+{{< tabs "auth-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 # Set credentials in environment variables
 export AZURE_CLIENT_ID="your-app-client-id"
@@ -229,6 +329,22 @@ scafctl auth login entra
 # Or explicitly specify the flow
 scafctl auth login entra --flow service-principal
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set credentials in environment variables
+$env:AZURE_CLIENT_ID = "your-app-client-id"
+$env:AZURE_TENANT_ID = "your-tenant-id"
+$env:AZURE_CLIENT_SECRET = "your-client-secret"
+
+# Login with service principal (auto-detected from env vars)
+scafctl auth login entra
+
+# Or explicitly specify the flow
+scafctl auth login entra --flow service-principal
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Environment Variables:**
 
@@ -248,6 +364,8 @@ Workload Identity enables secretless authentication for workloads running on Kub
 
 When running inside a properly configured AKS pod, the Azure Workload Identity webhook automatically injects the required environment variables:
 
+{{< tabs "auth-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Auto-detected when running in a configured pod
 scafctl auth login entra
@@ -255,6 +373,17 @@ scafctl auth login entra
 # Or explicitly specify the flow
 scafctl auth login entra --flow workload-identity
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Auto-detected when running in a configured pod
+scafctl auth login entra
+
+# Or explicitly specify the flow
+scafctl auth login entra --flow workload-identity
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Environment Variables (auto-injected by webhook):**
 
@@ -277,10 +406,20 @@ For development and testing outside of AKS, you can manually configure workload 
 
 1. **Register a new application** in the [Azure Portal](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade):
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
+```bash
    # Using Azure CLI
    az ad app create --display-name "scafctl-workload-identity-test"
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   # Using Azure CLI
+   az ad app create --display-name "scafctl-workload-identity-test"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 2. **Note the Application (client) ID** - you'll need this for `AZURE_CLIENT_ID`
 
@@ -299,7 +438,7 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
 1. **Get your Kubernetes cluster's OIDC issuer URL**:
 
    {{< tabs "auth-oidc-issuer" >}}
-   {{< tab "Bash" >}}
+   {{% tab "Bash" %}}
    ```bash
    # For AKS
    az aks show --name <cluster-name> --resource-group <rg-name> \
@@ -308,8 +447,8 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
    # For other clusters (e.g., kind, minikube with OIDC enabled)
    kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer'
    ```
-   {{< /tab >}}
-   {{< tab "PowerShell" >}}
+   {{% /tab %}}
+   {{% tab "PowerShell" %}}
    ```powershell
    az aks show --name <cluster-name> --resource-group <rg-name> `
      --query "oidcIssuerProfile.issuerUrl" -o tsv
@@ -317,7 +456,7 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
    # For other clusters
    (kubectl get --raw /.well-known/openid-configuration | ConvertFrom-Json).issuer
    ```
-   {{< /tab >}}
+   {{% /tab %}}
    {{< /tabs >}}
 
 2. **Create the federated credential** via Azure Portal or CLI:
@@ -339,14 +478,28 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
 
    **Example for a service account named `scafctl-sa` in the `default` namespace:**
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
+```bash
    az ad app federated-credential create --id <application-id> --parameters '{
      "name": "scafctl-test-credential",
      "issuer": "https://oidc.example.com/abc123",
      "subject": "system:serviceaccount:default:scafctl-sa",
      "audiences": ["api://AzureADTokenExchange"]
    }'
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   az ad app federated-credential create --id <application-id> --parameters '{
+     "name": "scafctl-test-credential",
+     "issuer": "https://oidc.example.com/abc123",
+     "subject": "system:serviceaccount:default:scafctl-sa",
+     "audiences": ["api://AzureADTokenExchange"]
+   }'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### Step 3: Create a Kubernetes Service Account and Generate Token
 
@@ -367,19 +520,34 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
 
 2. **Generate a token** using `kubectl create token`:
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
+```bash
    # Generate a token with the correct audience
    kubectl create token scafctl-sa \
      --namespace default \
      --audience "api://AzureADTokenExchange" \
      --duration 1h
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   # Generate a token with the correct audience
+   kubectl create token scafctl-sa `
+     --namespace default `
+     --audience "api://AzureADTokenExchange" `
+     --duration 1h
+```
+{{% /tab %}}
+{{< /tabs >}}
 
    **Important:** The `--audience` must match what you configured in the federated credential.
 
 3. **Save the token** to an environment variable or file:
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
+```bash
    # Save to environment variable
    export FEDERATED_TOKEN=$(kubectl create token scafctl-sa \
      --namespace default \
@@ -391,12 +559,31 @@ The federated identity credential tells Entra ID to trust tokens from your Kuber
      --namespace default \
      --audience "api://AzureADTokenExchange" \
      --duration 1h > /tmp/federated-token.txt
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   # Save to environment variable
+   $env:FEDERATED_TOKEN = $(kubectl create token scafctl-sa `
+     --namespace default `
+     --audience "api://AzureADTokenExchange" `
+     --duration 1h)
+
+   # Or save to a file
+   kubectl create token scafctl-sa `
+     --namespace default `
+     --audience "api://AzureADTokenExchange" `
+     --duration 1h > /tmp/federated-token.txt
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### Step 4: Authenticate with scafctl
 
 **Option A: Using the `--federated-token` flag (recommended for testing):**
 
+{{< tabs "auth-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 export AZURE_CLIENT_ID="<your-application-client-id>"
 export AZURE_TENANT_ID="<your-tenant-id>"
@@ -404,9 +591,22 @@ export AZURE_TENANT_ID="<your-tenant-id>"
 # Pass the token directly
 scafctl auth login entra --flow workload-identity --federated-token "$FEDERATED_TOKEN"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:AZURE_CLIENT_ID = "<your-application-client-id>"
+$env:AZURE_TENANT_ID = "<your-tenant-id>"
+
+# Pass the token directly
+scafctl auth login entra --flow workload-identity --federated-token "$FEDERATED_TOKEN"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Option B: Using the `AZURE_FEDERATED_TOKEN` environment variable:**
 
+{{< tabs "auth-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 export AZURE_CLIENT_ID="<your-application-client-id>"
 export AZURE_TENANT_ID="<your-tenant-id>"
@@ -414,9 +614,22 @@ export AZURE_FEDERATED_TOKEN="$FEDERATED_TOKEN"
 
 scafctl auth login entra --flow workload-identity
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:AZURE_CLIENT_ID = "<your-application-client-id>"
+$env:AZURE_TENANT_ID = "<your-tenant-id>"
+$env:AZURE_FEDERATED_TOKEN = "$FEDERATED_TOKEN"
+
+scafctl auth login entra --flow workload-identity
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Option C: Using a token file (simulates in-cluster behavior):**
 
+{{< tabs "auth-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 export AZURE_CLIENT_ID="<your-application-client-id>"
 export AZURE_TENANT_ID="<your-tenant-id>"
@@ -424,9 +637,22 @@ export AZURE_FEDERATED_TOKEN_FILE="/tmp/federated-token.txt"
 
 scafctl auth login entra --flow workload-identity
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:AZURE_CLIENT_ID = "<your-application-client-id>"
+$env:AZURE_TENANT_ID = "<your-tenant-id>"
+$env:AZURE_FEDERATED_TOKEN_FILE = "/tmp/federated-token.txt"
+
+scafctl auth login entra --flow workload-identity
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### Step 5: Verify Authentication
 
+{{< tabs "auth-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 # Check auth status
 scafctl auth status entra
@@ -435,11 +661,25 @@ scafctl auth status entra
 # Handler   Status         Identity                          IdentityType         TokenFile
 # entra     Authenticated  Workload Identity (12345678...)   workload-identity    (direct token)
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Check auth status
+scafctl auth status entra
+
+# Output for workload identity:
+# Handler   Status         Identity                          IdentityType         TokenFile
+# entra     Authenticated  Workload Identity (12345678...)   workload-identity    (direct token)
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### Complete Example Script
 
 Here's a complete script for testing workload identity locally:
 
+{{< tabs "auth-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 #!/bin/bash
 set -e
@@ -475,6 +715,44 @@ echo ""
 echo "Getting access token for Azure Resource Manager..."
 scafctl auth token entra --scope "https://management.azure.com/.default"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$ErrorActionPreference = "Stop"
+
+# Configuration - update these values
+$APP_CLIENT_ID = "12345678-1234-1234-1234-123456789012"
+$TENANT_ID = "your-tenant-id"
+$NAMESPACE = "default"
+$SERVICE_ACCOUNT = "scafctl-sa"
+
+# Generate a fresh token
+Write-Output "Generating service account token..."
+$FEDERATED_TOKEN = $(kubectl create token $SERVICE_ACCOUNT `
+  --namespace $NAMESPACE `
+  --audience "api://AzureADTokenExchange" `
+  --duration 1h)
+
+# Set environment variables
+$env:AZURE_CLIENT_ID = $APP_CLIENT_ID
+$env:AZURE_TENANT_ID = $TENANT_ID
+
+# Authenticate
+Write-Output "Authenticating with workload identity..."
+scafctl auth login entra --flow workload-identity --federated-token $FEDERATED_TOKEN
+
+# Verify
+Write-Output ""
+Write-Output "Authentication status:"
+scafctl auth status entra
+
+# Test token acquisition
+Write-Output ""
+Write-Output "Getting access token for Azure Resource Manager..."
+scafctl auth token entra --scope "https://management.azure.com/.default"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### Flow Priority and Interaction with Stored Credentials
 
@@ -498,9 +776,18 @@ When WIF is active, the stored device-code refresh token (if any) is bypassed bu
 
 **Stale stored credentials**: if you want a clean slate after switching to WIF, explicitly remove the stored device-code session:
 
+{{< tabs "auth-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth logout entra
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth logout entra
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This removes the refresh token and cached access tokens without affecting WIF, which is entirely driven by environment variables.
 
@@ -516,19 +803,19 @@ This means the token's claims don't match the federated credential configuration
 - Verify the `audience` in both the federated credential and `kubectl create token` command
 
 {{< tabs "auth-decode-token" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Decode the token to inspect its claims
 echo "$FEDERATED_TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Decode the token to inspect its claims
 $parts = $env:FEDERATED_TOKEN -split '\.'
 [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($parts[1] + '=' * (4 - $parts[1].Length % 4))) | ConvertFrom-Json
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Check these claims match your federated credential:
@@ -540,9 +827,18 @@ Check these claims match your federated credential:
 
 The token has expired. Generate a new one:
 
+{{< tabs "auth-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 kubectl create token scafctl-sa --audience "api://AzureADTokenExchange" --duration 1h
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+kubectl create token scafctl-sa --audience "api://AzureADTokenExchange" --duration 1h
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Error: "workload identity not configured"**
 
@@ -559,7 +855,7 @@ echo "AZURE_FEDERATED_TOKEN: ${AZURE_FEDERATED_TOKEN:0:20}..." # First 20 chars
 Verify your cluster's OIDC configuration is accessible:
 
 {{< tabs "auth-oidc-discovery" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get the OIDC configuration
 curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')/.well-known/openid-configuration" | jq .
@@ -567,13 +863,13 @@ curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer'
 # Get the JWKS (signing keys)
 curl -s "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri')" | jq .
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 $issuer = (kubectl get --raw /.well-known/openid-configuration | ConvertFrom-Json).issuer
 Invoke-RestMethod "$issuer/.well-known/openid-configuration"
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ---
@@ -582,9 +878,18 @@ Invoke-RestMethod "$issuer/.well-known/openid-configuration"
 
 The default GitHub login flow opens your browser for OAuth Authorization Code + PKCE authentication — the same approach used by `gh auth login` and the Entra handler:
 
+{{< tabs "auth-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This initiates a browser-based login:
 
@@ -612,9 +917,18 @@ This initiates a browser-based login:
 
 By default, the interactive flow starts a local HTTP server on a random (ephemeral) port. Use `--callback-port` to bind to a predictable port:
 
+{{< tabs "auth-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --callback-port 8400
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --callback-port 8400
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -622,9 +936,18 @@ scafctl auth login github --callback-port 8400
 
 For headless environments, SSH sessions, or when the browser cannot open, use the device code flow:
 
+{{< tabs "auth-tutorial-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --flow device-code
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --flow device-code
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 1. scafctl displays a code and URL
 2. Open the URL in your browser
@@ -653,9 +976,18 @@ Waiting for authentication...
 
 To authenticate with a GitHub Enterprise Server instance:
 
+{{< tabs "auth-tutorial-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --hostname github.example.com
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --hostname github.example.com
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This adjusts all OAuth and API endpoints to use your GHES instance.
 
@@ -663,14 +995,25 @@ This adjusts all OAuth and API endpoints to use your GHES instance.
 
 By default, scafctl uses its own OAuth App client ID (`Ov23li6xn492GhPmt4YG`). If your organization requires a custom OAuth App:
 
+{{< tabs "auth-tutorial-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --client-id your-custom-client-id
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --client-id your-custom-client-id
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Requesting Specific Scopes
 
 By default, login requests `gist`, `read:org`, `repo`, and `workflow` scopes (matching the `gh` CLI). To request different scopes:
 
+{{< tabs "auth-tutorial-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with additional scopes
 scafctl auth login github --scope repo --scope read:org --scope write:packages
@@ -678,7 +1021,19 @@ scafctl auth login github --scope repo --scope read:org --scope write:packages
 # Or comma-separated
 scafctl auth login github --scope "repo,read:org,write:packages"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with additional scopes
+scafctl auth login github --scope repo --scope read:org --scope write:packages
 
+# Or comma-separated
+scafctl auth login github --scope "repo,read:org,write:packages"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+> [!WARNING]
 > **Important:** GitHub scopes are fixed at login time. Unlike Entra ID, GitHub's
 > OAuth token refresh does not support changing scopes per-request. The `--scope`
 > flag on `scafctl auth token github` is not supported. If you need different
@@ -688,9 +1043,18 @@ scafctl auth login github --scope "repo,read:org,write:packages"
 
 The device code flow has a 5-minute default timeout. To extend it:
 
+{{< tabs "auth-tutorial-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --timeout 10m
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --timeout 10m
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -698,6 +1062,8 @@ scafctl auth login github --timeout 10m
 
 For non-interactive scenarios like CI/CD pipelines, use a Personal Access Token:
 
+{{< tabs "auth-tutorial-cmd-30" >}}
+{{% tab "Bash" %}}
 ```bash
 # Set token in environment (GITHUB_TOKEN takes precedence)
 export GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -708,6 +1074,20 @@ scafctl auth login github
 # Or explicitly specify the flow
 scafctl auth login github --flow pat
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set token in environment (GITHUB_TOKEN takes precedence)
+$env:GITHUB_TOKEN = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Login with PAT (auto-detected from env vars)
+scafctl auth login github
+
+# Or explicitly specify the flow
+scafctl auth login github --flow pat
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Environment Variables:**
 
@@ -760,10 +1140,20 @@ export SCAFCTL_GITHUB_APP_PRIVATE_KEY_PATH="/path/to/private-key.pem"
 
 ### Login
 
+{{< tabs "auth-tutorial-cmd-31" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with GitHub App (requires App credentials configured)
 scafctl auth login github --flow github-app
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with GitHub App (requires App credentials configured)
+scafctl auth login github --flow github-app
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Example Output
 
@@ -785,23 +1175,46 @@ The private key can be provided from multiple sources (checked in priority order
 | File path | `privateKeyPath` | `SCAFCTL_GITHUB_APP_PRIVATE_KEY_PATH` | ✅ Good — key in a file with restricted permissions |
 | Secret store | `privateKeySecretName` | — | ✅ Best — key encrypted by OS keychain |
 
+> [!WARNING]
 > **Security recommendation:** Prefer `privateKeySecretName` (encrypted secret store) or `privateKeyPath` (file with `chmod 600`) over inline `privateKey`. When the inline method is used, scafctl logs a warning recommending a more secure alternative.
 
 **Inline PEM (CI/CD secret):**
 
+{{< tabs "auth-tutorial-cmd-32" >}}
+{{% tab "Bash" %}}
 ```bash
 export SCAFCTL_GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA...
 -----END RSA PRIVATE KEY-----"
 scafctl auth login github --flow github-app
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:SCAFCTL_GITHUB_APP_PRIVATE_KEY = ""-----BEGIN"
+MIIEpAIBAAKCAQEA...
+-----END RSA PRIVATE KEY-----"
+scafctl auth login github --flow github-app
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **File path:**
 
+{{< tabs "auth-tutorial-cmd-33" >}}
+{{% tab "Bash" %}}
 ```bash
 export SCAFCTL_GITHUB_APP_PRIVATE_KEY_PATH="/path/to/private-key.pem"
 scafctl auth login github --flow github-app
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:SCAFCTL_GITHUB_APP_PRIVATE_KEY_PATH = "/path/to/private-key.pem"
+scafctl auth login github --flow github-app
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Secret store:**
 
@@ -818,9 +1231,18 @@ auth:
 
 The GitHub App flow works with GHES by setting `--hostname`:
 
+{{< tabs "auth-tutorial-cmd-34" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login github --flow github-app --hostname github.example.com
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login github --flow github-app --hostname github.example.com
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Notes
 - Installation tokens expire after 1 hour and are automatically cached
@@ -834,6 +1256,8 @@ scafctl auth login github --flow github-app --hostname github.example.com
 
 For local development, use the interactive browser OAuth flow:
 
+{{< tabs "auth-tutorial-cmd-35" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with GCP using browser OAuth (default — no gcloud required)
 scafctl auth login gcp
@@ -847,6 +1271,23 @@ scafctl auth login gcp --impersonate-service-account my-sa@my-project.iam.gservi
 # Login with a custom OAuth client ID (overrides the built-in default)
 scafctl auth login gcp --client-id YOUR_CLIENT_ID
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with GCP using browser OAuth (default — no gcloud required)
+scafctl auth login gcp
+
+# Login with specific scopes
+scafctl auth login gcp --scope https://www.googleapis.com/auth/bigquery
+
+# Login with service account impersonation
+scafctl auth login gcp --impersonate-service-account my-sa@my-project.iam.gserviceaccount.com
+
+# Login with a custom OAuth client ID (overrides the built-in default)
+scafctl auth login gcp --client-id YOUR_CLIENT_ID
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This will:
 1. Start a local HTTP server
@@ -854,16 +1295,27 @@ This will:
 3. Exchange the authorization code for refresh + access tokens
 4. Store the refresh token in your system's secret store
 
+> [!NOTE]
 > **Note:** scafctl uses Google's well-known ADC client credentials by default — the same ones used by `gcloud auth application-default login`. No gcloud installation is required. To use a custom OAuth client, see [GCP Custom OAuth Client Setup](gcp-custom-oauth-tutorial.md).
 
 ## GCP gcloud ADC Fallback
 
 If you already have gcloud configured and prefer to use its existing credentials:
 
+{{< tabs "auth-tutorial-cmd-36" >}}
+{{% tab "Bash" %}}
 ```bash
 # Use existing gcloud Application Default Credentials
 scafctl auth login gcp --flow gcloud-adc
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Use existing gcloud Application Default Credentials
+scafctl auth login gcp --flow gcloud-adc
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This reads the refresh token from `~/.config/gcloud/application_default_credentials.json` (produced by `gcloud auth application-default login`). Note that this flow is subject to your organization's RAPT re-authentication policies.
 
@@ -871,6 +1323,8 @@ This reads the refresh token from `~/.config/gcloud/application_default_credenti
 
 For non-interactive scenarios, use a service account key file:
 
+{{< tabs "auth-tutorial-cmd-37" >}}
+{{% tab "Bash" %}}
 ```bash
 # Point to your service account key JSON file
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/sa-key.json"
@@ -881,11 +1335,27 @@ scafctl auth login gcp
 # Or choose the flow explicitly
 scafctl auth login gcp --flow service-principal
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Point to your service account key JSON file
+$env:GOOGLE_APPLICATION_CREDENTIALS = "/path/to/sa-key.json"
+
+# Login with service account (auto-detected from env var)
+scafctl auth login gcp
+
+# Or choose the flow explicitly
+scafctl auth login gcp --flow service-principal
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## GCP Workload Identity Federation
 
 For Kubernetes and other cloud platforms:
 
+{{< tabs "auth-tutorial-cmd-38" >}}
+{{% tab "Bash" %}}
 ```bash
 # Point to external account JSON config
 export GOOGLE_EXTERNAL_ACCOUNT="/path/to/external-account.json"
@@ -896,15 +1366,39 @@ scafctl auth login gcp
 # Or explicitly
 scafctl auth login gcp --flow workload-identity
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Point to external account JSON config
+$env:GOOGLE_EXTERNAL_ACCOUNT = "/path/to/external-account.json"
+
+# Login (auto-detected)
+scafctl auth login gcp
+
+# Or explicitly
+scafctl auth login gcp --flow workload-identity
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## GCP Metadata Server (GCE/GKE/Cloud Run)
 
 On Google Compute Engine, GKE, and Cloud Run:
 
+{{< tabs "auth-tutorial-cmd-39" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login via metadata server (auto-detected on GCE)
 scafctl auth login gcp --flow metadata
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login via metadata server (auto-detected on GCE)
+scafctl auth login gcp --flow metadata
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -912,6 +1406,8 @@ scafctl auth login gcp --flow metadata
 
 To see your current authentication status:
 
+{{< tabs "auth-tutorial-cmd-40" >}}
+{{% tab "Bash" %}}
 ```bash
 # Show status for all handlers
 scafctl auth status
@@ -925,6 +1421,23 @@ scafctl auth status github
 # Output as JSON
 scafctl auth status -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Show status for all handlers
+scafctl auth status
+
+# Show status for a specific handler
+scafctl auth status entra
+
+# Show GitHub auth status
+scafctl auth status github
+
+# Output as JSON
+scafctl auth status -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Example Output
 
@@ -965,15 +1478,28 @@ gcp       Not Authenticated -          -        -         run 'scafctl auth logi
 
 Use `--exit-code` to make the command exit non-zero when any handler is not authenticated — handy in CI pre-flight checks:
 
+{{< tabs "auth-tutorial-cmd-41" >}}
+{{% tab "Bash" %}}
 ```bash
 # Fail the script if not authenticated
 scafctl auth status entra --exit-code || { echo "Not authenticated. Run: scafctl auth login entra"; exit 1; }
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Fail the script if not authenticated
+scafctl auth status entra --exit-code
+if ($LASTEXITCODE -ne 0) { Write-Output "Not authenticated. Run: scafctl auth login entra"; exit 1; }
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Proactive Expiry Warnings (--warn-within)
 
 Use `--warn-within <duration>` to exit non-zero if any authenticated token will expire within the given window. This catches near-expiry tokens **before** they cause a mid-job failure:
 
+{{< tabs "auth-tutorial-cmd-42" >}}
+{{% tab "Bash" %}}
 ```bash
 # Exit non-zero if any token expires within 10 minutes
 scafctl auth status --warn-within 10m
@@ -987,20 +1513,38 @@ scafctl auth status --exit-code --warn-within 15m || {
   exit 1
 }
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Exit non-zero if any token expires within 10 minutes
+scafctl auth status --warn-within 10m
+
+# Check a specific handler
+scafctl auth status entra --warn-within 1h
+
+# Combine with --exit-code for a full CI pre-flight check
+scafctl auth status --exit-code --warn-within 15m
+if ($LASTEXITCODE -ne 0) {
+  Write-Output "Auth pre-flight failed — not authenticated or token expiring soon"
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The JSON output includes a `cachedTokens` field showing how many access tokens are in the cache for each handler — useful for verifying token cache health:
 
 {{< tabs "auth-cached-tokens" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth status -o json | jq '.[].cachedTokens'
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 (scafctl auth status -o json | ConvertFrom-Json).cachedTokens
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ---
@@ -1009,6 +1553,8 @@ scafctl auth status -o json | jq '.[].cachedTokens'
 
 The `auth list` command shows metadata for all cached tokens (refresh tokens and access tokens) without revealing the actual token values:
 
+{{< tabs "auth-tutorial-cmd-43" >}}
+{{% tab "Bash" %}}
 ```bash
 # Show all cached tokens for all handlers
 scafctl auth list
@@ -1042,6 +1588,43 @@ scafctl auth list --purge-expired
 # Purge expired tokens for a specific handler
 scafctl auth list entra --purge-expired
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Show all cached tokens for all handlers
+scafctl auth list
+
+# Show cached tokens for a single handler
+scafctl auth list entra
+scafctl auth list github
+scafctl auth list gcp
+
+# Show only expired tokens
+scafctl auth list --expired-only
+
+# Show only valid tokens
+scafctl auth list --valid-only
+
+# Sort by expiry (soonest expiring first — useful for spotting tokens about to expire)
+scafctl auth list --sort expires-at
+
+# Sort by handler name
+scafctl auth list --sort handler
+
+# Sort by scope
+scafctl auth list --sort scope
+
+# Output as JSON for scripting
+scafctl auth list -o json
+
+# Remove all expired access tokens from the cache (refresh tokens and valid tokens are preserved)
+scafctl auth list --purge-expired
+
+# Purge expired tokens for a specific handler
+scafctl auth list entra --purge-expired
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Sort fields:**
 
@@ -1059,6 +1642,8 @@ The `getTokenCommand` column in the output shows the exact `scafctl auth token` 
 
 Over time the token cache can accumulate expired access tokens. Use `--purge-expired` to clean them up. Refresh tokens and still-valid access tokens are **not** affected:
 
+{{< tabs "auth-tutorial-cmd-44" >}}
+{{% tab "Bash" %}}
 ```bash
 # Remove expired cache entries across all handlers
 scafctl auth list --purge-expired
@@ -1069,6 +1654,20 @@ scafctl auth list --purge-expired
 # Purge only for a specific handler
 scafctl auth list gcp --purge-expired
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Remove expired cache entries across all handlers
+scafctl auth list --purge-expired
+# Output:
+# ✓ Purged 2 expired access token(s) from entra.
+# ✓ Purged 0 expired access token(s) from github.
+
+# Purge only for a specific handler
+scafctl auth list gcp --purge-expired
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 > `--purge-expired` cannot be combined with `--expired-only` or `--valid-only` (it exits early without listing).
 
@@ -1105,6 +1704,8 @@ spec:
 
 Run it (requires prior authentication via `scafctl auth login entra`):
 
+{{< tabs "auth-tutorial-cmd-45" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with Microsoft Graph scope for consent
 scafctl auth login entra --scope https://graph.microsoft.com/User.Read
@@ -1112,11 +1713,23 @@ scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 # Then run the resolver
 scafctl run resolver -f graph-example.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with Microsoft Graph scope for consent
+scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 
+# Then run the resolver
+scafctl run resolver -f graph-example.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+> [!CAUTION]
 > **Note:** If you see a "consent required" error, it means your login session
 > doesn't have consent for the requested API scope. Re-login with the `--scope`
 > flag to grant consent:
->
+> 
 > ```bash
 > scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 > ```
@@ -1205,6 +1818,8 @@ spec:
 
 Run it (requires prior authentication):
 
+{{< tabs "auth-tutorial-cmd-46" >}}
+{{% tab "Bash" %}}
 ```bash
 # Login with GitHub
 scafctl auth login github
@@ -1212,6 +1827,17 @@ scafctl auth login github
 # Run the resolver
 scafctl run resolver -f github-repos.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Login with GitHub
+scafctl auth login github
+
+# Run the resolver
+scafctl run resolver -f github-repos.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GitHub Enterprise Server API Example
 
@@ -1235,6 +1861,8 @@ spec:
 
 The `auth token` command retrieves a valid access token for debugging:
 
+{{< tabs "auth-tutorial-cmd-47" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get a token for Microsoft Graph (Entra supports per-request scopes)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default"
@@ -1245,7 +1873,22 @@ scafctl auth token github
 # Get a GCP token
 scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Get a token for Microsoft Graph (Entra supports per-request scopes)
+scafctl auth token entra --scope "https://graph.microsoft.com/.default"
 
+# Get a GitHub token (uses scopes from login; --scope is not supported)
+scafctl auth token github
+
+# Get a GCP token
+scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+> [!NOTE]
 > **Note:** The `--scope` flag is only supported on `auth token` for handlers
 > with the `scopes-on-token-request` capability (e.g., Entra ID and GCP). GitHub scopes
 > are fixed at login time — use `scafctl auth login github --scope <scope>` to
@@ -1260,32 +1903,63 @@ entra     https://graph.microsoft.com/.default        eyJ0eXAi...****      2026-
 
 The token is masked in table output for security. Use JSON output to get the full token:
 
+{{< tabs "auth-tutorial-cmd-48" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Token Caching
 
 Access tokens are cached to disk (encrypted) and reused if they have sufficient remaining validity:
 
+{{< tabs "auth-tutorial-cmd-49" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get a token valid for at least 5 minutes
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --min-valid-for 5m
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Get a token valid for at least 5 minutes
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --min-valid-for 5m
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Force Refresh
 
 If you need a fresh token regardless of cache state (e.g., after permission changes), use `--force-refresh`:
 
+{{< tabs "auth-tutorial-cmd-50" >}}
+{{% tab "Bash" %}}
 ```bash
 # Force acquiring a new token, bypassing the cache
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --force-refresh
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Force acquiring a new token, bypassing the cache
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" --force-refresh
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Printing the Raw Token (Scripting)
 
 Use `--raw` to print just the token value — ideal for shell scripting:
 
+{{< tabs "auth-tutorial-cmd-51" >}}
+{{% tab "Bash" %}}
 ```bash
 # Assign to a variable
 export TOKEN=$(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --raw)
@@ -1293,11 +1967,24 @@ export TOKEN=$(scafctl auth token gcp --scope "https://www.googleapis.com/auth/c
 # Use directly with curl
 curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Assign to a variable
+$env:TOKEN = $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --raw)
+
+# Use directly with curl
+curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Shell Export (eval-compatible)
 
 Use `--export` to get a shell export statement you can `eval` into the current shell. The variable is named `<HANDLER>_TOKEN`:
 
+{{< tabs "auth-tutorial-cmd-52" >}}
+{{% tab "Bash" %}}
 ```bash
 # Add a GCP token to the current shell environment
 eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
@@ -1310,11 +1997,29 @@ echo $GITHUB_TOKEN
 eval $(scafctl auth token entra --scope "https://management.azure.com/.default" --export)
 echo $ENTRA_TOKEN
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Add a GCP token to the current shell environment
+Invoke-Expression $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
+Write-Output $GCP_TOKEN
+
+# Other handlers follow the same pattern
+Invoke-Expression $(scafctl auth token github --export)
+Write-Output $GITHUB_TOKEN
+
+Invoke-Expression $(scafctl auth token entra --scope "https://management.azure.com/.default" --export)
+Write-Output $ENTRA_TOKEN
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Emitting a Ready-to-Run curl Command
 
 Use `--curl` to print a `curl` command with the `Authorization` header already populated — great for quick API call reproduction without any `jq` piping:
 
+{{< tabs "auth-tutorial-cmd-53" >}}
+{{% tab "Bash" %}}
 ```bash
 # Emit a curl one-liner for Microsoft Graph
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
@@ -1331,13 +2036,33 @@ scafctl auth token github --curl
 # Output:
 # curl -H "Authorization: Bearer ghp_..." "<URL>"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Emit a curl one-liner for Microsoft Graph
+scafctl auth token entra --scope "https://graph.microsoft.com/.default" `
+  --curl --curl-url "https://graph.microsoft.com/v1.0/me"
+# Output:
+# curl -H "Authorization: Bearer eyJ..." "https://graph.microsoft.com/v1.0/me"
+
+# Emit a curl one-liner for GCP
+scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" `
+  --curl --curl-url "https://storage.googleapis.com/storage/v1/b?project=my-project"
+
+# Emit without a URL (useful to inspect — fills in a placeholder)
+scafctl auth token github --curl
+# Output:
+# curl -H "Authorization: Bearer ghp_..." "<URL>"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Decoding the JWT (Header + Payload)
 
 Use `--decode` to inspect the full JWT structure — both the **header** and the **payload** — without needing an external decoder tool. Signature validation is intentionally skipped; this is for debugging only:
 
 {{< tabs "auth-jwt-decode" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Decode and display the full JWT (header and payload)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
@@ -1346,8 +2071,8 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json \
   | jq '{alg: .header.alg, audience: .payload.aud, upn: .payload.upn, expires: .payload.exp_human}'
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 
@@ -1355,7 +2080,7 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 $decoded = scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | ConvertFrom-Json
 $decoded | Select-Object @{N='alg';E={$_.header.alg}}, @{N='audience';E={$_.payload.aud}}, @{N='upn';E={$_.payload.upn}}, @{N='expires';E={$_.payload.exp_human}}
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Example output (table):
@@ -1390,10 +2115,20 @@ This is the single fastest way to check:
 
 Use `--clip` to copy the token directly to your clipboard without it appearing in your terminal (useful when pasting into browser DevTools or Postman):
 
+{{< tabs "auth-tutorial-cmd-54" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth token entra --scope "https://management.azure.com/.default" --clip
 # Output: ✓ Token copied to clipboard (expires in 58m42s).
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth token entra --scope "https://management.azure.com/.default" --clip
+# Output: ✓ Token copied to clipboard (expires in 58m42s).
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Inspecting Scoped Token Claims in Resolvers
 
@@ -1434,6 +2169,7 @@ When the access token is opaque (not a decodable JWT — common with Microsoft
 Graph tokens), `claims` will be `null` and a warning is emitted. Token metadata
 such as expiry and type is still returned.
 
+> [!CAUTION]
 > **Scope restriction:** The `scope` input is only valid for `claims` and
 > `status` operations. Using it with `groups` or `list` returns an error.
 
@@ -1442,7 +2178,7 @@ such as expiry and type is still returned.
 Get the full token for use with other tools:
 
 {{< tabs "auth-token-usage" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Approach 1: --raw (simplest)
 curl -H "Authorization: Bearer $(scafctl auth token entra --scope 'https://graph.microsoft.com/.default' --raw)" \
@@ -1459,8 +2195,8 @@ curl -H "Authorization: Bearer $TOKEN" https://graph.microsoft.com/v1.0/me
 # GitHub API example
 curl -H "Authorization: Bearer $(scafctl auth token github --raw)" https://api.github.com/user/repos
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Approach 1: --raw (simplest)
 $token = scafctl auth token entra --scope 'https://graph.microsoft.com/.default' --raw
@@ -1470,7 +2206,7 @@ Invoke-RestMethod -Uri 'https://graph.microsoft.com/v1.0/me' -Headers @{ Authori
 $token = (scafctl auth token entra --scope 'https://graph.microsoft.com/.default' -o json | ConvertFrom-Json).accessToken
 Invoke-RestMethod -Uri 'https://graph.microsoft.com/v1.0/me' -Headers @{ Authorization = "Bearer $token" }
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ---
@@ -1551,6 +2287,8 @@ auth:
 
 To clear stored credentials:
 
+{{< tabs "auth-tutorial-cmd-55" >}}
+{{% tab "Bash" %}}
 ```bash
 # Logout from Entra ID
 scafctl auth logout entra
@@ -1571,6 +2309,30 @@ scafctl auth logout --all -y
 # Force clear credentials even if not currently logged in
 scafctl auth logout entra --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Logout from Entra ID
+scafctl auth logout entra
+
+# Logout from GitHub
+scafctl auth logout github
+
+# Logout from GCP
+scafctl auth logout gcp
+
+# Logout from all registered handlers at once (prompts for confirmation)
+scafctl auth logout --all
+
+# Skip the confirmation prompt (for scripts and CI)
+scafctl auth logout --all --yes
+scafctl auth logout --all -y
+
+# Force clear credentials even if not currently logged in
+scafctl auth logout entra --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This removes:
 
@@ -1582,6 +2344,8 @@ This removes:
 
 Use `--dry-run` to see which credentials would be removed without actually removing them. Useful before running `--all` in a shared or production environment:
 
+{{< tabs "auth-tutorial-cmd-56" >}}
+{{% tab "Bash" %}}
 ```bash
 # Preview what would be removed for Entra
 scafctl auth logout entra --dry-run
@@ -1590,6 +2354,18 @@ scafctl auth logout entra --dry-run
 # Preview across all handlers
 scafctl auth logout --all --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Preview what would be removed for Entra
+scafctl auth logout entra --dry-run
+# Output: [dry-run] Would log out from Microsoft Entra ID (cached tokens and refresh token would be removed).
+
+# Preview across all handlers
+scafctl auth logout --all --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Example Output
 
@@ -1605,6 +2381,8 @@ The `auth diagnose` command (alias: `auth doctor`) runs a series of health check
 and reports any issues with your auth configuration. It's the first command to run
 when troubleshooting auth problems:
 
+{{< tabs "auth-tutorial-cmd-57" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run all checks and print a human-readable report
 scafctl auth diagnose
@@ -1626,6 +2404,31 @@ scafctl auth diagnose entra --live-token
 # Output as JSON for automated pipelines
 scafctl auth diagnose -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run all checks and print a human-readable report
+scafctl auth diagnose
+
+# Alias
+scafctl auth doctor
+
+# Scope checks to a single handler (skips checks for the others)
+scafctl auth diagnose entra
+scafctl auth diagnose github
+scafctl auth diagnose gcp
+
+# Also attempt a live token fetch for each authenticated handler
+scafctl auth diagnose --live-token
+
+# Scope live-token check to one handler
+scafctl auth diagnose entra --live-token
+
+# Output as JSON for automated pipelines
+scafctl auth diagnose -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What It Checks
 
@@ -1667,6 +2470,8 @@ scafctl auth diagnose -o json
 
 ### Using in CI Preflight
 
+{{< tabs "auth-tutorial-cmd-58" >}}
+{{% tab "Bash" %}}
 ```bash
 # Verify end-to-end auth before running a pipeline
 scafctl auth diagnose --live-token
@@ -1675,6 +2480,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Verify end-to-end auth before running a pipeline
+scafctl auth diagnose --live-token
+if ($? -ne 0) {
+  Write-Output "Auth health check failed. Check 'scafctl auth diagnose' output."
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -1708,9 +2525,18 @@ credentials expired: please run 'scafctl auth login entra'
 
 Your refresh token has expired (typically after 90 days of inactivity). Log in again:
 
+{{< tabs "auth-tutorial-cmd-59" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login entra
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login entra
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Consent Required
 
@@ -1722,6 +2548,8 @@ consent required: please login with the required scope
 
 Your login session does not have consent for the API scope your resolver is requesting. Re-login with the `--scope` flag to grant consent:
 
+{{< tabs "auth-tutorial-cmd-60" >}}
+{{% tab "Bash" %}}
 ```bash
 # For Microsoft Graph APIs
 scafctl auth login entra --scope https://graph.microsoft.com/User.Read
@@ -1729,6 +2557,17 @@ scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 # For Azure Resource Manager APIs
 scafctl auth login entra --scope https://management.azure.com/user_impersonation
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# For Microsoft Graph APIs
+scafctl auth login entra --scope https://graph.microsoft.com/User.Read
+
+# For Azure Resource Manager APIs
+scafctl auth login entra --scope https://management.azure.com/user_impersonation
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `--scope` flag tells Azure to request user consent for that specific API during the login flow.
 
@@ -1748,15 +2587,33 @@ This means the app registration does not have a redirect URI matching `http://lo
 
 2. **Use a specific port**: If the app registration only allows a specific URI like `http://localhost:8400`:
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-61" >}}
+{{% tab "Bash" %}}
+```bash
    scafctl auth login entra --client-id YOUR_CLIENT_ID --callback-port 8400
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   scafctl auth login entra --client-id YOUR_CLIENT_ID --callback-port 8400
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 3. **Use device code flow**: Device code does not require a redirect URI:
 
-   ```bash
+{{< tabs "auth-tutorial-cmd-62" >}}
+{{% tab "Bash" %}}
+```bash
    scafctl auth login entra --client-id YOUR_CLIENT_ID --flow device-code
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   scafctl auth login entra --client-id YOUR_CLIENT_ID --flow device-code
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Login Times Out With No Error
 
@@ -1769,6 +2626,8 @@ checking redirect URI registration.
 
 If you're getting 401 errors but you're authenticated, you may be authenticated to the wrong tenant:
 
+{{< tabs "auth-tutorial-cmd-63" >}}
+{{% tab "Bash" %}}
 ```bash
 # Check current auth status
 scafctl auth status entra
@@ -1777,6 +2636,18 @@ scafctl auth status entra
 scafctl auth logout entra
 scafctl auth login entra --tenant correct-tenant-id
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Check current auth status
+scafctl auth status entra
+
+# Log out and log in to the correct tenant
+scafctl auth logout entra
+scafctl auth login entra --tenant correct-tenant-id
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Scope Issues
 
@@ -1792,7 +2663,7 @@ Use `--decode` on `auth token` to inspect JWT claims directly without needing an
 external tool or manual base64 decoding:
 
 {{< tabs "auth-troubleshoot-claims" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Decode and display claims in table format (no signature validation)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
@@ -1800,8 +2671,8 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 # Output as JSON for further processing (e.g., with jq)
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | jq '.aud,.upn,.roles'
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 
@@ -1809,7 +2680,7 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 $decoded = scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json | ConvertFrom-Json
 $decoded.aud, $decoded.upn, $decoded.roles
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) are automatically augmented
@@ -1825,10 +2696,20 @@ Useful things to verify:
 
 Enable debug logging to see detailed auth information:
 
+{{< tabs "auth-tutorial-cmd-64" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl --log-level -1 auth status entra
 scafctl --log-level -1 run solution -f mysolution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl --log-level -1 auth status entra
+scafctl --log-level -1 run solution -f mysolution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Secret Store Issues
 
@@ -1853,10 +2734,20 @@ If you get 403 (Forbidden) errors on GitHub API calls:
 
 1. Check what scopes your token has: `scafctl auth status github`
 2. GitHub scopes are fixed at login time and cannot be changed per-request. Login again with the required scopes:
-   ```bash
+{{< tabs "auth-tutorial-cmd-65" >}}
+{{% tab "Bash" %}}
+```bash
    scafctl auth logout github
    scafctl auth login github --scope repo --scope read:org
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   scafctl auth logout github
+   scafctl auth login github --scope repo --scope read:org
+```
+{{% /tab %}}
+{{< /tabs >}}
 3. For PATs, ensure the token was created with sufficient scopes
 
 ### GitHub Enterprise Server: Connection Issues

--- a/docs/tutorials/auto-discovery-tutorial.md
+++ b/docs/tutorials/auto-discovery-tutorial.md
@@ -32,6 +32,8 @@ Many scafctl commands accept a `-f` / `--file` flag to specify the solution file
 
 This means you can simply `cd` into a project directory and run commands without specifying the file:
 
+{{< tabs "auto-discovery-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Instead of:
 scafctl run solution -f solution.yaml
@@ -39,6 +41,17 @@ scafctl run solution -f solution.yaml
 # Just run:
 scafctl run solution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Instead of:
+scafctl run solution -f solution.yaml
+
+# Just run:
+scafctl run solution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## How Auto-Discovery Works
 
@@ -105,6 +118,8 @@ Auto-discovery works with every command that accepts `-f`:
 
 ### Basic Usage — Run in Project Directory
 
+{{< tabs "auto-discovery-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Given this project structure:
 # my-project/
@@ -117,9 +132,27 @@ scafctl run solution          # discovers ./solution.yaml
 scafctl lint                  # discovers ./solution.yaml
 scafctl test functional       # discovers ./solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Given this project structure:
+# my-project/
+# ├── solution.yaml
+# └── templates/
+#     └── config.yaml.tpl
+
+cd my-project
+scafctl run solution          # discovers ./solution.yaml
+scafctl lint                  # discovers ./solution.yaml
+scafctl test functional       # discovers ./solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Conventional Subfolder
 
+{{< tabs "auto-discovery-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Given this project structure:
 # my-project/
@@ -131,9 +164,26 @@ scafctl test functional       # discovers ./solution.yaml
 cd my-project
 scafctl run solution          # discovers ./scafctl/solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Given this project structure:
+# my-project/
+# ├── scafctl/
+# │   └── solution.yaml
+# └── src/
+#     └── main.go
+
+cd my-project
+scafctl run solution          # discovers ./scafctl/solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Hidden Subfolder
 
+{{< tabs "auto-discovery-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Given this project structure:
 # my-project/
@@ -144,11 +194,27 @@ scafctl run solution          # discovers ./scafctl/solution.yaml
 cd my-project
 scafctl lint                  # discovers ./.scafctl/solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Given this project structure:
+# my-project/
+# ├── .scafctl/
+# │   └── solution.yaml
+# └── README.md
+
+cd my-project
+scafctl lint                  # discovers ./.scafctl/solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Explicit `-f` Overrides Discovery
 
 When you specify `-f`, auto-discovery is skipped entirely:
 
+{{< tabs "auto-discovery-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # Use a specific file regardless of what's in the current directory
 scafctl run solution -f path/to/other-solution.yaml
@@ -162,11 +228,30 @@ scafctl run solution -f https://example.com/solution.yaml
 # Use a catalog name
 scafctl run solution -f my-solution@1.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Use a specific file regardless of what's in the current directory
+scafctl run solution -f path/to/other-solution.yaml
+
+# Use stdin
+cat solution.yaml | scafctl lint -f -
+
+# Use a URL
+scafctl run solution -f https://example.com/solution.yaml
+
+# Use a catalog name
+scafctl run solution -f my-solution@1.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Interaction with `--cwd`
 
 When `--cwd` is set, auto-discovery searches relative to the specified directory instead of the process working directory:
 
+{{< tabs "auto-discovery-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # Discover solution inside another directory
 scafctl run solution --cwd /path/to/project
@@ -174,6 +259,17 @@ scafctl run solution --cwd /path/to/project
 # This is equivalent to:
 cd /path/to/project && scafctl run solution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Discover solution inside another directory
+scafctl run solution --cwd /path/to/project
+
+# This is equivalent to:
+cd /path/to/project; scafctl run solution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 All 18 candidate paths are resolved against the `--cwd` target.
 
@@ -192,9 +288,18 @@ Common causes:
 
 You can see the candidate paths scafctl checks with:
 
+{{< tabs "auto-discovery-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl config paths
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl config paths
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Best Practices
 

--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -31,9 +31,18 @@ The cache uses XDG Base Directory paths:
 
 You can view actual paths on your system with:
 
+{{< tabs "cache-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl config paths
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl config paths
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Viewing Cache Information
 
@@ -41,9 +50,18 @@ scafctl config paths
 
 See how much disk space the cache is using:
 
+{{< tabs "cache-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache info
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache info
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```
@@ -59,9 +77,18 @@ Total: 2.4 MB (157 files)
 
 Get cache info as JSON for scripting:
 
+{{< tabs "cache-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache info -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache info -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```json
@@ -96,9 +123,18 @@ Output:
 
 Remove all cached content:
 
+{{< tabs "cache-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache clear
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache clear
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 You'll be prompted to confirm:
 ```
@@ -116,9 +152,18 @@ Output after confirmation:
 
 Use `--force` to skip the confirmation prompt:
 
+{{< tabs "cache-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache clear --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache clear --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This is useful in scripts or CI/CD pipelines.
 
@@ -126,6 +171,8 @@ This is useful in scripts or CI/CD pipelines.
 
 Clear only a specific type of cache using `--kind`:
 
+{{< tabs "cache-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # Clear only HTTP cache
 scafctl cache clear --kind http
@@ -136,11 +183,27 @@ scafctl cache clear --kind build
 # Clear all caches (default)
 scafctl cache clear --kind all
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Clear only HTTP cache
+scafctl cache clear --kind http
+
+# Clear only build cache
+scafctl cache clear --kind build
+
+# Clear all caches (default)
+scafctl cache clear --kind all
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Clear by Pattern
 
 Clear cache entries matching a specific pattern:
 
+{{< tabs "cache-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Clear all entries with "github" in the name
 scafctl cache clear --name "*github*"
@@ -148,6 +211,17 @@ scafctl cache clear --name "*github*"
 # Clear entries starting with "api"
 scafctl cache clear --name "api*"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Clear all entries with "github" in the name
+scafctl cache clear --name "*github*"
+
+# Clear entries starting with "api"
+scafctl cache clear --name "api*"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The pattern supports glob wildcards (`*`, `?`).
 
@@ -155,9 +229,18 @@ The pattern supports glob wildcards (`*`, `?`).
 
 Get structured output for scripting:
 
+{{< tabs "cache-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache clear --force -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache clear --force -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```json
@@ -175,9 +258,18 @@ Output:
 
 If an HTTP provider is returning outdated data, clear the HTTP cache:
 
+{{< tabs "cache-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache clear --kind http --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache clear --kind http --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Then re-run your solution to fetch fresh data.
 
@@ -185,6 +277,8 @@ Then re-run your solution to fetch fresh data.
 
 Check cache size and clear if needed:
 
+{{< tabs "cache-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 # Check size
 scafctl cache info
@@ -192,6 +286,17 @@ scafctl cache info
 # Clear if too large
 scafctl cache clear --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Check size
+scafctl cache info
+
+# Clear if too large
+scafctl cache clear --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Automated Cleanup in CI/CD
 
@@ -210,6 +315,8 @@ Add cache cleanup to your CI/CD pipeline:
 
 Before running a critical deployment, ensure fresh data:
 
+{{< tabs "cache-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 #!/bin/bash
 # deploy.sh
@@ -220,6 +327,20 @@ scafctl cache clear --force
 # Run deployment
 scafctl run solution deploy -r env=production
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# PowerShell equivalent
+# deploy.sh
+
+# Clear all caches for fresh data
+scafctl cache clear --force
+
+# Run deployment
+scafctl run solution deploy -r env=production
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Command Reference
 
@@ -254,6 +375,8 @@ The build cache enables incremental builds by fingerprinting all build inputs (s
 
 ### Controlling Build Cache
 
+{{< tabs "cache-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # Build with cache (default)
 scafctl build solution my-solution.yaml
@@ -264,6 +387,20 @@ scafctl build solution my-solution.yaml --no-cache
 # Clear build cache
 scafctl cache clear --kind build --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Build with cache (default)
+scafctl build solution my-solution.yaml
+
+# Force a full rebuild, bypassing cache
+scafctl build solution my-solution.yaml --no-cache
+
+# Clear build cache
+scafctl cache clear --kind build --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Configuration
 
@@ -279,6 +416,8 @@ build:
 
 Set configuration via CLI:
 
+{{< tabs "cache-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 # Disable build cache globally
 scafctl config set build.enableCache false
@@ -286,6 +425,17 @@ scafctl config set build.enableCache false
 # Disable remote artifact auto-caching
 scafctl config set build.autoCacheRemoteArtifacts false
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Disable build cache globally
+scafctl config set build.enableCache false
+
+# Disable remote artifact auto-caching
+scafctl config set build.autoCacheRemoteArtifacts false
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Artifact Cache TTL
 
@@ -319,6 +469,8 @@ Common TTL values:
 
 Set via CLI:
 
+{{< tabs "cache-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # Set a 1-hour TTL for artifact cache
 scafctl config set catalog.cacheTTL 1h
@@ -326,6 +478,17 @@ scafctl config set catalog.cacheTTL 1h
 # Disable TTL (never expire)
 scafctl config set catalog.cacheTTL 0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set a 1-hour TTL for artifact cache
+scafctl config set catalog.cacheTTL 1h
+
+# Disable TTL (never expire)
+scafctl config set catalog.cacheTTL 0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### When to Use TTL
 
@@ -338,9 +501,18 @@ scafctl config set catalog.cacheTTL 0
 
 Even with a TTL configured, expired artifacts remain on disk until replaced. To reclaim disk space:
 
+{{< tabs "cache-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl cache clear --kind build --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl cache clear --kind build --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Catalog Tutorial"
-weight: 70
+weight: 60
 ---
 
 # Catalog Tutorial
@@ -72,9 +72,18 @@ This solution accepts a `name` parameter (defaulting to "World") and produces a 
 
 ### Step 2: Build It into the Catalog
 
+{{< tabs "catalog-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -90,9 +99,18 @@ The solution is now stored in your local catalog. The version (`1.0.0`) was read
 
 You can also specify the version on the command line, which overrides `metadata.version`:
 
+{{< tabs "catalog-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting.yaml --version 1.0.1
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting.yaml --version 1.0.1
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -117,9 +135,18 @@ Once a solution is in the catalog, you can run it by name instead of providing a
 
 ### Step 1: Run by Name
 
+{{< tabs "catalog-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -132,9 +159,18 @@ No file path needed — scafctl looked up `greeting` in the catalog and found th
 
 ### Step 2: Pass a Parameter
 
+{{< tabs "catalog-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -147,9 +183,18 @@ name: Alice
 
 When you have multiple versions, you can pin to a specific one:
 
+{{< tabs "catalog-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Bob
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Bob
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -162,9 +207,18 @@ name: Bob
 
 Use `-e` to extract just the value you care about:
 
+{{< tabs "catalog-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting -o yaml -e '_.message' -r name=Carol
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting -o yaml -e '_.message' -r name=Carol
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -186,9 +240,18 @@ Hello, Carol!
 
 ### Step 1: List Everything in the Catalog
 
+{{< tabs "catalog-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -209,17 +272,35 @@ Expected output:
 
 ### Step 2: Filter by Name
 
+{{< tabs "catalog-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows only artifacts with the name `greeting`.
 
 ### Step 3: Inspect a Specific Artifact
 
+{{< tabs "catalog-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog inspect greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog inspect greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -243,9 +324,18 @@ Without a version, `inspect` shows the highest version. Pin a version with `gree
 
 ### Step 4: Use a CEL Expression to Extract Fields
 
+{{< tabs "catalog-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog inspect greeting -o yaml -e '_.annotations'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog inspect greeting -o yaml -e '_.annotations'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -315,9 +405,18 @@ spec:
 
 ### Step 2: Build v2
 
+{{< tabs "catalog-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting-v2.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting-v2.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -329,9 +428,18 @@ Expected output:
 
 ### Step 3: Verify Both Versions Exist
 
+{{< tabs "catalog-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -352,9 +460,18 @@ Expected output:
 
 ### Step 4: Run Without a Version
 
+{{< tabs "catalog-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -368,9 +485,18 @@ Without a version, scafctl runs the **highest semantic version** — in this cas
 
 ### Step 5: Pin to the Old Version
 
+{{< tabs "catalog-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Alice
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Alice
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -383,9 +509,18 @@ The v1 solution doesn't have a timestamp — confirming you're running the origi
 
 ### Step 6: Try to Overwrite an Existing Version
 
+{{< tabs "catalog-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting-v2.yaml --version 2.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting-v2.yaml --version 2.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -395,9 +530,18 @@ Expected output:
 
 Use `--force` to overwrite:
 
+{{< tabs "catalog-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting-v2.yaml --version 2.0.0 --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting-v2.yaml --version 2.0.0 --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What You Learned
 
@@ -412,9 +556,18 @@ scafctl build solution greeting-v2.yaml --version 2.0.0 --force
 
 ### Step 1: Delete a Specific Version
 
+{{< tabs "catalog-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog delete greeting@1.0.1 --kind solution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog delete greeting@1.0.1 --kind solution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -426,9 +579,18 @@ You must specify both the name and version. The `--kind solution` flag tells sca
 
 ### Step 2: Verify It's Gone
 
+{{< tabs "catalog-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `1.0.1` entry should no longer appear.
 
@@ -436,9 +598,18 @@ The `1.0.1` entry should no longer appear.
 
 After deleting artifacts, blob data may remain on disk. Clean it up:
 
+{{< tabs "catalog-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog prune
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog prune
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -453,11 +624,22 @@ Expected output:
 
 Clean up the remaining test artifacts:
 
+{{< tabs "catalog-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog delete greeting@1.0.0 --kind solution
 scafctl catalog delete greeting@2.0.0 --kind solution
 scafctl catalog prune
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog delete greeting@1.0.0 --kind solution
+scafctl catalog delete greeting@2.0.0 --kind solution
+scafctl catalog prune
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What You Learned
 
@@ -476,15 +658,33 @@ The `save` and `load` commands let you transfer catalog artifacts between machin
 
 First, rebuild the greeting solution:
 
+{{< tabs "catalog-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution greeting.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution greeting.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 2: Export to a Tar Archive
 
+{{< tabs "catalog-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog save greeting@1.0.0 -o greeting-v1.tar
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog save greeting@1.0.0 -o greeting-v1.tar
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -498,24 +698,52 @@ The archive uses the standard **OCI Image Layout** format.
 
 Simulate receiving the tar on a different machine by deleting the local version:
 
+{{< tabs "catalog-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog delete greeting@1.0.0 --kind solution
 scafctl catalog prune
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog delete greeting@1.0.0 --kind solution
+scafctl catalog prune
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 4: Verify It's Gone
 
+{{< tabs "catalog-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output (empty or no greeting entries).
 
 ### Step 5: Import from the Tar Archive
 
+{{< tabs "catalog-tutorial-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog load --input greeting-v1.tar
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog load --input greeting-v1.tar
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -525,9 +753,18 @@ Expected output:
 
 ### Step 6: Confirm It Was Loaded
 
+{{< tabs "catalog-tutorial-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -542,9 +779,18 @@ Expected output:
 
 ### Step 7: Try Loading Again (Conflict)
 
+{{< tabs "catalog-tutorial-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog load --input greeting-v1.tar
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog load --input greeting-v1.tar
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -554,14 +800,25 @@ Expected output:
 
 Use `--force` to overwrite:
 
+{{< tabs "catalog-tutorial-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog load --input greeting-v1.tar --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog load --input greeting-v1.tar --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Air-Gapped Transfer Workflow
 
 Here's how the full workflow looks in practice:
 
+{{< tabs "catalog-tutorial-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 # On the connected machine:
 scafctl build solution deploy.yaml --version 1.0.0
@@ -572,6 +829,20 @@ cp deploy-v1.tar /Volumes/USB/
 scafctl catalog load --input /Volumes/USB/deploy-v1.tar
 scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# On the connected machine:
+scafctl build solution deploy.yaml --version 1.0.0
+scafctl catalog save deploy@1.0.0 -o deploy-v1.tar
+Copy-Item deploy-v1.tar /Volumes/USB/
+
+# Transfer USB to the air-gapped machine, then:
+scafctl catalog load --input /Volumes/USB/deploy-v1.tar
+scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What You Learned
 
@@ -590,9 +861,18 @@ Tags let you create freeform aliases for specific versions. Common uses include 
 
 Make sure you have `greeting@1.0.0` in the catalog, then tag it:
 
+{{< tabs "catalog-tutorial-cmd-30" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog tag greeting@1.0.0 stable
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog tag greeting@1.0.0 stable
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -602,17 +882,35 @@ Expected output:
 
 ### Step 2: View the Tag in the Catalog
 
+{{< tabs "catalog-tutorial-cmd-31" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog list --name greeting -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog list --name greeting -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The tag creates an alias that points to the same digest as the original version.
 
 ### Step 3: Tag for Different Environments
 
+{{< tabs "catalog-tutorial-cmd-32" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog tag greeting@1.0.0 production
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog tag greeting@1.0.0 production
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 You can create as many tags as needed. Tags are freeform strings — they cannot be valid semver versions (use `scafctl build` for that).
 
@@ -662,9 +960,18 @@ scafctl checks these credential locations in order:
 
 Make sure `greeting@1.0.0` is in your local catalog, then push it:
 
+{{< tabs "catalog-tutorial-cmd-33" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg/scafctl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg/scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -678,9 +985,18 @@ The path structure is: `<registry>/<repository>/solutions/<name>:<version>`
 
 ### Step 3: Push with a Different Name
 
+{{< tabs "catalog-tutorial-cmd-34" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog push greeting@1.0.0 --as hello-world --catalog ghcr.io/myorg/scafctl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog push greeting@1.0.0 --as hello-world --catalog ghcr.io/myorg/scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This pushes the same artifact under a different name in the remote registry.
 
@@ -688,9 +1004,18 @@ This pushes the same artifact under a different name in the remote registry.
 
 On a different machine (or after deleting the local copy):
 
+{{< tabs "catalog-tutorial-cmd-35" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -700,34 +1025,72 @@ Expected output:
 
 The artifact is now in your local catalog. You can run it with:
 
+{{< tabs "catalog-tutorial-cmd-36" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 5: Pull with a Different Local Name
 
+{{< tabs "catalog-tutorial-cmd-37" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0 --as my-greeting
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog pull ghcr.io/myorg/scafctl/solutions/greeting@1.0.0 --as my-greeting
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This stores the artifact locally under the name `my-greeting`.
 
 ### Step 6: Delete from a Remote Registry
 
+{{< tabs "catalog-tutorial-cmd-38" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog delete ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog delete ghcr.io/myorg/scafctl/solutions/greeting@1.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Note:** Not all registries support OCI DELETE. GitHub Container Registry (ghcr.io) requires deletion through the web interface at `https://github.com/orgs/YOUR_ORG/packages`. Docker Hub, Azure Container Registry, Harbor, and Amazon ECR support API-based deletion.
 
 ### Troubleshooting
 
 **403 Forbidden errors:**
 
+{{< tabs "catalog-tutorial-cmd-39" >}}
+{{% tab "Bash" %}}
 ```bash
 # Enable debug logging to see which auth config is being used
 scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg -d
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Enable debug logging to see which auth config is being used
+scafctl catalog push greeting@1.0.0 --catalog ghcr.io/myorg -d
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Check that:
 1. Your token has `write:packages` scope
@@ -738,10 +1101,20 @@ Check that:
 
 For local testing with registries that don't use HTTPS:
 
+{{< tabs "catalog-tutorial-cmd-40" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog push greeting@1.0.0 --catalog localhost:5000 --insecure
 scafctl catalog pull localhost:5000/solutions/greeting@1.0.0 --insecure
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog push greeting@1.0.0 --catalog localhost:5000 --insecure
+scafctl catalog pull localhost:5000/solutions/greeting@1.0.0 --insecure
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Supported Registries
 
@@ -899,9 +1272,18 @@ The `deployment-template` resolver uses a **static path** (`templates/deployment
 
 ### Step 3: Preview What Gets Bundled
 
+{{< tabs "catalog-tutorial-cmd-41" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution deploy-app/solution.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution deploy-app/solution.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -925,9 +1307,18 @@ The dry-run shows:
 
 ### Step 4: Build the Solution
 
+{{< tabs "catalog-tutorial-cmd-42" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution deploy-app/solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution deploy-app/solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -940,9 +1331,18 @@ Expected output:
 
 ### Step 5: Run from the Catalog with Dev Config
 
+{{< tabs "catalog-tutorial-cmd-43" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=dev
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=dev
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -971,9 +1371,18 @@ spec:
 
 ### Step 6: Switch to Prod
 
+{{< tabs "catalog-tutorial-cmd-44" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=prod
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f deploy-app -o yaml -e '_.["rendered-deployment"]' -r environment=prod
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -1111,9 +1520,18 @@ spec:
 
 ### Step 3: Preview the Bundle
 
+{{< tabs "catalog-tutorial-cmd-45" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution nested-demo/parent.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution nested-demo/parent.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -1131,10 +1549,20 @@ Notice that scafctl **recursively discovered** the child sub-solution (`sub/chil
 
 ### Step 4: Build and Run
 
+{{< tabs "catalog-tutorial-cmd-46" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution nested-demo/parent.yaml
 scafctl run resolver -f nested-demo -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution nested-demo/parent.yaml
+scafctl run resolver -f nested-demo -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### How It Works
 
@@ -1159,9 +1587,18 @@ After building a bundle, you can verify its integrity and examine its contents.
 
 ### Step 1: Verify the Bundle
 
+{{< tabs "catalog-tutorial-cmd-47" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle verify deploy-app@1.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle verify deploy-app@1.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -1181,9 +1618,18 @@ This checks that:
 
 See what files are inside the bundle without extracting them:
 
+{{< tabs "catalog-tutorial-cmd-48" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle extract deploy-app@1.0.0 --list-only
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle extract deploy-app@1.0.0 --list-only
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -1198,9 +1644,18 @@ Expected output:
 
 Extract the bundled files to inspect them:
 
+{{< tabs "catalog-tutorial-cmd-49" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle extract deploy-app@1.0.0 --output-dir ./extracted
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle extract deploy-app@1.0.0 --output-dir ./extracted
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Check the extracted files:
 
@@ -1223,9 +1678,18 @@ extracted/
 
 You can extract only the files needed by a specific resolver:
 
+{{< tabs "catalog-tutorial-cmd-50" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle extract deploy-app@1.0.0 --resolver config --output-dir ./config-only
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle extract deploy-app@1.0.0 --resolver config --output-dir ./config-only
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This uses static analysis to determine which files the `config` resolver references.
 
@@ -1271,9 +1735,18 @@ metadata:
 
 ### Step 2: Build v2
 
+{{< tabs "catalog-tutorial-cmd-51" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build solution deploy-app/solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build solution deploy-app/solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -1288,40 +1761,88 @@ Notice it now bundles 4 files (the new staging config was picked up by `configs/
 
 ### Step 3: Compare the Two Versions
 
+{{< tabs "catalog-tutorial-cmd-52" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The output shows files added, modified, and removed between the two versions.
 
 ### Step 4: Show Only File Changes
 
+{{< tabs "catalog-tutorial-cmd-53" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --files-only
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --files-only
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 5: Show Only Solution Structure Changes
 
+{{< tabs "catalog-tutorial-cmd-54" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --solution-only
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 --solution-only
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows only changes to the solution YAML itself (resolvers added/removed, actions changed, etc.).
 
 ### Step 6: Get Diff Output as YAML
 
+{{< tabs "catalog-tutorial-cmd-55" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl bundle diff deploy-app@1.0.0 deploy-app@2.0.0 -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 7: Clean Up
 
+{{< tabs "catalog-tutorial-cmd-56" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog delete deploy-app@1.0.0 --kind solution
 scafctl catalog delete deploy-app@2.0.0 --kind solution
 scafctl catalog prune
 rm -rf deploy-app/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog delete deploy-app@1.0.0 --kind solution
+scafctl catalog delete deploy-app@2.0.0 --kind solution
+scafctl catalog prune
+rm -rf deploy-app/
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What You Learned
 

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -16,15 +16,14 @@ CEL is used throughout scafctl for dynamic evaluation:
 - **Conditions** — Conditionally skip actions with `when`
 - **forEach** — Generate iteration lists dynamically
 
-```
-┌──────────────┐         ┌──────────────┐         ┌──────────────┐
-│  Resolver    │  ─ _ ─► │     CEL      │  ────►  │   Result     │
-│  Data        │         │  Expression  │         │   Value      │
-└──────────────┘         └──────────────┘         └──────────────┘
+```mermaid
+flowchart LR
+  A["Resolver<br/>Data"] -- "_ namespace" --> B["CEL<br/>Expression"] --> C["Result<br/>Value"]
 ```
 
 **Key principle:** In CEL expressions, all resolved values are available under the `_` namespace (e.g., `_.appName`, `_.config.port`).
 
+> [!NOTE]
 > **Hands-on:** Every section in this tutorial links to a runnable example file. Look for the **▶ Try it** callouts to run the examples yourself.
 
 ## Quick Start
@@ -53,9 +52,18 @@ spec:
 
 Run it:
 
+{{< tabs "cel-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f cel-basics.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f cel-basics.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -65,12 +73,16 @@ Output:
 }
 ```
 
+> [!NOTE]
 > **Tip**: `run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details.
 
-> **▶ Try it:** The complete example with more expressions is at [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+The complete example with more expressions is at [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 String literals use single quotes inside the expression. Numbers, booleans, and lists are written normally:
 
@@ -122,9 +134,18 @@ spec:
 
 Run it:
 
+{{< tabs "cel-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f cel-refs.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f cel-refs.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -136,7 +157,10 @@ Output:
 }
 ```
 
-> **▶ Try it:** This example is also in [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) — it includes operators, string operations, list comprehensions, and more.
+{{% details "▶ Try it" %}}
+This example is also in [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) — it includes operators, string operations, list comprehensions, and more.
+
+{{% /details %}}
 
 ### 3. Using `expr` in Inputs
 
@@ -265,10 +289,13 @@ size("hello")                         // 5
 "Hello %s, you are %d".format(["Alice", 30])  // "Hello Alice, you are 30"
 ```
 
-> **▶ Try it:** All the operators, string, list, and map operations above are runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+All the operators, string, list, and map operations above are runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 ---
 
@@ -276,10 +303,13 @@ size("hello")                         // 5
 
 scafctl extends CEL with project-specific functions for arrays, maps, strings, regex, filepath, GUID, sorting, time, marshalling, and debugging.
 
-> **▶ Try it:** All custom extension functions are demonstrated in a single runnable file — [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+All custom extension functions are demonstrated in a single runnable file — [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 ### Arrays
 
@@ -783,19 +813,25 @@ cel.bind(base, _.host + ":" + string(_.port),
 )
 ```
 
-> **▶ Try it:** Encoders, math, optionals, sets, and bindings are all runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+Encoders, math, optionals, sets, and bindings are all runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 ---
 
 ## Common Patterns
 
-> **▶ Try it:** All the patterns below are combined into one runnable file — [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+All the patterns below are combined into one runnable file — [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 ### Conditional Configuration
 
@@ -898,10 +934,13 @@ deployments:
             })
 ```
 
-> **▶ Try it:** For more data transformation patterns (filtering, aggregation, enrichment, serialization), see [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml):
-> ```bash
-> scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution
-> ```
+{{% details "▶ Try it" %}}
+For more data transformation patterns (filtering, aggregation, enrichment, serialization), see [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml)
+
+```bash
+scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution
+```
+{{% /details %}}
 
 ## Function Reference
 

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -11,16 +11,14 @@ This tutorial covers managing scafctl's application configuration using the `con
 
 scafctl uses a YAML configuration file to control application behavior including logging, HTTP client settings, resolver timeouts, catalog locations, and more.
 
-```
-┌──────────────────┐
-│  config init     │ ── Create config file
-│  config view     │ ── View current config
-│  config get/set  │ ── Read/write values
-│  config validate │ ── Validate config
-│  config schema   │ ── View JSON schema
-│  config paths    │ ── Show XDG paths
-└──────────────────┘
-```
+| Command | Description |
+|---------|-------------|
+| `config init` | Create config file |
+| `config view` | View current config |
+| `config get/set` | Read/write values |
+| `config validate` | Validate config |
+| `config schema` | View JSON schema |
+| `config paths` | Show XDG paths |
 
 ## Quick Start
 
@@ -28,6 +26,8 @@ scafctl uses a YAML configuration file to control application behavior including
 
 Create a new config file:
 
+{{< tabs "config-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Create minimal config
 scafctl config init
@@ -41,11 +41,30 @@ scafctl config init --dry-run
 # Write to custom path
 scafctl config init --output ./my-config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Create minimal config
+scafctl config init
+
+# Create with all options documented
+scafctl config init --full
+
+# Preview without writing
+scafctl config init --dry-run
+
+# Write to custom path
+scafctl config init --output ./my-config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### 2. View Configuration
 
 See the current effective configuration:
 
+{{< tabs "config-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Full config (YAML format)
 scafctl config view
@@ -59,14 +78,40 @@ scafctl config view -e '_.settings'
 # Interactive TUI explorer
 scafctl config view -i
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Full config (YAML format)
+scafctl config view
+
+# As JSON
+scafctl config view -o json
+
+# Filter with CEL expression
+scafctl config view -e '_.settings'
+
+# Interactive TUI explorer
+scafctl config view -i
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### 3. Show Config Sources
 
 See where each value comes from (file, environment, default):
 
+{{< tabs "config-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl config show
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl config show
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Getting and Setting Values
 
@@ -74,6 +119,8 @@ scafctl config show
 
 Use dot notation to read specific config values:
 
+{{< tabs "config-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get logging level
 scafctl config get logging.level
@@ -84,9 +131,25 @@ scafctl config get settings.defaultCatalog
 # Get HTTP timeout
 scafctl config get httpClient.timeout
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Get logging level
+scafctl config get logging.level
+
+# Get default catalog
+scafctl config get settings.defaultCatalog
+
+# Get HTTP timeout
+scafctl config get httpClient.timeout
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Write Values
 
+{{< tabs "config-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # Set logging level
 scafctl config set logging.level debug
@@ -100,9 +163,28 @@ scafctl config set resolver.concurrency 8
 # Enable a boolean
 scafctl config set httpClient.caching.enabled true
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set logging level
+scafctl config set logging.level debug
+
+# Set HTTP timeout
+scafctl config set httpClient.timeout 60s
+
+# Set resolver concurrency
+scafctl config set resolver.concurrency 8
+
+# Enable a boolean
+scafctl config set httpClient.caching.enabled true
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Reset to Default
 
+{{< tabs "config-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # Reset a value to its default
 scafctl config unset logging.level
@@ -110,11 +192,24 @@ scafctl config unset logging.level
 # Reset HTTP configuration
 scafctl config unset httpClient.timeout
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Reset a value to its default
+scafctl config unset logging.level
+
+# Reset HTTP configuration
+scafctl config unset httpClient.timeout
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Managing Catalogs
 
 ### Add a Catalog
 
+{{< tabs "config-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Add a local filesystem catalog
 scafctl config add-catalog my-catalog --type filesystem --path ~/my-solutions
@@ -125,23 +220,57 @@ scafctl config add-catalog company --type oci --url ghcr.io/myorg/scafctl-catalo
 # Add and set as default
 scafctl config add-catalog primary --type filesystem --path ~/catalogs/main --default
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Add a local filesystem catalog
+scafctl config add-catalog my-catalog --type filesystem --path ~/my-solutions
+
+# Add an OCI registry catalog
+scafctl config add-catalog company --type oci --url ghcr.io/myorg/scafctl-catalog
+
+# Add and set as default
+scafctl config add-catalog primary --type filesystem --path ~/catalogs/main --default
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Remove a Catalog
 
+{{< tabs "config-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl config remove-catalog my-catalog
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl config remove-catalog my-catalog
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Set Default Catalog
 
+{{< tabs "config-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl config use-catalog my-catalog
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl config use-catalog my-catalog
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Validation
 
 ### Validate Config File
 
+{{< tabs "config-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 # Validate current config
 scafctl config validate
@@ -149,9 +278,22 @@ scafctl config validate
 # Validate a specific file
 scafctl config validate path/to/config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Validate current config
+scafctl config validate
+
+# Validate a specific file
+scafctl config validate path/to/config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### View Config Schema
 
+{{< tabs "config-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Pretty-printed JSON Schema
 scafctl config schema
@@ -159,11 +301,24 @@ scafctl config schema
 # Minified (for piping)
 scafctl config schema --compact
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Pretty-printed JSON Schema
+scafctl config schema
+
+# Minified (for piping)
+scafctl config schema --compact
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## View System Paths
 
 See where scafctl stores files on your system:
 
+{{< tabs "config-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # Show all XDG paths
 scafctl config paths
@@ -174,6 +329,20 @@ scafctl config paths -o json
 # Show paths for a different platform
 scafctl config paths --platform linux
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Show all XDG paths
+scafctl config paths
+
+# As JSON
+scafctl config paths -o json
+
+# Show paths for a different platform
+scafctl config paths --platform linux
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Typical output:
 
@@ -226,9 +395,18 @@ The config file is located at the XDG config path:
 
 Override with the `--config` flag on any command:
 
+{{< tabs "config-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution my-solution --config ./custom-config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution my-solution --config ./custom-config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Examples
 
@@ -256,6 +434,8 @@ See [examples/config/full-config.yaml](../../examples/config/full-config.yaml) f
 
 ### Initial Setup
 
+{{< tabs "config-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Initialize config
 scafctl config init
@@ -267,9 +447,26 @@ scafctl config add-catalog local --type filesystem --path ~/scafctl-catalog --de
 scafctl config view
 scafctl config validate
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Initialize config
+scafctl config init
+
+# 2. Set up a catalog
+scafctl config add-catalog local --type filesystem --path ~/scafctl-catalog --default
+
+# 3. Verify
+scafctl config view
+scafctl config validate
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Switch Environments
 
+{{< tabs "config-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 # Use staging catalog
 scafctl config use-catalog staging
@@ -280,6 +477,20 @@ scafctl config set logging.level debug
 # After debugging, reset
 scafctl config unset logging.level
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Use staging catalog
+scafctl config use-catalog staging
+
+# Increase logging for debugging
+scafctl config set logging.level debug
+
+# After debugging, reset
+scafctl config unset logging.level
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/directory-provider-tutorial.md
+++ b/docs/tutorials/directory-provider-tutorial.md
@@ -53,9 +53,18 @@ spec:
 
 Run it:
 
+{{< tabs "directory-provider-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f list-dir.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f list-dir.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output (entries will vary based on your directory contents):
 
@@ -107,6 +116,7 @@ The output also provides summary fields: `totalCount`, `fileCount`, `dirCount`, 
 
 Enable `recursive: true` to traverse subdirectories. Control the depth with `maxDepth` (default: 10, maximum: 50).
 
+> [!TIP]
 > **Note:** The YAML snippets in the remaining sections show only the `spec:` or `workflow:` portion. To run them, place each snippet inside a complete solution file with `apiVersion`, `kind`, and `metadata` sections — like the `list-dir.yaml` example above.
 
 ```yaml
@@ -124,6 +134,7 @@ spec:
               maxDepth: 5
 ```
 
+> [!NOTE]
 > **Tip:** Use `excludeHidden: true` to skip files and directories starting with `.` (e.g., `.git`, `.env`).
 
 ---
@@ -174,6 +185,7 @@ spec:
               filterRegex: "_test\\.go$"
 ```
 
+> [!CAUTION]
 > **Note:** `filterGlob` and `filterRegex` are mutually exclusive. The provider returns an error if both are specified.
 
 ---
@@ -231,6 +243,7 @@ spec:
 
 Each entry will include `checksum` and `checksumAlgorithm` fields.
 
+> [!NOTE]
 > **Note:** Checksums require `includeContent: true` since the file must be read to compute the hash.
 
 ---
@@ -260,9 +273,18 @@ spec:
 
 Run it:
 
+{{< tabs "directory-provider-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f create-dirs.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f create-dirs.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The command completes silently on success. Verify the directory was created:
 
@@ -289,6 +311,7 @@ workflow:
         force: true
 ```
 
+> [!WARNING]
 > **Warning:** `force: true` permanently deletes the directory and all its contents. Use `--dry-run` first to verify what would be removed.
 
 ---
@@ -316,9 +339,18 @@ Both `path` (source) and `destination` are required. The source must be an exist
 
 All mutating operations (`mkdir`, `rmdir`, `copy`) support dry-run mode. Use `--dry-run` to see what would happen without making changes:
 
+{{< tabs "directory-provider-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 In dry-run mode, the provider returns the intended operation details without modifying the filesystem. The `list` operation runs normally since it is read-only.
 

--- a/docs/tutorials/dryrun-tutorial.md
+++ b/docs/tutorials/dryrun-tutorial.md
@@ -11,14 +11,9 @@ This tutorial covers using `--dry-run` to preview what a solution execution woul
 
 Dry-run mode resolves all values and builds an action execution plan, but never executes actions. This gives you a complete picture of what *would* happen:
 
-```
-┌──────────────┐     ┌──────────────┐     ┌──────────────┐
-│   Solution   │     │  Dry-Run     │     │   Report     │
-│   (.yaml)    │ ──► │  Generator   │ ──► │  (resolvers, │
-│              │     │              │     │   actions,   │
-│              │     │  No side     │     │   phases)    │
-│              │     │  effects!    │     │              │
-└──────────────┘     └──────────────┘     └──────────────┘
+```mermaid
+flowchart LR
+  A["Solution<br/>(.yaml)"] --> B["Dry-Run Generator<br/>⚠️ No side effects!"] --> C["Report<br/>(resolvers, actions, phases)"]
 ```
 
 ## When to Use Dry-Run
@@ -35,25 +30,52 @@ Dry-run mode resolves all values and builds an action execution plan, but never 
 
 ### Dry-Run a Full Solution
 
+{{< tabs "dryrun-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This resolves all values and shows the action plan without executing any actions.
 
 ### Dry-Run with JSON Output
 
+{{< tabs "dryrun-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --dry-run -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --dry-run -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Returns a structured JSON report with resolver values, action plan, phases, and warnings.
 
 ### Dry-Run with Verbose Output
 
+{{< tabs "dryrun-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --dry-run --verbose
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --dry-run --verbose
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Adds materialized inputs to each action in the report, showing exactly what values were resolved for each provider.
 
@@ -69,9 +91,18 @@ This solution has four resolvers (`greeting`, `target`, `port`, `endpoint`) and 
 
 ### Step 2: Run Dry-Run
 
+{{< tabs "dryrun-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f examples/dryrun/basic-dryrun.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f examples/dryrun/basic-dryrun.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The output shows:
 - **WhatIf messages** — Each action's provider-generated description of what it would do (e.g., `Would execute command echo Hello via bash`)
@@ -80,9 +111,18 @@ The output shows:
 
 ### Step 3: JSON Output for Automation
 
+{{< tabs "dryrun-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f examples/dryrun/basic-dryrun.yaml --dry-run -o json | jq .
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f examples/dryrun/basic-dryrun.yaml --dry-run -o json | ConvertFrom-Json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The JSON report contains:
 
@@ -116,9 +156,18 @@ The JSON report contains:
 
 ### Step 4: Conditional Actions
 
+{{< tabs "dryrun-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f examples/dryrun/conditional-dryrun.yaml --dry-run -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f examples/dryrun/conditional-dryrun.yaml --dry-run -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This example shows how dry-run reports conditional (`when`) actions and `finally` blocks. The action plan includes the `when` expression so you can see which conditions will be evaluated at runtime.
 
@@ -154,6 +203,8 @@ This example shows how dry-run reports conditional (`when`) actions and `finally
 
 Dry-run shows what *would* happen; snapshots capture what *did* happen. Combine them:
 
+{{< tabs "dryrun-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Preview what will happen
 scafctl run solution -f solution.yaml --dry-run -o json > plan.json
@@ -163,11 +214,26 @@ scafctl run resolver -f solution.yaml --snapshot --snapshot-file=actual.json
 
 # Compare plan vs actual if needed
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Preview what will happen
+scafctl run solution -f solution.yaml --dry-run -o json > plan.json
+
+# Execute and capture the result
+scafctl run resolver -f solution.yaml --snapshot --snapshot-file=actual.json
+
+# Compare plan vs actual if needed
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## CI Pipeline Integration
 
 Use dry-run in CI to validate solutions without side effects:
 
+{{< tabs "dryrun-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 # Verify all resolvers resolve successfully
 output=$(scafctl run solution -f solution.yaml --dry-run -o json)
@@ -179,11 +245,29 @@ if [ "$warnings" -gt 0 ]; then
   exit 1
 fi
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Verify all resolvers resolve successfully
+$output = scafctl run solution -f solution.yaml --dry-run -o json
+$parsed = $output | ConvertFrom-Json
+$warnings = $parsed.warnings.Count
+
+if ($warnings -gt 0) {
+  Write-Output "Dry-run reported warnings:"
+  $parsed.warnings
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Working Directory Override
 
 Use `--cwd` (`-C`) to run a dry-run against a solution in a different directory:
 
+{{< tabs "dryrun-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # Dry-run a solution from another directory
 scafctl --cwd /path/to/project dryrun -f solution.yaml
@@ -191,6 +275,17 @@ scafctl --cwd /path/to/project dryrun -f solution.yaml
 # Short form
 scafctl -C /path/to/project dryrun -f solution.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Dry-run a solution from another directory
+scafctl --cwd /path/to/project dryrun -f solution.yaml
+
+# Short form
+scafctl -C /path/to/project dryrun -f solution.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 All relative paths in the solution (file references, templates, etc.) resolve against the `--cwd` directory.
 

--- a/docs/tutorials/eval-tutorial.md
+++ b/docs/tutorials/eval-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Eval Tutorial"
-weight: 52
+weight: 42
 ---
 
 # Eval Tutorial
@@ -31,27 +31,58 @@ These commands are especially useful when writing or debugging resolver expressi
 
 Evaluate a simple expression:
 
+{{< tabs "eval-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval cel "1 + 2"
 # 3
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval cel "1 + 2"
+# 3
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 String operations:
 
+{{< tabs "eval-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval cel '"hello".upperAscii()'
 # HELLO
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval cel '"hello".upperAscii()'
+# HELLO
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Using Inline Data
 
 Pass JSON data to the expression via `--data`:
 
+{{< tabs "eval-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval cel '_.name + " is " + string(_.age)' \
   --data '{"name": "Alice", "age": 30}'
 # Alice is 30
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval cel '_.name + " is " + string(_.age)' `
+  --data '{"name": "Alice", "age": 30}'
+# Alice is 30
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The data is available under `_`, just like in solution resolvers.
 
@@ -59,6 +90,8 @@ The data is available under `_`, just like in solution resolvers.
 
 For larger datasets, use `--data-file`:
 
+{{< tabs "eval-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Create a data file
 cat > data.json << 'EOF'
@@ -75,11 +108,33 @@ EOF
 scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file data.json
 # ["item-a", "item-c"]
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Create a data file
+@'
+{
+  "items": [
+    {"name": "item-a", "active": true},
+    {"name": "item-b", "active": false},
+    {"name": "item-c", "active": true}
+  ]
+}
+'@ | Set-Content -Path data.json
+
+# Filter active items
+scafctl eval cel '_.items.filter(i, i.active).map(i, i.name)' --data-file data.json
+# ["item-a", "item-c"]
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Output Formats
 
 Use `-o` to control output format:
 
+{{< tabs "eval-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # JSON output
 scafctl eval cel '{"greeting": "hello", "count": 42}' -o json
@@ -87,11 +142,24 @@ scafctl eval cel '{"greeting": "hello", "count": 42}' -o json
 # YAML output
 scafctl eval cel '{"greeting": "hello", "count": 42}' -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# JSON output
+scafctl eval cel '{"greeting": "hello", "count": 42}' -o json
+
+# YAML output
+scafctl eval cel '{"greeting": "hello", "count": 42}' -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Built-in Functions
 
 Test scafctl's custom CEL extension functions:
 
+{{< tabs "eval-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # String functions
 scafctl eval cel '"hello-world".toCamelCase()'
@@ -103,7 +171,23 @@ scafctl eval cel '"hello-world".toPascalCase()'
 # List the available CEL functions
 scafctl eval cel 'true' --list-functions
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# String functions
+scafctl eval cel '"hello-world".toCamelCase()'
+# helloWorld
 
+scafctl eval cel '"hello-world".toPascalCase()'
+# HelloWorld
+
+# List the available CEL functions
+scafctl eval cel 'true' --list-functions
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+> [!NOTE]
 > **Tip:** Use `eval cel` to prototype resolver expressions before adding them to a solution. This is much faster than running the entire solution each time.
 
 ## 2. Evaluating Go Templates
@@ -112,16 +196,29 @@ scafctl eval cel 'true' --list-functions
 
 Render a template with inline data:
 
+{{< tabs "eval-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval template '{{.name}} has {{.count}} items' \
   --data '{"name": "project", "count": 5}'
 # project has 5 items
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval template '{{.name}} has {{.count}} items' `
+  --data '{"name": "project", "count": 5}'
+# project has 5 items
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Template Files
 
 For multi-line templates, use `--template-file`:
 
+{{< tabs "eval-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 cat > greeting.tmpl << 'EOF'
 Hello, {{.name}}!
@@ -133,31 +230,68 @@ EOF
 scafctl eval template --template-file greeting.tmpl \
   --data '{"name": "Alice", "items": ["task-1", "task-2", "task-3"]}'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+@'
+Hello, {{.name}}!
+You have {{len .items}} items:
+{{range .items}}- {{.}}
+{{end}}
+'@ | Set-Content -Path greeting.tmpl
+
+scafctl eval template --template-file greeting.tmpl `
+  --data '{"name": "Alice", "items": ["task-1", "task-2", "task-3"]}'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Data Files
 
 Combine template files with data files:
 
+{{< tabs "eval-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval template --template-file config.tmpl --data-file values.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval template --template-file config.tmpl --data-file values.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Writing Output to File
 
 Save rendered output to a file:
 
+{{< tabs "eval-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl eval template --template-file config.tmpl \
   --data-file values.json \
   --output generated-config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl eval template --template-file config.tmpl `
+  --data-file values.json `
+  --output generated-config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Tip:** Use `eval template` to preview scaffold/render actions before running the full solution workflow.
 
 ## 3. Validating Solution Files with `scafctl lint`
 
 While `eval cel` and `eval template` test individual expressions and templates, use the **`scafctl lint`** command to validate entire solution files against the schema and lint rules.
 
+> [!WARNING]
 > **Note:** `scafctl lint` is a separate top-level command, not part of `eval`. It's included here because validation is a natural part of the expression development workflow.
 
 ### Basic Validation
@@ -165,48 +299,58 @@ While `eval cel` and `eval template` test individual expressions and templates, 
 Check a solution file for schema errors and lint violations:
 
 {{< tabs "eval-lint-basic" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint -f solution.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl lint -f solution.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Get structured validation results:
 
 {{< tabs "eval-lint-json" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint -f solution.yaml -o json
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl lint -f solution.yaml -o json
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Filter by Severity
 
 Only show findings at or above a minimum severity level:
 
+{{< tabs "eval-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Show only warnings and errors (skip info)
 scafctl lint -f solution.yaml --severity warning
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Show only warnings and errors (skip info)
+scafctl lint -f solution.yaml --severity warning
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Quick Validation in Scripts
 
 Use quiet mode for CI/CD pipelines — returns exit code only (0 = clean, non-zero = errors):
 
 {{< tabs "eval-lint-quiet" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 if scafctl lint -f solution.yaml -o quiet; then
   echo "Valid!"
@@ -215,28 +359,46 @@ else
   exit 1
 fi
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl lint -f solution.yaml -o quiet
 if ($LASTEXITCODE -eq 0) { Write-Host "Valid!" } else { Write-Host "Validation failed"; exit 1 }
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Exploring Lint Rules
 
 List all available lint rules:
 
+{{< tabs "eval-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint rules
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint rules
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Get a detailed explanation of a specific rule:
 
+{{< tabs "eval-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint explain <rule-id>
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain <rule-id>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 See the [Linting Tutorial](linting-tutorial.md) for a deep dive into lint rules and custom validation workflows.
 
@@ -246,6 +408,8 @@ See the [Linting Tutorial](linting-tutorial.md) for a deep dive into lint rules 
 
 When building a new resolver, iterate quickly with `eval cel`:
 
+{{< tabs "eval-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Start with simple expression
 scafctl eval cel '"Hello, " + _.name' --data '{"name": "World"}'
@@ -256,11 +420,27 @@ scafctl eval cel '_.items.filter(i, i.enabled).map(i, i.name).join(", ")' \
 
 # 3. Once working, copy to solution YAML
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Start with simple expression
+scafctl eval cel '"Hello, " + _.name' --data '{"name": "World"}'
+
+# 2. Add complexity
+scafctl eval cel '_.items.filter(i, i.enabled).map(i, i.name).join(", ")' `
+  --data-file real-data.json
+
+# 3. Once working, copy to solution YAML
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Testing Template Rendering
 
 Preview template output before integrating into actions:
 
+{{< tabs "eval-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 # Test with known data
 scafctl eval template --template-file deploy.tmpl --data '{"env": "staging", "replicas": 3}'
@@ -268,23 +448,34 @@ scafctl eval template --template-file deploy.tmpl --data '{"env": "staging", "re
 # Test with real resolver output (from a snapshot)
 scafctl eval template --template-file deploy.tmpl --data-file snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Test with known data
+scafctl eval template --template-file deploy.tmpl --data '{"env": "staging", "replicas": 3}'
+
+# Test with real resolver output (from a snapshot)
+scafctl eval template --template-file deploy.tmpl --data-file snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Pre-commit Validation
 
 Add to your pre-commit hooks or CI pipeline:
 
 {{< tabs "eval-precommit" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Validate all solution files in a directory
 find . -name 'solution.yaml' -exec scafctl lint -f {} -o quiet \;
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 Get-ChildItem -Recurse -Filter 'solution.yaml' | ForEach-Object { scafctl lint -f $_.FullName -o quiet }
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Next Steps

--- a/docs/tutorials/exec-provider-tutorial.md
+++ b/docs/tutorials/exec-provider-tutorial.md
@@ -66,9 +66,18 @@ spec:
 
 Run it:
 
+{{< tabs "exec-provider-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f simple-exec.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f simple-exec.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -113,6 +122,7 @@ actions:
 
 Unlike traditional exec implementations that require a special flag for shell features, the embedded shell handles all POSIX syntax by default.
 
+> [!TIP]
 > **Note:** The YAML snippets in the remaining sections show only the `actions:` block. To run them, place each snippet inside a complete solution file with `apiVersion`, `kind`, `metadata`, `spec.resolvers: {}`, and `spec.workflow` sections — like the `simple-exec.yaml` example above.
 
 ```yaml
@@ -196,6 +206,7 @@ actions:
 
 The `args` values are appended to the command after being single-quoted for safety (e.g., `echo 'Hello' 'World' 'with special chars: $HOME ; rm -rf /'`).
 
+> [!NOTE]
 > **Tip**: Use `args` when the values come from user input or resolved values to prevent shell injection. Use inline command strings when you want shell expansion.
 
 ---
@@ -440,6 +451,7 @@ actions:
       command: "rm -rf /tmp/myapp"
 ```
 
+> [!NOTE]
 > **Note**: On Windows, the Go-native coreutils are enabled by default. Set the `SCAFCTL_CORE_UTILS=false` environment variable to disable them if needed.
 
 ---

--- a/docs/tutorials/extension-concepts.md
+++ b/docs/tutorials/extension-concepts.md
@@ -22,19 +22,10 @@ This page defines the core terminology and links to the detailed development gui
 
 ## Extension Matrix
 
-```
-                    ┌──────────────────────┬──────────────────────┐
-                    │      Builtin         │       Plugin         │
-┌───────────────────┼──────────────────────┼──────────────────────┤
-│                   │ Compiled into scafctl│ Standalone gRPC      │
-│   Provider        │ 16 built-in providers│ binary; auto-fetched │
-│                   │ (http, cel, exec...) │ from OCI catalogs    │
-├───────────────────┼──────────────────────┼──────────────────────┤
-│                   │ Compiled into scafctl│ Standalone gRPC      │
-│   Auth Handler    │ 3 built-in handlers  │ binary; auto-fetched │
-│                   │ (entra, github, gcp) │ from OCI catalogs    │
-└───────────────────┴──────────────────────┴──────────────────────┘
-```
+| | **Builtin** | **Plugin** |
+|---|---|---|
+| **Provider** | Compiled into scafctl; 16 built-in providers (http, cel, exec...) | Standalone gRPC binary; auto-fetched from OCI catalogs |
+| **Auth Handler** | Compiled into scafctl; 3 built-in handlers (entra, github, gcp) | Standalone gRPC binary; auto-fetched from OCI catalogs |
 
 ## When to Choose Builtin vs Plugin
 

--- a/docs/tutorials/file-provider-tutorial.md
+++ b/docs/tutorials/file-provider-tutorial.md
@@ -54,9 +54,18 @@ spec:
 
 Run it:
 
+{{< tabs "file-provider-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f read-file.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f read-file.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -99,9 +108,18 @@ spec:
 
 Run it:
 
+{{< tabs "file-provider-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f write-file.yaml --output-dir /tmp/demo
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f write-file.yaml --output-dir /tmp/demo
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The output includes a `status` field showing what happened:
 
@@ -216,6 +234,7 @@ Output includes per-file status and summary counts:
 }
 ```
 
+> [!NOTE]
 > **Note:** `filesWritten` counts files actually written to disk (`created + overwritten + appended`), not the total number of entries.
 
 ---
@@ -328,6 +347,7 @@ If `.gitignore` already contains `dist/` and `.env`, only `build/` and `node_mod
 
 **Empty content** is a no-op — the file is not modified and not created if missing. Status: `unchanged`.
 
+> [!CAUTION]
 > **Note:** `dedupe: true` is only valid with `onConflict: append`. Using it with any other strategy returns a validation error.
 
 ---
@@ -424,6 +444,8 @@ Two CLI flags control conflict behavior across an entire solution run:
 
 Sets the default conflict strategy for all file provider actions:
 
+{{< tabs "file-provider-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Error if any generated file already exists
 scafctl run solution -f solution.yaml --output-dir ./out --on-conflict error
@@ -434,6 +456,20 @@ scafctl run solution -f solution.yaml --output-dir ./out --on-conflict overwrite
 # Skip all existing files (one-time scaffolding)
 scafctl run solution -f solution.yaml --output-dir ./out --on-conflict skip
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Error if any generated file already exists
+scafctl run solution -f solution.yaml --output-dir ./out --on-conflict error
+
+# Force overwrite everything
+scafctl run solution -f solution.yaml --output-dir ./out --on-conflict overwrite
+
+# Skip all existing files (one-time scaffolding)
+scafctl run solution -f solution.yaml --output-dir ./out --on-conflict skip
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `--on-conflict` flag is the **lowest-priority** override. Provider-level and entry-level `onConflict` settings always take precedence.
 
@@ -441,15 +477,33 @@ The `--on-conflict` flag is the **lowest-priority** override. Provider-level and
 
 Creates `.bak` backups for all mutating file operations:
 
+{{< tabs "file-provider-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir ./out --backup
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir ./out --backup
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Both flags work with `run solution` and `run provider`:
 
+{{< tabs "file-provider-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider file operation=write path=config.yaml content="new" --on-conflict overwrite --backup
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider file operation=write path=config.yaml content="new" --on-conflict overwrite --backup
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -457,9 +511,18 @@ scafctl run provider file operation=write path=config.yaml content="new" --on-co
 
 Use `--dry-run` to see what would happen without writing any files:
 
+{{< tabs "file-provider-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir ./out --dry-run -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir ./out --dry-run -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Dry-run output includes planned statuses:
 
@@ -511,9 +574,18 @@ workflow:
 
 Or via CLI flags:
 
+{{< tabs "file-provider-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir ./generated --on-conflict overwrite --backup
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir ./generated --on-conflict overwrite --backup
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### One-Time Scaffolding (Never Overwrite)
 
@@ -569,9 +641,18 @@ workflow:
 
 Fail the entire solution if any output file would be overwritten:
 
+{{< tabs "file-provider-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir ./out --on-conflict error
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir ./out --on-conflict error
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 For `write-tree`, the `error` strategy collects all conflicts and reports them in a single error. Use `failFast: true` to stop at the first conflict:
 

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -45,15 +45,33 @@ spec:
 
 Run the test:
 
+{{< tabs "functional-testing-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 If your solution file is named `solution.yaml` (or any other well-known name like `scafctl.yaml`) in the current directory or `scafctl/`/`.scafctl/` subdirectories, you can omit `-f` entirely:
 
+{{< tabs "functional-testing-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -70,6 +88,7 @@ Each test specifies a `command` (the scafctl subcommand to run) and one or more
 `assertions` to validate the output. The runner automatically injects
 `-f <sandbox-copy-of-solution>` unless you set `injectFile: false`.
 
+> [!NOTE]
 > **Note:** The YAML snippets in the remaining sections of this tutorial show only the `cases:` block or relevant portion. To use them, add them to the `spec.testing.cases` section of your solution file — like the `solution.yaml` example above.
 
 ---
@@ -111,6 +130,7 @@ assertions:
   - expression: '__stderr.contains("warning") && __stdout.contains("success")'
 ```
 
+> [!WARNING]
 > **Important**: `__output` is only populated when stdout is valid JSON. If you need structured
 > output, include `"-o", "json"` in your test's `args` field. If your expression references
 > `__output` when it's `nil`, the test reports as `error` (not `fail`) with a diagnostic message.
@@ -312,6 +332,8 @@ cases:
 
 Create or update snapshots:
 
+{{< tabs "functional-testing-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Update all snapshots
 scafctl test functional -f solution.yaml --update-snapshots
@@ -322,6 +344,20 @@ scafctl test functional -f solution.yaml --update-snapshots --filter "snapshot-*
 # Run normally (compares against existing snapshots)
 scafctl test functional -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Update all snapshots
+scafctl test functional -f solution.yaml --update-snapshots
+
+# Update specific snapshots
+scafctl test functional -f solution.yaml --update-snapshots --filter "snapshot-*"
+
+# Run normally (compares against existing snapshots)
+scafctl test functional -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Snapshots are automatically normalized:
 - JSON map keys are sorted deterministically
@@ -491,6 +527,7 @@ cases:
       - contains: "validation error"
 ```
 
+> [!CAUTION]
 > **Note**: `exitCode` and `expectFailure` are **mutually exclusive** — setting both is a
 > validation error. `exitCode` is strictly more expressive.
 
@@ -512,15 +549,33 @@ cases:
 
 Default per-test timeout is `30s`. Override globally with `--test-timeout`:
 
+{{< tabs "functional-testing-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --test-timeout 1m
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --test-timeout 1m
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Set a global timeout for the entire run with `--timeout`:
 
+{{< tabs "functional-testing-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --timeout 10m
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --timeout 10m
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -599,6 +654,7 @@ cases:
       - expression: __exitCode == 0
 ```
 
+> [!WARNING]
 > **Important**: Never include `-f` or `--file` in `args` — the runner always rejects this
 > regardless of the `injectFile` setting.
 
@@ -620,6 +676,8 @@ cases:
 
 Filter by tags:
 
+{{< tabs "functional-testing-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run only "smoke" tests
 scafctl test functional -f solution.yaml --tag smoke
@@ -627,6 +685,17 @@ scafctl test functional -f solution.yaml --tag smoke
 # Combine with name filter
 scafctl test functional -f solution.yaml --tag render --filter "render-*"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run only "smoke" tests
+scafctl test functional -f solution.yaml --tag smoke
+
+# Combine with name filter
+scafctl test functional -f solution.yaml --tag render --filter "render-*"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 A test matches if it has **any** of the specified tags (OR logic). Tags inherited via
 `extends` are included in the match.
@@ -874,9 +943,18 @@ When `testing.config` appears in multiple compose files:
 
 Generate JUnit XML reports for CI systems:
 
+{{< tabs "functional-testing-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --report-file results.xml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --report-file results.xml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 JUnit output uses `<failure>` for assertion failures and `<error>` for infrastructure/setup
 issues (e.g., init step failures), making it easy to distinguish test bugs from environment
@@ -894,9 +972,18 @@ problems.
 
 Stop on the first failure per solution:
 
+{{< tabs "functional-testing-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --fail-fast
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --fail-fast
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Other solutions continue to run. Use this for quick feedback during debugging.
 
@@ -904,9 +991,18 @@ Other solutions continue to run. Use this for quick feedback during debugging.
 
 For CI pipelines, use quiet format for exit-code-only behavior:
 
+{{< tabs "functional-testing-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml -o quiet
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml -o quiet
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -914,6 +1010,8 @@ scafctl test functional -f solution.yaml -o quiet
 
 List available tests without running them:
 
+{{< tabs "functional-testing-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test list -f solution.yaml
 
@@ -923,6 +1021,19 @@ scafctl test list -f solution.yaml --include-builtins
 # List from a directory
 scafctl test list --tests-path ./solutions/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test list -f solution.yaml
+
+# Include builtin tests
+scafctl test list -f solution.yaml --include-builtins
+
+# List from a directory
+scafctl test list --tests-path ./solutions/
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Example output:
 
@@ -940,6 +1051,8 @@ my-solution          temporarily-disabled    render solution                 Wai
 
 Run specific tests, solutions, or tags:
 
+{{< tabs "functional-testing-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Filter by test name glob
 scafctl test functional -f solution.yaml --filter "render-*"
@@ -957,6 +1070,27 @@ scafctl test functional --tests-path ./solutions/ --filter "terraform-*/render-*
 scafctl test functional --tests-path ./solutions/ \
   --solution "terraform-*" --tag smoke --filter "render-*"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Filter by test name glob
+scafctl test functional -f solution.yaml --filter "render-*"
+
+# Filter by tag
+scafctl test functional -f solution.yaml --tag smoke
+
+# Filter by solution name (directory scan)
+scafctl test functional --tests-path ./solutions/ --solution "terraform-*"
+
+# Combined solution/test-name format
+scafctl test functional --tests-path ./solutions/ --filter "terraform-*/render-*"
+
+# Combine all filters (ANDed: must match all)
+scafctl test functional --tests-path ./solutions/ `
+  --solution "terraform-*" --tag smoke --filter "render-*"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 When `--tag`, `--filter`, and `--solution` are combined, they are **ANDed**: a test must
 match the solution filter AND the name filter AND have a matching tag.
@@ -967,6 +1101,8 @@ match the solution filter AND the name filter AND have a matching tag.
 
 Tests run sequentially by default. Use `-j` to run tests in parallel:
 
+{{< tabs "functional-testing-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run up to 4 tests concurrently
 scafctl test functional -f solution.yaml -j 4
@@ -974,6 +1110,17 @@ scafctl test functional -f solution.yaml -j 4
 # Force sequential execution (equivalent to -j 1)
 scafctl test functional -f solution.yaml --sequential
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run up to 4 tests concurrently
+scafctl test functional -f solution.yaml -j 4
+
+# Force sequential execution (equivalent to -j 1)
+scafctl test functional -f solution.yaml --sequential
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Each test gets its own isolated sandbox — no shared mutable state between concurrent tests.
 
@@ -983,9 +1130,18 @@ Each test gets its own isolated sandbox — no shared mutable state between conc
 
 Use `-v` to see command details, init output, and assertion counts:
 
+{{< tabs "functional-testing-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml -v
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml -v
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Verbose output for passing tests shows assertion counts:
 
@@ -1005,17 +1161,35 @@ Verbose failure output includes the full command, sandbox path, stdout, stderr, 
 
 Preserve sandbox directories for failed tests to inspect files manually:
 
+{{< tabs "functional-testing-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --keep-sandbox
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --keep-sandbox
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Dry Run
 
 Validate test definitions without executing any commands:
 
+{{< tabs "functional-testing-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This resolves `extends` chains, validates test names, and reports discovery results.
 Exits 0 if valid, exit code 3 if invalid.
@@ -1024,6 +1198,8 @@ Exits 0 if valid, exit code 3 if invalid.
 
 Use `--cwd` (`-C`) to run tests against solutions in a different directory:
 
+{{< tabs "functional-testing-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run tests from a project in another directory
 scafctl --cwd /path/to/project test functional -f solution.yaml
@@ -1031,6 +1207,17 @@ scafctl --cwd /path/to/project test functional -f solution.yaml
 # Short form
 scafctl -C /path/to/project test functional
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run tests from a project in another directory
+scafctl --cwd /path/to/project test functional -f solution.yaml
+
+# Short form
+scafctl -C /path/to/project test functional
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The sandbox copies files relative to the working directory, so test `files` entries resolve correctly against `--cwd`.
 
@@ -1049,9 +1236,18 @@ By default, four builtin tests run for every solution:
 
 Builtins run before user-defined tests. Skip all builtins:
 
+{{< tabs "functional-testing-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --skip-builtins
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --skip-builtins
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Or skip specific ones in your solution's `testing.config`:
 
@@ -1081,6 +1277,8 @@ Invalid names are rejected during parsing and surfaced as lint errors.
 
 The CLI provides shorthand aliases:
 
+{{< tabs "functional-testing-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 # These are all equivalent:
 scafctl test functional -f solution.yaml
@@ -1092,6 +1290,21 @@ scafctl test list -f solution.yaml
 scafctl test ls -f solution.yaml
 scafctl test l -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# These are all equivalent:
+scafctl test functional -f solution.yaml
+scafctl test func -f solution.yaml
+scafctl test fn -f solution.yaml
+
+# These are all equivalent:
+scafctl test list -f solution.yaml
+scafctl test ls -f solution.yaml
+scafctl test l -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -1141,9 +1354,18 @@ tests, giving you a tight feedback loop during development.
 
 ### Basic Usage
 
+{{< tabs "functional-testing-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f solution.yaml --watch
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f solution.yaml --watch
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `--watch` (or `-w`) flag:
 1. Runs all matched tests immediately
@@ -1156,6 +1378,8 @@ The `--watch` (or `-w`) flag:
 
 Combine `--watch` with filters to focus on specific tests:
 
+{{< tabs "functional-testing-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 # Only re-run smoke tests
 scafctl test functional -f solution.yaml --watch --tag smoke
@@ -1166,6 +1390,20 @@ scafctl test functional -f solution.yaml --watch --filter "render-*"
 # Watch an entire directory of solutions
 scafctl test functional --tests-path ./solutions/ --watch
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Only re-run smoke tests
+scafctl test functional -f solution.yaml --watch --tag smoke
+
+# Only re-run tests matching a name pattern
+scafctl test functional -f solution.yaml --watch --filter "render-*"
+
+# Watch an entire directory of solutions
+scafctl test functional --tests-path ./solutions/ --watch
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What Gets Watched
 
@@ -1232,10 +1470,20 @@ spec:
               value: Hello
 ```
 
+{{< tabs "functional-testing-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 # All compose files under tests/ are watched automatically
 scafctl test functional -f solution.yaml --watch
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# All compose files under tests/ are watched automatically
+scafctl test functional -f solution.yaml --watch
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Editing any file under `tests/` triggers a re-run. Creating a new compose file
 in the directory also triggers re-discovery and a new run.
@@ -1243,20 +1491,47 @@ in the directory also triggers re-discovery and a new run.
 ### Tips
 
 - **Use with `--verbose`** to see full assertion counts on each re-run:
-  ```bash
+{{< tabs "functional-testing-cmd-22" >}}
+{{% tab "Bash" %}}
+```bash
   scafctl test functional -f solution.yaml --watch -v
-  ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+  scafctl test functional -f solution.yaml --watch -v
+```
+{{% /tab %}}
+{{< /tabs >}}
 - **Combine with `--fail-fast`** to stop early when iterating on a broken test:
-  ```bash
+{{< tabs "functional-testing-cmd-23" >}}
+{{% tab "Bash" %}}
+```bash
   scafctl test functional -f solution.yaml --watch --fail-fast
-  ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+  scafctl test functional -f solution.yaml --watch --fail-fast
+```
+{{% /tab %}}
+{{< /tabs >}}
 - **CI environments** should not use `--watch` — it's designed for interactive
   development only.
 - **Progress output** is automatically re-created for each watch cycle on TTY
   terminals. Use `--no-progress` if you find the spinners distracting:
-  ```bash
+{{< tabs "functional-testing-cmd-24" >}}
+{{% tab "Bash" %}}
+```bash
   scafctl test functional -f solution.yaml --watch --no-progress
-  ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+  scafctl test functional -f solution.yaml --watch --no-progress
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -1268,13 +1543,24 @@ solution's structure. No commands are executed; it performs structural analysis 
 
 ### Basic Usage
 
+{{< tabs "functional-testing-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test init -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test init -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This outputs YAML to stdout that you can paste into your solution's `spec.testing.cases` section or
 redirect to a file:
 
+{{< tabs "functional-testing-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 # Save to a file
 scafctl test init -f solution.yaml > tests.yaml
@@ -1282,6 +1568,17 @@ scafctl test init -f solution.yaml > tests.yaml
 # Append to an existing compose test file
 scafctl test init -f solution.yaml >> solution-tests.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Save to a file
+scafctl test init -f solution.yaml > tests.yaml
+
+# Append to an existing compose test file
+scafctl test init -f solution.yaml >> solution-tests.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### What Gets Generated
 
@@ -1507,9 +1804,18 @@ spec:
 
 ### Step 2 — Generate a Test for `render solution`
 
+{{< tabs "functional-testing-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl render solution -f my-app.yaml -r env=prod -o test
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl render solution -f my-app.yaml -r env=prod -o test
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 scafctl executes `render solution -f my-app.yaml -r env=prod`, captures the JSON output, and prints:
 
@@ -1541,9 +1847,18 @@ The same flag works with `run resolver` and `run solution`.
 
 **Capture resolver output:**
 
+{{< tabs "functional-testing-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f my-app.yaml -r env=staging -o test
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f my-app.yaml -r env=staging -o test
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Produces a test that asserts on the resolved values:
 
@@ -1563,9 +1878,18 @@ run-resolver-env-staging:
 
 **Capture action execution output:**
 
+{{< tabs "functional-testing-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f my-app.yaml -r env=prod -o test
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f my-app.yaml -r env=prod -o test
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Produces a test confirming action results and statuses:
 
@@ -1610,9 +1934,18 @@ spec:
 
 Then run it:
 
+{{< tabs "functional-testing-cmd-30" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f my-app.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f my-app.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The test passes immediately — the snapshot was already written with correct content during generation.
 
@@ -1622,9 +1955,18 @@ The test passes immediately — the snapshot was already written with correct co
 
 By default the test name is derived from the command and arguments. Use `--test-name` to set an explicit name:
 
+{{< tabs "functional-testing-cmd-31" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl render solution -f my-app.yaml -r env=prod -o test --test-name render-prod
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl render solution -f my-app.yaml -r env=prod -o test --test-name render-prod
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output test name becomes `render-prod` and the snapshot is written to `testdata/render-prod.json`.
 
@@ -1671,9 +2013,18 @@ The snapshot:
 
 To refresh a snapshot after an intentional change:
 
+{{< tabs "functional-testing-cmd-32" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl test functional -f my-app.yaml --update-snapshots --filter render-prod
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl test functional -f my-app.yaml --update-snapshots --filter render-prod
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 

--- a/docs/tutorials/gcp-custom-oauth-tutorial.md
+++ b/docs/tutorials/gcp-custom-oauth-tutorial.md
@@ -13,6 +13,7 @@ You may want to set up your own OAuth client if:
 - You need specific OAuth consent screen branding or approval
 - You want full control over the client lifecycle and scopes
 
+> [!CAUTION]
 > **Note:** If you were previously seeing `invalid_grant - reauth related error (invalid_rapt)` errors, upgrading scafctl to the latest version resolves this — the native browser OAuth flow is no longer affected by gcloud's RAPT token expiry.
 
 ## Prerequisites
@@ -25,6 +26,8 @@ You may want to set up your own OAuth client if:
 
 Pick an existing project or create a new one to host the OAuth client:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # List existing projects
 gcloud projects list
@@ -35,11 +38,27 @@ gcloud projects create my-scafctl-project --name="scafctl OAuth"
 # Set your working project
 gcloud config set project my-scafctl-project
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# List existing projects
+gcloud projects list
+
+# Or create a new one
+gcloud projects create my-scafctl-project --name="scafctl OAuth"
+
+# Set your working project
+gcloud config set project my-scafctl-project
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Step 2: Configure the OAuth Consent Screen
 
 Before creating an OAuth client, you must configure the consent screen. This defines what users see when they authenticate.
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Enable the required API
 gcloud services enable iap.googleapis.com
@@ -49,7 +68,21 @@ gcloud alpha iap oauth-brands create \
   --application_title="scafctl" \
   --support_email="your-email@example.com"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Enable the required API
+gcloud services enable iap.googleapis.com
 
+# For an internal app (only users in your org):
+gcloud alpha iap oauth-brands create `
+  --application_title="scafctl" `
+  --support_email="your-email@example.com"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+> [!CAUTION]
 > **Note:** If your project has never had an OAuth consent screen configured, you may need to set it up via the [Google Cloud Console](https://console.cloud.google.com/apis/credentials/consent) the first time. Choose **Internal** (org-only) or **External** (any Google account) depending on your use case.
 
 ### Console Alternative
@@ -70,12 +103,24 @@ If the `gcloud` commands above don't work for your setup (the consent screen API
 
 Create a **Desktop application** OAuth client:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 gcloud alpha iap oauth-clients create \
   "projects/$(gcloud config get-value project)/brands/$(gcloud config get-value project)" \
   --display_name="scafctl-cli"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+gcloud alpha iap oauth-clients create `
+  "projects/$(gcloud config get-value project)/brands/$(gcloud config get-value project)" `
+  --display_name="scafctl-cli"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Note:** The `gcloud alpha iap oauth-clients` commands may have limited availability. The recommended approach is to use the Console.
 
 ### Console Approach (Recommended)
@@ -94,6 +139,7 @@ Client ID:     123456789-abc123def456.apps.googleusercontent.com
 Client Secret: GOCSPX-xxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
+> [!NOTE]
 > **Note:** Despite the name, the client secret for desktop OAuth apps is **not confidential** — it is embedded in the application. This is standard for public OAuth clients (see [Google's documentation](https://developers.google.com/identity/protocols/oauth2/native-app)).
 
 ## Step 4: Configure scafctl
@@ -115,27 +161,55 @@ auth:
 
 Then log in normally:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login gcp
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login gcp
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Option B: CLI Flag (One-off)
 
 Pass the client ID directly on the command line:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login gcp --client-id "123456789-abc123def456.apps.googleusercontent.com"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login gcp --client-id "123456789-abc123def456.apps.googleusercontent.com"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Note:** When using the `--client-id` flag without a config file, the client secret will be empty. This works for OAuth clients configured as public clients but may fail if Google requires the secret. The config file approach is preferred because it allows setting both `clientId` and `clientSecret`.
 
 ## Step 5: Authenticate
 
 With the custom client configured, run:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login gcp
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login gcp
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This will:
 
@@ -147,9 +221,18 @@ This will:
 
 ### Verify Authentication
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth status gcp
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth status gcp
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -186,9 +269,18 @@ auth:
 
 Or via the CLI:
 
+{{< tabs "gcp-custom-oauth-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl auth login gcp --impersonate-service-account deploy@my-project.iam.gserviceaccount.com
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth login gcp --impersonate-service-account deploy@my-project.iam.gserviceaccount.com
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Configuration Reference
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -19,6 +19,8 @@ Think of it as a way to define "what you want" (data + operations) in YAML, and 
 
 ## Installation
 
+{{< tabs "getting-started-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Build from source
 go build -ldflags "-s -w" -o scafctl ./cmd/scafctl/scafctl.go
@@ -26,6 +28,17 @@ go build -ldflags "-s -w" -o scafctl ./cmd/scafctl/scafctl.go
 # Move to PATH
 mv scafctl /usr/local/bin/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Build from source
+go build -ldflags "-s -w" -o scafctl ./cmd/scafctl/scafctl.go
+
+# Move to PATH (macOS/Linux)
+Move-Item -Force ./scafctl /usr/local/bin/scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Quick Start
 
@@ -61,9 +74,18 @@ spec:
 
 Run it:
 
+{{< tabs "getting-started-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f hello.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f hello.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -76,11 +98,12 @@ This solution has two parts:
 - **Resolver** (`greeting`) — gathers a value using the `static` provider
 - **Action** (`say-hello`) — runs a shell command that references the resolver via `_.greeting`
 
+> [!NOTE]
 > **Want to go deeper with resolvers?** The [Resolver Tutorial](resolver-tutorial.md) covers parameters, dependencies, transforms, validation, and more.
 
 ### 2. Action Dependencies
 
-Actions can depend on other actions and access their results. Create a new file called `action-deps.yaml`:
+Actions can depend on other actions and access their results. scafctl automatically infers dependencies from `__actions` references in CEL expressions and Go templates. Create a new file called `action-deps.yaml`:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -98,20 +121,28 @@ spec:
           url: https://httpbin.org/get
 
       process:
-        dependsOn: [fetch-data]
         provider: exec
         inputs:
           command:
             expr: "'echo Got status: ' + string(__actions['fetch-data'].results.statusCode)"
 ```
 
-The `process` action uses `dependsOn` to wait for `fetch-data` to complete, then accesses its results via the `__actions` namespace.
+Because `process` references `__actions['fetch-data']`, scafctl automatically determines that `process` depends on `fetch-data` and schedules it to run after `fetch-data` completes. You can still use `dependsOn` to declare dependencies that aren't expressed via `__actions` references (e.g., ordering actions that don't consume each other's results).
 
 Run it:
 
+{{< tabs "getting-started-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f action-deps.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f action-deps.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -187,6 +218,8 @@ See [Provider Reference](provider-reference.md) for full documentation.
 
 ## Common Commands
 
+{{< tabs "getting-started-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run a solution from file
 scafctl run solution -f solution.yaml
@@ -206,33 +239,33 @@ scafctl run solution -f solution.yaml --dry-run
 # Render without executing
 scafctl render solution -f solution.yaml
 
-# Show dependency graph
-scafctl render solution --graph -f solution.yaml
+# Show resolver dependency graph
+scafctl run resolver --graph -f solution.yaml
 
 # List available providers
 scafctl get provider
 
-# Explain a provider
-scafctl explain provider http
+# Get details about a specific provider
+scafctl get provider http
 
 # Pass parameters
 scafctl run solution -f solution.yaml -r key1=value1 -r key2=value2
 
 # Interactive output exploration
-scafctl render solution -f solution.yaml -i
+scafctl run resolver -f solution.yaml -i
 
 # JSON/YAML output
 scafctl render solution -f solution.yaml -o json
 
 # Scaffold a new solution
-scafctl new solution --name my-app --output my-app.yaml
+scafctl new solution --name my-app --description "My application scaffold" --output my-app.yaml
 
 # Browse and download examples
 scafctl examples list
 scafctl examples get resolvers/hello-world.yaml -o hello.yaml
 
 # Evaluate a CEL expression
-scafctl eval cel '"hello".upperAscii()'
+scafctl eval cel --expression '"hello".upperAscii()'
 
 # Validate a solution file
 scafctl lint -f solution.yaml
@@ -243,6 +276,66 @@ scafctl lint rules
 # Explain a lint rule
 scafctl lint explain <rule-id>
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run a solution from file
+scafctl run solution -f solution.yaml
+
+# Run a solution from catalog (by name)
+scafctl run solution my-solution
+
+# Build a solution to local catalog
+scafctl build solution solution.yaml --version 1.0.0
+
+# List cataloged solutions
+scafctl catalog list
+
+# Dry-run (show what would happen)
+scafctl run solution -f solution.yaml --dry-run
+
+# Render without executing
+scafctl render solution -f solution.yaml
+
+# Show resolver dependency graph
+scafctl run resolver --graph -f solution.yaml
+
+# List available providers
+scafctl get provider
+
+# Get details about a specific provider
+scafctl get provider http
+
+# Pass parameters
+scafctl run solution -f solution.yaml -r key1=value1 -r key2=value2
+
+# Interactive output exploration
+scafctl run resolver -f solution.yaml -i
+
+# JSON/YAML output
+scafctl render solution -f solution.yaml -o json
+
+# Scaffold a new solution
+scafctl new solution --name my-app --description "My application scaffold" --output my-app.yaml
+
+# Browse and download examples
+scafctl examples list
+scafctl examples get resolvers/hello-world.yaml -o hello.yaml
+
+# Evaluate a CEL expression
+scafctl eval cel --expression '"hello".upperAscii()'
+
+# Validate a solution file
+scafctl lint -f solution.yaml
+
+# List lint rules
+scafctl lint rules
+
+# Explain a lint rule
+scafctl lint explain <rule-id>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Go Templates Tutorial"
-weight: 60
+weight: 55
 ---
 
 # Go Templates Tutorial
@@ -46,11 +46,9 @@ scafctl supports Go templates in two ways:
 1. **`go-template` provider** — Render templates in resolvers and actions
 2. **`tmpl` field** — Use Go template syntax in provider inputs (alternative to `expr`)
 
-```
-┌──────────────┐     ┌──────────────┐     ┌──────────────┐
-│  Resolver    │ ──► │  Go Template │ ──► │  Rendered    │
-│  Data (_)    │     │  Provider    │     │  Output      │
-└──────────────┘     └──────────────┘     └──────────────┘
+```mermaid
+flowchart LR
+  A["Resolver<br/>Data (_)"] --> B["Go Template<br/>Provider"] --> C["Rendered<br/>Output"]
 ```
 
 **When to use Go templates vs CEL:**
@@ -97,9 +95,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -115,6 +122,7 @@ Hello, World!
 - All resolver values are available at the template root — access them with `{{ .resolverName }}`.
 - The `-e _.greeting` flag filters the output to just the `greeting` resolver, and `-o yaml` renders it cleanly.
 
+> [!NOTE]
 > **Key point:** The `go-template` provider requires two inputs: `name` (an identifier for the template) and `template` (the Go template string to render).
 
 ---
@@ -193,10 +201,20 @@ The `environment` resolver tries the `parameter` provider first (looking for a `
 
 Run without passing any parameters — the environment defaults to `development`:
 
+{{< tabs "go-templates-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Tip:** The `-e _.deployment_config` flag filters the output to just the `deployment_config` resolver, and `-o yaml` renders it cleanly.
 
 Output:
@@ -218,9 +236,18 @@ Since `"development"` doesn't match `"production"` or `"staging"`, the `{{ else 
 
 Pass `-r env=staging` to override the environment:
 
+{{< tabs "go-templates-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -239,9 +266,18 @@ The `{{ else if eq .environment "staging" }}` branch is now active.
 
 ### Step 4: Switch to Production
 
+{{< tabs "go-templates-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -322,9 +358,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -425,9 +470,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -444,6 +498,7 @@ enable_metrics: ON
 enable_tracing: ON
 ```
 
+> [!NOTE]
 > **Note:** Map iteration order is sorted alphabetically by key in Go templates.
 
 ### What You Learned
@@ -517,15 +572,33 @@ spec:
 
 First, check the untrimmed version:
 
+{{< tabs "go-templates-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Then compare with the trimmed version:
 
+{{< tabs "go-templates-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Compare the Outputs
 
@@ -710,15 +783,33 @@ spec:
 
 ### Step 3: Run It
 
+{{< tabs "go-templates-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f template-from-file.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f template-from-file.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 4: Verify the Output
 
+{{< tabs "go-templates-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 cat /tmp/scafctl-demo/config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+cat /tmp/scafctl-demo/config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 You should see:
 
@@ -753,6 +844,7 @@ features:
 4. Setting `missingKey: "error"` ensures the render fails if any referenced variable is missing — catching typos early.
 5. The workflow action wrote the rendered output to disk.
 
+> [!NOTE]
 > **Tip:** See [template-render.yaml](../../examples/actions/template-render.yaml) for a more comprehensive file-based template example with timestamps and dynamic output paths.
 
 ---
@@ -761,6 +853,7 @@ features:
 
 By default, templates silently render `<no value>` when you reference a nested key that doesn't exist in the data. This can lead to broken output that's hard to debug. The `missingKey` option controls this behavior — and setting it to `"error"` is the best way to catch mistakes early.
 
+> [!NOTE]
 > **Note:** The `missingKey` option applies to keys missing *within* the data passed to the template (e.g., a map field that doesn't exist). It does not apply to missing resolvers — scafctl validates resolver references at build time and will reject the solution if a referenced resolver doesn't exist.
 
 ### Step 1: Create the Solution File
@@ -814,9 +907,18 @@ spec:
 
 First, comment out or remove the `strict_mode` resolver (it will cause a failure, which we'll explore in the next step). Then run:
 
+{{< tabs "go-templates-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -830,9 +932,18 @@ The template rendered successfully, but the missing `owner` key silently became 
 
 Now add back the `strict_mode` resolver and run:
 
+{{< tabs "go-templates-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This time the command **fails** with an error telling you exactly which key is missing. Instead of silently producing broken output, `missingKey: "error"` catches the problem immediately.
 
@@ -854,9 +965,18 @@ Add the `owner` field to the `app` resolver's value:
 
 Re-run and both resolvers now succeed:
 
+{{< tabs "go-templates-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```yaml
 App: my-app, Owner: platform-team
@@ -929,9 +1049,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -1006,9 +1135,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -1087,9 +1225,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f template-tmpl-field.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f template-tmpl-field.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Observe the Output
 
@@ -1187,21 +1334,48 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f template-foreach.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f template-foreach.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Verify the Output
 
+{{< tabs "go-templates-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 ls /tmp/scafctl-demo/services/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+ls /tmp/scafctl-demo/services/
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 You'll see three files: `api.yaml`, `worker.yaml`, `gateway.yaml`. Each contains its own config:
 
+{{< tabs "go-templates-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 cat /tmp/scafctl-demo/services/api.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+cat /tmp/scafctl-demo/services/api.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```yaml
 # Auto-generated service config
@@ -1316,9 +1490,18 @@ spec:
 
 ### Step 3: Run It
 
+{{< tabs "go-templates-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Result:
 - `templates/k8s/deployment.yaml.tpl` → `output/k8s/deployment.yaml` (rendered, `.tpl` stripped)
@@ -1463,15 +1646,33 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f template-readme-generator.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f template-readme-generator.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: View the Result
 
+{{< tabs "go-templates-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 cat /tmp/scafctl-demo/README.md
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+cat /tmp/scafctl-demo/README.md
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -1570,9 +1771,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -1584,17 +1794,35 @@ The `upper` function uppercases the string, and `trunc 5` truncates it to 5 char
 
 Try the other resolvers:
 
+{{< tabs "go-templates-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-sprig.yaml -e _.config -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-sprig.yaml -e _.config -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```
 port=8080, tls=true, debug=false
 ```
 
+{{< tabs "go-templates-tutorial-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```
 MyAppService
@@ -1607,6 +1835,7 @@ MyAppService
 - **`dict` and `merge`** — Create and merge maps for configuration defaults.
 - **String helpers** — `camelcase`, `snakecase`, `kebabcase`, `title`, `upper`, `lower`, `trim`, `replace`, and many more.
 
+> [!NOTE]
 > **Tip:** See the [Sprig documentation](https://masterminds.github.io/sprig/) for the full list of available functions grouped by category: strings, math, dates, lists, dicts, crypto, encoding, and more.
 
 ---
@@ -1658,9 +1887,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -1741,9 +1979,18 @@ spec:
 
 ### Step 2: Run It
 
+{{< tabs "go-templates-tutorial-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Check the Output
 
@@ -1798,10 +2045,20 @@ spec:
         name: slugify-demo
 ```
 
+{{< tabs "go-templates-tutorial-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f slugify-demo.yaml -e _.dns-label
 # Output: my-cool-project-v2
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f slugify-demo.yaml -e _.dns-label
+# Output: my-cool-project-v2
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Key behaviors
 
@@ -1975,38 +2232,84 @@ scafctl provides tools to explore all available Go template functions — both S
 
 List all available functions:
 
+{{< tabs "go-templates-tutorial-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get go-template-functions
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get go-template-functions
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Filter to custom functions only:
 
+{{< tabs "go-templates-tutorial-cmd-30" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get go-template-functions --custom
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get go-template-functions --custom
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Filter to Sprig functions only:
 
+{{< tabs "go-templates-tutorial-cmd-31" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get go-template-functions --sprig
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get go-template-functions --sprig
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Get details for a specific function:
 
+{{< tabs "go-templates-tutorial-cmd-32" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get go-template-functions toHcl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get go-template-functions toHcl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output as JSON:
 
+{{< tabs "go-templates-tutorial-cmd-33" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get go-template-functions -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get go-template-functions -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Using the MCP Server
 
 If you use an AI agent with the scafctl MCP server, you can ask:
 
+> [!NOTE]
 > **You:** "What Go template functions are available for data formatting?"
 
 The AI calls `list_go_template_functions` and returns a curated list of matching functions with descriptions and examples.
@@ -2076,6 +2379,7 @@ transform:
 
 Append the marker as an inline comment on any line that should be ignored. Only those lines are protected — the rest of the template renders normally.
 
+> [!NOTE]
 > **Note:** `line` and `start`/`end` are mutually exclusive within a single entry. Different entries can use different modes.
 
 ### Multiple Ignored Blocks
@@ -2125,10 +2429,20 @@ goTemplate:
 
 You can inspect cache statistics anytime:
 
+{{< tabs "go-templates-tutorial-cmd-34" >}}
+{{% tab "Bash" %}}
 ```bash
 # View cache stats via the CLI
 scafctl get config -e 'cfg.goTemplate'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# View cache stats via the CLI
+scafctl get config -e 'cfg.goTemplate'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Programmatically (for provider or plugin developers):
 

--- a/docs/tutorials/hcl-provider-tutorial.md
+++ b/docs/tutorials/hcl-provider-tutorial.md
@@ -61,9 +61,18 @@ spec:
 
 Run it:
 
+{{< tabs "hcl-provider-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f parse-hcl.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f parse-hcl.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Expected output:
 
@@ -958,6 +967,8 @@ The HCL provider extracts the following Terraform/OpenTofu block types:
 
 You can also run the HCL provider directly from the command line:
 
+{{< tabs "hcl-provider-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Parse a file
 scafctl run provider hcl path=./main.tf -o json
@@ -980,22 +991,50 @@ scafctl run provider hcl operation=validate path=./main.tf -o json
 # Validate a directory
 scafctl run provider hcl operation=validate dir=./terraform -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Parse a file
+scafctl run provider hcl path=./main.tf -o json
+
+# Parse a directory
+scafctl run provider hcl dir=./terraform -o json
+
+# Format inline HCL
+scafctl run provider hcl operation=format 'content=variable "x" { type=string }' -o json
+
+# Format a file
+scafctl run provider hcl operation=format path=./main.tf -o json
+
+# Format all files in a directory
+scafctl run provider hcl operation=format dir=./terraform -o json
+
+# Validate a file
+scafctl run provider hcl operation=validate path=./main.tf -o json
+
+# Validate a directory
+scafctl run provider hcl operation=validate dir=./terraform -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 {{< tabs "hcl-file-input" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Use a pre-built example input file
 scafctl run provider hcl --input @examples/providers/hcl-format.yaml -o json
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Wrap @file in single quotes to avoid splatting operator
 scafctl run provider hcl --input '@examples/providers/hcl-format.yaml' -o json
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
+{{< tabs "hcl-provider-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider hcl path=./main.tf --dry-run
 
@@ -1005,6 +1044,19 @@ scafctl run provider hcl operation=format path=./main.tf --dry-run
 # Dry run (validate)
 scafctl run provider hcl operation=validate path=./main.tf --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider hcl path=./main.tf --dry-run
+
+# Dry run (format)
+scafctl run provider hcl operation=format path=./main.tf --dry-run
+
+# Dry run (validate)
+scafctl run provider hcl operation=validate path=./main.tf --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Dry-run returns an empty structure without reading or modifying anything. For `parse`:
 

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -15,27 +15,42 @@ scafctl includes a built-in linter that checks solution YAML files for:
 - **Best practices** — Missing descriptions, unused resolvers, naming conventions
 - **Correctness** — Broken resolver references, invalid CEL expressions, circular dependencies
 
-```
-┌──────────────┐         ┌──────────────┐         ┌──────────────┐
-│  Solution    │  ────►  │  scafctl     │  ────►  │  Findings    │
-│  YAML        │         │    lint      │         │  (warnings,  │
-│              │         │              │         │   errors)    │
-└──────────────┘         └──────────────┘         └──────────────┘
+```mermaid
+flowchart LR
+  A["Solution<br/>YAML"] --> B["scafctl<br/>lint"] --> C["Findings<br/>(warnings, errors)"]
 ```
 
 ## 1. Linting a Solution
 
 ### Basic Lint
 
+{{< tabs "linting-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 If your solution file is in a well-known location (`solution.yaml`, `scafctl.yaml`, etc. in the current directory or `scafctl/`/`.scafctl/` subdirectories), you can omit `-f`:
 
+{{< tabs "linting-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output shows findings in a table with severity, rule, message, and location.
 
@@ -43,9 +58,18 @@ Output shows findings in a table with severity, rule, message, and location.
 
 Get structured results for CI/CD integration:
 
+{{< tabs "linting-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint -f solution.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint -f solution.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```json
 {
@@ -68,6 +92,8 @@ scafctl lint -f solution.yaml -o json
 
 For scripts and CI pipelines — exit code only:
 
+{{< tabs "linting-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 if scafctl lint -f solution.yaml -o quiet; then
   echo "Lint passed"
@@ -76,6 +102,18 @@ else
   exit 1
 fi
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+if (scafctl lint -f solution.yaml -o quiet) {
+  Write-Output "Lint passed"
+} else {
+  Write-Output "Lint failed"
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 2. Exploring Lint Rules
 
@@ -83,9 +121,18 @@ fi
 
 See all available lint rules:
 
+{{< tabs "linting-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint rules
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint rules
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows:
 
@@ -97,6 +144,8 @@ This shows:
 
 ### Filter by Format
 
+{{< tabs "linting-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # JSON output for tooling
 scafctl lint rules -o json
@@ -104,20 +153,49 @@ scafctl lint rules -o json
 # YAML output
 scafctl lint rules -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# JSON output for tooling
+scafctl lint rules -o json
+
+# YAML output
+scafctl lint rules -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 3. Understanding a Rule
 
 Get detailed information about any lint rule:
 
+{{< tabs "linting-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint explain <rule-id>
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain <rule-id>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 For example:
 
+{{< tabs "linting-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint explain missing-description
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain missing-description
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows:
 
@@ -130,9 +208,18 @@ This shows:
 
 ### JSON Output
 
+{{< tabs "linting-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint explain missing-description -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain missing-description -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 4. Linting in CI/CD
 
@@ -152,6 +239,8 @@ scafctl lint explain missing-description -o json
 
 ### Pre-commit Hook
 
+{{< tabs "linting-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 #!/bin/bash
 # .git/hooks/pre-commit
@@ -159,6 +248,20 @@ git diff --cached --name-only --diff-filter=ACM | grep 'solution.yaml$' | while 
   scafctl lint -f "$file" -o quiet || exit 1
 done
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# PowerShell equivalent
+# .git/hooks/pre-commit
+git diff --cached --name-only --diff-filter=ACM |
+  Select-String 'solution.yaml$' |
+  ForEach-Object {
+    scafctl lint -f $_.Line -o quiet
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+  }
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Task Runner Integration
 
@@ -273,9 +376,18 @@ The `unreachable-test-path` rule detects `files` entries in test cases that refe
 
 For more details:
 
+{{< tabs "linting-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint explain unreachable-test-path
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain unreachable-test-path
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 6. Using Lint with the MCP Server
 

--- a/docs/tutorials/logging-tutorial.md
+++ b/docs/tutorials/logging-tutorial.md
@@ -13,16 +13,14 @@ By default, scafctl produces **no structured log output**. Only styled user mess
 
 When you need to see what's happening under the hood — debugging a solution, reporting a bug, or feeding structured logs to a log aggregation system — scafctl gives you full control over log verbosity, format, and destination.
 
-```
-┌──────────────────────────────────────────────────┐
-│  Default:     No logs, just styled output        │
-│  --debug:     Console-format debug logs          │
-│  --log-level: Named or numeric verbosity         │
-│  --log-format: console (default) or json         │
-│  --log-file:  Write logs to a file               │
-│  Env vars:    Override from CI/CD or scripts     │
-└──────────────────────────────────────────────────┘
-```
+| Flag | Description |
+|------|-------------|
+| *(default)* | No logs, just styled output |
+| `--debug` | Console-format debug logs |
+| `--log-level` | Named or numeric verbosity |
+| `--log-format` | `console` (default) or `json` |
+| `--log-file` | Write logs to a file |
+| Env vars | Override from CI/CD or scripts |
 
 ## Quick Start
 
@@ -30,6 +28,8 @@ When you need to see what's happening under the hood — debugging a solution, r
 
 Run any command — you'll see only styled user-facing messages:
 
+{{< tabs "logging-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml
 # Output: styled results, errors show as ❌ messages
@@ -38,17 +38,41 @@ scafctl run solution -f invalid.yaml
 # Output: ❌ failed to load solution from 'invalid.yaml': ...
 # No JSON log noise on stderr
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml
+# Output: styled results, errors show as ❌ messages
+
+scafctl run solution -f invalid.yaml
+# Output: ❌ failed to load solution from 'invalid.yaml': ...
+# No JSON log noise on stderr
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Enable Debug Logging
 
 The quickest way to see what scafctl is doing:
 
+{{< tabs "logging-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --debug
 
 # or equivalently:
 scafctl run solution -f solution.yaml --log-level debug
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --debug
+
+# or equivalently:
+scafctl run solution -f solution.yaml --log-level debug
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows colored, human-readable logs on stderr alongside normal output:
 
@@ -72,6 +96,8 @@ scafctl supports both **named levels** (recommended) and **numeric V-levels** fo
 | `debug` | Verbose debugging | Troubleshooting solutions |
 | `trace` | Very verbose | Deep debugging |
 
+{{< tabs "logging-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Show only errors
 scafctl run solution -f solution.yaml --log-level error
@@ -82,6 +108,20 @@ scafctl run solution -f solution.yaml --log-level info
 # Maximum verbosity
 scafctl run solution -f solution.yaml --log-level trace
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Show only errors
+scafctl run solution -f solution.yaml --log-level error
+
+# Show info and above
+scafctl run solution -f solution.yaml --log-level info
+
+# Maximum verbosity
+scafctl run solution -f solution.yaml --log-level trace
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Numeric V-Levels
 
@@ -93,6 +133,8 @@ For fine-grained control matching the internal `V()` levels used in the code:
 | `2` | `trace` | Internal data flow, template rendering |
 | `3` | _(no alias)_ | Ultra-verbose internals |
 
+{{< tabs "logging-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Same as --log-level debug
 scafctl run solution -f solution.yaml --log-level 1
@@ -103,6 +145,20 @@ scafctl run solution -f solution.yaml --log-level 2
 # Ultra-verbose (no named alias)
 scafctl run solution -f solution.yaml --log-level 3
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Same as --log-level debug
+scafctl run solution -f solution.yaml --log-level 1
+
+# Same as --log-level trace
+scafctl run solution -f solution.yaml --log-level 2
+
+# Ultra-verbose (no named alias)
+scafctl run solution -f solution.yaml --log-level 3
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Log Formats
 
@@ -110,11 +166,22 @@ scafctl run solution -f solution.yaml --log-level 3
 
 Human-readable, colored output. Best for terminal use:
 
+{{< tabs "logging-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --debug
 # or explicitly:
 scafctl run solution -f solution.yaml --log-level debug --log-format console
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --debug
+# or explicitly:
+scafctl run solution -f solution.yaml --log-level debug --log-format console
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -127,9 +194,18 @@ Output:
 
 Structured JSON, ideal for log aggregation (Splunk, Datadog, ELK), piping to `jq`, or machine parsing:
 
+{{< tabs "logging-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --log-level info --log-format json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --log-level info --log-format json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -141,26 +217,29 @@ Output:
 Filter with `jq`:
 
 {{< tabs "logging-json-filter" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --log-level debug --log-format json 2>&1 | jq 'select(.level == "error")'
 ```
 
+> [!NOTE]
 > **Note:** The above command uses [jq](https://jqlang.github.io/jq/), a command-line JSON processor. Install it separately if not already available.
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run solution -f solution.yaml --log-level debug --log-format json 2>&1 |
   ForEach-Object { $_ | ConvertFrom-Json } |
   Where-Object { $_.level -eq 'error' }
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Log File Output
 
 Write logs to a file instead of (or in addition to) stderr:
 
+{{< tabs "logging-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Logs go to file only; stderr shows just styled output
 scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/scafctl.log
@@ -168,14 +247,34 @@ scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/scafctl.
 # Logs go to BOTH file and stderr (combine with --debug)
 scafctl run solution -f solution.yaml --debug --log-file /tmp/scafctl.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Logs go to file only; stderr shows just styled output
+scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/scafctl.log
+
+# Logs go to BOTH file and stderr (combine with --debug)
+scafctl run solution -f solution.yaml --debug --log-file /tmp/scafctl.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 When `--debug` and `--log-file` are used together, logs are written to both destinations. Without `--debug`, the file receives the logs and stderr stays clean.
 
 View the log file:
 
+{{< tabs "logging-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 tail -f /tmp/scafctl.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+tail -f /tmp/scafctl.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Environment Variables
 
@@ -190,6 +289,8 @@ Environment variables are useful for CI/CD pipelines, container environments, an
 
 ### Examples
 
+{{< tabs "logging-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # CI/CD: structured JSON logs for log aggregation
 export SCAFCTL_LOG_LEVEL=info
@@ -204,6 +305,24 @@ scafctl run solution -f solution.yaml
 # Quick debug in shell
 SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# CI/CD: structured JSON logs for log aggregation
+$env:SCAFCTL_LOG_LEVEL = "info"
+$env:SCAFCTL_LOG_FORMAT = "json"
+scafctl run solution -f solution.yaml
+
+# Container: debug to a file
+$env:SCAFCTL_DEBUG = "1"
+$env:SCAFCTL_LOG_PATH = "/var/log/scafctl.log"
+scafctl run solution -f solution.yaml
+
+# Quick debug in shell
+SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Precedence
 
@@ -237,6 +356,8 @@ logging:
 
 Manage via CLI:
 
+{{< tabs "logging-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 # Set persistent log level
 scafctl config set logging.level info
@@ -248,11 +369,28 @@ scafctl config set logging.format json
 scafctl config unset logging.level
 scafctl config unset logging.format
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set persistent log level
+scafctl config set logging.level info
+
+# Set persistent format
+scafctl config set logging.format json
+
+# Reset to defaults
+scafctl config unset logging.level
+scafctl config unset logging.format
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Common Workflows
 
 ### Debugging a Failing Solution
 
+{{< tabs "logging-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Step 1: Run with debug to see what's happening
 scafctl run solution -f solution.yaml --debug
@@ -263,13 +401,37 @@ scafctl run solution -f solution.yaml --log-level trace
 # Step 3: Capture logs for a bug report
 scafctl run solution -f solution.yaml --log-level trace --log-format json --log-file debug.log 2>&1
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Step 1: Run with debug to see what's happening
+scafctl run solution -f solution.yaml --debug
+
+# Step 2: If you need even more detail
+scafctl run solution -f solution.yaml --log-level trace
+
+# Step 3: Capture logs for a bug report
+scafctl run solution -f solution.yaml --log-level trace --log-format json --log-file debug.log 2>&1
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CI/CD Pipeline
 
+{{< tabs "logging-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # Fail-fast with only error logs in JSON for log aggregation
 scafctl run solution -f solution.yaml --log-level error --log-format json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Fail-fast with only error logs in JSON for log aggregation
+scafctl run solution -f solution.yaml --log-level error --log-format json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Or set via environment:
 
@@ -286,6 +448,8 @@ steps:
 
 Use `--log-file` to keep stderr clean while still capturing logs:
 
+{{< tabs "logging-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 # Logs to file, styled output to stderr, data to stdout
 scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/run.log -o json > results.json
@@ -293,11 +457,24 @@ scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/run.log 
 # Review logs separately
 cat /tmp/run.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Logs to file, styled output to stderr, data to stdout
+scafctl run solution -f solution.yaml --log-level debug --log-file /tmp/run.log -o json > results.json
+
+# Review logs separately
+cat /tmp/run.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Temporary Debug Session
 
 Set and unset config for a debugging session:
 
+{{< tabs "logging-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # Enable debug temporarily via config
 scafctl config set logging.level debug
@@ -308,12 +485,35 @@ scafctl run solution -f solution.yaml
 # Reset when done
 scafctl config unset logging.level
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Enable debug temporarily via config
+scafctl config set logging.level debug
+
+# Run your commands...
+scafctl run solution -f solution.yaml
+
+# Reset when done
+scafctl config unset logging.level
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Or use the environment variable (no config changes needed):
 
+{{< tabs "logging-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+SCAFCTL_DEBUG=1 scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## OpenTelemetry Integration
 
@@ -348,10 +548,20 @@ Trace IDs only appear when **both** conditions are true:
 1. `--otel-endpoint` is set (or `OTEL_EXPORTER_OTLP_ENDPOINT` env var).
 2. A trace span is active at the time the log record is emitted.
 
+{{< tabs "logging-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
   scafctl run solution -f solution.yaml --log-level debug --log-format json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 `
+  scafctl run solution -f solution.yaml --log-level debug --log-format json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Local console-format logs (without `--log-format json`) do **not** include the
 trace/span IDs — they only appear in the OTLP log stream and in JSON format.

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server Tutorial"
-weight: 55
+weight: 65
 ---
 
 # MCP Server Tutorial
@@ -36,9 +36,18 @@ scafctl libraries (solution, provider, CEL, catalog, auth)
 
 Run the `--info` flag to confirm the server is built and can list its tools:
 
+{{< tabs "mcp-server-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --info
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --info
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 You should see JSON output listing all available tools:
 
@@ -81,9 +90,18 @@ If this works, the MCP server is ready.
 
 You can start the server interactively for testing:
 
+{{< tabs "mcp-server-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The server listens on stdin/stdout for JSON-RPC 2.0 messages. Press `Ctrl+C` to stop. Normally, your AI client starts and stops the server automatically.
 
@@ -307,6 +325,7 @@ spec:
 
 No files needed — this tool lists the built-in providers.
 
+> [!NOTE]
 > **You:** "What solution providers are available?"
 
 The AI calls `list_providers` and returns something like:
@@ -341,6 +360,7 @@ provider name to see its full input schema and examples.
 
 Uses the `mcp-demo/solution.yaml` file created above.
 
+> [!NOTE]
 > **You:** "Explain what the greeting-service solution does"
 
 The AI calls `inspect_solution` with `path: "mcp-demo/solution.yaml"` and returns something like:
@@ -378,6 +398,7 @@ validation, and actions.
 
 Uses the `mcp-demo/solution.yaml` file created above.
 
+> [!NOTE]
 > **You:** "Validate my mcp-demo/solution.yaml file"
 
 The AI calls `lint_solution` with `file: "mcp-demo/solution.yaml"` and returns something like:
@@ -391,6 +412,7 @@ and 2 actions.
 
 To see what lint findings look like, you can also try validating the intentionally broken example:
 
+> [!NOTE]
 > **You:** "Lint the file examples/solutions/bad-solution-yaml/solution.yaml"
 
 The AI calls `lint_solution` and returns structured findings with severity, location, and descriptions for each issue.
@@ -399,8 +421,9 @@ The AI calls `lint_solution` and returns structured findings with severity, loca
 
 No files needed — you provide the expression and data inline.
 
+> [!NOTE]
 > **You:** "Evaluate this CEL expression with sample data: `_.items.filter(i, i.enabled).map(i, i.name)`"
->
+> 
 > Use this data: `{"items": [{"name": "alpha", "enabled": true}, {"name": "beta", "enabled": false}, {"name": "gamma", "enabled": true}]}`
 
 The AI calls `evaluate_cel` with the expression and data, and returns something like:
@@ -414,6 +437,7 @@ Type:   list(string)
 
 You can also test expressions used in your solution:
 
+> [!NOTE]
 > **You:** "Evaluate this: `_.style == "formal" ? "Good day, " + _.username + "." : "Hello, " + _.username + "!"` with data `{"style": "formal", "username": "Alice"}`"
 
 ```
@@ -425,6 +449,7 @@ Type:   string
 
 No files needed.
 
+> [!NOTE]
 > **You:** "What custom CEL functions can I use for string manipulation?"
 
 The AI calls `list_cel_functions` with `custom_only: true` and returns something like:
@@ -448,6 +473,7 @@ Use `evaluate_cel` to test any of these interactively.
 
 No files needed.
 
+> [!NOTE]
 > **You:** "What Go template functions are available for string manipulation?"
 
 The AI calls `list_go_template_functions` and returns something like:
@@ -476,6 +502,7 @@ Use `evaluate_go_template` to test any of these interactively.
 
 You can also filter to specific categories:
 
+> [!NOTE]
 > **You:** "List only the custom Go template functions"
 
 The AI calls `list_go_template_functions` with `custom_only: true` and returns the custom scafctl functions.
@@ -484,6 +511,7 @@ The AI calls `list_go_template_functions` with `custom_only: true` and returns t
 
 This tool queries your local catalog. If you haven't added solutions to the catalog yet, the result will be empty.
 
+> [!NOTE]
 > **You:** "What solutions are in my local catalog?"
 
 The AI calls `catalog_list` with `kind: "solution"` and returns something like:
@@ -509,6 +537,7 @@ Found 2 solutions in your local catalog:
 
 No files needed — this inspects your current auth state.
 
+> [!NOTE]
 > **You:** "Am I authenticated for any services?"
 
 The AI calls `auth_status` and returns something like:
@@ -535,6 +564,7 @@ Run `scafctl auth login <handler>` to authenticate.
 
 Uses the `mcp-demo/solution.yaml` file created above.
 
+> [!NOTE]
 > **You:** "Show me the action graph for mcp-demo/solution.yaml"
 
 The AI calls `render_solution` with `path: "mcp-demo/solution.yaml"` and `graph_type: "action"` and returns something like:
@@ -552,6 +582,7 @@ Execution order:
 
 You can also request the resolver dependency graph:
 
+> [!NOTE]
 > **You:** "Show me the resolver dependency graph for mcp-demo/solution.yaml"
 
 ```
@@ -570,6 +601,7 @@ Resolution order:
 
 No files needed — you specify the provider by name.
 
+> [!NOTE]
 > **You:** "What inputs does the `exec` provider accept?"
 
 The AI calls `get_provider_schema` with `name: "exec"` and returns structured JSON with:
@@ -609,44 +641,52 @@ These tools help AI agents write correct solution YAML by giving them access to 
 
 #### Get the Solution Schema
 
+> [!NOTE]
 > **You:** "What fields are valid in a solution YAML file?"
 
 The AI calls `get_solution_schema` and receives the full JSON Schema for the solution format — every field, type, validation rule, and description. This prevents the AI from inventing fields that don't exist.
 
 You can also ask about a specific section:
 
+> [!NOTE]
 > **You:** "What goes in the metadata section of a solution?"
 
 The AI calls `get_solution_schema` with `field: "metadata"` and returns just the metadata schema, showing fields like `name`, `version`, `description`, `tags`, etc. with their validation constraints.
 
 #### Explain a Kind
 
+> [!NOTE]
 > **You:** "What fields does a resolver have?"
 
 The AI calls `explain_kind` with `kind: "resolver"` and returns a structured breakdown of all resolver fields, including nested types, documentation, and validation tags.
 
 #### Browse Examples
 
+> [!NOTE]
 > **You:** "Show me example action configurations"
 
 The AI calls `list_examples` with `category: "actions"` to see all available action examples, then calls `get_example` with a specific path to read the example content. This gives it real, tested patterns to reference when writing new YAML.
 
+> [!NOTE]
 > **You:** "Show me how to set up a solution with parameters and validation"
 
 The AI calls `get_example` with `path: "solutions/email-notifier/solution.yaml"` to get a practical reference, then uses `get_solution_schema` to verify the structure.
 
 #### Explain a Concept
 
+> [!NOTE]
 > **You:** "What is a resolver and how does it work?"
 
 The AI calls `explain_concepts` with `name: "resolver"` and returns a detailed explanation including the concept summary, category, examples, and related concepts.
 
+> [!NOTE]
 > **You:** "What testing concepts does scafctl support?"
 
 The AI calls `explain_concepts` with `category: "testing"` and gets summaries for all testing-related concepts — functional testing, test sandbox, test scaffold, and test assertions.
 
 #### Inspect Solution File Dependencies
 
+> [!NOTE]
 > **You:** "What files does my solution depend on?"
 
 The AI calls `inspect_solution` with `path: "solution.yaml"` and the response includes a `fileDependencies` array listing all external files referenced by providers (e.g., template files loaded via `go-template`, HCL files via `hcl`), along with which resolver references each file.
@@ -676,7 +716,7 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `list_examples` | List available scafctl example files with category filtering (solutions, resolvers, actions, providers, etc.) |
 | `list_providers` | List all providers with capability and category filtering |
 | `list_solutions` | List solutions from the local catalog with name filtering |
-| `preview_action` | Preview what each action in a workflow would do WITHOUT executing — shows materialized inputs, deferred values, phases, and dependencies |
+| `preview_action` | Preview what each action in a workflow would do WITHOUT executing — shows materialized inputs, deferred values, phases, dependencies, and cross-section references (`crossSectionRefs`) for finally actions reading main-section results |
 | `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value, output schema, and source positions. Use `resolver` param to focus on a single resolver and its dependencies |
 | `render_solution` | Render action, resolver, or action-deps graphs as structured JSON |
 | `run_solution_tests` | Execute functional tests defined in a solution and return structured results. Use `verbose=true` for full assertion details |
@@ -740,39 +780,84 @@ The prompts instruct the AI to:
 
 Print the full tool list and verify the server starts correctly:
 
+{{< tabs "mcp-server-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --info
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --info
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Enable File Logging
 
 When the MCP server runs over stdio, application logs go to stderr by default. For persistent logs, use `--log-file`:
 
+{{< tabs "mcp-server-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --log-file /tmp/scafctl-mcp.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Then tail the log in another terminal:
 
+{{< tabs "mcp-server-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 tail -f /tmp/scafctl-mcp.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+tail -f /tmp/scafctl-mcp.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Test with Raw JSON-RPC
 
 You can test the server manually by sending JSON-RPC messages:
 
+{{< tabs "mcp-server-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | scafctl mcp serve
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+Write-Output '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | scafctl mcp serve
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Debug Logging
 
 Enable verbose logging to see tool calls and responses:
 
+{{< tabs "mcp-server-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --log-level debug --log-file /tmp/scafctl-mcp-debug.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --log-level debug --log-file /tmp/scafctl-mcp-debug.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 11. Troubleshooting
 
@@ -780,9 +865,18 @@ scafctl mcp serve --log-level debug --log-file /tmp/scafctl-mcp-debug.log
 
 The AI client cannot find the `scafctl` binary. Ensure it's on your `$PATH`:
 
+{{< tabs "mcp-server-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 which scafctl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+which scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 If using a non-standard install location, use the full path in your MCP configuration:
 
@@ -815,6 +909,8 @@ Error: solution "my-solution" has no workflow defined; use 'scafctl run resolver
 
 This means the solution contains only resolvers and no `spec.workflow` section. Use `scafctl run resolver` instead:
 
+{{< tabs "mcp-server-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # For solutions with ONLY resolvers (no spec.workflow):
 scafctl run resolver -f ./my-solution.yaml -r key=value
@@ -822,6 +918,17 @@ scafctl run resolver -f ./my-solution.yaml -r key=value
 # For solutions WITH actions (spec.workflow.actions):
 scafctl run solution -f ./my-solution.yaml -r key=value
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# For solutions with ONLY resolvers (no spec.workflow):
+scafctl run resolver -f ./my-solution.yaml -r key=value
+
+# For solutions WITH actions (spec.workflow.actions):
+scafctl run solution -f ./my-solution.yaml -r key=value
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `create_solution` MCP prompt instructs the AI to suggest the correct command based on whether the generated solution includes a workflow.
 
@@ -829,6 +936,8 @@ The `create_solution` MCP prompt instructs the AI to suggest the correct command
 
 If a tool returns an auth error, set up authentication before starting the server:
 
+{{< tabs "mcp-server-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 # Authenticate first
 scafctl auth login <provider>
@@ -836,6 +945,17 @@ scafctl auth login <provider>
 # Then start the server (or let the AI client start it)
 scafctl mcp serve
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Authenticate first
+scafctl auth login <provider>
+
+# Then start the server (or let the AI client start it)
+scafctl mcp serve
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The MCP server inherits the same auth context as the CLI. If `scafctl run solution` works with your credentials, the MCP server will too.
 
@@ -882,6 +1002,8 @@ If you are behind a corporate proxy, ensure proxy environment variables are avai
 
 The MCP server supports three transport protocols:
 
+{{< tabs "mcp-server-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 # Default: stdio (JSON-RPC 2.0 over stdin/stdout)
 scafctl mcp serve
@@ -892,6 +1014,20 @@ scafctl mcp serve --transport sse --addr :8080
 # HTTP: Streamable HTTP transport
 scafctl mcp serve --transport http --addr :8080
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Default: stdio (JSON-RPC 2.0 over stdin/stdout)
+scafctl mcp serve
+
+# SSE: Server-Sent Events over HTTP
+scafctl mcp serve --transport sse --addr :8080
+
+# HTTP: Streamable HTTP transport
+scafctl mcp serve --transport http --addr :8080
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 SSE and HTTP transports are useful for remote or multi-client scenarios where stdio is not available.
 
@@ -928,9 +1064,18 @@ The server includes built-in observability via hooks and middleware:
 
 Enable detailed logging with:
 
+{{< tabs "mcp-server-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --log-file /tmp/scafctl-mcp.log
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Auto-Completion
 
@@ -987,9 +1132,18 @@ The server supports two client interaction capabilities:
 
 For high-throughput scenarios, you can tune the stdio transport:
 
+{{< tabs "mcp-server-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl mcp serve --worker-pool-size 4 --queue-size 200
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl mcp serve --worker-pool-size 4 --queue-size 200
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 10. Protocol Features
 

--- a/docs/tutorials/multi-platform-plugin-build.md
+++ b/docs/tutorials/multi-platform-plugin-build.md
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Platform Plugin Build Tutorial"
-weight: 14
+weight: 140
 ---
 
 # Multi-Platform Plugin Build Tutorial
@@ -54,6 +54,8 @@ GOOS=windows GOARCH=amd64 go build -o dist/${PLUGIN_NAME}-windows-amd64.exe ./cm
 Use `scafctl build plugin` to package all binaries into a single
 multi-platform artifact:
 
+{{< tabs "multi-platform-plugin-build-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build plugin \
   --name my-provider \
@@ -65,6 +67,21 @@ scafctl build plugin \
   --platform darwin/arm64=./dist/my-provider-darwin-arm64 \
   --platform windows/amd64=./dist/my-provider-windows-amd64.exe
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build plugin `
+  --name my-provider `
+  --kind provider `
+  --version 1.0.0 `
+  --platform linux/amd64=./dist/my-provider-linux-amd64 `
+  --platform linux/arm64=./dist/my-provider-linux-arm64 `
+  --platform darwin/amd64=./dist/my-provider-darwin-amd64 `
+  --platform darwin/arm64=./dist/my-provider-darwin-arm64 `
+  --platform windows/amd64=./dist/my-provider-windows-amd64.exe
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This creates an OCI image index in the local catalog with one manifest per
 platform.
@@ -91,9 +108,18 @@ platform.
 
 Push the multi-platform artifact to an OCI registry:
 
+{{< tabs "multi-platform-plugin-build-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl catalog push my-provider@1.0.0 --catalog ghcr.io/myorg/scafctl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl catalog push my-provider@1.0.0 --catalog ghcr.io/myorg/scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The image index and all platform manifests are pushed together.
 
@@ -126,6 +152,8 @@ On `darwin/arm64` (Apple Silicon), scafctl will:
 You don't need to build for all platforms. For example, if your plugin
 only supports Linux:
 
+{{< tabs "multi-platform-plugin-build-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build plugin \
   --name my-provider \
@@ -134,6 +162,18 @@ scafctl build plugin \
   --platform linux/amd64=./dist/linux-amd64/my-provider \
   --platform linux/arm64=./dist/linux-arm64/my-provider
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build plugin `
+  --name my-provider `
+  --kind provider `
+  --version 1.0.0 `
+  --platform linux/amd64=./dist/linux-amd64/my-provider `
+  --platform linux/arm64=./dist/linux-arm64/my-provider
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 If a user on an unsupported platform tries to use this plugin, they'll get a
 clear error:
@@ -146,6 +186,8 @@ Error: platform "darwin/arm64" not found in image index (available: [linux/amd64
 
 The same workflow works for auth handler plugins:
 
+{{< tabs "multi-platform-plugin-build-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build plugin \
   --name github-auth \
@@ -154,11 +196,25 @@ scafctl build plugin \
   --platform linux/amd64=./dist/github-auth-linux-amd64 \
   --platform darwin/arm64=./dist/github-auth-darwin-arm64
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build plugin `
+  --name github-auth `
+  --kind auth-handler `
+  --version 2.0.0 `
+  --platform linux/amd64=./dist/github-auth-linux-amd64 `
+  --platform darwin/arm64=./dist/github-auth-darwin-arm64
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Overwriting Existing Versions
 
 Use `--force` to overwrite an existing version:
 
+{{< tabs "multi-platform-plugin-build-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl build plugin \
   --name my-provider \
@@ -167,6 +223,18 @@ scafctl build plugin \
   --platform linux/amd64=./dist/my-provider-linux-amd64 \
   --force
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl build plugin `
+  --name my-provider `
+  --kind provider `
+  --version 1.0.0 `
+  --platform linux/amd64=./dist/my-provider-linux-amd64 `
+  --force
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## How It Works Internally
 

--- a/docs/tutorials/output-dir-tutorial.md
+++ b/docs/tutorials/output-dir-tutorial.md
@@ -122,9 +122,18 @@ spec:
 
 ### Step 3: Run with `--output-dir`
 
+{{< tabs "output-dir-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir /tmp/demo-output
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir /tmp/demo-output
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 4: Verify
 
@@ -217,9 +226,18 @@ Because resolvers always use CWD and actions use `--output-dir`, this effectivel
 
 Use `--dry-run` with `--output-dir` to preview what files would be written and where:
 
+{{< tabs "output-dir-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir /tmp/demo-output --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir /tmp/demo-output --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This resolves all values and shows the action plan but doesn't create any files or directories. Use this to verify paths before a real run.
 
@@ -229,6 +247,8 @@ This resolves all values and shows the action plan but doesn't create any files 
 
 The `--output-dir` flag also works with `run provider` when the capability is `action`:
 
+{{< tabs "output-dir-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Write a file to the output directory using the file provider directly
 scafctl run provider file --capability action --output-dir /tmp/demo-output \
@@ -238,7 +258,22 @@ scafctl run provider file --capability action --output-dir /tmp/demo-output \
 cat /tmp/demo-output/hello.txt
 # Output: world
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Write a file to the output directory using the file provider directly
+scafctl run provider file --capability action --output-dir /tmp/demo-output `
+  -i '{"operation": "write", "path": "hello.txt", "content": "world"}'
 
+# Verify
+cat /tmp/demo-output/hello.txt
+# Output: world
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< tabs "output-dir-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Create a directory inside the output directory
 scafctl run provider directory --capability action --output-dir /tmp/demo-output \
@@ -247,14 +282,37 @@ scafctl run provider directory --capability action --output-dir /tmp/demo-output
 # Verify
 ls -la /tmp/demo-output/sub/nested
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Create a directory inside the output directory
+scafctl run provider directory --capability action --output-dir /tmp/demo-output `
+  -i '{"operation": "mkdir", "path": "sub/nested"}'
+
+# Verify
+ls -la /tmp/demo-output/sub/nested
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The flag only applies when `--capability action` is used. Resolver-mode provider runs ignore `--output-dir`:
 
+{{< tabs "output-dir-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # --output-dir is ignored for resolver capability (reads from CWD)
 scafctl run provider file --capability resolver --output-dir /tmp/demo-output \
   -i '{"operation": "read", "path": "source.txt"}'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# --output-dir is ignored for resolver capability (reads from CWD)
+scafctl run provider file --capability resolver --output-dir /tmp/demo-output `
+  -i '{"operation": "read", "path": "source.txt"}'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -270,6 +328,8 @@ action:
 
 The CLI flag always overrides the configured default:
 
+{{< tabs "output-dir-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # Uses the configured default
 scafctl run solution -f solution.yaml
@@ -277,6 +337,17 @@ scafctl run solution -f solution.yaml
 # Overrides the configured default
 scafctl run solution -f solution.yaml --output-dir /tmp/override
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Uses the configured default
+scafctl run solution -f solution.yaml
+
+# Overrides the configured default
+scafctl run solution -f solution.yaml --output-dir /tmp/override
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -400,12 +471,23 @@ spec:
           path: cmd/server
 ```
 
+{{< tabs "output-dir-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --output-dir ./generated/my-service
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --output-dir ./generated/my-service
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CI/CD: Build Artifacts to a Staging Directory
 
+{{< tabs "output-dir-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 # In a CI pipeline, write outputs to a staging dir
 scafctl run solution -f build.yaml --output-dir "$BUILD_DIR/artifacts"
@@ -413,6 +495,17 @@ scafctl run solution -f build.yaml --output-dir "$BUILD_DIR/artifacts"
 # Then upload or deploy from that directory
 aws s3 sync "$BUILD_DIR/artifacts" s3://my-bucket/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# In a CI pipeline, write outputs to a staging dir
+scafctl run solution -f build.yaml --output-dir "$BUILD_DIR/artifacts"
+
+# Then upload or deploy from that directory
+aws s3 sync "$BUILD_DIR/artifacts" s3://my-bucket/
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Template Rendering with Source Separation
 
@@ -451,10 +544,20 @@ spec:
             tmpl: "{{ .template }}"
 ```
 
+{{< tabs "output-dir-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # Templates stay in source, rendered output goes elsewhere
 scafctl run solution -f solution.yaml --output-dir ./dist
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Templates stay in source, rendered output goes elsewhere
+scafctl run solution -f solution.yaml --output-dir ./dist
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 

--- a/docs/tutorials/plugin-auto-fetch-tutorial.md
+++ b/docs/tutorials/plugin-auto-fetch-tutorial.md
@@ -65,6 +65,8 @@ Version constraints follow [semver](https://semver.org/) conventions:
 
 Use `scafctl plugins install` to download plugin binaries before running a solution:
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Install plugins for a solution
 scafctl plugins install -f solution.yaml
@@ -75,6 +77,20 @@ scafctl plugins install -f solution.yaml --platform linux/amd64
 # Use a custom cache directory
 scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Install plugins for a solution
+scafctl plugins install -f solution.yaml
+
+# Install for a specific platform (useful in CI)
+scafctl plugins install -f solution.yaml --platform linux/amd64
+
+# Use a custom cache directory
+scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This is useful for:
 - **CI/CD**: Pre-fetch plugins in a setup step, then run solutions offline
@@ -85,6 +101,8 @@ This is useful for:
 
 View what's in your local plugin cache:
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Table view (default)
 scafctl plugins list
@@ -95,6 +113,20 @@ scafctl plugins list -o json
 # YAML output
 scafctl plugins list -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Table view (default)
+scafctl plugins list
+
+# JSON output
+scafctl plugins list -o json
+
+# YAML output
+scafctl plugins list -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Lock Files for Reproducibility
 
@@ -158,6 +190,8 @@ $XDG_CACHE_HOME/scafctl/plugins/
 
 ### Managing the Cache
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # List cached plugins
 scafctl plugins list
@@ -166,6 +200,18 @@ scafctl plugins list
 # To clear the entire cache:
 rm -rf ~/.cache/scafctl/plugins/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# List cached plugins
+scafctl plugins list
+
+# Cache is at $env:LOCALAPPDATA\scafctl\plugins\ (Windows)
+# To clear the entire cache:
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Multi-Platform Support
 
@@ -182,10 +228,20 @@ When fetching, scafctl:
 
 ### Specifying a Target Platform
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Fetch for a different platform
 scafctl plugins install -f solution.yaml --platform linux/amd64
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Fetch for a different platform
+scafctl plugins install -f solution.yaml --platform linux/amd64
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This is useful for cross-platform CI where you build on one architecture but deploy on another.
 
@@ -193,9 +249,18 @@ This is useful for cross-platform CI where you build on one architecture but dep
 
 When you run a solution that declares plugin dependencies:
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The prepare phase automatically:
 1. Reads `bundle.plugins` from the solution
@@ -209,6 +274,8 @@ No explicit `plugins install` step is needed — but pre-fetching is recommended
 
 ## Example: End-to-End Workflow
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Develop your solution with plugin dependencies
 cat > solution.yaml << 'EOF'
@@ -244,6 +311,45 @@ scafctl run solution -f solution.yaml
 # 5. Check what's cached
 scafctl plugins list
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Develop your solution with plugin dependencies
+@'
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: data-pipeline
+  version: 1.0.0
+spec:
+  resolvers:
+    data:
+      resolve:
+        with:
+          - provider: my-db-provider
+            inputs:
+              connection: "postgres://localhost/db"
+  bundle:
+    plugins:
+      - name: my-db-provider
+        kind: provider
+        version: "^2.0.0"
+'@ | Set-Content solution.yaml
+
+# 2. Build to create a lock file (pins plugin versions)
+scafctl build solution solution.yaml --version 1.0.0
+
+# 3. Pre-fetch plugins (optional but recommended)
+scafctl plugins install -f solution.yaml
+
+# 4. Run the solution (plugins loaded from cache)
+scafctl run solution -f solution.yaml
+
+# 5. Check what's cached
+scafctl plugins list
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Troubleshooting
 
@@ -270,6 +376,8 @@ Error: resolved version 3.0.0 does not satisfy constraint ^1.0.0
 
 If a cached binary seems corrupt:
 
+{{< tabs "plugin-auto-fetch-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Remove the specific plugin from cache
 rm -rf ~/.cache/scafctl/plugins/<plugin-name>/<version>/
@@ -277,3 +385,14 @@ rm -rf ~/.cache/scafctl/plugins/<plugin-name>/<version>/
 # Re-fetch
 scafctl plugins install -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Remove the specific plugin from cache
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\<plugin-name>\<version>\"
+
+# Re-fetch
+scafctl plugins install -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}

--- a/docs/tutorials/plugin-development.md
+++ b/docs/tutorials/plugin-development.md
@@ -5,6 +5,7 @@ weight: 130
 
 # Plugin Development Guide
 
+> [!NOTE]
 > **This page is an overview.** Detailed plugin development instructions are now part of each extension type's development guide.
 
 ## What is a Plugin?
@@ -20,14 +21,9 @@ scafctl supports two types of plugins:
 
 ## Architecture
 
-```
-┌─────────────────────┐        gRPC        ┌──────────────────────┐
-│      scafctl        │◄──────────────────►│    Your Plugin       │
-│                     │                     │                      │
-│  - Discovers plugin │                     │  - Implements gRPC   │
-│  - Calls extension  │                     │  - Exposes handlers  │
-│  - Manages lifecycle│                     │  - Handles execution │
-└─────────────────────┘                     └──────────────────────┘
+```mermaid
+flowchart LR
+  A["scafctl<br/>- Discovers plugin<br/>- Calls extension<br/>- Manages lifecycle"] <-- "gRPC" --> B["Your Plugin<br/>- Implements gRPC<br/>- Exposes handlers<br/>- Handles execution"]
 ```
 
 Each plugin binary exposes **one** extension type (provider OR auth handler). The handshake cookie determines which type the host expects.
@@ -49,13 +45,26 @@ scafctl resolves plugins through two mechanisms:
 
 2. **Directory Scanning** — For local development, place plugin binaries in the plugin cache:
 
-   ```bash
+{{< tabs "plugin-development-cmd-1" >}}
+{{% tab "Bash" %}}
+```bash
    mkdir -p "$(scafctl paths cache)/plugins"
    cp my-plugin "$(scafctl paths cache)/plugins/"
-   ```
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+   $pluginDir = "$(scafctl paths cache)/plugins"
+   New-Item -ItemType Directory -Force -Path $pluginDir
+   Copy-Item my-plugin $pluginDir
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Plugin CLI Commands
 
+{{< tabs "plugin-development-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Pre-fetch plugins declared in a solution
 scafctl plugins install -f my-solution.yaml
@@ -66,6 +75,20 @@ scafctl plugins list
 # Push to a remote registry
 scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Pre-fetch plugins declared in a solution
+scafctl plugins install -f my-solution.yaml
+
+# List cached plugin binaries
+scafctl plugins list
+
+# Push to a remote registry
+scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -17,6 +17,7 @@ Providers can be delivered in two ways:
 | **Distribution** | Ships with scafctl releases | OCI catalog artifact (`kind: provider`) or standalone binary |
 | **Interface** | `provider.Provider` (2 methods) | `plugin.ProviderPlugin` (3 methods) |
 
+> [!WARNING]
 > **Prerequisite**: Read the [Extension Concepts](extension-concepts.md) page for terminology (provider vs plugin vs auth handler).
 
 The bulk of this guide covers the `provider.Provider` interface used by both delivery models. The [Delivering as a Plugin](#delivering-as-a-plugin) section at the end covers the additional steps for the plugin model.
@@ -108,6 +109,7 @@ func (p *MyProvider) Execute(ctx context.Context, input any) (*provider.Output, 
 }
 ```
 
+> [!NOTE]
 > **Convention**: All built-in providers export a `ProviderName` constant, build the
 > descriptor in the constructor (not in `Descriptor()`), and name the constructor
 > `New<Name>Provider()` (e.g., `NewMyProvider`, `NewEnvProvider`).
@@ -337,9 +339,10 @@ if ok {
 }
 ```
 
+> [!CAUTION]
 > **Note**: All context helpers except `DryRunFromContext` return a two-value
 > `(value, bool)` — the `bool` indicates whether the value was present in the context.
->
+> 
 > **Dry-run mechanisms**: There are two dry-run approaches:
 > 1. **`DryRunFromContext(ctx)`** — Checked in `Execute()` when running via `run provider --dry-run`. Return mock data to avoid side effects.
 > 2. **`WhatIf` on `Descriptor`** — Called by `run solution --dry-run` to generate a human-readable description of what the provider would do. Providers are never executed during solution dry-run.
@@ -458,6 +461,7 @@ func DefaultRegistry(ctx context.Context) (*provider.Registry, error) {
 }
 ```
 
+> [!CAUTION]
 > **Note**: `DefaultRegistry` takes a `context.Context` and `Register()` returns an
 > `error`. Constructor names follow the `New<Name>Provider()` convention
 > (e.g., `NewEnvProvider`, `NewHTTPProvider`).
@@ -915,14 +919,9 @@ Instead of compiling your provider into the scafctl binary, you can ship it as a
 
 ### Architecture
 
-```
-┌─────────────────────┐        gRPC        ┌──────────────────────┐
-│      scafctl        │◄──────────────────►│    Your Plugin       │
-│                     │                     │                      │
-│  - Discovers plugin │                     │  - Implements gRPC   │
-│  - Calls providers  │                     │  - Exposes providers │
-│  - Manages lifecycle│                     │  - Handles execution │
-└─────────────────────┘                     └──────────────────────┘
+```mermaid
+flowchart LR
+  A["scafctl<br/>- Discovers plugin<br/>- Calls providers<br/>- Manages lifecycle"] <-- "gRPC" --> B["Your Plugin<br/>- Implements gRPC<br/>- Exposes providers<br/>- Handles execution"]
 ```
 
 Plugins use [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin) with gRPC for communication.
@@ -948,11 +947,22 @@ type ProviderPlugin interface {
 
 #### 1. Create Plugin Directory
 
+{{< tabs "provider-development-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 mkdir my-plugin && cd my-plugin
 go mod init github.com/myorg/my-plugin
 go get github.com/oakwood-commons/scafctl
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+mkdir my-plugin; cd my-plugin
+go mod init github.com/myorg/my-plugin
+go get github.com/oakwood-commons/scafctl
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 #### 2. Implement the Plugin
 
@@ -1041,10 +1051,13 @@ func main() {
 }
 ```
 
+> [!NOTE]
 > **Key difference from builtin**: Each `GetProviderDescriptor` / `ExecuteProvider` / `DescribeWhatIf` call receives the provider name, allowing one plugin to expose multiple providers. The core logic (schemas, execution, dry-run) is identical.
 
 #### 3. Build and Install
 
+{{< tabs "provider-development-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Build
 go build -o scafctl-plugin-mine .
@@ -1053,6 +1066,19 @@ go build -o scafctl-plugin-mine .
 mkdir -p "$(scafctl paths cache)/plugins"
 cp scafctl-plugin-mine "$(scafctl paths cache)/plugins/"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Build
+go build -o scafctl-plugin-mine .
+
+# Install to plugin cache
+$pluginDir = "$(scafctl paths cache)/plugins"
+New-Item -ItemType Directory -Force -Path $pluginDir
+Copy-Item scafctl-plugin-mine $pluginDir
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 #### 4. Use in Solutions
 
@@ -1076,9 +1102,18 @@ spec:
 
 **Via Local Installation**:
 
+{{< tabs "provider-development-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f my-solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f my-solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Multi-Provider Plugin
 
@@ -1165,6 +1200,8 @@ See the [Plugin Auto-Fetching Tutorial](plugin-auto-fetch-tutorial.md) for full 
 
 ### Plugin CLI Commands
 
+{{< tabs "provider-development-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Pre-fetch plugins declared in a solution
 scafctl plugins install -f my-solution.yaml
@@ -1175,9 +1212,25 @@ scafctl plugins list
 # Push to a remote registry
 scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Pre-fetch plugins declared in a solution
+scafctl plugins install -f my-solution.yaml
+
+# List cached plugin binaries
+scafctl plugins list
+
+# Push to a remote registry
+scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Plugin Debugging
 
+{{< tabs "provider-development-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # Enable debug logging
 scafctl --log-level -1 run solution -f solution.yaml
@@ -1185,6 +1238,17 @@ scafctl --log-level -1 run solution -f solution.yaml
 # Run plugin directly (waits for gRPC connection)
 ./my-plugin
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Enable debug logging
+scafctl --log-level -1 run solution -f solution.yaml
+
+# Run plugin directly (waits for gRPC connection)
+./my-plugin
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 | Issue | Cause | Solution |
 |-------|-------|----------|

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -1,6 +1,6 @@
 ---
 title: "Provider Output Shapes"
-weight: 18
+weight: 74
 ---
 
 # Provider Output Shapes
@@ -11,18 +11,12 @@ Quick reference for what each built-in provider returns in resolver output — t
 
 When a resolver uses a provider, the resolved value becomes accessible to other resolvers. The **output shape** determines what fields are available:
 
-```
-┌─────────────────────┐         ┌──────────────────┐
-│ Resolver: api_data  │         │ Resolver: summary │
-│ provider: http      │  ───►   │ expr: _.api_data  │
-│ output: {           │         │   .body.items     │
-│   body: {...}       │         │   | size()        │
-│   statusCode: 200   │         └──────────────────┘
-│   headers: {...}    │
-│ }                   │
-└─────────────────────┘
+```mermaid
+flowchart LR
+  A["Resolver: api_data<br/>provider: http<br/>output: body, statusCode, headers"] --> B["Resolver: summary<br/>expr: _.api_data<br/>.body.items | size()"]
 ```
 
+> [!NOTE]
 > **Tip:** Use the MCP tool `get_provider_output_shape` to query output schemas programmatically, or `get_provider_schema` for full provider documentation.
 
 ---
@@ -237,6 +231,8 @@ Varies by operation — parse returns structured data, format/validate return st
 
 ### CLI
 
+{{< tabs "provider-output-shapes-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # View full provider info including output schemas
 scafctl get provider http -o json
@@ -244,6 +240,17 @@ scafctl get provider http -o json
 # View all providers
 scafctl get providers
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# View full provider info including output schemas
+scafctl get provider http -o json
+
+# View all providers
+scafctl get providers
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### MCP Tools
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -7,6 +7,7 @@ weight: 110
 
 This document provides a reference for all built-in providers in scafctl.
 
+> [!TIP]
 > **Note:** All YAML examples in this reference show only the relevant resolver or action snippet. To use them, place each snippet inside a complete solution file with `apiVersion`, `kind`, `metadata`, and `spec` sections. See the [Getting Started](getting-started.md) tutorial for the full solution structure.
 
 ## Overview
@@ -804,6 +805,7 @@ transform:
           - line: "# scafctl:ignore"
 ```
 
+> [!NOTE]
 > **Note:** `line` and `start`/`end` are mutually exclusive within a single entry, but different entries can use different modes.
 
 The content between `start` and `end` markers (including the markers themselves) passes through unchanged. For `line` mode, the entire line containing the marker is preserved.
@@ -1324,6 +1326,7 @@ inspect its claims on demand.
 | `flow` | string | Auth flow that produced the token (when `scope` input was set) |
 | `sessionId` | string | Stable session identifier (when `scope` input was set) |
 
+> [!WARNING]
 > **Opaque tokens:** When `scope` is provided and the access token is not a
 > decodable JWT (e.g., encrypted Microsoft Graph tokens), claims will be `null`
 > and a warning is added to the output. Token metadata (expiry, type) is still
@@ -1503,9 +1506,18 @@ resolve:
 
 Usage:
 
+{{< tabs "provider-reference-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f sol.yaml -r environment=production
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f sol.yaml -r environment=production
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -1551,10 +1563,20 @@ resolve:
 
 Manage secrets via CLI:
 
+{{< tabs "provider-reference-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl secrets set api-key "my-secret-value"
 scafctl secrets list
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl secrets set api-key "my-secret-value"
+scafctl secrets list
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -55,9 +55,18 @@ spec:
 
 ### Step 2: Run the Solution
 
+{{< tabs "resolver-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f hello.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f hello.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```
@@ -68,6 +77,7 @@ Output:
 ╰ _ ─────────── map: 1/1 ╯
 ```
 
+> [!NOTE]
 > **Tip**: Add `-o json` to get JSON output: `scafctl run resolver -f hello.yaml -o json`
 
 ### Understanding the Structure
@@ -121,9 +131,18 @@ spec:
 
 ### Step 2: Run with Parameters
 
+{{< tabs "resolver-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greet.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greet.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -138,9 +157,18 @@ Output:
 
 Pass a parameter:
 
+{{< tabs "resolver-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greet.yaml -r user_name=Alice
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f greet.yaml -r user_name=Alice
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -166,17 +194,17 @@ region: us-west-2
 
 Run with the file:
 {{< tabs "resolver-param-file" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f greet.yaml -r @params.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Wrap @file in single quotes to avoid splatting operator
 scafctl run resolver -f greet.yaml -r '@params.yaml'
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Output:
@@ -261,9 +289,18 @@ spec:
 
 ### Step 2: Run and Observe Phases
 
+{{< tabs "resolver-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f config.yaml --progress
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f config.yaml --progress
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `--progress` flag shows how resolvers execute in phases based on dependencies:
 
@@ -323,9 +360,18 @@ spec:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f transform.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f transform.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -335,6 +381,7 @@ Output:
 }
 ```
 
+> [!NOTE]
 > **Tip**: `scafctl run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details on the execution metadata.
 
 The value was trimmed of whitespace, then lowercased — each transform step feeds into the next.
@@ -375,9 +422,18 @@ spec:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f enrich.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f enrich.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output (timestamp will vary):
 
@@ -433,9 +489,18 @@ spec:
 
 Run it with a valid port:
 
+{{< tabs "resolver-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f validated-config.yaml -r port=8080 -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f validated-config.yaml -r port=8080 -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -447,9 +512,18 @@ Output:
 
 Run it with an invalid port to see the validation error:
 
+{{< tabs "resolver-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f validated-config.yaml -r port=80
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f validated-config.yaml -r port=80
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -497,9 +571,18 @@ spec:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f email-validator.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f email-validator.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -511,9 +594,18 @@ Output:
 
 Now try an invalid value that fails **both** validations — not a valid email format **and** ends with `.test`:
 
+{{< tabs "resolver-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -570,9 +662,18 @@ spec:
 
 Run it with `development` (default) — the `prod_secrets` resolver is skipped:
 
+{{< tabs "resolver-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f conditional.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f conditional.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output (only `environment` is resolved; `prod_secrets` is skipped):
 
@@ -584,9 +685,18 @@ Output (only `environment` is resolved; `prod_secrets` is skipped):
 
 Run it with `production` — the `prod_secrets` resolver executes:
 
+{{< tabs "resolver-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f conditional.yaml -r env=production -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f conditional.yaml -r env=production -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -629,9 +739,18 @@ spec:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f phase-condition.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f phase-condition.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -687,9 +806,18 @@ spec:
 
 Run it (the HTTP and file providers will fail, so it falls back to static):
 
+{{< tabs "resolver-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f fallback.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f fallback.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -793,9 +921,18 @@ spec:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f http-example.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f http-example.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output (body and headers will vary):
 
@@ -845,10 +982,20 @@ spec:
 
 Run it (requires the `API_TOKEN` environment variable to be set):
 
+{{< tabs "resolver-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 export API_TOKEN=your-token-here
 scafctl run resolver -f auth-api.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:API_TOKEN = "your-token-here"
+scafctl run resolver -f auth-api.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -894,9 +1041,18 @@ spec:
                   : 'postgres://localhost:5432/app_dev'
 ```
 
+{{< tabs "resolver-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f env-config.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f env-config.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -909,13 +1065,23 @@ Output:
 ╰ _ ─────────── map: 1/2 ╯
 ```
 
+> [!NOTE]
 > **Note**: Fields marked `sensitive: true` are shown as `[REDACTED]` in table output.
 
 Structured output (JSON, YAML) reveals sensitive values for machine consumption:
 
+{{< tabs "resolver-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f env-config.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f env-config.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -928,10 +1094,20 @@ Output:
 
 Use `--show-sensitive` to reveal values in table output:
 
+{{< tabs "resolver-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f env-config.yaml --show-sensitive
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f env-config.yaml --show-sensitive
+```
+{{% /tab %}}
+{{< /tabs >}}
 
+> [!NOTE]
 > **Sensitive Redaction Behavior**: Sensitive values are redacted in table/interactive output (human-facing) but revealed in JSON/YAML output (machine-facing), following the same model as Terraform. Use `--show-sensitive` to reveal values in all output formats.
 
 ### Pattern 2: Feature Toggles
@@ -974,9 +1150,18 @@ spec:
                 }
 ```
 
+{{< tabs "resolver-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f feature-toggles.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f feature-toggles.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -1027,9 +1212,18 @@ spec:
               expression: "'postgres://app:' + _.db_password + '@db.example.com:5432/app'"
 ```
 
+{{< tabs "resolver-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f secrets.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f secrets.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -1042,13 +1236,23 @@ Output:
 ╰ _ ──────────────── map: 1/2  ╯
 ```
 
+> [!NOTE]
 > **Note**: Both resolvers are marked `sensitive: true`, so their values are redacted in table output.
 
 Structured output reveals the actual values:
 
+{{< tabs "resolver-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f secrets.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f secrets.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -1059,6 +1263,7 @@ Output:
 }
 ```
 
+> [!NOTE]
 > **Tip**: Use table output (the default) when sharing your screen or in CI logs to avoid accidentally exposing secrets. Use `-o json` or `-o yaml` when piping to downstream tools that need the actual values.
 
 ### Pattern 4: Multi-Stage Pipeline
@@ -1123,9 +1328,18 @@ spec:
               message: "No active users found"
 ```
 
+{{< tabs "resolver-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f pipeline.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f pipeline.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -1186,16 +1400,16 @@ spec:
 Run it to see the result:
 
 {{< tabs "resolver-foreach-run" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver doubled -f foreach-demo.yaml -o json
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run resolver doubled -f foreach-demo.yaml -o json
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 #### Filtering with `when` and `forEach`
@@ -1284,14 +1498,18 @@ With `filter: true` the output contains only matched items:
 
 Run it:
 
+{{< tabs "resolver-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver activeUsers -f foreach-filter-demo.yaml -o json
 ```
-
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
-# PowerShell
 scafctl run resolver activeUsers -f foreach-filter-demo.yaml -o json
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 #### `filter` vs `keepSkipped`
 

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -30,6 +30,8 @@ This tutorial covers the `scafctl run provider` command — a tool for executing
 
 The `scafctl run provider` command takes a provider name as its first argument. Provider inputs can be passed as positional `key=value` arguments or via the traditional `--input` flag:
 
+{{< tabs "run-provider-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Positional key=value (recommended)
 scafctl run provider <provider-name> <key>=<value>
@@ -37,6 +39,17 @@ scafctl run provider <provider-name> <key>=<value>
 # Explicit --input flag
 scafctl run provider <provider-name> --input <key>=<value>
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Positional key=value (recommended)
+scafctl run provider <provider-name> <key>=<value>
+
+# Explicit --input flag
+scafctl run provider <provider-name> --input <key>=<value>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Both forms can be mixed freely. When the same key appears multiple times, later values override earlier ones.
 
@@ -44,9 +57,18 @@ Both forms can be mixed freely. When the same key appears multiple times, later 
 
 Run the `static` provider to return a simple value:
 
+{{< tabs "run-provider-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider static value=hello
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider static value=hello
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -66,6 +88,8 @@ Inputs can be passed as positional `key=value` arguments or via the `--input` fl
 
 ### Simple Key-Value Pairs
 
+{{< tabs "run-provider-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Positional key=value (recommended)
 scafctl run provider http url=https://httpbin.org/get method=GET
@@ -73,6 +97,17 @@ scafctl run provider http url=https://httpbin.org/get method=GET
 # Explicit --input flag
 scafctl run provider http --input url=https://httpbin.org/get --input method=GET
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Positional key=value (recommended)
+scafctl run provider http url=https://httpbin.org/get method=GET
+
+# Explicit --input flag
+scafctl run provider http --input url=https://httpbin.org/get --input method=GET
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -93,9 +128,18 @@ Output:
 
 Comma-separated values are automatically converted to arrays:
 
+{{< tabs "run-provider-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider exec command=echo args=hello,world
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider exec shell=pwsh command=Write-Output "args=hello,world"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Values Containing Commas
 
@@ -103,17 +147,35 @@ If a value itself contains commas (not intended as array separators), wrap it in
 quotes inside the flag value. Use single quotes around the entire flag to prevent
 shell interpretation:
 
+{{< tabs "run-provider-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Multiple Values for the Same Key
 
 Repeating the same key creates an array:
 
+{{< tabs "run-provider-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider exec command=echo args=hello args=world
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider exec shell=pwsh command=Write-Output "args=hello args=world"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -136,17 +198,17 @@ headers:
 ### Run with File Input
 
 {{< tabs "runprov-file-input" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http --input @inputs.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Wrap @file in single quotes to avoid splatting operator
 scafctl run provider http --input '@inputs.yaml'
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Output:
@@ -168,16 +230,16 @@ the values are combined into an array. To override a file value, omit
 that key from the file:
 
 {{< tabs "runprov-mixed-input" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http --input @inputs.yaml timeout=30
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run provider http --input '@inputs.yaml' timeout=30
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 This loads all values from `inputs.yaml` and adds `timeout=30`.
@@ -190,6 +252,8 @@ When you pass inputs, scafctl validates the input keys against the provider's
 schema. Unknown keys are rejected early with a helpful error message. If the
 key is close to a valid one (a likely typo), a suggestion is included:
 
+{{< tabs "run-provider-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 # Typo in key name
 scafctl run provider http urll=https://example.com
@@ -199,14 +263,38 @@ scafctl run provider http urll=https://example.com
 scafctl run provider http unknown=value
 # Error: provider "http" does not accept input "unknown" (valid inputs: body, headers, method, timeout, url)
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Typo in key name
+scafctl run provider http urll=https://example.com
+# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: body, headers, method, timeout, url)
+
+# Completely unknown key
+scafctl run provider http unknown=value
+# Error: provider "http" does not accept input "unknown" (valid inputs: body, headers, method, timeout, url)
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This validation also applies to resolver and solution parameters:
 
+{{< tabs "run-provider-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 # Typo in parameter name
 scafctl run resolver -f solution.yaml envrionment=prod
 # Error: solution does not accept input "envrionment" — did you mean "environment"? (valid inputs: environment, region)
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Typo in parameter name
+scafctl run resolver -f solution.yaml envrionment=prod
+# Error: solution does not accept input "envrionment" — did you mean "environment"? (valid inputs: environment, region)
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -224,18 +312,37 @@ Providers declare capabilities that define what kind of operation they perform:
 
 By default, `scafctl run provider` uses the provider's first declared capability. Use `--capability` to select a specific one:
 
+{{< tabs "run-provider-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run a provider with a specific capability
 scafctl run provider cel expression="1 + 2" --capability transform
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run a provider with a specific capability
+scafctl run provider cel expression="1 + 2" --capability transform
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Viewing Available Capabilities
 
 Use `scafctl get provider <name>` to see which capabilities a provider supports:
 
+{{< tabs "run-provider-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get provider cel
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get provider cel
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -243,15 +350,23 @@ scafctl get provider cel
 
 Use `--dry-run` to see what would be executed without actually running the provider:
 
+{{< tabs "run-provider-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http url=https://example.com --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider http url=https://example.com --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The provider will return simulated output without performing any side effects (no HTTP request, no command execution, etc.).
 
-{{% hint info %}}
-**Provider vs solution dry-run**: `run provider --dry-run` invokes the provider's `Execute()` method with a dry-run context flag, so the provider returns mock data. `run solution --dry-run` is different — it uses the WhatIf model where resolvers run normally and actions are never executed. See [Dry-Run & WhatIf design]({{< relref "/docs/design/dryrun-whatif" >}}) for details.
-{{% /hint %}}
+> [!NOTE]
+> **Provider vs solution dry-run**: `run provider --dry-run` invokes the provider's `Execute()` method with a dry-run context flag, so the provider returns mock data. `run solution --dry-run` is different — it uses the WhatIf model where resolvers run normally and actions are never executed. See [Dry-Run & WhatIf design]({{< relref "/docs/design/dryrun-whatif" >}}) for details.
 
 ---
 
@@ -259,6 +374,8 @@ The provider will return simulated output without performing any side effects (n
 
 The default output format is JSON. Use `-o` to change it:
 
+{{< tabs "run-provider-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 # JSON output (default)
 scafctl run provider static value=hello -o json
@@ -272,22 +389,39 @@ scafctl run provider static value=hello -o table
 # Quiet mode (exit code only)
 scafctl run provider static value=hello -o quiet
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# JSON output (default)
+scafctl run provider static value=hello -o json
+
+# YAML output
+scafctl run provider static value=hello -o yaml
+
+# Table output
+scafctl run provider static value=hello -o table
+
+# Quiet mode (exit code only)
+scafctl run provider static value=hello -o quiet
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Interactive Mode
 
 Explore complex output in an interactive TUI:
 
 {{< tabs "runprov-interactive" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http --input url=https://httpbin.org/get -i
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run provider http --input url=https://httpbin.org/get -i
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### CEL Expressions
@@ -295,25 +429,34 @@ scafctl run provider http --input url=https://httpbin.org/get -i
 Filter or transform output using CEL expressions:
 
 {{< tabs "runprov-cel-expr" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http url=https://httpbin.org/get -e "_.data"
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run provider http url=https://httpbin.org/get -e '_.data'
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Execution Metrics
 
 Use `--show-metrics` to display timing information:
 
+{{< tabs "run-provider-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http url=https://httpbin.org/get --show-metrics
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider http url=https://httpbin.org/get --show-metrics
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -321,6 +464,8 @@ scafctl run provider http url=https://httpbin.org/get --show-metrics
 
 Load providers from plugin executables using `--plugin-dir`:
 
+{{< tabs "run-provider-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # Load plugins from a directory
 scafctl run provider echo message=hello --plugin-dir ./plugins
@@ -328,6 +473,17 @@ scafctl run provider echo message=hello --plugin-dir ./plugins
 # Multiple plugin directories
 scafctl run provider my-plugin key=value --plugin-dir ./plugins --plugin-dir /opt/plugins
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Load plugins from a directory
+scafctl run provider Write-Output "message=hello --plugin-dir ./plugins"
+
+# Multiple plugin directories
+scafctl run provider my-plugin key=value --plugin-dir ./plugins --plugin-dir /opt/plugins
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 See the [Provider Development Guide](provider-development.md) for creating custom providers (including [plugin delivery](provider-development.md#delivering-as-a-plugin)).
 
@@ -337,15 +493,33 @@ See the [Provider Development Guide](provider-development.md) for creating custo
 
 ### List All Providers
 
+{{< tabs "run-provider-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get providers
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get providers
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### View Provider Details
 
+{{< tabs "run-provider-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get provider http
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get provider http
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This shows the provider's schema, capabilities, examples, and auto-generated CLI usage examples.
 
@@ -353,9 +527,18 @@ This shows the provider's schema, capabilities, examples, and auto-generated CLI
 
 When you run `--help` with a specific provider name, the help output automatically includes the provider's input parameters with types, required/optional status, defaults, and descriptions:
 
+{{< tabs "run-provider-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http --help
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider http --help
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 At the end of the standard help text, you'll see a section like:
 
@@ -370,23 +553,52 @@ Provider Inputs (http):
 
 This works for any provider — just include the provider name before `--help`:
 
+{{< tabs "run-provider-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider env --help
 scafctl run provider static --help
 scafctl run provider file --help
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider env --help
+scafctl run provider static --help
+scafctl run provider file --help
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Filter by Capability
 
+{{< tabs "run-provider-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get providers --capability=validation
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get providers --capability=validation
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Browse Interactively
 
+{{< tabs "run-provider-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get providers -i
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get providers -i
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -394,30 +606,68 @@ scafctl get providers -i
 
 ### Read an Environment Variable
 
+{{< tabs "run-provider-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider env operation=get name=HOME
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider env operation=get name=HOME
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Execute a Shell Command
 
+{{< tabs "run-provider-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider exec command=date
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider exec command=date
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Read a File
 
+{{< tabs "run-provider-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider file operation=read path=README.md
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider file operation=read path=README.md
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### List a Directory
 
+{{< tabs "run-provider-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider directory operation=list path=./pkg
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider directory operation=list path=./pkg
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Evaluate a CEL Expression
 
+{{< tabs "run-provider-tutorial-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 # Simple expression (no commas)
 scafctl run provider cel expression="1 + 2"
@@ -425,33 +675,80 @@ scafctl run provider cel expression="1 + 2"
 # Expressions with commas must be quoted to avoid CSV splitting
 scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Simple expression (no commas)
+scafctl run provider cel expression="1 + 2"
+
+# Expressions with commas must be quoted to avoid CSV splitting
+scafctl run provider cel 'expression="[1,2,3].map(x, x * 2)"'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Make an HTTP Request
 
+{{< tabs "run-provider-tutorial-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider http url=https://httpbin.org/get method=GET
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider http url=https://httpbin.org/get method=GET
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Get Git Repository Status
 
+{{< tabs "run-provider-tutorial-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider git operation=status path=.
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider git operation=status path=.
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Render a Go Template
 
+{{< tabs "run-provider-tutorial-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider go-template name=greeting 'template=Hello World'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider go-template name=greeting 'template=Hello World'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Redact Sensitive Output
 
 Use `--redact` to mask sensitive values in the output. This example retrieves
 a secret (which must already exist in the scafctl secrets store):
 
+{{< tabs "run-provider-tutorial-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run provider secret operation=get name=my-secret --redact
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run provider secret operation=get name=my-secret --redact
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -28,9 +28,8 @@ This tutorial covers the `scafctl run resolver` command — a debugging and insp
 
 ---
 
-{{% hint info %}}
-**A note on `__execution` metadata**: When using JSON or YAML output, `run resolver` automatically includes an `__execution` key containing execution metadata (timing, dependency graph, provider stats). Throughout this tutorial, examples use `--hide-execution` to keep output focused on resolver values. See [Execution Metadata](#execution-metadata) for details on this feature.
-{{% /hint %}}
+> [!NOTE]
+> **A note on `__execution` metadata**: When using JSON or YAML output, `run resolver` automatically includes an `__execution` key containing execution metadata (timing, dependency graph, provider stats). Throughout this tutorial, examples use `--hide-execution` to keep output focused on resolver values. See [Execution Metadata](#execution-metadata) for details on this feature.
 
 ## Run All Resolvers
 
@@ -73,9 +72,18 @@ spec:
 
 ### Step 2: Run All Resolvers
 
+{{< tabs "run-resolver-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f demo.yaml --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f demo.yaml --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -89,9 +97,18 @@ region       us-west-2
 
 ### Step 3: Get JSON Output
 
+{{< tabs "run-resolver-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -103,6 +120,7 @@ Output:
 }
 ```
 
+> [!NOTE]
 > **Tip**: Unlike `run solution`, this command never executes actions — it's safe for inspection.
 
 ---
@@ -113,9 +131,18 @@ Pass resolver names as positional arguments to execute only those resolvers (plu
 
 ### Step 1: Run a Single Resolver
 
+{{< tabs "run-resolver-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver environment -f demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver environment -f demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -127,9 +154,18 @@ Output:
 
 ### Step 2: Run Multiple Resolvers
 
+{{< tabs "run-resolver-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver environment region -f demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver environment region -f demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -183,9 +219,18 @@ spec:
 
 Running just `endpoint` automatically includes `base_url` (its dependency):
 
+{{< tabs "run-resolver-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -202,9 +247,18 @@ Note that `base_url` is included (it's a dependency of `endpoint`) but `unrelate
 
 If you request a resolver that doesn't exist, you get a clear error:
 
+{{< tabs "run-resolver-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver nonexistent -f demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver nonexistent -f demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -218,9 +272,18 @@ Output:
 
 By default, `run resolver` includes a `__execution` key in the output alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. timeline). Use `--hide-execution` to suppress it when you only need the resolved values.
 
+{{< tabs "run-resolver-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f dep-demo.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f dep-demo.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Current sections:
 
@@ -274,12 +337,22 @@ Example JSON output:
 
 ### Combine with Named Resolvers
 
+{{< tabs "run-resolver-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver endpoint -f dep-demo.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `__execution` section only includes metadata for the requested resolvers and their dependencies.
 
+> [!NOTE]
 > **Tip**: Use `--hide-execution` to suppress `__execution` when you only need the resolved values. For `run solution`, execution metadata is opt-in via `--show-execution`.
 
 ---
@@ -320,9 +393,18 @@ spec:
 
 Running the resolver fails because the transformed value (`68000`) exceeds the valid port range:
 
+{{< tabs "run-resolver-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f phases-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f phases-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -336,9 +418,18 @@ The validation error blocks the output entirely — you can't see the resolved v
 
 Use `--skip-validation` to bypass the validation phase and see the actual value:
 
+{{< tabs "run-resolver-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --skip-validation -f phases-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --skip-validation -f phases-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -354,9 +445,18 @@ Now you can see the problem: the transform added `8000` to `60000`, producing `6
 
 Use `--skip-transform` to see the raw resolved value before any transformations:
 
+{{< tabs "run-resolver-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --skip-transform -f phases-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --skip-transform -f phases-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -368,6 +468,7 @@ Output:
 
 This reveals the provider returned `60000` — confirming the root cause is the input value, not the transform logic.
 
+> [!WARNING]
 > **Note**: `--skip-transform` implies `--skip-validation` because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
 
 ---
@@ -378,9 +479,18 @@ The `--graph` flag renders the resolver dependency graph **without executing any
 
 ### ASCII Graph (default)
 
+{{< tabs "run-resolver-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph -f dep-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --graph -f dep-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -405,48 +515,59 @@ Statistics:
 
 ### Graphviz DOT Format
 
+> [!WARNING]
 > **Prerequisite:** Requires [Graphviz](https://graphviz.org/) (`dot` command) to be installed.
 
 Generate DOT output and pipe it to Graphviz for a visual diagram:
 
 {{< tabs "runres-graph-dot" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph --graph-format=dot -f dep-demo.yaml | dot -Tpng > graph.png
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run resolver --graph --graph-format=dot -f dep-demo.yaml | dot -Tpng -o graph.png
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Mermaid Format
 
 Generate a Mermaid diagram for embedding in Markdown or documentation:
 
+{{< tabs "run-resolver-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph --graph-format=mermaid -f dep-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --graph --graph-format=mermaid -f dep-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### JSON Format
 
 Get the graph as structured JSON for programmatic analysis:
 
 {{< tabs "runres-graph-json" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | jq .
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run resolver --graph --graph-format=json -f dep-demo.yaml | ConvertFrom-Json
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
+> [!NOTE]
 > **Bash users:** The above command uses [jq](https://jqlang.github.io/jq/), a command-line JSON processor. Install it separately if not already available.
 
 The JSON output includes:
@@ -459,18 +580,37 @@ The JSON output includes:
 
 The graph stats include a **critical path** — the longest chain of dependencies that determines the minimum sequential execution depth. This helps identify bottlenecks:
 
+{{< tabs "run-resolver-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph --graph-format=json -f dep-demo.yaml -e '_.stats.criticalPath'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --graph --graph-format=json -f dep-demo.yaml -e '_.stats.criticalPath'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Graph in Execution Metadata
 
 When running resolvers normally, the dependency graph and a provider usage summary are automatically embedded in `__execution`:
 
+{{< tabs "run-resolver-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph'
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.providerSummary'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph'
+scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.providerSummary'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The **providerSummary** shows per-provider statistics: resolver count, total duration, call count, success/failure counts, and average duration.
 
@@ -478,10 +618,11 @@ The **providerSummary** shows per-provider statistics: resolver count, total dur
 
 The `dependencyGraph` in `__execution` includes a `diagrams` field with pre-rendered ASCII, DOT, and Mermaid representations. Use the `-e` flag (CEL expression) to extract a specific diagram:
 
+> [!WARNING]
 > **Prerequisite:** The DOT diagram commands below require [Graphviz](https://graphviz.org/) to be installed.
 
 {{< tabs "runres-extract-diagrams" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Extract the Mermaid diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.mermaid'
@@ -492,8 +633,8 @@ scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.
 # Extract the ASCII diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.ascii'
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Extract the Mermaid diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.mermaid'
@@ -504,32 +645,31 @@ scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.
 # Extract the ASCII diagram
 scafctl run resolver -f dep-demo.yaml -o json -e '_.__execution.dependencyGraph.diagrams.ascii'
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 You can also extract diagrams when running only specific resolvers:
 
 {{< tabs "runres-extract-subset" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get the Mermaid diagram for just endpoint and unrelated (and their deps)
 scafctl run resolver endpoint unrelated -f dep-demo.yaml -o json \
   -e '_.__execution.dependencyGraph.diagrams.mermaid'
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run resolver endpoint unrelated -f dep-demo.yaml -o json `
   -e '_.__execution.dependencyGraph.diagrams.mermaid'
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 This is useful for generating focused dependency visualizations of a resolver subset without rendering the full solution graph.
 
-{{% hint info %}}
-`--graph` is mutually exclusive with `--snapshot`.
-{{% /hint %}}
+> [!NOTE]
+> `--graph` is mutually exclusive with `--snapshot`.
 
 ---
 
@@ -539,9 +679,18 @@ The `--snapshot` flag executes resolvers and saves the complete execution state 
 
 ### Basic Snapshot
 
+{{< tabs "run-resolver-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --snapshot --snapshot-file=snapshot.json -f demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --snapshot --snapshot-file=snapshot.json -f demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This creates a snapshot file containing:
 - **metadata**: Solution name, version, build version, timestamp, total duration, and execution status
@@ -552,9 +701,18 @@ This creates a snapshot file containing:
 
 Use `--redact` to replace sensitive resolver values with `<redacted>`:
 
+{{< tabs "run-resolver-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --snapshot --snapshot-file=snapshot.json --redact -f demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --snapshot --snapshot-file=snapshot.json --redact -f demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Resolvers marked with `sensitive: true` will have their values replaced in the snapshot.
 
@@ -565,9 +723,8 @@ Resolvers marked with `sensitive: true` will have their values replaced in the s
 - **Testing**: Compare snapshots between runs to detect regressions
 - **Support**: Redacted snapshots can be shared without exposing secrets
 
-{{% hint info %}}
-`--snapshot` requires `--snapshot-file` to be specified. It is mutually exclusive with `--graph`.
-{{% /hint %}}
+> [!NOTE]
+> `--snapshot` requires `--snapshot-file` to be specified. It is mutually exclusive with `--graph`.
 
 ---
 
@@ -575,6 +732,8 @@ Resolvers marked with `sensitive: true` will have their values replaced in the s
 
 The command supports all standard output formats:
 
+{{< tabs "run-resolver-tutorial-cmd-18" >}}
+{{% tab "Bash" %}}
 ```bash
 # Table (default) — human-readable bordered table
 scafctl run resolver -f demo.yaml --hide-execution
@@ -594,6 +753,29 @@ scafctl run resolver -f demo.yaml -i
 # CEL expression filtering
 scafctl run resolver -f demo.yaml -e '_.environment'
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Table (default) — human-readable bordered table
+scafctl run resolver -f demo.yaml --hide-execution
+
+# JSON — for scripting and piping
+scafctl run resolver -f demo.yaml -o json --hide-execution
+
+# YAML — for configuration contexts
+scafctl run resolver -f demo.yaml -o yaml --hide-execution
+
+# Quiet — suppress output (useful for exit code checks)
+scafctl run resolver -f demo.yaml -o quiet
+
+# Interactive TUI — explore and search results
+scafctl run resolver -f demo.yaml -i
+
+# CEL expression filtering
+scafctl run resolver -f demo.yaml -e '_.environment'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -601,6 +783,8 @@ scafctl run resolver -f demo.yaml -e '_.environment'
 
 Use the `--cwd` (or `-C`) global flag to run commands as if you were in a different directory. This is useful when scripting or when your solution files live in a different location:
 
+{{< tabs "run-resolver-tutorial-cmd-19" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run resolvers from a solution in another directory
 scafctl --cwd /path/to/project run resolver -f solution.yaml
@@ -611,6 +795,20 @@ scafctl -C /path/to/project run resolver -f solution.yaml
 # Combine with other flags
 scafctl -C /path/to/project run resolver -f solution.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run resolvers from a solution in another directory
+scafctl --cwd /path/to/project run resolver -f solution.yaml
+
+# Short form (similar to git -C)
+scafctl -C /path/to/project run resolver -f solution.yaml
+
+# Combine with other flags
+scafctl -C /path/to/project run resolver -f solution.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 All relative paths (including `-f`, `--output-dir`, etc.) are resolved against the specified working directory instead of the current directory.
 
@@ -623,29 +821,47 @@ A common debugging workflow is to inspect how resolver dependencies cascade.
 ### Step 1: Visualize the Graph
 
 {{< tabs "runres-debug-graph" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
-scafctl render solution --graph -f dep-demo.yaml
+scafctl run resolver --graph -f dep-demo.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
-scafctl render solution --graph -f dep-demo.yaml
+scafctl run resolver --graph -f dep-demo.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Step 2: Run Target Resolver
 
+{{< tabs "run-resolver-tutorial-cmd-20" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Step 3: Inspect a Single Resolver's Value
 
+{{< tabs "run-resolver-tutorial-cmd-21" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver base_url -f dep-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver base_url -f dep-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This lets you progressively narrow down which resolver is producing unexpected output.
 
@@ -661,7 +877,7 @@ Parameters can be passed in two equivalent ways:
 Both forms can be mixed freely.
 
 {{< tabs "runres-params" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Positional key=value syntax (recommended)
 scafctl run resolver -f parameterized.yaml env=staging
@@ -684,8 +900,8 @@ scafctl run resolver -f parameterized.yaml -r @params.yaml
 # Mix both forms (-r values and positional values are combined)
 scafctl run resolver -f parameterized.yaml -r env=prod region=us-east1
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 # Positional key=value syntax (recommended)
 scafctl run resolver -f parameterized.yaml env=staging
@@ -708,7 +924,7 @@ scafctl run resolver -f parameterized.yaml -r '@params.yaml'
 # Mix both forms
 scafctl run resolver -f parameterized.yaml -r env=prod region=us-east1
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Dynamic Help Text
@@ -716,9 +932,18 @@ scafctl run resolver -f parameterized.yaml -r env=prod region=us-east1
 When you specify a solution file with `--help`, the command shows the solution's
 resolver parameters alongside the standard help text:
 
+{{< tabs "run-resolver-tutorial-cmd-22" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f param-demo.yaml --help
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f param-demo.yaml --help
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This appends a table showing which resolvers accept CLI parameters, their types,
 and descriptions — making it easy to discover what inputs a solution expects
@@ -758,9 +983,18 @@ spec:
               expression: "'https://config.' + __self + '.example.com'"
 ```
 
+{{< tabs "run-resolver-tutorial-cmd-23" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f param-demo.yaml environment=staging -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f param-demo.yaml environment=staging -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 
@@ -777,6 +1011,8 @@ Parameter keys are validated against the solution's parameter-type resolver name
 Unknown keys are rejected early with a helpful error message that suggests the
 closest valid key when a typo is detected:
 
+{{< tabs "run-resolver-tutorial-cmd-24" >}}
+{{% tab "Bash" %}}
 ```bash
 # Typo: "envronment" instead of "environment"
 scafctl run resolver -f param-demo.yaml envronment=staging
@@ -786,6 +1022,19 @@ scafctl run resolver -f param-demo.yaml envronment=staging
 scafctl run resolver -f param-demo.yaml unknown=value
 # Error: solution does not accept input "unknown" (valid inputs: environment)
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Typo: "envronment" instead of "environment"
+scafctl run resolver -f param-demo.yaml envronment=staging
+# Error: solution does not accept input "envronment" — did you mean "environment"?
+
+# Completely unknown key
+scafctl run resolver -f param-demo.yaml unknown=value
+# Error: solution does not accept input "unknown" (valid inputs: environment)
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -795,37 +1044,76 @@ scafctl run resolver -f param-demo.yaml unknown=value
 
 Check that all resolvers succeed without running actions:
 
+{{< tabs "run-resolver-tutorial-cmd-25" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f demo.yaml -o quiet
 echo "Exit code: $?"
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f demo.yaml -o quiet
+Write-Output "Exit code: $LASTEXITCODE"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Partial Execution for Debugging
 
 Isolate a failing resolver and its dependencies:
 
+{{< tabs "run-resolver-tutorial-cmd-26" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Inspect Raw Resolved Values
 
 Skip transforms to see what providers actually return:
 
+{{< tabs "run-resolver-tutorial-cmd-27" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --skip-transform -f dep-demo.yaml -o json --hide-execution
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --skip-transform -f dep-demo.yaml -o json --hide-execution
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Preview Execution Plan
 
 Use `--graph` to see the resolver execution plan without running anything:
 
+{{< tabs "run-resolver-tutorial-cmd-28" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver --graph -f dep-demo.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver --graph -f dep-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Comparing Resolver Outputs
 
+{{< tabs "run-resolver-tutorial-cmd-29" >}}
+{{% tab "Bash" %}}
 ```bash
 # Get current values
 scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide-execution > current.json
@@ -834,12 +1122,33 @@ scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide
 scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution > staging.json
 diff current.json staging.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Get current values
+scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide-execution > current.json
+
+# Change parameters and compare
+scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution > staging.json
+diff current.json staging.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Show Execution Metrics
 
+{{< tabs "run-resolver-tutorial-cmd-30" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f demo.yaml --show-metrics -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f demo.yaml --show-metrics -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Metrics are displayed on stderr after execution completes.
 
@@ -856,6 +1165,8 @@ Metrics are displayed on stderr after execution completes.
 
 ## Quick Reference
 
+{{< tabs "run-resolver-tutorial-cmd-31" >}}
+{{% tab "Bash" %}}
 ```bash
 # All resolvers
 scafctl run resolver -f solution.yaml --hide-execution
@@ -895,6 +1206,49 @@ scafctl run resolver -f solution.yaml -i
 # Aliases: res, resolvers
 scafctl run res -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# All resolvers
+scafctl run resolver -f solution.yaml --hide-execution
+
+# Named resolvers (with dependencies)
+scafctl run resolver db config -f solution.yaml --hide-execution
+
+# JSON output (includes __execution metadata by default)
+scafctl run resolver -f solution.yaml -o json
+
+# JSON output without __execution metadata
+scafctl run resolver -f solution.yaml -o json --hide-execution
+
+# Skip transform and validation phases
+scafctl run resolver --skip-transform -f solution.yaml
+
+# Dependency graph (ASCII)
+scafctl run resolver --graph -f solution.yaml
+
+# Dependency graph (DOT/Mermaid/JSON)
+scafctl run resolver --graph --graph-format=dot -f solution.yaml
+scafctl run resolver --graph --graph-format=mermaid -f solution.yaml
+scafctl run resolver --graph --graph-format=json -f solution.yaml
+
+# Snapshot execution state
+scafctl run resolver --snapshot --snapshot-file=out.json -f solution.yaml
+
+# Snapshot with sensitive value redaction
+scafctl run resolver --snapshot --snapshot-file=out.json --redact -f solution.yaml
+
+# With parameters
+scafctl run resolver -f solution.yaml -r key=value
+
+# Interactive exploration
+scafctl run resolver -f solution.yaml -i
+
+# Aliases: res, resolvers
+scafctl run res -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Next Steps
 

--- a/docs/tutorials/scaffolding-tutorial.md
+++ b/docs/tutorials/scaffolding-tutorial.md
@@ -11,23 +11,33 @@ This tutorial covers using `scafctl new solution` to quickly scaffold new soluti
 
 The `new solution` command generates a complete, valid solution YAML file based on your inputs. Instead of writing YAML from scratch (and getting field names wrong), scaffolding gives you a working starting point.
 
-```
-┌──────────────┐         ┌──────────────┐         ┌──────────────┐
-│  Parameters  │  ────►  │  scafctl     │  ────►  │  Solution    │
-│  (name, etc) │         │  new solution│         │  YAML File   │
-└──────────────┘         └──────────────┘         └──────────────┘
+```mermaid
+flowchart LR
+  A["Parameters<br/>(name, etc)"] --> B["scafctl<br/>new solution"] --> C["Solution<br/>YAML File"]
 ```
 
 ## 1. Quick Start
 
 ### Generate a Basic Solution
 
+{{< tabs "scaffolding-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl new solution \
   --name my-app \
   --description "My application configuration" \
   --output my-app.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl new solution `
+  --name my-app `
+  --description "My application configuration" `
+  --output my-app.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This generates a valid solution file with:
 - Correct `apiVersion` and `kind`
@@ -40,37 +50,39 @@ This generates a valid solution file with:
 Immediately validate the generated file:
 
 {{< tabs "scaffolding-lint-verify" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint -f my-app.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl lint -f my-app.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Run it:
 
 {{< tabs "scaffolding-run-solution" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f my-app.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl run solution -f my-app.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ## 2. Choosing Providers
 
 Specify which providers to include in the scaffolded solution:
 
+{{< tabs "scaffolding-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Include specific providers
 scafctl new solution \
@@ -79,6 +91,18 @@ scafctl new solution \
   --providers http,cel,exec \
   --output api-collector.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Include specific providers
+scafctl new solution `
+  --name api-collector `
+  --description "Collect data from APIs" `
+  --providers http,cel,exec `
+  --output api-collector.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The generator creates resolver examples using each specified provider with correct input schemas.
 
@@ -86,22 +110,40 @@ The generator creates resolver examples using each specified provider with corre
 
 Not sure which providers to use? List them first:
 
+{{< tabs "scaffolding-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get provider
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get provider
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Or get details on a specific provider:
 
+{{< tabs "scaffolding-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl get provider http
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl get provider http
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## 3. Starting from Examples
 
 Instead of scaffolding from scratch, you can also start from an existing example:
 
 {{< tabs "scaffolding-from-examples" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Browse available solution examples
 scafctl examples list --category solutions
@@ -112,14 +154,14 @@ scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
 # Modify and validate
 scafctl lint -f my-solution.yaml
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl examples list --category solutions
 scafctl examples get solutions/email-notifier/solution.yaml -o my-solution.yaml
 scafctl lint -f my-solution.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 This is useful when you want a more complete starting point with real patterns (parameters, validation, actions, composition).
@@ -130,6 +172,8 @@ This is useful when you want a more complete starting point with real patterns (
 
 For solutions that just gather and transform data without side-effect actions:
 
+{{< tabs "scaffolding-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl new solution \
   --name data-collector \
@@ -137,17 +181,39 @@ scafctl new solution \
   --providers static,env,http,cel \
   --output data-collector.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl new solution `
+  --name data-collector `
+  --description "Gather configuration from multiple sources" `
+  --providers static,env,http,cel `
+  --output data-collector.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Then run with the resolver command:
 
+{{< tabs "scaffolding-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f data-collector.yaml -o yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f data-collector.yaml -o yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Full Workflow Solution
 
 For solutions with actions:
 
+{{< tabs "scaffolding-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl new solution \
   --name deploy-pipeline \
@@ -155,13 +221,24 @@ scafctl new solution \
   --providers static,exec,cel \
   --output deploy-pipeline.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl new solution `
+  --name deploy-pipeline `
+  --description "Deployment automation pipeline" `
+  --providers static,exec,cel `
+  --output deploy-pipeline.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Adding Tests After Scaffolding
 
 Once your solution works, add functional tests:
 
 {{< tabs "scaffolding-add-tests" >}}
-{{< tab "Bash" >}}
+{{% tab "Bash" %}}
 ```bash
 # Validate the solution
 scafctl lint -f my-solution.yaml
@@ -169,12 +246,12 @@ scafctl lint -f my-solution.yaml
 # Use the MCP server to generate test scaffolding (if using AI tools)
 # Or see the Functional Testing Tutorial for manual test writing
 ```
-{{< /tab >}}
-{{< tab "PowerShell" >}}
+{{% /tab %}}
+{{% tab "PowerShell" %}}
 ```powershell
 scafctl lint -f my-solution.yaml
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ## 5. Workflow

--- a/docs/tutorials/security-hardening.md
+++ b/docs/tutorials/security-hardening.md
@@ -1,6 +1,6 @@
 ---
 title: Security Hardening
-weight: 80
+weight: 68
 ---
 
 # Security Hardening Guide
@@ -96,10 +96,20 @@ The minimum accepted iteration count for decryption is 600,000 to prevent KDF do
 
 If the OS keychain is cleared or reset (e.g., OS reinstall), existing encrypted secrets become orphaned and are automatically deleted on next startup. To prevent data loss:
 
+{{< tabs "security-hardening-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Before clearing the keychain, export your secrets
 scafctl secrets export --encrypt --output secrets-backup.enc
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Before clearing the keychain, export your secrets
+scafctl secrets export --encrypt --output secrets-backup.enc
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Plugin Security
 
@@ -114,6 +124,8 @@ run 'scafctl build solution' to generate a lock file with pinned digests
 
 Always use lock files in production:
 
+{{< tabs "security-hardening-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 # Generate a lock file with pinned versions and digests
 scafctl build solution -f solution.yaml
@@ -121,6 +133,17 @@ scafctl build solution -f solution.yaml
 # The lock file pins exact versions and digests
 cat .scafctl.lock.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Generate a lock file with pinned versions and digests
+scafctl build solution -f solution.yaml
+
+# The lock file pins exact versions and digests
+cat .scafctl.lock.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Supply Chain Best Practices
 
@@ -152,10 +175,20 @@ auth:
     privateKeySecretName: "github-app-private-key"
 ```
 
+{{< tabs "security-hardening-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Store the key in the secret store first
 scafctl secrets set github-app-private-key < private-key.pem
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Store the key in the secret store first
+scafctl secrets set github-app-private-key < private-key.pem
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Template and Expression Security
 

--- a/docs/tutorials/snapshots-tutorial.md
+++ b/docs/tutorials/snapshots-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Snapshots Tutorial"
-weight: 80
+weight: 76
 ---
 
 # Snapshots Tutorial
@@ -16,11 +16,9 @@ Snapshots capture the state of resolver execution — values, timing, status, er
 - **Auditing** — Record what ran and what it produced
 - **Sharing** — Send a snapshot to a teammate for review (with redaction for secrets)
 
-```
-┌─────────────┐     ┌──────────────┐     ┌──────────────┐
-│   render    │ ──► │   Snapshot   │ ──► │  show / diff │
-│  solution   │     │   (JSON)     │     │   commands   │
-└─────────────┘     └──────────────┘     └──────────────┘
+```mermaid
+flowchart LR
+  A["render<br/>solution"] --> B["Snapshot<br/>(JSON)"] --> C["show / diff<br/>commands"]
 ```
 
 ## When to Use Snapshots
@@ -49,20 +47,41 @@ Snapshots are **flag-triggered** (`--snapshot`), never automatically created. He
 
 Snapshots are created with `scafctl render solution`:
 
+{{< tabs "snapshots-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Render and save snapshot
 scafctl render solution -f my-solution.yaml \
   --snapshot --snapshot-file=snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Render and save snapshot
+scafctl render solution -f my-solution.yaml `
+  --snapshot --snapshot-file=snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### From `run resolver`
 
 You can also capture snapshots when running resolvers only (without actions):
 
+{{< tabs "snapshots-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run resolver -f my-solution.yaml \
   --snapshot --snapshot-file=snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f my-solution.yaml `
+  --snapshot --snapshot-file=snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This is useful when you want to inspect resolver execution without triggering actions.
 
@@ -70,34 +89,73 @@ This is useful when you want to inspect resolver execution without triggering ac
 
 Or use the dedicated save command:
 
+{{< tabs "snapshots-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot save -f my-solution.yaml --output snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot save -f my-solution.yaml --output snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### With Parameters
 
+{{< tabs "snapshots-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl render solution -f my-solution.yaml \
   -r env=production \
   --snapshot --snapshot-file=prod-snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl render solution -f my-solution.yaml `
+  -r env=production `
+  --snapshot --snapshot-file=prod-snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### With Redaction
 
 Redact sensitive values (resolvers marked `sensitive: true`):
 
+{{< tabs "snapshots-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl render solution -f my-solution.yaml \
   --snapshot --snapshot-file=safe-snapshot.json --redact
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl render solution -f my-solution.yaml `
+  --snapshot --snapshot-file=safe-snapshot.json --redact
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Viewing Snapshots
 
 ### Summary View (Default)
 
+{{< tabs "snapshots-tutorial-cmd-6" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot show snapshot.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot show snapshot.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```
@@ -120,25 +178,52 @@ Parameters:
 
 ### Resolver Details
 
+{{< tabs "snapshots-tutorial-cmd-7" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot show snapshot.json --format resolvers
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot show snapshot.json --format resolvers
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Shows each resolver's name, status, value, duration, and provider calls.
 
 ### JSON Output
 
+{{< tabs "snapshots-tutorial-cmd-8" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot show snapshot.json --format json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot show snapshot.json --format json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Full snapshot data for programmatic processing.
 
 ### Verbose Mode
 
+{{< tabs "snapshots-tutorial-cmd-9" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot show snapshot.json --verbose
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot show snapshot.json --verbose
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Includes additional details like individual provider call timing.
 
@@ -146,9 +231,18 @@ Includes additional details like individual provider call timing.
 
 ### Basic Diff
 
+{{< tabs "snapshots-tutorial-cmd-10" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot diff before.json after.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot diff before.json after.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```
@@ -172,19 +266,40 @@ Added Resolvers:
 
 Filter out non-deterministic fields:
 
+{{< tabs "snapshots-tutorial-cmd-11" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot diff before.json after.json \
   --ignore-fields duration,providerCalls
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot diff before.json after.json `
+  --ignore-fields duration,providerCalls
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Show Only Changes
 
+{{< tabs "snapshots-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl snapshot diff before.json after.json --ignore-unchanged
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl snapshot diff before.json after.json --ignore-unchanged
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Output Formats
 
+{{< tabs "snapshots-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
 ```bash
 # Human-readable (default)
 scafctl snapshot diff before.json after.json --format human
@@ -198,11 +313,30 @@ scafctl snapshot diff before.json after.json --format unified
 # Save diff to file
 scafctl snapshot diff before.json after.json --output diff-report.json --format json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Human-readable (default)
+scafctl snapshot diff before.json after.json --format human
+
+# JSON for CI pipelines
+scafctl snapshot diff before.json after.json --format json
+
+# Unified diff format
+scafctl snapshot diff before.json after.json --format unified
+
+# Save diff to file
+scafctl snapshot diff before.json after.json --output diff-report.json --format json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Common Workflows
 
 ### Debugging a Failure
 
+{{< tabs "snapshots-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Capture the failing state
 scafctl snapshot save -f broken-solution.yaml --output failing.json
@@ -216,9 +350,28 @@ scafctl snapshot save -f fixed-solution.yaml --output fixed.json
 # 4. Verify the fix
 scafctl snapshot diff failing.json fixed.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Capture the failing state
+scafctl snapshot save -f broken-solution.yaml --output failing.json
+
+# 2. Inspect what went wrong
+scafctl snapshot show failing.json --format resolvers --verbose
+
+# 3. Fix the issue and re-capture
+scafctl snapshot save -f fixed-solution.yaml --output fixed.json
+
+# 4. Verify the fix
+scafctl snapshot diff failing.json fixed.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Regression Testing
 
+{{< tabs "snapshots-tutorial-cmd-15" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Capture baseline
 scafctl snapshot save -f solution.yaml --output baseline.json \
@@ -241,9 +394,38 @@ if ! scafctl snapshot diff baseline.json current.json \
   exit 1
 fi
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Capture baseline
+scafctl snapshot save -f solution.yaml --output baseline.json `
+  --ignore-fields duration
+
+# 2. Make changes to the solution
+# ...
+
+# 3. Capture new state
+scafctl snapshot save -f solution.yaml --output current.json
+
+# 4. Compare (ignore timing differences)
+scafctl snapshot diff baseline.json current.json `
+  --ignore-fields duration,providerCalls --format json
+
+# 5. Use exit code in CI
+scafctl snapshot diff baseline.json current.json `
+  --ignore-fields duration,providerCalls --ignore-unchanged
+if ($LASTEXITCODE -ne 0) {
+  Write-Output "Snapshot regression detected!"
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Environment Comparison
 
+{{< tabs "snapshots-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
 ```bash
 # Capture staging
 scafctl render solution -f solution.yaml -r env=staging \
@@ -256,13 +438,39 @@ scafctl render solution -f solution.yaml -r env=production \
 # Compare configurations
 scafctl snapshot diff staging.json production.json --ignore-unchanged
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Capture staging
+scafctl render solution -f solution.yaml -r env=staging `
+  --snapshot --snapshot-file=staging.json
+
+# Capture production
+scafctl render solution -f solution.yaml -r env=production `
+  --snapshot --snapshot-file=production.json
+
+# Compare configurations
+scafctl snapshot diff staging.json production.json --ignore-unchanged
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Safe Sharing
 
+{{< tabs "snapshots-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
 ```bash
 # Redact secrets before sharing
 scafctl snapshot save -f solution.yaml --output shareable.json --redact
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Redact secrets before sharing
+scafctl snapshot save -f solution.yaml --output shareable.json --redact
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Examples
 

--- a/docs/tutorials/soldiff-tutorial.md
+++ b/docs/tutorials/soldiff-tutorial.md
@@ -32,9 +32,18 @@ Solution diffing answers the question: **"What structurally changed between two 
 
 ### Basic Comparison
 
+{{< tabs "soldiff-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl solution diff solution-v1.yaml solution-v2.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl solution diff solution-v1.yaml solution-v2.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Output:
 ```
@@ -52,9 +61,18 @@ Summary: 5 total | 2 added | 0 removed | 3 changed
 
 ### JSON Output
 
+{{< tabs "soldiff-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl solution diff solution-v1.yaml solution-v2.yaml -o json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl solution diff solution-v1.yaml solution-v2.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Returns structured JSON with `changes` array and `summary` object — useful for CI pipelines and programmatic processing.
 
@@ -74,9 +92,18 @@ cat examples/soldiff/solution-v2.yaml
 
 ### Step 2: Compare Them
 
+{{< tabs "soldiff-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The diff shows:
 - `metadata.version` changed from `1.0.0` to `2.0.0`
@@ -89,6 +116,8 @@ The diff shows:
 
 In a CI pipeline, use JSON output to assert no unexpected changes:
 
+{{< tabs "soldiff-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Fail if any resolvers were removed
 diff_output=$(scafctl solution diff baseline.yaml current.yaml -o json)
@@ -98,6 +127,19 @@ if [ "$removed" -gt 0 ]; then
   exit 1
 fi
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Fail if any resolvers were removed
+$diff_output = scafctl solution diff baseline.yaml current.yaml -o json
+$parsed = $diff_output | ConvertFrom-Json
+if ($parsed.summary.removed -gt 0) {
+  Write-Output "ERROR: Resolvers were removed!"
+  exit 1
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## What Gets Compared
 
@@ -138,6 +180,8 @@ for _, c := range result.Changes {
 
 Solution diff compares *structure* (YAML schema), while snapshot diff compares *runtime output* (resolver values, timing). Use both for comprehensive change analysis:
 
+{{< tabs "soldiff-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 # 1. Compare structure
 scafctl solution diff v1.yaml v2.yaml
@@ -147,6 +191,19 @@ scafctl run resolver -f v1.yaml --snapshot --snapshot-file=before.json
 scafctl run resolver -f v2.yaml --snapshot --snapshot-file=after.json
 scafctl snapshot diff before.json after.json
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# 1. Compare structure
+scafctl solution diff v1.yaml v2.yaml
+
+# 2. Compare runtime behavior
+scafctl run resolver -f v1.yaml --snapshot --snapshot-file=before.json
+scafctl run resolver -f v2.yaml --snapshot --snapshot-file=after.json
+scafctl snapshot diff before.json after.json
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## See Also
 

--- a/docs/tutorials/telemetry-tutorial.md
+++ b/docs/tutorials/telemetry-tutorial.md
@@ -25,6 +25,8 @@ OTLP endpoint every signal is exported for backend analysis.
 
 ### Flags (per-invocation)
 
+{{< tabs "telemetry-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 # Point at a local OTel Collector
 scafctl run solution -f solution.yaml \
@@ -35,6 +37,20 @@ scafctl run solution -f solution.yaml \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
   scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Point at a local OTel Collector
+scafctl run solution -f solution.yaml `
+  --otel-endpoint localhost:4317 `
+  --otel-insecure          # disable TLS (development only)
+
+# Override with environment variable instead
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = 'localhost:4317'
+scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 | Flag | Env override | Default | Description |
 |------|-------------|---------|-------------|
@@ -60,6 +76,8 @@ any extra code).
 
 Control verbosity:
 
+{{< tabs "telemetry-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml \
   --log-level debug \
@@ -67,6 +85,17 @@ scafctl run solution -f solution.yaml \
   --otel-endpoint localhost:4317 \
   --otel-insecure
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml `
+  --log-level debug `
+  --log-format json `
+  --otel-endpoint localhost:4317 `
+  --otel-insecure
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 See the [Logging Tutorial](logging-tutorial.md) for full flag reference.
 
@@ -98,11 +127,22 @@ Without `--otel-endpoint`, tracing is disabled (noop). To inspect traces locally
 run a local collector such as [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer)
 or Jaeger and point scafctl at it:
 
+{{< tabs "telemetry-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Start local Jaeger (see examples/telemetry/ for Docker Compose)
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
   scafctl run solution -f solution.yaml --otel-insecure
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Start local Jaeger (see examples/telemetry/ for Docker Compose)
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = 'localhost:4317'
+scafctl run solution -f solution.yaml --otel-insecure
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Metrics
 
@@ -151,12 +191,24 @@ Services started:
 
 ### Run a traced command
 
+{{< tabs "telemetry-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
   scafctl run solution -f examples/actions/hello-world.yaml \
   --otel-insecure \
   --log-level debug
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = 'localhost:4317'
+scafctl run solution -f examples/actions/hello-world.yaml `
+  --otel-insecure `
+  --log-level debug
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### View traces in Jaeger
 
@@ -179,11 +231,22 @@ docker compose down
 Point scafctl at your organisation's OTLP endpoint (no `--otel-insecure` flag
 for TLS-enabled collectors):
 
+{{< tabs "telemetry-tutorial-cmd-5" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml \
   --otel-endpoint otel-collector.example.com:4317 \
   --log-level info
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml `
+  --otel-endpoint otel-collector.example.com:4317 `
+  --log-level info
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Use the environment variable in CI/CD pipelines instead of flags:
 

--- a/docs/tutorials/template-directory-rendering.md
+++ b/docs/tutorials/template-directory-rendering.md
@@ -332,9 +332,18 @@ spec:
 
 Run it:
 
+{{< tabs "template-directory-rendering-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Inspect the output:
 
@@ -471,9 +480,18 @@ workflow:
 
 Use `--dry-run` to preview what would be written without touching the filesystem:
 
+{{< tabs "template-directory-rendering-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl run solution -f solution.yaml --dry-run
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f solution.yaml --dry-run
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The `write-tree` action will report all paths that *would* be written, including
 paths transformed by `outputPath`, without creating any files.

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Validation Patterns Tutorial"
-weight: 17
+weight: 72
 ---
 
 # Validation Patterns Tutorial
@@ -11,16 +11,16 @@ Learn how to validate resolver outputs, enforce constraints on inputs, and use s
 
 scafctl offers multiple validation layers that work together to ensure configuration correctness:
 
-```
-┌─────────────────────────────────────────────┐
-│             Solution YAML                    │
-├─────────┬──────────┬──────────┬─────────────┤
-│  Lint   │  Schema  │ Validate │  Result     │
-│  Rules  │  Helper  │ Provider │  Schema     │
-│         │  Tags    │          │             │
-├─────────┴──────────┴──────────┴─────────────┤
-│      Runtime Validation (CEL + Regex)        │
-└─────────────────────────────────────────────┘
+```mermaid
+block-beta
+  columns 4
+  block:top:4
+    A["Solution YAML"]
+  end
+  B["Lint<br/>Rules"] C["Schema<br/>Helper Tags"] D["Validate<br/>Provider"] E["Result<br/>Schema"]
+  block:bottom:4
+    F["Runtime Validation (CEL + Regex)"]
+  end
 ```
 
 - **Schema helper tags** — provider-level input constraints (type, length, pattern, enum)
@@ -82,9 +82,18 @@ schema := schemahelper.ObjectSchema(
 
 When a resolver passes invalid input to this provider, the lint system catches it at analysis time:
 
+{{< tabs "validation-patterns-tutorial-cmd-1" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint my-solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint my-solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```
 ERROR [invalid-provider-input-type] resolver 'deploy': input 'replicas' expects integer, got string
@@ -138,10 +147,13 @@ spec:
               message: "Must be a valid Kubernetes resource name"
 ```
 
-> **▶ Try it:**
-> ```bash
-> scafctl run solution regex-patterns.yaml
-> ```
+{{% details "▶ Try it" %}}
+Run this example
+
+```bash
+scafctl run solution regex-patterns.yaml
+```
+{{% /details %}}
 
 ### Pattern: CEL Expression Validation
 
@@ -195,6 +207,7 @@ spec:
               message: "Password must contain a special character"
 ```
 
+> [!NOTE]
 > **Tip:** `__self` refers to the resolver's current value inside validate and transform phases. Use `_` to access the full resolver data map for cross-field validation.
 
 ### Pattern: Cross-Field Validation
@@ -302,9 +315,18 @@ ERROR: action 'deploy' result does not match schema: property 'status' must be o
 
 `scafctl lint` catches issues without executing the solution:
 
+{{< tabs "validation-patterns-tutorial-cmd-2" >}}
+{{% tab "Bash" %}}
 ```bash
 scafctl lint my-solution.yaml
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint my-solution.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Key Validation Rules
 
@@ -320,6 +342,8 @@ scafctl lint my-solution.yaml
 | `permissive-result-schema` | info | `resultSchema` without `type` constraint |
 | `undefined-required-property` | error | Required property not defined in `properties` |
 
+{{< tabs "validation-patterns-tutorial-cmd-3" >}}
+{{% tab "Bash" %}}
 ```bash
 # Lint with auto-fix where possible
 scafctl lint --fix my-solution.yaml
@@ -327,6 +351,17 @@ scafctl lint --fix my-solution.yaml
 # Lint all solutions in a directory
 scafctl lint ./solutions/
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Lint with auto-fix where possible
+scafctl lint --fix my-solution.yaml
+
+# Lint all solutions in a directory
+scafctl lint ./solutions/
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ---
 
@@ -432,10 +467,20 @@ validate:
 
 When validation fails, scafctl provides structured error messages. Use the MCP `explain_error` tool or inspect the output directly:
 
+{{< tabs "validation-patterns-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
 ```bash
 # Run with verbose output to see validation details
 scafctl run solution my-solution.yaml -v 2
 ```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Run with verbose output to see validation details
+scafctl run solution my-solution.yaml -v 2
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Common validation error patterns and their meaning:
 

--- a/examples/actions/exclusive-actions.yaml
+++ b/examples/actions/exclusive-actions.yaml
@@ -81,6 +81,10 @@ spec:
 
     finally:
       # Always runs, reports final status regardless of errors.
+      # This finally action reads main-section results via __actions (cross-section references).
+      # No dependsOn is needed — all main actions complete before finally begins.
+      # The references to updateDatabase and migrateDatabase appear in crossSectionRefs
+      # on the rendered graph (informational only, not scheduling dependencies).
       auditLog:
         description: Write an audit log entry
         displayName: Audit Log

--- a/examples/actions/finally-cleanup.yaml
+++ b/examples/actions/finally-cleanup.yaml
@@ -103,10 +103,14 @@ spec:
         inputs:
           command: "echo 'Workflow completed, all cleanup finished'"
 
-      # Upload logs regardless of test outcome
+      # Upload logs regardless of test outcome.
+      # This finally action reads the run-tests result via __actions (cross-section reference).
+      # No dependsOn is needed — all main actions complete before finally begins.
+      # The reference to run-tests appears in crossSectionRefs on the rendered graph (informational).
       upload-logs:
-        description: Upload execution logs
+        description: Upload execution logs with test outcome
         displayName: Upload Logs
         provider: exec
         inputs:
-          command: "echo 'Uploading execution logs...'"
+          command:
+            expr: "'echo Uploading logs (tests: ' + string(__actions['run-tests'].status) + ')'"

--- a/examples/actions/result-schema-validation.yaml
+++ b/examples/actions/result-schema-validation.yaml
@@ -140,10 +140,6 @@ spec:
       summary:
         description: Create summary using validated action results
         provider: exec
-        dependsOn:
-          - fetch-user
-          - list-tags
-          - get-deployment-info
         inputs:
           command:
             expr: |

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,37 @@
+{{- /* Render hook for links: resolves .md file references to proper Hugo page URLs */ -}}
+{{- $url := .Destination -}}
+{{- $text := .Text -}}
+{{- $title := .Title -}}
+
+{{- /* Detect external links */ -}}
+{{- $isExternal := or (hasPrefix $url "http://") (hasPrefix $url "https://") (hasPrefix $url "mailto:") -}}
+
+{{- if not $isExternal -}}
+  {{- /* Split anchor from URL */ -}}
+  {{- $anchor := "" -}}
+  {{- if strings.Contains $url "#" -}}
+    {{- $parts := split $url "#" -}}
+    {{- $url = index $parts 0 -}}
+    {{- $anchor = index $parts 1 -}}
+  {{- end -}}
+
+  {{- /* Resolve .md links to Hugo page paths */ -}}
+  {{- if strings.HasSuffix $url ".md" -}}
+    {{- with .Page.GetPage $url -}}
+      {{- $url = .RelPermalink -}}
+    {{- else -}}
+      {{- /* Fallback: keep original .md URL and warn so broken links surface during build */ -}}
+      {{- warnf "render-link: could not resolve .md link %q on page %q — check the file exists in Hugo's content tree" $url .Page.RelPermalink -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- /* Re-attach anchor */ -}}
+  {{- with $anchor -}}
+    {{- $url = printf "%s#%s" $url . -}}
+  {{- end -}}
+{{- end -}}
+
+<a href="{{ $url | safeURL }}"
+  {{- with $title }} title="{{ . }}"{{ end -}}
+  {{- if $isExternal }} target="_blank" rel="noopener noreferrer"{{ end -}}
+>{{ $text }}</a>

--- a/pkg/action/graph.go
+++ b/pkg/action/graph.go
@@ -59,10 +59,19 @@ type ExpandedAction struct {
 	// ForEachMetadata contains expansion information if this action was expanded from a forEach.
 	ForEachMetadata *ForEachExpansionMetadata `json:"forEachMetadata,omitempty" yaml:"forEachMetadata,omitempty" doc:"ForEach expansion info"`
 
-	// Dependencies contains the effective dependencies for this expanded action.
-	// For regular actions, this matches DependsOn plus any implicit dependencies from __actions references.
+	// Dependencies contains the same-section scheduling dependencies for this expanded action.
+	// This includes explicit dependsOn entries and any __actions references that resolve to actions
+	// within the same section. Only same-section deps affect ExecutionOrder / FinallyOrder phase
+	// computation; use CrossSectionRefs for informational traceability of cross-section reads.
 	// For expanded forEach actions, this includes dependencies on all iterations of referenced forEach actions.
-	Dependencies []string `json:"dependencies" yaml:"dependencies" doc:"Effective dependencies for scheduling"`
+	Dependencies []string `json:"dependencies" yaml:"dependencies" doc:"Same-section scheduling dependencies"`
+
+	// CrossSectionRefs lists action names from a different section that this action reads via
+	// __actions references (e.g., a finally action reading results from a main actions action).
+	// These are informational only—they do not affect FinallyOrder or ExecutionOrder phase
+	// computation because cross-section ordering is guaranteed structurally (all main actions
+	// complete before any finally action runs).
+	CrossSectionRefs []string `json:"crossSectionRefs,omitempty" yaml:"crossSectionRefs,omitempty" doc:"Cross-section __actions references (informational, not scheduling deps)"`
 
 	// ExpandedExclusive contains the effective exclusive action names for this expanded action.
 	// For forEach base action references, this expands to all iterations (e.g., "deploy" → "deploy[0]", "deploy[1]").
@@ -221,11 +230,22 @@ func expandSection(
 		}
 	}
 
-	// Second pass: compute dependencies with rewriting for forEach expansions
+	// Build the set of action names that belong to this section for cross-section detection.
+	sectionNames := make(map[string]struct{}, len(expanded))
+	for name := range expanded {
+		sectionNames[name] = struct{}{}
+	}
+
+	// Second pass: compute dependencies with rewriting for forEach expansions.
+	// Only same-section deps are placed in Dependencies and the scheduling deps map.
+	// Cross-section __actions references are recorded in CrossSectionRefs (informational).
 	for name, expandedAction := range expanded {
-		effectiveDeps := computeEffectiveDependencies(expandedAction, forEachExpansions)
-		expandedAction.Dependencies = effectiveDeps
-		deps[name] = effectiveDeps
+		sameDeps, crossRefs := computeEffectiveDependencies(expandedAction, forEachExpansions, sectionNames)
+		expandedAction.Dependencies = sameDeps
+		if len(crossRefs) > 0 {
+			expandedAction.CrossSectionRefs = crossRefs
+		}
+		deps[name] = sameDeps
 	}
 
 	// Third pass: compute expanded exclusive references with forEach rewriting
@@ -369,43 +389,69 @@ func createExpandedAction(
 // computeEffectiveDependencies computes the effective dependencies for an expanded action.
 // This includes explicit dependsOn entries and implicit dependencies from __actions references.
 // Dependencies on forEach actions are rewritten to depend on all iterations.
+// computeEffectiveDependencies resolves all __actions references and explicit dependsOn entries
+// for an expanded action and partitions them into two groups:
+//
+//   - sameSectionDeps: references to actions within sectionNames — used for scheduling
+//     (fed into ExecutionOrder / FinallyOrder phase computation).
+//   - crossSectionRefs: references to actions outside sectionNames — informational only,
+//     recorded in CrossSectionRefs for traceability. Cross-section ordering is guaranteed
+//     structurally (all main actions complete before any finally action starts).
 func computeEffectiveDependencies(
 	expanded *ExpandedAction,
 	forEachExpansions map[string][]string,
-) []string {
-	depSet := sets.Set[string]{}
+	sectionNames map[string]struct{},
+) ([]string, []string) {
+	sameSet := sets.Set[string]{}
+	crossSet := sets.Set[string]{}
 
-	// Add explicit dependsOn entries
+	insertRef := func(ref string) {
+		if _, inSection := sectionNames[ref]; inSection {
+			sameSet.Insert(ref)
+		} else {
+			crossSet.Insert(ref)
+		}
+	}
+
+	insertRefs := func(rawRef string) {
+		if expandedNames, ok := forEachExpansions[rawRef]; ok {
+			for _, n := range expandedNames {
+				insertRef(n)
+			}
+		} else {
+			insertRef(rawRef)
+		}
+	}
+
+	// Add explicit dependsOn entries (validated upstream to be same-section, but route
+	// through insertRef so cross-section smuggled entries are still partitioned correctly).
 	if expanded.Action != nil {
 		for _, dep := range expanded.DependsOn {
-			// Check if this dependency was expanded by forEach
-			if expandedNames, ok := forEachExpansions[dep]; ok {
-				// Depend on all iterations
-				depSet.Insert(expandedNames...)
-			} else {
-				depSet.Insert(dep)
-			}
+			insertRefs(dep)
 		}
 	}
 
-	// Add implicit dependencies from __actions references in deferred inputs
+	// Add implicit dependencies from __actions references in deferred inputs.
 	for _, dv := range expanded.DeferredInputs {
-		refs := extractActionsRefsFromDeferred(dv)
-		for _, ref := range refs {
-			// Check if this dependency was expanded by forEach
-			if expandedNames, ok := forEachExpansions[ref]; ok {
-				// Depend on all iterations
-				depSet.Insert(expandedNames...)
-			} else {
-				depSet.Insert(ref)
-			}
+		for _, ref := range extractActionsRefsFromDeferred(dv) {
+			insertRefs(ref)
 		}
 	}
 
-	// Convert to sorted slice for deterministic order
-	deps := sets.List(depSet)
-	sort.Strings(deps)
-	return deps
+	// Add implicit dependencies from __actions references in the when condition.
+	// The when expression is evaluated at runtime (not deferred via DeferredInputs), so we
+	// extract its __actions references here to partition them into scheduling vs informational.
+	if expanded.Action != nil && expanded.When != nil && expanded.When.Expr != nil {
+		for _, ref := range parseActionsRefsForGraph(string(*expanded.When.Expr)) {
+			insertRefs(ref)
+		}
+	}
+
+	same := sets.List(sameSet)
+	sort.Strings(same)
+	cross := sets.List(crossSet)
+	sort.Strings(cross)
+	return same, cross
 }
 
 // computeExpandedExclusive computes the effective exclusive action names for an expanded action.

--- a/pkg/action/graph_test.go
+++ b/pkg/action/graph_test.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -283,6 +284,73 @@ func TestBuildGraph_ImplicitDependencies(t *testing.T) {
 	require.Len(t, graph.ExecutionOrder, 2)
 	assert.Equal(t, []string{"task_a"}, graph.ExecutionOrder[0])
 	assert.Equal(t, []string{"task_b"}, graph.ExecutionOrder[1])
+}
+
+func TestBuildGraph_ImplicitDependencies_WhenCondition(t *testing.T) {
+	ctx := context.Background()
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"task_a": {
+				Provider: "shell",
+			},
+			"task_b": {
+				Provider: "shell",
+				// References task_a in when condition, no explicit dependsOn
+				When: &spec.Condition{Expr: graphCelExpr("__actions.task_a.results.status == 'success'")},
+			},
+		},
+	}
+
+	graph, err := BuildGraph(ctx, w, nil, nil)
+	require.NoError(t, err)
+
+	// task_b should have implicit dependency on task_a inferred from when condition
+	taskB := graph.Actions["task_b"]
+	assert.Contains(t, taskB.Dependencies, "task_a")
+
+	// Should have two phases: task_a must run before task_b
+	require.Len(t, graph.ExecutionOrder, 2)
+	assert.Equal(t, []string{"task_a"}, graph.ExecutionOrder[0])
+	assert.Equal(t, []string{"task_b"}, graph.ExecutionOrder[1])
+}
+
+func TestBuildGraph_WhenCondition_ForEachDependency(t *testing.T) {
+	// When a when condition references a forEach action, the dependency should be
+	// rewritten to all iterations of that action.
+	ctx := context.Background()
+	resolverData := map[string]any{
+		"regions": []any{"us-east", "eu-west"},
+	}
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"deploy": {
+				Provider: "shell",
+				ForEach: &spec.ForEachClause{
+					Item: "region",
+					In:   rslvrRef("regions"),
+				},
+			},
+			"notify": {
+				Provider: "shell",
+				// when references the forEach base action name
+				When: &spec.Condition{Expr: graphCelExpr("__actions.deploy.results.status == 'success'")},
+			},
+		},
+	}
+
+	graph, err := BuildGraph(ctx, w, resolverData, nil)
+	require.NoError(t, err)
+
+	// notify should depend on both forEach iterations
+	notify := graph.Actions["notify"]
+	assert.Contains(t, notify.Dependencies, "deploy[0]")
+	assert.Contains(t, notify.Dependencies, "deploy[1]")
+
+	// deploy iterations must run before notify
+	require.Len(t, graph.ExecutionOrder, 2)
+	assert.ElementsMatch(t, []string{"deploy[0]", "deploy[1]"}, graph.ExecutionOrder[0])
+	assert.Equal(t, []string{"notify"}, graph.ExecutionOrder[1])
 }
 
 func TestBuildGraph_ForEachExpansion(t *testing.T) {
@@ -942,4 +1010,125 @@ func TestEvaluateForEachArray_TypeConversions(t *testing.T) {
 		}, map[string]any{"mapval": map[string]any{"key": "val"}})
 		assert.Error(t, err)
 	})
+}
+
+// TestBuildGraph_Finally_WhenCondition_AutoDep verifies that a finally action with
+// a when condition referencing __actions.<name> from the main section has the
+// reference recorded in CrossSectionRefs (not Dependencies), since cross-section
+// ordering is guaranteed structurally and does not affect FinallyOrder phase
+// computation.
+func TestBuildGraph_Finally_WhenCondition_AutoDep(t *testing.T) {
+	ctx := context.Background()
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"build": {Provider: "shell"},
+		},
+		Finally: map[string]*Action{
+			"report": {
+				Provider: "shell",
+				// when references a regular action — dependency is auto-inferred
+				When: &spec.Condition{Expr: graphCelExpr("__actions.build.status == 'succeeded'")},
+				Inputs: map[string]*spec.ValueRef{
+					"message": literalRef("done"),
+				},
+			},
+		},
+	}
+
+	graph, err := BuildGraph(ctx, w, nil, nil)
+	require.NoError(t, err)
+
+	// report's Dependencies must be empty — "build" is in a different section and
+	// cross-section ordering is guaranteed structurally, not via FinallyOrder phases.
+	report := graph.Actions["report"]
+	require.NotNil(t, report)
+	assert.Empty(t, report.Dependencies,
+		"finally action Dependencies must not contain cross-section refs")
+
+	// "build" must appear in CrossSectionRefs instead (informational traceability)
+	assert.Contains(t, report.CrossSectionRefs, "build",
+		"finally action with when referencing __actions.build should record build in CrossSectionRefs")
+
+	// FinallyOrder must still have exactly one phase containing report
+	require.Len(t, graph.FinallyOrder, 1)
+	assert.Contains(t, graph.FinallyOrder[0], "report")
+}
+
+// TestBuildGraph_Finally_WhenCondition_IntraSection verifies that a finally action
+// with a when condition referencing another finally action produces correct
+// intra-section phase ordering.
+func TestBuildGraph_Finally_WhenCondition_IntraSection(t *testing.T) {
+	ctx := context.Background()
+	w := &Workflow{
+		Finally: map[string]*Action{
+			"cleanup-a": {Provider: "shell"},
+			"cleanup-b": {
+				Provider: "shell",
+				// when references another finally action — dep must produce phase ordering
+				When: &spec.Condition{Expr: graphCelExpr("__actions['cleanup-a'].status == 'succeeded'")},
+				Inputs: map[string]*spec.ValueRef{
+					"message": literalRef("b done"),
+				},
+			},
+		},
+	}
+
+	graph, err := BuildGraph(ctx, w, nil, nil)
+	require.NoError(t, err)
+
+	cleanupB := graph.Actions["cleanup-b"]
+	require.NotNil(t, cleanupB)
+	assert.Contains(t, cleanupB.Dependencies, "cleanup-a",
+		"intra-finally when condition dep should be auto-inferred")
+
+	// cleanup-a must be scheduled before cleanup-b
+	require.Len(t, graph.FinallyOrder, 2)
+	assert.Equal(t, []string{"cleanup-a"}, graph.FinallyOrder[0])
+	assert.Equal(t, []string{"cleanup-b"}, graph.FinallyOrder[1])
+}
+
+// BenchmarkBuildGraph_AutoDeps measures the cost of auto-dependency inference
+// for a workflow with many actions each referencing __actions in their inputs.
+func BenchmarkBuildGraph_AutoDeps(b *testing.B) {
+	ctx := context.Background()
+
+	// Build a workflow where each action depends on the previous via __actions refs
+	// (linear chain of 50 actions).
+	const n = 50
+	actions := make(map[string]*Action, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("action-%02d", i)
+		a := &Action{Provider: "shell"}
+		if i > 0 {
+			prevName := fmt.Sprintf("action-%02d", i-1)
+			a.Inputs = map[string]*spec.ValueRef{
+				"prev_result": graphExprRef("__actions." + prevName + ".results.output"),
+			}
+		} else {
+			a.Inputs = map[string]*spec.ValueRef{
+				"command": literalRef("echo start"),
+			}
+		}
+		actions[name] = a
+	}
+
+	w := &Workflow{Actions: actions}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildGraph(ctx, w, nil, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseActionsRefsForGraph measures the cost of the string-scanner
+// reference extractor on a realistic multi-reference expression.
+func BenchmarkParseActionsRefsForGraph(b *testing.B) {
+	expr := `__actions.build.results.artifact + " " + __actions.test.results.summary + " " + __actions["deploy"].results.status`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = parseActionsRefsForGraph(expr)
+	}
 }

--- a/pkg/action/graph_visualization.go
+++ b/pkg/action/graph_visualization.go
@@ -17,8 +17,12 @@ type GraphVisualization struct {
 	// FinallyPhases contains finally action phases.
 	FinallyPhases []*VisualizationPhase `json:"finallyPhases,omitempty" yaml:"finallyPhases,omitempty" doc:"Finally/cleanup action phases" maxItems:"100"`
 
-	// Edges represents dependencies between actions.
-	Edges []*VisualizationEdge `json:"edges" yaml:"edges" doc:"Dependencies between actions" maxItems:"10000"`
+	// Edges represents same-section scheduling dependencies between actions.
+	Edges []*VisualizationEdge `json:"edges" yaml:"edges" doc:"Same-section scheduling dependencies" maxItems:"10000"`
+
+	// CrossSectionEdges represents informational cross-section references
+	// (e.g. finally actions reading main-section results via __actions).
+	CrossSectionEdges []*VisualizationEdge `json:"crossSectionEdges,omitempty" yaml:"crossSectionEdges,omitempty" doc:"Informational cross-section references" maxItems:"10000"`
 
 	// Stats contains graph statistics.
 	Stats *VisualizationStats `json:"stats" yaml:"stats" doc:"Graph statistics"`
@@ -33,19 +37,21 @@ type VisualizationPhase struct {
 
 // VisualizationEdge represents a dependency edge.
 type VisualizationEdge struct {
-	From  string `json:"from" yaml:"from" doc:"Source action name" maxLength:"256" example:"deploy"`
-	To    string `json:"to" yaml:"to" doc:"Target action name" maxLength:"256" example:"build"`
-	Label string `json:"label,omitempty" yaml:"label,omitempty" doc:"Edge label" maxLength:"128" example:"depends_on"`
+	From         string `json:"from" yaml:"from" doc:"Source action name" maxLength:"256" example:"deploy"`
+	To           string `json:"to" yaml:"to" doc:"Target action name" maxLength:"256" example:"build"`
+	Label        string `json:"label,omitempty" yaml:"label,omitempty" doc:"Edge label" maxLength:"128" example:"depends_on"`
+	CrossSection bool   `json:"crossSection,omitempty" yaml:"crossSection,omitempty" doc:"Whether this edge crosses workflow sections (informational, not scheduling)"`
 }
 
 // VisualizationStats contains graph statistics.
 type VisualizationStats struct {
-	TotalActions    int     `json:"totalActions" yaml:"totalActions" doc:"Total number of actions" maximum:"1000" example:"10"`
-	TotalPhases     int     `json:"totalPhases" yaml:"totalPhases" doc:"Total number of phases" maximum:"100" example:"3"`
-	MaxParallelism  int     `json:"maxParallelism" yaml:"maxParallelism" doc:"Maximum parallelism across all phases" maximum:"1000" example:"4"`
-	AvgDependencies float64 `json:"avgDependencies" yaml:"avgDependencies" doc:"Average number of dependencies per action"`
-	HasFinally      bool    `json:"hasFinally" yaml:"hasFinally" doc:"Whether the graph has finally actions"`
-	ForEachCount    int     `json:"forEachCount" yaml:"forEachCount" doc:"Number of forEach actions" maximum:"1000" example:"2"`
+	TotalActions        int     `json:"totalActions" yaml:"totalActions" doc:"Total number of actions" maximum:"1000" example:"10"`
+	TotalPhases         int     `json:"totalPhases" yaml:"totalPhases" doc:"Total number of phases" maximum:"100" example:"3"`
+	MaxParallelism      int     `json:"maxParallelism" yaml:"maxParallelism" doc:"Maximum parallelism across all phases" maximum:"1000" example:"4"`
+	AvgDependencies     float64 `json:"avgDependencies" yaml:"avgDependencies" doc:"Average same-section scheduling dependencies per action"`
+	AvgCrossSectionRefs float64 `json:"avgCrossSectionRefs,omitempty" yaml:"avgCrossSectionRefs,omitempty" doc:"Average cross-section references per action"`
+	HasFinally          bool    `json:"hasFinally" yaml:"hasFinally" doc:"Whether the graph has finally actions"`
+	ForEachCount        int     `json:"forEachCount" yaml:"forEachCount" doc:"Number of forEach actions" maximum:"1000" example:"2"`
 }
 
 // BuildVisualization creates visualization data from a Graph.
@@ -59,9 +65,10 @@ func BuildVisualization(graph *Graph) *GraphVisualization {
 	}
 
 	viz := &GraphVisualization{
-		Phases:        make([]*VisualizationPhase, 0, len(graph.ExecutionOrder)),
-		FinallyPhases: make([]*VisualizationPhase, 0, len(graph.FinallyOrder)),
-		Edges:         make([]*VisualizationEdge, 0),
+		Phases:            make([]*VisualizationPhase, 0, len(graph.ExecutionOrder)),
+		FinallyPhases:     make([]*VisualizationPhase, 0, len(graph.FinallyOrder)),
+		Edges:             make([]*VisualizationEdge, 0),
+		CrossSectionEdges: make([]*VisualizationEdge, 0),
 	}
 
 	// Build main action phases
@@ -82,12 +89,24 @@ func BuildVisualization(graph *Graph) *GraphVisualization {
 		})
 	}
 
-	// Build edges from action dependencies
+	// Build edges from same-section action dependencies
 	for name, action := range graph.Actions {
 		for _, dep := range action.Dependencies {
 			viz.Edges = append(viz.Edges, &VisualizationEdge{
 				From: name,
 				To:   dep,
+			})
+		}
+	}
+
+	// Build cross-section edges from informational references
+	for name, action := range graph.Actions {
+		for _, ref := range action.CrossSectionRefs {
+			viz.CrossSectionEdges = append(viz.CrossSectionEdges, &VisualizationEdge{
+				From:         name,
+				To:           ref,
+				Label:        "reads",
+				CrossSection: true,
 			})
 		}
 	}
@@ -98,6 +117,12 @@ func BuildVisualization(graph *Graph) *GraphVisualization {
 			return viz.Edges[i].From < viz.Edges[j].From
 		}
 		return viz.Edges[i].To < viz.Edges[j].To
+	})
+	sort.Slice(viz.CrossSectionEdges, func(i, j int) bool {
+		if viz.CrossSectionEdges[i].From != viz.CrossSectionEdges[j].From {
+			return viz.CrossSectionEdges[i].From < viz.CrossSectionEdges[j].From
+		}
+		return viz.CrossSectionEdges[i].To < viz.CrossSectionEdges[j].To
 	})
 
 	// Calculate stats
@@ -128,17 +153,22 @@ func calculateVisualizationStats(graph *Graph, _ *GraphVisualization) *Visualiza
 	}
 	stats.MaxParallelism = maxParallelism
 
-	// Calculate average dependencies
+	// Calculate average dependencies and cross-section refs
 	totalDeps := 0
+	totalCrossRefs := 0
 	forEachCount := 0
 	for _, action := range graph.Actions {
 		totalDeps += len(action.Dependencies)
+		totalCrossRefs += len(action.CrossSectionRefs)
 		if action.ForEachMetadata != nil {
 			forEachCount++
 		}
 	}
 	if len(graph.Actions) > 0 {
 		stats.AvgDependencies = float64(totalDeps) / float64(len(graph.Actions))
+		if totalCrossRefs > 0 {
+			stats.AvgCrossSectionRefs = float64(totalCrossRefs) / float64(len(graph.Actions))
+		}
 	}
 	stats.ForEachCount = forEachCount
 
@@ -178,11 +208,21 @@ func (v *GraphVisualization) RenderASCII(w io.Writer) error {
 			fmt.Fprintf(w, "Phase %d:\n", phase.Phase)
 			for _, actionName := range phase.Actions {
 				deps := v.getDependencies(actionName)
-				if len(deps) > 0 {
+				crossRefs := v.getCrossSectionRefs(actionName)
+				hasDeps := len(deps) > 0 || len(crossRefs) > 0
+				if hasDeps {
 					fmt.Fprintf(w, "  - %s\n", actionName)
-					fmt.Fprintln(w, "    depends on:")
-					for _, dep := range deps {
-						fmt.Fprintf(w, "      * %s\n", dep)
+					if len(deps) > 0 {
+						fmt.Fprintln(w, "    depends on:")
+						for _, dep := range deps {
+							fmt.Fprintf(w, "      * %s\n", dep)
+						}
+					}
+					if len(crossRefs) > 0 {
+						fmt.Fprintln(w, "    reads from:")
+						for _, ref := range crossRefs {
+							fmt.Fprintf(w, "      ~ %s\n", ref)
+						}
 					}
 				} else {
 					fmt.Fprintf(w, "  - %s\n", actionName)
@@ -198,6 +238,9 @@ func (v *GraphVisualization) RenderASCII(w io.Writer) error {
 	fmt.Fprintf(w, "  Total Phases: %d\n", v.Stats.TotalPhases)
 	fmt.Fprintf(w, "  Max Parallelism: %d\n", v.Stats.MaxParallelism)
 	fmt.Fprintf(w, "  Avg Dependencies: %.2f\n", v.Stats.AvgDependencies)
+	if v.Stats.AvgCrossSectionRefs > 0 {
+		fmt.Fprintf(w, "  Avg Cross-Section Refs: %.2f\n", v.Stats.AvgCrossSectionRefs)
+	}
 	if v.Stats.ForEachCount > 0 {
 		fmt.Fprintf(w, "  ForEach Expansions: %d\n", v.Stats.ForEachCount)
 	}
@@ -218,6 +261,18 @@ func (v *GraphVisualization) getDependencies(actionName string) []string {
 	}
 	sort.Strings(deps)
 	return deps
+}
+
+// getCrossSectionRefs returns cross-section references for an action.
+func (v *GraphVisualization) getCrossSectionRefs(actionName string) []string {
+	refs := make([]string, 0)
+	for _, edge := range v.CrossSectionEdges {
+		if edge.From == actionName {
+			refs = append(refs, edge.To)
+		}
+	}
+	sort.Strings(refs)
+	return refs
 }
 
 // RenderDOT generates GraphViz DOT format.
@@ -275,6 +330,18 @@ func (v *GraphVisualization) RenderDOT(w io.Writer) error {
 			label = fmt.Sprintf(" [label=\"%s\"]", edge.Label)
 		}
 		fmt.Fprintf(w, "  \"%s\" -> \"%s\"%s;\n", edge.From, edge.To, label)
+	}
+
+	// Cross-section edges (dashed)
+	if len(v.CrossSectionEdges) > 0 {
+		fmt.Fprintln(w, "  // Cross-section references")
+		for _, edge := range v.CrossSectionEdges {
+			label := "reads"
+			if edge.Label != "" {
+				label = edge.Label
+			}
+			fmt.Fprintf(w, "  \"%s\" -> \"%s\" [style=dashed, label=\"%s\", color=grey];\n", edge.From, edge.To, label)
+		}
 	}
 
 	fmt.Fprintln(w, "}")
@@ -338,6 +405,17 @@ func (v *GraphVisualization) RenderMermaid(w io.Writer) error {
 		} else {
 			fmt.Fprintf(w, "  %s --> %s\n", fromID, toID)
 		}
+	}
+
+	// Cross-section edges (dotted)
+	for _, edge := range v.CrossSectionEdges {
+		fromID := sanitizeMermaidID(edge.From)
+		toID := sanitizeMermaidID(edge.To)
+		label := "reads"
+		if edge.Label != "" {
+			label = edge.Label
+		}
+		fmt.Fprintf(w, "  %s -.->|%s| %s\n", fromID, label, toID)
 	}
 
 	// Styles

--- a/pkg/action/graph_visualization_test.go
+++ b/pkg/action/graph_visualization_test.go
@@ -476,3 +476,126 @@ func TestGraphVisualization_ComplexGraph(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(buf.String(), "graph LR"))
 }
+
+func TestBuildVisualization_CrossSectionEdges(t *testing.T) {
+	graph := &Graph{
+		Actions: map[string]*ExpandedAction{
+			"build": {ExpandedName: "build", Dependencies: nil, Section: "actions"},
+			"test":  {ExpandedName: "test", Dependencies: []string{"build"}, Section: "actions"},
+			"report": {
+				ExpandedName:     "report",
+				Dependencies:     []string{},
+				CrossSectionRefs: []string{"test"},
+				Section:          "finally",
+			},
+		},
+		ExecutionOrder: [][]string{{"build"}, {"test"}},
+		FinallyOrder:   [][]string{{"report"}},
+	}
+
+	viz := BuildVisualization(graph)
+
+	// Same-section edges only
+	require.Len(t, viz.Edges, 1)
+	assert.Equal(t, "test", viz.Edges[0].From)
+	assert.Equal(t, "build", viz.Edges[0].To)
+
+	// Cross-section edges
+	require.Len(t, viz.CrossSectionEdges, 1)
+	assert.Equal(t, "report", viz.CrossSectionEdges[0].From)
+	assert.Equal(t, "test", viz.CrossSectionEdges[0].To)
+	assert.Equal(t, "reads", viz.CrossSectionEdges[0].Label)
+	assert.True(t, viz.CrossSectionEdges[0].CrossSection)
+
+	// Stats
+	assert.InDelta(t, 1.0/3.0, viz.Stats.AvgDependencies, 0.01) // 1 dep / 3 actions
+	assert.InDelta(t, 1.0/3.0, viz.Stats.AvgCrossSectionRefs, 0.01)
+}
+
+func TestGraphVisualization_RenderASCII_CrossSectionRefs(t *testing.T) {
+	graph := &Graph{
+		Actions: map[string]*ExpandedAction{
+			"build": {ExpandedName: "build", Section: "actions"},
+			"report": {
+				ExpandedName:     "report",
+				CrossSectionRefs: []string{"build"},
+				Section:          "finally",
+			},
+		},
+		ExecutionOrder: [][]string{{"build"}},
+		FinallyOrder:   [][]string{{"report"}},
+	}
+
+	viz := BuildVisualization(graph)
+	var buf bytes.Buffer
+	err := viz.RenderASCII(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "reads from:")
+	assert.Contains(t, output, "~ build")
+}
+
+func TestGraphVisualization_RenderDOT_CrossSectionRefs(t *testing.T) {
+	graph := &Graph{
+		Actions: map[string]*ExpandedAction{
+			"build": {ExpandedName: "build", Section: "actions"},
+			"report": {
+				ExpandedName:     "report",
+				CrossSectionRefs: []string{"build"},
+				Section:          "finally",
+			},
+		},
+		ExecutionOrder: [][]string{{"build"}},
+		FinallyOrder:   [][]string{{"report"}},
+	}
+
+	viz := BuildVisualization(graph)
+	var buf bytes.Buffer
+	err := viz.RenderDOT(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Cross-section references")
+	assert.Contains(t, output, `style=dashed`)
+	assert.Contains(t, output, `"report" -> "build"`)
+}
+
+func TestGraphVisualization_RenderMermaid_CrossSectionRefs(t *testing.T) {
+	graph := &Graph{
+		Actions: map[string]*ExpandedAction{
+			"build": {ExpandedName: "build", Section: "actions"},
+			"report": {
+				ExpandedName:     "report",
+				CrossSectionRefs: []string{"build"},
+				Section:          "finally",
+			},
+		},
+		ExecutionOrder: [][]string{{"build"}},
+		FinallyOrder:   [][]string{{"report"}},
+	}
+
+	viz := BuildVisualization(graph)
+	var buf bytes.Buffer
+	err := viz.RenderMermaid(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "-.->|reads|")
+}
+
+func TestGraphVisualization_GetCrossSectionRefs(t *testing.T) {
+	viz := &GraphVisualization{
+		CrossSectionEdges: []*VisualizationEdge{
+			{From: "report", To: "build", Label: "reads", CrossSection: true},
+			{From: "report", To: "test", Label: "reads", CrossSection: true},
+		},
+	}
+
+	refs := viz.getCrossSectionRefs("report")
+	assert.Len(t, refs, 2)
+	assert.Equal(t, []string{"build", "test"}, refs)
+
+	// No refs for unknown action
+	assert.Empty(t, viz.getCrossSectionRefs("unknown"))
+}

--- a/pkg/action/renderer.go
+++ b/pkg/action/renderer.go
@@ -90,6 +90,11 @@ type RenderedAction struct {
 	// DependsOn lists action names that must complete first.
 	DependsOn []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" doc:"Dependency list" maxItems:"100"`
 
+	// CrossSectionRefs lists action names from the other workflow section that this action
+	// reads via __actions references. Informational only — does not affect phase scheduling.
+	// Populated for finally actions that read from workflow.actions via __actions.<name>.
+	CrossSectionRefs []string `json:"crossSectionRefs,omitempty" yaml:"crossSectionRefs,omitempty" doc:"Cross-section __actions references (informational)" maxItems:"100"`
+
 	// When contains the condition for execution.
 	// Can be a boolean (already evaluated) or a DeferredValue (requires runtime evaluation).
 	When any `json:"when,omitempty" yaml:"when,omitempty" doc:"Execution condition (bool or deferred)"`
@@ -257,14 +262,15 @@ func renderAction(action *ExpandedAction) *RenderedAction {
 	}
 
 	rendered := &RenderedAction{
-		Name:        action.ExpandedName,
-		Description: action.Description,
-		DisplayName: action.DisplayName,
-		Sensitive:   action.Sensitive,
-		Provider:    action.Provider,
-		DependsOn:   action.Dependencies,
-		Section:     action.Section,
-		Inputs:      buildRenderedInputs(action),
+		Name:             action.ExpandedName,
+		Description:      action.Description,
+		DisplayName:      action.DisplayName,
+		Sensitive:        action.Sensitive,
+		Provider:         action.Provider,
+		DependsOn:        action.Dependencies,
+		CrossSectionRefs: action.CrossSectionRefs,
+		Section:          action.Section,
+		Inputs:           buildRenderedInputs(action),
 	}
 
 	// Set original name if this is a forEach iteration

--- a/pkg/action/renderer_test.go
+++ b/pkg/action/renderer_test.go
@@ -452,9 +452,10 @@ func TestRender_WithFinallySection(t *testing.T) {
 				Section:      "actions",
 			},
 			"cleanup": {
-				Action:       &Action{Name: "cleanup", Provider: "shell"},
-				ExpandedName: "cleanup",
-				Section:      "finally",
+				Action:           &Action{Name: "cleanup", Provider: "shell"},
+				ExpandedName:     "cleanup",
+				Section:          "finally",
+				CrossSectionRefs: []string{"build"},
 			},
 			"notify": {
 				Action:       &Action{Name: "notify", Provider: "http"},
@@ -482,6 +483,10 @@ func TestRender_WithFinallySection(t *testing.T) {
 	assert.Equal(t, "actions", rendered.Actions["build"].Section)
 	assert.Equal(t, "finally", rendered.Actions["cleanup"].Section)
 	assert.Equal(t, "finally", rendered.Actions["notify"].Section)
+
+	// Check CrossSectionRefs round-trip
+	assert.Equal(t, []string{"build"}, rendered.Actions["cleanup"].CrossSectionRefs)
+	assert.Empty(t, rendered.Actions["build"].CrossSectionRefs)
 }
 
 func TestRender_WithSensitiveFlag(t *testing.T) {

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -438,11 +439,15 @@ func validateDependsOn(action *Action, section string, workflow *Workflow, errs 
 		}
 
 		if _, exists := validActions[dep]; !exists {
+			msg := fmt.Sprintf("dependency %q not found in %s section", dep, section)
+			if section == "finally" {
+				msg += fmt.Sprintf("; to read results from %q, reference it via __actions['%s'] in your inputs or when condition (dependencies are auto-inferred from __actions references)", dep, dep)
+			}
 			errs.AddError(&ValidationError{
 				Section:    section,
 				ActionName: action.Name,
 				Field:      "dependsOn",
-				Message:    fmt.Sprintf("dependency %q not found in %s section", dep, section),
+				Message:    msg,
 			})
 		}
 
@@ -517,35 +522,67 @@ func validateProvider(action *Action, section string, registry RegistryInterface
 	}
 }
 
-// validateActionsReferences validates __actions references in action inputs.
+// validateActionsReferences validates __actions references in action inputs and when condition.
+// Dependencies are automatically inferred from __actions references during graph
+// building, so only existence of the referenced action is validated here.
 func validateActionsReferences(action *Action, section string, workflow *Workflow, errs *AggregatedValidationError) {
-	// Rule 9: __actions.<name> references must be valid
-	refs := extractActionsReferences(action)
+	// Build a map from ref name -> the field that first introduces it, so each
+	// validation error names the correct source field ("inputs" or "when").
+	refField := make(map[string]string)
+
+	// Collect refs from inputs first.
+	inputRefs := make(map[string]struct{})
+	for _, valueRef := range action.Inputs {
+		extractRefsFromValueRef(valueRef, inputRefs)
+	}
+	for ref := range inputRefs {
+		refField[ref] = "inputs"
+	}
+
+	// Collect refs from when condition; only record the field if not already seen in inputs.
+	if action.When != nil && action.When.Expr != nil {
+		whenRefs := make(map[string]struct{})
+		extractRefsFromExpression(action.When.Expr, whenRefs)
+		for ref := range whenRefs {
+			if _, alreadyInInputs := refField[ref]; !alreadyInInputs {
+				refField[ref] = "when"
+			}
+		}
+	}
+
+	// Sort ref names for deterministic validation error ordering.
+	refs := make([]string, 0, len(refField))
+	for ref := range refField {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
 
 	for _, ref := range refs {
-		// For regular actions: referenced action must be in dependsOn
+		field := refField[ref]
+		// Self-references create an implicit cycle during graph building; catch them early.
+		if ref == action.Name {
+			errs.AddError(&ValidationError{
+				Section:    section,
+				ActionName: action.Name,
+				Field:      field,
+				Message:    fmt.Sprintf("__actions reference to %q: an action cannot reference itself", ref),
+			})
+			continue
+		}
+
+		// For regular actions: referenced action must exist in the actions section
 		if section == "actions" {
-			if !slices.Contains(action.DependsOn, ref) {
-				// Also check if the action exists at all
-				if _, exists := workflow.Actions[ref]; !exists {
-					errs.AddError(&ValidationError{
-						Section:    section,
-						ActionName: action.Name,
-						Field:      "inputs",
-						Message:    fmt.Sprintf("__actions reference to %q: action not found", ref),
-					})
-				} else {
-					errs.AddError(&ValidationError{
-						Section:    section,
-						ActionName: action.Name,
-						Field:      "inputs",
-						Message:    fmt.Sprintf("__actions reference to %q requires it to be listed in dependsOn", ref),
-					})
-				}
+			if _, exists := workflow.Actions[ref]; !exists {
+				errs.AddError(&ValidationError{
+					Section:    section,
+					ActionName: action.Name,
+					Field:      field,
+					Message:    fmt.Sprintf("__actions reference to %q: action not found", ref),
+				})
 			}
 		}
 
-		// For finally actions: referenced action must exist in regular actions or be in dependsOn
+		// For finally actions: referenced action must exist in regular actions or finally actions
 		if section == "finally" {
 			_, inActions := workflow.Actions[ref]
 			_, inFinally := workflow.Finally[ref]
@@ -554,47 +591,12 @@ func validateActionsReferences(action *Action, section string, workflow *Workflo
 				errs.AddError(&ValidationError{
 					Section:    section,
 					ActionName: action.Name,
-					Field:      "inputs",
+					Field:      field,
 					Message:    fmt.Sprintf("__actions reference to %q: action not found", ref),
 				})
 			}
-
-			// If referencing a finally action, it must be in dependsOn
-			if inFinally && !slices.Contains(action.DependsOn, ref) && ref != action.Name {
-				errs.AddError(&ValidationError{
-					Section:    section,
-					ActionName: action.Name,
-					Field:      "inputs",
-					Message:    fmt.Sprintf("__actions reference to finally action %q requires it to be listed in dependsOn", ref),
-				})
-			}
 		}
 	}
-}
-
-// extractActionsReferences extracts action names referenced via __actions from inputs and when condition.
-func extractActionsReferences(action *Action) []string {
-	refs := make(map[string]struct{})
-
-	// Extract from inputs
-	for _, valueRef := range action.Inputs {
-		if valueRef == nil {
-			continue
-		}
-		extractRefsFromValueRef(valueRef, refs)
-	}
-
-	// Extract from when condition
-	if action.When != nil && action.When.Expr != nil {
-		extractRefsFromExpression(action.When.Expr, refs)
-	}
-
-	// Convert to slice
-	result := make([]string, 0, len(refs))
-	for ref := range refs {
-		result = append(result, ref)
-	}
-	return result
 }
 
 // extractRefsFromValueRef extracts __actions references from a ValueRef.
@@ -659,18 +661,46 @@ func extractRefsFromTemplate(tmpl *gotmpl.GoTemplatingContent, refs map[string]s
 // parseActionsRefsFromString parses __actions.<name> patterns from a string.
 func parseActionsRefsFromString(s string, refs map[string]struct{}) {
 	// Pattern: __actions.actionName or __actions["actionName"]
-	// actionName can be followed by .field or ["field"]
+	// Occurrences inside single-quoted, double-quoted, or backtick-delimited string
+	// literals are skipped so that e.g. 'prefix_actions.build' in a CEL string does
+	// not produce a false dep.
 
-	// Simple pattern matching for __actions.name
+	const sentinel = "__actions"
 	idx := 0
-	for idx < len(s) {
-		// Find __actions
-		actionsIdx := strings.Index(s[idx:], "__actions")
-		if actionsIdx == -1 {
-			break
-		}
-		idx += actionsIdx + len("__actions")
+	quoteChar := byte(0) // 0 = not inside a quoted string
 
+	for idx < len(s) {
+		ch := s[idx]
+
+		// Track quote context; handle backslash-escaped quotes inside strings.
+		// Backtick strings are raw (no escape sequences), so only the closing
+		// backtick ends them.
+		if quoteChar == 0 {
+			if ch == '"' || ch == '\'' || ch == '`' {
+				quoteChar = ch
+				idx++
+				continue
+			}
+		} else {
+			// Backtick strings cannot contain escape sequences
+			if quoteChar != '`' && ch == '\\' && idx+1 < len(s) {
+				idx += 2 // skip escaped character (e.g. \", \')
+				continue
+			}
+			if ch == quoteChar {
+				quoteChar = 0
+			}
+			idx++
+			continue
+		}
+
+		// Only attempt matches outside quoted strings
+		if !strings.HasPrefix(s[idx:], sentinel) {
+			idx++
+			continue
+		}
+
+		idx += len(sentinel)
 		if idx >= len(s) {
 			break
 		}

--- a/pkg/action/validation_test.go
+++ b/pkg/action/validation_test.go
@@ -489,7 +489,7 @@ func TestValidateWorkflow_ActionsReferences(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("__actions reference without dependsOn", func(t *testing.T) {
+	t.Run("__actions reference without dependsOn is valid (auto-inferred)", func(t *testing.T) {
 		w := &Workflow{
 			Actions: map[string]*Action{
 				"build": {Provider: "shell"},
@@ -502,8 +502,7 @@ func TestValidateWorkflow_ActionsReferences(t *testing.T) {
 			},
 		}
 		err := ValidateWorkflow(w, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "requires it to be listed in dependsOn")
+		assert.NoError(t, err)
 	})
 
 	t.Run("__actions reference to nonexistent action", func(t *testing.T) {
@@ -540,7 +539,7 @@ func TestValidateWorkflow_ActionsReferences(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("finally __actions reference to finally requires dependsOn", func(t *testing.T) {
+	t.Run("finally __actions reference to finally without dependsOn is valid (auto-inferred)", func(t *testing.T) {
 		w := &Workflow{
 			Finally: map[string]*Action{
 				"cleanup1": {Provider: "shell"},
@@ -553,11 +552,10 @@ func TestValidateWorkflow_ActionsReferences(t *testing.T) {
 			},
 		}
 		err := ValidateWorkflow(w, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "requires it to be listed in dependsOn")
+		assert.NoError(t, err)
 	})
 
-	t.Run("template __actions reference", func(t *testing.T) {
+	t.Run("template __actions reference without dependsOn is valid (auto-inferred)", func(t *testing.T) {
 		w := &Workflow{
 			Actions: map[string]*Action{
 				"build": {Provider: "shell"},
@@ -570,8 +568,83 @@ func TestValidateWorkflow_ActionsReferences(t *testing.T) {
 			},
 		}
 		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("self-reference in actions section is rejected", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"deploy": {
+					Provider: "shell",
+					Inputs: map[string]*spec.ValueRef{
+						"status": {Expr: celExpr("__actions.deploy.results.status")},
+					},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "requires it to be listed in dependsOn")
+		assert.Contains(t, err.Error(), "cannot reference itself")
+	})
+
+	t.Run("self-reference in finally section is rejected", func(t *testing.T) {
+		w := &Workflow{
+			Finally: map[string]*Action{
+				"cleanup": {
+					Provider: "shell",
+					Inputs: map[string]*spec.ValueRef{
+						"status": {Expr: celExpr("__actions.cleanup.results.status")},
+					},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot reference itself")
+	})
+
+	t.Run("finally __actions reference to nonexistent action is rejected", func(t *testing.T) {
+		w := &Workflow{
+			Finally: map[string]*Action{
+				"cleanup": {
+					Provider: "shell",
+					Inputs: map[string]*spec.ValueRef{
+						"status": {Expr: celExpr("__actions.nonexistent.results.status")},
+					},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "action not found")
+	})
+
+	t.Run("self-reference via when condition in actions section is rejected", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"deploy": {
+					Provider: "shell",
+					When:     &spec.Condition{Expr: celExpr("__actions.deploy.results.status == 'success'")},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot reference itself")
+	})
+
+	t.Run("when condition referencing another valid action is accepted", func(t *testing.T) {
+		w := &Workflow{
+			Actions: map[string]*Action{
+				"build": {Provider: "shell"},
+				"deploy": {
+					Provider: "shell",
+					When:     &spec.Condition{Expr: celExpr("__actions.build.results.status == 'success'")},
+				},
+			},
+		}
+		err := ValidateWorkflow(w, nil)
+		assert.NoError(t, err)
 	})
 }
 
@@ -840,6 +913,46 @@ func TestParseActionsRefsFromString(t *testing.T) {
 			name:     "no __actions reference",
 			input:    "some.other.path",
 			expected: []string{},
+		},
+		{
+			name:     "reference inside double-quoted string is ignored",
+			input:    `"__actions.build.results are ready"`,
+			expected: []string{},
+		},
+		{
+			name:     "reference inside single-quoted string is ignored",
+			input:    `'__actions.build.results are ready'`,
+			expected: []string{},
+		},
+		{
+			name:     "real ref after quoted false-positive",
+			input:    `"ignore __actions.fake.x" + __actions.real.results`,
+			expected: []string{"real"},
+		},
+		{
+			name:     "mixed real and quoted refs",
+			input:    `__actions.producer.results.value > 0 ? "__actions.commented.out" : __actions.consumer.inputs.x`,
+			expected: []string{"producer", "consumer"},
+		},
+		{
+			name:     "backslash-escaped quote does not end string",
+			input:    `"prefix \"__actions.fake.x\" end" + __actions.real.results`,
+			expected: []string{"real"},
+		},
+		{
+			name:     "reference inside backtick string is ignored",
+			input:    "`__actions.build.results are ready`",
+			expected: []string{},
+		},
+		{
+			name:     "real ref after backtick false-positive",
+			input:    "`ignore __actions.fake.x` + __actions.real.results",
+			expected: []string{"real"},
+		},
+		{
+			name:     "backslash inside backtick does not escape",
+			input:    "`test \\__actions.fake.x` + __actions.real.results",
+			expected: []string{"real"},
 		},
 	}
 

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -61,7 +61,6 @@ type SolutionOptions struct {
 	NoCache         bool
 
 	// Mode flags (mutually exclusive)
-	Graph        bool   // --graph: Show resolver dependency graph
 	ActionGraph  bool   // --action-graph: Show action dependency graph
 	GraphFormat  string // --graph-format: Graph format (ascii, dot, mermaid, json)
 	Snapshot     bool   // --snapshot: Save execution snapshot
@@ -87,29 +86,20 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	cCmd := &cobra.Command{
 		Use:     "solution",
 		Aliases: []string{"sol", "s", "solutions"},
-		Short:   "Render a solution's action graph, dependency graph, or snapshot",
-		Long: `Render a solution as an executor-ready action graph, dependency graph, or snapshot.
+		Short:   "Render a solution's action graph or snapshot",
+		Long: `Render a solution as an executor-ready action graph or snapshot.
+
+NOTE: Resolver dependency graph visualization has moved to 'scafctl run resolver --graph'.
 
 DEFAULT MODE (action graph):
   Resolves all defined resolvers, then builds the action graph with materialized
   inputs where possible. Expressions referencing __actions are preserved as
   deferred expressions for runtime evaluation.
 
-GRAPH MODE (--graph):
-  Visualizes the resolver dependency graph showing execution phases, parallelization
-  opportunities, and dependencies. Useful for understanding resolver execution order.
-  
-  Supported formats:
-    ascii   - Human-readable ASCII art (default)
-    dot     - Graphviz DOT format (pipe to 'dot' command)
-    mermaid - Mermaid diagram syntax
-    json    - Machine-readable JSON format
-
 ACTION GRAPH MODE (--action-graph):
   Visualizes the action dependency graph showing execution phases, parallel actions,
   finally blocks, and dependencies. Useful for understanding action execution order.
-  
-  Supported formats are the same as --graph.
+  Use --graph-format to control the output format (ascii, dot, mermaid, json).
 
 SNAPSHOT MODE (--snapshot):
   Executes resolvers and saves the execution state to a snapshot file for
@@ -125,15 +115,6 @@ Examples:
 
   # Render action graph as YAML
   scafctl render solution -f ./solution.yaml -o yaml
-
-  # Show resolver dependency graph (ASCII)
-  scafctl render solution -f ./solution.yaml --graph
-
-  # Generate PNG graph using Graphviz
-  scafctl render solution -f ./solution.yaml --graph --graph-format=dot | dot -Tpng > graph.png
-
-  # Generate Mermaid diagram
-  scafctl render solution -f ./solution.yaml --graph --graph-format=mermaid
 
   # Show action dependency graph (ASCII)
   scafctl render solution -f ./solution.yaml --action-graph
@@ -181,9 +162,6 @@ Examples:
 
 			// Validate mutually exclusive modes
 			modeCount := 0
-			if options.Graph {
-				modeCount++
-			}
 			if options.ActionGraph {
 				modeCount++
 			}
@@ -191,7 +169,7 @@ Examples:
 				modeCount++
 			}
 			if modeCount > 1 {
-				err := fmt.Errorf("--graph, --action-graph, and --snapshot are mutually exclusive")
+				err := fmt.Errorf("--action-graph and --snapshot are mutually exclusive")
 				writeSolutionError(options, err.Error())
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -204,7 +182,17 @@ Examples:
 			}
 
 			// Validate output format
-			if options.Output != "" && !options.Graph && !options.ActionGraph {
+			if options.ActionGraph && options.flagsChanged["output"] {
+				err := fmt.Errorf("--output is not applicable with --action-graph; use --graph-format to control the output format")
+				writeSolutionError(options, err.Error())
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if options.ActionGraph && options.flagsChanged["output-file"] {
+				err := fmt.Errorf("--output-file is not applicable with --action-graph; graph output is written directly to stdout")
+				writeSolutionError(options, err.Error())
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+			if options.Output != "" && !options.ActionGraph {
 				err = output.ValidateOutputType(options.Output, ValidOutputTypes)
 				if err != nil {
 					writeSolutionError(options, err.Error())
@@ -229,7 +217,6 @@ Examples:
 	cCmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
 
 	// Graph mode flags
-	cCmd.Flags().BoolVar(&options.Graph, "graph", false, "Show resolver dependency graph instead of action graph")
 	cCmd.Flags().BoolVar(&options.ActionGraph, "action-graph", false, "Show action dependency graph (ASCII, DOT, Mermaid, JSON)")
 	cCmd.Flags().StringVar(&options.GraphFormat, "graph-format", "ascii", "Graph output format: ascii, dot, mermaid, json")
 
@@ -255,9 +242,6 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	lgr := logger.FromContext(ctx)
 
 	// Route to appropriate mode
-	if o.Graph {
-		return o.runGraph(ctx, *lgr)
-	}
 	if o.ActionGraph {
 		return o.runActionGraphVisualization(ctx, *lgr)
 	}
@@ -346,40 +330,6 @@ func (o *SolutionOptions) runActionGraph(ctx context.Context, lgr logr.Logger) e
 
 	// Write output
 	return o.writeOutput(ctx, rendered)
-}
-
-// runGraph renders the resolver dependency graph (--graph mode)
-func (o *SolutionOptions) runGraph(ctx context.Context, lgr logr.Logger) error {
-	lgr.V(1).Info("rendering dependency graph",
-		"file", o.File,
-		"format", o.GraphFormat)
-
-	// Load the solution
-	sol, err := o.loadSolution(ctx)
-	if err != nil {
-		return o.exitWithCode(err, exitcode.FileNotFound)
-	}
-
-	if !sol.Spec.HasResolvers() {
-		return o.exitWithCode(fmt.Errorf("solution does not define any resolvers"), exitcode.ValidationFailed)
-	}
-
-	resolvers := sol.Spec.ResolversToSlice()
-	lgr.V(1).Info("building dependency graph", "resolvers", len(resolvers))
-
-	// Build dependency graph
-	graph, err := resolver.BuildGraph(resolvers, nil)
-	if err != nil {
-		return o.exitWithCode(fmt.Errorf("failed to build dependency graph: %w", err), exitcode.RenderFailed)
-	}
-
-	lgr.V(1).Info("graph built successfully",
-		"nodes", len(graph.Nodes),
-		"phases", len(graph.Phases),
-		"maxParallelism", graph.Stats.MaxParallelism)
-
-	// Render the graph
-	return o.renderGraph(graph, graph)
 }
 
 // runActionGraphVisualization renders the action graph visualization (--action-graph mode)

--- a/pkg/cmd/scafctl/render/solution_test.go
+++ b/pkg/cmd/scafctl/render/solution_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -63,18 +65,6 @@ func TestCommandSolution(t *testing.T) {
 				require.NotNil(t, flag)
 				assert.Equal(t, "o", flag.Shorthand)
 				assert.Equal(t, "json", flag.DefValue)
-			},
-		},
-		{
-			name: "has_graph_flag",
-			validate: func(t *testing.T) {
-				ioStreams, _, _ := terminal.NewTestIOStreams()
-				cliParams := &settings.Run{}
-				cmd := CommandSolution(cliParams, ioStreams, "render")
-
-				flag := cmd.Flags().Lookup("graph")
-				require.NotNil(t, flag)
-				assert.Equal(t, "false", flag.DefValue)
 			},
 		},
 		{
@@ -476,4 +466,56 @@ func TestSolutionOptions_TimeoutDefaults(t *testing.T) {
 	phaseTimeout := cmd.Flags().Lookup("phase-timeout")
 	require.NotNil(t, phaseTimeout)
 	assert.Equal(t, "5m0s", phaseTimeout.DefValue)
+}
+
+// TestSolutionOptions_ModeValidation exercises the three validation error paths
+// in the RunE callback: mutual exclusion, snapshot-file requirement, and
+// --output incompatibility with --action-graph.
+func TestSolutionOptions_ModeValidation(t *testing.T) {
+	// Path to a small real solution file so the command has a valid -f value.
+	// The validation errors are returned before solution loading occurs.
+	solutionFile := "../../../../tests/integration/solutions/actions/auto-deps/solution.yaml"
+	if _, err := os.Stat(solutionFile); err != nil {
+		t.Fatalf("test fixture not found at %s: %v", solutionFile, err)
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "action-graph and snapshot are mutually exclusive",
+			args:    []string{"-f", solutionFile, "--action-graph", "--snapshot", "--snapshot-file=" + filepath.Join(t.TempDir(), "snap.json")},
+			wantErr: "--action-graph and --snapshot are mutually exclusive",
+		},
+		{
+			name:    "snapshot without snapshot-file is rejected",
+			args:    []string{"-f", solutionFile, "--snapshot"},
+			wantErr: "--snapshot-file is required when using --snapshot",
+		},
+		{
+			name:    "output flag incompatible with action-graph",
+			args:    []string{"-f", solutionFile, "--action-graph", "--output=yaml"},
+			wantErr: "--output is not applicable with --action-graph",
+		},
+		{
+			name:    "output-file flag incompatible with action-graph",
+			args:    []string{"-f", solutionFile, "--action-graph", "--output-file=out.json"},
+			wantErr: "--output-file is not applicable with --action-graph",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ioStreams, _, _ := terminal.NewTestIOStreams()
+			cliParams := &settings.Run{}
+			cmd := CommandSolution(cliParams, ioStreams, "render")
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -504,6 +504,9 @@ func (o *SolutionOptions) writeDryRunTable(ctx context.Context, report *dryrun.R
 			if len(act.Dependencies) > 0 {
 				w.Plainlnf("    (depends on: %s)", strings.Join(act.Dependencies, ", "))
 			}
+			if len(act.CrossSectionRefs) > 0 {
+				w.Plainlnf("    (reads from: %s)", strings.Join(act.CrossSectionRefs, ", "))
+			}
 			if len(act.DeferredInputs) > 0 {
 				for k, v := range act.DeferredInputs {
 					w.Plainlnf("    (deferred: %s = %s)", k, v)

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -46,6 +46,7 @@ type WhatIfAction struct {
 	Phase              int               `json:"phase" yaml:"phase" doc:"Execution phase number" maximum:"100" example:"1"`
 	Section            string            `json:"section" yaml:"section" doc:"Workflow section (actions or finally)" maxLength:"16" example:"actions"`
 	Dependencies       []string          `json:"dependencies,omitempty" yaml:"dependencies,omitempty" doc:"Action dependencies" maxItems:"100"`
+	CrossSectionRefs   []string          `json:"crossSectionRefs,omitempty" yaml:"crossSectionRefs,omitempty" doc:"Cross-section action references (informational, not scheduling)" maxItems:"100"`
 	When               string            `json:"when,omitempty" yaml:"when,omitempty" doc:"Conditional expression" maxLength:"2048" example:"_.enabled == true"`
 	MaterializedInputs map[string]any    `json:"materializedInputs,omitempty" yaml:"materializedInputs,omitempty" doc:"Inputs resolved at plan time (only with --verbose)"`
 	DeferredInputs     map[string]string `json:"deferredInputs,omitempty" yaml:"deferredInputs,omitempty" doc:"Inputs deferred until runtime"`
@@ -115,12 +116,13 @@ func Generate(ctx context.Context, sol *solution.Solution, opts Options) (*Repor
 			for _, name := range names {
 				ea := graph.Actions[name]
 				entry := WhatIfAction{
-					Name:         name,
-					Provider:     ea.Provider,
-					Description:  ea.Description,
-					Dependencies: ea.Dependencies,
-					Section:      ea.Section,
-					Phase:        phaseMap[name],
+					Name:             name,
+					Provider:         ea.Provider,
+					Description:      ea.Description,
+					Dependencies:     ea.Dependencies,
+					CrossSectionRefs: ea.CrossSectionRefs,
+					Section:          ea.Section,
+					Phase:            phaseMap[name],
 				}
 
 				if ea.When != nil && ea.When.Expr != nil {

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -360,7 +360,8 @@ Check for common issues:
 - Circular dependencies in resolvers or actions
 - Invalid CEL expressions in when/expr fields
 - Type mismatches (resolver type vs actual value)
-- Missing dependsOn when referencing other resolvers/actions
+- Missing dependsOn when referencing other resolvers (same-section action dependencies are auto-inferred from __actions references)
+- Using dependsOn in workflow.finally to reference a workflow.actions action — this is a validation error; use __actions.<name> in inputs or when instead (the ref appears in crossSectionRefs on the rendered graph)
 
 7. Call preview_resolvers with path %q to check if resolvers execute successfully and produce expected values
 8. If the solution has tests, call run_solution_tests with path %q to verify test results
@@ -473,7 +474,8 @@ func (s *Server) handleAddActionPrompt(_ context.Context, request mcp.GetPromptR
 	}
 
 	featureHints := make([]string, 0, 6)
-	featureHints = append(featureHints, "dependsOn: list of action names this depends on")
+	featureHints = append(featureHints, "dependsOn: explicit ordering for same-section actions. If inputs or when already reference __actions.<name> within the same section, that dependency is auto-inferred and dependsOn is optional (still required for ordering without a data dependency)")
+	featureHints = append(featureHints, "dependsOn in workflow.finally: can only reference other finally actions—never actions in workflow.actions. To read results from a main action in finally, use __actions.<name> in inputs or when; the reference appears in crossSectionRefs on the rendered graph (informational only—cross-section ordering is guaranteed structurally)")
 	featureHints = append(featureHints, "when: CEL expression for conditional execution")
 	featureHints = append(featureHints, "onError: 'fail' (default) or 'continue'")
 	featureHints = append(featureHints, "retry: { maxAttempts, backoff: fixed|linear|exponential, initialDelay, maxDelay }")

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -136,6 +136,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		MaterializedInputs map[string]any      `json:"materializedInputs,omitempty"`
 		DeferredInputs     map[string]string   `json:"deferredInputs,omitempty"`
 		Dependencies       []string            `json:"dependencies,omitempty"`
+		CrossSectionRefs   []string            `json:"crossSectionRefs,omitempty"`
 		When               string              `json:"when,omitempty"`
 		Section            string              `json:"section"`
 		Phase              int                 `json:"phase"`
@@ -182,6 +183,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 			Provider:           ea.Provider,
 			MaterializedInputs: ea.MaterializedInputs,
 			Dependencies:       ea.Dependencies,
+			CrossSectionRefs:   ea.CrossSectionRefs,
 			Section:            ea.Section,
 			Phase:              phaseMap[name],
 		}

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,3 +1,5 @@
 module github.com/oakwood-commons/scafctl/site
 
 go 1.26.1
+
+require github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,0 +1,2 @@
+github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9 h1:IqP5Z74ab1Y5Clr2VjpP086LYXCAouI181XVelpEyY4=
+github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1510,50 +1510,6 @@ func TestIntegration_RenderSolutionYAML(t *testing.T) {
 // Snapshot feature tests moved to resolver tests since snapshot isn't on run solution
 
 // ============================================================================
-// Resolver Graph Tests
-// ============================================================================
-
-func TestIntegration_ResolverGraph(t *testing.T) {
-	t.Parallel()
-	stdout, _, exitCode := runScafctl(t,
-		"render", "solution",
-		"-f", "examples/actions/hello-world.yaml",
-		"--graph",
-	)
-
-	assert.Equal(t, 0, exitCode)
-	// Should show dependency relationships
-	assert.Contains(t, stdout, "Resolver Dependency Graph")
-	t.Logf("graph output: %s", stdout)
-}
-
-func TestIntegration_ResolverGraphMermaid(t *testing.T) {
-	t.Parallel()
-	stdout, _, exitCode := runScafctl(t,
-		"render", "solution",
-		"-f", "examples/actions/hello-world.yaml",
-		"--graph",
-		"--graph-format", "mermaid",
-	)
-
-	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "graph")
-}
-
-func TestIntegration_ResolverGraphJSON(t *testing.T) {
-	t.Parallel()
-	stdout, _, exitCode := runScafctl(t,
-		"render", "solution",
-		"-f", "examples/actions/hello-world.yaml",
-		"--graph",
-		"--graph-format", "json",
-	)
-
-	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "phases")
-}
-
-// ============================================================================
 // Action Graph Tests
 // ============================================================================
 
@@ -1570,6 +1526,20 @@ func TestIntegration_ActionGraph(t *testing.T) {
 	assert.Contains(t, stdout, "Action Dependency Graph")
 	assert.Contains(t, stdout, "Phase")
 	t.Logf("action graph output: %s", stdout)
+}
+
+// TestIntegration_RenderSolution_GraphFlagRemoved verifies that the legacy --graph
+// flag (removed in PR #145) is no longer accepted by "render solution".
+func TestIntegration_RenderSolution_GraphFlagRemoved(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"render", "solution",
+		"-f", "examples/actions/hello-world.yaml",
+		"--graph",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "unknown flag")
 }
 
 func TestIntegration_ActionGraphMermaid(t *testing.T) {
@@ -2662,8 +2632,8 @@ func TestIntegration_RenderSolution_FromCatalog_ByName(t *testing.T) {
 	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
-	// Render the solution graph from catalog by name (using --graph flag since resolver-demo has no workflow)
-	stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", "resolver-demo", "--graph")
+	// Render the resolver graph from catalog by name
+	stdout, _, exitCode := runScafctl(t, "run", "resolver", "-f", "resolver-demo", "--graph")
 	assert.Equal(t, 0, exitCode)
 	// Should have graph output with resolver info
 	assert.Contains(t, stdout, "environment")

--- a/tests/integration/solutions/actions/alias/solution.yaml
+++ b/tests/integration/solutions/actions/alias/solution.yaml
@@ -57,7 +57,6 @@ spec:
       verifyWithFullRef:
         description: Verify alias and __actions references return the same values
         provider: cel
-        dependsOn: [fetchConfiguration]
         inputs:
           expression: |
             {"aliasRegion": cfgAlias.region, "fullRefRegion": cfgFull.region}

--- a/tests/integration/solutions/actions/auto-deps/solution.yaml
+++ b/tests/integration/solutions/actions/auto-deps/solution.yaml
@@ -1,0 +1,187 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-auto-deps
+  version: 1.0.0
+  description: |
+    Functional tests for auto-inferred action dependencies.
+    Verifies that __actions references in CEL expressions and
+    Go templates automatically create dependency edges without
+    requiring explicit dependsOn declarations.
+
+spec:
+  workflow:
+    actions:
+      produce:
+        description: Produce a value
+        provider: cel
+        inputs:
+          expression: |
+            {"value": 42, "label": "produced"}
+
+      consume-expr:
+        description: Consume via CEL expression (no dependsOn)
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo consumed ' + string(__actions.produce.results.value)"
+
+      consume-tmpl:
+        description: Consume via Go template (no dependsOn)
+        provider: exec
+        inputs:
+          command:
+            tmpl: "echo label={{ .__actions.produce.results.label }}"
+
+      consume-conditional:
+        description: Conditional action with when referencing __actions (no dependsOn)
+        provider: exec
+        when:
+          expr: "__actions.produce.results.value > 0"
+        inputs:
+          command:
+            expr: "'echo condition-passed'"
+
+      chain-end:
+        description: Chain end consuming earlier auto-dep action
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo chained'"
+          env:
+            expr: '{"PREV_EXIT": string(__actions["consume-expr"].results.exitCode)}'
+
+    finally:
+      report:
+        description: Finally action referencing regular actions (auto-inferred)
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo produce=' + __actions.produce.status + ' chain=' + __actions['chain-end'].status"
+
+  testing:
+    cases:
+      _run-base:
+        description: Base template for run tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, auto-deps]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, auto-deps, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      all-succeed:
+        description: All actions succeed with auto-inferred dependencies
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.status == "succeeded"
+            message: "Overall status should be succeeded"
+          - expression: __output.actions["produce"].status == "succeeded"
+          - expression: __output.actions["consume-expr"].status == "succeeded"
+          - expression: __output.actions["consume-tmpl"].status == "succeeded"
+          - expression: __output.actions["consume-conditional"].status == "succeeded"
+          - expression: __output.actions["chain-end"].status == "succeeded"
+
+      execution-order:
+        description: Auto-inferred dependencies create correct phase ordering
+        extends: [_render-base]
+        assertions:
+          - expression: __output.executionOrder[0].exists(a, a == "produce")
+            message: "produce must run first (depended on by consume-expr and consume-tmpl)"
+          - expression: '!__output.executionOrder[0].exists(a, a == "consume-expr")'
+            message: "consume-expr must not be in first phase"
+          - expression: '!__output.executionOrder[0].exists(a, a == "consume-tmpl")'
+            message: "consume-tmpl must not be in first phase"
+          - expression: '!__output.executionOrder[0].exists(a, a == "consume-conditional")'
+            message: "consume-conditional must not be in first phase (when condition depends on produce)"
+
+      cel-consume-output:
+        description: CEL expression consumer receives produced value
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["consume-expr"].results.stdout.contains("consumed 42")
+            message: "Consumer should receive produced value via __actions reference"
+
+      tmpl-consume-output:
+        description: Go template consumer receives produced label
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["consume-tmpl"].results.stdout.contains("label=produced")
+            message: "Template consumer should receive produced label via __actions reference"
+
+      parallel-consumers:
+        description: Independent consumers run in the same phase
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder.exists(phase,
+                phase.exists(a, a == "consume-expr") && phase.exists(a, a == "consume-tmpl")
+              )
+            message: "consume-expr and consume-tmpl should run in the same phase (both only depend on produce)"
+
+      finally-runs:
+        description: Finally action successfully references regular action results
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["report"].status == "succeeded"
+            message: "Finally action should succeed with auto-inferred dependencies"
+          - expression: __output.actions["report"].results.stdout.contains("produce=succeeded")
+            message: "Finally action should access produce status via __actions"
+
+      render-finally-cross-section-refs:
+        description: Finally action cross-section __actions refs appear in crossSectionRefs, not dependencies
+        extends: [_render-base]
+        assertions:
+          - expression: has(__output.actions["report"].crossSectionRefs)
+            message: "report should have crossSectionRefs (reads __actions.produce and __actions['chain-end'])"
+          - expression: __output.actions["report"].crossSectionRefs.exists(r, r == "produce")
+            message: "crossSectionRefs should contain produce"
+          - expression: __output.actions["report"].crossSectionRefs.exists(r, r == "chain-end")
+            message: "crossSectionRefs should contain chain-end"
+          - expression: "!has(__output.actions[\"report\"].dependsOn) || size(__output.actions[\"report\"].dependsOn) == 0"
+            message: "report dependsOn must be empty — cross-section refs are not scheduling deps"
+
+      when-auto-dep-runs:
+        description: Action with when condition referencing __actions executes after referenced action
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["consume-conditional"].status == "succeeded"
+            message: "consume-conditional should succeed when produce.results.value > 0"
+          - expression: __output.actions["consume-conditional"].results.stdout.contains("condition-passed")
+            message: "consume-conditional should execute its command when condition is true"
+
+      when-auto-dep-phase-order:
+        description: when condition auto-dep produces correct phase ordering
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.executionOrder.exists(phase,
+                phase.exists(a, a == "produce")
+              )
+            message: "produce must appear in executionOrder"
+          - expression: >
+              __output.executionOrder.exists(phase,
+                phase.exists(a, a == "consume-conditional")
+              )
+            message: "consume-conditional must appear in executionOrder"
+          - expression: >
+              __output.executionOrder.filter(phase,
+                phase.exists(a, a == "produce")
+              ).size() == 1 &&
+              __output.executionOrder.filter(phase,
+                phase.exists(a, a == "consume-conditional")
+              ).size() == 1 &&
+              !__output.executionOrder.exists(phase,
+                phase.exists(a, a == "produce") &&
+                phase.exists(b, b == "consume-conditional")
+              )
+            message: "produce and consume-conditional must not share a phase (produce must precede consume-conditional)"

--- a/tests/integration/solutions/actions/finally-failure/solution.yaml
+++ b/tests/integration/solutions/actions/finally-failure/solution.yaml
@@ -1,0 +1,70 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-finally-failure
+  version: 1.0.0
+  description: |
+    Verifies that finally actions with cross-section __actions references
+    still run when the referenced main action has a non-zero exit code.
+
+spec:
+  workflow:
+    actions:
+      failing-action:
+        description: Main action that exits non-zero
+        provider: exec
+        onError: continue
+        inputs:
+          command: "sh -c 'exit 1'"
+
+    finally:
+      report-failure:
+        description: Finally action that reads main action exit code via __actions
+        provider: exec
+        when:
+          expr: "__actions['failing-action'].results.success == false"
+        inputs:
+          command:
+            expr: "'echo failure-detected: exitCode=' + string(__actions['failing-action'].results.exitCode)"
+
+  testing:
+    cases:
+      _run-base:
+        description: Base template for finally failure tests
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, finally, failure]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, finally, failure, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      finally-runs-after-failure:
+        description: Finally action with cross-section ref runs when main action exits non-zero
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.actions["failing-action"].results.success == false
+            message: "Main action should have non-zero exit code"
+          - expression: __output.actions["report-failure"].status == "succeeded"
+            message: "Finally action must still run when main action fails"
+          - expression: __output.actions["report-failure"].results.stdout.contains("failure-detected")
+            message: "Finally action should detect the failure via __actions cross-section ref"
+
+      cross-section-ref-not-in-deps:
+        description: Cross-section ref from finally to failed main action is in crossSectionRefs not dependencies
+        extends: [_render-base]
+        assertions:
+          - expression: has(__output.actions["report-failure"].crossSectionRefs)
+            message: "report-failure should have crossSectionRefs"
+          - expression: __output.actions["report-failure"].crossSectionRefs.exists(r, r == "failing-action")
+            message: "crossSectionRefs should contain failing-action"
+          - expression: "!has(__output.actions[\"report-failure\"].dependsOn) || size(__output.actions[\"report-failure\"].dependsOn) == 0"
+            message: "dependsOn must be empty — cross-section refs are not scheduling deps"

--- a/tests/integration/solutions/actions/finally/solution.yaml
+++ b/tests/integration/solutions/actions/finally/solution.yaml
@@ -37,8 +37,13 @@ spec:
 
     finally:
       cleanupDb:
-        description: Always clean up database
+        description: Always clean up database — reads main action result via __actions (cross-section ref)
         provider: exec
+        # No dependsOn needed — cross-section ordering is guaranteed structurally.
+        # __actions.setupDb in the when condition is recorded in crossSectionRefs on the
+        # rendered graph (informational). The when condition is always true so the action runs.
+        when:
+          expr: "__actions.setupDb.status == 'succeeded' || __actions.setupDb.status != 'succeeded'"
         inputs:
           command:
             expr: "'echo Dropping database ' + _.dbName"
@@ -95,3 +100,14 @@ spec:
         assertions:
           - expression: __output.actions["cleanupDb"].results.stdout.contains("Dropping database test_db")
             message: "Cleanup should reference the database name"
+
+      render-cross-section-refs:
+        description: Verify finally action that reads __actions.<main> has crossSectionRefs in rendered graph
+        extends: [_render-base]
+        assertions:
+          - expression: has(__output.actions["cleanupDb"].crossSectionRefs)
+            message: "cleanupDb should have crossSectionRefs (reads __actions.setupDb in when)"
+          - expression: __output.actions["cleanupDb"].crossSectionRefs.exists(r, r == "setupDb")
+            message: "crossSectionRefs should contain setupDb"
+          - expression: "!has(__output.actions[\"cleanupDb\"].dependsOn) || size(__output.actions[\"cleanupDb\"].dependsOn) == 0"
+            message: "cleanupDb dependsOn must be empty — cross-section refs are not scheduling deps"


### PR DESCRIPTION
- Replace `--graph` flag from `render solution` with `run resolver --graph` for resolver dependency graph visualization; update integration tests accordingly
- Remove the `__actions` reference dependsOn requirement from action validation: dependencies are now auto-inferred from __actions references during graph building, eliminating the need to manually list them in `dependsOn`
- Update validation tests and examples to reflect auto-inferred dependency behavior
- Add auto-deps integration test solution demonstrating implicit __actions dependencies
- Add Hugo render hook (layouts/_default/_markup/render-link.html) to resolve .md file references to proper Hugo page URLs with external link handling
- Convert all 40 tutorial files to use {{% tab %}} (percent syntax) for proper Markdown rendering inside tab shortcodes
- Fix PowerShell multiline commands across 10 tutorial files (backtick continuations were collapsed to a single line)
- Convert 11 ASCII box diagrams to Mermaid flowcharts across tutorial files; replace \n with <br/> for correct Mermaid line breaks in node labels
- Convert 98 blockquote callouts to markdown alert format (NOTE/WARNING/CAUTION/TIP) across all tutorial files
- Convert 8 'Try it' callouts to collapsible details shortcodes in cel-tutorial and validation-patterns-tutorial
- Replace logging/config ASCII reference boxes with proper Markdown tables
- Replace extension-concepts ASCII matrix with a Markdown table
