### PR TITLE
test: expand unit test coverage across catalog, auth, build, bundle, …

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+ignore:
+  - "pkg/plugin/proto/*.pb.go"
+
 coverage:
   status:
     project:

--- a/pkg/catalog/local_coverage_test.go
+++ b/pkg/catalog/local_coverage_test.go
@@ -1,0 +1,272 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalCatalog_FetchWithBundle_NoBundleLayer(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("sol-no-bundle", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	// Store without bundle data
+	_, err := cat.Store(ctx, ref, []byte("solution content"), nil, nil, false)
+	require.NoError(t, err)
+
+	// FetchWithBundle should return nil for bundleData
+	content, bundleData, info, err := cat.FetchWithBundle(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("solution content"), content)
+	assert.Nil(t, bundleData)
+	assert.Equal(t, ref.Name, info.Reference.Name)
+}
+
+func TestLocalCatalog_FetchWithBundle_WithBundle(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("sol-with-bundle", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	bundleContent := []byte("bundled tar data")
+	_, err := cat.Store(ctx, ref, []byte("solution content"), bundleContent, nil, false)
+	require.NoError(t, err)
+
+	content, bundleData, info, err := cat.FetchWithBundle(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("solution content"), content)
+	assert.Equal(t, bundleContent, bundleData)
+	assert.Equal(t, ref.Name, info.Reference.Name)
+}
+
+func TestLocalCatalog_FetchWithBundle_NotFound(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("nonexistent", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	_, _, _, err := cat.FetchWithBundle(ctx, ref) //nolint:dogsled // only testing error path
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestWriteTarEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes valid tar entry", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+
+		err := writeTarEntry(tw, "test.txt", []byte("hello world"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		// Verify we can read it back
+		content, err := extractFileFromTar(buf.Bytes(), "test.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hello world"), content)
+	})
+
+	t.Run("writes multiple entries", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+
+		require.NoError(t, writeTarEntry(tw, "a.txt", []byte("aaa")))
+		require.NoError(t, writeTarEntry(tw, "b.txt", []byte("bbb")))
+		require.NoError(t, tw.Close())
+
+		contentA, err := extractFileFromTar(buf.Bytes(), "a.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("aaa"), contentA)
+
+		contentB, err := extractFileFromTar(buf.Bytes(), "b.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("bbb"), contentB)
+	})
+}
+
+func TestExtractFileFromTar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts existing file", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		require.NoError(t, writeTarEntry(tw, "dir/file.txt", []byte("content")))
+		require.NoError(t, writeTarEntry(tw, "other.txt", []byte("other")))
+		require.NoError(t, tw.Close())
+
+		content, err := extractFileFromTar(buf.Bytes(), "dir/file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("content"), content)
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		require.NoError(t, writeTarEntry(tw, "existing.txt", []byte("data")))
+		require.NoError(t, tw.Close())
+
+		_, err := extractFileFromTar(buf.Bytes(), "missing.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in tar")
+	})
+
+	t.Run("handles empty tar", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		require.NoError(t, tw.Close())
+
+		_, err := extractFileFromTar(buf.Bytes(), "any.txt")
+		require.Error(t, err)
+	})
+}
+
+func TestLocalCatalog_StoreForce(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("force-test", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	_, err := cat.Store(ctx, ref, []byte("v1"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Without force should fail
+	_, err = cat.Store(ctx, ref, []byte("v2"), nil, nil, false)
+	require.Error(t, err)
+	assert.True(t, IsExists(err))
+
+	// With force should succeed
+	_, err = cat.Store(ctx, ref, []byte("v2"), nil, nil, true)
+	require.NoError(t, err)
+
+	// Verify updated content
+	content, _, err := cat.Fetch(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v2"), content)
+}
+
+func TestLocalCatalog_StoreWithAnnotations(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("annotated", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	annotations := map[string]string{
+		"custom-key": "custom-value",
+		"author":     "test",
+	}
+
+	info, err := cat.Store(ctx, ref, []byte("content"), nil, annotations, false)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-value", info.Annotations["custom-key"])
+	assert.Equal(t, "test", info.Annotations["author"])
+	// Built-in annotations should also be present
+	assert.Equal(t, "solution", info.Annotations[AnnotationArtifactType])
+	assert.Equal(t, "annotated", info.Annotations[AnnotationArtifactName])
+}
+
+func TestLocalCatalog_ConcurrentAccess(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	// Store a base artifact
+	ref := testRef("concurrent", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+	_, err := cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Concurrent reads should not panic.
+	// Collect errors via a channel and assert in the main goroutine to avoid
+	// calling testing.T from multiple goroutines (which is not safe).
+	errs := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, _, fetchErr := cat.Fetch(ctx, ref)
+			errs <- fetchErr
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		require.NoError(t, <-errs)
+	}
+}
+
+func TestLocalCatalog_Prune_NoOrphans(t *testing.T) {
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("kept", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+	_, err := cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+	require.NoError(t, err)
+
+	result, err := cat.Prune(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.RemovedManifests)
+	assert.Equal(t, 0, result.RemovedBlobs)
+}
+
+func TestNewLocalCatalogAt_InvalidPath(t *testing.T) {
+	// Path to a file (not a directory) to trigger an error scenario
+	tmpFile := t.TempDir() + "/testfile"
+	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o600))
+
+	// Try to create catalog in a subdirectory of a file (impossible)
+	_, err := NewLocalCatalogAt(tmpFile+"/subdir", logr.Discard())
+	require.Error(t, err)
+}
+
+// Benchmarks
+
+func BenchmarkLocalCatalog_Store(b *testing.B) {
+	tmpDir := b.TempDir()
+	cat, err := NewLocalCatalogAt(tmpDir, logr.Discard())
+	require.NoError(b, err)
+	ctx := context.Background()
+	content := []byte("benchmark content")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ref := testRef("bench", fmt.Sprintf("1.0.%d", i))
+		ref.Kind = ArtifactKindSolution
+		_, _ = cat.Store(ctx, ref, content, nil, nil, false)
+	}
+}
+
+func BenchmarkLocalCatalog_Fetch(b *testing.B) {
+	tmpDir := b.TempDir()
+	cat, err := NewLocalCatalogAt(tmpDir, logr.Discard())
+	require.NoError(b, err)
+	ctx := context.Background()
+
+	ref := testRef("bench", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+	_, err = cat.Store(ctx, ref, []byte("benchmark content"), nil, nil, false)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = cat.Fetch(ctx, ref)
+	}
+}

--- a/pkg/catalog/remote_test.go
+++ b/pkg/catalog/remote_test.go
@@ -1,0 +1,254 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRemoteCatalog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults name to registry when empty", func(t *testing.T) {
+		t.Parallel()
+		cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+			Registry:   "ghcr.io",
+			Repository: "myorg/scafctl",
+			Logger:     logr.Discard(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ghcr.io", cat.Name())
+	})
+
+	t.Run("uses explicit name", func(t *testing.T) {
+		t.Parallel()
+		cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+			Name:       "company-registry",
+			Registry:   "ghcr.io",
+			Repository: "myorg/scafctl",
+			Logger:     logr.Discard(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "company-registry", cat.Name())
+	})
+
+	t.Run("insecure flag configures transport", func(t *testing.T) {
+		t.Parallel()
+		cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+			Name:       "test",
+			Registry:   "localhost:5000",
+			Repository: "test",
+			Insecure:   true,
+			Logger:     logr.Discard(),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, cat)
+		assert.Equal(t, "localhost:5000", cat.Registry())
+	})
+}
+
+func TestRemoteCatalog_Name(t *testing.T) {
+	t.Parallel()
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "my-catalog",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-catalog", cat.Name())
+}
+
+func TestRemoteCatalog_Registry(t *testing.T) {
+	t.Parallel()
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "test",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io", cat.Registry())
+}
+
+func TestRemoteCatalog_Repository(t *testing.T) {
+	t.Parallel()
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "test",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "org/repo", cat.Repository())
+}
+
+func TestRemoteCatalog_buildRepositoryPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		registry   string
+		repository string
+		ref        Reference
+		expected   string
+	}{
+		{
+			name:       "full path with repository",
+			registry:   "ghcr.io",
+			repository: "myorg/scafctl",
+			ref:        Reference{Kind: ArtifactKindSolution, Name: "my-solution"},
+			expected:   "ghcr.io/myorg/scafctl/solutions/my-solution",
+		},
+		{
+			name:       "path without repository",
+			registry:   "ghcr.io",
+			repository: "",
+			ref:        Reference{Kind: ArtifactKindSolution, Name: "my-solution"},
+			expected:   "ghcr.io/solutions/my-solution",
+		},
+		{
+			name:       "provider artifact",
+			registry:   "registry.example.com",
+			repository: "team/artifacts",
+			ref:        Reference{Kind: ArtifactKindProvider, Name: "my-provider"},
+			expected:   "registry.example.com/team/artifacts/providers/my-provider",
+		},
+		{
+			name:       "auth-handler artifact",
+			registry:   "ghcr.io",
+			repository: "org/repo",
+			ref:        Reference{Kind: ArtifactKindAuthHandler, Name: "my-auth"},
+			expected:   "ghcr.io/org/repo/auth-handlers/my-auth",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+				Name:       "test",
+				Registry:   tc.registry,
+				Repository: tc.repository,
+				Logger:     logr.Discard(),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, cat.buildRepositoryPath(tc.ref))
+		})
+	}
+}
+
+func TestRemoteCatalog_tagForRef(t *testing.T) {
+	t.Parallel()
+
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "test",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		ref      Reference
+		expected string
+	}{
+		{
+			name:     "with version",
+			ref:      Reference{Kind: ArtifactKindSolution, Name: "sol", Version: semver.MustParse("1.2.3")},
+			expected: "1.2.3",
+		},
+		{
+			name:     "with digest",
+			ref:      Reference{Kind: ArtifactKindSolution, Name: "sol", Digest: "sha256:abc123"},
+			expected: "sha256:abc123",
+		},
+		{
+			name:     "digest takes precedence over version",
+			ref:      Reference{Kind: ArtifactKindSolution, Name: "sol", Version: semver.MustParse("1.0.0"), Digest: "sha256:abc123"},
+			expected: "sha256:abc123",
+		},
+		{
+			name:     "no version or digest returns latest",
+			ref:      Reference{Kind: ArtifactKindSolution, Name: "sol"},
+			expected: "latest",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, cat.tagForRef(tc.ref))
+		})
+	}
+}
+
+func TestRemoteCatalog_getRepository(t *testing.T) {
+	t.Parallel()
+
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "test",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+
+	ref := Reference{Kind: ArtifactKindSolution, Name: "my-solution"}
+	repo, err := cat.getRepository(ref)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+}
+
+// Benchmarks
+
+func BenchmarkNewRemoteCatalog(b *testing.B) {
+	cfg := RemoteCatalogConfig{
+		Name:       "bench",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewRemoteCatalog(cfg)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkRemoteCatalog_buildRepositoryPath(b *testing.B) {
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "bench",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(b, err)
+	ref := Reference{Kind: ArtifactKindSolution, Name: "my-solution"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cat.buildRepositoryPath(ref)
+	}
+}
+
+func BenchmarkRemoteCatalog_tagForRef(b *testing.B) {
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "bench",
+		Registry:   "ghcr.io",
+		Repository: "org/repo",
+		Logger:     logr.Discard(),
+	})
+	require.NoError(b, err)
+	ref := Reference{Kind: ArtifactKindSolution, Name: "sol", Version: semver.MustParse("1.2.3")}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cat.tagForRef(ref)
+	}
+}

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -21,6 +21,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// clockSkewCheckFunc is the function used to perform the clock skew check.
+// Tests can replace this to avoid real network calls.
+var clockSkewCheckFunc = diagnose.RunClockSkewCheck
+
 // CommandDiagnose creates the 'auth diagnose' command.
 func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
@@ -163,7 +167,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 			}
 
 			// ── 3.5. Clock skew ───────────────────────────────────────────────
-			addCheck(diagnose.RunClockSkewCheck())
+			addCheck(clockSkewCheckFunc())
 
 			// ── 4. Handler authentication status & token health ───────────────
 			// When a handler name is provided, scope checks to that handler only.

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -1,0 +1,476 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	// Replace the clock skew check with a fast, offline stub so tests
+	// don't make real HTTPS calls (~3 s each).
+	clockSkewCheckFunc = func() diagnose.Check {
+		return diagnose.Check{
+			Category: "clock",
+			Name:     "clock skew",
+			Status:   diagnose.StatusOK,
+			Message:  "stubbed — no network call",
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func TestCommandDiagnose_Structure(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+
+	assert.Equal(t, "diagnose", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "doctor")
+	assert.Contains(t, cmd.Short, "diagnostics")
+}
+
+func TestCommandDiagnose_Flags(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+
+	flag := cmd.Flags().Lookup("live-token")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestCommandDiagnose_AcceptsMaxOneArg(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	ctx, _ := newTestContext(t)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"arg1", "arg2"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts at most 1 arg")
+}
+
+func TestCommandDiagnose_NoWriterInContext(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(context.Background()) // no writer
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestCommandDiagnose_Authenticated(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{
+		Name:     "Test User",
+		Username: "testuser@example.com",
+	})
+	mock.StatusResult.ExpiresAt = time.Now().Add(1 * time.Hour)
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "[ok]")
+	assert.Contains(t, output, "authenticated")
+}
+
+func TestCommandDiagnose_NotAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "[warn]")
+	assert.Contains(t, output, "not authenticated")
+}
+
+func TestCommandDiagnose_StatusError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.StatusErr = assert.AnError
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "[fail]")
+}
+
+func TestCommandDiagnose_WithConfigSections(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	cfg := &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Entra:  &config.EntraAuthConfig{ClientID: "entra-client", TenantID: "entra-tenant"},
+			GitHub: &config.GitHubAuthConfig{ClientID: "gh-client", Hostname: "github.com"},
+			GCP:    &config.GCPAuthConfig{ClientID: "gcp-client", ImpersonateServiceAccount: "sa@project.iam"},
+		},
+	}
+	ctx = config.WithConfig(ctx, cfg)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "entra-client")
+	assert.Contains(t, output, "entra-tenant")
+	assert.Contains(t, output, "gh-client")
+	assert.Contains(t, output, "github.com")
+	assert.Contains(t, output, "gcp-client")
+	assert.Contains(t, output, "sa@project.iam")
+}
+
+func TestCommandDiagnose_TokenCache_AllValid(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "test-handler", IsExpired: false},
+		{Handler: "test-handler", IsExpired: false},
+	}
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "2 cached token(s)")
+}
+
+func TestCommandDiagnose_TokenCache_SomeExpired(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "test-handler", IsExpired: false},
+		{Handler: "test-handler", IsExpired: true},
+	}
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "1 expired")
+	assert.Contains(t, output, "[warn]")
+}
+
+func TestCommandDiagnose_TokenCache_Error(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.ListCachedTokensErr = assert.AnError
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "could not read cached tokens")
+}
+
+func TestCommandDiagnose_LiveToken_Success(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.CapabilitiesValue = nil // no CapScopesOnTokenRequest
+	mock.SetToken(&auth.Token{
+		AccessToken: "test-token",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--live-token"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "token acquired successfully")
+}
+
+func TestCommandDiagnose_LiveToken_Failure(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.CapabilitiesValue = nil // no CapScopesOnTokenRequest
+	mock.SetTokenError(assert.AnError)
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--live-token"})
+
+	err := cmd.Execute()
+	require.Error(t, err) // failCount > 0
+
+	output := buf.String()
+	assert.Contains(t, output, "[fail]")
+}
+
+func TestCommandDiagnose_LiveToken_RequiresScope(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	mock.CapabilitiesValue = []auth.Capability{auth.CapScopesOnTokenRequest}
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--live-token"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "[info]")
+	assert.Contains(t, output, "handler requires --scope")
+}
+
+func TestCommandDiagnose_ScopedToHandler(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"test-handler"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "not authenticated")
+}
+
+func TestCommandDiagnose_SummaryAllPassed(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Config file may not exist in test env, so we may get warnings.
+	// Just verify diagnostics completed successfully.
+	assert.Contains(t, output, "Diagnostics complete")
+}
+
+func TestCommandDiagnose_StructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Structured output should contain JSON, not human messages
+	assert.Contains(t, output, "registry")
+}
+
+// Benchmarks
+
+func BenchmarkCommandDiagnose(b *testing.B) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	}
+}
+
+func BenchmarkDiagnose_Authenticated(b *testing.B) {
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetAuthenticated(&auth.Claims{Name: "User"})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = withTestHandler(ctx, mock)
+
+		cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+	}
+}

--- a/pkg/cmd/scafctl/auth/login_coverage_test.go
+++ b/pkg/cmd/scafctl/auth/login_coverage_test.go
@@ -1,0 +1,374 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplayLoginResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		result   *auth.Result
+		flow     auth.Flow
+		expected []string
+	}{
+		{
+			name: "full claims interactive",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Name:     "Test User",
+					Username: "testuser",
+					Email:    "test@example.com",
+					TenantID: "tenant-123",
+				},
+				ExpiresAt: time.Now().Add(time.Hour),
+			},
+			flow:     auth.FlowInteractive,
+			expected: []string{"Authentication successful", "Test User", "testuser", "test@example.com", "tenant-123", "Interactive"},
+		},
+		{
+			name: "service principal flow",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Email: "sp@example.com",
+				},
+			},
+			flow:     auth.FlowServicePrincipal,
+			expected: []string{"Authentication successful", "sp@example.com", "Service Principal"},
+		},
+		{
+			name: "workload identity flow",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Email: "wi@example.com",
+				},
+			},
+			flow:     auth.FlowWorkloadIdentity,
+			expected: []string{"Authentication successful", "Workload Identity"},
+		},
+		{
+			name: "PAT flow",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Username: "ghuser",
+				},
+			},
+			flow:     auth.FlowPAT,
+			expected: []string{"Authentication successful", "ghuser", "Personal Access Token"},
+		},
+		{
+			name: "metadata flow",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Email: "svc@project.iam.gserviceaccount.com",
+				},
+			},
+			flow:     auth.FlowMetadata,
+			expected: []string{"Authentication successful", "Metadata Server"},
+		},
+		{
+			name: "name equals username should not duplicate",
+			result: &auth.Result{
+				Claims: &auth.Claims{
+					Name:     "sameuser",
+					Username: "sameuser",
+				},
+			},
+			flow:     auth.FlowInteractive,
+			expected: []string{"Authentication successful", "sameuser"},
+		},
+		{
+			name: "minimal claims",
+			result: &auth.Result{
+				Claims: &auth.Claims{},
+			},
+			flow:     auth.FlowDeviceCode,
+			expected: []string{"Authentication successful"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			streams := terminal.NewIOStreams(nil, &buf, &buf, false)
+			w := writer.New(streams, settings.NewCliParams())
+
+			err := displayLoginResult(w, tc.result, tc.flow)
+			require.NoError(t, err)
+
+			output := buf.String()
+			for _, exp := range tc.expected {
+				assert.Contains(t, output, exp)
+			}
+		})
+	}
+}
+
+func TestParseFlow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		flowStr     string
+		handlerName string
+		expected    auth.Flow
+		wantErr     bool
+	}{
+		{name: "empty returns default", flowStr: "", handlerName: "entra", expected: auth.Flow(""), wantErr: false},
+		{name: "device-code", flowStr: "device-code", handlerName: "entra", expected: auth.FlowDeviceCode, wantErr: false},
+		{name: "interactive", flowStr: "interactive", handlerName: "github", expected: auth.FlowInteractive, wantErr: false},
+		{name: "service-principal", flowStr: "service-principal", handlerName: "entra", expected: auth.FlowServicePrincipal, wantErr: false},
+		{name: "pat", flowStr: "pat", handlerName: "github", expected: auth.FlowPAT, wantErr: false},
+		{name: "workload-identity", flowStr: "workload-identity", handlerName: "entra", expected: auth.FlowWorkloadIdentity, wantErr: false},
+		{name: "invalid flow", flowStr: "invalid", handlerName: "entra", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			flow, err := parseFlow(tc.flowStr, tc.handlerName)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, flow)
+			}
+		})
+	}
+}
+
+func TestCommandLogin_Structure(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+
+	assert.Equal(t, "login <handler>", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.True(t, cmd.SilenceUsage)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandLogin_Flags(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+
+	flags := cmd.Flags()
+	assert.NotNil(t, flags.Lookup("tenant"), "tenant flag should exist")
+	assert.NotNil(t, flags.Lookup("client-id"), "client-id flag should exist")
+	assert.NotNil(t, flags.Lookup("hostname"), "hostname flag should exist")
+	assert.NotNil(t, flags.Lookup("timeout"), "timeout flag should exist")
+	assert.NotNil(t, flags.Lookup("flow"), "flow flag should exist")
+	assert.NotNil(t, flags.Lookup("federated-token"), "federated-token flag should exist")
+	assert.NotNil(t, flags.Lookup("scope"), "scope flag should exist")
+	assert.NotNil(t, flags.Lookup("impersonate-service-account"), "impersonate flag should exist")
+	assert.NotNil(t, flags.Lookup("force"), "force flag should exist")
+	assert.NotNil(t, flags.Lookup("skip-if-authenticated"), "skip-if-authenticated flag should exist")
+	assert.NotNil(t, flags.Lookup("callback-port"), "callback-port flag should exist")
+}
+
+func TestCommandLogin_FlagDefaults(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	flags := cmd.Flags()
+
+	timeout := flags.Lookup("timeout")
+	require.NotNil(t, timeout)
+	assert.Equal(t, "5m0s", timeout.DefValue)
+
+	force := flags.Lookup("force")
+	require.NotNil(t, force)
+	assert.Equal(t, "false", force.DefValue)
+	assert.Equal(t, "f", force.Shorthand)
+
+	skipAuth := flags.Lookup("skip-if-authenticated")
+	require.NotNil(t, skipAuth)
+	assert.Equal(t, "false", skipAuth.DefValue)
+
+	callbackPort := flags.Lookup("callback-port")
+	require.NotNil(t, callbackPort)
+	assert.Equal(t, "0", callbackPort.DefValue)
+}
+
+func TestCommandLogin_UnsupportedCapabilityFlags(t *testing.T) {
+	t.Parallel()
+
+	// Test that --hostname on a handler without CapHostname fails
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+	}
+	// No CapHostname
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--hostname", "enterprise.example.com"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--hostname is not supported")
+}
+
+func TestCommandLogin_ImpersonateServiceAccount_NonGCP(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
+	mock.SetNotAuthenticated()
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--impersonate-service-account", "sa@project.iam.gserviceaccount.com"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--impersonate-service-account is only supported")
+}
+
+func TestCommandLogin_SkipIfAuthenticated(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
+	mock.SetAuthenticated(&auth.Claims{
+		Email: "existing@example.com",
+	})
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--skip-if-authenticated"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Already authenticated")
+	assert.Contains(t, output, "skipping login")
+
+	// Login should NOT have been called
+	assert.Empty(t, mock.LoginCalls)
+}
+
+func TestCommandLogin_ForceReAuth(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+		auth.CapFederatedToken,
+	}
+	mock.SetAuthenticated(&auth.Claims{
+		Email: "existing@example.com",
+	})
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{
+			Email: "new@example.com",
+		},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--force"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Login should have been called despite existing auth
+	require.NotEmpty(t, mock.LoginCalls)
+}
+
+// Benchmarks
+
+func BenchmarkCommandLogin(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	}
+}
+
+func BenchmarkDisplayLoginResult(b *testing.B) {
+	var buf bytes.Buffer
+	streams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(streams, settings.NewCliParams())
+	result := &auth.Result{
+		Claims: &auth.Claims{
+			Name:     "Test User",
+			Email:    "test@example.com",
+			TenantID: "tenant-123",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		_ = displayLoginResult(w, result, auth.FlowInteractive)
+	}
+}

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -1,0 +1,317 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandBuildSolution_Structure(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+
+	assert.Equal(t, "solution [file]", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "sol")
+	assert.Contains(t, cmd.Aliases, "s")
+	assert.Contains(t, cmd.Short, "Build a solution")
+}
+
+func TestCommandBuildSolution_Flags(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+
+	flagTests := []struct {
+		name     string
+		defValue string
+	}{
+		{"name", ""},
+		{"version", ""},
+		{"force", "false"},
+		{"no-bundle", "false"},
+		{"no-vendor", "false"},
+		{"bundle-max-size", "50MB"},
+		{"dry-run", "false"},
+		{"dedupe", "true"},
+		{"dedupe-threshold", "4KB"},
+		{"no-cache", "false"},
+	}
+
+	for _, tc := range flagTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			flag := cmd.Flags().Lookup(tc.name)
+			require.NotNil(t, flag, "flag %q should exist", tc.name)
+			assert.Equal(t, tc.defValue, flag.DefValue)
+		})
+	}
+}
+
+func TestCommandBuildSolution_RequiresArgs(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetArgs([]string{}) // no args
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+func TestRunBuildSolution_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:      "/nonexistent/path/solution.yaml",
+		IOStreams: ioStreams,
+		CliParams: settings.NewCliParams(),
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.Error(t, err)
+}
+
+func TestRunBuildSolution_InvalidSolution(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "bad-solution.yaml")
+	require.NoError(t, os.WriteFile(solFile, []byte("this is not valid yaml: [[["), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:      solFile,
+		IOStreams: ioStreams,
+		CliParams: settings.NewCliParams(),
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.Error(t, err)
+}
+
+func TestRunBuildSolution_NoVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:      solFile,
+		IOStreams: ioStreams,
+		CliParams: settings.NewCliParams(),
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.Error(t, err)
+}
+
+func TestPrintDryRunOutput_StaticFiles(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{
+		LocalFiles: []bundler.FileEntry{
+			{RelPath: "scripts/deploy.sh", Source: bundler.StaticAnalysis},
+			{RelPath: "data/config.json", Source: bundler.ExplicitInclude},
+			{RelPath: "tests/test.yaml", Source: bundler.TestInclude},
+		},
+	}
+
+	sol := &solution.Solution{}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "scripts/deploy.sh")
+	assert.Contains(t, output, "data/config.json")
+	assert.Contains(t, output, "tests/test.yaml")
+	assert.Contains(t, output, "Static analysis discovered")
+	assert.Contains(t, output, "Explicit includes")
+	assert.Contains(t, output, "Test file includes")
+	assert.Contains(t, output, "3 bundled file(s)")
+}
+
+func TestPrintDryRunOutput_CatalogRefs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{
+		CatalogRefs: []bundler.CatalogRefEntry{
+			{Ref: "my-dep@1.0.0", VendorPath: ".vendor/my-dep"},
+		},
+	}
+
+	sol := &solution.Solution{}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "my-dep@1.0.0")
+	assert.Contains(t, output, ".vendor/my-dep")
+	assert.Contains(t, output, "1 vendored dependency")
+}
+
+func TestPrintDryRunOutput_CatalogRefsNotVendored(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{
+		CatalogRefs: []bundler.CatalogRefEntry{
+			{Ref: "dep@2.0.0", VendorPath: ".vendor/dep"},
+		},
+	}
+
+	sol := &solution.Solution{}
+	opts := &SolutionOptions{File: "solution.yaml", NoVendor: true}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "not vendored")
+}
+
+func TestPrintDryRunOutput_ComposedFiles(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{}
+	sol := &solution.Solution{}
+	sol.Compose = []string{"resolvers.yaml", "actions.yaml"}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "Composed files")
+	assert.Contains(t, output, "resolvers.yaml")
+	assert.Contains(t, output, "actions.yaml")
+	assert.Contains(t, output, "merged into solution")
+}
+
+func TestPrintDryRunOutput_Plugins(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{}
+	sol := &solution.Solution{}
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "my-plugin", Kind: "provider", Version: "1.0.0"},
+	}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "Plugin dependencies")
+	assert.Contains(t, output, "my-plugin")
+	assert.Contains(t, output, "provider")
+	assert.Contains(t, output, "1 plugin(s)")
+}
+
+func TestPrintDryRunOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{}
+	sol := &solution.Solution{}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	printDryRunOutput(w, discovery, sol, opts)
+
+	output := buf.String()
+	assert.Contains(t, output, "0 bundled file(s)")
+}
+
+// Benchmarks
+
+func BenchmarkPrintDryRunOutput(b *testing.B) {
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	discovery := &bundler.DiscoveryResult{
+		LocalFiles: []bundler.FileEntry{
+			{RelPath: "scripts/deploy.sh", Source: bundler.StaticAnalysis},
+			{RelPath: "data/config.json", Source: bundler.ExplicitInclude},
+		},
+	}
+	sol := &solution.Solution{}
+	opts := &SolutionOptions{File: "solution.yaml"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		printDryRunOutput(w, discovery, sol, opts)
+	}
+}
+
+func BenchmarkCommandBuildSolution(b *testing.B) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandBuildSolution(cliParams, ioStreams, "build")
+	}
+}

--- a/pkg/cmd/scafctl/bundle/bundle_test.go
+++ b/pkg/cmd/scafctl/bundle/bundle_test.go
@@ -1,0 +1,322 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandBundle(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandBundle(cliParams, ioStreams, "")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "bundle", cmd.Use)
+	assert.Equal(t, []string{"bun"}, cmd.Aliases)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.True(t, cmd.SilenceUsage)
+	assert.Nil(t, cmd.RunE, "parent bundle command should not have RunE, it is a group command")
+}
+
+func TestCommandBundle_Subcommands(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandBundle(cliParams, ioStreams, "")
+
+	subCmds := cmd.Commands()
+	require.Len(t, subCmds, 3, "should have 3 subcommands: verify, diff, extract")
+
+	cmdNames := make([]string, len(subCmds))
+	for i, c := range subCmds {
+		cmdNames[i] = c.Name()
+	}
+	assert.Contains(t, cmdNames, "verify")
+	assert.Contains(t, cmdNames, "diff")
+	assert.Contains(t, cmdNames, "extract")
+}
+
+func TestCommandVerify(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandVerify(cliParams, ioStreams, "")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "verify <artifact-ref>", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.True(t, cmd.SilenceUsage)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandVerify_Flags(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandVerify(cliParams, ioStreams, "")
+
+	paramsFlag := cmd.Flags().Lookup("params")
+	require.NotNil(t, paramsFlag, "params flag should exist")
+	assert.Equal(t, "", paramsFlag.DefValue)
+
+	paramsFileFlag := cmd.Flags().Lookup("params-file")
+	require.NotNil(t, paramsFileFlag, "params-file flag should exist")
+	assert.Equal(t, "", paramsFileFlag.DefValue)
+
+	strictFlag := cmd.Flags().Lookup("strict")
+	require.NotNil(t, strictFlag, "strict flag should exist")
+	assert.Equal(t, "false", strictFlag.DefValue)
+}
+
+func TestCommandVerify_RequiresExactlyOneArg(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	// No args should fail
+	cmd := CommandVerify(cliParams, ioStreams, "")
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	// Two args should fail
+	cmd2 := CommandVerify(cliParams, ioStreams, "")
+	cmd2.SilenceErrors = true
+	cmd2.SetArgs([]string{"ref1", "ref2"})
+	err = cmd2.Execute()
+	assert.Error(t, err)
+}
+
+func TestCommandDiff(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandDiff(cliParams, ioStreams, "")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "diff <ref-a> <ref-b>", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.True(t, cmd.SilenceUsage)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandDiff_Flags(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandDiff(cliParams, ioStreams, "")
+
+	filesOnlyFlag := cmd.Flags().Lookup("files-only")
+	require.NotNil(t, filesOnlyFlag, "files-only flag should exist")
+	assert.Equal(t, "false", filesOnlyFlag.DefValue)
+
+	solutionOnlyFlag := cmd.Flags().Lookup("solution-only")
+	require.NotNil(t, solutionOnlyFlag, "solution-only flag should exist")
+	assert.Equal(t, "false", solutionOnlyFlag.DefValue)
+
+	ignoreFlag := cmd.Flags().Lookup("ignore")
+	require.NotNil(t, ignoreFlag, "ignore flag should exist")
+	assert.Equal(t, "[]", ignoreFlag.DefValue)
+
+	outputFlag := cmd.Flags().Lookup("output")
+	require.NotNil(t, outputFlag, "output flag should exist")
+
+	interactiveFlag := cmd.Flags().Lookup("interactive")
+	require.NotNil(t, interactiveFlag, "interactive flag should exist")
+
+	expressionFlag := cmd.Flags().Lookup("expression")
+	require.NotNil(t, expressionFlag, "expression flag should exist")
+}
+
+func TestCommandDiff_RequiresExactlyTwoArgs(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	// No args should fail
+	cmd := CommandDiff(cliParams, ioStreams, "")
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	// One arg should fail
+	cmd2 := CommandDiff(cliParams, ioStreams, "")
+	cmd2.SilenceErrors = true
+	cmd2.SetArgs([]string{"ref1"})
+	err = cmd2.Execute()
+	assert.Error(t, err)
+
+	// Three args should fail
+	cmd3 := CommandDiff(cliParams, ioStreams, "")
+	cmd3.SilenceErrors = true
+	cmd3.SetArgs([]string{"ref1", "ref2", "ref3"})
+	err = cmd3.Execute()
+	assert.Error(t, err)
+}
+
+func TestCommandExtract(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandExtract(cliParams, ioStreams, "")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "extract <artifact-ref>", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.True(t, cmd.SilenceUsage)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandExtract_Flags(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandExtract(cliParams, ioStreams, "")
+
+	outputDirFlag := cmd.Flags().Lookup("output-dir")
+	require.NotNil(t, outputDirFlag, "output-dir flag should exist")
+	assert.Equal(t, ".", outputDirFlag.DefValue)
+
+	resolverFlag := cmd.Flags().Lookup("resolver")
+	require.NotNil(t, resolverFlag, "resolver flag should exist")
+	assert.Equal(t, "[]", resolverFlag.DefValue)
+
+	actionFlag := cmd.Flags().Lookup("action")
+	require.NotNil(t, actionFlag, "action flag should exist")
+	assert.Equal(t, "[]", actionFlag.DefValue)
+
+	includeFlag := cmd.Flags().Lookup("include")
+	require.NotNil(t, includeFlag, "include flag should exist")
+	assert.Equal(t, "[]", includeFlag.DefValue)
+
+	listOnlyFlag := cmd.Flags().Lookup("list-only")
+	require.NotNil(t, listOnlyFlag, "list-only flag should exist")
+	assert.Equal(t, "false", listOnlyFlag.DefValue)
+
+	flattenFlag := cmd.Flags().Lookup("flatten")
+	require.NotNil(t, flattenFlag, "flatten flag should exist")
+	assert.Equal(t, "false", flattenFlag.DefValue)
+}
+
+func TestCommandExtract_RequiresExactlyOneArg(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	// No args should fail
+	cmd := CommandExtract(cliParams, ioStreams, "")
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	// Two args should fail
+	cmd2 := CommandExtract(cliParams, ioStreams, "")
+	cmd2.SilenceErrors = true
+	cmd2.SetArgs([]string{"ref1", "ref2"})
+	err = cmd2.Execute()
+	assert.Error(t, err)
+}
+
+func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		s        string
+		prefix   string
+		expected bool
+	}{
+		{name: "matching prefix", s: "glob:pattern", prefix: "glob:", expected: true},
+		{name: "plugin prefix", s: "plugin:myplugin", prefix: "plugin:", expected: true},
+		{name: "no match", s: "static/path", prefix: "glob:", expected: false},
+		{name: "empty string", s: "", prefix: "glob:", expected: false},
+		{name: "empty prefix", s: "anything", prefix: "", expected: true},
+		{name: "both empty", s: "", prefix: "", expected: true},
+		{name: "exact match", s: "glob:", prefix: "glob:", expected: true},
+		{name: "prefix longer than string", s: "gl", prefix: "glob:", expected: false},
+		{name: "pattern prefix", s: "pattern matched", prefix: "pattern ", expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, hasPrefix(tc.s, tc.prefix))
+		})
+	}
+}
+
+// Benchmarks
+
+func BenchmarkCommandBundle(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandBundle(cliParams, ioStreams, "")
+	}
+}
+
+func BenchmarkCommandVerify(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandVerify(cliParams, ioStreams, "")
+	}
+}
+
+func BenchmarkCommandDiff(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandDiff(cliParams, ioStreams, "")
+	}
+}
+
+func BenchmarkCommandExtract(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandExtract(cliParams, ioStreams, "")
+	}
+}

--- a/pkg/cmd/scafctl/render/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/render/solution_coverage_test.go
@@ -1,0 +1,421 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── renderGraph tests ────────────────────────────────────────────────────────
+
+// errGraphRenderer always returns an error for the specified format.
+type errGraphRenderer struct {
+	failFormat string
+}
+
+func (e *errGraphRenderer) RenderASCII(w io.Writer) error {
+	if e.failFormat == "ascii" {
+		return fmt.Errorf("ascii render failed")
+	}
+	_, err := w.Write([]byte("ascii output"))
+	return err
+}
+
+func (e *errGraphRenderer) RenderDOT(w io.Writer) error {
+	if e.failFormat == "dot" {
+		return fmt.Errorf("dot render failed")
+	}
+	_, err := w.Write([]byte("digraph {}"))
+	return err
+}
+
+func (e *errGraphRenderer) RenderMermaid(w io.Writer) error {
+	if e.failFormat == "mermaid" {
+		return fmt.Errorf("mermaid render failed")
+	}
+	_, err := w.Write([]byte("graph TD"))
+	return err
+}
+
+func TestSolutionOptions_renderGraph(t *testing.T) {
+	t.Parallel()
+
+	newOpts := func(format string) (*SolutionOptions, *bytes.Buffer) {
+		var buf bytes.Buffer
+		return &SolutionOptions{
+			IOStreams:   &terminal.IOStreams{Out: &buf, ErrOut: &buf},
+			CliParams:   &settings.Run{},
+			GraphFormat: format,
+		}, &buf
+	}
+
+	t.Run("ascii_success", func(t *testing.T) {
+		t.Parallel()
+		opts, buf := newOpts("ascii")
+		graph := &errGraphRenderer{}
+		err := opts.renderGraph(graph, graph)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "ascii output")
+	})
+
+	t.Run("ascii_failure", func(t *testing.T) {
+		t.Parallel()
+		opts, _ := newOpts("ascii")
+		graph := &errGraphRenderer{failFormat: "ascii"}
+		err := opts.renderGraph(graph, graph)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ascii")
+	})
+
+	t.Run("dot_success", func(t *testing.T) {
+		t.Parallel()
+		opts, buf := newOpts("dot")
+		graph := &errGraphRenderer{}
+		err := opts.renderGraph(graph, graph)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "digraph")
+	})
+
+	t.Run("dot_failure", func(t *testing.T) {
+		t.Parallel()
+		opts, _ := newOpts("dot")
+		graph := &errGraphRenderer{failFormat: "dot"}
+		err := opts.renderGraph(graph, graph)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DOT")
+	})
+
+	t.Run("mermaid_success", func(t *testing.T) {
+		t.Parallel()
+		opts, buf := newOpts("mermaid")
+		graph := &errGraphRenderer{}
+		err := opts.renderGraph(graph, graph)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "graph TD")
+	})
+
+	t.Run("mermaid_failure", func(t *testing.T) {
+		t.Parallel()
+		opts, _ := newOpts("mermaid")
+		graph := &errGraphRenderer{failFormat: "mermaid"}
+		err := opts.renderGraph(graph, graph)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Mermaid")
+	})
+
+	t.Run("json_success", func(t *testing.T) {
+		t.Parallel()
+		opts, buf := newOpts("json")
+		data := map[string]string{"key": "value"}
+		graph := &errGraphRenderer{}
+		err := opts.renderGraph(graph, data)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		assert.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+		assert.Equal(t, "value", decoded["key"])
+	})
+
+	t.Run("unsupported_format", func(t *testing.T) {
+		t.Parallel()
+		opts, _ := newOpts("invalid-format")
+		graph := &errGraphRenderer{}
+		err := opts.renderGraph(graph, graph)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported graph format")
+		assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+	})
+}
+
+// ── getEffectiveResolverConfig tests ─────────────────────────────────────────
+
+func TestSolutionOptions_getEffectiveResolverConfig(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{
+		ResolverTimeout: settings.DefaultResolverTimeout,
+		PhaseTimeout:    settings.DefaultPhaseTimeout,
+		flagsChanged:    map[string]bool{},
+	}
+
+	cfg := opts.getEffectiveResolverConfig(context.Background())
+	assert.Equal(t, settings.DefaultResolverTimeout, cfg.Timeout)
+	assert.Equal(t, settings.DefaultPhaseTimeout, cfg.PhaseTimeout)
+}
+
+// ── writeOutput tests (extensions) ───────────────────────────────────────────
+
+func TestSolutionOptions_writeOutput_ToFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	opts := &SolutionOptions{
+		OutputFile: dir + "/out",
+		Output:     "json",
+		IOStreams:  &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams:  &settings.Run{},
+	}
+
+	err := opts.writeOutput(context.Background(), []byte(`{"ok":true}`))
+	require.NoError(t, err)
+	assert.Equal(t, dir+"/out.json", opts.OutputFile)
+}
+
+func TestSolutionOptions_writeOutput_NoWriter(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{
+		IOStreams: &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams: &settings.Run{},
+	}
+
+	// Context without writer — should not panic
+	err := opts.writeOutput(context.Background(), []byte("data"))
+	require.NoError(t, err)
+}
+
+// ── Run routing tests ────────────────────────────────────────────────────────
+
+func TestSolutionOptions_Run_ActionGraphRoute(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{
+		ActionGraph: true,
+		IOStreams:   &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams:   &settings.Run{},
+		getter:      &mockGetter{err: fmt.Errorf("load error")},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load error")
+}
+
+func TestSolutionOptions_Run_SnapshotRoute(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{
+		Snapshot:     true,
+		SnapshotFile: "/tmp/test-snap.json",
+		IOStreams:    &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams:    &settings.Run{},
+		getter:       &mockGetter{err: fmt.Errorf("load error")},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load error")
+}
+
+func TestSolutionOptions_Run_DefaultRoute(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{
+		IOStreams: &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams: &settings.Run{},
+		getter:    &mockGetter{err: fmt.Errorf("load error")},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load error")
+}
+
+// ── runActionGraph validation tests ──────────────────────────────────────────
+
+func TestSolutionOptions_runActionGraph_NoWorkflow(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Metadata: solution.Metadata{Name: "no-wf"},
+	}
+
+	opts := &SolutionOptions{
+		IOStreams: &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams: &settings.Run{},
+		getter:    &mockGetter{sol: sol},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define a workflow")
+}
+
+func TestSolutionOptions_runActionGraphVisualization_NoWorkflow(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Metadata: solution.Metadata{Name: "no-wf"},
+	}
+
+	opts := &SolutionOptions{
+		ActionGraph: true,
+		IOStreams:   &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams:   &settings.Run{},
+		getter:      &mockGetter{sol: sol},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define a workflow")
+}
+
+func TestSolutionOptions_runSnapshot_NoResolvers(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Metadata: solution.Metadata{Name: "no-resolvers"},
+	}
+
+	opts := &SolutionOptions{
+		Snapshot:     true,
+		SnapshotFile: "/tmp/snap.json",
+		IOStreams:    &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		CliParams:    &settings.Run{},
+		getter:       &mockGetter{sol: sol},
+	}
+
+	ctx := setupWriterContext()
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define any resolvers")
+}
+
+// ── exitWithCode code extraction tests ───────────────────────────────────────
+
+func TestSolutionOptions_exitWithCode_Codes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code int
+	}{
+		{"file-not-found", exitcode.FileNotFound},
+		{"validation-failed", exitcode.ValidationFailed},
+		{"render-failed", exitcode.RenderFailed},
+		{"invalid-input", exitcode.InvalidInput},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &SolutionOptions{
+				IOStreams: &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+				CliParams: &settings.Run{},
+			}
+			err := opts.exitWithCode(fmt.Errorf("err"), tc.code)
+			assert.Equal(t, tc.code, exitcode.GetCode(err))
+			assert.Equal(t, "err", err.Error())
+		})
+	}
+}
+
+// ── Command flags extended tests ─────────────────────────────────────────────
+
+func TestCommandSolution_AllFlags(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+	cmd := CommandSolution(cliParams, ioStreams, "render")
+
+	expectedFlags := []string{
+		"file", "output", "output-file", "resolver", "compact",
+		"no-timestamp", "no-cache", "action-graph", "graph-format",
+		"snapshot", "snapshot-file", "redact", "test-name",
+		"resolver-timeout", "phase-timeout",
+	}
+
+	for _, name := range expectedFlags {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			flag := cmd.Flags().Lookup(name)
+			assert.NotNil(t, flag, "flag %q should exist", name)
+		})
+	}
+}
+
+func TestCommandSolution_FlagDefaults(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+	cmd := CommandSolution(cliParams, ioStreams, "render")
+
+	tests := []struct {
+		flag     string
+		defValue string
+	}{
+		{"output", "json"},
+		{"graph-format", "ascii"},
+		{"compact", "false"},
+		{"no-timestamp", "false"},
+		{"no-cache", "false"},
+		{"action-graph", "false"},
+		{"snapshot", "false"},
+		{"redact", "false"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.flag, func(t *testing.T) {
+			t.Parallel()
+			flag := cmd.Flags().Lookup(tc.flag)
+			require.NotNil(t, flag)
+			assert.Equal(t, tc.defValue, flag.DefValue)
+		})
+	}
+}
+
+// ── writeToFile extended tests ───────────────────────────────────────────────
+
+func TestSolutionOptions_writeToFile_WritesContents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	opts := &SolutionOptions{
+		OutputFile: dir + "/result.json",
+		Output:     "json",
+	}
+
+	data := []byte(`{"rendered": true}`)
+	err := opts.writeToFile(data)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(opts.OutputFile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"rendered": true}`, string(content))
+}
+
+// ── helper ───────────────────────────────────────────────────────────────────
+
+func setupWriterContext() context.Context {
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(context.Background(), w)
+	l := logr.Discard()
+	ctx = logger.WithLogger(ctx, &l)
+	return ctx
+}

--- a/pkg/cmd/scafctl/run/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/run/solution_coverage_test.go
@@ -1,0 +1,589 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/dryrun"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolutionOptions_getActionIOStreams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		wantNil bool
+	}{
+		{name: "json returns nil", output: "json", wantNil: true},
+		{name: "yaml returns nil", output: "yaml", wantNil: true},
+		{name: "quiet returns nil", output: "quiet", wantNil: true},
+		{name: "test returns nil", output: "test", wantNil: true},
+		{name: "table returns streams", output: "table", wantNil: false},
+		{name: "auto returns streams", output: "auto", wantNil: false},
+		{name: "empty returns streams", output: "", wantNil: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			opts := &SolutionOptions{}
+			opts.Output = tc.output
+			opts.IOStreams = &terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+
+			result := opts.getActionIOStreams()
+			if tc.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.NotNil(t, result.Out)
+				assert.NotNil(t, result.ErrOut)
+			}
+		})
+	}
+}
+
+func TestActionRegistryAdapter_Has(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry()
+	adapter := &actionRegistryAdapter{registry: reg}
+
+	assert.True(t, adapter.Has("static"))
+	assert.False(t, adapter.Has("nonexistent"))
+}
+
+func TestActionRegistryAdapter_Get(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry()
+	adapter := &actionRegistryAdapter{registry: reg}
+
+	provider, ok := adapter.Get("static")
+	assert.True(t, ok)
+	assert.NotNil(t, provider)
+
+	provider, ok = adapter.Get("nonexistent")
+	assert.False(t, ok)
+	assert.Nil(t, provider)
+}
+
+func TestNewActionProgressCallback(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+
+	cb := NewActionProgressCallback(w)
+	require.NotNil(t, cb)
+	assert.Equal(t, w, cb.w)
+}
+
+func TestActionProgressCallback_Methods(t *testing.T) {
+	t.Parallel()
+
+	newCB := func() (*bytes.Buffer, *ActionProgressCallback) {
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		return &buf, NewActionProgressCallback(w)
+	}
+
+	t.Run("OnActionStart", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionStart("deploy")
+		assert.Contains(t, buf.String(), "deploy")
+	})
+
+	t.Run("OnActionComplete", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionComplete("deploy", nil)
+		assert.Contains(t, buf.String(), "deploy")
+	})
+
+	t.Run("OnActionFailed", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionFailed("deploy", assert.AnError)
+		assert.Contains(t, buf.String(), "deploy")
+		assert.Contains(t, buf.String(), "Failed")
+	})
+
+	t.Run("OnActionSkipped", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionSkipped("deploy", "not ready")
+		assert.Contains(t, buf.String(), "deploy")
+		assert.Contains(t, buf.String(), "not ready")
+	})
+
+	t.Run("OnActionTimeout", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionTimeout("deploy", 30*time.Second)
+		assert.Contains(t, buf.String(), "deploy")
+		assert.Contains(t, buf.String(), "Timeout")
+	})
+
+	t.Run("OnActionCancelled", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnActionCancelled("deploy")
+		assert.Contains(t, buf.String(), "deploy")
+		assert.Contains(t, buf.String(), "Cancelled")
+	})
+
+	t.Run("OnRetryAttempt", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnRetryAttempt("deploy", 1, 3, assert.AnError)
+		assert.Contains(t, buf.String(), "Retry")
+		assert.Contains(t, buf.String(), "1/3")
+	})
+
+	t.Run("OnForEachProgress", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnForEachProgress("deploy", 5, 10)
+		assert.Contains(t, buf.String(), "5/10")
+	})
+
+	t.Run("OnPhaseStart", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnPhaseStart(1, []string{"deploy", "test"})
+		assert.Contains(t, buf.String(), "phase 1")
+		assert.Contains(t, buf.String(), "deploy")
+	})
+
+	t.Run("OnPhaseComplete", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnPhaseComplete(1)
+		assert.Contains(t, buf.String(), "phase 1")
+	})
+
+	t.Run("OnFinallyStart", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnFinallyStart()
+		assert.Contains(t, buf.String(), "finally")
+	})
+
+	t.Run("OnFinallyComplete", func(t *testing.T) {
+		t.Parallel()
+		buf, cb := newCB()
+		cb.OnFinallyComplete()
+		assert.Contains(t, buf.String(), "finally")
+	})
+}
+
+func TestSolutionOptions_writeActionOutput_Quiet(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{}
+	opts.Output = "quiet"
+
+	err := opts.writeActionOutput(context.Background(), &action.ExecutionResult{}, nil)
+	assert.NoError(t, err)
+}
+
+func TestSolutionOptions_writeActionOutput_UnsupportedFormat(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{}
+	opts.Output = "invalid-format"
+
+	err := opts.writeActionOutput(context.Background(), &action.ExecutionResult{}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported output format")
+}
+
+func TestSolutionOptions_writeActionOutputDefault_NilWriter(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{}
+	// No writer in context
+	err := opts.writeActionOutputDefault(context.Background(), &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{},
+	})
+	assert.NoError(t, err)
+}
+
+func TestSolutionOptions_writeActionOutputDefault_StreamedSuccess(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {Streamed: true, Status: action.StatusSucceeded},
+		},
+	}
+
+	err := opts.writeActionOutputDefault(ctx, result)
+	assert.NoError(t, err)
+	// Streamed success should produce no extra output
+}
+
+func TestSolutionOptions_writeActionOutputDefault_StreamedFailed(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {Streamed: true, Status: action.StatusFailed, Error: "timeout occurred"},
+		},
+	}
+
+	err := opts.writeActionOutputDefault(ctx, result)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "timeout occurred")
+}
+
+func TestSolutionOptions_writeActionOutputDefault_NonStreamedSuccess(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {
+				Streamed: false,
+				Status:   action.StatusSucceeded,
+				Results:  map[string]any{"stdout": "hello world\n"},
+			},
+		},
+	}
+
+	err := opts.writeActionOutputDefault(ctx, result)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "hello world")
+}
+
+func TestSolutionOptions_writeActionOutputDefault_NonStreamedFailed(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {
+				Streamed: false,
+				Status:   action.StatusFailed,
+				Error:    "command failed",
+				Results:  map[string]any{"stderr": "error output\n"},
+			},
+		},
+	}
+
+	err := opts.writeActionOutputDefault(ctx, result)
+	assert.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "command failed")
+}
+
+func TestSolutionOptions_writeActionOutputDefault_Skipped(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {
+				Streamed:   false,
+				Status:     action.StatusSkipped,
+				SkipReason: "condition not met",
+			},
+		},
+	}
+
+	err := opts.writeActionOutputDefault(ctx, result)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "condition not met")
+}
+
+func TestSolutionOptions_writeActionOutputStructured_JSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {Status: action.StatusSucceeded},
+		},
+	}
+
+	err := opts.writeActionOutputStructured(ctx, result, nil, "json")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(buf.String()), "{"))
+}
+
+func TestSolutionOptions_writeActionOutputStructured_YAML(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	result := &action.ExecutionResult{
+		Actions: map[string]*action.ActionResult{
+			"deploy": {Status: action.StatusSucceeded},
+		},
+	}
+
+	err := opts.writeActionOutputStructured(ctx, result, nil, "yaml")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, buf.String())
+}
+
+func TestSolutionOptions_writeDryRunOutput_JSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	opts.Output = "json"
+
+	report := &dryrun.Report{
+		Solution: "test-solution",
+		Version:  "1.0.0",
+	}
+
+	err := opts.writeDryRunOutput(ctx, report)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "test-solution")
+}
+
+func TestSolutionOptions_writeDryRunOutput_YAML(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &SolutionOptions{}
+	opts.Output = "yaml"
+
+	report := &dryrun.Report{
+		Solution: "test-solution",
+	}
+
+	err := opts.writeDryRunOutput(ctx, report)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "test-solution")
+}
+
+func TestSolutionOptions_writeDryRunOutput_Quiet(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{}
+	opts.Output = "quiet"
+
+	report := &dryrun.Report{Solution: "test"}
+	err := opts.writeDryRunOutput(context.Background(), report)
+	assert.NoError(t, err)
+}
+
+func TestSolutionOptions_writeDryRunTable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil writer", func(t *testing.T) {
+		t.Parallel()
+		opts := &SolutionOptions{}
+		err := opts.writeDryRunTable(context.Background(), &dryrun.Report{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("with action plan", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		opts := &SolutionOptions{}
+		report := &dryrun.Report{
+			Solution:    "my-solution",
+			Version:     "2.0.0",
+			HasWorkflow: true,
+			ActionPlan: []dryrun.WhatIfAction{
+				{
+					Name:         "deploy",
+					Phase:        0,
+					WhatIf:       "Would deploy the application",
+					When:         "env == 'prod'",
+					Dependencies: []string{"build"},
+				},
+			},
+		}
+
+		err := opts.writeDryRunTable(ctx, report)
+		assert.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "DRY RUN")
+		assert.Contains(t, output, "my-solution")
+		assert.Contains(t, output, "deploy")
+		assert.Contains(t, output, "Would deploy the application")
+		assert.Contains(t, output, "env == 'prod'")
+		assert.Contains(t, output, "build")
+	})
+
+	t.Run("no workflow", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		opts := &SolutionOptions{}
+		report := &dryrun.Report{
+			Solution:    "no-workflow",
+			HasWorkflow: false,
+		}
+
+		err := opts.writeDryRunTable(ctx, report)
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "No workflow defined")
+	})
+
+	t.Run("with warnings", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		opts := &SolutionOptions{}
+		report := &dryrun.Report{
+			Solution:    "warn-sol",
+			HasWorkflow: true,
+			Warnings:    []string{"resolver 'db' has no inputs", "action 'cleanup' unreachable"},
+		}
+
+		err := opts.writeDryRunTable(ctx, report)
+		assert.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "Warnings")
+		assert.Contains(t, output, "resolver 'db' has no inputs")
+	})
+
+	t.Run("with deferred inputs and cross section refs", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		opts := &SolutionOptions{}
+		report := &dryrun.Report{
+			Solution:    "complex",
+			HasWorkflow: true,
+			ActionPlan: []dryrun.WhatIfAction{
+				{
+					Name:               "deploy",
+					Phase:              0,
+					WhatIf:             "Would deploy",
+					CrossSectionRefs:   []string{"build.output"},
+					DeferredInputs:     map[string]string{"image": "{{build.output.image}}"},
+					MaterializedInputs: map[string]any{"env": "production"},
+				},
+			},
+		}
+
+		err := opts.writeDryRunTable(ctx, report)
+		assert.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "build.output")
+		assert.Contains(t, output, "deferred")
+	})
+}
+
+// Benchmarks
+
+func BenchmarkActionProgressCallback(b *testing.B) {
+	var buf bytes.Buffer
+	streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	cb := NewActionProgressCallback(w)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cb.OnActionStart("deploy")
+		cb.OnActionComplete("deploy", nil)
+	}
+}
+
+func BenchmarkGetActionIOStreams(b *testing.B) {
+	opts := &SolutionOptions{}
+	opts.Output = "json"
+	opts.IOStreams = &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		opts.getActionIOStreams()
+	}
+}

--- a/pkg/solution/soltesting/runner_coverage_test.go
+++ b/pkg/solution/soltesting/runner_coverage_test.go
@@ -1,0 +1,233 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/shellexec"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting/mockexec"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateSkipExpression_TrueExpression(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	result, err := runner.evaluateSkipExpression(ctx, "true")
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestEvaluateSkipExpression_FalseExpression(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	result, err := runner.evaluateSkipExpression(ctx, "false")
+	require.NoError(t, err)
+	assert.False(t, result)
+}
+
+func TestEvaluateSkipExpression_SubprocessVariable(t *testing.T) {
+	runner := &Runner{
+		BinaryPath: "/usr/bin/scafctl",
+		IOStreams:  &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	result, err := runner.evaluateSkipExpression(ctx, "subprocess")
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestEvaluateSkipExpression_SubprocessFalseWhenEmpty(t *testing.T) {
+	runner := &Runner{
+		BinaryPath: "",
+		IOStreams:  &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	result, err := runner.evaluateSkipExpression(ctx, "subprocess")
+	require.NoError(t, err)
+	assert.False(t, result)
+}
+
+func TestEvaluateSkipExpression_InvalidExpression(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	_, err := runner.evaluateSkipExpression(ctx, "invalid_func()")
+	assert.Error(t, err)
+}
+
+func TestEvaluateSkipExpression_NonBoolResult(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	_, err := runner.evaluateSkipExpression(ctx, `"string_value"`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must return bool")
+}
+
+func TestComposeExecMocks_MatchingRule(t *testing.T) {
+	mock, err := mockexec.New([]mockexec.Rule{
+		{
+			Command:  "echo hello",
+			Stdout:   "hello\n",
+			ExitCode: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	composed := composeExecMocks([]*mockexec.MockExec{mock})
+	require.NotNil(t, composed)
+}
+
+func TestComposeExecMocks_NoMatchingRule(t *testing.T) {
+	mock, err := mockexec.New([]mockexec.Rule{
+		{
+			Command:  "echo hello",
+			Stdout:   "hello\n",
+			ExitCode: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	composed := composeExecMocks([]*mockexec.MockExec{mock})
+	require.NotNil(t, composed)
+
+	// Call with a non-matching command — should return an error
+	ctx := context.Background()
+	runFn := composed
+	_, runErr := runFn(ctx, &shellexec.RunOptions{
+		Command: "ls",
+		Args:    []string{"-la"},
+	})
+	assert.Error(t, runErr)
+}
+
+func TestComposeExecMocks_MultipleMocks(t *testing.T) {
+	mock1, err := mockexec.New([]mockexec.Rule{
+		{Command: "echo hello", Stdout: "hello\n", ExitCode: 0},
+	})
+	require.NoError(t, err)
+
+	mock2, err := mockexec.New([]mockexec.Rule{
+		{Command: "echo world", Stdout: "world\n", ExitCode: 0},
+	})
+	require.NoError(t, err)
+
+	composed := composeExecMocks([]*mockexec.MockExec{mock1, mock2})
+	require.NotNil(t, composed)
+}
+
+func TestRunnerEmitTestStart_WithCallback(t *testing.T) {
+	var started []string
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+		Progress: &testProgressTracker{
+			onTestStart: func(solution, test string) {
+				started = append(started, solution+"/"+test)
+			},
+		},
+	}
+	runner.emitTestStart("my-solution", "my-test")
+	assert.Equal(t, []string{"my-solution/my-test"}, started)
+}
+
+func TestRunnerEmitTestStart_WithoutCallback(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+		Progress:  nil,
+	}
+	// Should not panic
+	runner.emitTestStart("my-solution", "my-test")
+}
+
+func TestRunnerEmitTestComplete_WithCallback(t *testing.T) {
+	var completed []TestResult
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+		Progress: &testProgressTracker{
+			onTestComplete: func(result TestResult) {
+				completed = append(completed, result)
+			},
+		},
+	}
+	result := TestResult{
+		Solution: "my-solution",
+		Test:     "my-test",
+		Status:   StatusPass,
+	}
+	runner.emitTestComplete(result)
+	require.Len(t, completed, 1)
+	assert.Equal(t, StatusPass, completed[0].Status)
+}
+
+func TestRunnerEmitTestComplete_WithoutCallback(t *testing.T) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+		Progress:  nil,
+	}
+	// Should not panic
+	runner.emitTestComplete(TestResult{})
+}
+
+// testProgressTracker implements TestProgressCallback for testing.
+type testProgressTracker struct {
+	onTestStart    func(solution, test string)
+	onTestComplete func(result TestResult)
+}
+
+func (t *testProgressTracker) OnTestStart(solution, test string) {
+	if t.onTestStart != nil {
+		t.onTestStart(solution, test)
+	}
+}
+
+func (t *testProgressTracker) OnTestComplete(result TestResult) {
+	if t.onTestComplete != nil {
+		t.onTestComplete(result)
+	}
+}
+
+func (t *testProgressTracker) Wait() {}
+
+// Benchmarks
+
+func BenchmarkEvaluateSkipExpression(b *testing.B) {
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = runner.evaluateSkipExpression(ctx, "true")
+	}
+}
+
+func BenchmarkComposeExecMocks(b *testing.B) {
+	mock, err := mockexec.New([]mockexec.Rule{
+		{Command: "echo hello", Stdout: "hello\n", ExitCode: 0},
+	})
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		composeExecMocks([]*mockexec.MockExec{mock})
+	}
+}


### PR DESCRIPTION
…render, run, and soltesting packages

Add comprehensive unit tests to improve coverage across multiple packages:

- pkg/catalog: add local_coverage_test.go and remote_test.go covering FetchWithBundle, store/fetch flows, and remote catalog interactions
- pkg/cmd/scafctl/auth: add diagnose_test.go and login_coverage_test.go; extract clockSkewCheckFunc as a package-level variable to allow tests to stub out real network calls
- pkg/cmd/scafctl/build: add solution_coverage_test.go covering solution build flows
- pkg/cmd/scafctl/bundle: add bundle_test.go covering bundle command behavior
- pkg/cmd/scafctl/render: add solution_coverage_test.go covering render flows
- pkg/cmd/scafctl/run: add solution_coverage_test.go covering run command paths
- pkg/solution/soltesting: add runner_coverage_test.go covering skip expression evaluation and runner behavior

Also update codecov.yml to ignore generated protobuf files (pkg/plugin/proto/*.pb.go) from coverage reporting.