### PR TITLE
fix(spec): add MarshalYAML/JSON and UnmarshalJSON to ValueRef for cat…

### DIFF
--- a/pkg/spec/valueref.go
+++ b/pkg/spec/valueref.go
@@ -5,6 +5,7 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -88,6 +89,120 @@ func (v *ValueRef) UnmarshalYAML(node *yaml.Node) error {
 	default:
 		return fmt.Errorf("unsupported YAML node kind: %v", node.Kind)
 	}
+}
+
+// MarshalYAML implements custom YAML marshalling for ValueRef.
+// This is required to survive the deepCopySolution YAML round-trip used in compose/bundling.
+// Without it, the Literal field (tagged yaml:"-") would be silently dropped during marshaling.
+func (v ValueRef) MarshalYAML() (any, error) {
+	if v.Literal != nil {
+		return v.Literal, nil
+	}
+	if v.Resolver != nil {
+		return map[string]any{"rslvr": *v.Resolver}, nil
+	}
+	if v.Expr != nil {
+		return map[string]any{"expr": string(*v.Expr)}, nil
+	}
+	if v.Tmpl != nil {
+		return map[string]any{"tmpl": string(*v.Tmpl)}, nil
+	}
+	return nil, nil
+}
+
+// MarshalJSON implements custom JSON marshalling for ValueRef.
+// Mirrors MarshalYAML to ensure consistent serialization across formats.
+func (v ValueRef) MarshalJSON() ([]byte, error) {
+	if v.Literal != nil {
+		return json.Marshal(v.Literal)
+	}
+	if v.Resolver != nil {
+		return json.Marshal(map[string]any{"rslvr": *v.Resolver})
+	}
+	if v.Expr != nil {
+		return json.Marshal(map[string]any{"expr": string(*v.Expr)})
+	}
+	if v.Tmpl != nil {
+		return json.Marshal(map[string]any{"tmpl": string(*v.Tmpl)})
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for ValueRef.
+// Mirrors UnmarshalYAML to ensure consistent deserialization across formats.
+func (v *ValueRef) UnmarshalJSON(data []byte) error {
+	// Clear all fields to avoid stale state when reusing a ValueRef instance.
+	*v = ValueRef{}
+
+	// Check if the data is a JSON object containing known keys.
+	// We use json.RawMessage to detect key presence before typed decoding,
+	// so that malformed refs like {"expr": {}} error instead of silently
+	// becoming literals.
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) == nil {
+		_, hasRslvr := obj["rslvr"]
+		_, hasExpr := obj["expr"]
+		_, hasTmpl := obj["tmpl"]
+
+		knownCount := 0
+		if hasRslvr {
+			knownCount++
+		}
+		if hasExpr {
+			knownCount++
+		}
+		if hasTmpl {
+			knownCount++
+		}
+
+		if knownCount > 1 {
+			var found []string
+			if hasRslvr {
+				found = append(found, "rslvr")
+			}
+			if hasExpr {
+				found = append(found, "expr")
+			}
+			if hasTmpl {
+				found = append(found, "tmpl")
+			}
+			return fmt.Errorf("invalid value ref: expected exactly one of rslvr, expr, or tmpl, but found [%s]", strings.Join(found, ", "))
+		}
+
+		if knownCount == 1 {
+			// Known key is present — decode into typed struct.
+			// If the value has the wrong type (e.g. {"expr": {}}), this will
+			// return an error instead of silently treating it as a literal.
+			var raw struct {
+				Resolver *string                     `json:"rslvr"`
+				Expr     *celexp.Expression          `json:"expr"`
+				Tmpl     *gotmpl.GoTemplatingContent `json:"tmpl"`
+			}
+			if err := json.Unmarshal(data, &raw); err != nil {
+				return fmt.Errorf("invalid value ref: %w", err)
+			}
+			// Reject null values for known keys (e.g. {"rslvr": null}).
+			// This matches UnmarshalYAML behavior where rslvr:null would be
+			// treated as a literal map, not a typed ref with a nil value.
+			if raw.Resolver == nil && raw.Expr == nil && raw.Tmpl == nil {
+				return fmt.Errorf("invalid value ref: known key has null value")
+			}
+			v.Resolver = raw.Resolver
+			v.Expr = raw.Expr
+			v.Tmpl = raw.Tmpl
+			return nil
+		}
+
+		// Object with no known keys — fall through to literal.
+	}
+
+	// Not an object, or object without known keys — treat as literal.
+	var literal any
+	if err := json.Unmarshal(data, &literal); err != nil {
+		return err
+	}
+	v.Literal = literal
+	return nil
 }
 
 // IterationContext holds the context for forEach iteration variables.

--- a/pkg/spec/valueref_test.go
+++ b/pkg/spec/valueref_test.go
@@ -5,6 +5,7 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -472,4 +473,561 @@ func TestIterationContext(t *testing.T) {
 	assert.Equal(t, 3, ctx.Index)
 	assert.Equal(t, "myItem", ctx.ItemAlias)
 	assert.Equal(t, "myIndex", ctx.IndexAlias)
+}
+
+func TestValueRef_MarshalYAML_Literal(t *testing.T) {
+	tests := []struct {
+		name     string
+		vr       ValueRef
+		expected string
+	}{
+		{
+			name:     "string literal",
+			vr:       ValueRef{Literal: "hello world"},
+			expected: "hello world\n",
+		},
+		{
+			name:     "integer literal",
+			vr:       ValueRef{Literal: 42},
+			expected: "42\n",
+		},
+		{
+			name:     "float literal",
+			vr:       ValueRef{Literal: 3.14},
+			expected: "3.14\n",
+		},
+		{
+			name:     "boolean literal",
+			vr:       ValueRef{Literal: true},
+			expected: "true\n",
+		},
+		{
+			name:     "array literal",
+			vr:       ValueRef{Literal: []any{1, 2, 3}},
+			expected: "- 1\n- 2\n- 3\n",
+		},
+		{
+			name:     "map literal",
+			vr:       ValueRef{Literal: map[string]any{"key": "value"}},
+			expected: "key: value\n",
+		},
+		{
+			name:     "file path literal",
+			vr:       ValueRef{Literal: "./templates/main.tf.tmpl"},
+			expected: "./templates/main.tf.tmpl\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(&tt.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestValueRef_MarshalYAML_Resolver(t *testing.T) {
+	resolver := "environment"
+	vr := ValueRef{Resolver: &resolver}
+
+	data, err := yaml.Marshal(&vr)
+	require.NoError(t, err)
+	assert.Equal(t, "rslvr: environment\n", string(data))
+}
+
+func TestValueRef_MarshalYAML_Expr(t *testing.T) {
+	expr := celexp.Expression("_.env == 'prod'")
+	vr := ValueRef{Expr: &expr}
+
+	data, err := yaml.Marshal(&vr)
+	require.NoError(t, err)
+	assert.Equal(t, "expr: _.env == 'prod'\n", string(data))
+}
+
+func TestValueRef_MarshalYAML_Tmpl(t *testing.T) {
+	tmpl := gotmpl.GoTemplatingContent("{{ .name }}")
+	vr := ValueRef{Tmpl: &tmpl}
+
+	data, err := yaml.Marshal(&vr)
+	require.NoError(t, err)
+	assert.Equal(t, "tmpl: '{{ .name }}'\n", string(data))
+}
+
+func TestValueRef_MarshalYAML_Nil(t *testing.T) {
+	vr := ValueRef{}
+
+	data, err := yaml.Marshal(&vr)
+	require.NoError(t, err)
+	assert.Equal(t, "null\n", string(data))
+}
+
+func TestValueRef_YAML_RoundTrip(t *testing.T) {
+	resolver := "environment"
+	expr := celexp.Expression("_.env == 'prod'")
+	tmpl := gotmpl.GoTemplatingContent("{{ .name }}")
+
+	tests := []struct {
+		name string
+		vr   ValueRef
+	}{
+		{
+			name: "string literal",
+			vr:   ValueRef{Literal: "hello world"},
+		},
+		{
+			name: "integer literal",
+			vr:   ValueRef{Literal: 42},
+		},
+		{
+			name: "float literal",
+			vr:   ValueRef{Literal: 3.14},
+		},
+		{
+			name: "boolean literal",
+			vr:   ValueRef{Literal: true},
+		},
+		{
+			name: "array literal",
+			vr:   ValueRef{Literal: []any{1, 2, 3}},
+		},
+		{
+			name: "map literal",
+			vr:   ValueRef{Literal: map[string]any{"key": "value"}},
+		},
+		{
+			name: "file path literal",
+			vr:   ValueRef{Literal: "./templates/main.tf.tmpl"},
+		},
+		{
+			name: "resolver reference",
+			vr:   ValueRef{Resolver: &resolver},
+		},
+		{
+			name: "expression",
+			vr:   ValueRef{Expr: &expr},
+		},
+		{
+			name: "template",
+			vr:   ValueRef{Tmpl: &tmpl},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal
+			data, err := yaml.Marshal(&tt.vr)
+			require.NoError(t, err)
+
+			// Unmarshal
+			var got ValueRef
+			err = yaml.Unmarshal(data, &got)
+			require.NoError(t, err)
+
+			// Compare
+			assert.Equal(t, tt.vr.Literal, got.Literal, "Literal mismatch")
+			if tt.vr.Resolver != nil {
+				require.NotNil(t, got.Resolver)
+				assert.Equal(t, *tt.vr.Resolver, *got.Resolver, "Resolver mismatch")
+			} else {
+				assert.Nil(t, got.Resolver)
+			}
+			if tt.vr.Expr != nil {
+				require.NotNil(t, got.Expr)
+				assert.Equal(t, string(*tt.vr.Expr), string(*got.Expr), "Expr mismatch")
+			} else {
+				assert.Nil(t, got.Expr)
+			}
+			if tt.vr.Tmpl != nil {
+				require.NotNil(t, got.Tmpl)
+				assert.Equal(t, string(*tt.vr.Tmpl), string(*got.Tmpl), "Tmpl mismatch")
+			} else {
+				assert.Nil(t, got.Tmpl)
+			}
+		})
+	}
+}
+
+func TestValueRef_YAML_RoundTrip_InMap(t *testing.T) {
+	// Simulates how ValueRef is used in practice: as values in a map (e.g., action inputs)
+	resolver := "environment"
+	expr := celexp.Expression("_.count * 2")
+
+	inputs := map[string]*ValueRef{
+		"message": {Literal: "hello world"},
+		"count":   {Literal: 42},
+		"path":    {Literal: "./templates/main.tf.tmpl"},
+		"env":     {Resolver: &resolver},
+		"doubled": {Expr: &expr},
+	}
+
+	data, err := yaml.Marshal(inputs)
+	require.NoError(t, err)
+
+	var got map[string]*ValueRef
+	err = yaml.Unmarshal(data, &got)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello world", got["message"].Literal)
+	assert.Equal(t, 42, got["count"].Literal)
+	assert.Equal(t, "./templates/main.tf.tmpl", got["path"].Literal)
+	require.NotNil(t, got["env"].Resolver)
+	assert.Equal(t, "environment", *got["env"].Resolver)
+	require.NotNil(t, got["doubled"].Expr)
+	assert.Equal(t, "_.count * 2", string(*got["doubled"].Expr))
+}
+
+func TestValueRef_MarshalJSON_Literal(t *testing.T) {
+	tests := []struct {
+		name     string
+		vr       ValueRef
+		expected string
+	}{
+		{
+			name:     "string literal",
+			vr:       ValueRef{Literal: "hello"},
+			expected: `"hello"`,
+		},
+		{
+			name:     "integer literal",
+			vr:       ValueRef{Literal: 42},
+			expected: `42`,
+		},
+		{
+			name:     "boolean literal",
+			vr:       ValueRef{Literal: true},
+			expected: `true`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(&tt.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestValueRef_MarshalJSON_Resolver(t *testing.T) {
+	resolver := "environment"
+	vr := ValueRef{Resolver: &resolver}
+
+	data, err := json.Marshal(&vr)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"rslvr":"environment"}`, string(data))
+}
+
+func TestValueRef_MarshalJSON_Nil(t *testing.T) {
+	vr := ValueRef{}
+
+	data, err := json.Marshal(&vr)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestValueRef_UnmarshalJSON_Literal(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected any
+	}{
+		{
+			name:     "string literal",
+			json:     `"hello world"`,
+			expected: "hello world",
+		},
+		{
+			name:     "integer literal",
+			json:     `42`,
+			expected: float64(42), // JSON numbers decode as float64
+		},
+		{
+			name:     "float literal",
+			json:     `3.14`,
+			expected: 3.14,
+		},
+		{
+			name:     "boolean literal",
+			json:     `true`,
+			expected: true,
+		},
+		{
+			name:     "array literal",
+			json:     `[1, 2, 3]`,
+			expected: []any{float64(1), float64(2), float64(3)},
+		},
+		{
+			name:     "null literal",
+			json:     `null`,
+			expected: nil,
+		},
+		{
+			name:     "map literal without known keys",
+			json:     `{"key": "value"}`,
+			expected: map[string]any{"key": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var vr ValueRef
+			err := json.Unmarshal([]byte(tt.json), &vr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, vr.Literal)
+			assert.Nil(t, vr.Resolver)
+			assert.Nil(t, vr.Expr)
+			assert.Nil(t, vr.Tmpl)
+		})
+	}
+}
+
+func TestValueRef_UnmarshalJSON_Resolver(t *testing.T) {
+	var vr ValueRef
+	err := json.Unmarshal([]byte(`{"rslvr":"environment"}`), &vr)
+	require.NoError(t, err)
+
+	assert.Nil(t, vr.Literal)
+	require.NotNil(t, vr.Resolver)
+	assert.Equal(t, "environment", *vr.Resolver)
+	assert.Nil(t, vr.Expr)
+	assert.Nil(t, vr.Tmpl)
+}
+
+func TestValueRef_UnmarshalJSON_Expr(t *testing.T) {
+	var vr ValueRef
+	err := json.Unmarshal([]byte(`{"expr":"_.env == 'prod'"}`), &vr)
+	require.NoError(t, err)
+
+	assert.Nil(t, vr.Literal)
+	assert.Nil(t, vr.Resolver)
+	require.NotNil(t, vr.Expr)
+	assert.Equal(t, "_.env == 'prod'", string(*vr.Expr))
+	assert.Nil(t, vr.Tmpl)
+}
+
+func TestValueRef_UnmarshalJSON_MultipleFields_Error(t *testing.T) {
+	var vr ValueRef
+	err := json.Unmarshal([]byte(`{"rslvr":"environment","expr":"_.env"}`), &vr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected exactly one of rslvr, expr, or tmpl, but found")
+}
+
+func TestValueRef_JSON_RoundTrip(t *testing.T) {
+	resolver := "environment"
+	expr := celexp.Expression("_.env == 'prod'")
+	tmpl := gotmpl.GoTemplatingContent("{{ .name }}")
+
+	tests := []struct {
+		name string
+		vr   ValueRef
+	}{
+		{name: "string literal", vr: ValueRef{Literal: "hello world"}},
+		{name: "number literal", vr: ValueRef{Literal: float64(42)}},
+		{name: "boolean literal", vr: ValueRef{Literal: true}},
+		{name: "resolver", vr: ValueRef{Resolver: &resolver}},
+		{name: "expression", vr: ValueRef{Expr: &expr}},
+		{name: "template", vr: ValueRef{Tmpl: &tmpl}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(&tt.vr)
+			require.NoError(t, err)
+
+			var got ValueRef
+			err = json.Unmarshal(data, &got)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.vr.Literal, got.Literal, "Literal mismatch")
+			if tt.vr.Resolver != nil {
+				require.NotNil(t, got.Resolver)
+				assert.Equal(t, *tt.vr.Resolver, *got.Resolver)
+			}
+			if tt.vr.Expr != nil {
+				require.NotNil(t, got.Expr)
+				assert.Equal(t, string(*tt.vr.Expr), string(*got.Expr))
+			}
+			if tt.vr.Tmpl != nil {
+				require.NotNil(t, got.Tmpl)
+				assert.Equal(t, string(*tt.vr.Tmpl), string(*got.Tmpl))
+			}
+		})
+	}
+}
+
+func TestValueRef_UnmarshalJSON_MalformedTypedRef_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "expr with wrong type (object)",
+			json: `{"expr": {}}`,
+		},
+		{
+			name: "rslvr with wrong type (array)",
+			json: `{"rslvr": []}`,
+		},
+		{
+			name: "tmpl with wrong type (number)",
+			json: `{"tmpl": 42}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var vr ValueRef
+			err := json.Unmarshal([]byte(tt.json), &vr)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid value ref")
+		})
+	}
+}
+
+func TestValueRef_UnmarshalJSON_ClearsStaleState(t *testing.T) {
+	// Start with a ValueRef that has Literal set
+	vr := ValueRef{Literal: "stale"}
+
+	// Unmarshal a resolver ref into the same instance
+	err := json.Unmarshal([]byte(`{"rslvr":"env"}`), &vr)
+	require.NoError(t, err)
+
+	assert.Nil(t, vr.Literal, "stale Literal should be cleared")
+	require.NotNil(t, vr.Resolver)
+	assert.Equal(t, "env", *vr.Resolver)
+
+	// Now unmarshal a literal into the same instance
+	err = json.Unmarshal([]byte(`"hello"`), &vr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", vr.Literal)
+	assert.Nil(t, vr.Resolver, "stale Resolver should be cleared")
+	assert.Nil(t, vr.Expr, "stale Expr should be cleared")
+	assert.Nil(t, vr.Tmpl, "stale Tmpl should be cleared")
+}
+
+func TestValueRef_UnmarshalJSON_NullKnownKey_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "null rslvr",
+			json: `{"rslvr": null}`,
+		},
+		{
+			name: "null expr",
+			json: `{"expr": null}`,
+		},
+		{
+			name: "null tmpl",
+			json: `{"tmpl": null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var vr ValueRef
+			err := json.Unmarshal([]byte(tt.json), &vr)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "null value")
+		})
+	}
+}
+
+func BenchmarkValueRef_MarshalYAML(b *testing.B) {
+	expr := celexp.Expression("_.env == 'prod'")
+	cases := []struct {
+		name string
+		vr   ValueRef
+	}{
+		{"literal_string", ValueRef{Literal: "hello"}},
+		{"literal_int", ValueRef{Literal: 42}},
+		{"expr", ValueRef{Expr: &expr}},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var err error
+			for b.Loop() {
+				_, err = yaml.Marshal(&tc.vr)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkValueRef_UnmarshalYAML(b *testing.B) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"literal_string", []byte(`"hello"`)},
+		{"literal_int", []byte(`42`)},
+		{"expr", []byte(`expr: _.env == 'prod'`)},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var err error
+			for b.Loop() {
+				var vr ValueRef
+				err = yaml.Unmarshal(tc.data, &vr)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkValueRef_MarshalJSON(b *testing.B) {
+	expr := celexp.Expression("_.env == 'prod'")
+	cases := []struct {
+		name string
+		vr   ValueRef
+	}{
+		{"literal_string", ValueRef{Literal: "hello"}},
+		{"literal_int", ValueRef{Literal: 42}},
+		{"expr", ValueRef{Expr: &expr}},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var err error
+			for b.Loop() {
+				_, err = json.Marshal(&tc.vr)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkValueRef_UnmarshalJSON(b *testing.B) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"literal_string", []byte(`"hello"`)},
+		{"literal_int", []byte(`42`)},
+		{"expr", []byte(`{"expr":"_.env == 'prod'"}`)},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var err error
+			for b.Loop() {
+				var vr ValueRef
+				err = json.Unmarshal(tc.data, &vr)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
…alog builds

Add MarshalYAML, MarshalJSON, and UnmarshalJSON to ValueRef so literal
values survive the deepCopySolution YAML round-trip used in catalog
bundling. Without these, the Literal field (tagged yaml:"-") was
silently dropped during marshaling, causing all literal provider inputs
to serialize as {}.

UnmarshalJSON uses json.RawMessage to detect known keys before typed
decoding, rejecting malformed refs (e.g. {"expr": {}}) instead of
silently treating them as literals. Clears all fields on entry to
prevent stale state when reusing instances.
