### PR TITLE
feat(catalog): resolve file write paths against caller's CWD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,31 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /site
+    schedule:
+      interval: weekly
+    groups:
+      docs-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /scripts
+    schedule:
+      interval: weekly
+    groups:
+      scripts-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/docs/design/catalog-build-bundling.md
+++ b/docs/design/catalog-build-bundling.md
@@ -151,6 +151,7 @@ The build command walks the parsed solution YAML and extracts literal file paths
 - Catalog references (e.g., `deploy-to-k8s@2.0.0`) and URLs (`https://...`) are excluded.
 - Absolute paths are rejected during build with a clear error — bundled solutions must use relative paths.
 - Discovered paths are resolved relative to the bundle root (the directory containing the solution YAML).
+- Both resolvers and workflow actions are analyzed. For the `file` provider, only `read` operations are bundled — `write` actions produce output paths that should not be treated as bundle inputs.
 
 **Recursive discovery for sub-solutions:** When a sub-solution is discovered via the `solution` provider, the build command recursively analyzes the sub-solution's YAML for its own local file references. All paths are normalized relative to the parent solution's bundle root.
 

--- a/docs/design/catalog.md
+++ b/docs/design/catalog.md
@@ -295,10 +295,23 @@ Flow:
 3. Fetch artifact if not cached
 4. Check and load required plugins
 5. Load solution YAML
-6. Resolve resolvers
-7. Render or execute actions
+6. Resolve resolvers (CWD is the bundle extraction directory)
+7. Execute actions (relative paths resolve against the **caller's CWD**)
 
 Catalog resolution is a read-only operation.
+
+### Working Directory Handling
+
+Catalog solutions with bundles are extracted to a temporary directory, and
+`os.Chdir` moves the process CWD there so resolvers can read bundled template
+files. Before this `os.Chdir`, the original caller CWD is captured. During the
+action execution phase, the caller's CWD is injected into the context via
+`provider.WithWorkingDirectory`, so file-writing actions resolve relative paths
+against the caller's directory — matching the behaviour of local `-f` file runs.
+
+When `--output-dir` is set, it takes precedence over the caller CWD for action
+path resolution. See [Output Directory](./output-dir.md) and
+[Working Directory](./cwd.md) for details.
 
 ---
 

--- a/docs/design/cwd.md
+++ b/docs/design/cwd.md
@@ -136,3 +136,35 @@ The `--cwd` value is validated at entry point (CLI root or MCP `contextWithCwd`)
 3. Verified to be a directory (not a file)
 
 Invalid values produce a clear error before any command logic executes.
+
+---
+
+## Catalog Solution CWD
+
+When running a catalog solution (bare name), the bundle is extracted to a temporary
+directory and the process CWD is changed there so resolvers can read bundled files.
+
+However, file-writing **actions** need to resolve relative paths against the
+caller's original working directory — not the temporary bundle directory. The CLI
+injects the caller's CWD into the action execution context via
+`provider.WithWorkingDirectory(actionCtx, originalCwd)`. This ensures
+`AbsFromContext` resolves relative action paths against the caller's CWD, matching
+the behaviour of local `-f` file runs.
+
+```
+Catalog run:  scafctl run solution my-app
+
+1. User is in /projects/my-app (caller CWD)
+2. Bundle extracted to /tmp/scafctl-bundle-xyz/
+3. os.Chdir(/tmp/scafctl-bundle-xyz/)   ← resolvers read bundled files here
+4. originalCwd captured as /projects/my-app
+5. actionCtx = WithWorkingDirectory(ctx, originalCwd)
+6. Actions resolve "./output" → /projects/my-app/output  ← correct
+```
+
+This aligns with how tools like `npm init`, `cargo init`, and `cookiecutter` work
+— they scaffold into the directory you run them from, regardless of where the
+template source lives.
+
+When `--output-dir` is specified, it takes precedence over the context CWD for
+action path resolution (unchanged behaviour).

--- a/docs/design/output-dir.md
+++ b/docs/design/output-dir.md
@@ -166,6 +166,7 @@ When `--output-dir` is specified, the directory is automatically created (includ
 | `__cwd` escape hatch | Injected as built-in variable for action expressions needing original CWD. |
 | Exec default workingDir | Empty workingDir in action mode defaults to output-dir. |
 | Backward compatible | No `--output-dir` → all paths resolve via CWD, exactly as before. |
+| Catalog CWD | Catalog solutions inject the caller's CWD into the action context so relative paths resolve against the caller's directory, not the temporary bundle extraction directory. |
 | Auto-create | `os.MkdirAll` before execution starts. Fail-fast on error. |
 
 ---

--- a/examples/solutions/catalog-cwd/data/license-header.txt
+++ b/examples/solutions/catalog-cwd/data/license-header.txt
@@ -1,0 +1,1 @@
+Apache-2.0 Licensed

--- a/examples/solutions/catalog-cwd/solution.yaml
+++ b/examples/solutions/catalog-cwd/solution.yaml
@@ -1,0 +1,78 @@
+# Catalog CWD Example
+# Demonstrates that catalog solutions write files to the caller's CWD by
+# default, matching the behaviour of local -f file runs. This aligns with
+# how npm init, cargo init, and cookiecutter work — they scaffold into the
+# directory you run them from.
+#
+# Build into local catalog:
+#   cd examples/solutions/catalog-cwd
+#   scafctl build solution solution.yaml --version 1.0.0
+#
+# Run from any directory (files land in your current directory):
+#   mkdir /tmp/my-project && cd /tmp/my-project
+#   scafctl run solution catalog-cwd-demo
+#
+# Run with --output-dir override:
+#   scafctl run solution catalog-cwd-demo --output-dir /tmp/output
+#
+# Verify:
+#   cat /tmp/my-project/README.md
+#   cat /tmp/my-project/config/settings.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: catalog-cwd-demo
+  version: 1.0.0
+  description: |
+    Demonstrates catalog solution CWD resolution. When run from the catalog,
+    file-writing actions resolve relative paths against the caller's working
+    directory — matching local -f file runs.
+
+bundle:
+  include:
+    - data/**
+
+spec:
+  resolvers:
+    project_name:
+      description: Project name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-project
+
+    bundled-license:
+      description: Read license template from bundle
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data/license-header.txt
+
+  workflow:
+    actions:
+      write-readme:
+        description: Write README to caller's CWD
+        provider: file
+        inputs:
+          operation: write
+          path: README.md
+          content:
+            expr: '"# " + _.project_name + "\n\nScaffolded by scafctl catalog-cwd-demo.\n"'
+
+
+      write-config:
+        description: Write config with bundled data
+        provider: file
+        inputs:
+          operation: write
+          path: config/settings.yaml
+          createDirs: true
+          content:
+            expr: |
+              "# " + string(_["bundled-license"].content) + "\nproject:\n  name: " + _.project_name + "\n  version: 0.1.0\n"

--- a/pkg/catalog/local.go
+++ b/pkg/catalog/local.go
@@ -327,6 +327,14 @@ func (c *LocalCatalog) reassembleDedup(ctx context.Context, ociManifest ocispec.
 	// Write the manifest as a v1-compatible manifest (downgrade version)
 	v1Manifest := bundleManifest
 	v1Manifest.Version = 1
+	// Deep-copy Files to avoid mutating bundleManifest via shared slice backing array
+	v1Manifest.Files = make([]struct {
+		Path   string `json:"path"`
+		Size   int64  `json:"size"`
+		Digest string `json:"digest"`
+		Layer  int    `json:"layer"`
+	}, len(bundleManifest.Files))
+	copy(v1Manifest.Files, bundleManifest.Files)
 	// Zero out layer fields for v1
 	for i := range v1Manifest.Files {
 		v1Manifest.Files[i].Layer = 0

--- a/pkg/catalog/local_coverage_test.go
+++ b/pkg/catalog/local_coverage_test.go
@@ -270,3 +270,77 @@ func BenchmarkLocalCatalog_Fetch(b *testing.B) {
 		_, _, _ = cat.Fetch(ctx, ref)
 	}
 }
+
+func TestLocalCatalog_StoreDedup_FetchWithBundle_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cat := newTestCatalog(t)
+	ctx := context.Background()
+
+	ref := testRef("dedup-roundtrip", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	solutionYAML := []byte("apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: test\n")
+
+	// Build a small tar with one file (simulating what CreateDeduplicatedBundle does)
+	var smallTarBuf bytes.Buffer
+	tw := tar.NewWriter(&smallTarBuf)
+	fileContent := []byte("hello from bundle")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "data/info.txt",
+		Size: int64(len(fileContent)),
+		Mode: 0o644,
+	}))
+	_, err := tw.Write(fileContent)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	// Build a manifest JSON pointing to layer 2 (small tar)
+	manifestJSON := []byte(fmt.Sprintf(`{
+		"version": 2,
+		"root": ".",
+		"files": [
+			{"path": "data/info.txt", "size": %d, "digest": "sha256:abc", "layer": 2}
+		]
+	}`, len(fileContent)))
+
+	_, err = cat.StoreDedup(ctx, ref, solutionYAML, manifestJSON, smallTarBuf.Bytes(), nil, nil, false)
+	require.NoError(t, err)
+
+	// FetchWithBundle should reassemble and return correct content
+	content, bundleData, info, err := cat.FetchWithBundle(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, solutionYAML, content)
+	assert.Equal(t, ref.Name, info.Reference.Name)
+	require.NotNil(t, bundleData, "bundle data should not be nil")
+
+	// Extract the file from the reassembled tar and verify its content
+	extracted, err := extractFileFromTar(bundleData, "data/info.txt")
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, extracted, "extracted bundle file should match original content, not solution YAML")
+}
+
+func BenchmarkLocalCatalog_ReassembleDedup(b *testing.B) {
+	tmpDir := b.TempDir()
+	cat, err := NewLocalCatalogAt(tmpDir, logr.Discard())
+	require.NoError(b, err)
+	ctx := context.Background()
+
+	ref := testRef("bench-dedup", "1.0.0")
+	ref.Kind = ArtifactKindSolution
+
+	var smallTarBuf bytes.Buffer
+	tw := tar.NewWriter(&smallTarBuf)
+	require.NoError(b, tw.WriteHeader(&tar.Header{Name: "data/f.txt", Size: 5, Mode: 0o644}))
+	_, _ = tw.Write([]byte("hello"))
+	require.NoError(b, tw.Close())
+
+	manifestJSON := []byte(`{"version":2,"root":".","files":[{"path":"data/f.txt","size":5,"digest":"sha256:abc","layer":2}]}`)
+	_, err = cat.StoreDedup(ctx, ref, []byte("sol"), manifestJSON, smallTarBuf.Bytes(), nil, nil, false)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _ = cat.FetchWithBundle(ctx, ref)
+	}
+}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -344,6 +344,13 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		actionCtx = provider.WithBackup(actionCtx, true)
 	}
 
+	// Ensure actions resolve relative paths against the caller's original working
+	// directory rather than the process CWD, which may have been changed to a
+	// temporary bundle extraction directory for catalog solutions. This aligns
+	// catalog runs with local -f behaviour: files land in the caller's CWD unless
+	// --output-dir is explicitly specified (which takes precedence in ResolvePath).
+	actionCtx = provider.WithWorkingDirectory(actionCtx, originalCwd)
+
 	// Dry run — execute resolvers in dry-run mode and show structured report
 	if o.DryRun {
 		return o.executeDryRun(actionCtx, sol, reg, params)

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -6,10 +6,12 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 )
@@ -76,6 +78,14 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		}
 	}
 
+	// Capture caller's CWD before prepare.Solution may os.Chdir to a bundle temp dir
+	originalCwd, err := provider.GetWorkingDirectory(ctx)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to get working directory: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
+	}
+
 	// Load solution
 	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
@@ -90,6 +100,16 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+
+	// If bundle extraction changed the process CWD, pin the resolver context
+	// to the bundle dir so file reads resolve within the extracted bundle,
+	// not against any caller-provided cwd override.
+	if bundleCwd, cwdErr := os.Getwd(); cwdErr == nil && bundleCwd != originalCwd {
+		ctx = provider.WithWorkingDirectory(ctx, bundleCwd)
+	}
+
+	// Separate action context resolves paths against the caller's CWD.
+	actionCtx := provider.WithWorkingDirectory(ctx, originalCwd)
 
 	sol := prepResult.Solution
 
@@ -110,7 +130,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	// Build the action graph (this materializes inputs)
-	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(actionCtx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action definitions and dependencies. Use lint_solution to find structural issues."),

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/dryrun"
@@ -113,6 +114,14 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 		}
 	}
 
+	// Capture caller's CWD before prepare.Solution may os.Chdir to a bundle temp dir
+	originalCwd, err := provider.GetWorkingDirectory(ctx)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to get working directory: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
+	}
+
 	// Load solution
 	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
@@ -127,6 +136,16 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+
+	// If bundle extraction changed the process CWD, pin the resolver context
+	// to the bundle dir so file reads resolve within the extracted bundle,
+	// not against any caller-provided cwd override.
+	if bundleCwd, cwdErr := os.Getwd(); cwdErr == nil && bundleCwd != originalCwd {
+		ctx = provider.WithWorkingDirectory(ctx, bundleCwd)
+	}
+
+	// Separate action context resolves paths against the caller's CWD.
+	actionCtx := provider.WithWorkingDirectory(ctx, originalCwd)
 
 	sol := prepResult.Solution
 	reg := prepResult.Registry
@@ -172,7 +191,7 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 
 	// Generate structured report
 	verbose := request.GetBool("verbose", false)
-	report, err := dryrun.Generate(ctx, sol, dryrun.Options{
+	report, err := dryrun.Generate(actionCtx, sol, dryrun.Options{
 		Registry:     reg,
 		ResolverData: resolverData,
 		Verbose:      verbose,

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -415,6 +415,14 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 		}
 	}
 
+	// Capture caller's CWD before prepare.Solution may os.Chdir to a bundle temp dir
+	originalCwd, err := provider.GetWorkingDirectory(ctx)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to get working directory: %v", err),
+			WithSuggestion("This is an internal error — please report it"),
+		), nil
+	}
+
 	// Load solution via prepare.Solution
 	prepResult, err := prepare.Solution(ctx, path,
 		prepare.WithRegistry(s.registry),
@@ -454,6 +462,16 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 		defer prepResult.Cleanup()
 	}
 
+	// If bundle extraction changed the process CWD, pin the resolver context
+	// to the bundle dir so file reads resolve within the extracted bundle,
+	// not against any caller-provided cwd override.
+	if bundleCwd, cwdErr := os.Getwd(); cwdErr == nil && bundleCwd != originalCwd {
+		ctx = provider.WithWorkingDirectory(ctx, bundleCwd)
+	}
+
+	// Separate action context resolves paths against the caller's CWD.
+	actionCtx := provider.WithWorkingDirectory(ctx, originalCwd)
+
 	sol := prepResult.Solution
 	reg := prepResult.Registry
 
@@ -469,9 +487,9 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 	case "resolver":
 		return s.renderResolverGraph(sol, reg)
 	case "action-deps":
-		return s.renderActionDepsGraph(ctx, sol, params, outputDir)
+		return s.renderActionDepsGraph(ctx, actionCtx, sol, params, outputDir)
 	default:
-		return s.renderActionGraph(ctx, sol, params, outputDir)
+		return s.renderActionGraph(ctx, actionCtx, sol, params, outputDir)
 	}
 }
 
@@ -515,7 +533,7 @@ func (s *Server) renderResolverGraph(sol *solution.Solution, reg *provider.Regis
 }
 
 // renderActionGraph executes resolvers, builds, and renders the action graph.
-func (s *Server) renderActionGraph(ctx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) { //nolint:unparam // error is always nil per MCP pattern
+func (s *Server) renderActionGraph(resolverCtx, actionCtx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) { //nolint:unparam // error is always nil per MCP pattern
 	if !sol.Spec.HasWorkflow() {
 		suggestion := "Add a spec.workflow section with actions to the solution"
 		if sol.Spec.HasResolvers() {
@@ -528,7 +546,7 @@ func (s *Server) renderActionGraph(ctx context.Context, sol *solution.Solution, 
 	}
 
 	// Execute resolvers to get data for action inputs
-	resolverData, err := s.executeResolversForRender(ctx, sol, params)
+	resolverData, err := s.executeResolversForRender(resolverCtx, sol, params)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
 			WithSuggestion("Check resolver configuration with preview_resolvers"),
@@ -537,7 +555,7 @@ func (s *Server) renderActionGraph(ctx context.Context, sol *solution.Solution, 
 	}
 
 	// Build the action graph
-	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(actionCtx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action dependencies and provider configurations"),
@@ -577,7 +595,7 @@ func (s *Server) renderActionGraph(ctx context.Context, sol *solution.Solution, 
 }
 
 // renderActionDepsGraph builds and returns the action dependency visualization.
-func (s *Server) renderActionDepsGraph(ctx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) {
+func (s *Server) renderActionDepsGraph(resolverCtx, actionCtx context.Context, sol *solution.Solution, params map[string]any, outputDir string) (*mcp.CallToolResult, error) {
 	if !sol.Spec.HasWorkflow() {
 		return newStructuredError(ErrCodeValidationError, "solution does not define a workflow",
 			WithSuggestion("Add a spec.workflow section with actions to the solution"),
@@ -586,7 +604,7 @@ func (s *Server) renderActionDepsGraph(ctx context.Context, sol *solution.Soluti
 	}
 
 	// Execute resolvers to get data for action inputs
-	resolverData, err := s.executeResolversForRender(ctx, sol, params)
+	resolverData, err := s.executeResolversForRender(resolverCtx, sol, params)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("resolver execution failed: %v", err),
 			WithSuggestion("Check resolver configuration with preview_resolvers"),
@@ -595,7 +613,7 @@ func (s *Server) renderActionDepsGraph(ctx context.Context, sol *solution.Soluti
 	}
 
 	// Build the action graph
-	graph, err := action.BuildGraph(ctx, sol.Spec.Workflow, resolverData, nil)
+	graph, err := action.BuildGraph(actionCtx, sol.Spec.Workflow, resolverData, nil)
 	if err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to build action graph: %v", err),
 			WithSuggestion("Check action dependencies and provider configurations"),

--- a/pkg/provider/path_test.go
+++ b/pkg/provider/path_test.go
@@ -367,6 +367,29 @@ func TestResolvePath_ActionModeOutputDirTakesPrecedenceOverContextCWD(t *testing
 	assert.Equal(t, "/output/dir/subdir/file.txt", result)
 }
 
+func TestResolvePath_ActionModeContextCWDUsedWithoutOutputDir(t *testing.T) {
+	// Simulates a catalog solution run without --output-dir: action mode is set,
+	// context working directory is the caller's CWD, but no output directory.
+	// ResolvePath should resolve against the context CWD (not os.Getwd).
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/caller/project")
+	ctx = WithExecutionMode(ctx, CapabilityAction)
+
+	result, err := ResolvePath(ctx, "output/file.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/caller/project/output/file.txt", result)
+}
+
+func BenchmarkResolvePath_ActionModeContextCWDNoOutputDir(b *testing.B) {
+	ctx := context.Background()
+	ctx = WithWorkingDirectory(ctx, "/caller/project")
+	ctx = WithExecutionMode(ctx, CapabilityAction)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ResolvePath(ctx, "output/file.txt")
+	}
+}
+
 // ── WorkingDirectory context round-trip tests ──
 
 func TestWorkingDirectoryFromContext_NotSet(t *testing.T) {

--- a/pkg/solution/bundler/discover.go
+++ b/pkg/solution/bundler/discover.go
@@ -449,9 +449,14 @@ func walkActionInputs(actions map[string]*actionpkg.Action, localFiles *[]string
 		}
 		switch a.Provider {
 		case "file":
-			if path := extractLiteralString(a.Inputs, "path"); path != "" {
-				if isLocalPath(path) {
-					*localFiles = append(*localFiles, path)
+			// Only bundle paths for read operations. Non-read operations
+			// (write/delete/exists) are outputs or runtime checks and are
+			// intentionally excluded from bundling.
+			if op := extractLiteralString(a.Inputs, "operation"); op == "" || op == "read" {
+				if path := extractLiteralString(a.Inputs, "path"); path != "" {
+					if isLocalPath(path) {
+						*localFiles = append(*localFiles, path)
+					}
 				}
 			}
 		case "solution":

--- a/pkg/solution/bundler/discover_test.go
+++ b/pkg/solution/bundler/discover_test.go
@@ -390,3 +390,117 @@ func TestWithWalkDirFunc(t *testing.T) {
 	cfg.walkDir(".", nil)
 	assert.True(t, called)
 }
+
+func TestDiscoverFiles_SkipsActionWritePaths(t *testing.T) {
+	// File write actions produce output files — their paths should not be
+	// treated as source files to bundle. Only read paths should be discovered.
+	sol := &solution.Solution{}
+	err := sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test
+  version: 1.0.0
+spec:
+  resolvers:
+    data:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      write-output:
+        provider: file
+        inputs:
+          operation: write
+          path: "output.txt"
+          content:
+            rslvr: data
+      delete-file:
+        provider: file
+        inputs:
+          operation: delete
+          path: "temp.txt"
+`))
+	require.NoError(t, err)
+
+	result, err := DiscoverFiles(sol, t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, result.LocalFiles, "write/delete action paths must not be bundled")
+}
+
+func TestDiscoverFiles_IncludesActionReadPaths(t *testing.T) {
+	// File read actions in the workflow DO need their paths bundled.
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "input.txt"), []byte("data"), 0o644))
+
+	sol := &solution.Solution{}
+	err := sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test
+  version: 1.0.0
+spec:
+  resolvers:
+    data:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      read-input:
+        provider: file
+        inputs:
+          operation: read
+          path: "input.txt"
+`))
+	require.NoError(t, err)
+
+	result, err := DiscoverFiles(sol, tmpDir)
+	require.NoError(t, err)
+	require.Len(t, result.LocalFiles, 1)
+	assert.Equal(t, "input.txt", result.LocalFiles[0].RelPath)
+}
+
+func BenchmarkWalkActionInputs(b *testing.B) {
+	sol := &solution.Solution{}
+	err := sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bench
+  version: 1.0.0
+spec:
+  workflow:
+    actions:
+      write-a:
+        provider: file
+        inputs:
+          operation: write
+          path: "a.txt"
+          content:
+            rslvr: data
+      write-b:
+        provider: file
+        inputs:
+          operation: write
+          path: "b.txt"
+          content:
+            rslvr: data
+      read-c:
+        provider: file
+        inputs:
+          operation: read
+          path: "c.txt"
+`))
+	require.NoError(b, err)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		analyzeProviderInputs(sol)
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -5430,6 +5430,109 @@ func TestIntegration_RunSolution_OutputDir_HelpFlag(t *testing.T) {
 }
 
 // ============================================================================
+// Catalog CWD Resolution Tests
+// ============================================================================
+
+func TestIntegration_RunSolution_CatalogWritesToCallerCWD(t *testing.T) {
+	// When running a catalog solution (bare name) without --output-dir,
+	// file write actions with relative paths should land in the caller's CWD,
+	// NOT in the temporary bundle extraction directory.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	projectRoot := findProjectRoot()
+
+	// Build the catalog-cwd solution into the local catalog
+	_, stderr, exitCode := runScafctlInDir(t, filepath.Join(projectRoot, "tests/integration/solutions/catalog-cwd"),
+		"build", "solution", "solution.yaml", "--version", "1.0.0", "--force",
+	)
+	require.Equalf(t, 0, exitCode, "build failed: %s", stderr)
+
+	// Run by bare name from a fresh temp working directory
+	workDir := t.TempDir()
+	stdout, stderr, exitCode := runScafctlInDir(t, workDir,
+		"run", "solution", "catalog-cwd-test",
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstderr: %s", exitCode, stderr)
+
+	// Verify action outputs landed in the caller's CWD
+	assert.FileExists(t, filepath.Join(workDir, "catalog-output.txt"))
+	assert.FileExists(t, filepath.Join(workDir, "sub/config.yaml"))
+	assert.FileExists(t, filepath.Join(workDir, "cwd-ref.txt"))
+
+	// Verify greeting content
+	greeting, err := os.ReadFile(filepath.Join(workDir, "catalog-output.txt"))
+	if assert.NoError(t, err) {
+		assert.Contains(t, string(greeting), "Hello from catalog-cwd test")
+	}
+
+	// Verify nested config content
+	configContent, err := os.ReadFile(filepath.Join(workDir, "sub/config.yaml"))
+	if assert.NoError(t, err) {
+		assert.Contains(t, string(configContent), "app: catalog-cwd-test")
+		assert.Contains(t, string(configContent), "version: 1.0.0")
+	}
+
+	// Verify __cwd points to workDir, not a temp bundle directory
+	cwdRef, err := os.ReadFile(filepath.Join(workDir, "cwd-ref.txt"))
+	if assert.NoError(t, err) {
+		assert.Contains(t, string(cwdRef), "cwd="+workDir,
+			"__cwd should reference the caller's CWD, not a bundle temp dir")
+	}
+
+	// Verify bundled file content was correctly extracted and written
+	assert.FileExists(t, filepath.Join(workDir, "bundled-output.txt"))
+	bundledContent, err := os.ReadFile(filepath.Join(workDir, "bundled-output.txt"))
+	if assert.NoError(t, err) {
+		assert.Equal(t, "bundled info content\n", string(bundledContent),
+			"bundled file content should match original data/info.txt, not the solution YAML")
+	}
+}
+
+func TestIntegration_RunSolution_CatalogOutputDirOverridesCWD(t *testing.T) {
+	// When --output-dir is set, it should still override even for catalog runs.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	projectRoot := findProjectRoot()
+
+	// Build the catalog-cwd solution into the local catalog
+	_, stderr, exitCode := runScafctlInDir(t, filepath.Join(projectRoot, "tests/integration/solutions/catalog-cwd"),
+		"build", "solution", "solution.yaml", "--version", "1.0.0", "--force",
+	)
+	require.Equalf(t, 0, exitCode, "build failed: %s", stderr)
+
+	// Run by bare name with --output-dir
+	workDir := t.TempDir()
+	outputDir := t.TempDir()
+	stdout, stderr, exitCode := runScafctlInDir(t, workDir,
+		"run", "solution", "catalog-cwd-test",
+		"--output-dir", outputDir,
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstderr: %s", exitCode, stderr)
+
+	// Verify action outputs landed in --output-dir, not CWD
+	assert.FileExists(t, filepath.Join(outputDir, "catalog-output.txt"))
+	assert.FileExists(t, filepath.Join(outputDir, "sub/config.yaml"))
+	assert.FileExists(t, filepath.Join(outputDir, "cwd-ref.txt"))
+	assert.FileExists(t, filepath.Join(outputDir, "bundled-output.txt"))
+
+	// Verify files did NOT land in the caller's CWD
+	assert.NoFileExists(t, filepath.Join(workDir, "catalog-output.txt"),
+		"action output should not land in CWD when --output-dir is set")
+	assert.NoFileExists(t, filepath.Join(workDir, "sub/config.yaml"),
+		"action output should not land in CWD when --output-dir is set")
+}
+
+// ============================================================================
 // Telemetry Flag Tests
 // ============================================================================
 

--- a/tests/integration/solutions/catalog-cwd/data/info.txt
+++ b/tests/integration/solutions/catalog-cwd/data/info.txt
@@ -1,0 +1,1 @@
+bundled info content

--- a/tests/integration/solutions/catalog-cwd/solution.yaml
+++ b/tests/integration/solutions/catalog-cwd/solution.yaml
@@ -1,0 +1,100 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: catalog-cwd-test
+  version: 1.0.0
+  description: |
+    Integration test for catalog solution CWD resolution.
+    When run from a catalog (bare name), relative paths in file write actions
+    should resolve against the caller's CWD — matching local -f file behaviour.
+
+bundle:
+  include:
+    - data/**
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting message
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello from catalog-cwd test
+
+    config-data:
+      description: Static config data
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: catalog-cwd-test
+                version: "1.0.0"
+
+    bundle-data:
+      description: Read bundled file to verify bundle extraction
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data/info.txt
+
+  workflow:
+    actions:
+      write-greeting:
+        description: Write greeting to relative path (should land in caller CWD)
+        provider: file
+        inputs:
+          operation: write
+          path: catalog-output.txt
+          content:
+            rslvr: greeting
+
+      write-config:
+        description: Write nested file using relative path
+        provider: file
+        inputs:
+          operation: write
+          path: sub/config.yaml
+          createDirs: true
+          content:
+            expr: '"app: " + _["config-data"].appName + "\nversion: " + _["config-data"].version'
+
+      write-cwd-ref:
+        description: Write __cwd reference for verification
+        provider: file
+        inputs:
+          operation: write
+          path: cwd-ref.txt
+          content:
+            expr: '"cwd=" + __cwd'
+
+      write-bundled:
+        description: Write bundled file content to verify bundle extraction round-trip
+        provider: file
+        inputs:
+          operation: write
+          path: bundled-output.txt
+          content:
+            expr: '_["bundle-data"].content'
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      resolvers-work:
+        description: Verify resolvers produce expected values
+        command: [run, resolver]
+        args: ["-o", "json"]
+        files: ["data/**"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "Hello from catalog-cwd test"
+          - contains: "catalog-cwd-test"
+          - contains: "bundled info content"


### PR DESCRIPTION
BREAKING CHANGE: Catalog solutions now write files relative to the caller's working directory instead of a temporary bundle extraction directory. Use --output-dir to override.

This change aligns catalog solution behavior with local file runs (-f) and common scaffolding tools (npm init, cargo init, cookiecutter).

Changes:
- Inject originalCwd into action context via WithWorkingDirectory
- Fix bundler to skip file paths for write operations in static analysis
- Fix bundle extraction layer corruption from shallow struct copy
- Apply CWD fix to MCP server tool handlers (dry-run, render, preview)

Fixes:
- Catalog solutions with file write actions now correctly scaffold into the user's current directory
- Bundler no longer fails on solutions with write action paths that don't exist as source files
- Bundle extraction no longer corrupts file contents due to layer index mutation

Testing:
- Add integration tests for catalog CWD and output-dir override
- Add unit tests for bundler action operation filtering
- Add round-trip regression test for StoreDedup/FetchWithBundle
- Add benchmarks for path resolution and catalog operations

Docs:
- Update cwd.md, catalog.md, output-dir.md design docs
- Update catalog-build-bundling.md with action analysis rules
- Add catalog-cwd example solution
