### PR TITLE
feat(provider): add message provider for rich terminal output

### DIFF
--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -128,7 +128,7 @@ scafctl eval cel --expression 'has(config.timeout)' --file config.json
 ```
 scafctl eval template --template '{{ .name | upper }}' --var name=hello
 scafctl eval template --template-file deploy.tmpl --data '{"env": "prod"}'
-scafctl eval template --template '{{ ._.config.host }}' --file resolvers.json
+scafctl eval template --template '{{ .config.host }}' --file resolvers.json
 ```
 
 **File:** `pkg/cmd/scafctl/eval/template.go`

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -526,7 +526,7 @@ type Descriptor struct {
   // Optional - if nil, the generic extraction logic is used which handles:
   // - ValueRef.Resolver references
   // - CEL expressions (_.resolverName patterns)
-  // - Go templates ({{._.resolverName}} patterns with default delimiters)
+  // - Go templates ({{.resolverName}} patterns with default delimiters)
   // Providers should implement this when they have custom input formats that may
   // contain resolver references, such as templates with custom delimiters.
   // The function receives the raw inputs map and returns resolver names that this input depends on.
@@ -1113,6 +1113,65 @@ resolve:
         message: "Current value"
         value:
           rslvr: someResolver
+~~~
+
+---
+
+### message
+
+Outputs styled, feature-rich terminal messages during solution execution. Supports built-in message types (success, warning, error, info, debug, plain), custom formatting with colors and icons via lipgloss, destination control (stdout/stderr), and respects `--quiet` and `--no-color` flags. For dynamic interpolation, use the framework's `tmpl:` or `expr:` ValueRef on the `message` input.
+
+**Capabilities:** `action`
+
+**Input Fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | string | — | Message text. Use `tmpl:` or `expr:` ValueRef for dynamic content. |
+| `type` | enum | `info` | `success`, `warning`, `error`, `info`, `debug`, `plain` |
+| `label` | string | — | Contextual prefix rendered as dimmed `[label]` between icon and message |
+| `style` | object | — | Custom formatting that merges on top of type defaults: `color`, `bold`, `italic`, `icon` |
+| `destination` | enum | `stdout` | `stdout` or `stderr` |
+| `newline` | bool | `true` | Whether to append trailing newline |
+
+~~~yaml
+# Built-in type styling
+resolve:
+  with:
+    - provider: message
+      inputs:
+        message: "Deployment completed successfully"
+        type: success
+
+# Custom styling with icon
+resolve:
+  with:
+    - provider: message
+      inputs:
+        message: "Starting pipeline"
+        style:
+          color: "#FF5733"
+          bold: true
+          icon: "\U0001F680"
+
+# Go template interpolation via tmpl: ValueRef
+resolve:
+  with:
+    - provider: message
+      inputs:
+        message:
+          tmpl: "Deploying {{ .appName }} to {{ .environment }}"
+        type: info
+
+# CEL expression via expr: ValueRef
+resolve:
+  with:
+    - provider: message
+      inputs:
+        message:
+          expr: "'Processed ' + string(size(_.items)) + ' items'"
+        type: success
+
 ~~~
 
 ---

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -43,6 +43,7 @@ Step-by-step guides for learning scafctl features.
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution with embedded and external shells
 - [Directory Provider Tutorial](directory-provider-tutorial.md) — Listing, scanning, and managing directories
 - [HCL Provider Tutorial](hcl-provider-tutorial.md) — Parse, format, validate, and generate Terraform/OpenTofu HCL configuration files
+- [Message Provider Tutorial](message-provider-tutorial.md) — Rich terminal output with styled messages, templates, and quiet-mode control
 - [Provider Output Shapes](provider-output-shapes.md) — Quick reference for provider output data shapes
 - [Provider Reference](provider-reference.md) — Complete documentation for all built-in providers
 

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -970,7 +970,7 @@ inputs:
 ```yaml
 inputs:
   message:
-    tmpl: "Deploying {{ ._.project }} to {{ ._.environment }}"
+    tmpl: "Deploying {{ .project }} to {{ .environment }}"
 ```
 
 ---

--- a/docs/tutorials/message-provider-tutorial.md
+++ b/docs/tutorials/message-provider-tutorial.md
@@ -1,0 +1,413 @@
+---
+title: "Message Provider Tutorial"
+weight: 75
+---
+
+# Message Provider Tutorial
+
+This tutorial covers using the **message** provider for rich terminal output during solution execution — styled messages with icons, colors, and dynamic interpolation via `tmpl:`/`expr:` ValueRefs.
+
+## Overview
+
+The message provider replaces awkward `exec` + `echo` patterns with first-class terminal messaging that integrates with scafctl's `--quiet`, `--no-color`, and `--dry-run` flags.
+
+```mermaid
+flowchart LR
+  A["Resolver<br/>Data"] --> B["Message<br/>Provider"]
+  B -- "styled output" --> C["Terminal<br/>(stdout/stderr)"]
+  B -- "data" --> D["Output<br/>{success, message}"]
+```
+
+**Key features:**
+- Built-in message types: `success`, `warning`, `error`, `info`, `debug`, `plain`
+- Custom styling: colors (hex or named), bold, italic, custom icons/emoji
+- Contextual labels: dimmed `[label]` prefixes for step tracking (e.g., `[step 2/5]`, `[deploy]`)
+- Dynamic interpolation via framework `tmpl:` and `expr:` ValueRefs (with automatic dependency detection)
+- Respects `--quiet` flag (messages suppressed in quiet mode)
+- Trailing newline control via the `newline` field
+- Dry-run awareness via `--dry-run`
+
+## Quick Start
+
+### Step 1: Create the Solution File
+
+Create a file called `message-basics.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-basics
+  version: 1.0.0
+
+spec:
+  resolvers:
+    hello:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Hello from the message provider!"
+              type: info
+```
+
+### Step 2: Run It
+
+```bash
+scafctl run resolver -f ./message-basics.yaml
+```
+
+The message provider outputs the styled message to the terminal and returns the result as resolver data. You should see the message displayed with the info icon and styling, along with a table showing the resolver output containing `{"message":"Hello from the message provider!","success":true}`.
+
+### 3. Message Types
+
+Each type has a default icon and color:
+
+| Type | Icon | Color |
+|------|------|-------|
+| `success` | ✅ | Green |
+| `warning` | ⚠️ | Yellow |
+| `error` | ❌ | Red |
+| `info` | 💡 | Cyan |
+| `debug` | 🐛 | Magenta |
+| `plain` | — | None |
+
+Create a file called `message-types.yaml` and add the following:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-types
+  version: 1.0.0
+
+spec:
+  resolvers:
+    step1:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Build succeeded"
+              type: success
+
+    step2:
+      dependsOn: [step1]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "3 deprecation warnings found"
+              type: warning
+```
+
+Run it:
+
+```bash
+scafctl run resolver -f ./message-types.yaml
+```
+
+You should see the styled messages followed by a table with resolver output data:
+
+```
+✅ Build succeeded
+⚠️  3 deprecation warnings found
+```
+
+> **▶ Try it:** Run [examples/providers/message-types.yaml](../../examples/providers/message-types.yaml) to see all types.
+
+## Custom Styling
+
+Customize the appearance with the `style` object. Style fields **merge on top of** the `type` defaults — only the fields you specify are overridden, and the rest are inherited from the type.
+
+Create a file called `message-style.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-style
+  version: 1.0.0
+
+spec:
+  resolvers:
+    deploy-start:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Starting deployment pipeline"
+              type: success
+              style:
+                icon: "🚀"  # override icon; color and bold inherited from success
+```
+
+For fully custom styling (no type base), use `type: plain`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-custom
+  version: 1.0.0
+
+spec:
+  resolvers:
+    custom:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Starting deployment pipeline"
+              type: plain
+              style:
+                color: "#FF5733"
+                bold: true
+                icon: "🚀"
+```
+
+### Style Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `color` | string | ANSI color name (`green`, `red`) or hex (`#FF5733`) |
+| `bold` | bool | Bold text |
+| `italic` | bool | Italic text |
+| `icon` | string | Emoji or character prefix (`🚀`, `📦`, `→`) |
+
+When `style` is set and `--no-color` is **not** active, style fields merge on top of the type's defaults. Only the fields you specify are overridden — unset fields keep their type defaults. Set `icon: ""` to explicitly disable the type's default icon.
+
+> **▶ Try it:** Run [examples/providers/message-custom-style.yaml](../../examples/providers/message-custom-style.yaml).
+
+## Labels
+
+Add contextual prefix labels to messages with the `label` field. Labels are rendered as dimmed `[label]` text between the icon and the message:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-labels
+  version: 1.0.0
+
+spec:
+  resolvers:
+    step1:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Installing dependencies"
+              type: info
+              label: "step 1/3"
+```
+
+Output: `💡 [step 1/3] Installing dependencies`
+
+Labels support `tmpl:` and `expr:` ValueRef for dynamic content:
+
+```yaml
+label:
+  tmpl: "{{ .config.appName }}"
+```
+
+## Dynamic Messages
+
+The message provider accepts a plain `message` string. For dynamic interpolation, use the framework's standard `tmpl:` or `expr:` ValueRef on the `message` input. This is the same mechanism available to all providers, and the framework automatically detects resolver dependencies — no `dependsOn` needed.
+
+### Go Templates via `tmpl:`
+
+Create a file called `message-template.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-template
+  version: 1.0.0
+
+spec:
+  resolvers:
+    config:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: my-service
+                version: 2.0.0
+
+    deploy-msg:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                tmpl: "Deploying {{ .config.appName }} v{{ .config.version }}"
+              type: info
+```
+
+Output: `💡 Deploying my-service v2.0.0`
+
+> **Note:** Go templates access resolver data directly with `{{ .resolverName }}`. In CEL expressions, use the `_` prefix: `_.resolverName`.
+
+### CEL Expressions via `expr:`
+
+Create a file called `message-cel.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-cel
+  version: 1.0.0
+
+spec:
+  resolvers:
+    items:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: [a, b, c, d, e]
+
+    status:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                expr: "'Processed ' + string(size(_.items)) + ' items successfully'"
+              type: success
+```
+
+Output: `✅ Processed 5 items successfully`
+
+> **▶ Try it:** Run [examples/providers/message-dynamic.yaml](../../examples/providers/message-dynamic.yaml).
+
+## Quiet Mode
+
+The message provider respects the `--quiet` flag. When `--quiet` is passed, all messages are suppressed from terminal output. The rendered message text is still available in the resolver output data, so downstream resolvers can use it.
+
+```bash
+# Messages are displayed normally
+scafctl run resolver -f ./message-basics.yaml
+
+# Messages are suppressed with --quiet
+scafctl run resolver -f ./message-basics.yaml --quiet
+```
+
+## Destination Control
+
+Direct messages to `stdout` (default) or `stderr`. Create a file called `message-stderr.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-stderr
+  version: 1.0.0
+
+spec:
+  resolvers:
+    error-log:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Connection failed: timeout after 30s"
+              type: error
+              destination: stderr
+```
+
+## Newline Control
+
+The `newline` field (default: `true`) appends a trailing newline to the rendered output, so the terminal writer does a single `fmt.Fprint` unconditionally.
+
+Create a file called `message-newline.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: message-newline
+  version: 1.0.0
+
+spec:
+  resolvers:
+    inline:
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Status: "
+              type: plain
+              newline: false
+          - provider: message
+            inputs:
+              message: "READY"
+              style:
+                color: green
+                bold: true
+```
+
+## Output Data
+
+The message provider returns its rendered text in the output, making it accessible to downstream resolvers:
+
+```json
+{
+  "success": true,
+  "message": "Deploying my-service v2.0.0"
+}
+```
+
+## Dry-Run Support
+
+With `--dry-run`, the message provider does not write to the terminal. Instead, it returns a description of what would happen:
+
+```bash
+scafctl run resolver -f ./solution.yaml --dry-run -o json
+```
+
+Output includes:
+```json
+{
+  "success": true,
+  "message": "[dry-run] Would output info message to stdout: Deploying my-service"
+}
+```
+
+## Complete Example
+
+See [examples/solutions/message-demo/solution.yaml](../../examples/solutions/message-demo/solution.yaml) for a complete solution workflow using the message provider with actions, resolvers, and templates.
+
+## CLI Reference
+
+```bash
+# Run message provider directly
+scafctl run provider message --input message="Hello" --input type=success
+
+# Run with JSON output
+scafctl run provider message --input message="Hello" -o json
+
+# Dry-run
+scafctl run provider message --input message="Hello" --dry-run
+```
+
+## Shell Eval / Piping
+
+Solutions that produce shell-eval output work cleanly with `run solution` — action
+output is never prefixed with labels, so it's always pipe-safe:
+
+```bash
+eval "$(scafctl run solution -f ./proxy.yaml)"
+scafctl run solution -f ./proxy.yaml | Invoke-Expression   # PowerShell
+```
+
+For debugging multi-action workflows, use `--progress` to see action
+start/complete events or `--show-execution` for full metadata.
+
+> **Note:** When using structured output modes (`-o json`, `-o yaml`, `-o quiet`),
+> terminal messages are redirected to stderr so they don't corrupt the structured
+> envelope on stdout.

--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -257,7 +257,10 @@ Sensitive fields are declared on the Descriptor (see [Mark Sensitive Data](#4-ma
 
 ## Execute Method
 
-The `Execute` method receives validated inputs and returns an `Output`:
+The `Execute` method receives validated inputs and returns an `Output`.
+
+> [!IMPORTANT]
+> **Inputs are pre-resolved by the framework.** When users write `tmpl:`, `expr:`, or `rslvr:` ValueRefs on any input field, the framework evaluates them **before** calling your provider. Your `Execute` method always receives plain, already-resolved values (strings, numbers, maps, etc.). **Do not** implement Go template or CEL evaluation inside your provider — that's the framework's job. See [Don't Duplicate ValueRef Handling](#6-dont-duplicate-valueref-handling).
 
 ```go
 func (p *MyProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
@@ -688,6 +691,33 @@ resolve:
     },
 },
 ```
+
+### 6. Don't Duplicate ValueRef Handling
+
+The scafctl framework provides a universal **ValueRef** system that allows users to use `tmpl:` (Go templates), `expr:` (CEL expressions), or `rslvr:` (resolver references) on **any** provider input field. The framework evaluates these before calling your provider and automatically detects resolver dependencies from the references — users don't even need `dependsOn`.
+
+**Do not** implement Go template parsing or CEL evaluation inside your provider. Your `Execute` method receives already-resolved plain values.
+
+```yaml
+# Users can write this for ANY provider — the framework handles it:
+resolvers:
+  greeting:
+    resolve:
+      with:
+        - provider: my-provider
+          inputs:
+            # tmpl: ValueRef — framework evaluates, provider receives plain string
+            url:
+              tmpl: "https://api.example.com/{{ .environment }}/data"
+            # expr: ValueRef — framework evaluates, provider receives plain string
+            query:
+              expr: "'status=' + _.filterMode"
+            # rslvr: ValueRef — framework resolves, provider receives the value
+            token:
+              rslvr: apiToken
+```
+
+In your provider's `Execute`, all three inputs arrive as plain strings. The framework also auto-detects that this resolver depends on `environment`, `filterMode`, and `apiToken` — no manual `dependsOn` required.
 
 ## Directory Structure
 

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -225,6 +225,13 @@ Varies by operation — parse returns structured data, format/validate return st
 | validation | `valid` | bool | Always `true` on success |
 | | `details` | string | `"all validations passed"` |
 
+### `message`
+
+| Capability | Fields | Type | Description |
+|-----------|--------|------|-------------|
+| action | `success` | bool | Always `true` on success |
+| | `message` | string | Rendered message text |
+
 ---
 
 ## Discovering Output Shapes

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -38,6 +38,7 @@ Providers are execution primitives used by resolvers and actions. Each provider 
 | [hcl](#hcl) | ✅ | ✅ | ❌ | ❌ |
 | [http](#http) | ✅ | ✅ | ❌ | ✅ |
 | [identity](#identity) | ✅ | ❌ | ❌ | ❌ |
+| [message](#message) | ❌ | ✅ | ❌ | ✅ |
 | [metadata](#metadata) | ✅ | ❌ | ❌ | ❌ |
 | [parameter](#parameter) | ✅ | ❌ | ❌ | ❌ |
 | [secret](#secret) | ✅ | ❌ | ❌ | ❌ |
@@ -1464,6 +1465,107 @@ resolvers:
               "Running " + _.runtime_meta.solution.name +
               " v" + _.runtime_meta.solution.version +
               " via " + _.runtime_meta.entrypoint
+```
+
+---
+
+## message
+
+Outputs styled terminal messages with built-in types, custom formatting via lipgloss, destination control, and respects `--quiet` and `--no-color` flags. For dynamic interpolation, use the framework's `tmpl:` or `expr:` ValueRef on the `message` input — the provider does not handle templating internally.
+
+### Capabilities
+
+`action`
+
+### Inputs
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `message` | string | ✅ | Message text to output. Use `tmpl:` or `expr:` ValueRef for dynamic interpolation. |
+| `type` | string | ❌ | Message type: `success`, `warning`, `error`, `info` (default), `debug`, `plain` |
+| `label` | string | ❌ | Contextual prefix rendered as dimmed `[label]` between icon and message (e.g., `step 2/5`) |
+| `style` | object | ❌ | Custom formatting that merges on top of type defaults: `color` (hex or named), `bold`, `italic`, `icon` |
+| `destination` | string | ❌ | Output target: `stdout` (default) or `stderr` |
+| `newline` | bool | ❌ | Append trailing newline (default: `true`) |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | Always `true` on success |
+| `message` | string | Rendered message text |
+
+### Examples
+
+**Built-in type styling:**
+
+```yaml
+resolvers:
+  step1:
+    resolve:
+      with:
+        - provider: message
+          inputs:
+            message: "Build succeeded"
+            type: success
+```
+
+**Custom style with icon:**
+
+```yaml
+resolvers:
+  deploy:
+    resolve:
+      with:
+        - provider: message
+          inputs:
+            message: "Starting pipeline"
+            style:
+              color: "#FF5733"
+              bold: true
+              icon: "\U0001F680"
+```
+
+**Go template interpolation via `tmpl:` ValueRef:**
+
+```yaml
+resolvers:
+  config:
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value:
+              appName: my-service
+              version: 2.0.0
+  deploy-msg:
+    resolve:
+      with:
+        - provider: message
+          inputs:
+            message:
+              tmpl: "Deploying {{ .config.appName }} v{{ .config.version }}"
+            type: info
+```
+
+**CEL expression via `expr:` ValueRef:**
+
+```yaml
+resolvers:
+  items:
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value: [a, b, c]
+  status:
+    resolve:
+      with:
+        - provider: message
+          inputs:
+            message:
+              expr: "'Processed ' + string(size(_.items)) + ' items'"
+            type: success
 ```
 
 ---

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -977,7 +977,7 @@ spec:
               url: https://httpbin.org/headers
               headers:
                 Authorization:
-                  tmpl: "Bearer {{._.api_token}}"
+                  tmpl: "Bearer {{.api_token}}"
 ```
 
 Run it (requires the `API_TOKEN` environment variable to be set):

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ scafctl examples list -o json
 |-----------|-------------|
 | [actions/](actions/) | Workflow automation with actions |
 | [exec/](exec/) | Exec provider shell execution patterns |
-| [providers/](providers/) | Provider-specific solution examples (http, exec, hcl, github, identity, metadata) |
+| [providers/](providers/) | Provider-specific solution examples (http, exec, hcl, github, identity, message, metadata) |
 | [resolvers/](resolvers/) | Dynamic value resolution patterns |
 | [solutions/](solutions/) | Complete end-to-end solution examples |
 | [snapshots/](snapshots/) | Execution snapshot capture and comparison |
@@ -156,6 +156,7 @@ Complete solutions demonstrating real-world use cases.
 | [tested-solution/](solutions/tested-solution/) | Functional testing features: assertions, inheritance, tags, watch mode |
 | [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` — generates starter test suites |
 | [github-auth/](solutions/github-auth/) | GitHub authentication — identity, API calls, and status checks |
+| [message-demo/](solutions/message-demo/) | Message provider — styled terminal output with templates |
 
 ---
 

--- a/examples/providers/message-custom-style.yaml
+++ b/examples/providers/message-custom-style.yaml
@@ -1,0 +1,82 @@
+# Message Provider — Custom Styling
+#
+# Demonstrates the message provider with custom styling. Style fields merge on
+# top of the type defaults — only the fields you specify are overridden.
+# Use type: plain for fully custom styling with no inherited defaults.
+#
+# Run: scafctl run resolver -f examples/providers/message-custom-style.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: message-custom-style-example
+  version: 1.0.0
+  description: Demonstrates custom message styling with colors, icons, and formatting
+
+spec:
+  resolvers:
+    rocket-msg:
+      description: Success type with custom icon (color and bold inherited from success)
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Starting deployment pipeline"
+              type: success
+              style:
+                icon: "\U0001F680"
+
+    package-msg:
+      description: Fully custom style using plain type as base
+      dependsOn: [rocket-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Installing dependencies"
+              type: plain
+              style:
+                color: "green"
+                icon: "\U0001F4E6"
+
+    italic-msg:
+      description: Info type with added italic styling
+      dependsOn: [package-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Tip: Use --verbose for detailed output"
+              type: info
+              style:
+                italic: true
+
+    bold-red:
+      description: Error type with custom icon override
+      dependsOn: [italic-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "CRITICAL: Service health check failed"
+              type: error
+              style:
+                icon: "\U0001F6A8"
+
+    no-newline-msgs:
+      description: Messages without trailing newlines for inline output
+      dependsOn: [bold-red]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Status: "
+              type: plain
+              newline: false
+          - provider: message
+            inputs:
+              message: "READY"
+              style:
+                color: "green"
+                bold: true

--- a/examples/providers/message-dynamic.yaml
+++ b/examples/providers/message-dynamic.yaml
@@ -1,0 +1,47 @@
+# Message Provider — Templated and Dynamic Messages
+#
+# Demonstrates tmpl: and expr: ValueRef for dynamic message generation
+# using resolver data. The framework auto-detects dependencies.
+#
+# Run: scafctl run resolver -f examples/providers/message-dynamic.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: message-dynamic-example
+  version: 1.0.0
+  description: Demonstrates templated and CEL-based dynamic messages
+
+spec:
+  resolvers:
+    config:
+      description: Simulated configuration data
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: my-service
+                version: 2.5.0
+                replicas: 3
+
+    go-template-msg:
+      description: Message using Go template interpolation with resolver data
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                tmpl: "Deploying {{ .config.appName }} v{{ .config.version }} with {{ .config.replicas }} replicas"
+              type: info
+
+    cel-expression-msg:
+      description: Message using CEL expression for dynamic text
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                expr: "'Application ' + _.config.appName + ' (v' + _.config.version + ') is ready for deployment'"
+              type: success

--- a/examples/providers/message-types.yaml
+++ b/examples/providers/message-types.yaml
@@ -1,0 +1,75 @@
+# Message Provider — Basic Message Types
+#
+# Demonstrates the message provider outputting different message types
+# with built-in styling (icons and colors).
+#
+# Run: scafctl run resolver -f examples/providers/message-types.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: message-types-example
+  version: 1.0.0
+  description: Demonstrates all built-in message types with their default styling
+
+spec:
+  resolvers:
+    success-msg:
+      description: Output a success message
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Deployment completed successfully"
+              type: success
+
+    warning-msg:
+      description: Output a warning message
+      dependsOn: [success-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "API version v1 is deprecated, please upgrade to v2"
+              type: warning
+
+    error-msg:
+      description: Output an error message to stderr
+      dependsOn: [warning-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Failed to connect to backup service"
+              type: error
+              destination: stderr
+
+    info-msg:
+      description: Output an informational message (default type)
+      dependsOn: [error-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Processing 42 items in batch mode"
+
+    debug-msg:
+      description: Output a debug message
+      dependsOn: [info-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Cache hit ratio: 0.95"
+              type: debug
+
+    plain-msg:
+      description: Output a plain message without any styling
+      dependsOn: [debug-msg]
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "--- Process complete ---"
+              type: plain

--- a/examples/resolver-stress-demo.yaml
+++ b/examples/resolver-stress-demo.yaml
@@ -417,7 +417,7 @@ spec:
             inputs:
               # Using Go template (tmpl:) instead of CEL expression
               value:
-                tmpl: "api.{{ ._.environment }}.{{ ._.base_domain }}"
+                tmpl: "api.{{ .environment }}.{{ .base_domain }}"
               expression: "'api.' + _.environment + '.' + _.base_domain"
       validate:
         with:

--- a/examples/solutions/message-demo/solution.yaml
+++ b/examples/solutions/message-demo/solution.yaml
@@ -1,0 +1,92 @@
+# Message Demo Solution
+#
+# A complete solution demonstrating the message provider in a realistic
+# workflow with resolvers, actions, and rich terminal output.
+#
+# Run: scafctl run solution -f examples/solutions/message-demo/solution.yaml -r environment=production
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: message-demo
+  version: 1.0.0
+  description: Demonstrates the message provider in a complete solution workflow with styled terminal output
+
+spec:
+  resolvers:
+    environment:
+      description: Target deployment environment
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: environment
+          - provider: static
+            inputs:
+              value: staging
+
+    config:
+      description: Application configuration
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: demo-service
+                version: 3.1.0
+                healthEndpoint: /health
+                port: 8080
+
+  workflow:
+    actions:
+      start-banner:
+        description: Display deployment start banner
+        provider: message
+        inputs:
+          message:
+            tmpl: "Starting deployment of {{ .config.appName }} v{{ .config.version }} to {{ .environment }}"
+          label: "step 1/4"
+          style:
+            icon: "\U0001F680"
+            color: cyan
+
+      validate-env:
+        description: Validate environment and show status
+        dependsOn: [start-banner]
+        provider: message
+        inputs:
+          message:
+            expr: |
+              _.environment in ['staging', 'production']
+                ? 'Environment validated: ' + _.environment
+                : 'Invalid environment: ' + _.environment
+          label: "step 2/4"
+          type:
+            expr: |
+              _.environment in ['staging', 'production']
+                ? 'success'
+                : 'error'
+
+      show-config:
+        description: Display deployment configuration
+        dependsOn: [validate-env]
+        provider: message
+        inputs:
+          message:
+            tmpl: "Deploying {{ .config.appName }} on port {{ .config.port }}"
+          label: "step 3/4"
+          style:
+            color: "#87CEEB"
+            icon: "\U0001F4E6"
+
+      deploy-complete:
+        description: Show deployment completion
+        dependsOn: [show-config]
+        provider: message
+        inputs:
+          message:
+            tmpl: "Deployment of {{ .config.appName }} to {{ .environment }} completed successfully"
+          label: "step 4/4"
+          type: success

--- a/pkg/action/deferred.go
+++ b/pkg/action/deferred.go
@@ -48,16 +48,20 @@ func (d *DeferredValue) Evaluate(ctx context.Context, resolverData, additionalVa
 	}
 
 	if d.OriginalTmpl != "" {
-		// For templates, merge resolver data with additional vars at the template data level
-		templateData := map[string]any{
-			"_": resolverData,
+		// Spread resolver data at the top level so templates can use
+		// {{ .resolverName }} directly. The "._" prefix is a CEL convention
+		// and is not supported in Go templates.
+		templateData := make(map[string]any, len(resolverData)+len(additionalVars))
+		for k, v := range resolverData {
+			templateData[k] = v
 		}
 		for k, v := range additionalVars {
 			templateData[k] = v
 		}
 		result, err := gotmpl.Execute(ctx, gotmpl.TemplateOptions{
-			Content: d.OriginalTmpl,
-			Data:    templateData,
+			Content:    d.OriginalTmpl,
+			Data:       templateData,
+			MissingKey: gotmpl.MissingKeyError,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute deferred template: %w", err)

--- a/pkg/action/deferred_test.go
+++ b/pkg/action/deferred_test.go
@@ -204,12 +204,18 @@ func TestMaterialize(t *testing.T) {
 			},
 		},
 		{
-			name:         "tmpl without __actions - evaluates immediately",
-			valueRef:     &spec.ValueRef{Tmpl: ptr(gotmpl.GoTemplatingContent(`Env: {{ ._.env }}`))},
+			name:         "tmpl without __actions - evaluates immediately (direct access)",
+			valueRef:     &spec.ValueRef{Tmpl: ptr(gotmpl.GoTemplatingContent(`Env: {{ .env }}`))},
 			resolverData: map[string]any{"env": "staging"},
 			checkResult: func(t *testing.T, result any) {
 				assert.Equal(t, "Env: staging", result)
 			},
+		},
+		{
+			name:         "tmpl without __actions - underscore prefix errors",
+			valueRef:     &spec.ValueRef{Tmpl: ptr(gotmpl.GoTemplatingContent(`Env: {{ ._.env }}`))},
+			resolverData: map[string]any{"env": "staging"},
+			expectError:  true,
 		},
 		{
 			name:         "tmpl with __actions - returns deferred",

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -16,7 +16,6 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/oakwood-commons/scafctl/pkg/telemetry"
-	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -105,9 +104,9 @@ func WithDefaultTimeout(d time.Duration) ExecutorOption {
 }
 
 // WithIOStreams sets the terminal IO streams for provider output streaming.
-// When set, providers that support streaming (e.g., exec) can write output
-// directly to the terminal in real-time. For parallel actions, each action
-// gets a prefixed writer to attribute output clearly.
+// When set, providers that support streaming (e.g., exec, message) can write
+// output directly to the terminal in real-time. All actions share the same
+// raw streams; use the message provider for structured terminal output.
 func WithIOStreams(streams *provider.IOStreams) ExecutorOption {
 	return func(e *Executor) {
 		e.ioStreams = streams
@@ -410,12 +409,6 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 		return nil
 	}
 
-	// Determine if this is a parallel phase (multiple actions)
-	isParallel := len(actionsToRun) > 1
-
-	// Build per-action IOStreams for parallel phases using PrefixedWriter
-	actionIOStreams := e.buildActionIOStreams(actionsToRun, isParallel)
-
 	// Determine concurrency limit
 	concurrency := len(actionsToRun)
 	if e.maxConcurrency > 0 && concurrency > e.maxConcurrency {
@@ -447,10 +440,10 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 				return
 			}
 
-			// Inject per-action IOStreams into context
+			// Inject IOStreams into context for streaming providers
 			actionCtx := ctx
-			if streams, ok := actionIOStreams[actionName]; ok {
-				actionCtx = provider.WithIOStreams(ctx, streams)
+			if e.ioStreams != nil {
+				actionCtx = provider.WithIOStreams(ctx, e.ioStreams)
 			}
 
 			// Execute the action
@@ -476,30 +469,6 @@ func (e *Executor) executePhase(ctx context.Context, graph *Graph, actionNames [
 	}
 
 	return nil
-}
-
-// buildActionIOStreams creates per-action IO streams. For parallel phases (multiple actions),
-// each action gets a PrefixedWriter so output is clearly attributed. For single-action
-// phases, the raw IOStreams are used directly for clean, unprefixed output.
-func (e *Executor) buildActionIOStreams(actionNames []string, isParallel bool) map[string]*provider.IOStreams {
-	streams := make(map[string]*provider.IOStreams, len(actionNames))
-
-	if e.ioStreams == nil {
-		return streams
-	}
-
-	for _, name := range actionNames {
-		if isParallel {
-			streams[name] = &provider.IOStreams{
-				Out:    terminal.NewPrefixedWriter(e.ioStreams.Out, name),
-				ErrOut: terminal.NewPrefixedWriter(e.ioStreams.ErrOut, name),
-			}
-		} else {
-			streams[name] = e.ioStreams
-		}
-	}
-
-	return streams
 }
 
 // executeAction executes a single action with retry, timeout, and error handling.

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -936,6 +936,141 @@ func TestWithIOStreams_ActionExecutor(t *testing.T) {
 	assert.Equal(t, streams, e.ioStreams)
 }
 
+func TestExecutor_IOStreamsInjectedIntoActionContext(t *testing.T) {
+	// Verify that IOStreams set on the executor are propagated to actions
+	// via the provider context, so streaming providers can write output.
+	var receivedStreams *provider.IOStreams
+
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "streaming-provider",
+		execute: func(ctx context.Context, _ any) (*provider.Output, error) {
+			if streams, ok := provider.IOStreamsFromContext(ctx); ok {
+				receivedStreams = streams
+			}
+			return &provider.Output{Data: map[string]any{"success": true}}, nil
+		},
+	})
+
+	streams := &provider.IOStreams{
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithIOStreams(streams),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"stream-action": {
+				Provider: "streaming-provider",
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, ExecutionSucceeded, result.FinalStatus)
+	assert.NotNil(t, receivedStreams, "IOStreams should be injected into action context")
+	assert.Equal(t, streams, receivedStreams, "Action should receive the same IOStreams as the executor")
+}
+
+func TestExecutor_NoIOStreams_NilContext(t *testing.T) {
+	// Verify that when no IOStreams are set on the executor,
+	// actions do not receive IOStreams in their context.
+	var hasStreams bool
+
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "check-provider",
+		execute: func(ctx context.Context, _ any) (*provider.Output, error) {
+			_, hasStreams = provider.IOStreamsFromContext(ctx)
+			return &provider.Output{Data: map[string]any{"success": true}}, nil
+		},
+	})
+
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"check-action": {
+				Provider: "check-provider",
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, ExecutionSucceeded, result.FinalStatus)
+	assert.False(t, hasStreams, "IOStreams should not be in context when not set on executor")
+}
+
+func TestExecutor_IOStreamsSharedAcrossParallelActions(t *testing.T) {
+	// Verify that all parallel actions in a phase share the same IOStreams
+	// when set on the executor (no per-action PrefixedWriter).
+	var collectedStreams sync.Map
+
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "parallel-provider",
+		execute: func(ctx context.Context, input any) (*provider.Output, error) {
+			if streams, ok := provider.IOStreamsFromContext(ctx); ok {
+				inputs := input.(map[string]any)
+				name := inputs["name"].(string)
+				collectedStreams.Store(name, streams)
+			}
+			return &provider.Output{Data: map[string]any{"success": true}}, nil
+		},
+	})
+
+	streams := &provider.IOStreams{
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithIOStreams(streams),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	// Two independent actions → both run in parallel in the same phase
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"action-1": {
+				Provider: "parallel-provider",
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "action-1"},
+				},
+			},
+			"action-2": {
+				Provider: "parallel-provider",
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "action-2"},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, ExecutionSucceeded, result.FinalStatus)
+
+	// Both actions should have received the same IOStreams pointer
+	s1, ok1 := collectedStreams.Load("action-1")
+	s2, ok2 := collectedStreams.Load("action-2")
+	assert.True(t, ok1, "action-1 should have received IOStreams")
+	assert.True(t, ok2, "action-2 should have received IOStreams")
+	if ok1 && ok2 {
+		assert.Same(t, s1.(*provider.IOStreams), s2.(*provider.IOStreams),
+			"Parallel actions should share the same IOStreams (no PrefixedWriter)")
+	}
+}
+
 func TestOptionsFromAppConfig(t *testing.T) {
 	cfg := ConfigInput{
 		DefaultTimeout: 5 * time.Minute,

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -412,6 +413,26 @@ func (o *sharedResolverOptions) executeResolvers(
 
 	// Attach solution metadata to the context so providers (e.g., metadata) can access it.
 	ctx = provider.WithSolutionMetadata(ctx, solutionMetaFromSolution(sol))
+
+	// Inject IOStreams so streaming providers (message, exec, etc.) can write to the terminal
+	// during resolver execution. For structured output modes (json/yaml), route provider
+	// stdout to stderr to avoid corrupting the data envelope on stdout.
+	// For quiet mode, discard all provider output to honour the --quiet contract.
+	if o.IOStreams != nil {
+		providerOut := o.IOStreams.Out
+		providerErr := o.IOStreams.ErrOut
+		switch strings.ToLower(o.Output) {
+		case "json", "yaml":
+			providerOut = o.IOStreams.ErrOut
+		case "quiet":
+			providerOut = io.Discard
+			providerErr = io.Discard
+		}
+		ctx = provider.WithIOStreams(ctx, &provider.IOStreams{
+			Out:    providerOut,
+			ErrOut: providerErr,
+		})
+	}
 
 	// Execute resolvers
 	resultCtx, err := executor.Execute(ctx, resolvers, params)

--- a/pkg/cmd/scafctl/run/progress.go
+++ b/pkg/cmd/scafctl/run/progress.go
@@ -24,6 +24,7 @@ type ProgressReporter struct {
 	barStarts  map[string]time.Time
 	barPhases  map[string]int
 	barElapsed map[string]time.Duration // Store calculated elapsed time on completion
+	barFailed  map[string]bool          // Track whether an aborted bar was a failure (vs skip)
 	total      int
 	startTime  time.Time
 	writer     io.Writer
@@ -44,6 +45,7 @@ func NewProgressReporter(writer io.Writer, total int) *ProgressReporter {
 		barStarts:  make(map[string]time.Time),
 		barPhases:  make(map[string]int),
 		barElapsed: make(map[string]time.Duration),
+		barFailed:  make(map[string]bool),
 		total:      total,
 		startTime:  time.Now(),
 		writer:     writer,
@@ -64,17 +66,43 @@ func (p *ProgressReporter) StartPhase(phaseNum int, resolverNames []string) {
 		resolverName := name // Capture for closure
 		elapsedOnComplete := decor.Any(func(s decor.Statistics) string {
 			if s.Completed {
-				if elapsed, ok := p.barElapsed[resolverName]; ok {
+				p.mu.Lock()
+				elapsed, ok := p.barElapsed[resolverName]
+				p.mu.Unlock()
+				if ok {
 					return format.Duration(elapsed)
 				}
 			}
 			return "" // Show nothing while in progress
 		})
 
+		// Build a status decorator that distinguishes completion, failure, and skip.
+		resolverStatus := name // Capture for closure
+		statusDecorator := decor.Any(func(s decor.Statistics) string {
+			if s.Completed {
+				return "✓ "
+			}
+			if s.Aborted {
+				p.mu.Lock()
+				failed := p.barFailed[resolverStatus]
+				p.mu.Unlock()
+				if failed {
+					return "✗ "
+				}
+				return "⊘ "
+			}
+			// In-progress spinner frames
+			p.mu.Lock()
+			start := p.barStarts[resolverStatus]
+			p.mu.Unlock()
+			frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+			return frames[int(time.Since(start).Milliseconds()/80)%len(frames)] + " "
+		}, decor.WCSyncSpace)
+
 		bar := p.progress.AddBar(1,
 			mpb.PrependDecorators(
 				decor.Name(fmt.Sprintf("[%d] %s", phaseNum, name), decor.WCSyncSpaceR),
-				decor.OnComplete(decor.Spinner([]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}, decor.WCSyncSpace), "✓ "),
+				statusDecorator,
 			),
 			mpb.AppendDecorators(elapsedOnComplete),
 			mpb.BarFillerClearOnComplete(),
@@ -103,6 +131,7 @@ func (p *ProgressReporter) Failed(resolverName string, _ error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	p.barFailed[resolverName] = true
 	if bar, ok := p.bars[resolverName]; ok {
 		bar.Abort(false)
 	}
@@ -114,7 +143,7 @@ func (p *ProgressReporter) Skipped(resolverName string) {
 	defer p.mu.Unlock()
 
 	if bar, ok := p.bars[resolverName]; ok {
-		bar.SetTotal(0, true)
+		bar.Abort(false)
 	}
 }
 

--- a/pkg/cmd/scafctl/run/progress_test.go
+++ b/pkg/cmd/scafctl/run/progress_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProgressReporter(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 5)
+	require.NotNil(t, pr)
+	assert.Equal(t, 5, pr.total)
+	assert.NotNil(t, pr.bars)
+	assert.NotNil(t, pr.barStarts)
+	assert.NotNil(t, pr.barFailed)
+}
+
+func TestProgressReporter_StartPhase(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 3)
+
+	pr.StartPhase(1, []string{"resolver-a", "resolver-b"})
+
+	assert.Contains(t, pr.bars, "resolver-a")
+	assert.Contains(t, pr.bars, "resolver-b")
+	assert.Contains(t, pr.barStarts, "resolver-a")
+	assert.Equal(t, 1, pr.barPhases["resolver-a"])
+}
+
+func TestProgressReporter_Complete(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	pr.StartPhase(1, []string{"resolver-a"})
+
+	pr.Complete("resolver-a")
+
+	assert.Contains(t, pr.barElapsed, "resolver-a")
+	assert.Greater(t, pr.barElapsed["resolver-a"], time.Duration(0))
+}
+
+func TestProgressReporter_Complete_UnknownResolver(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+
+	// Should not panic on unknown resolver
+	pr.Complete("nonexistent")
+}
+
+func TestProgressReporter_Failed(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	pr.StartPhase(1, []string{"resolver-a"})
+
+	pr.Failed("resolver-a", errors.New("boom"))
+
+	assert.True(t, pr.barFailed["resolver-a"])
+}
+
+func TestProgressReporter_Skipped(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	pr.StartPhase(1, []string{"resolver-a"})
+
+	pr.Skipped("resolver-a")
+
+	// Skipped bars are aborted but NOT marked as failed
+	assert.False(t, pr.barFailed["resolver-a"])
+}
+
+func TestProgressReporter_Skipped_UnknownResolver(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+
+	// Should not panic on unknown resolver
+	pr.Skipped("nonexistent")
+}
+
+func TestProgressReporter_Failed_UnknownResolver(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+
+	// Should not panic on unknown resolver
+	pr.Failed("nonexistent", errors.New("boom"))
+	assert.True(t, pr.barFailed["nonexistent"])
+}
+
+func TestProgressReporter_Wait(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	pr.StartPhase(1, []string{"resolver-a"})
+	pr.Complete("resolver-a")
+
+	dur := pr.Wait()
+	assert.Greater(t, dur, time.Duration(0))
+}
+
+func TestProgressReporter_TotalDuration(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	time.Sleep(1 * time.Millisecond) // Ensure non-zero elapsed time.
+
+	dur := pr.TotalDuration()
+	assert.Greater(t, dur, time.Duration(0))
+}
+
+func TestProgressCallback(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 3)
+	cb := NewProgressCallback(pr)
+	require.NotNil(t, cb)
+
+	cb.OnPhaseStart(1, []string{"a", "b"})
+	assert.Contains(t, pr.bars, "a")
+	assert.Contains(t, pr.bars, "b")
+
+	cb.OnResolverComplete("a")
+	assert.Contains(t, pr.barElapsed, "a")
+
+	cb.OnResolverFailed("b", errors.New("fail"))
+	assert.True(t, pr.barFailed["b"])
+}
+
+func TestProgressCallback_OnResolverSkipped(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 1)
+	cb := NewProgressCallback(pr)
+
+	cb.OnPhaseStart(1, []string{"skippable"})
+	cb.OnResolverSkipped("skippable")
+
+	assert.False(t, pr.barFailed["skippable"])
+}
+
+func TestProgressReporter_MultiplePhases(t *testing.T) {
+	t.Parallel()
+	pr := NewProgressReporter(io.Discard, 4)
+
+	pr.StartPhase(1, []string{"a", "b"})
+	pr.Complete("a")
+	pr.Failed("b", errors.New("err"))
+
+	pr.StartPhase(2, []string{"c", "d"})
+	pr.Complete("c")
+	pr.Skipped("d")
+
+	assert.Contains(t, pr.barElapsed, "a")
+	assert.True(t, pr.barFailed["b"])
+	assert.Contains(t, pr.barElapsed, "c")
+	assert.False(t, pr.barFailed["d"])
+	assert.Equal(t, 1, pr.barPhases["a"])
+	assert.Equal(t, 2, pr.barPhases["c"])
+}
+
+func BenchmarkProgressReporter_Lifecycle(b *testing.B) {
+	for b.Loop() {
+		pr := NewProgressReporter(io.Discard, 3)
+		pr.StartPhase(1, []string{"a", "b", "c"})
+		pr.Complete("a")
+		pr.Failed("b", errors.New("err"))
+		pr.Skipped("c")
+		pr.Wait()
+	}
+}

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -6,6 +6,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -373,6 +374,26 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	// Set up execution context
 	ctx = provider.WithExecutionMode(ctx, capability)
 	ctx = provider.WithDryRun(ctx, o.DryRun)
+
+	// Inject IOStreams so streaming providers (exec, message, etc.) can write to the terminal.
+	// For structured output modes (json/yaml), route provider stdout to stderr to
+	// avoid corrupting the structured envelope that kvx writes to stdout.
+	// For quiet mode, discard all provider output to honour the --quiet contract.
+	if o.IOStreams != nil {
+		providerOut := o.IOStreams.Out
+		providerErr := o.IOStreams.ErrOut
+		switch strings.ToLower(o.Output) {
+		case "json", "yaml":
+			providerOut = o.IOStreams.ErrOut
+		case "quiet":
+			providerOut = io.Discard
+			providerErr = io.Discard
+		}
+		ctx = provider.WithIOStreams(ctx, &provider.IOStreams{
+			Out:    providerOut,
+			ErrOut: providerErr,
+		})
+	}
 
 	// Inject conflict strategy and backup into context for file providers
 	if o.OnConflict != "" {

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -44,7 +44,8 @@ type SolutionOptions struct {
 	MaxActionConcurrency int
 	DryRun               bool
 
-	// Verbose includes MaterializedInputs in dry-run reports.
+	// Verbose enables additional detail in output. In dry-run mode, includes
+	// materialized inputs. In normal execution, shows condition-based skips.
 	Verbose bool
 
 	// ShowExecution enables __execution metadata in output
@@ -193,7 +194,7 @@ Examples:
 	cCmd.Flags().DurationVar(&options.ActionTimeout, "action-timeout", settings.DefaultActionTimeout, "Default timeout per action")
 	cCmd.Flags().IntVar(&options.MaxActionConcurrency, "max-action-concurrency", 0, "Maximum concurrent actions (0=unlimited)")
 	cCmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Validate and show what would be executed without running")
-	cCmd.Flags().BoolVar(&options.Verbose, "verbose", false, "When combined with --dry-run, include materialized inputs in report")
+	cCmd.Flags().BoolVar(&options.Verbose, "verbose", false, "Show additional execution detail (skipped actions, materialized inputs in dry-run)")
 	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata in output (phases, timing, dependencies, providers)")
 
 	// File conflict strategy flags
@@ -354,14 +355,6 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Dry run — execute resolvers in dry-run mode and show structured report
 	if o.DryRun {
 		return o.executeDryRun(actionCtx, sol, reg, params)
-	}
-
-	// Warn if --verbose is used without --dry-run
-	if o.Verbose {
-		w := writer.FromContext(ctx)
-		if w != nil {
-			w.Warningf("--verbose has no effect without --dry-run")
-		}
 	}
 
 	// Execute resolvers if present
@@ -610,12 +603,18 @@ func (o *SolutionOptions) writeActionOutput(ctx context.Context, result *action.
 // writeActionOutputDefault writes the default/table output for action execution.
 // Actions that already streamed to the terminal are skipped. For non-streamed actions,
 // any stdout/stderr from the results is printed. Failed/skipped actions show a status line.
+// When verbose is enabled, a status line for every action is written to stderr.
 func (o *SolutionOptions) writeActionOutputDefault(ctx context.Context, result *action.ExecutionResult) error {
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return nil
 	}
 	for name, ar := range result.Actions {
+		// Verbose: show a status line for every action on stderr
+		if o.Verbose {
+			o.writeVerboseActionStatus(w, name, ar)
+		}
+
 		// Skip actions that already streamed their output to the terminal
 		if ar.Streamed {
 			// If the action failed despite streaming, show the error
@@ -643,13 +642,36 @@ func (o *SolutionOptions) writeActionOutputDefault(ctx context.Context, result *
 			}
 			w.Errorf("Error [%s]: %s", name, ar.Error)
 		case action.StatusSkipped:
-			w.WarnStderrf("Skipped [%s]: %s", name, ar.SkipReason)
+			// Verbose mode already shows skip status via writeVerboseActionStatus.
+			// Only show the non-verbose skip line when verbose is off and it's not a condition skip.
+			if !o.Verbose && ar.SkipReason != action.SkipReasonCondition {
+				w.WarnStderrf("Skipped [%s]: %s", name, ar.SkipReason)
+			}
 		case action.StatusPending, action.StatusRunning, action.StatusCancelled:
 			// These statuses should not appear in final results; ignore.
 		}
 	}
 
 	return nil
+}
+
+// writeVerboseActionStatus writes a single action status line to stderr.
+func (o *SolutionOptions) writeVerboseActionStatus(w *writer.Writer, name string, ar *action.ActionResult) {
+	dur := ar.Duration()
+	switch ar.Status {
+	case action.StatusSucceeded:
+		w.PlainStderrf("  ✓ %s (%s)", name, dur)
+	case action.StatusSkipped:
+		w.PlainStderrf("  ○ %s (skipped: %s)", name, ar.SkipReason)
+	case action.StatusFailed:
+		w.PlainStderrf("  ✗ %s (failed: %s)", name, ar.Error)
+	case action.StatusTimeout:
+		w.PlainStderrf("  ✗ %s (timeout)", name)
+	case action.StatusCancelled:
+		w.PlainStderrf("  ○ %s (cancelled)", name)
+	case action.StatusPending, action.StatusRunning:
+		// Should not appear in final results; ignore.
+	}
 }
 
 // writeActionOutputStructured writes action results as JSON or YAML (the full execution envelope).

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -996,7 +997,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		Verbose: true, // --verbose without --dry-run
+		Verbose: true, // --verbose without --dry-run should not warn
 	}
 
 	lgr := logger.Get(0)
@@ -1004,11 +1005,11 @@ spec:
 	w := writer.New(streams, cliParams)
 	ctx = writer.WithWriter(ctx, w)
 
-	// Run may error (action timeout etc) — we only care about the warning
+	// Run may error (action timeout etc) — we care that no warning is emitted
 	_ = opts.Run(ctx)
 
 	output := stdout.String()
-	assert.Contains(t, output, "--verbose has no effect without --dry-run")
+	assert.NotContains(t, output, "--verbose has no effect")
 }
 
 func BenchmarkSolutionOptions_resolveOutputDir(b *testing.B) {
@@ -1022,5 +1023,120 @@ func BenchmarkSolutionOptions_resolveOutputDir(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		_, _ = opts.resolveOutputDir(context.Background(), false)
+	}
+}
+
+func TestWriteVerboseActionStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	end := now.Add(1 * time.Second)
+
+	tests := []struct {
+		name     string
+		result   *action.ActionResult
+		contains string
+	}{
+		{
+			name: "succeeded",
+			result: &action.ActionResult{
+				Status:    action.StatusSucceeded,
+				StartTime: &now,
+				EndTime:   &end,
+			},
+			contains: "✓ test-action",
+		},
+		{
+			name: "skipped",
+			result: &action.ActionResult{
+				Status:     action.StatusSkipped,
+				SkipReason: action.SkipReasonCondition,
+			},
+			contains: "○ test-action (skipped: condition)",
+		},
+		{
+			name: "failed",
+			result: &action.ActionResult{
+				Status: action.StatusFailed,
+				Error:  "something broke",
+			},
+			contains: "✗ test-action (failed: something broke)",
+		},
+		{
+			name: "timeout",
+			result: &action.ActionResult{
+				Status: action.StatusTimeout,
+			},
+			contains: "✗ test-action (timeout)",
+		},
+		{
+			name: "cancelled",
+			result: &action.ActionResult{
+				Status: action.StatusCancelled,
+			},
+			contains: "○ test-action (cancelled)",
+		},
+		{
+			name: "pending ignored",
+			result: &action.ActionResult{
+				Status: action.StatusPending,
+			},
+			contains: "",
+		},
+		{
+			name: "running ignored",
+			result: &action.ActionResult{
+				Status: action.StatusRunning,
+			},
+			contains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			streams := &terminal.IOStreams{
+				In:     nil,
+				Out:    &bytes.Buffer{},
+				ErrOut: &stderr,
+			}
+			cliParams := settings.NewCliParams()
+			w := writer.New(streams, cliParams)
+			opts := &SolutionOptions{}
+
+			opts.writeVerboseActionStatus(w, "test-action", tt.result)
+
+			if tt.contains == "" {
+				assert.Empty(t, stderr.String())
+			} else {
+				assert.Contains(t, stderr.String(), tt.contains)
+			}
+		})
+	}
+}
+
+func BenchmarkWriteVerboseActionStatus(b *testing.B) {
+	now := time.Now()
+	end := now.Add(1 * time.Second)
+	ar := &action.ActionResult{
+		Status:    action.StatusSucceeded,
+		StartTime: &now,
+		EndTime:   &end,
+	}
+
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
+	}
+	cliParams := settings.NewCliParams()
+	w := writer.New(streams, cliParams)
+	opts := &SolutionOptions{}
+
+	b.ResetTimer()
+	for b.Loop() {
+		opts.writeVerboseActionStatus(w, "bench-action", ar)
 	}
 }

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -289,6 +289,9 @@ func DescriptionFromPath(path string) string {
 		"providers/identity-scoped-claims.yaml":      "Identity provider — get claims from a scoped access token",
 		"providers/identity-scoped-status.yaml":      "Identity provider — check scoped token status and metadata",
 		"providers/metadata-full.yaml":               "Metadata provider — returns runtime metadata about scafctl and the current solution",
+		"providers/message-types.yaml":               "Message provider — all six built-in message types (success, warning, error, info, debug, plain)",
+		"providers/message-custom-style.yaml":        "Message provider — custom colors, bold, italic, icons, and newline control",
+		"providers/message-dynamic.yaml":             "Message provider — Go template interpolation and CEL expression messages",
 		"providers/metadata-single-field.yaml":       "Metadata provider — use CEL to extract a single field from runtime metadata",
 		"providers/security-example.yaml":            "Security hardening patterns across providers",
 	}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -20,8 +20,10 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	resolverRefs "github.com/oakwood-commons/scafctl/pkg/resolver/refs"
 	"github.com/oakwood-commons/scafctl/pkg/schema"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
@@ -493,13 +495,49 @@ func lintExpressions(inputs map[string]*spec.ValueRef, location string, result *
 		}
 
 		if val.Tmpl != nil && string(*val.Tmpl) != "" {
-			if err := validateTemplateSyntax(string(*val.Tmpl)); err != nil {
+			tmplStr := string(*val.Tmpl)
+			if err := validateTemplateSyntax(tmplStr); err != nil {
 				result.addFinding(SeverityError, "template", inputLoc,
 					fmt.Sprintf("invalid Go template: %v", err),
 					"Fix the template syntax",
 					"invalid-template")
 			}
+
+			// Check for _.resolverName pattern in Go templates (should be .resolverName)
+			lintTemplateUnderscorePrefix(tmplStr, inputLoc, result)
 		}
+	}
+}
+
+// lintTemplateUnderscorePrefix flags when a Go template uses {{ ._.resolverName }}
+// which is not supported — the correct syntax is {{ .resolverName }}.
+// Uses Go template AST parsing to avoid false positives from literal text.
+func lintTemplateUnderscorePrefix(tmpl, location string, result *Result) {
+	refs, err := gotmpl.GetGoTemplateReferences(tmpl, "", "")
+	if err != nil {
+		return // Template parse errors are caught by validateTemplateSyntax
+	}
+	seen := make(map[string]bool)
+	for _, ref := range refs {
+		// Check for paths starting with "._.something" — the underscore-root pattern.
+		// Skip paths starting with ".__" (e.g., .__self, .__actions) which are legitimate.
+		if !strings.HasPrefix(ref.Path, "._") || strings.HasPrefix(ref.Path, ".__") {
+			continue
+		}
+		// Extract the resolver name: "._.config.host" → "config"
+		parts := strings.SplitN(strings.TrimPrefix(ref.Path, "._"), ".", 3)
+		if len(parts) < 2 || parts[1] == "" {
+			continue
+		}
+		name := parts[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		result.addFinding(SeverityError, "template", location,
+			fmt.Sprintf("Go template uses '{{ ._.%s }}' which is not supported — use '{{ .%s }}' instead (the '._' prefix is a CEL convention)", name, name),
+			fmt.Sprintf("Replace '._.%s' with '.%s' in the template", name, name),
+			"tmpl-underscore-prefix")
 	}
 }
 
@@ -536,6 +574,18 @@ func collectReferencedResolvers(sol *solution.Solution) map[string]bool {
 				scanExpressionForResolverRefs(string(*vr.Expr), resolverRefPattern, refs)
 			}
 			if vr.Tmpl != nil {
+				// Use the Go template AST to extract references, which handles
+				// both {{ .resolverName }} and {{ ._.resolverName }} patterns.
+				tmplRefs, err := gotmpl.GetGoTemplateReferences(string(*vr.Tmpl), "", "")
+				if err == nil {
+					for _, ref := range tmplRefs {
+						name := resolverRefs.ExtractResolverName(ref.Path)
+						if name != "" {
+							refs[name] = true
+						}
+					}
+				}
+				// Also scan with regex as a fallback
 				scanExpressionForResolverRefs(string(*vr.Tmpl), resolverRefPattern, refs)
 			}
 			if vr.Literal != nil {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1043,3 +1043,67 @@ func TestLintProviderInputsForStep_ExecCommandInjection(t *testing.T) {
 	findings := filterFindingsByRule(result, "exec-command-injection")
 	assert.Len(t, findings, 1)
 }
+
+func TestLintTemplateUnderscorePrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmpl        string
+		expectError bool
+		errorCount  int
+	}{
+		{
+			name:        "underscore prefix triggers error",
+			tmpl:        "{{ ._.config.appName }}",
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name:        "multiple underscore refs same resolver",
+			tmpl:        "{{ ._.config.appName }} {{ ._.config.version }}",
+			expectError: true,
+			errorCount:  1, // deduplicated per resolver name
+		},
+		{
+			name:        "multiple different underscore refs",
+			tmpl:        "{{ ._.config.appName }} {{ ._.env }}",
+			expectError: true,
+			errorCount:  2,
+		},
+		{
+			name:        "direct access - no error",
+			tmpl:        "{{ .config.appName }}",
+			expectError: false,
+		},
+		{
+			name:        "no dot-underscore - no error",
+			tmpl:        "plain text with no templates",
+			expectError: false,
+		},
+		{
+			name:        "__self is not flagged",
+			tmpl:        "{{ .__self }}",
+			expectError: false,
+		},
+		{
+			name:        "__actions is not flagged",
+			tmpl:        "{{ .__actions.build.result }}",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &Result{Findings: make([]*Finding, 0)}
+			lintTemplateUnderscorePrefix(tt.tmpl, "resolvers.msg.resolve.with[0].inputs.message", result)
+			findings := filterFindingsByRule(result, "tmpl-underscore-prefix")
+			if tt.expectError {
+				assert.Len(t, findings, tt.errorCount)
+				if len(findings) > 0 {
+					assert.Equal(t, SeverityError, findings[0].Severity)
+				}
+			} else {
+				assert.Empty(t, findings)
+			}
+		})
+	}
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -294,6 +294,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Wrong — dynamic value in command string:\nprovider: exec\ninputs:\n  command:\n    expr: \"'echo ' + _.userInput\"\n\n# Correct — static command, dynamic args:\nprovider: exec\ninputs:\n  command: echo\n  args:\n    - expr: \"_.userInput\"",
 		},
 	},
+	"tmpl-underscore-prefix": {
+		Rule:        "tmpl-underscore-prefix",
+		Severity:    string(SeverityError),
+		Category:    "template",
+		Description: "A Go template uses '{{ ._.resolverName }}' which is not supported. Use '{{ .resolverName }}' instead.",
+		Why:         "Go templates spread resolver data at the top level, so resolvers are accessed directly with '{{ .resolverName }}'. The '._' prefix is a CEL convention ('_.resolverName') that does not apply to Go templates. Using '._' in a Go template will cause a runtime error.",
+		Fix:         "Replace '{{ ._.resolverName }}' with '{{ .resolverName }}'. In Go templates, access resolvers directly. Use '._' only in CEL expressions (expr:).",
+		Examples: []string{
+			"# Wrong:\ntmpl: \"Deploying {{ ._.config.appName }}\"\n\n# Correct:\ntmpl: \"Deploying {{ .config.appName }}\"",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 30 rules — update this when new rules are added
-	assert.Equal(t, 30, len(KnownRules), "expected 30 known lint rules")
+	// We expect exactly 31 rules — update this when new rules are added
+	assert.Equal(t, 31, len(KnownRules), "expected 31 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/tools_action_test.go
+++ b/pkg/mcp/tools_action_test.go
@@ -99,7 +99,7 @@ spec:
         provider: exec
         inputs:
           command:
-            tmpl: "echo {{ .resolvers.greeting }}"
+            tmpl: "echo {{ .greeting }}"
 `), 0o644)
 		require.NoError(t, err)
 

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/hclprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/httpprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/identityprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/messageprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/metadataprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/parameterprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/secretprovider"
@@ -76,6 +77,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		identityprovider.NewIdentityProvider(),
 		hclprovider.NewHCLProvider(),
 		metadataprovider.New(),
+		messageprovider.NewMessageProvider(),
 	}
 
 	// Initialize secrets store for the secret provider.
@@ -145,6 +147,7 @@ func ProviderNames() []string {
 		"hcl",
 		"github",
 		"metadata",
+		"message",
 	}
 }
 

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -74,7 +74,7 @@ func TestProviderNames(t *testing.T) {
 	names := ProviderNames()
 
 	// Should have all built-in providers
-	expectedCount := 18 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl, github, metadata
+	expectedCount := 19 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl, github, metadata, message
 	assert.Len(t, names, expectedCount, "should have %d built-in providers", expectedCount)
 
 	// Verify expected names are present
@@ -97,6 +97,7 @@ func TestProviderNames(t *testing.T) {
 		"hcl",
 		"github",
 		"metadata",
+		"message",
 	}
 
 	for _, expected := range expectedNames {
@@ -175,6 +176,7 @@ func TestAllProvidersRegistered(t *testing.T) {
 		{"hcl", "HCL"},
 		{"metadata", "metadata"},
 		{"github", "GitHub"},
+		{"message", "message"},
 	}
 
 	for _, expected := range expectedProviders {

--- a/pkg/provider/builtin/messageprovider/message.go
+++ b/pkg/provider/builtin/messageprovider/message.go
@@ -1,0 +1,448 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package messageprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/oakwood-commons/scafctl/pkg/ptrs"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// messageStyle holds the resolved styling attributes for rendering a message.
+// It starts from type defaults and is then merged with any style overrides.
+type messageStyle struct {
+	icon   string
+	color  string
+	bold   bool
+	italic bool
+}
+
+// typeDefaults maps each message type to its default icon and color.
+// NOTE: These values are intentionally duplicated from pkg/terminal/styles/styles.go
+// because the message provider uses lipgloss directly (not the shared output helpers)
+// to support the style-merge behavior. If the shared styles change, update these too.
+var typeDefaults = map[string]messageStyle{
+	typeSuccess: {icon: "✅", color: "#00FF00", bold: true},
+	typeWarning: {icon: "⚠️", color: "#FFFF00"},
+	typeError:   {icon: "❌", color: "#FF0000", bold: true},
+	typeInfo:    {icon: "💡", color: "#00FFFF"},
+	typeDebug:   {icon: "🐛", color: "#FF00FF", bold: true},
+	typePlain:   {},
+}
+
+// ProviderName is the name of this provider used for error wrapping and identification.
+const ProviderName = "message"
+
+// Field name constants for input map keys.
+const (
+	fieldMessage     = "message"
+	fieldType        = "type"
+	fieldLabel       = "label"
+	fieldStyle       = "style"
+	fieldDestination = "destination"
+	fieldNewline     = "newline"
+
+	// Style sub-fields.
+	fieldStyleColor  = "color"
+	fieldStyleBold   = "bold"
+	fieldStyleItalic = "italic"
+	fieldStyleIcon   = "icon"
+)
+
+// Message type constants used by the message provider. These conceptually align
+// with the standard terminal output levels but are not a 1:1 mapping to
+// pkg/terminal/output message type definitions.
+const (
+	typeSuccess = "success"
+	typeWarning = "warning"
+	typeError   = "error"
+	typeInfo    = "info"
+	typeDebug   = "debug"
+	typePlain   = "plain"
+)
+
+// Destination constants.
+const (
+	destStdout = "stdout"
+	destStderr = "stderr"
+)
+
+// Maximum message length to prevent abuse.
+const maxMessageLength = 8192
+
+// Maximum label length.
+const maxLabelLength = 100
+
+// labelStyle renders the label prefix in dimmed text.
+var labelStyle = lipgloss.NewStyle().Faint(true)
+
+// messageOutputSchema defines the output shape for the message provider.
+var messageOutputSchema = schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+	"success": schemahelper.BoolProp("Whether the message was output successfully"),
+	"message": schemahelper.StringProp("The rendered message text (plain text, no ANSI codes)"),
+})
+
+// MessageProvider outputs styled, feature-rich terminal messages during solution execution.
+type MessageProvider struct {
+	descriptor *provider.Descriptor
+}
+
+// NewMessageProvider creates a new message provider instance.
+func NewMessageProvider() *MessageProvider {
+	version, _ := semver.NewVersion("1.0.0")
+	return &MessageProvider{
+		descriptor: &provider.Descriptor{
+			Name:        ProviderName,
+			DisplayName: "Message Provider",
+			APIVersion:  "v1",
+			Version:     version,
+			Description: "Outputs styled, feature-rich terminal messages during solution execution. Supports message types (success, warning, error, info, debug, plain), custom formatting with colors and icons via lipgloss, and respects --quiet and --no-color flags. Use the framework's tmpl: or expr: ValueRef on the message input for dynamic interpolation.",
+			Category:    "utility",
+			Tags:        []string{"output", "message", "terminal", "logging", "display"},
+			WhatIf: func(_ context.Context, input any) (string, error) {
+				inputs, ok := input.(map[string]any)
+				if !ok {
+					return "", nil
+				}
+				msgType := stringField(inputs, fieldType, typeInfo)
+				dest := stringField(inputs, fieldDestination, destStdout)
+				label := stringField(inputs, fieldLabel, "")
+				msg := stringField(inputs, fieldMessage, "")
+				if msg == "" {
+					if label != "" {
+						return fmt.Sprintf("Would output %s message [%s] to %s", msgType, label, dest), nil
+					}
+					return fmt.Sprintf("Would output %s message to %s", msgType, dest), nil
+				}
+				// Truncate long messages in dry-run description.
+				if len(msg) > 80 {
+					msg = msg[:77] + "..."
+				}
+				if label != "" {
+					return fmt.Sprintf("Would output %s message [%s]: %q to %s", msgType, label, msg, dest), nil
+				}
+				return fmt.Sprintf("Would output %s message: %q to %s", msgType, msg, dest), nil
+			},
+			Capabilities: []provider.Capability{
+				provider.CapabilityAction,
+			},
+			Schema: schemahelper.ObjectSchema([]string{fieldMessage}, map[string]*jsonschema.Schema{
+				fieldMessage: schemahelper.StringProp(
+					"The message text to output. For dynamic interpolation, use tmpl: or expr: ValueRef on this input instead of passing templates directly.",
+					schemahelper.WithExample("Deployment completed successfully"),
+					schemahelper.WithMaxLength(maxMessageLength),
+				),
+				fieldLabel: schemahelper.StringProp(
+					"Optional contextual prefix displayed in brackets before the message text (e.g., 'deploy', 'step 2/5'). Rendered as dimmed [label] between the icon and message. Supports tmpl: and expr: ValueRef for dynamic labels.",
+					schemahelper.WithExample("step 1/3"),
+					schemahelper.WithMaxLength(maxLabelLength),
+				),
+				fieldType: schemahelper.StringProp(
+					"The message type that determines icon and color styling. Maps to built-in terminal output styles: success (✅ green), warning (⚠️ yellow), error (❌ red), info (💡 cyan), debug (🐛 magenta), plain (no styling).",
+					schemahelper.WithEnum(typeSuccess, typeWarning, typeError, typeInfo, typeDebug, typePlain),
+					schemahelper.WithDefault(typeInfo),
+					schemahelper.WithMaxLength(*ptrs.IntPtr(10)),
+				),
+				fieldStyle: schemahelper.ObjectProp(
+					"Custom formatting overrides that merge on top of the 'type' defaults. Only the fields you specify are overridden; unset fields keep their type defaults. For example, type=success with style.icon=\"🚀\" gives green+bold from success but replaces the ✅ icon.",
+					nil,
+					map[string]*jsonschema.Schema{
+						fieldStyleColor: schemahelper.StringProp(
+							"Text color as ANSI color name (e.g., 'green', 'red', 'cyan') or hex code (e.g., '#FF5733'). Overrides the type's default color.",
+							schemahelper.WithExample("#FF5733"),
+							schemahelper.WithMaxLength(*ptrs.IntPtr(20)),
+						),
+						fieldStyleBold: schemahelper.BoolProp(
+							"Whether to render the message in bold. When omitted, inherits from the type default (e.g., success and debug types default to bold).",
+						),
+						fieldStyleItalic: schemahelper.BoolProp(
+							"Whether to render the message in italic. When omitted, inherits from the type default.",
+						),
+						fieldStyleIcon: schemahelper.StringProp(
+							"Custom icon or emoji prefix for the message (e.g., '🚀', '📦', '→'). Overrides the type's default icon. Set to empty string to disable the icon entirely.",
+							schemahelper.WithExample("🚀"),
+							schemahelper.WithMaxLength(*ptrs.IntPtr(10)),
+						),
+					},
+				),
+				fieldDestination: schemahelper.StringProp(
+					"Where to write the message output.",
+					schemahelper.WithEnum(destStdout, destStderr),
+					schemahelper.WithDefault(destStdout),
+					schemahelper.WithMaxLength(*ptrs.IntPtr(10)),
+				),
+
+				fieldNewline: schemahelper.BoolProp(
+					"Whether to append a trailing newline after the message.",
+					schemahelper.WithDefault(true),
+				),
+			}),
+			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				provider.CapabilityAction: messageOutputSchema,
+			},
+			Examples: []provider.Example{
+				{
+					Name:        "Success message",
+					Description: "Output a success message with default styling",
+					YAML: `name: deploy-success
+provider: message
+inputs:
+  message: "Deployment completed successfully"
+  type: success`,
+				},
+				{
+					Name:        "Labeled message",
+					Description: "Output a message with a contextual label prefix",
+					YAML: `name: deploy-step
+provider: message
+inputs:
+  message: "Installing dependencies"
+  type: info
+  label: "step 2/5"`,
+				},
+				{
+					Name:        "Type with style override",
+					Description: "Use success type as the base, but override the icon. Color and bold are inherited from success defaults.",
+					YAML: `name: deploy-start
+provider: message
+inputs:
+  message: "Starting deployment pipeline"
+  type: success
+  style:
+    icon: "🚀"`,
+				},
+				{
+					Name:        "Fully custom style",
+					Description: "Output a message with fully custom color, icon, and bold formatting (no type needed)",
+					YAML: `name: custom-deploy
+provider: message
+inputs:
+  message: "Starting deployment pipeline"
+  type: plain
+  style:
+    color: "#FF5733"
+    bold: true
+    icon: "🚀"`,
+				},
+			},
+		},
+	}
+}
+
+// Descriptor returns the provider descriptor.
+func (p *MessageProvider) Descriptor() *provider.Descriptor {
+	return p.descriptor
+}
+
+// Execute outputs a styled message to the terminal.
+func (p *MessageProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected map[string]any, got %T", ProviderName, input)
+	}
+	lgr := logger.FromContext(ctx)
+
+	// Resolve the message text (required for both normal and dry-run execution).
+	msgStr, ok := inputs[fieldMessage].(string)
+	if !ok || msgStr == "" {
+		return nil, fmt.Errorf("%s: 'message' must be provided", ProviderName)
+	}
+
+	// Check for dry-run mode.
+	if provider.DryRunFromContext(ctx) {
+		return p.executeDryRun(inputs)
+	}
+
+	// Get configuration fields.
+	msgType := stringField(inputs, fieldType, typeInfo)
+	dest := stringField(inputs, fieldDestination, destStdout)
+	newline := boolField(inputs, fieldNewline, true)
+
+	// Get settings from context for quiet/noColor.
+	noColor := false
+	isQuiet := false
+	if runSettings, ok := settings.FromContext(ctx); ok {
+		noColor = runSettings.NoColor
+		isQuiet = runSettings.IsQuiet
+	}
+
+	// Format the message for terminal output.
+	styled := p.formatMessage(msgStr, msgType, inputs, noColor, newline)
+
+	// Build a plain-text version for output data (no ANSI codes, no trailing newline).
+	// The newline is a terminal-output concern; structured data should not embed it.
+	plain := p.formatMessage(msgStr, msgType, inputs, true, false)
+
+	// Write to the terminal unless suppressed by --quiet.
+	streamed := false
+	if !isQuiet {
+		ioStreams, ok := provider.IOStreamsFromContext(ctx)
+		if ok && ioStreams != nil {
+			if err := p.writeToTerminal(ioStreams, styled, dest); err != nil {
+				return nil, fmt.Errorf("%s: failed to write output: %w", ProviderName, err)
+			}
+			streamed = true
+		}
+	}
+
+	lgr.V(1).Info("Message output",
+		fieldType, msgType,
+		fieldDestination, dest,
+		"written", !isQuiet,
+	)
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"message": plain,
+		},
+		Streamed: streamed,
+	}, nil
+}
+
+// formatMessage applies styling to the message text. It starts with the type
+// defaults (icon, color, bold) and merges any style overrides on top. Only the
+// fields explicitly set in style are overridden; everything else keeps the type
+// default. The trailing newline is baked into the output.
+func (p *MessageProvider) formatMessage(text, msgType string, inputs map[string]any, noColor, newline bool) string {
+	// Start with type defaults; fall back to info for unknown types.
+	ms, ok := typeDefaults[msgType]
+	if !ok {
+		ms = typeDefaults[typeInfo]
+	}
+
+	// Merge style overrides on top (even in noColor — we need icon resolution).
+	hasExplicitIcon := false
+	if styleMap, ok := inputs[fieldStyle].(map[string]any); ok {
+		if icon, ok := styleMap[fieldStyleIcon].(string); ok {
+			ms.icon = icon // empty string disables the icon
+			hasExplicitIcon = true
+		}
+		if !noColor {
+			if color, ok := styleMap[fieldStyleColor].(string); ok {
+				ms.color = color
+			}
+			if bold, ok := styleMap[fieldStyleBold].(bool); ok {
+				ms.bold = bold
+			}
+			if italic, ok := styleMap[fieldStyleItalic].(bool); ok {
+				ms.italic = italic
+			}
+		}
+	}
+
+	// In noColor mode, omit the default type icon (consistent with pkg/terminal/output)
+	// but still honor an explicit style.icon override.
+	if noColor && !hasExplicitIcon {
+		ms.icon = ""
+	}
+
+	if noColor {
+		s := text
+		if label, ok := inputs[fieldLabel].(string); ok && label != "" {
+			s = "[" + label + "] " + s
+		}
+		if ms.icon != "" {
+			s = ms.icon + " " + s
+		}
+		if newline {
+			s += "\n"
+		}
+		return s
+	}
+
+	// Build lipgloss style.
+	style := lipgloss.NewStyle()
+	if ms.color != "" {
+		style = style.Foreground(lipgloss.Color(ms.color))
+	}
+	if ms.bold {
+		style = style.Bold(true)
+	}
+	if ms.italic {
+		style = style.Italic(true)
+	}
+
+	// Render: icon + [label] + styled message
+	styled := style.Render(text)
+
+	// Prepend label in dimmed brackets if provided.
+	if label, ok := inputs[fieldLabel].(string); ok && label != "" {
+		styled = labelStyle.Render("["+label+"]") + " " + styled
+	}
+
+	if ms.icon != "" {
+		styled = ms.icon + " " + styled
+	}
+
+	if newline {
+		styled += "\n"
+	}
+
+	return styled
+}
+
+// writeToTerminal writes the fully-rendered message to the appropriate stream.
+// The caller is responsible for verifying IOStreams are available before calling.
+func (p *MessageProvider) writeToTerminal(ioStreams *provider.IOStreams, msg, dest string) error {
+	var w io.Writer
+	switch dest {
+	case destStderr:
+		w = ioStreams.ErrOut
+	default:
+		w = ioStreams.Out
+	}
+
+	if w == nil {
+		return fmt.Errorf("no writer available for destination %q", dest)
+	}
+
+	_, err := fmt.Fprint(w, msg)
+	return err
+}
+
+// executeDryRun returns a simulated output for dry-run mode.
+func (p *MessageProvider) executeDryRun(inputs map[string]any) (*provider.Output, error) {
+	msgType := stringField(inputs, fieldType, typeInfo)
+	dest := stringField(inputs, fieldDestination, destStdout)
+	label := stringField(inputs, fieldLabel, "")
+	msg := stringField(inputs, fieldMessage, "<dynamic>")
+
+	desc := fmt.Sprintf("[dry-run] Would output %s message to %s: %s", msgType, dest, msg)
+	if label != "" {
+		desc = fmt.Sprintf("[dry-run] Would output %s message [%s] to %s: %s", msgType, label, dest, msg)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"message": desc,
+		},
+	}, nil
+}
+
+// stringField extracts a string value from the inputs map with a default fallback.
+func stringField(inputs map[string]any, key, def string) string {
+	if v, ok := inputs[key].(string); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+// boolField extracts a bool value from the inputs map with a default fallback.
+func boolField(inputs map[string]any, key string, def bool) bool {
+	if v, ok := inputs[key].(bool); ok {
+		return v
+	}
+	return def
+}

--- a/pkg/provider/builtin/messageprovider/message_test.go
+++ b/pkg/provider/builtin/messageprovider/message_test.go
@@ -1,0 +1,788 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package messageprovider
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCtx returns a context with logger, IOStreams backed by buffers, and optional settings.
+func testCtx(t *testing.T, runSettings *settings.Run) (context.Context, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: stderr})
+	if runSettings != nil {
+		ctx = settings.IntoContext(ctx, runSettings)
+	} else {
+		ctx = settings.IntoContext(ctx, &settings.Run{})
+	}
+	return ctx, stdout, stderr
+}
+
+func TestNewMessageProvider(t *testing.T) {
+	p := NewMessageProvider()
+	require.NotNil(t, p)
+	assert.Equal(t, "message", p.Descriptor().Name)
+	assert.Equal(t, "Message Provider", p.Descriptor().DisplayName)
+	assert.Equal(t, "v1", p.Descriptor().APIVersion)
+	assert.Contains(t, p.Descriptor().Capabilities, provider.CapabilityAction)
+	assert.NotContains(t, p.Descriptor().Capabilities, provider.CapabilityFrom)
+	assert.Equal(t, "utility", p.Descriptor().Category)
+	assert.NotEmpty(t, p.Descriptor().Examples)
+}
+
+func TestMessageProvider_Execute_InvalidInput(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, "not-a-map")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected map[string]any")
+}
+
+func TestMessageProvider_Execute_MissingMessage(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'message' must be provided")
+}
+
+func TestMessageProvider_Execute_PlainMessage(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "hello world",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	data := out.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "hello world", data["message"])
+	assert.True(t, out.Streamed)
+	assert.Equal(t, "hello world\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_AllMessageTypes(t *testing.T) {
+	types := []string{typeSuccess, typeWarning, typeError, typeInfo, typeDebug, typePlain}
+	for _, msgType := range types {
+		t.Run(msgType, func(t *testing.T) {
+			p := NewMessageProvider()
+			ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+			out, err := p.Execute(ctx, map[string]any{
+				"message": "test message",
+				"type":    msgType,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			assert.True(t, out.Streamed)
+			assert.Contains(t, stdout.String(), "test message")
+
+			data := out.Data.(map[string]any)
+			assert.True(t, data["success"].(bool))
+			assert.Contains(t, data["message"].(string), "test message")
+		})
+	}
+}
+
+func TestMessageProvider_Execute_TypeStyling_NoColor(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "styled",
+		"type":    "success",
+	})
+	require.NoError(t, err)
+	// In noColor mode, default type icons are omitted (consistent with terminal/output).
+	assert.Equal(t, "styled\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_TypeStyling_WithColor(t *testing.T) {
+	types := []string{typeSuccess, typeWarning, typeError, typeInfo, typeDebug}
+	for _, msgType := range types {
+		t.Run(msgType, func(t *testing.T) {
+			p := NewMessageProvider()
+			ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+			_, err := p.Execute(ctx, map[string]any{
+				"message": "styled",
+				"type":    msgType,
+			})
+			require.NoError(t, err)
+			// With color, the output should contain the message text.
+			assert.Contains(t, stdout.String(), "styled")
+		})
+	}
+}
+
+func TestMessageProvider_Execute_OutputDataNoANSI(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "deploy finished",
+		"type":    "success",
+	})
+	require.NoError(t, err)
+	data := out.Data.(map[string]any)
+	msg := data["message"].(string)
+	// Output data must never contain ANSI escape codes, even when terminal uses color.
+	assert.NotContains(t, msg, "\x1b[")
+	assert.Contains(t, msg, "deploy finished")
+}
+
+func TestMessageProvider_Execute_CustomStyle(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "custom styled",
+		"style": map[string]any{
+			"color":  "#FF5733",
+			"bold":   true,
+			"italic": true,
+			"icon":   "\U0001F680",
+		},
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "\U0001F680")
+	assert.Contains(t, result, "custom styled")
+}
+
+func TestMessageProvider_Execute_CustomStyle_IconOnly(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "with icon",
+		"style": map[string]any{
+			"icon": "\U0001F4E6",
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "\U0001F4E6")
+	assert.Contains(t, stdout.String(), "with icon")
+}
+
+func TestMessageProvider_Execute_CustomStyle_NoColor_FallsBackToType(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "fallback",
+		"type":    "plain",
+		"style": map[string]any{
+			"color": "#FF0000",
+			"bold":  true,
+		},
+	})
+	require.NoError(t, err)
+	// When noColor is true, colors/bold are stripped. Plain type has no icon.
+	assert.Equal(t, "fallback\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_NoColor_StyleIconStillApplied(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "with icon",
+		"type":    "plain",
+		"style": map[string]any{
+			"icon": "\U0001F680",
+		},
+	})
+	require.NoError(t, err)
+	// Explicit style.icon is still honored in noColor mode.
+	assert.Equal(t, "\U0001F680 with icon\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_NoColor_StyleIconDisabled(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no icon",
+		"type":    "success",
+		"style": map[string]any{
+			"icon": "",
+		},
+	})
+	require.NoError(t, err)
+	// Empty icon override disables the icon.
+	assert.Equal(t, "no icon\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_UnknownTypeFallsBackToInfo(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "unknown type",
+		"type":    "nonexistent",
+	})
+	require.NoError(t, err)
+	// In noColor mode, default type icons are omitted.
+	assert.Equal(t, "unknown type\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_StyleMergesOnType(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	// Use success type (✅ green bold) but override only the icon to 🚀.
+	// Color and bold should be inherited from success defaults.
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "merged",
+		"type":    "success",
+		"style": map[string]any{
+			"icon": "🚀",
+		},
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "🚀")
+	assert.Contains(t, result, "merged")
+	// Should NOT contain the default success icon since it was overridden.
+	assert.NotContains(t, result, "✅")
+}
+
+func TestMessageProvider_Execute_StyleDisableIcon(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	// Use success type but explicitly disable the icon with empty string.
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no icon",
+		"type":    "success",
+		"style": map[string]any{
+			"icon": "",
+		},
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "no icon")
+	assert.NotContains(t, result, "✅")
+}
+
+func TestMessageProvider_Execute_StyleAddsBoldToType(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	// Warning type (⚠️ yellow, no bold) + style adds italic.
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "italic warning",
+		"type":    "warning",
+		"style": map[string]any{
+			"italic": true,
+		},
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "⚠️")
+	assert.Contains(t, result, "italic warning")
+}
+
+func TestMessageProvider_Execute_StyleOverridesColor(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	// Use info type but override color. Icon (💡) should be preserved.
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "custom color",
+		"type":    "info",
+		"style": map[string]any{
+			"color": "#FF5733",
+		},
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "💡")
+	assert.Contains(t, result, "custom color")
+}
+
+func TestMessageProvider_Execute_Label(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "Installing dependencies",
+		"type":    "plain",
+		"label":   "step 2/5",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "[step 2/5] Installing dependencies\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_Label_WithTypeIcon(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "Deploying service",
+		"type":    "success",
+		"label":   "deploy",
+	})
+	require.NoError(t, err)
+	// noColor: no default icon + label + message
+	assert.Equal(t, "[deploy] Deploying service\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_Label_WithColor(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "Deploying service",
+		"type":    "success",
+		"label":   "deploy",
+	})
+	require.NoError(t, err)
+	result := stdout.String()
+	assert.Contains(t, result, "✅")
+	assert.Contains(t, result, "[deploy]")
+	assert.Contains(t, result, "Deploying service")
+}
+
+func TestMessageProvider_Execute_Label_Empty(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no label",
+		"type":    "plain",
+		"label":   "",
+	})
+	require.NoError(t, err)
+	// Empty label should not add brackets.
+	assert.Equal(t, "no label\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_Label_NoLabel(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no label field",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	// Missing label field should not add brackets.
+	assert.Equal(t, "no label field\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_DestinationStderr(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, stderr := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message":     "error log",
+		"type":        "plain",
+		"destination": "stderr",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "error log\n", stderr.String())
+}
+
+func TestMessageProvider_Execute_NewlineFalse(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no newline",
+		"type":    "plain",
+		"newline": false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "no newline", stdout.String())
+}
+
+func TestMessageProvider_Execute_NewlineTrue(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "with newline",
+		"type":    "plain",
+		"newline": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "with newline\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_NewlineDefault(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "default newline",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	// Default is newline=true.
+	assert.Equal(t, "default newline\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_NewlineFalse_CustomStyle(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no trailing",
+		"newline": false,
+		"style": map[string]any{
+			"color": "green",
+		},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, stdout.String(), "\n")
+}
+
+func TestMessageProvider_Execute_QuietSuppressed(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{IsQuiet: true, NoColor: true})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "should be suppressed",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
+	assert.False(t, out.Streamed)
+	// Rendered message still available in output data.
+	data := out.Data.(map[string]any)
+	assert.Equal(t, "should be suppressed", data["message"])
+}
+
+func TestMessageProvider_Execute_NotQuiet(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{IsQuiet: false, NoColor: true})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "visible",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "visible\n", stdout.String())
+	assert.True(t, out.Streamed)
+}
+
+func TestMessageProvider_Execute_DryRun(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message":     "deploy now",
+		"type":        "warning",
+		"destination": "stderr",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String()) // Dry-run doesn't write to terminal.
+
+	data := out.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Contains(t, data["message"].(string), "[dry-run]")
+	assert.Contains(t, data["message"].(string), "warning")
+	assert.Contains(t, data["message"].(string), "stderr")
+}
+
+func TestMessageProvider_Execute_DryRun_NoMessage(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"type": "info",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'message' must be provided")
+}
+
+func TestMessageProvider_Execute_DryRun_WithLabel(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "deploy now",
+		"type":    "info",
+		"label":   "step 1",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
+
+	data := out.Data.(map[string]any)
+	assert.Contains(t, data["message"].(string), "[dry-run]")
+	assert.Contains(t, data["message"].(string), "[step 1]")
+}
+
+func TestMessageProvider_Execute_NilWriter(t *testing.T) {
+	p := NewMessageProvider()
+	// Create IOStreams with nil Out to trigger the nil writer error path.
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: nil, ErrOut: nil})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "should fail",
+		"type":    "plain",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no writer available")
+}
+
+func TestMessageProvider_Execute_NilStderrWriter(t *testing.T) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: &bytes.Buffer{}, ErrOut: nil})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message":     "should fail",
+		"type":        "plain",
+		"destination": "stderr",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no writer available")
+}
+
+func TestMessageProvider_Execute_NoIOStreams(t *testing.T) {
+	p := NewMessageProvider()
+	// Context WITHOUT IOStreams.
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "will succeed without streaming",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	// Message is still in output data even without IOStreams.
+	data := out.Data.(map[string]any)
+	assert.Equal(t, "will succeed without streaming", data["message"])
+	assert.True(t, data["success"].(bool))
+	// Streamed should be false since no IOStreams were available.
+	assert.False(t, out.Streamed)
+}
+
+func TestMessageProvider_Execute_PlainMessage_NoSettings(t *testing.T) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+	// No settings in context - defaults to noColor=false, isQuiet=false.
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "no settings",
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Equal(t, "no settings\n", stdout.String())
+}
+
+func TestMessageProvider_WhatIf(t *testing.T) {
+	p := NewMessageProvider()
+	desc := p.Descriptor()
+	require.NotNil(t, desc.WhatIf)
+
+	tests := []struct {
+		name     string
+		input    any
+		contains string
+	}{
+		{
+			name:     "with message",
+			input:    map[string]any{"message": "hello", "type": "success"},
+			contains: "Would output success message",
+		},
+		{
+			name:     "with expression (via ValueRef)",
+			input:    map[string]any{"type": "info"},
+			contains: "Would output info message",
+		},
+		{
+			name:     "no message",
+			input:    map[string]any{"type": "warning", "destination": "stderr"},
+			contains: "Would output warning message to stderr",
+		},
+		{
+			name: "long message truncated",
+			input: map[string]any{
+				"message": strings.Repeat("x", 100),
+			},
+			contains: "...",
+		},
+		{
+			name:     "with label",
+			input:    map[string]any{"message": "hello", "type": "success", "label": "deploy"},
+			contains: "[deploy]",
+		},
+		{
+			name:     "no message with label",
+			input:    map[string]any{"type": "info", "label": "step 1"},
+			contains: "[step 1]",
+		},
+		{
+			name:     "invalid input type",
+			input:    "not-a-map",
+			contains: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := desc.WhatIf(context.Background(), tt.input)
+			require.NoError(t, err)
+			if tt.contains != "" {
+				assert.Contains(t, msg, tt.contains)
+			}
+		})
+	}
+}
+
+func TestStringField(t *testing.T) {
+	m := map[string]any{"key": "val", "empty": ""}
+	assert.Equal(t, "val", stringField(m, "key", "def"))
+	assert.Equal(t, "def", stringField(m, "missing", "def"))
+	assert.Equal(t, "def", stringField(m, "empty", "def"))
+}
+
+func TestBoolField(t *testing.T) {
+	m := map[string]any{"yes": true, "no": false}
+	assert.True(t, boolField(m, "yes", false))
+	assert.False(t, boolField(m, "no", true))
+	assert.True(t, boolField(m, "missing", true))
+}
+
+func TestDescriptorValidation(t *testing.T) {
+	p := NewMessageProvider()
+	err := provider.ValidateDescriptor(p.Descriptor())
+	require.NoError(t, err, "message provider descriptor should be valid")
+}
+
+// --- Benchmarks ---
+
+func BenchmarkExecutePlainMessage(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": "benchmark message",
+		"type":    "plain",
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecuteStyledMessage(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: false})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": "benchmark styled",
+		"type":    "success",
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecuteCustomStyle(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: false})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": "benchmark custom",
+		"style": map[string]any{
+			"color":  "#FF5733",
+			"bold":   true,
+			"italic": true,
+			"icon":   "\U0001F680",
+		},
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecuteStyleMerge(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: false})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": "benchmark merge",
+		"type":    "success",
+		"style": map[string]any{
+			"icon": "🚀",
+		},
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecuteWithLabel(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: false})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": "benchmark label",
+		"type":    "info",
+		"label":   "step 3/5",
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}

--- a/pkg/resolver/valueref_test.go
+++ b/pkg/resolver/valueref_test.go
@@ -305,15 +305,20 @@ func TestValueRef_Resolve_Tmpl(t *testing.T) {
 	}{
 		{
 			name:        "simple variable",
-			tmpl:        "{{ ._.environment }}",
+			tmpl:        "{{ .environment }}",
 			expected:    "production",
 			expectError: false,
 		},
 		{
 			name:        "multiple variables",
-			tmpl:        "{{ ._.environment }}-{{ ._.region }}",
+			tmpl:        "{{ .environment }}-{{ .region }}",
 			expected:    "production-us-west-2",
 			expectError: false,
+		},
+		{
+			name:        "underscore prefix not supported",
+			tmpl:        "{{ ._.environment }}",
+			expectError: true,
 		},
 	}
 

--- a/pkg/spec/valueref.go
+++ b/pkg/spec/valueref.go
@@ -271,10 +271,14 @@ func (v *ValueRef) ResolveWithIterationContext(ctx context.Context, resolverData
 
 	// Go template
 	if v.Tmpl != nil {
-		templateData := map[string]any{
-			"_":      resolverData,
-			"__self": self,
+		// Spread resolver data at the top level so templates can use
+		// {{ .resolverName }} directly. The "._" prefix is a CEL convention
+		// and is not supported in Go templates.
+		templateData := make(map[string]any, len(resolverData)+4)
+		for k, val := range resolverData {
+			templateData[k] = val
 		}
+		templateData["__self"] = self
 		// Also add iteration variables at top level for template convenience
 		if iterCtx != nil {
 			templateData["__item"] = iterCtx.Item
@@ -287,8 +291,9 @@ func (v *ValueRef) ResolveWithIterationContext(ctx context.Context, resolverData
 			}
 		}
 		result, err := gotmpl.Execute(ctx, gotmpl.TemplateOptions{
-			Content: string(*v.Tmpl),
-			Data:    templateData,
+			Content:    string(*v.Tmpl),
+			Data:       templateData,
+			MissingKey: gotmpl.MissingKeyError,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute template: %w", err)

--- a/pkg/spec/valueref_test.go
+++ b/pkg/spec/valueref_test.go
@@ -299,16 +299,21 @@ func TestValueRef_Resolve_Tmpl(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "simple variable",
-			tmpl:        "{{ ._.environment }}",
+			name:        "direct resolver access",
+			tmpl:        "{{ .environment }}",
 			expected:    "production",
 			expectError: false,
 		},
 		{
-			name:        "multiple variables",
-			tmpl:        "{{ ._.environment }}-{{ ._.region }}",
+			name:        "direct multiple variables",
+			tmpl:        "{{ .environment }}-{{ .region }}",
 			expected:    "production-us-west-2",
 			expectError: false,
+		},
+		{
+			name:        "underscore prefix is not supported",
+			tmpl:        "{{ ._.environment }}",
+			expectError: true,
 		},
 	}
 

--- a/pkg/terminal/writer/writer.go
+++ b/pkg/terminal/writer/writer.go
@@ -210,6 +210,23 @@ func (w *Writer) Plainlnf(format string, args ...any) {
 	w.Plainln(fmt.Sprintf(format, args...))
 }
 
+// PlainStderr writes a plain message to stderr without any styling.
+// Use this for diagnostic output that must not corrupt structured stdout
+// but also does not warrant warning/error formatting.
+// Respects --quiet flag only.
+func (w *Writer) PlainStderr(msg string) {
+	if w.cliParams.IsQuiet {
+		return
+	}
+	fmt.Fprintln(w.ioStreams.ErrOut, msg)
+}
+
+// PlainStderrf writes a formatted plain message to stderr without any styling.
+// Respects --quiet flag only.
+func (w *Writer) PlainStderrf(format string, args ...any) {
+	w.PlainStderr(fmt.Sprintf(format, args...))
+}
+
 // IOStreams returns the underlying IOStreams.
 // Useful when you need direct access to the streams for structured output.
 func (w *Writer) IOStreams() *terminal.IOStreams {

--- a/pkg/terminal/writer/writer_test.go
+++ b/pkg/terminal/writer/writer_test.go
@@ -119,6 +119,31 @@ func TestWarnStderr_Quiet(t *testing.T) {
 	assert.Empty(t, errBuf.String())
 }
 
+func TestPlainStderr(t *testing.T) {
+	w, outBuf, errBuf := newTestWriter()
+
+	w.PlainStderr("diagnostic output")
+	assert.Empty(t, outBuf.String(), "PlainStderr should not write to stdout")
+	assert.Contains(t, errBuf.String(), "diagnostic output")
+	assert.NotContains(t, errBuf.String(), "⚠️", "PlainStderr should not add warning styling")
+}
+
+func TestPlainStderrf(t *testing.T) {
+	w, outBuf, errBuf := newTestWriter()
+
+	w.PlainStderrf("step %d: %s", 1, "completed")
+	assert.Empty(t, outBuf.String(), "PlainStderrf should not write to stdout")
+	assert.Contains(t, errBuf.String(), "step 1: completed")
+}
+
+func TestPlainStderr_Quiet(t *testing.T) {
+	w, _, errBuf := newTestWriter()
+	w.cliParams.IsQuiet = true
+
+	w.PlainStderr("diagnostic output")
+	assert.Empty(t, errBuf.String())
+}
+
 func TestError(t *testing.T) {
 	w, _, errBuf := newTestWriter()
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -211,7 +211,7 @@ tasks:
         SKIPPED=0
 
         # Directories/files that are intentionally invalid and should be skipped
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -562,6 +562,27 @@ func TestIntegration_RunProvider_PositionalMultipleInputs(t *testing.T) {
 }
 
 // ============================================================================
+// Run Provider — Message Provider Tests
+// ============================================================================
+
+func TestIntegration_RunProvider_Message(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "message", "--input", "message=hello from message provider", "--input", "type=plain", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "hello from message provider")
+	assert.Contains(t, stdout, "\"success\"")
+}
+
+func TestIntegration_RunProvider_MessageDryRun(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "run", "provider", "message", "--input", "message=dry run test", "--input", "type=info", "--dry-run", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "[dry-run]")
+}
+
+// ============================================================================
 // Run Provider — Unknown Input Key Validation Tests
 // ============================================================================
 

--- a/tests/integration/solutions/lint-tmpl-underscore/solution.yaml
+++ b/tests/integration/solutions/lint-tmpl-underscore/solution.yaml
@@ -1,0 +1,80 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-tmpl-underscore
+  version: 1.0.0
+  description: |
+    Tests that scafctl lint detects the unsupported {{ ._.resolverName }}
+    syntax in Go templates and reports the tmpl-underscore-prefix rule.
+
+spec:
+  resolvers:
+    config:
+      description: Static config resolver
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                appName: my-app
+
+    greeting:
+      description: Greeting using underscore prefix (should trigger lint error)
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                tmpl: "Hello from {{ ._.config.appName }}"
+
+  testing:
+    config:
+      # lint: solution intentionally has tmpl-underscore-prefix lint error
+      # resolve-defaults: tmpl value is a literal string (not resolved as template here)
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
+
+    cases:
+      underscore-prefix-detected:
+        description: Lint should report tmpl-underscore-prefix for ._.config usage
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [template, lint, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Solution with ._ prefix in Go template should fail lint"
+          - expression: __output.errorCount >= 1
+            message: "At least one error should be reported"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "tmpl-underscore-prefix")
+            message: "A tmpl-underscore-prefix finding should be present"
+
+      underscore-prefix-severity:
+        description: tmpl-underscore-prefix findings should have error severity
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [template, lint, negative]
+        expectFailure: true
+        assertions:
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "tmpl-underscore-prefix" && f.severity == "error")
+            message: "tmpl-underscore-prefix findings should have error severity"
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "tmpl-underscore-prefix" && f.category == "template")
+            message: "tmpl-underscore-prefix findings should have template category"
+
+      underscore-prefix-suggestion:
+        description: Finding should suggest replacing ._.config with .config
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [template, lint, negative]
+        expectFailure: true
+        assertions:
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "tmpl-underscore-prefix" &&
+                f.suggestion.contains(".config"))
+            message: "Finding should suggest the correct syntax"

--- a/tests/integration/solutions/message-provider/solution.yaml
+++ b/tests/integration/solutions/message-provider/solution.yaml
@@ -1,0 +1,120 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: message-provider-test
+  version: 1.0.0
+  description: Integration tests for the message provider
+
+spec:
+  resolvers:
+    plain_msg:
+      description: Plain message output
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Hello from message provider"
+              type: plain
+
+    success_msg:
+      description: Success message output
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Operation completed"
+              type: success
+
+    templated_msg:
+      description: Go template message with resolver data
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                tmpl: "Greeting: {{ .plain_msg.message }}"
+              type: plain
+
+    cel_msg:
+      description: CEL expression message
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message:
+                expr: "'CEL says: ' + string(_.success_msg.success)"
+              type: plain
+
+    no_newline_msg:
+      description: Message without trailing newline
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "no-newline"
+              type: plain
+              newline: false
+
+    labeled_msg:
+      description: Message with contextual label
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: "Installing deps"
+              type: info
+              label: "step 1"
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      basic-execution:
+        description: Verify message provider runs successfully
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('"message"')
+
+      plain-message-output:
+        description: Verify plain message text appears in output
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('Hello from message provider')
+
+      success-message-data:
+        description: Verify success message sets success=true in output
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('Operation completed')
+
+      templated-message:
+        description: Verify Go template interpolation with resolver data
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('Greeting:')
+
+      cel-expression-message:
+        description: Verify CEL expression computes message from resolver data
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('CEL says:')
+
+      labeled-message:
+        description: Verify label appears in terminal output
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __stdout.contains('Installing deps')


### PR DESCRIPTION
Add message provider for styled terminal output and improve action
output behavior for shell eval/piping use cases.

Message provider:
- New built-in provider for terminal messages (info/warn/error/success/debug)
- Supports custom styles (icon, color) and Go template interpolation
- Validates message input before dry-run check
- Returns rendered plain text in output data (no ANSI codes or trailing newline)
- Omits default type icon in --no-color mode (explicit style.icon still honored)
- Adds success field to CapabilityFrom output schema
- Inject IOStreams in run provider command for streaming providers
- Route provider stdout to stderr for structured output modes (json/yaml/quiet)
- Full documentation, tutorial, examples, and integration tests

Action output:
- Remove [actionName] label prefixes from parallel action stdout
- Remove buildActionIOStreams and PrefixedWriter from executor
- All actions share raw IOStreams for clean, pipe-safe output
- Suppress condition-based skip messages by default
- Make --verbose general-purpose (was dry-run-only):
  shows ✓ succeeded (with duration), ○ skipped (with reason), ✗ failed
  on stderr for every action
- Fix progress bar skipped resolver display (use Abort instead of SetTotal)

BREAKING CHANGE: Parallel action stdout no longer includes [actionName]
label prefixes. Use --progress or --show-execution for debugging.
BREAKING CHANGE: --verbose now shows action status during normal execution.
