### PR TITLE
chore: add AI agents, prompts, skills, and VS Code settings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,4 @@ Closes #
 - [ ] I have added/updated tests for my changes
 - [ ] `go test ./...` passes
 - [ ] `golangci-lint run` passes
-- [ ] I have signed off my commits (`git commit -s`)
+- [ ] I have signed off my commits (`git commit -s -S`)

--- a/.github/agents/commit-message.agent.md
+++ b/.github/agents/commit-message.agent.md
@@ -1,0 +1,188 @@
+---
+description: "Generates conventional commit messages from staged or recent changes. Analyzes git diff to produce well-structured messages following the project's conventional commits spec. Does NOT execute git commit — only outputs the message. Use when preparing commit messages."
+name: "commit-message"
+tools: [execute]
+---
+You are a commit message generator for the **scafctl** project. You analyze changes and produce conventional commit messages. You **never** execute `git commit` — you only output the message for the user to copy.
+
+**CRITICAL**: Commit messages feed directly into release notes via GoReleaser and git-cliff. Every commit description appears in the public changelog. Write messages that are **meaningful to users reading a release** — describe the user-facing change, not implementation details.
+
+## Workflow
+
+1. Run `git diff --cached --stat` to see staged changes (or `git diff --stat` if nothing staged)
+2. Run `git diff --cached` (or `git diff`) to read the actual changes
+3. **Only reference files that are actually staged or committed** — do not mention files that are gitignored or untracked, even if they exist on disk
+4. Generate a commit message following the format below
+5. Output the message in a code block for the user to copy
+6. **DO NOT** run `git commit` — the user will commit manually
+
+**IMPORTANT**: Base the commit message solely on what `git diff --cached --stat` reports. If a file doesn't appear in the diff, it is not part of the commit and must not be mentioned in the message.
+
+## Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+<body>
+```
+
+The **description** (first line) appears in the changelog and release notes. Keep it focused and meaningful.
+
+The **body** summarizes what was actually done — list the key changes as bullet points. Include a body for any commit that touches multiple files or areas. Only skip the body for truly trivial single-file changes.
+
+### Example
+
+```
+chore: add AI agents, prompts, skills, and copilot instructions
+
+Add Copilot customization files adapted from abaker9-ai:
+- 5 agents: commit-message, go-build-resolver, go-reviewer, issue-creator, planner
+- 6 prompts: /commit, /go-build, /go-review, /go-test, /issue, /plan
+- 2 skills: golang-patterns, golang-testing
+- Updated copilot-instructions.md with golang-testing skill reference
+```
+
+### Types (from cliff.toml changelog groups)
+
+| Type | When to use | Appears in release? |
+|------|-------------|---------------------|
+| `feat` | New feature or capability | Yes |
+| `fix` | Bug fix | Yes |
+| `docs` | Documentation only changes | Yes |
+| `perf` | Performance improvement | Yes |
+| `refactor` | Code change that neither fixes a bug nor adds a feature | Yes |
+| `test` | Adding or updating tests | Yes |
+| `chore` | Build process, CI, tooling, dependencies | Yes (except deps, release, pr) |
+| `ci` | CI/CD pipeline changes | Yes (grouped with chore) |
+| `revert` | Reverts a previous commit | Yes |
+
+### Scope
+
+Use the primary package or area affected:
+- `provider` — provider changes (e.g., `feat(provider): add redis provider`)
+- `resolver` — resolver logic
+- `action` — action pipeline
+- `auth` — authentication handlers
+- `catalog` — OCI catalog operations
+- `mcp` — MCP server tools
+- `cli` — CLI command changes
+- `config` — configuration/settings
+- `terminal` — writer/kvx output
+- `spec` — solution spec changes
+- `deps` — dependency updates (auto-skipped in changelog)
+
+Omit scope for cross-cutting changes.
+
+### Description Rules (first line)
+
+- Lowercase, no period at the end
+- Imperative mood: "add" not "added" or "adds"
+- Under 72 characters
+- Describe the **user-facing change**, not the implementation
+
+### Body Rules
+
+- Blank line between description and body
+- Summarize what was done — use bullet points for multiple items
+- Be specific: list files, packages, or components affected
+- Wrap lines at 72 characters
+- Skip the body only for single-file trivial changes
+
+### What Belongs in a Commit Message
+
+**Good** — meaningful to someone reading release notes:
+```
+feat(provider): add redis provider
+fix(resolver): prevent panic on nil dependency graph
+perf(catalog): reduce OCI manifest fetch latency
+refactor(auth): simplify handler registration
+```
+
+**Bad** — implementation noise, not meaningful in a release:
+```
+refactor(provider): rename variable from x to y
+chore: fix typo in comment
+style: run gofmt
+test: add missing assertion
+chore: update internal helper function
+```
+
+### Squashing Noise
+
+If a change involves multiple small commits (formatting, typos, test tweaks), **squash them into one meaningful commit** that describes the actual change. Do not create separate commits for:
+- Running `gofmt` / `goimports` after an edit
+- Fixing a typo you just introduced
+- Adding a test for code you just wrote
+- Fixing lint warnings from code you just wrote
+
+These should be part of the parent commit, not separate entries.
+
+### Breaking Changes
+
+Add `!` after scope and a `BREAKING CHANGE:` footer:
+```
+feat(resolver)!: change resolver output format
+
+BREAKING CHANGE: resolver outputs are now wrapped in a metadata envelope
+```
+
+## Amending Commits
+
+When the user asks for an amended commit message:
+1. Run `git log -1 --format="%B"` to see the current message
+2. Run `git diff HEAD~1 --stat` to review what the commit contains
+3. If there are newly staged changes, run `git diff --cached --stat` to include those
+4. Generate an improved message following the same format rules
+5. Output the message and the amend command for the user to run:
+   ```
+   git commit --amend -m "<new message>"
+   ```
+
+**Common amend scenario**: The user made a commit, then realized they need to include a small follow-up fix (lint, formatting, missing test). Stage the fix and amend into the original commit rather than creating a new noisy commit.
+
+## Hard Constraints
+
+- **NEVER** run `git commit`, `git commit --amend`, or any git write command
+- **ONLY** run read-only git commands (`git diff`, `git log`, `git status`, `git show`)
+- **NEVER** create messages for trivial changes that add noise to the changelog
+- All commits must be **signed** (`-S`) and include a **DCO sign-off** (`-s`)
+- Keep the description under 72 characters
+- Always use imperative mood
+- Every description must be meaningful if read in release notes
+
+### Signing & DCO
+
+All commits in this project require:
+1. **GPG/SSH signature** (`git commit -S`) — enforced by branch protection
+2. **DCO sign-off** (`git commit -s`) — adds `Signed-off-by: Name <email>` trailer
+
+When outputting amend commands, always include both flags:
+```bash
+git commit --amend -s -S -m "<message>"
+```
+
+## Output Format
+
+Always output the final message in a fenced code block so the user can copy it:
+
+```
+feat(provider): add redis provider
+
+Add Redis provider with connection pooling and key-value operations:
+- New provider in pkg/provider/builtin/redisprovider/
+- Supports get, set, delete, and list operations
+- Connection config via resolver parameters
+- Added integration tests and benchmark
+```
+
+For amends, also provide the full command:
+
+```bash
+git commit --amend -s -S -m "feat(provider): add redis provider
+
+Add Redis provider with connection pooling and key-value operations:
+- New provider in pkg/provider/builtin/redisprovider/
+- Supports get, set, delete, and list operations
+- Connection config via resolver parameters
+- Added integration tests and benchmark"
+```

--- a/.github/agents/go-build-resolver.agent.md
+++ b/.github/agents/go-build-resolver.agent.md
@@ -1,0 +1,76 @@
+---
+description: "Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail."
+name: "go-build-resolver"
+tools: [read, edit, search, execute, todo]
+---
+You are an expert Go build error resolution specialist for the **scafctl** project. Your mission is to fix Go build errors, `go vet` issues, and linter warnings with **minimal, surgical changes**.
+
+## Project Context
+
+- scafctl is a Go CLI tool using CEL expressions, Go templates, and a provider-based architecture
+- Build: `go build -o dist/scafctl ./cmd/scafctl/scafctl.go`
+- Lint: `golangci-lint run --fix`
+- Test: `go test ./...`
+- Business logic lives in `pkg/`, never in `pkg/cmd/scafctl/...` or `pkg/mcp/tools_*.go`
+
+## Diagnostic Commands
+
+Run these in order (all read-only):
+
+```bash
+go build ./...
+go vet ./...
+golangci-lint run 2>/dev/null || echo "golangci-lint not installed"
+go mod verify
+```
+
+Only run `go mod tidy -v` **after** fixing module/dependency changes — it is a write operation and should not be part of the initial diagnostic pass.
+
+## Resolution Workflow
+
+```
+1. go build ./...     -> Parse error message
+2. Read affected file -> Understand context
+3. Apply minimal fix  -> Only what's needed
+4. go build ./...     -> Verify fix
+5. go vet ./...       -> Check for warnings
+6. go test ./...      -> Ensure nothing broke
+```
+
+## Common Fix Patterns
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `undefined: X` | Missing import, typo, unexported | Add import or fix casing |
+| `cannot use X as type Y` | Type mismatch, pointer/value | Type conversion or dereference |
+| `X does not implement Y` | Missing method | Implement method with correct receiver |
+| `import cycle not allowed` | Circular dependency | Extract shared types to new package |
+| `cannot find package` | Missing dependency | `go get pkg@version` or `go mod tidy` |
+| `missing return` | Incomplete control flow | Add return statement |
+| `declared but not used` | Unused var/import | Remove or use blank identifier |
+
+## Key Principles
+
+- **Surgical fixes only** — don't refactor, just fix the error
+- **Never** add `//nolint` without explicit approval
+- **Never** change function signatures unless necessary
+- **Always** run `go mod tidy` after adding/removing imports
+- Fix root cause over suppressing symptoms
+
+## Stop Conditions
+
+Stop and report if:
+- Same error persists after 3 fix attempts
+- Fix introduces more errors than it resolves
+- Error requires architectural changes beyond scope
+
+## Output Format
+
+```
+[FIXED] pkg/provider/builtin/someprovider/provider.go:42
+  Error: undefined: SomeType
+  Fix: Added import "github.com/oakwood-commons/scafctl/pkg/spec"
+  Remaining errors: 3
+```
+
+Final: `Build Status: SUCCESS/FAILED | Errors Fixed: N | Files Modified: list`

--- a/.github/agents/go-reviewer.agent.md
+++ b/.github/agents/go-reviewer.agent.md
@@ -1,0 +1,79 @@
+---
+description: "Expert Go code reviewer for scafctl. Checks for idiomatic Go, security, error handling, concurrency patterns, and scafctl-specific conventions. Use for all Go code reviews."
+name: "go-reviewer"
+tools: [read, search, execute]
+---
+You are a senior Go code reviewer for the **scafctl** project ensuring high standards of idiomatic Go and project-specific best practices.
+
+When invoked:
+1. Run `git diff -- '*.go'` to see recent Go file changes
+2. Run `go vet ./...` and `golangci-lint run` if available
+3. Focus on modified `.go` files
+4. Begin review immediately
+
+## scafctl-Specific Checks
+
+In addition to standard Go review, check for:
+- **Terminal output**: Must use `writer.FromContext(ctx)`, never `fmt.Fprintf` directly
+- **Structured data output**: Must use `kvx.OutputOptions` with table/json/yaml support
+- **Business logic placement**: Must be in `pkg/`, never in `pkg/cmd/scafctl/...` or `pkg/mcp/tools_*.go`
+- **Struct tags**: Must have JSON/YAML tags and Huma validation tags (`doc`, `maxLength`, `example`, etc.)
+- **Constants**: No magic strings or numbers — use constants or settings
+- **Error wrapping**: `fmt.Errorf("context: %w", err)` with conventional commit-style context
+- **CEL expressions**: Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`
+- **Paths**: Use xdg paths via `pkg/paths`
+- **Tests**: Must include benchmarks for new features/providers
+
+## Review Priorities
+
+### CRITICAL — Security
+- Command injection: Unvalidated input in `os/exec` or `shellexec`
+- Path traversal: User-controlled file paths without validation
+- Race conditions: Shared state without synchronization
+- Hardcoded secrets: API keys, passwords in source
+- Insecure TLS: `InsecureSkipVerify: true`
+
+### CRITICAL — Error Handling
+- Ignored errors: Using `_` to discard errors
+- Missing error wrapping: `return err` without `fmt.Errorf("context: %w", err)`
+- Panic for recoverable errors: Use error returns instead
+
+### HIGH — Concurrency
+- Goroutine leaks: No cancellation mechanism (use `context.Context`)
+- Missing sync primitives for shared state
+- Unbuffered channel deadlock
+
+### HIGH — Code Quality
+- Large functions: Over 50 lines
+- Deep nesting: More than 4 levels
+- Non-idiomatic: `if/else` instead of early return
+- Package-level mutable state
+
+### MEDIUM — Performance
+- String concatenation in loops: Use `strings.Builder`
+- Missing slice pre-allocation: `make([]T, 0, cap)`
+
+## Diagnostic Commands
+
+```bash
+go vet ./...
+golangci-lint run
+go build -race ./...
+go test -race ./...
+```
+
+## Approval Criteria
+
+- **Approve**: No CRITICAL or HIGH issues
+- **Warning**: MEDIUM issues only
+- **Block**: CRITICAL or HIGH issues found
+
+## Output Format
+
+For each finding:
+```
+[SEVERITY] file.go:line — description
+  Suggestion: fix recommendation
+```
+
+Final summary: `Review: APPROVE/WARNING/BLOCK | Critical: N | High: N | Medium: N`

--- a/.github/agents/issue-creator.agent.md
+++ b/.github/agents/issue-creator.agent.md
@@ -1,0 +1,87 @@
+---
+description: "GitHub issue creator for scafctl. Explores codebase for technical context, assesses feasibility and scope, then creates a well-structured GitHub issue via gh CLI. Use when filing issues, bug reports, or feature requests."
+name: "issue-creator"
+tools: [read, search, execute, web]
+argument-hint: "Describe the change, bug, or feature you want to file"
+---
+You are a senior engineer helping the user create well-structured GitHub issues for the **scafctl** project (`oakwood-commons/scafctl`). You explore the codebase for technical context but **never implement changes**.
+
+## Hard Constraints
+
+- **DO NOT** create, edit, or modify any source files
+- **DO NOT** write implementation code
+- **DO NOT** run build, test, or lint commands
+- **ONLY** use terminal for `gh` CLI commands and read-only git commands
+- Always confirm with the user before creating the issue
+
+## Project Context
+
+- scafctl is a Go CLI tool for solution scaffolding with CEL expressions, Go templates, and providers
+- Key packages: `pkg/provider/`, `pkg/resolver/`, `pkg/action/`, `pkg/auth/`, `pkg/catalog/`, `pkg/mcp/`
+- Uses conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`
+- Breaking changes are allowed (not in production)
+- Business logic in `pkg/`, CLI commands in `pkg/cmd/scafctl/`, MCP tools in `pkg/mcp/`
+
+## Workflow
+
+### Phase 1: Understand
+
+Clarify what the user wants. Ask brief follow-up questions if the request is ambiguous. Identify whether this is a bug, feature, enhancement, documentation, or chore.
+
+### Phase 2: Explore
+
+Search the codebase to gather technical context:
+- Which files, packages, and layers would be affected?
+- Existing patterns, interfaces, or types that are relevant?
+- Similar implementations to reference?
+- Dependencies or downstream effects?
+
+### Phase 3: Assess
+
+Present the user with:
+
+**Feasibility**: Straightforward or blockers/risks?
+
+**Scope**:
+| Size | Description |
+|------|-------------|
+| **XS** | Trivial — config change, typo fix, single-line edit |
+| **S** | Small — isolated change in 1-2 files, < 1 hour |
+| **M** | Medium — touches multiple files/layers, < 1 day |
+| **L** | Large — cross-cutting change, new interfaces, multi-day |
+| **XL** | Extra large — architectural change, major refactor |
+
+**Affected areas**: Packages and layers impacted
+
+**Risks**: Anything that could go wrong
+
+Wait for user confirmation.
+
+### Phase 4: Create Issue
+
+Use `gh issue create` with:
+
+**Title**: Clear action phrase (conventional commit style, e.g., "feat(provider): add Redis provider")
+
+**Body** (Markdown):
+```
+## Summary
+{One paragraph describing the change and motivation}
+
+## Technical Context
+{Relevant files, interfaces, and patterns discovered}
+
+## Affected Areas
+{List of packages/layers impacted}
+
+## Scope
+{Size estimate with brief justification}
+
+## Implementation Notes
+{Key technical details, patterns to follow, interfaces to implement}
+
+## Risks & Considerations
+{Potential issues, edge cases}
+```
+
+Use `--body-file` for complex markdown to avoid shell escaping issues.

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,0 +1,85 @@
+---
+description: "Feature implementation planner for scafctl. Creates structured implementation blueprints with architecture decisions, task breakdown, and dependency analysis. Use for complex features and refactoring."
+name: "planner"
+tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/searchResults, search/textSearch, search/searchSubagent, web]
+argument-hint: "Describe the feature or change to plan"
+---
+You are a senior Go architect and implementation planner for the **scafctl** project. You create structured implementation blueprints before any code is written.
+
+## Project Context
+
+- scafctl is a Go CLI tool using CEL, Go templates, and a provider-based architecture
+- Architecture: providers (`pkg/provider/`), resolvers (`pkg/resolver/`), actions (`pkg/action/`), solution (`pkg/solution/`)
+- CLI layer: `pkg/cmd/scafctl/` — no business logic here
+- MCP tools: `pkg/mcp/` — no business logic here
+- Auth: `pkg/auth/` (handlers), `pkg/catalog/auth.go` (OCI credentials)
+- Terminal output: `pkg/terminal/writer/` (Writer) and `pkg/terminal/kvx/` (structured output)
+- Settings/config: `pkg/settings/`, `pkg/config/`
+- Tests: `testify/assert`, mocks in `mock.go`, benchmarks required
+
+## Planning Process
+
+1. **Understand** — Analyze the request, identify constraints
+2. **Research** — Search the codebase for existing patterns, interfaces, and conventions
+3. **Design** — Create the implementation blueprint
+4. **Review** — Identify risks, edge cases, and dependencies
+
+## Blueprint Template
+
+### 1. Summary
+One paragraph describing what will be built and why.
+
+### 2. Architecture Decisions
+- Which layers are affected (provider, resolver, action, solution, CLI, MCP)?
+- New packages or types needed?
+- Interface changes?
+- Config/settings changes?
+
+### 3. Task Breakdown
+Ordered list of implementation steps, each with:
+- What to create/modify
+- Which file(s)
+- Estimated complexity (S/M/L)
+- Dependencies on other tasks
+
+### 4. Interface Design
+Define interfaces FIRST — these are the contracts:
+```go
+type SomeInterface interface {
+    Method(ctx context.Context, params...) (Result, error)
+}
+```
+
+### 5. Error Handling
+- New sentinel errors needed?
+- Error wrapping strategy using `fmt.Errorf("context: %w", err)`
+
+### 6. Testing Strategy
+- Unit tests with table-driven patterns and `testify/assert`
+- Benchmark tests for new features/providers
+- Integration tests: CLI (`tests/integration/cli_test.go`), solutions (`tests/integration/solutions/`), API (`tests/integration/api_test.go`)
+- E2E validation: `task test:e2e`
+
+### 7. Documentation & Examples
+- Docs updates (`pkg/docs/`, `docs/`)
+- Example solutions (`examples/`)
+- MCP tool updates if applicable (`pkg/mcp/`)
+- Tutorial updates (`docs/tutorials/`)
+
+### 8. Risks & Edge Cases
+- What could go wrong?
+- Performance concerns?
+- Security implications?
+- Breaking changes?
+
+## Principles
+
+- **Read-only** — This agent plans but does not modify code
+- **Interface-driven** — Define contracts before implementations
+- **Incremental** — Break work into small, independently testable pieces
+- **Convention-following** — Match existing codebase patterns
+- **Complete** — Include docs, examples, MCP tools, and integration tests in every plan
+
+## Output
+
+Produce a structured blueprint following the template above. Each task should be small enough to implement and test independently.

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -1,0 +1,120 @@
+---
+description: "Fetch PR review comments for the current branch, triage them, fix legitimate issues, and respond/resolve threads via gh CLI. Use when addressing PR feedback."
+name: "pr-reviewer"
+tools: [read, edit, search, execute, todo]
+argument-hint: "Optional: PR number or 'resolve' to auto-resolve addressed comments"
+---
+You are a PR review comment handler for the **scafctl** project. You fetch review comments from the PR matching the current branch, triage them, implement fixes, and respond/resolve threads.
+
+## Workflow
+
+### Phase 1: Fetch Comments
+
+1. Get the current branch: `git branch --show-current`
+2. Fetch the PR and its review comments:
+   ```bash
+   gh pr view --json number,title,url,reviews,reviewDecision,headRefName
+   ```
+3. Fetch review threads (pending and resolved) via GraphQL:
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               isOutdated
+               path
+               line
+               comments(first: 20) {
+                 nodes {
+                   id
+                   body
+                   author { login }
+                   createdAt
+                 }
+               }
+             }
+           }
+         }
+       }
+     }' -f owner=oakwood-commons -f repo=scafctl -F pr=<PR_NUMBER>
+   ```
+
+### Phase 2: Triage
+
+For each unresolved review thread, classify it:
+
+| Category | Action |
+|----------|--------|
+| **Actionable** | Code change needed — fix it |
+| **Question** | Reviewer asked a question — answer it |
+| **Nit/Style** | Minor style preference — fix if trivial, otherwise explain |
+| **Already addressed** | Fixed in a subsequent commit — respond and resolve |
+| **Disagree** | Explain reasoning, suggest alternative |
+| **Outdated** | Code has changed, comment no longer applies — note and resolve |
+
+Present the triage summary to the user:
+```
+PR #123: <title>
+Review Decision: <CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED>
+
+Unresolved threads: N
+
+1. [Actionable] path/to/file.go:42 — @reviewer: "should use Writer here"
+2. [Question]   pkg/auth/handler.go:15 — @reviewer: "why not use interfaces?"
+3. [Nit]        pkg/config/config.go:8 — @reviewer: "prefer constants"
+4. [Outdated]   pkg/resolver/resolver.go:30 — @reviewer: "missing error wrap"
+```
+
+**Wait for user approval** before making any changes or responding to comments.
+
+### Phase 3: Address Comments
+
+For each approved actionable comment:
+1. Read the file and understand the context
+2. Make the fix
+3. Run `go build ./...` and `go vet ./...` to verify
+4. Report what was fixed
+
+### Phase 4: Respond & Resolve
+
+After fixes are made, respond to review threads:
+
+**To reply to a thread:**
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!, $body: String!) {
+    addPullRequestReviewThread(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+      comment { id }
+    }
+  }' -f threadId=<THREAD_ID> -f body="<response>"
+```
+
+**To resolve a thread:**
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId=<THREAD_ID>
+```
+
+Response templates:
+- **Fixed**: "Fixed in `<brief description>`. Thanks!"
+- **Question answered**: "<answer>"
+- **Nit accepted**: "Good catch, fixed."
+- **Disagree**: "<reasoning>. Happy to discuss further."
+- **Outdated**: "This was addressed in a subsequent change — the code now does X."
+
+## Hard Constraints
+
+- **NEVER** resolve threads without user approval
+- **NEVER** respond to comments without user approval
+- **NEVER** dismiss reviews
+- **NEVER** run `git commit` or `git push` — only make code changes
+- Always present the triage summary and wait for the user before acting
+- When fixing code, follow all scafctl conventions (Writer, kvx, struct tags, etc.)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@ See `pkg/httpc/README.md`
 ## Conventions
 
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- **Signing**: All commits must be GPG/SSH signed (`-S`) and include DCO sign-off (`-s`)
 - **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
 - **Testing**: Use `testify/assert`, mocks in `mock.go` files
 - **Breaking changes**: Allowed—this app is not in production. Note when doing so.
@@ -107,6 +108,7 @@ golangci-lint run --fix          # Run Linter and auto-fix issues
 **IMPORTANT**: Add benchmark tests for any new features or providers in `*_test.go` files using Go's `testing` package.
 **IMPORTANT**: After any change, run `task test:e2e` to ensure everything passes.
 **IMPORTANT**: Never use magic strings or numbers; always define constants or use settings for configuration values.
+**IMPORTANT**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Only generate commit messages — let the user execute the commit.
 **IMPORTANT**: Never commit or push any code without approval first
 
 ---
@@ -216,3 +218,4 @@ go test -cover ./...
 ## Reference
 
 See skill: `golang-patterns` for comprehensive Go idioms and patterns.
+See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.

--- a/.github/prompts/commit.prompt.md
+++ b/.github/prompts/commit.prompt.md
@@ -1,0 +1,15 @@
+---
+description: "Generate a conventional commit message from staged or recent changes. Outputs the message only — does not run git commit."
+agent: "commit-message"
+---
+Analyze the current changes and generate a conventional commit message. **Output the message only — do not commit.**
+
+1. Check `git diff --cached --stat` for staged changes (fall back to `git diff --stat`)
+2. Read the actual diff to understand what changed
+3. If asked to amend, check `git log -1` for the last commit
+4. Generate a message: `<type>(<scope>): <description>` + body with bullet points summarizing key changes
+5. Output in a code block for the user to copy
+
+Always include a body unless the change is a single trivial file edit.
+Types: feat, fix, docs, perf, refactor, style, test, chore, ci, revert
+Add `!` and `BREAKING CHANGE:` footer for breaking changes.

--- a/.github/prompts/go-build.prompt.md
+++ b/.github/prompts/go-build.prompt.md
@@ -1,0 +1,13 @@
+---
+description: "Fix Go build errors, go vet warnings, and linter issues with minimal surgical changes."
+agent: "go-build-resolver"
+---
+Diagnose and fix the current Go build errors:
+
+1. Run `go build ./...` to identify compilation errors
+2. Run `go vet ./...` to find vet warnings
+3. Apply minimal, surgical fixes — don't refactor
+4. Run `go build ./...` again to verify
+5. Run `go test ./...` to ensure nothing broke
+
+Stop if the same error persists after 3 attempts or the fix requires architectural changes.

--- a/.github/prompts/go-review.prompt.md
+++ b/.github/prompts/go-review.prompt.md
@@ -1,0 +1,12 @@
+---
+description: "Run Go code review on recent changes. Checks for idiomatic Go, security, error handling, concurrency, and scafctl conventions."
+agent: "go-reviewer"
+---
+Review the current Go code changes for:
+- Security vulnerabilities (command injection, path traversal, hardcoded secrets)
+- Error handling (ignored errors, missing wrapping, panics for recoverable errors)
+- Concurrency issues (goroutine leaks, race conditions, deadlocks)
+- Code quality (function length, nesting depth, idiomatic patterns)
+- scafctl conventions (Writer usage, kvx output, struct tags, business logic placement)
+
+Run `go vet ./...` and `golangci-lint run` first, then review the code.

--- a/.github/prompts/go-test.prompt.md
+++ b/.github/prompts/go-test.prompt.md
@@ -1,0 +1,13 @@
+---
+description: "Run Go tests with race detection and check coverage. Reports failures and coverage gaps."
+agent: "go-build-resolver"
+---
+Run the Go test suite and report results:
+
+1. Run `go test -race -count=1 ./...` — report any failures
+2. Run `go test -coverprofile=coverage.out ./...` — check coverage
+3. Run `go tool cover -func=coverage.out | tail -1` — report total coverage
+4. If failures exist, diagnose root cause and suggest fixes
+5. Identify packages with coverage below 80%
+
+Focus on recently changed packages first. Use `git diff --name-only -- '*.go'` to identify them.

--- a/.github/prompts/issue.prompt.md
+++ b/.github/prompts/issue.prompt.md
@@ -1,0 +1,11 @@
+---
+description: "File a GitHub issue with codebase exploration and feasibility assessment."
+agent: "issue-creator"
+argument-hint: "Describe the change, bug, or feature (e.g., 'Add pagination to catalog list')"
+---
+Create a GitHub issue for the described change. Follow this process:
+
+1. **Explore** the codebase for relevant files, patterns, and interfaces
+2. **Assess** feasibility, scope (XS/S/M/L/XL), risks, and affected areas
+3. **Wait** for user confirmation before creating anything
+4. **Create** the issue via `gh issue create` with appropriate title and structured body

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -1,0 +1,17 @@
+---
+description: "Create an implementation plan for a scafctl feature. Produces a structured blueprint with architecture decisions, task breakdown, interface design, and testing strategy."
+agent: "planner"
+argument-hint: "Describe the feature to plan (e.g., 'Add OAuth auth handler')"
+---
+Create a structured implementation blueprint for the described feature:
+
+1. **Summary** — What and why
+2. **Architecture decisions** — Layers affected, new types, interface changes
+3. **Task breakdown** — Ordered steps with files, complexity, dependencies
+4. **Interface design** — Define contracts first
+5. **Error handling** — Sentinel errors, wrapping strategy
+6. **Testing strategy** — Unit tests, benchmarks, integration tests (CLI, solution, API)
+7. **Documentation** — Docs, examples, MCP tools, tutorials
+8. **Risks & edge cases** — What could go wrong
+
+Follow scafctl conventions: provider-based architecture, CEL/Go templates, Writer for output, kvx for data.

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,0 +1,14 @@
+---
+description: "Fetch and triage PR review comments for the current branch. Analyzes comments, fixes issues, and responds/resolves threads via gh CLI."
+agent: "pr-reviewer"
+argument-hint: "Optional: 'resolve' to also respond and resolve addressed threads"
+---
+Fetch review comments from the PR for the current branch and triage them:
+
+1. Get current branch and find the matching PR via `gh pr view`
+2. Fetch all unresolved review threads via GitHub GraphQL API
+3. Classify each thread: actionable, question, nit, already addressed, disagree, outdated
+4. Present the triage summary and wait for approval
+5. Fix actionable items, then respond to and resolve threads
+
+**Always waits for approval before making changes or responding to comments.**

--- a/.github/skills/golang-patterns/SKILL.md
+++ b/.github/skills/golang-patterns/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: golang-patterns
+description: "Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications. Use when writing, reviewing, or refactoring Go code."
+---
+# Go Development Patterns
+
+Idiomatic Go patterns and best practices for building robust, efficient, and maintainable applications.
+
+## When to Activate
+
+- Writing new Go code
+- Reviewing Go code
+- Refactoring existing Go code
+- Designing Go packages/modules
+
+## Core Principles
+
+### 1. Simplicity and Clarity
+
+Go favors simplicity over cleverness. Code should be obvious and easy to read.
+
+```go
+// Good: Clear and direct
+func GetUser(ctx context.Context, id string) (*User, error) {
+    user, err := db.FindUser(ctx, id)
+    if err != nil {
+        return nil, fmt.Errorf("get user %s: %w", id, err)
+    }
+    return user, nil
+}
+```
+
+### 2. Make the Zero Value Useful
+
+Design types so their zero value is immediately usable without initialization.
+
+```go
+// Good: Zero value is useful
+type Counter struct {
+    mu    sync.Mutex
+    count int // zero value is 0, ready to use
+}
+
+func (c *Counter) Inc() {
+    c.mu.Lock()
+    c.count++
+    c.mu.Unlock()
+}
+```
+
+### 3. Accept Interfaces, Return Structs
+
+Functions should accept interface parameters and return concrete types.
+
+```go
+func ProcessData(r io.Reader) (*Result, error) {
+    data, err := io.ReadAll(r)
+    if err != nil {
+        return nil, err
+    }
+    return &Result{Data: data}, nil
+}
+```
+
+## Error Handling Patterns
+
+### Error Wrapping with Context
+
+```go
+func LoadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config %s: %w", path, err)
+    }
+    var cfg Config
+    if err := json.Unmarshal(data, &cfg); err != nil {
+        return nil, fmt.Errorf("parse config %s: %w", path, err)
+    }
+    return &cfg, nil
+}
+```
+
+### Custom Error Types
+
+```go
+type ValidationError struct {
+    Field   string
+    Message string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation failed on %s: %s", e.Field, e.Message)
+}
+
+var (
+    ErrNotFound     = errors.New("resource not found")
+    ErrUnauthorized = errors.New("unauthorized")
+    ErrInvalidInput = errors.New("invalid input")
+)
+```
+
+### Error Checking with errors.Is and errors.As
+
+```go
+func HandleError(err error) {
+    if errors.Is(err, sql.ErrNoRows) {
+        log.Println("No records found")
+        return
+    }
+    var validationErr *ValidationError
+    if errors.As(err, &validationErr) {
+        log.Printf("Validation error on field %s: %s",
+            validationErr.Field, validationErr.Message)
+        return
+    }
+    log.Printf("unexpected error: %v", err)
+}
+```
+
+## Concurrency Patterns
+
+### Worker Pool
+
+```go
+func WorkerPool(ctx context.Context, jobs <-chan Job, results chan<- Result, numWorkers int) {
+    var wg sync.WaitGroup
+    for i := 0; i < numWorkers; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for job := range jobs {
+                results <- process(job)
+            }
+        }()
+    }
+    wg.Wait()
+    close(results)
+}
+```
+
+### Context for Cancellation and Timeouts
+
+```go
+func FetchWithTimeout(ctx context.Context, url string) ([]byte, error) {
+    ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil {
+        return nil, fmt.Errorf("create request: %w", err)
+    }
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("fetch %s: %w", url, err)
+    }
+    defer resp.Body.Close()
+    return io.ReadAll(resp.Body)
+}
+```
+
+### Graceful Shutdown
+
+```go
+func GracefulShutdown(server *http.Server) {
+    quit := make(chan os.Signal, 1)
+    signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+    <-quit
+    log.Println("Shutting down server...")
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    if err := server.Shutdown(ctx); err != nil {
+        log.Fatalf("server forced to shutdown: %v", err)
+    }
+    log.Println("Server exited")
+}
+```
+
+### errgroup for Coordinated Goroutines
+
+```go
+func FetchAll(ctx context.Context, urls []string) ([][]byte, error) {
+    g, ctx := errgroup.WithContext(ctx)
+    results := make([][]byte, len(urls))
+
+    for i, url := range urls {
+        i, url := i, url
+        g.Go(func() error {
+            data, err := FetchWithTimeout(ctx, url)
+            if err != nil {
+                return err
+            }
+            results[i] = data
+            return nil
+        })
+    }
+    if err := g.Wait(); err != nil {
+        return nil, err
+    }
+    return results, nil
+}
+```
+
+### Avoiding Goroutine Leaks
+
+```go
+// Good: Properly handles cancellation
+func safeFetch(ctx context.Context, url string) <-chan []byte {
+    ch := make(chan []byte, 1) // Buffered channel
+    go func() {
+        data, err := fetch(url)
+        if err != nil {
+            return
+        }
+        select {
+        case ch <- data:
+        case <-ctx.Done():
+        }
+    }()
+    return ch
+}
+```
+
+## Interface Design
+
+### Small, Focused Interfaces
+
+```go
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+
+type Writer interface {
+    Write(p []byte) (n int, err error)
+}
+
+// Compose interfaces as needed
+type ReadWriter interface {
+    Reader
+    Writer
+}
+```
+
+### Define Interfaces Where They're Used
+
+```go
+// In the consumer package, not the provider
+package service
+
+type UserStore interface {
+    GetUser(ctx context.Context, id string) (*User, error)
+    SaveUser(ctx context.Context, user *User) error
+}
+
+type Service struct {
+    store UserStore
+}
+```
+
+## Package Organization
+
+### Avoid Package-Level State
+
+```go
+// Bad: Global mutable state
+var db *sql.DB
+
+// Good: Dependency injection
+type Server struct {
+    db *sql.DB
+}
+
+func NewServer(db *sql.DB) *Server {
+    return &Server{db: db}
+}
+```
+
+## Struct Design
+
+### Functional Options Pattern
+
+```go
+type Server struct {
+    addr    string
+    timeout time.Duration
+    logger  *log.Logger
+}
+
+type Option func(*Server)
+
+func WithTimeout(d time.Duration) Option {
+    return func(s *Server) { s.timeout = d }
+}
+
+func WithLogger(l *log.Logger) Option {
+    return func(s *Server) { s.logger = l }
+}
+
+func NewServer(addr string, opts ...Option) *Server {
+    s := &Server{
+        addr:    addr,
+        timeout: 30 * time.Second,
+        logger:  log.Default(),
+    }
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+## Memory and Performance
+
+### Preallocate Slices When Size is Known
+
+```go
+// Good: Single allocation
+func processItems(items []Item) []Result {
+    results := make([]Result, 0, len(items))
+    for _, item := range items {
+        results = append(results, process(item))
+    }
+    return results
+}
+```
+
+### Avoid String Concatenation in Loops
+
+```go
+// Good: strings.Builder
+func join(parts []string) string {
+    var sb strings.Builder
+    for i, p := range parts {
+        if i > 0 {
+            sb.WriteString(",")
+        }
+        sb.WriteString(p)
+    }
+    return sb.String()
+}
+```
+
+## Quick Reference: Go Idioms
+
+| Idiom | Description |
+|-------|-------------|
+| Accept interfaces, return structs | Functions accept interface params, return concrete types |
+| Errors are values | Treat errors as first-class values, not exceptions |
+| Don't communicate by sharing memory | Use channels for coordination |
+| Make the zero value useful | Types should work without explicit initialization |
+| A little copying is better than a little dependency | Avoid unnecessary external deps |
+| Clear is better than clever | Prioritize readability |
+| Return early | Handle errors first, keep happy path unindented |
+
+## Struct Tags
+
+Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
+- All fields: `doc`
+- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
+- Integers: `maximum`, `example`
+- Arrays: `maxItems` (no `example`)
+- Objects/maps: no `example` tag
+
+```go
+type Provider struct {
+    Name    string `json:"name" yaml:"name" doc:"Provider name" maxLength:"128" example:"redis"`
+    Version string `json:"version" yaml:"version" doc:"Semantic version" pattern:"^v?\\d+\\.\\d+\\.\\d+$" patternDescription:"semver format" example:"1.0.0"`
+    Port    int    `json:"port" yaml:"port" doc:"Listen port" maximum:"65535" example:"8080"`
+}
+```
+
+## Anti-Patterns to Avoid
+
+```go
+// Bad: Naked returns in long functions
+func process() (result int, err error) {
+    // ... 50 lines ...
+    return // What is being returned?
+}
+
+// Bad: Using panic for control flow
+func GetUser(id string) *User {
+    user, err := db.Find(id)
+    if err != nil {
+        panic(err) // Don't do this
+    }
+    return user
+}
+
+// Bad: Passing context in struct
+type Request struct {
+    ctx context.Context // Context should be first param
+    ID  string
+}
+
+// Good: Context as first parameter
+func ProcessRequest(ctx context.Context, id string) error {
+    // ...
+    return nil
+}
+```

--- a/.github/skills/golang-testing/SKILL.md
+++ b/.github/skills/golang-testing/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: golang-testing
+description: "Go testing patterns including table-driven tests, subtests, benchmarks, fuzzing, and test coverage. Use when writing tests, improving coverage, or debugging test failures."
+---
+# Go Testing Patterns
+
+Comprehensive Go testing patterns for writing reliable, maintainable tests.
+
+## When to Activate
+
+- Writing new Go functions or methods
+- Adding test coverage to existing code
+- Creating benchmarks for performance-critical code
+- Implementing fuzz tests for input validation
+- Debugging test failures
+
+## Table-Driven Tests
+
+The standard pattern for Go tests. Enables comprehensive coverage with minimal code.
+
+```go
+func TestParseConfig(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    *Config
+        wantErr bool
+    }{
+        {
+            name:  "valid config",
+            input: `{"host": "localhost", "port": 8080}`,
+            want:  &Config{Host: "localhost", Port: 8080},
+        },
+        {
+            name:    "invalid JSON",
+            input:   `{invalid}`,
+            wantErr: true,
+        },
+        {
+            name:    "empty input",
+            input:   "",
+            wantErr: true,
+        },
+        {
+            name:  "minimal config",
+            input: `{}`,
+            want:  &Config{},
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ParseConfig(tt.input)
+            if tt.wantErr {
+                assert.Error(t, err)
+                return
+            }
+            assert.NoError(t, err)
+            assert.Equal(t, tt.want, got)
+        })
+    }
+}
+```
+
+## Subtests and Sub-benchmarks
+
+### Organizing Related Tests
+
+```go
+func TestUser(t *testing.T) {
+    db := setupTestDB(t)
+
+    t.Run("Create", func(t *testing.T) {
+        user := &User{Name: "Alice"}
+        err := db.CreateUser(user)
+        assert.NoError(t, err)
+        assert.NotEmpty(t, user.ID)
+    })
+
+    t.Run("Get", func(t *testing.T) {
+        user, err := db.GetUser("alice-id")
+        assert.NoError(t, err)
+        assert.Equal(t, "Alice", user.Name)
+    })
+}
+```
+
+### Parallel Subtests
+
+```go
+func TestParallel(t *testing.T) {
+    tests := []struct {
+        name  string
+        input string
+    }{
+        {"case1", "input1"},
+        {"case2", "input2"},
+        {"case3", "input3"},
+    }
+    for _, tt := range tests {
+        tt := tt // Capture range variable
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            result := Process(tt.input)
+            _ = result
+        })
+    }
+}
+```
+
+## Test Helpers
+
+### Helper Functions
+
+```go
+func setupTestDB(t *testing.T) *sql.DB {
+    t.Helper()
+    db, err := sql.Open("sqlite3", ":memory:")
+    if err != nil {
+        t.Fatalf("failed to open database: %v", err)
+    }
+    t.Cleanup(func() { db.Close() })
+    if _, err := db.Exec(schema); err != nil {
+        t.Fatalf("failed to create schema: %v", err)
+    }
+    return db
+}
+```
+
+### Temporary Files and Directories
+
+```go
+func TestFileProcessing(t *testing.T) {
+    tmpDir := t.TempDir() // Automatically cleaned up
+    testFile := filepath.Join(tmpDir, "test.txt")
+    err := os.WriteFile(testFile, []byte("test content"), 0644)
+    require.NoError(t, err)
+
+    result, err := ProcessFile(testFile)
+    require.NoError(t, err)
+    assert.NotNil(t, result)
+}
+```
+
+## Mocking with Interfaces
+
+### Interface-Based Mocking
+
+```go
+// Define interface for dependencies
+type UserRepository interface {
+    GetUser(ctx context.Context, id string) (*User, error)
+    SaveUser(ctx context.Context, user *User) error
+}
+
+// Mock implementation for tests
+// Convention: place mocks in a dedicated mock.go file in the same package
+type MockUserRepository struct {
+    GetUserFunc  func(ctx context.Context, id string) (*User, error)
+    SaveUserFunc func(ctx context.Context, user *User) error
+}
+
+func (m *MockUserRepository) GetUser(ctx context.Context, id string) (*User, error) {
+    return m.GetUserFunc(ctx, id)
+}
+
+func (m *MockUserRepository) SaveUser(ctx context.Context, user *User) error {
+    return m.SaveUserFunc(ctx, user)
+}
+
+// Test using mock
+func TestUserService(t *testing.T) {
+    mock := &MockUserRepository{
+        GetUserFunc: func(ctx context.Context, id string) (*User, error) {
+            if id == "123" {
+                return &User{ID: "123", Name: "Alice"}, nil
+            }
+            return nil, ErrNotFound
+        },
+    }
+    service := NewUserService(mock)
+    user, err := service.GetUserProfile(context.Background(), "123")
+    assert.NoError(t, err)
+    assert.Equal(t, "Alice", user.Name)
+}
+```
+
+## Benchmarks
+
+Use `b.Loop()` (not `for i := 0; i < b.N; i++`) and always call `b.ReportAllocs()` before `b.ResetTimer()`. Benchmark-only files should use `*_benchmark_test.go` naming.
+
+### Basic Benchmarks
+
+```go
+func BenchmarkProcess(b *testing.B) {
+    data := generateTestData(1000)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for b.Loop() {
+        Process(data)
+    }
+}
+
+// Run: go test -bench=BenchmarkProcess -benchmem
+```
+
+### Benchmark with Different Sizes
+
+```go
+func BenchmarkSort(b *testing.B) {
+    sizes := []int{100, 1000, 10000, 100000}
+    for _, size := range sizes {
+        b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+            data := generateRandomSlice(size)
+            b.ReportAllocs()
+            b.ResetTimer()
+            for b.Loop() {
+                tmp := make([]int, len(data))
+                copy(tmp, data)
+                sort.Ints(tmp)
+            }
+        })
+    }
+}
+```
+
+## Fuzzing (Go 1.18+)
+
+### Basic Fuzz Test
+
+```go
+func FuzzParseJSON(f *testing.F) {
+    f.Add(`{"name": "test"}`)
+    f.Add(`{"count": 123}`)
+    f.Add(`[]`)
+    f.Add(`""`)
+
+    f.Fuzz(func(t *testing.T, input string) {
+        var result map[string]interface{}
+        err := json.Unmarshal([]byte(input), &result)
+        if err != nil {
+            return // Invalid JSON is expected
+        }
+        _, err = json.Marshal(result)
+        if err != nil {
+            t.Errorf("Marshal failed after successful Unmarshal: %v", err)
+        }
+    })
+}
+
+// Run: go test -fuzz=FuzzParseJSON -fuzztime=30s
+```
+
+## HTTP Handler Testing
+
+```go
+func TestHealthHandler(t *testing.T) {
+    req := httptest.NewRequest(http.MethodGet, "/health", nil)
+    w := httptest.NewRecorder()
+    HealthHandler(w, req)
+
+    resp := w.Result()
+    defer resp.Body.Close()
+
+    assert.Equal(t, http.StatusOK, resp.StatusCode)
+    body, _ := io.ReadAll(resp.Body)
+    assert.Equal(t, "OK", string(body))
+}
+```
+
+## Test Coverage
+
+### Running Coverage
+
+```bash
+go test -cover ./...                              # Quick summary
+go test -coverprofile=coverage.out ./...           # Generate profile
+go tool cover -html=coverage.out                   # View in browser
+go tool cover -func=coverage.out                   # Function summary
+go test -race -coverprofile=coverage.out ./...     # With race detection
+```
+
+### Coverage Targets
+
+| Code Type | Target |
+|-----------|--------|
+| Critical business logic | 100% |
+| Public APIs | 90%+ |
+| General code | 80%+ |
+| Generated code | Exclude |
+
+## Testing Commands
+
+```bash
+go test ./...                                # All tests
+go test -v ./...                             # Verbose
+go test -run TestAdd ./...                   # Specific test
+go test -run "TestUser/Create" ./...         # Specific subtest
+go test -race ./...                          # Race detector
+go test -short ./...                         # Short tests only
+go test -timeout 30s ./...                   # With timeout
+go test -bench=. -benchmem ./...             # Benchmarks
+go test -fuzz=FuzzParse -fuzztime=30s ./...  # Fuzzing
+go test -count=10 ./...                      # Flaky test detection
+```
+
+## Best Practices
+
+**DO:**
+- Use table-driven tests for comprehensive coverage
+- Test behavior, not implementation
+- Use `t.Helper()` in helper functions
+- Use `t.Parallel()` for independent tests
+- Clean up resources with `t.Cleanup()`
+- Use meaningful test names that describe the scenario
+- Use `testify/assert` and `testify/require` for assertions
+- Place mocks in `mock.go` files
+
+**DON'T:**
+- Test private functions directly (test through public API)
+- Use `time.Sleep()` in tests (use channels or conditions)
+- Ignore flaky tests (fix or remove them)
+- Mock everything (prefer integration tests when possible)
+- Skip error path testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,22 +8,29 @@ See our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Getting Started
 
-### Developer Certificate of Origin (DCO)
+### Developer Certificate of Origin (DCO) & Commit Signing
 
-All contributions must be signed off per the [Developer Certificate of Origin](https://developercertificate.org/).
-This certifies you have the right to submit the contribution under the project's license.
+All commits must be:
+1. **GPG/SSH signed** (`-S`) — verifies commit author identity
+2. **DCO signed-off** (`-s`) — certifies you have the right to submit the contribution under the project's license per the [Developer Certificate of Origin](https://developercertificate.org/)
 
-Sign commits with `-s`:
+Sign commits with both `-s` and `-S`:
 
 ```bash
-git commit -s -m "feat(provider): add new provider"
+git commit -s -S -m "feat(provider): add new provider"
 ```
 
 If you forget, amend the last commit:
 
 ```bash
-git commit --amend -s --no-edit
+git commit --amend -s -S --no-edit
 ```
+
+> **Tip**: To sign all commits automatically, configure Git once:
+> ```bash
+> git config --global commit.gpgSign true
+> git config --global user.signingkey <YOUR_KEY_ID>
+> ```
 
 ### Getting Help and Support Expectations
 


### PR DESCRIPTION
Add Copilot customization files adapted from abaker9-ai:
- 5 agents: commit-message, go-build-resolver, go-reviewer, issue-creator, planner
- 6 prompts: /commit, /go-build, /go-review, /go-test, /issue, /plan
- 2 skills: golang-patterns, golang-testing
- VS Code settings with Go format-on-save, golangci-lint, race detection
- Updated copilot-instructions.md with golang-testing skill reference, commit signing/DCO requirements, and no-auto-commit rule