### PR TITLE
fix(test): eliminate duplicate progress output and duration mismatch …

### DIFF
--- a/.github/skills/golang-testing/SKILL.md
+++ b/.github/skills/golang-testing/SKILL.md
@@ -315,7 +315,6 @@ go test -count=10 ./...                      # Flaky test detection
 - Use meaningful test names that describe the scenario
 - Use `testify/assert` and `testify/require` for assertions
 - Place mocks in `mock.go` files
-- Try not to test private functions directly (test through public API)
 
 **DON'T:**
 - Use `time.Sleep()` in tests (use channels or conditions)

--- a/docs/design/functional-testing.md
+++ b/docs/design/functional-testing.md
@@ -1018,7 +1018,40 @@ terraform-scaffold   temporarily-disabled        render solution                
 
 ## Output
 
-### Table (default)
+### Interactive Progress (default, TTY)
+
+When running on a TTY terminal, tests show animated spinners that resolve to
+final status lines as each test completes. Completed tests scroll upward
+(via mpb's `PopCompletedMode`) while active tests animate at the bottom.
+
+After all tests complete, only failure details and a summary line are printed —
+the per-test table is **not** repeated since the progress lines already showed
+each result. This eliminates the previous duplication where every test appeared
+twice with mismatched durations.
+
+All durations shown in progress lines use `TestResult.Duration` (the pure
+execution time measured inside the runner), ensuring consistency between
+progress output and structured (JSON/YAML) output.
+
+~~~
+ ✓ terraform-scaffold :: builtin:parse               pass   1ms
+ ✓ terraform-scaffold :: builtin:lint                 pass   45ms
+ ✓ terraform-scaffold :: renders-dev-defaults         pass   12ms
+ ✗ terraform-scaffold :: renders-prod-override        fail   15ms
+ ✓ terraform-scaffold :: rejects-invalid-env          pass   8ms
+ ⊘ terraform-scaffold :: temporarily-disabled         skip
+
+Failures:
+  terraform-scaffold/renders-prod-override: exit code mismatch
+    [exitCode] expected 1 got 0: exit code assertion failed
+
+5 passed, 1 failed, 0 errors, 1 skipped (121ms)
+~~~
+
+### Table (non-TTY / `--no-progress`)
+
+When progress output is disabled (piped output, `--no-progress` flag, or
+non-table output format), the full per-test table is shown as the only view:
 
 ~~~
 SOLUTION             TEST                        STATUS   DURATION

--- a/pkg/cmd/scafctl/run/progress.go
+++ b/pkg/cmd/scafctl/run/progress.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/terminal/format"
@@ -15,13 +16,14 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 )
 
+var runSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
 // ProgressReporter outputs execution progress using mpb.
 // It provides visual feedback during resolver execution by displaying
 // progress bars for each resolver in the current phase.
 type ProgressReporter struct {
 	progress   *mpb.Progress
 	bars       map[string]*mpb.Bar
-	barStarts  map[string]time.Time
 	barPhases  map[string]int
 	barElapsed map[string]time.Duration // Store calculated elapsed time on completion
 	barFailed  map[string]bool          // Track whether an aborted bar was a failure (vs skip)
@@ -38,11 +40,11 @@ func NewProgressReporter(writer io.Writer, total int) *ProgressReporter {
 		mpb.WithOutput(writer),
 		mpb.WithWidth(40),
 		mpb.WithRefreshRate(100*time.Millisecond),
+		mpb.PopCompletedMode(),
 	)
 	return &ProgressReporter{
 		progress:   p,
 		bars:       make(map[string]*mpb.Bar),
-		barStarts:  make(map[string]time.Time),
 		barPhases:  make(map[string]int),
 		barElapsed: make(map[string]time.Duration),
 		barFailed:  make(map[string]bool),
@@ -59,7 +61,6 @@ func (p *ProgressReporter) StartPhase(phaseNum int, resolverNames []string) {
 	defer p.mu.Unlock()
 
 	for _, name := range resolverNames {
-		p.barStarts[name] = time.Now()
 		p.barPhases[name] = phaseNum
 
 		// Create a decorator that shows elapsed time on completion (reads from barElapsed map)
@@ -77,7 +78,9 @@ func (p *ProgressReporter) StartPhase(phaseNum int, resolverNames []string) {
 		})
 
 		// Build a status decorator that distinguishes completion, failure, and skip.
+		// Uses an atomic counter for spinner frame selection instead of wall-clock time.
 		resolverStatus := name // Capture for closure
+		var spinCount atomic.Uint64
 		statusDecorator := decor.Any(func(s decor.Statistics) string {
 			if s.Completed {
 				return "✓ "
@@ -91,12 +94,9 @@ func (p *ProgressReporter) StartPhase(phaseNum int, resolverNames []string) {
 				}
 				return "⊘ "
 			}
-			// In-progress spinner frames
-			p.mu.Lock()
-			start := p.barStarts[resolverStatus]
-			p.mu.Unlock()
-			frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-			return frames[int(time.Since(start).Milliseconds()/80)%len(frames)] + " "
+			// In-progress spinner
+			idx := spinCount.Add(1) - 1
+			return runSpinnerFrames[idx%uint64(len(runSpinnerFrames))] + " "
 		}, decor.WCSyncSpace)
 
 		bar := p.progress.AddBar(1,
@@ -112,14 +112,12 @@ func (p *ProgressReporter) StartPhase(phaseNum int, resolverNames []string) {
 }
 
 // Complete marks a resolver as successfully completed.
-func (p *ProgressReporter) Complete(resolverName string) {
+// elapsed is the pure execution time measured by the caller.
+func (p *ProgressReporter) Complete(resolverName string, elapsed time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Calculate and store elapsed time at the moment of completion
-	if startTime, ok := p.barStarts[resolverName]; ok {
-		p.barElapsed[resolverName] = time.Since(startTime)
-	}
+	p.barElapsed[resolverName] = elapsed
 
 	if bar, ok := p.bars[resolverName]; ok {
 		bar.Increment()
@@ -175,8 +173,8 @@ func (c *ProgressCallback) OnPhaseStart(phaseNum int, resolverNames []string) {
 }
 
 // OnResolverComplete is called when a resolver completes successfully.
-func (c *ProgressCallback) OnResolverComplete(resolverName string) {
-	c.reporter.Complete(resolverName)
+func (c *ProgressCallback) OnResolverComplete(resolverName string, elapsed time.Duration) {
+	c.reporter.Complete(resolverName, elapsed)
 }
 
 // OnResolverFailed is called when a resolver fails.

--- a/pkg/cmd/scafctl/run/progress_test.go
+++ b/pkg/cmd/scafctl/run/progress_test.go
@@ -4,6 +4,7 @@
 package run
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"testing"
@@ -19,7 +20,6 @@ func TestNewProgressReporter(t *testing.T) {
 	require.NotNil(t, pr)
 	assert.Equal(t, 5, pr.total)
 	assert.NotNil(t, pr.bars)
-	assert.NotNil(t, pr.barStarts)
 	assert.NotNil(t, pr.barFailed)
 }
 
@@ -31,7 +31,6 @@ func TestProgressReporter_StartPhase(t *testing.T) {
 
 	assert.Contains(t, pr.bars, "resolver-a")
 	assert.Contains(t, pr.bars, "resolver-b")
-	assert.Contains(t, pr.barStarts, "resolver-a")
 	assert.Equal(t, 1, pr.barPhases["resolver-a"])
 }
 
@@ -40,10 +39,10 @@ func TestProgressReporter_Complete(t *testing.T) {
 	pr := NewProgressReporter(io.Discard, 1)
 	pr.StartPhase(1, []string{"resolver-a"})
 
-	pr.Complete("resolver-a")
+	pr.Complete("resolver-a", 150*time.Millisecond)
 
 	assert.Contains(t, pr.barElapsed, "resolver-a")
-	assert.Greater(t, pr.barElapsed["resolver-a"], time.Duration(0))
+	assert.Equal(t, 150*time.Millisecond, pr.barElapsed["resolver-a"])
 }
 
 func TestProgressReporter_Complete_UnknownResolver(t *testing.T) {
@@ -51,7 +50,7 @@ func TestProgressReporter_Complete_UnknownResolver(t *testing.T) {
 	pr := NewProgressReporter(io.Discard, 1)
 
 	// Should not panic on unknown resolver
-	pr.Complete("nonexistent")
+	pr.Complete("nonexistent", 10*time.Millisecond)
 }
 
 func TestProgressReporter_Failed(t *testing.T) {
@@ -96,7 +95,7 @@ func TestProgressReporter_Wait(t *testing.T) {
 	t.Parallel()
 	pr := NewProgressReporter(io.Discard, 1)
 	pr.StartPhase(1, []string{"resolver-a"})
-	pr.Complete("resolver-a")
+	pr.Complete("resolver-a", 50*time.Millisecond)
 
 	dur := pr.Wait()
 	assert.Greater(t, dur, time.Duration(0))
@@ -121,8 +120,9 @@ func TestProgressCallback(t *testing.T) {
 	assert.Contains(t, pr.bars, "a")
 	assert.Contains(t, pr.bars, "b")
 
-	cb.OnResolverComplete("a")
+	cb.OnResolverComplete("a", 100*time.Millisecond)
 	assert.Contains(t, pr.barElapsed, "a")
+	assert.Equal(t, 100*time.Millisecond, pr.barElapsed["a"])
 
 	cb.OnResolverFailed("b", errors.New("fail"))
 	assert.True(t, pr.barFailed["b"])
@@ -144,16 +144,18 @@ func TestProgressReporter_MultiplePhases(t *testing.T) {
 	pr := NewProgressReporter(io.Discard, 4)
 
 	pr.StartPhase(1, []string{"a", "b"})
-	pr.Complete("a")
+	pr.Complete("a", 50*time.Millisecond)
 	pr.Failed("b", errors.New("err"))
 
 	pr.StartPhase(2, []string{"c", "d"})
-	pr.Complete("c")
+	pr.Complete("c", 75*time.Millisecond)
 	pr.Skipped("d")
 
 	assert.Contains(t, pr.barElapsed, "a")
+	assert.Equal(t, 50*time.Millisecond, pr.barElapsed["a"])
 	assert.True(t, pr.barFailed["b"])
 	assert.Contains(t, pr.barElapsed, "c")
+	assert.Equal(t, 75*time.Millisecond, pr.barElapsed["c"])
 	assert.False(t, pr.barFailed["d"])
 	assert.Equal(t, 1, pr.barPhases["a"])
 	assert.Equal(t, 2, pr.barPhases["c"])
@@ -163,9 +165,52 @@ func BenchmarkProgressReporter_Lifecycle(b *testing.B) {
 	for b.Loop() {
 		pr := NewProgressReporter(io.Discard, 3)
 		pr.StartPhase(1, []string{"a", "b", "c"})
-		pr.Complete("a")
+		pr.Complete("a", 50*time.Millisecond)
 		pr.Failed("b", errors.New("err"))
 		pr.Skipped("c")
 		pr.Wait()
 	}
+}
+
+// ── Decorator state verification tests ────────────────────────────────────────
+
+func TestProgressReporter_StartPhase_Complete_RendersWithoutPanic(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	pr := NewProgressReporter(&buf, 1)
+	pr.StartPhase(1, []string{"resolver-x"})
+	pr.Complete("resolver-x", 200*time.Millisecond)
+	pr.Wait()
+
+	// Verify internal state for decorator correctness
+	assert.Equal(t, 200*time.Millisecond, pr.barElapsed["resolver-x"])
+	assert.False(t, pr.barFailed["resolver-x"])
+}
+
+func TestProgressReporter_StartPhase_Failed_RendersWithoutPanic(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	pr := NewProgressReporter(&buf, 1)
+	pr.StartPhase(1, []string{"resolver-y"})
+	pr.Failed("resolver-y", errors.New("boom"))
+	pr.Wait()
+
+	assert.True(t, pr.barFailed["resolver-y"])
+}
+
+func TestProgressReporter_StartPhase_Skipped_RendersWithoutPanic(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	pr := NewProgressReporter(&buf, 1)
+	pr.StartPhase(1, []string{"resolver-z"})
+	pr.Skipped("resolver-z")
+	pr.Wait()
+
+	assert.False(t, pr.barFailed["resolver-z"])
+}
+
+func TestRunSpinnerFrames_PackageLevel(t *testing.T) {
+	t.Parallel()
+	assert.Len(t, runSpinnerFrames, 10, "runSpinnerFrames should have 10 frames")
+	assert.Equal(t, "⠋", runSpinnerFrames[0])
 }

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -255,7 +255,14 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 	outputOpts.Format = format
 	outputOpts.Ctx = ctx
 
-	if err := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed); err != nil {
+	// When stdout is not a terminal (e.g. redirected to a file), include
+	// per-test rows in the report even if progress was shown on stderr.
+	reportProgress := runner.Progress
+	if !kvx.IsTerminal(opts.IOStreams.Out) {
+		reportProgress = nil
+	}
+
+	if err := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed, reportProgress); err != nil {
 		if w != nil {
 			w.Errorf("reporting failed: %s", err)
 		}
@@ -379,7 +386,14 @@ func runWatchMode(ctx context.Context, opts *FunctionalOptions, w *writer.Writer
 				outputOpts.Format = format
 				outputOpts.Ctx = ctx
 
-				if reportErr := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed); reportErr != nil {
+				// When stdout is not a terminal, include per-test rows
+				// in the report even if progress was shown on stderr.
+				watchReportProgress := runner.Progress
+				if !kvx.IsTerminal(opts.IOStreams.Out) {
+					watchReportProgress = nil
+				}
+
+				if reportErr := soltesting.ReportResults(results, outputOpts, opts.Verbose, elapsed, watchReportProgress); reportErr != nil {
 					if w != nil {
 						w.Errorf("[watch] reporting failed: %s", reportErr)
 					}

--- a/pkg/cmd/scafctl/test/progress.go
+++ b/pkg/cmd/scafctl/test/progress.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
@@ -27,11 +28,10 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 // in sync.Map fields that are safe for concurrent lock-free reads.
 type MPBTestProgress struct {
 	progress *mpb.Progress
-	// mu protects bars and barStarts only. It must NOT be held when mpb's
+	// mu protects bars only. It must NOT be held when mpb's
 	// render goroutine might call decorator closures.
-	mu        sync.Mutex
-	bars      map[string]*mpb.Bar
-	barStarts map[string]time.Time
+	mu   sync.Mutex
+	bars map[string]*mpb.Bar
 	// results and barElapsed are read by decorator closures from mpb's render
 	// goroutine, so they use sync.Map to avoid lock ordering issues.
 	results    sync.Map // key → *soltesting.TestResult
@@ -44,11 +44,11 @@ func NewMPBTestProgress(w io.Writer) *MPBTestProgress {
 		mpb.WithOutput(w),
 		mpb.WithWidth(0),
 		mpb.WithRefreshRate(100*time.Millisecond),
+		mpb.PopCompletedMode(),
 	)
 	return &MPBTestProgress{
-		progress:  p,
-		bars:      make(map[string]*mpb.Bar),
-		barStarts: make(map[string]time.Time),
+		progress: p,
+		bars:     make(map[string]*mpb.Bar),
 	}
 }
 
@@ -60,14 +60,16 @@ func (p *MPBTestProgress) barKey(solution, test string) string {
 func (p *MPBTestProgress) OnTestStart(solution, test string) {
 	key := p.barKey(solution, test)
 
-	p.mu.Lock()
-	p.barStarts[key] = time.Now()
-	p.mu.Unlock()
-
 	// Elapsed time — shown only after completion.
 	// Reads from sync.Map; no mutex needed.
+	// Suppresses duration for skipped tests (typically 0).
 	elapsedDecor := decor.Any(func(s decor.Statistics) string {
 		if s.Completed || s.Aborted {
+			if v, ok := p.results.Load(key); ok {
+				if r, ok := v.(*soltesting.TestResult); ok && r.Status == soltesting.StatusSkip {
+					return ""
+				}
+			}
 			if v, ok := p.barElapsed.Load(key); ok {
 				if d, ok := v.(time.Duration); ok {
 					return fmtDuration(d)
@@ -90,15 +92,36 @@ func (p *MPBTestProgress) OnTestStart(solution, test string) {
 		return ""
 	})
 
+	// Icon decorator — driven by actual test result status so that
+	// skipped tests render ⊘ instead of the generic ✓ completion icon.
+	// Reads from sync.Map; no mutex needed.
+	var spinCount atomic.Uint64
+	iconDecor := decor.Any(func(s decor.Statistics) string {
+		if s.Completed || s.Aborted {
+			if v, ok := p.results.Load(key); ok {
+				if r, ok := v.(*soltesting.TestResult); ok {
+					switch r.Status {
+					case soltesting.StatusPass:
+						return "✓ "
+					case soltesting.StatusFail, soltesting.StatusError:
+						return "✗ "
+					case soltesting.StatusSkip:
+						return "⊘ "
+					}
+				}
+			}
+			if s.Aborted {
+				return "✗ "
+			}
+			return "✓ "
+		}
+		idx := spinCount.Add(1) - 1
+		return spinnerFrames[idx%uint64(len(spinnerFrames))] + " "
+	}, decor.WCSyncSpace)
+
 	bar := p.progress.AddBar(1,
 		mpb.PrependDecorators(
-			decor.OnAbort(
-				decor.OnComplete(
-					decor.Spinner(spinnerFrames, decor.WCSyncSpace),
-					"✓ ",
-				),
-				"✗ ",
-			),
+			iconDecor,
 			decor.Name(key, decor.WCSyncSpaceR),
 		),
 		mpb.AppendDecorators(statusDecor, decor.Name("  "), elapsedDecor),
@@ -111,22 +134,16 @@ func (p *MPBTestProgress) OnTestStart(solution, test string) {
 }
 
 // OnTestComplete records the result and marks the bar finished.
+// Invariant: sync.Map stores (result, elapsed) MUST happen before the bar
+// state transition (Increment/Abort) so decorator closures see the data
+// when mpb's render goroutine reads it.
 func (p *MPBTestProgress) OnTestComplete(result soltesting.TestResult) {
 	key := p.barKey(result.Solution, result.Test)
 	resultCopy := result
 
 	// Store result and elapsed in sync.Map so decorators can read lock-free.
 	p.results.Store(key, &resultCopy)
-
-	p.mu.Lock()
-	start, hasStart := p.barStarts[key]
-	p.mu.Unlock()
-
-	if hasStart {
-		p.barElapsed.Store(key, time.Since(start))
-	} else {
-		p.barElapsed.Store(key, result.Duration)
-	}
+	p.barElapsed.Store(key, result.Duration)
 
 	p.mu.Lock()
 	bar, ok := p.bars[key]

--- a/pkg/cmd/scafctl/test/progress_test.go
+++ b/pkg/cmd/scafctl/test/progress_test.go
@@ -383,3 +383,117 @@ func BenchmarkFmtDuration(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkMPBTestProgress_Lifecycle(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var buf bytes.Buffer
+		p := NewMPBTestProgress(&buf)
+		p.OnTestStart("sol", "test-1")
+		p.OnTestComplete(soltesting.TestResult{
+			Solution: "sol",
+			Test:     "test-1",
+			Status:   soltesting.StatusPass,
+			Duration: 50 * time.Millisecond,
+		})
+		p.Wait()
+	}
+}
+
+// ── MPBTestProgress decorator logic tests ─────────────────────────────────────
+
+func TestMPBTestProgress_SkipResult_StoredCorrectly(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := NewMPBTestProgress(&buf)
+
+	p.OnTestStart("sol", "skip-test")
+	p.OnTestComplete(soltesting.TestResult{
+		Solution: "sol",
+		Test:     "skip-test",
+		Status:   soltesting.StatusSkip,
+		Duration: 0,
+	})
+
+	key := p.barKey("sol", "skip-test")
+	v, ok := p.results.Load(key)
+	require.True(t, ok, "result should be stored after completion")
+	r := v.(*soltesting.TestResult)
+	assert.Equal(t, soltesting.StatusSkip, r.Status)
+
+	elapsed, ok := p.barElapsed.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(0), elapsed.(time.Duration))
+
+	p.Wait()
+}
+
+func TestMPBTestProgress_FailResult_StoredCorrectly(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := NewMPBTestProgress(&buf)
+
+	p.OnTestStart("sol", "fail-test")
+	p.OnTestComplete(soltesting.TestResult{
+		Solution: "sol",
+		Test:     "fail-test",
+		Status:   soltesting.StatusFail,
+		Duration: 100 * time.Millisecond,
+	})
+
+	key := p.barKey("sol", "fail-test")
+	v, ok := p.results.Load(key)
+	require.True(t, ok)
+	r := v.(*soltesting.TestResult)
+	assert.Equal(t, soltesting.StatusFail, r.Status)
+
+	p.Wait()
+}
+
+func TestMPBTestProgress_ErrorResult_StoredCorrectly(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := NewMPBTestProgress(&buf)
+
+	p.OnTestStart("sol", "err-test")
+	p.OnTestComplete(soltesting.TestResult{
+		Solution: "sol",
+		Test:     "err-test",
+		Status:   soltesting.StatusError,
+		Duration: 5 * time.Millisecond,
+	})
+
+	key := p.barKey("sol", "err-test")
+	v, ok := p.results.Load(key)
+	require.True(t, ok)
+	r := v.(*soltesting.TestResult)
+	assert.Equal(t, soltesting.StatusError, r.Status)
+
+	p.Wait()
+}
+
+func TestMPBTestProgress_PassResult_StoredCorrectly(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := NewMPBTestProgress(&buf)
+
+	p.OnTestStart("sol", "pass-test")
+	p.OnTestComplete(soltesting.TestResult{
+		Solution: "sol",
+		Test:     "pass-test",
+		Status:   soltesting.StatusPass,
+		Duration: 50 * time.Millisecond,
+	})
+
+	key := p.barKey("sol", "pass-test")
+	v, ok := p.results.Load(key)
+	require.True(t, ok)
+	r := v.(*soltesting.TestResult)
+	assert.Equal(t, soltesting.StatusPass, r.Status)
+
+	elapsed, ok := p.barElapsed.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, 50*time.Millisecond, elapsed.(time.Duration))
+
+	p.Wait()
+}

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -44,8 +44,9 @@ type RegistryInterface interface {
 type ProgressCallback interface {
 	// OnPhaseStart is called when a new execution phase begins
 	OnPhaseStart(phaseNum int, resolverNames []string)
-	// OnResolverComplete is called when a resolver completes successfully
-	OnResolverComplete(resolverName string)
+	// OnResolverComplete is called when a resolver completes successfully.
+	// elapsed is the pure execution time of the resolver.
+	OnResolverComplete(resolverName string, elapsed time.Duration)
 	// OnResolverFailed is called when a resolver fails
 	OnResolverFailed(resolverName string, err error)
 	// OnResolverSkipped is called when a resolver is skipped due to when condition
@@ -389,7 +390,9 @@ func (e *Executor) executePhase(ctx context.Context, phase *PhaseGroup, failedRe
 				return
 			}
 
+			resolverStart := time.Now()
 			skipped, err := e.executeResolver(phaseCtx, r, phase.Phase)
+			resolverElapsed := time.Since(resolverStart)
 			switch {
 			case err != nil:
 				if e.progressCallback != nil {
@@ -404,7 +407,7 @@ func (e *Executor) executePhase(ctx context.Context, phase *PhaseGroup, failedRe
 			default:
 				// Resolver completed successfully
 				if e.progressCallback != nil {
-					e.progressCallback.OnResolverComplete(r.Name)
+					e.progressCallback.OnResolverComplete(r.Name, resolverElapsed)
 				}
 				resultChan <- resolverResult{resolverName: r.Name}
 			}

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -1629,10 +1629,10 @@ func TestExecutor_Execute_NilValueRefInput(t *testing.T) {
 
 type noopProgressCallback struct{}
 
-func (n *noopProgressCallback) OnPhaseStart(_ int, _ []string)     {}
-func (n *noopProgressCallback) OnResolverComplete(_ string)        {}
-func (n *noopProgressCallback) OnResolverFailed(_ string, _ error) {}
-func (n *noopProgressCallback) OnResolverSkipped(_ string)         {}
+func (n *noopProgressCallback) OnPhaseStart(_ int, _ []string)               {}
+func (n *noopProgressCallback) OnResolverComplete(_ string, _ time.Duration) {}
+func (n *noopProgressCallback) OnResolverFailed(_ string, _ error)           {}
+func (n *noopProgressCallback) OnResolverSkipped(_ string)                   {}
 
 func TestWithProgressCallback(t *testing.T) {
 	reg := newMockRegistry()

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -60,12 +60,20 @@ func Summarize(results []TestResult) ResultSummary {
 // For quiet format it writes nothing.
 // The elapsed parameter, when > 0, overrides the summed individual durations
 // in the summary line with the actual wall-clock time.
-func ReportResults(results []TestResult, opts *kvx.OutputOptions, verbose bool, elapsed time.Duration) error {
+// When progress is non-nil and format is table, only failures and the summary
+// line are printed — per-test rows were already shown by the progress callback.
+func ReportResults(results []TestResult, opts *kvx.OutputOptions, verbose bool, elapsed time.Duration, progress TestProgressCallback) error {
 	switch {
 	case kvx.IsQuietFormat(opts.Format):
 		return nil
-	case kvx.IsKvxFormat(opts.Format):
-		return reportTable(results, opts.IOStreams.Out, verbose, elapsed)
+	case opts.Format == kvx.OutputFormatTable || opts.Format == kvx.OutputFormatAuto || opts.Format == "":
+		progressShown := progress != nil
+		return reportTable(results, opts.IOStreams.Out, verbose, elapsed, progressShown)
+	case opts.Format == kvx.OutputFormatList:
+		// List format falls back to table for test results since test output
+		// is inherently tabular.
+		progressShown := progress != nil
+		return reportTable(results, opts.IOStreams.Out, verbose, elapsed, progressShown)
 	default:
 		// JSON / YAML
 		return opts.Write(buildReportData(results, elapsed))
@@ -129,12 +137,28 @@ func buildReportData(results []TestResult, elapsed time.Duration) reportData {
 }
 
 // reportTable writes a human-readable table to w.
-func reportTable(results []TestResult, w io.Writer, verbose bool, elapsed time.Duration) error {
+// When progressShown is true, per-test rows are omitted (they were already
+// displayed by the progress callback) and only failures + summary are shown.
+func reportTable(results []TestResult, w io.Writer, verbose bool, elapsed time.Duration, progressShown bool) error {
 	if len(results) == 0 {
 		fmt.Fprintln(w, "No tests found.")
 		return nil
 	}
 
+	// When progress was not shown, render the full per-test table.
+	if !progressShown {
+		reportTableRows(results, w, verbose)
+	}
+
+	// Always show failure details and summary.
+	reportFailures(results, w, verbose)
+	reportSummaryLine(results, w, elapsed)
+
+	return nil
+}
+
+// reportTableRows writes column headers and one row per test result.
+func reportTableRows(results []TestResult, w io.Writer, verbose bool) {
 	// Compute column widths
 	solW, testW := 8, 4 // min widths for "SOLUTION" and "TEST"
 	for _, r := range results {
@@ -165,8 +189,11 @@ func reportTable(results []TestResult, w io.Writer, verbose bool, elapsed time.D
 			fmt.Fprintf(w, "%-*s  %-*s  %-8s  %s\n", solW, r.Solution, testW, r.Test, status, dur)
 		}
 	}
+}
 
-	// Failure/error details
+// reportFailures writes detailed failure/error information.
+// When verbose is true, assertion counts are included in each failure entry.
+func reportFailures(results []TestResult, w io.Writer, verbose bool) {
 	var failures []TestResult
 	for _, r := range results {
 		if r.Status == StatusFail || r.Status == StatusError {
@@ -174,28 +201,39 @@ func reportTable(results []TestResult, w io.Writer, verbose bool, elapsed time.D
 		}
 	}
 
-	if len(failures) > 0 {
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Failures:")
-		for _, f := range failures {
+	if len(failures) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Failures:")
+	for _, f := range failures {
+		if verbose {
+			counts := formatAssertionCounts(f.Assertions)
+			if counts != "" {
+				fmt.Fprintf(w, "  %s/%s: %s %s\n", f.Solution, f.Test, f.Message, counts)
+			} else {
+				fmt.Fprintf(w, "  %s/%s: %s\n", f.Solution, f.Test, f.Message)
+			}
+		} else {
 			fmt.Fprintf(w, "  %s/%s: %s\n", f.Solution, f.Test, f.Message)
-			for _, a := range f.Assertions {
-				if !a.Passed {
-					fmt.Fprintf(w, "    [%s] %s: %s\n", a.Type, a.Input, a.Message)
-				}
+		}
+		for _, a := range f.Assertions {
+			if !a.Passed {
+				fmt.Fprintf(w, "    [%s] %s: %s\n", a.Type, a.Input, a.Message)
 			}
 		}
 	}
+}
 
-	// Summary
+// reportSummaryLine writes the one-line summary (e.g. "5 passed, 1 failed, ...").
+func reportSummaryLine(results []TestResult, w io.Writer, elapsed time.Duration) {
 	summary := Summarize(results)
 	summary.WallDuration = elapsed
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%d passed, %d failed, %d errors, %d skipped (%s)\n",
 		summary.Passed, summary.Failed, summary.Errors, summary.Skipped,
 		format.Duration(summary.ElapsedDuration()))
-
-	return nil
 }
 
 // listEntry holds test information for list display.

--- a/pkg/solution/soltesting/reporter_test.go
+++ b/pkg/solution/soltesting/reporter_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProgress implements TestProgressCallback for testing.
+type stubProgress struct{}
+
+func (s *stubProgress) OnTestStart(_, _ string)     {}
+func (s *stubProgress) OnTestComplete(_ TestResult) {}
+func (s *stubProgress) Wait()                       {}
+
+func newTestOutputOpts(buf *bytes.Buffer, format kvx.OutputFormat) *kvx.OutputOptions {
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	opts := kvx.NewOutputOptions(ioStreams)
+	opts.Format = format
+	return opts
+}
+
+func sampleResults() []TestResult {
+	return []TestResult{
+		{Solution: "sol-a", Test: "test-1", Status: StatusPass, Duration: 100 * time.Millisecond},
+		{Solution: "sol-a", Test: "test-2", Status: StatusFail, Duration: 50 * time.Millisecond, Message: "assertion failed"},
+		{Solution: "sol-b", Test: "test-3", Status: StatusSkip, Duration: 0},
+	}
+}
+
+func TestReportResults_QuietFormat(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatQuiet)
+
+	err := ReportResults(sampleResults(), opts, false, time.Second, nil)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "quiet format should produce no output")
+}
+
+func TestReportResults_TableFormat_NoProgress(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatTable)
+
+	err := ReportResults(sampleResults(), opts, false, time.Second, nil)
+	require.NoError(t, err)
+	output := buf.String()
+	// Per-test rows should be present when no progress was shown
+	assert.Contains(t, output, "sol-a")
+	assert.Contains(t, output, "test-1")
+	assert.Contains(t, output, "test-2")
+}
+
+func TestReportResults_TableFormat_WithProgress(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatTable)
+
+	err := ReportResults(sampleResults(), opts, false, time.Second, &stubProgress{})
+	require.NoError(t, err)
+	output := buf.String()
+	// Per-test rows should be suppressed, but summary and failures should be present.
+	assert.Contains(t, output, "Failures:", "failures section header should be shown")
+	assert.Contains(t, output, "test-2", "specific failing test should be shown in failures section")
+	assert.Contains(t, output, "passed", "summary line should be shown")
+
+	// The normal per-test table output should be suppressed when progress was shown.
+	assert.NotContains(t, output, "test-1", "passing per-test row should be suppressed")
+	assert.NotContains(t, output, "test-3", "skipped per-test row should be suppressed")
+	assert.NotContains(t, output, "sol-b", "solution identifier from per-test rows should be suppressed")
+}
+
+func TestReportResults_JSONFormat(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatJSON)
+
+	err := ReportResults(sampleResults(), opts, false, 500*time.Millisecond, nil)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, `"status"`)
+	assert.Contains(t, output, `"summary"`)
+}
+
+func TestReportResults_YAMLFormat(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatYAML)
+
+	err := ReportResults(sampleResults(), opts, false, 500*time.Millisecond, nil)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "status:")
+	assert.Contains(t, output, "summary:")
+}
+
+func TestReportResults_AutoFormat_NoProgress(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatAuto)
+
+	err := ReportResults(sampleResults(), opts, false, time.Second, nil)
+	require.NoError(t, err)
+	output := buf.String()
+	// Auto format on non-TTY should behave like table
+	assert.Contains(t, output, "sol-a")
+}
+
+func BenchmarkReportResults_Table(b *testing.B) {
+	results := sampleResults()
+	var buf bytes.Buffer
+	opts := newTestOutputOpts(&buf, kvx.OutputFormatTable)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf.Reset()
+		_ = ReportResults(results, opts, false, time.Second, nil)
+	}
+}

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -668,7 +669,7 @@ func TestSummarize(t *testing.T) {
 
 func TestReportTableEmpty(t *testing.T) {
 	var buf strings.Builder
-	err := reportTable(nil, &buf, false, 0)
+	err := reportTable(nil, &buf, false, 0, false)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No tests found")
 }
@@ -680,7 +681,7 @@ func TestReportTableBasic(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	err := reportTable(results, &buf, false, 0)
+	err := reportTable(results, &buf, false, 0, false)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -709,7 +710,7 @@ func TestReportTableVerbose(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	err := reportTable(results, &buf, true, 0)
+	err := reportTable(results, &buf, true, 0, false)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -942,4 +943,204 @@ func TestRunnerGlobalTimeout(t *testing.T) {
 	require.Len(t, results, 1)
 	// Test should fail or error due to timeout
 	assert.NotEqual(t, StatusPass, results[0].Status)
+}
+
+// ── reportTable with progressShown tests ─────────────────────────────────────
+
+func TestReportTable_ProgressShown_SkipsTableRows(t *testing.T) {
+	results := []TestResult{
+		{Solution: "sol", Test: "test-a", Status: StatusPass, Duration: 50 * time.Millisecond},
+		{Solution: "sol", Test: "test-b", Status: StatusPass, Duration: 60 * time.Millisecond},
+	}
+
+	var buf strings.Builder
+	err := reportTable(results, &buf, false, 0, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Should NOT contain the table header or per-test rows
+	assert.NotContains(t, output, "SOLUTION")
+	assert.NotContains(t, output, "TEST")
+	assert.NotContains(t, output, "STATUS")
+	assert.NotContains(t, output, "DURATION")
+	assert.NotContains(t, output, "test-a")
+	assert.NotContains(t, output, "test-b")
+	// Should contain the summary line
+	assert.Contains(t, output, "2 passed, 0 failed")
+}
+
+func TestReportTable_ProgressShown_ShowsFailures(t *testing.T) {
+	results := []TestResult{
+		{Solution: "sol", Test: "pass", Status: StatusPass, Duration: 50 * time.Millisecond},
+		{
+			Solution: "sol", Test: "fail", Status: StatusFail, Duration: 60 * time.Millisecond, Message: "exit code mismatch",
+			Assertions: []AssertionResult{
+				{Type: "exitCode", Input: "expected 1 got 0", Passed: false, Message: "exit code assertion failed"},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	err := reportTable(results, &buf, false, 0, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Failures:")
+	assert.Contains(t, output, "sol/fail: exit code mismatch")
+	assert.Contains(t, output, "[exitCode] expected 1 got 0: exit code assertion failed")
+	assert.Contains(t, output, "1 passed, 1 failed")
+}
+
+func TestReportTable_ProgressShown_ShowsSummary(t *testing.T) {
+	results := []TestResult{
+		{Solution: "sol", Test: "t1", Status: StatusPass, Duration: 10 * time.Millisecond},
+		{Solution: "sol", Test: "t2", Status: StatusSkip},
+	}
+
+	var buf strings.Builder
+	err := reportTable(results, &buf, false, 500*time.Millisecond, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "1 passed, 0 failed, 0 errors, 1 skipped (500ms)")
+}
+
+func TestReportTable_ProgressShown_VerboseAssertionCounts(t *testing.T) {
+	results := []TestResult{
+		{
+			Solution: "sol", Test: "fail-test", Status: StatusFail, Duration: 50 * time.Millisecond,
+			Message: "assertion failed",
+			Assertions: []AssertionResult{
+				{Passed: true},
+				{Passed: false, Type: "expr", Input: "__exitCode == 0", Message: "got 1"},
+				{Passed: true},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	err := reportTable(results, &buf, true, 0, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Failures:")
+	assert.Contains(t, output, "(2/3)")
+}
+
+func TestReportTable_NoProgress_FullTable(t *testing.T) {
+	results := []TestResult{
+		{Solution: "sol", Test: "test-x", Status: StatusPass, Duration: 100 * time.Millisecond},
+	}
+
+	var buf strings.Builder
+	err := reportTable(results, &buf, false, 0, false)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "SOLUTION")
+	assert.Contains(t, output, "test-x")
+	assert.Contains(t, output, "PASS")
+	assert.Contains(t, output, "1 passed")
+}
+
+// ── reportFailures tests ─────────────────────────────────────────────────────
+
+func TestReportFailures_NoFailures(t *testing.T) {
+	results := []TestResult{
+		{Solution: "sol", Test: "pass", Status: StatusPass},
+	}
+
+	var buf strings.Builder
+	reportFailures(results, &buf, false)
+	assert.Empty(t, buf.String(), "no output expected when all tests pass")
+}
+
+func TestReportFailures_WithVerboseAssertionCounts(t *testing.T) {
+	results := []TestResult{
+		{
+			Solution: "sol", Test: "fail", Status: StatusFail, Message: "boom",
+			Assertions: []AssertionResult{
+				{Passed: true},
+				{Passed: false, Type: "regex", Input: "expected.*", Message: "no match"},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	reportFailures(results, &buf, true)
+
+	output := buf.String()
+	assert.Contains(t, output, "Failures:")
+	assert.Contains(t, output, "sol/fail: boom (1/2)")
+	assert.Contains(t, output, "[regex] expected.*: no match")
+}
+
+// ── reportSummaryLine tests ──────────────────────────────────────────────────
+
+func TestReportSummaryLine(t *testing.T) {
+	results := []TestResult{
+		{Solution: "s", Test: "a", Status: StatusPass, Duration: 50 * time.Millisecond},
+		{Solution: "s", Test: "b", Status: StatusFail, Duration: 30 * time.Millisecond},
+		{Solution: "s", Test: "c", Status: StatusError, Duration: 10 * time.Millisecond},
+		{Solution: "s", Test: "d", Status: StatusSkip},
+	}
+
+	var buf strings.Builder
+	reportSummaryLine(results, &buf, 200*time.Millisecond)
+
+	output := buf.String()
+	assert.Contains(t, output, "1 passed, 1 failed, 1 errors, 1 skipped (200ms)")
+}
+
+func TestReportSummaryLine_WallDurationOverride(t *testing.T) {
+	results := []TestResult{
+		{Solution: "s", Test: "a", Status: StatusPass, Duration: 50 * time.Millisecond},
+	}
+
+	var buf strings.Builder
+	reportSummaryLine(results, &buf, 1*time.Second)
+
+	output := buf.String()
+	// Wall duration (1s) should override summed duration (50ms)
+	assert.Contains(t, output, "1.00s")
+}
+
+// ── Benchmarks ───────────────────────────────────────────────────────────────
+
+func BenchmarkReportTable_Full(b *testing.B) {
+	results := make([]TestResult, 20)
+	for i := range results {
+		results[i] = TestResult{
+			Solution: "bench-sol",
+			Test:     fmt.Sprintf("test-%d", i),
+			Status:   StatusPass,
+			Duration: time.Duration(i+1) * time.Millisecond,
+		}
+	}
+	var buf strings.Builder
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf.Reset()
+		_ = reportTable(results, &buf, false, 500*time.Millisecond, false)
+	}
+}
+
+func BenchmarkReportTable_ProgressShown(b *testing.B) {
+	results := make([]TestResult, 20)
+	for i := range results {
+		results[i] = TestResult{
+			Solution: "bench-sol",
+			Test:     fmt.Sprintf("test-%d", i),
+			Status:   StatusPass,
+			Duration: time.Duration(i+1) * time.Millisecond,
+		}
+	}
+	var buf strings.Builder
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf.Reset()
+		_ = reportTable(results, &buf, false, 500*time.Millisecond, true)
+	}
 }


### PR DESCRIPTION
…in test functional

Fixes #179. The 'scafctl test functional' command was printing each test result twice — once via progress lines and again in a summary table — with mismatched durations between the two views.

Root cause: progress callbacks used wall-clock time (time.Since) while the summary table used TestResult.Duration (pure execution time).

Changes:
- resolver: add elapsed time param to ProgressCallback.OnResolverComplete so the executor passes pure execution time rather than wall-clock drift
- run/progress: remove barStarts map; use passed duration in Complete(); replace time.Since-based spinner animation with sync/atomic counter; add PopCompletedMode so completed bars scroll up as static log lines
- test/progress: remove barStarts map and time.Since call in OnTestComplete; always use result.Duration for displayed duration; add PopCompletedMode to MPBTestProgress
- soltesting/reporter: refactor reportTable into three composable helpers (reportTableRows, reportFailures, reportSummaryLine); add progressShown logic to ReportResults via TestProgressCallback param — when non-nil, per-test rows are suppressed (already shown by progress) while failures and summary are always shown; verbose failure details include assertion counts
- functional: pass runner.Progress to both ReportResults call sites
- docs: update functional-testing.md Output section to document new interactive progress and non-TTY table behavior
- tests: update existing reporter tests for new signatures; add 10 new unit tests and 3 benchmarks covering progress-suppressed reporting, failure details, summary line, and MPB lifecycle
