### PR TITLE
chore: optimize AI customization files for best practices

### DIFF
--- a/.github/agents/commit-message.agent.md
+++ b/.github/agents/commit-message.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Generates conventional commit messages from staged or recent changes. Analyzes git diff to produce well-structured messages following the project's conventional commits spec. Does NOT execute git commit — only outputs the message. Use when preparing commit messages."
 name: "commit-message"
-tools: [execute]
+tools: [read, execute]
 ---
 You are a commit message generator for the **scafctl** project. You analyze changes and produce conventional commit messages. You **never** execute `git commit` — you only output the message for the user to copy.
 

--- a/.github/agents/go-build-resolver.agent.md
+++ b/.github/agents/go-build-resolver.agent.md
@@ -2,6 +2,10 @@
 description: "Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail."
 name: "go-build-resolver"
 tools: [read, edit, search, execute, todo]
+handoffs:
+  - label: "Generate commit message"
+    prompt: "Generate a commit message for the fixes just applied."
+    agent: "commit-message"
 ---
 You are an expert Go build error resolution specialist for the **scafctl** project. Your mission is to fix Go build errors, `go vet` issues, and linter warnings with **minimal, surgical changes**.
 

--- a/.github/agents/go-reviewer.agent.md
+++ b/.github/agents/go-reviewer.agent.md
@@ -2,6 +2,10 @@
 description: "Expert Go code reviewer for scafctl. Checks for idiomatic Go, security, error handling, concurrency patterns, and scafctl-specific conventions. Use for all Go code reviews."
 name: "go-reviewer"
 tools: [read, search, execute]
+handoffs:
+  - label: "Fix reported issues"
+    prompt: "Fix the issues identified in the code review."
+    agent: "go-build-resolver"
 ---
 You are a senior Go code reviewer for the **scafctl** project ensuring high standards of idiomatic Go and project-specific best practices.
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,8 +1,12 @@
 ---
 description: "Feature implementation planner for scafctl. Creates structured implementation blueprints with architecture decisions, task breakdown, and dependency analysis. Use for complex features and refactoring."
 name: "planner"
-tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/searchResults, search/textSearch, search/searchSubagent, web]
+tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, web, agent]
 argument-hint: "Describe the feature or change to plan"
+handoffs:
+  - label: "File GitHub issue"
+    prompt: "Create a GitHub issue from the implementation plan just produced."
+    agent: "issue-creator"
 ---
 You are a senior Go architect and implementation planner for the **scafctl** project. You create structured implementation blueprints before any code is written.
 

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -3,6 +3,13 @@ description: "Fetch PR review comments for the current branch, triage them, fix 
 name: "pr-reviewer"
 tools: [read, edit, search, execute, todo]
 argument-hint: "Optional: PR number or 'resolve' to auto-resolve addressed comments"
+handoffs:
+  - label: "Fix build errors"
+    prompt: "Fix any build or lint errors introduced while addressing PR comments."
+    agent: "go-build-resolver"
+  - label: "Generate commit message"
+    prompt: "Generate a commit message for the PR review fixes."
+    agent: "commit-message"
 ---
 You are a PR review comment handler for the **scafctl** project. You fetch review comments from the PR matching the current branch, triage them, implement fixes, and respond/resolve threads.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,72 +21,25 @@ Commands returning structured data should use **kvx** with `OutputOptions`:
 ### HTTP Client
 See `pkg/httpc/README.md`
 
-### Docs, Examples, and Tutorials
-
-- Use `pkg/docs/` for generating and managing documentation and tutorials.
-- Use `pkg/examples/` for storing example configurations and usage scenarios.
-- Always create documentation, tutorials, and examples for new features, providers and commands.
-- Always update documentation, tutorials, and examples when features, providers or commands change.
-
-
 ### Paths
-
-- Use xdg paths via the pkg/paths package
+- Use xdg paths via the `pkg/paths` package
 
 ### Configuration
+- Use `pkg/settings` for storing defaults and managing settings
+- Use `pkg/config/` for storing, loading, and managing application configuration
 
-- Use `pkg/settings` for storing defaults and managing settings.
-- Use `pkg/config/` for storing, loading and managing application configuration. Services should store their config in this package when it makes sense.
-
-### CLI integration tests
-
-- Use `tests/integration/cli_test.go` for integration tests of CLI commands.
-- Always add new commands to the CLI integration tests.
-
-### Solution integration tests
-
-- Use `tests/integration/solutions/` for integration tests of **non-API** features (providers, resolvers, actions, plugins, solutions, etc.).
-- Always create solution integration tests whenever a non-API feature, provider, or command is added or updated.
-- Solution integration tests **cannot** test API/server features — use API integration tests instead.
-
-### API integration tests
-
-- Use `tests/integration/api_test.go` for integration tests of **API/server** features (REST endpoints, middleware, auth, rate limiting, etc.).
-- Always add new API endpoints to the API integration tests.
-- API features must **only** be tested here, not in solution integration tests.
-
-### `settings` Package
+### CEL
+Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`. For CEL provider, prefer the `expression` field over `expr`.
 
 ## Conventions
 
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
 - **Signing**: All commits must be GPG/SSH signed (`-S`) and include DCO sign-off (`-s`)
 - **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
-- **Testing**: Use `testify/assert`, mocks in `mock.go` files
 - **Breaking changes**: Allowed—this app is not in production. Note when doing so.
 - **Backward compatibility**: Do not do it, see Breaking changes above.
 
-## Struct Tags
-
-Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
-- All fields: `doc`
-- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
-- Integers: `maximum`, `example`
-- Arrays: `maxItems` (no `example`)
-- Objects/maps: no `example` tag
-
-## Special Field Types
-
-| Field | Type | Package |
-|-------|------|---------|
-| `expr` | `Expression` | `pkg/celexp` |
-| `tmpl` | `GoTemplatingContent` | `pkg/gotmpl` |
-
-## CEL
-Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`. For CEL provider, prefer the `expression` field over `expr`.
-
 ## Build & Test Commands
-Standard Go commands for development (task runner available but use raw commands for AI agents):
 
 ```bash
 # Build
@@ -97,125 +50,23 @@ go test ./...                    # Run all tests
 
 # Linting
 golangci-lint run --fix          # Run Linter and auto-fix issues
-
 ```
 
-**IMPORTANT**: Never include business logic in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`) or API packages (future) instead, put it into proper shared domain packages (`pkg/...`)
+The project uses `task` (go-task/task) as a convenience wrapper, but AI agents should use raw Go commands for clarity and portability.
 
-**Note**: The project uses `task` (go-task/task) as a convenience wrapper, but AI agents should use raw Go commands for clarity and portability.
+## Critical Rules
 
-**IMPORTANT**: Always update documentation, tutorials, examples, mcp server tools (if applicable) when features, providers or commands change or added.
-**IMPORTANT**: Add benchmark tests for any new features or providers in `*_test.go` files using Go's `testing` package.
-**IMPORTANT**: After any change, run `task test:e2e` to ensure everything passes.
-**IMPORTANT**: Never use magic strings or numbers; always define constants or use settings for configuration values.
-**IMPORTANT**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Only generate commit messages — let the user execute the commit.
-**IMPORTANT**: Never commit or push any code without approval first
-
----
-paths:
-  - "**/*.go"
-  - "**/go.mod"
-  - "**/go.sum"
----
-- **gofmt/goimports**: Auto-format `.go` files after edit
-- **go vet**: Run static analysis after editing `.go` files
-- **staticcheck**: Run extended static checks on modified packages
-
-## Formatting
-
-- **gofmt** and **goimports** are mandatory — no style debates
-
-## Design Principles
-
-- Accept interfaces, return structs
-- Keep interfaces small (1-3 methods)
-
-## Error Handling
-
-Always wrap errors with context:
-
-```go
-if err != nil {
-    return fmt.Errorf("failed to create user: %w", err)
-}
-```
-
-## Functional Options
-
-```go
-type Option func(*Server)
-
-func WithPort(port int) Option {
-    return func(s *Server) { s.port = port }
-}
-
-func NewServer(opts ...Option) *Server {
-    s := &Server{port: 8080}
-    for _, opt := range opts {
-        opt(s)
-    }
-    return s
-}
-```
-
-## Small Interfaces
-
-Define interfaces where they are used, not where they are implemented.
-
-## Dependency Injection
-
-Use constructor functions to inject dependencies:
-
-```go
-func NewUserService(repo UserRepository, logger Logger) *UserService {
-    return &UserService{repo: repo, logger: logger}
-}
-```
-
-## Secret Management
-
-```go
-apiKey := os.Getenv("OPENAI_API_KEY")
-if apiKey == "" {
-    log.Fatal("OPENAI_API_KEY not configured")
-}
-```
+- **Business logic placement**: Never in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`), or API packages — put it in shared domain packages (`pkg/...`)
+- **After any change**: Run `task test:e2e` to ensure everything passes
+- **No magic values**: Always define constants or use settings for configuration values
+- **Git safety**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Never commit or push without approval first
 
 ## Security Scanning
 
-- Use **gosec** for static security analysis:
-  ```bash
-  gosec ./...
-  ```
-
-## Context & Timeouts
-
-Always use `context.Context` for timeout control:
-
-```go
-ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-defer cancel()
-```
-
-## Framework
-
-Use the standard `go test` with **table-driven tests**.
-
-## Race Detection
-
-Always run with the `-race` flag:
-
 ```bash
-go test -race ./...
+gosec ./...
 ```
 
-## Coverage
+## Additional Conventions
 
-```bash
-go test -cover ./...
-```
-
-## Reference
-
-See skill: `golang-patterns` for comprehensive Go idioms and patterns.
-See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.
+Go coding conventions (struct tags, error handling, design patterns), testing rules, integration test scoping, and documentation requirements are in `.github/instructions/*.instructions.md` files — they load automatically when editing relevant files.

--- a/.github/hooks/git-safety.json
+++ b/.github/hooks/git-safety.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/scripts/git-safety.sh",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/go-format.json
+++ b/.github/hooks/go-format.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/scripts/go-format.sh",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.github/hooks/scripts/git-safety.sh
+++ b/.github/hooks/scripts/git-safety.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block git commit/push/amend unless user explicitly approves.
+# Reads JSON from stdin, checks if the command is a git write operation.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the command being run
+cmd=$(echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//')
+
+# Check for git write operations
+if echo "$cmd" | grep -qE 'git\s+(commit|push|amend|reset\s+--hard|rebase|force-push)'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Git write operation detected. This project requires explicit user approval before committing, pushing, or rewriting history."
+  }
+}
+EOF
+  exit 0
+fi

--- a/.github/hooks/scripts/go-format.sh
+++ b/.github/hooks/scripts/go-format.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format .go files after edits
+# Reads JSON from stdin, checks if a .go file was edited, runs goimports.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the file path from the tool input (handles replace_string_in_file, create_file, etc.)
+file=$(echo "$input" | grep -o '"filePath"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"filePath"[[:space:]]*:[[:space:]]*"//;s/"$//')
+
+# Only proceed for .go files
+if [[ -z "$file" || "$file" != *.go ]]; then
+  exit 0
+fi
+
+# Only format if the file exists
+if [[ ! -f "$file" ]]; then
+  exit 0
+fi
+
+# Run goimports if available, fall back to gofmt
+if command -v goimports &>/dev/null; then
+  goimports -w "$file"
+elif command -v gofmt &>/dev/null; then
+  gofmt -w "$file"
+fi

--- a/.github/instructions/cli-commands.instructions.md
+++ b/.github/instructions/cli-commands.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "CLI command layer rules for scafctl. Commands are thin wiring — no business logic. Use Writer for output, kvx for data, cobra for flags. Use when editing CLI command packages."
+applyTo: "pkg/cmd/scafctl/**/*.go"
+---
+
+# CLI Command Layer
+
+Commands are **thin wiring only** — they parse flags, call domain packages, and render output.
+
+## Rules
+
+- **No business logic** — delegate to packages in `pkg/`
+- Use `writer.FromContext(ctx)` for all terminal output, never `fmt.Fprintf`
+- Use `kvx.OutputOptions` for structured data (table/json/yaml/quiet)
+- Use `cobra.Command` for command definition and flag binding
+- Wire up `settings.Run` parameters from flags
+- Always add new commands to CLI integration tests (`tests/integration/cli_test.go`)

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Documentation and examples conventions for scafctl. Use when creating or updating docs, tutorials, or examples."
+applyTo: docs/**, examples/**, pkg/docs/**, pkg/examples/**
+---
+
+# Documentation & Examples
+
+- Use `pkg/docs/` for generating and managing documentation and tutorials
+- Use `pkg/examples/` for storing example configurations and usage scenarios
+- Always create documentation, tutorials, and examples for new features, providers, and commands
+- Always update documentation, tutorials, and examples when features, providers, or commands change
+- Always update MCP server tools (if applicable) when features, providers, or commands change

--- a/.github/instructions/go-conventions.instructions.md
+++ b/.github/instructions/go-conventions.instructions.md
@@ -1,0 +1,93 @@
+---
+description: "Go coding conventions for scafctl: struct tags, Huma validation, error handling, design principles, functional options, context/timeouts, and formatting. Use when writing or editing Go code."
+applyTo: "**/*.go"
+---
+
+# Go Conventions
+
+## Struct Tags
+
+Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
+- All fields: `doc`
+- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
+- Integers: `maximum`, `example`
+- Arrays: `maxItems` (no `example`)
+- Objects/maps: no `example` tag
+
+## Special Field Types
+
+| Field | Type | Package |
+|-------|------|---------|
+| `expr` | `Expression` | `pkg/celexp` |
+| `tmpl` | `GoTemplatingContent` | `pkg/gotmpl` |
+
+## Error Handling
+
+Always wrap errors with context:
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to create user: %w", err)
+}
+```
+
+## Design Principles
+
+- Accept interfaces, return structs
+- Keep interfaces small (1-3 methods)
+- Define interfaces where they are used, not where they are implemented
+
+## Dependency Injection
+
+Use constructor functions to inject dependencies:
+
+```go
+func NewUserService(repo UserRepository, logger Logger) *UserService {
+    return &UserService{repo: repo, logger: logger}
+}
+```
+
+## Functional Options
+
+```go
+type Option func(*Server)
+
+func WithPort(port int) Option {
+    return func(s *Server) { s.port = port }
+}
+
+func NewServer(opts ...Option) *Server {
+    s := &Server{port: 8080}
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+## Context & Timeouts
+
+Always use `context.Context` for timeout control:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+defer cancel()
+```
+
+## Secret Management
+
+```go
+apiKey := os.Getenv("OPENAI_API_KEY")
+if apiKey == "" {
+    log.Fatal("OPENAI_API_KEY not configured")
+}
+```
+
+## Formatting
+
+- **gofmt** and **goimports** are mandatory — no style debates
+- Never use magic strings or numbers; always define constants or use settings
+
+## Reference
+
+See skill: `golang-patterns` for comprehensive Go idioms and patterns.

--- a/.github/instructions/go-modules.instructions.md
+++ b/.github/instructions/go-modules.instructions.md
@@ -1,0 +1,11 @@
+---
+description: "Go module rules for scafctl. Run go mod tidy after dependency changes. Never edit go.sum manually. Use when editing go.mod."
+applyTo: "**/go.mod"
+---
+
+# Go Modules
+
+- Run `go mod tidy -v` after adding or removing dependencies
+- Never edit `go.sum` manually — it is auto-generated
+- Pin dependencies to specific versions, not branches
+- Use `go mod verify` to check module integrity

--- a/.github/instructions/go-testing.instructions.md
+++ b/.github/instructions/go-testing.instructions.md
@@ -1,0 +1,42 @@
+---
+description: "Go testing conventions for scafctl: table-driven tests, testify/assert, benchmarks, race detection, and coverage. Use when writing or editing Go test files."
+applyTo: "**/*_test.go"
+---
+
+# Go Testing Conventions
+
+## Framework
+
+- Use standard `go test` with **table-driven tests**
+- Use `testify/assert` for assertions
+- Place mocks in `mock.go` files
+
+## Race Detection
+
+Always run with the `-race` flag:
+
+```bash
+go test -race ./...
+```
+
+## Coverage
+
+```bash
+go test -cover ./...
+```
+
+## Benchmarks
+
+Add benchmark tests for any new features or providers:
+
+```go
+func BenchmarkMyFeature(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        // benchmark code
+    }
+}
+```
+
+## Reference
+
+See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Integration test rules for scafctl: CLI, solution, and API test scope boundaries. Use when writing or editing integration tests."
+applyTo: "tests/integration/**"
+---
+
+# Integration Test Rules
+
+## CLI Integration Tests (`tests/integration/cli_test.go`)
+
+- Always add new commands to the CLI integration tests
+- Tests CLI command behavior and output
+
+## Solution Integration Tests (`tests/integration/solutions/`)
+
+- For **non-API** features: providers, resolvers, actions, plugins, solutions
+- Always create solution integration tests when a non-API feature, provider, or command is added or updated
+- **Cannot** test API/server features — use API integration tests instead
+
+## API Integration Tests (`tests/integration/api_test.go`)
+
+- For **API/server** features: REST endpoints, middleware, auth, rate limiting
+- Always add new API endpoints to the API integration tests
+- API features must **only** be tested here, not in solution integration tests
+
+## Scope Boundaries
+
+| Feature Type | Test Location |
+|-------------|---------------|
+| CLI commands | `tests/integration/cli_test.go` |
+| Providers, resolvers, actions, plugins | `tests/integration/solutions/` |
+| REST endpoints, middleware, auth | `tests/integration/api_test.go` |

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -1,0 +1,22 @@
+---
+description: "Markdown formatting rules: tilde fences for nested backticks, ASCII-only characters. Use when writing or editing markdown."
+applyTo: "**/*.md"
+---
+
+# Markdown Authoring Rules
+
+## Code Blocks
+
+When a markdown code block contains backticks (Go raw strings, heredocs, shell, template literals), use tilde fences instead of backtick fences to avoid delimiter collisions.
+
+If tilde fences are not suitable, use 4+ backtick fences as the outer delimiter.
+
+## Characters
+
+Use only ASCII characters in markdown files:
+
+- Use `--` instead of em dashes
+- Use `---` for horizontal rules
+- Use straight quotes (`"`, `'`) instead of curly/smart quotes
+- Use `...` instead of ellipsis characters
+- Use standard hyphens (`-`) instead of en dashes

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "MCP tool handler rules for scafctl. Handlers are thin wrappers — no business logic. Parse inputs, call domain packages, format output. Use when editing MCP tool files."
+applyTo: "pkg/mcp/tools_*.go"
+---
+
+# MCP Tool Handlers
+
+MCP tool handlers are **thin wrappers** — they parse tool inputs, call domain packages, and format results.
+
+## Rules
+
+- **No business logic** — delegate to packages in `pkg/`
+- Register tools in `register*Tools()` methods on `*Server`
+- Use `mcp.NewTool()` with descriptive names, descriptions, and typed parameters
+- Use `mcp.With*HintAnnotation()` for tool metadata (read-only, destructive, idempotent)
+- Return `mcp.NewToolResultText()` or `mcp.NewToolResultError()` — never panic
+- Always add Huma-style parameter descriptions and constraints

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Provider implementation rules for scafctl. Providers implement the Provider interface with Descriptor() and Execute(). Must include benchmarks, tests, and mock.go. Use when creating or editing providers."
+applyTo: "pkg/provider/**/*.go"
+---
+
+# Provider Layer
+
+Providers are **stateless execution primitives** that implement the Provider interface.
+
+## Interface
+
+Implement both methods:
+- `Descriptor()` returns provider metadata, schema, and capabilities
+- `Execute(ctx, input)` runs the provider logic
+
+## Rules
+
+- Define `ProviderName` and `Version` constants
+- Implement `Descriptor()` returning name, version, API version, schema, and capabilities
+- Use `schemahelper` for JSON schema generation
+- Define a testable ops interface (e.g., `EnvOps`) and inject via constructor for mockability
+- Provide `DefaultXxxOps` struct for real implementations
+- Place mocks in `mock.go`
+- Always include benchmark tests (`*_benchmark_test.go`)
+- Register in `pkg/provider/builtin/builtin.go`
+- Add struct tags with Huma validation on all Descriptor fields
+
+## Package naming
+
+- `pkg/provider/builtin/<name>provider/` (e.g., `envprovider`, `httpprovider`)
+- Main file matches the provider name (e.g., `env.go`, `http.go`)

--- a/.github/prompts/completeness-check.prompt.md
+++ b/.github/prompts/completeness-check.prompt.md
@@ -1,0 +1,18 @@
+---
+description: "Check if staged changes have corresponding docs, tutorials, examples, integration tests, and MCP tools."
+agent: "agent"
+argument-hint: "Optional: specific area to check"
+---
+Review staged changes and check if supporting artifacts exist:
+
+1. Run `git diff --cached --stat` to identify what changed
+2. For each feature, provider, or command, verify:
+   - Docs in `docs/` or `pkg/docs/`
+   - Tutorials in `docs/tutorials/` for user-facing features
+   - Examples in `examples/`
+   - Solution integration tests in `tests/integration/solutions/`
+   - CLI integration tests in `tests/integration/cli_test.go`
+   - API integration tests in `tests/integration/api_test.go`
+   - MCP server tools in `pkg/mcp/tools_*.go`
+3. Report present vs missing as a checklist
+4. Do not create anything, just report the gaps

--- a/.github/prompts/go-test.prompt.md
+++ b/.github/prompts/go-test.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Run Go tests with race detection and check coverage. Reports failures and coverage gaps."
+description: "Run Go tests with race detection, check coverage, and diagnose failures via go-build-resolver."
 agent: "go-build-resolver"
 ---
 Run the Go test suite and report results:

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,14 +1,13 @@
 ---
 description: "Fetch and triage PR review comments for the current branch. Analyzes comments, fixes issues, and responds/resolves threads via gh CLI."
 agent: "pr-reviewer"
-argument-hint: "Optional: 'resolve' to also respond and resolve addressed threads"
+argument-hint: "PR URL (e.g., https://github.com/oakwood-commons/scafctl/pull/123)"
 ---
-Fetch review comments from the PR for the current branch and triage them:
+Address unresolved PR review comments. Use `gh` CLI and the **GitHub GraphQL API (v4)** to fetch review threads — the REST API does not expose the `isResolved` field.
 
-1. Get current branch and find the matching PR via `gh pr view`
-2. Fetch all unresolved review threads via GitHub GraphQL API
-3. Classify each thread: actionable, question, nit, already addressed, disagree, outdated
-4. Present the triage summary and wait for approval
-5. Fix actionable items, then respond to and resolve threads
-
-**Always waits for approval before making changes or responding to comments.**
+1. Fetch all review threads via GraphQL; **skip comments that are already resolved**
+2. For each unresolved comment, assess whether it's a legit problem with the code
+3. If it needs fixing: make the fix, reply to the thread confirming it's fixed, and mark it resolved
+4. If you disagree with a comment: **discuss it with me before deciding** — don't resolve or dismiss it
+5. After all changes are made, run `task test:e2e` and make sure everything passes
+6. **Do not commit** — I will handle that

--- a/.github/skills/golang-testing/SKILL.md
+++ b/.github/skills/golang-testing/SKILL.md
@@ -317,7 +317,6 @@ go test -count=10 ./...                      # Flaky test detection
 - Place mocks in `mock.go` files
 
 **DON'T:**
-- Test private functions directly (test through public API)
 - Use `time.Sleep()` in tests (use channels or conditions)
 - Ignore flaky tests (fix or remove them)
 - Mock everything (prefer integration tests when possible)

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -32,7 +32,7 @@ spec:
 ```
 
 ```bash
-scafctl run solution hello.yaml -o yaml
+scafctl run solution -f hello.yaml -o yaml
 # greeting: "Hello, world!"
 ```
 

--- a/docs/design/catalog-build-bundling.md
+++ b/docs/design/catalog-build-bundling.md
@@ -70,7 +70,7 @@ my-solution/
   workflow.yaml        # ← Not included in build
 ```
 
-After `scafctl build solution ./solution.yaml && scafctl catalog push ...`, a consumer running `scafctl run solution my-solution@1.0.0` on a different machine will get file-not-found errors for every local reference, and network errors for unavailable catalog dependencies.
+After `scafctl build solution -f ./solution.yaml && scafctl catalog push ...`, a consumer running `scafctl run solution my-solution@1.0.0` on a different machine will get file-not-found errors for every local reference, and network errors for unavailable catalog dependencies.
 
 ---
 
@@ -343,7 +343,7 @@ The `bundle` section sits at the top level alongside `metadata`, `catalog`, `com
 The `scafctl build solution` command gains the following behavior:
 
 ```
-scafctl build solution ./my-solution.yaml
+scafctl build solution -f ./my-solution.yaml
 ```
 
 1. **Parse** the solution YAML.
@@ -374,7 +374,7 @@ scafctl build solution ./my-solution.yaml
 #### Dry-Run Output
 
 ```bash
-$ scafctl build solution ./solution.yaml --dry-run
+$ scafctl build solution -f ./solution.yaml --dry-run
 
 Bundle analysis for ./solution.yaml:
 
@@ -878,7 +878,7 @@ workflow:
 ### Build
 
 ```bash
-$ scafctl build solution ./solution.yaml
+$ scafctl build solution -f ./solution.yaml
 
   Composed 2 files into solution
   Bundled 7 files (15.5 KB)
@@ -1244,15 +1244,12 @@ Re-resolve and update vendored dependencies without a full rebuild, enabling qui
 ### Command Specification
 
 ```bash
-scafctl vendor update [solution-path]
+scafctl vendor update [-f solution-path]
 ```
-
-| Argument | Description |
-|----------|-------------|
-| `[solution-path]` | Path to solution YAML (default: `./solution.yaml`) |
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `-f` | `auto-discover` | Path to solution YAML file; if omitted, auto-discover a solution file and fall back to `./solution.yaml` only when discovery finds nothing |
 | `--dependency` | — | Update only this dependency (repeatable); if omitted, update all |
 | `--dry-run` | `false` | Show what would be updated without making changes |
 | `--lock-only` | `false` | Update `solution.lock` without re-vendoring files |

--- a/docs/design/catalog-cli-design-decision.md
+++ b/docs/design/catalog-cli-design-decision.md
@@ -80,7 +80,7 @@ Add a `scafctl catalog tag` command to create full references:
 
 ```bash
 # Build locally
-scafctl build solution deploy.yaml --version 1.0.0
+scafctl build solution -f deploy.yaml --version 1.0.0
 
 # Tag with full remote reference
 scafctl catalog tag deploy@1.0.0 ghcr.io/myorg/solutions/deploy:1.0.0

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -81,6 +81,36 @@ scafctl run solution "example@>=1.0 <2.0"  # planned
 scafctl run solution "example@^1.2"         # planned
 ~~~
 
+### File Paths vs. Catalog References
+
+When a command accepts both a positional name argument and a `-f`/`--file` flag, the CLI distinguishes catalog references from local file paths:
+
+| Input | Interpretation | Example |
+|-------|---------------|---------|
+| Bare name | Catalog reference | `my-app`, `deploy` |
+| Versioned name | Catalog reference | `my-app@1.0.0`, `deploy@^1.2` |
+| Registry reference | Catalog reference | `ghcr.io/org/sol:v1`, `localhost:5000/sol` |
+| URL | Remote reference | `https://example.com/sol.yaml` |
+| Starts with `/` or `.` | **Rejected** — use `-f` | `/tmp/sol.yaml`, `./sol.yaml` |
+| Ends with `.yaml`, `.yml`, `.json` | **Rejected** — use `-f` | `solution.yaml` |
+| Path with separators, non-hostname first segment | **Rejected** — use `-f` | `configs/solution`, `relative/path/sol` |
+| Windows path | **Rejected** — use `-f` | `C:\dir\sol`, `dir\sol` |
+
+To pass a local file path, always use the `-f`/`--file` flag:
+
+~~~bash
+# Correct: file via -f flag
+scafctl run solution -f ./solution.yaml
+
+# Correct: catalog reference as positional arg
+scafctl run solution my-app@1.0.0
+
+# Error: local file path as positional arg
+scafctl run solution solution.yaml   # rejected with helpful error
+~~~
+
+This separation keeps the CLI unambiguous — positional arguments are always catalog/registry lookups while `-f` is always a file path.
+
 ---
 
 ## Running a Solution
@@ -434,13 +464,13 @@ Build a solution for the local catalog (analogous to `docker build`):
 
 ~~~bash
 # Build a solution from file
-scafctl build solution ./solution.yaml --version 1.0.0
+scafctl build solution -f ./solution.yaml --version 1.0.0
 
 # Build using version from metadata
-scafctl build solution ./solution.yaml
+scafctl build solution -f ./solution.yaml
 
 # Overwrite existing version
-scafctl build solution ./solution.yaml --version 1.0.0 --force
+scafctl build solution -f ./solution.yaml --version 1.0.0 --force
 ~~~
 
 The build process validates, resolves dependencies, bundles local files, vendors catalog dependencies, and packages artifacts into the local catalog. See [catalog-build-bundling.md](../design/catalog-build-bundling.md) for the full bundling design.
@@ -449,19 +479,19 @@ Additional build flags:
 
 ~~~bash
 # Dry-run: show what would be bundled without building
-scafctl build solution ./solution.yaml --dry-run
+scafctl build solution -f ./solution.yaml --dry-run
 
 # Skip file bundling (legacy single-layer artifact)
-scafctl build solution ./solution.yaml --no-bundle
+scafctl build solution -f ./solution.yaml --no-bundle
 
 # Skip vendoring catalog dependencies
-scafctl build solution ./solution.yaml --no-vendor
+scafctl build solution -f ./solution.yaml --no-vendor
 
 # Set max bundle size
-scafctl build solution ./solution.yaml --bundle-max-size 100MB
+scafctl build solution -f ./solution.yaml --bundle-max-size 100MB
 
 # Re-resolve and update the lock file
-scafctl build solution ./solution.yaml --update-lock
+scafctl build solution -f ./solution.yaml --update-lock
 ~~~
 
 ### Publishing Artifacts

--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -379,10 +379,10 @@ The build cache enables incremental builds by fingerprinting all build inputs (s
 {{% tab "Bash" %}}
 ```bash
 # Build with cache (default)
-scafctl build solution my-solution.yaml
+scafctl build solution -f my-solution.yaml
 
 # Force a full rebuild, bypassing cache
-scafctl build solution my-solution.yaml --no-cache
+scafctl build solution -f my-solution.yaml --no-cache
 
 # Clear build cache
 scafctl cache clear --kind build --force
@@ -391,10 +391,10 @@ scafctl cache clear --kind build --force
 {{% tab "PowerShell" %}}
 ```powershell
 # Build with cache (default)
-scafctl build solution my-solution.yaml
+scafctl build solution -f my-solution.yaml
 
 # Force a full rebuild, bypassing cache
-scafctl build solution my-solution.yaml --no-cache
+scafctl build solution -f my-solution.yaml --no-cache
 
 # Clear build cache
 scafctl cache clear --kind build --force

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -75,12 +75,12 @@ This solution accepts a `name` parameter (defaulting to "World") and produces a 
 {{< tabs "catalog-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting.yaml
+scafctl build solution -f greeting.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting.yaml
+scafctl build solution -f greeting.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -102,12 +102,12 @@ You can also specify the version on the command line, which overrides `metadata.
 {{< tabs "catalog-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting.yaml --version 1.0.1
+scafctl build solution -f greeting.yaml --version 1.0.1
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting.yaml --version 1.0.1
+scafctl build solution -f greeting.yaml --version 1.0.1
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -122,7 +122,7 @@ Expected output:
 
 ### What You Learned
 
-- `scafctl build solution FILE` packages a solution YAML into the local OCI catalog
+- `scafctl build solution -f FILE` packages a solution YAML into the local OCI catalog
 - The name and version come from `metadata.name` and `metadata.version` by default
 - Use `--version` to override the version at build time
 - Use `--name` to override the name at build time
@@ -408,12 +408,12 @@ spec:
 {{< tabs "catalog-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting-v2.yaml
+scafctl build solution -f greeting-v2.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting-v2.yaml
+scafctl build solution -f greeting-v2.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -512,12 +512,12 @@ The v1 solution doesn't have a timestamp — confirming you're running the origi
 {{< tabs "catalog-tutorial-cmd-15" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting-v2.yaml --version 2.0.0
+scafctl build solution -f greeting-v2.yaml --version 2.0.0
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting-v2.yaml --version 2.0.0
+scafctl build solution -f greeting-v2.yaml --version 2.0.0
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -533,12 +533,12 @@ Use `--force` to overwrite:
 {{< tabs "catalog-tutorial-cmd-16" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting-v2.yaml --version 2.0.0 --force
+scafctl build solution -f greeting-v2.yaml --version 2.0.0 --force
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting-v2.yaml --version 2.0.0 --force
+scafctl build solution -f greeting-v2.yaml --version 2.0.0 --force
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -661,12 +661,12 @@ First, rebuild the greeting solution:
 {{< tabs "catalog-tutorial-cmd-21" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution greeting.yaml
+scafctl build solution -f greeting.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution greeting.yaml
+scafctl build solution -f greeting.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -821,7 +821,7 @@ Here's how the full workflow looks in practice:
 {{% tab "Bash" %}}
 ```bash
 # On the connected machine:
-scafctl build solution deploy.yaml --version 1.0.0
+scafctl build solution -f deploy.yaml --version 1.0.0
 scafctl catalog save deploy@1.0.0 -o deploy-v1.tar
 cp deploy-v1.tar /Volumes/USB/
 
@@ -833,7 +833,7 @@ scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
 {{% tab "PowerShell" %}}
 ```powershell
 # On the connected machine:
-scafctl build solution deploy.yaml --version 1.0.0
+scafctl build solution -f deploy.yaml --version 1.0.0
 scafctl catalog save deploy@1.0.0 -o deploy-v1.tar
 Copy-Item deploy-v1.tar /Volumes/USB/
 
@@ -1275,12 +1275,12 @@ The `deployment-template` resolver uses a **static path** (`templates/deployment
 {{< tabs "catalog-tutorial-cmd-41" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution deploy-app/solution.yaml --dry-run
+scafctl build solution -f deploy-app/solution.yaml --dry-run
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution deploy-app/solution.yaml --dry-run
+scafctl build solution -f deploy-app/solution.yaml --dry-run
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1310,12 +1310,12 @@ The dry-run shows:
 {{< tabs "catalog-tutorial-cmd-42" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution deploy-app/solution.yaml
+scafctl build solution -f deploy-app/solution.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution deploy-app/solution.yaml
+scafctl build solution -f deploy-app/solution.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1523,12 +1523,12 @@ spec:
 {{< tabs "catalog-tutorial-cmd-45" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution nested-demo/parent.yaml --dry-run
+scafctl build solution -f nested-demo/parent.yaml --dry-run
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution nested-demo/parent.yaml --dry-run
+scafctl build solution -f nested-demo/parent.yaml --dry-run
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1552,13 +1552,13 @@ Notice that scafctl **recursively discovered** the child sub-solution (`sub/chil
 {{< tabs "catalog-tutorial-cmd-46" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution nested-demo/parent.yaml
+scafctl build solution -f nested-demo/parent.yaml
 scafctl run resolver -f nested-demo -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution nested-demo/parent.yaml
+scafctl build solution -f nested-demo/parent.yaml
 scafctl run resolver -f nested-demo -o json
 ```
 {{% /tab %}}
@@ -1738,12 +1738,12 @@ metadata:
 {{< tabs "catalog-tutorial-cmd-51" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl build solution deploy-app/solution.yaml
+scafctl build solution -f deploy-app/solution.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl build solution deploy-app/solution.yaml
+scafctl build solution -f deploy-app/solution.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -228,7 +228,7 @@ scafctl run solution -f solution.yaml
 scafctl run solution my-solution
 
 # Build a solution to local catalog
-scafctl build solution solution.yaml --version 1.0.0
+scafctl build solution -f solution.yaml --version 1.0.0
 
 # List cataloged solutions
 scafctl catalog list
@@ -286,7 +286,7 @@ scafctl run solution -f solution.yaml
 scafctl run solution my-solution
 
 # Build a solution to local catalog
-scafctl build solution solution.yaml --version 1.0.0
+scafctl build solution -f solution.yaml --version 1.0.0
 
 # List cataloged solutions
 scafctl catalog list

--- a/docs/tutorials/plugin-auto-fetch-tutorial.md
+++ b/docs/tutorials/plugin-auto-fetch-tutorial.md
@@ -300,7 +300,7 @@ spec:
 EOF
 
 # 2. Build to create a lock file (pins plugin versions)
-scafctl build solution solution.yaml --version 1.0.0
+scafctl build solution -f solution.yaml --version 1.0.0
 
 # 3. Pre-fetch plugins (optional but recommended)
 scafctl plugins install -f solution.yaml
@@ -337,7 +337,7 @@ spec:
 '@ | Set-Content solution.yaml
 
 # 2. Build to create a lock file (pins plugin versions)
-scafctl build solution solution.yaml --version 1.0.0
+scafctl build solution -f solution.yaml --version 1.0.0
 
 # 3. Pre-fetch plugins (optional but recommended)
 scafctl plugins install -f solution.yaml

--- a/docs/tutorials/soldiff-tutorial.md
+++ b/docs/tutorials/soldiff-tutorial.md
@@ -35,12 +35,12 @@ Solution diffing answers the question: **"What structurally changed between two 
 {{< tabs "soldiff-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl solution diff solution-v1.yaml solution-v2.yaml
+scafctl solution diff -f solution-v1.yaml -f solution-v2.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl solution diff solution-v1.yaml solution-v2.yaml
+scafctl solution diff -f solution-v1.yaml -f solution-v2.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -64,12 +64,12 @@ Summary: 5 total | 2 added | 0 removed | 3 changed
 {{< tabs "soldiff-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl solution diff solution-v1.yaml solution-v2.yaml -o json
+scafctl solution diff -f solution-v1.yaml -f solution-v2.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl solution diff solution-v1.yaml solution-v2.yaml -o json
+scafctl solution diff -f solution-v1.yaml -f solution-v2.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -95,12 +95,12 @@ cat examples/soldiff/solution-v2.yaml
 {{< tabs "soldiff-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
+scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
+scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -120,7 +120,7 @@ In a CI pipeline, use JSON output to assert no unexpected changes:
 {{% tab "Bash" %}}
 ```bash
 # Fail if any resolvers were removed
-diff_output=$(scafctl solution diff baseline.yaml current.yaml -o json)
+diff_output=$(scafctl solution diff -f baseline.yaml -f current.yaml -o json)
 removed=$(echo "$diff_output" | jq '.summary.removed')
 if [ "$removed" -gt 0 ]; then
   echo "ERROR: Resolvers were removed!"
@@ -131,7 +131,7 @@ fi
 {{% tab "PowerShell" %}}
 ```powershell
 # Fail if any resolvers were removed
-$diff_output = scafctl solution diff baseline.yaml current.yaml -o json
+$diff_output = scafctl solution diff -f baseline.yaml -f current.yaml -o json
 $parsed = $diff_output | ConvertFrom-Json
 if ($parsed.summary.removed -gt 0) {
   Write-Output "ERROR: Resolvers were removed!"
@@ -184,7 +184,7 @@ Solution diff compares *structure* (YAML schema), while snapshot diff compares *
 {{% tab "Bash" %}}
 ```bash
 # 1. Compare structure
-scafctl solution diff v1.yaml v2.yaml
+scafctl solution diff -f v1.yaml -f v2.yaml
 
 # 2. Compare runtime behavior
 scafctl run resolver -f v1.yaml --snapshot --snapshot-file=before.json
@@ -195,7 +195,7 @@ scafctl snapshot diff before.json after.json
 {{% tab "PowerShell" %}}
 ```powershell
 # 1. Compare structure
-scafctl solution diff v1.yaml v2.yaml
+scafctl solution diff -f v1.yaml -f v2.yaml
 
 # 2. Compare runtime behavior
 scafctl run resolver -f v1.yaml --snapshot --snapshot-file=before.json

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -151,7 +151,7 @@ spec:
 Run this example
 
 ```bash
-scafctl run solution regex-patterns.yaml
+scafctl run solution -f regex-patterns.yaml
 ```
 {{% /details %}}
 
@@ -471,13 +471,13 @@ When validation fails, scafctl provides structured error messages. Use the MCP `
 {{% tab "Bash" %}}
 ```bash
 # Run with verbose output to see validation details
-scafctl run solution my-solution.yaml -v 2
+scafctl run solution -f my-solution.yaml -v 2
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
 # Run with verbose output to see validation details
-scafctl run solution my-solution.yaml -v 2
+scafctl run solution -f my-solution.yaml -v 2
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/examples/README.md
+++ b/examples/README.md
@@ -305,7 +305,7 @@ scafctl snapshot diff /tmp/snap-a.json /tmp/snap-b.json
 ### Build and Run from Catalog
 ```bash
 # Build a solution into the catalog
-scafctl build solution examples/resolver-demo.yaml --version 1.0.0
+scafctl build solution -f examples/resolver-demo.yaml --version 1.0.0
 
 # Run by name (no file path needed)
 scafctl run resolver resolver-demo
@@ -317,7 +317,7 @@ scafctl catalog list
 ### Export and Import (Air-Gapped Transfer)
 ```bash
 # Build and export a solution
-scafctl build solution examples/resolver-demo.yaml --version 1.0.0
+scafctl build solution -f examples/resolver-demo.yaml --version 1.0.0
 scafctl catalog save resolver-demo -o resolver-demo.tar
 
 # Transfer the tar file to another machine, then import
@@ -330,8 +330,8 @@ scafctl run resolver resolver-demo
 ### Version Management
 ```bash
 # Build multiple versions
-scafctl build solution examples/resolver-demo.yaml --version 1.0.0
-scafctl build solution examples/resolver-demo.yaml --version 2.0.0
+scafctl build solution -f examples/resolver-demo.yaml --version 1.0.0
+scafctl build solution -f examples/resolver-demo.yaml --version 2.0.0
 
 # Export specific version
 scafctl catalog save resolver-demo@1.0.0 -o resolver-demo-v1.tar

--- a/examples/catalog/bundling-example/README.md
+++ b/examples/catalog/bundling-example/README.md
@@ -28,13 +28,13 @@ bundling-example/
 See what files would be included:
 
 ```bash
-scafctl build solution examples/catalog/bundling-example/solution.yaml --dry-run
+scafctl build solution -f examples/catalog/bundling-example/solution.yaml --dry-run
 ```
 
 ### 2. Build to Catalog
 
 ```bash
-scafctl build solution examples/catalog/bundling-example/solution.yaml --version 1.0.0
+scafctl build solution -f examples/catalog/bundling-example/solution.yaml --version 1.0.0
 ```
 
 ### 3. Verify the Bundle

--- a/examples/catalog/bundling-example/solution.yaml
+++ b/examples/catalog/bundling-example/solution.yaml
@@ -7,8 +7,8 @@
 # - Dynamic file paths (require explicit includes)
 #
 # Usage:
-#   scafctl build solution examples/catalog/bundling-example/solution.yaml --dry-run
-#   scafctl build solution examples/catalog/bundling-example/solution.yaml --version 1.0.0
+#   scafctl build solution -f examples/catalog/bundling-example/solution.yaml --dry-run
+#   scafctl build solution -f examples/catalog/bundling-example/solution.yaml --version 1.0.0
 #   scafctl run resolver bundling-example -r environment=dev
 
 apiVersion: scafctl.io/v1

--- a/examples/catalog/remote-registry-workflow.md
+++ b/examples/catalog/remote-registry-workflow.md
@@ -25,7 +25,7 @@ echo "YOUR_TOKEN" | podman login ghcr.io -u YOUR_USERNAME --password-stdin
 
 ```bash
 # Build the example solution
-scafctl build solution examples/resolver-demo.yaml --version 1.0.0
+scafctl build solution -f examples/resolver-demo.yaml --version 1.0.0
 
 # Verify it's in the local catalog
 scafctl catalog list
@@ -82,7 +82,7 @@ jobs:
       - name: Build and Push
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          scafctl build solution solution.yaml --version $VERSION
+          scafctl build solution -f solution.yaml --version $VERSION
           scafctl catalog push my-solution@$VERSION --catalog ghcr.io/${{ github.repository_owner }}/scafctl
 ```
 

--- a/examples/soldiff/solution-v1.yaml
+++ b/examples/soldiff/solution-v1.yaml
@@ -6,10 +6,10 @@
 #
 # Usage:
 #   # Compare the two solutions
-#   scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
+#   scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
 #
 #   # Output as JSON
-#   scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml -o json
+#   scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/soldiff/solution-v2.yaml
+++ b/examples/soldiff/solution-v2.yaml
@@ -5,7 +5,7 @@
 # updated action. Compare against solution-v1.yaml to see the diff.
 #
 # Usage:
-#   scafctl solution diff examples/soldiff/solution-v1.yaml examples/soldiff/solution-v2.yaml
+#   scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/solutions/catalog-cwd/solution.yaml
+++ b/examples/solutions/catalog-cwd/solution.yaml
@@ -6,7 +6,7 @@
 #
 # Build into local catalog:
 #   cd examples/solutions/catalog-cwd
-#   scafctl build solution solution.yaml --version 1.0.0
+#   scafctl build solution -f solution.yaml --version 1.0.0
 #
 # Run from any directory (files land in your current directory):
 #   mkdir /tmp/my-project && cd /tmp/my-project

--- a/examples/solutions/nested-bundle/parent.yaml
+++ b/examples/solutions/nested-bundle/parent.yaml
@@ -18,7 +18,7 @@
 #   scafctl run resolver -f examples/solutions/nested-bundle/parent.yaml
 #
 # Bundle build (includes all nested files automatically):
-#   scafctl build solution examples/solutions/nested-bundle/parent.yaml --dry-run
+#   scafctl build solution -f examples/solutions/nested-bundle/parent.yaml --dry-run
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 	}
 
 	cmd := &cobra.Command{
-		Use:          "solution [file]",
+		Use:          "solution",
 		Aliases:      []string{"sol", "s"},
 		Short:        "Build a solution into the local catalog",
 		SilenceUsage: true,
@@ -79,31 +80,45 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 			Use --dry-run to see what would be bundled without storing.
 
 			Examples:
-			  # Build solution using version from metadata
-			  scafctl build solution ./my-solution.yaml
+			  # Build solution using version from metadata (auto-discovery)
+			  scafctl build solution
+
+			  # Build solution from a specific file
+			  scafctl build solution -f ./my-solution.yaml
 
 			  # Build with explicit version (overrides metadata)
-			  scafctl build solution ./solution.yaml --version 1.0.0
+			  scafctl build solution -f ./solution.yaml --version 1.0.0
 
 			  # Build with explicit name
-			  scafctl build solution ./solution.yaml --name my-solution --version 1.0.0
+			  scafctl build solution -f ./solution.yaml --name my-solution --version 1.0.0
 
 			  # Overwrite existing version
-			  scafctl build solution ./solution.yaml --version 1.0.0 --force
+			  scafctl build solution -f ./solution.yaml --version 1.0.0 --force
 
 			  # Preview what would be bundled
-			  scafctl build solution ./solution.yaml --dry-run
+			  scafctl build solution -f ./solution.yaml --dry-run
 
 			  # Build without bundling
-			  scafctl build solution ./solution.yaml --no-bundle
+			  scafctl build solution -f ./solution.yaml --no-bundle
 		`),
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			options.File = args[0]
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if options.File == "" {
+				getter := get.NewGetter()
+				options.File = getter.FindSolution()
+				if options.File == "" {
+					err := fmt.Errorf("no -f/--file specified and no solution file found in default locations")
+					if w := writer.FromContext(cmd.Context()); w != nil {
+						w.Errorf("%v", err)
+					}
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+			}
 			return runBuildSolution(cmd.Context(), options)
 		},
 	}
 
+	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Path to the solution file (auto-discovered if not provided)")
 	cmd.Flags().StringVar(&options.Name, "name", "", "Artifact name (default: extracted from solution metadata)")
 	cmd.Flags().StringVar(&options.Version, "version", "", "Semantic version (default: extracted from solution metadata)")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Overwrite existing version")

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -26,7 +26,7 @@ func TestCommandBuildSolution_Structure(t *testing.T) {
 
 	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
 
-	assert.Equal(t, "solution [file]", cmd.Use)
+	assert.Equal(t, "solution", cmd.Use)
 	assert.Contains(t, cmd.Aliases, "sol")
 	assert.Contains(t, cmd.Aliases, "s")
 	assert.Contains(t, cmd.Short, "Build a solution")
@@ -75,7 +75,7 @@ func TestCommandBuildSolution_RequiresArgs(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg")
+	assert.Contains(t, err.Error(), "no -f/--file specified")
 }
 
 func TestRunBuildSolution_FileNotFound(t *testing.T) {

--- a/pkg/cmd/scafctl/explain/explain_test.go
+++ b/pkg/cmd/scafctl/explain/explain_test.go
@@ -33,7 +33,7 @@ func TestCommandExplain(t *testing.T) {
 		// Has solution subcommand for explaining specific solution instances
 		subCmds := cmd.Commands()
 		assert.Len(t, subCmds, 1)
-		assert.Equal(t, "solution [path]", subCmds[0].Use)
+		assert.Equal(t, "solution [name[@version]]", subCmds[0].Use)
 	})
 
 	t.Run("explain command requires kind argument", func(t *testing.T) {

--- a/pkg/cmd/scafctl/explain/solution.go
+++ b/pkg/cmd/scafctl/explain/solution.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ import (
 type SolutionOptions struct {
 	IOStreams *terminal.IOStreams
 	CliParams *settings.Run
-	Path      string
+	File      string
 }
 
 // CommandSolution creates the 'explain solution' subcommand
@@ -26,7 +28,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	options := &SolutionOptions{}
 
 	cCmd := &cobra.Command{
-		Use:     "solution [path]",
+		Use:     "solution [name[@version]]",
 		Aliases: []string{"solutions", "sol", "s"},
 		Short:   "Explain a solution's metadata and structure",
 		Long: `Show detailed documentation for a solution including its metadata,
@@ -39,24 +41,40 @@ The output includes:
   - Required parameters summary
   - Catalog and visibility information
 
+Solutions can be loaded from:
+  - Catalog name or remote registry ref: Use as positional argument (e.g., "my-app")
+  - URL: Use as positional argument or with -f/--file (e.g., "https://example.com/my-solution.yaml")
+  - Local file: Use -f/--file flag (e.g., -f ./my-solution.yaml)
+  - Auto-discovery: If no source is specified, searches for solution.yaml
+
+NOTE: Positional arguments accept catalog names, remote registry refs, and URLs.
+Local file paths must use -f/--file.
+
 Examples:
   # Explain a solution from a file
-  scafctl explain solution ./my-solution.yaml
+  scafctl explain solution -f ./my-solution.yaml
+
+  # Explain a solution from catalog
+  scafctl explain solution my-app
 
   # Explain using default file discovery
-  scafctl explain solution
-
-  # Explain a solution from a URL
-  scafctl explain solution https://example.com/solution.yaml`,
+  scafctl explain solution`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cCmd *cobra.Command, args []string) error {
-			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Name())
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
 
+			w := writer.New(ioStreams, cliParams)
+
 			if len(args) > 0 {
-				options.Path = args[0]
+				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl explain solution"); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				options.File = args[0]
 			}
 
 			return options.Run(ctx)
@@ -64,7 +82,7 @@ Examples:
 		SilenceUsage: true,
 	}
 
-	cCmd.Flags().StringVarP(&options.Path, "path", "p", "", "Path to the solution file (local file or URL)")
+	cCmd.Flags().StringVarP(&options.File, "file", "f", "", "Path to the solution file (local file, URL, or '-' for stdin)")
 
 	return cCmd
 }
@@ -73,7 +91,7 @@ Examples:
 func (o *SolutionOptions) Run(ctx context.Context) error {
 	w := writer.New(o.IOStreams, o.CliParams)
 
-	sol, err := LoadSolution(ctx, o.Path)
+	sol, err := LoadSolution(ctx, o.File)
 	if err != nil {
 		w.Errorf("%v", err)
 		return err

--- a/pkg/cmd/scafctl/explain/solution_test.go
+++ b/pkg/cmd/scafctl/explain/solution_test.go
@@ -43,7 +43,7 @@ func TestCommandSolution(t *testing.T) {
 
 		cmd := CommandSolution(cliParams, ioStreams, "scafctl/explain")
 
-		assert.Equal(t, "solution [path]", cmd.Use)
+		assert.Equal(t, "solution [name[@version]]", cmd.Use)
 		assert.Contains(t, cmd.Aliases, "solutions")
 		assert.Contains(t, cmd.Aliases, "sol")
 		assert.Contains(t, cmd.Aliases, "s")
@@ -51,7 +51,7 @@ func TestCommandSolution(t *testing.T) {
 		assert.NotEmpty(t, cmd.Long)
 	})
 
-	t.Run("has path flag", func(t *testing.T) {
+	t.Run("has file flag", func(t *testing.T) {
 		outBuf := &bytes.Buffer{}
 		errBuf := &bytes.Buffer{}
 		ioStreams := &terminal.IOStreams{
@@ -62,9 +62,9 @@ func TestCommandSolution(t *testing.T) {
 
 		cmd := CommandSolution(cliParams, ioStreams, "scafctl/explain")
 
-		flag := cmd.Flags().Lookup("path")
+		flag := cmd.Flags().Lookup("file")
 		require.NotNil(t, flag)
-		assert.Equal(t, "p", flag.Shorthand)
+		assert.Equal(t, "f", flag.Shorthand)
 	})
 }
 
@@ -298,7 +298,7 @@ func TestSolutionOptions_Run_WithMock(t *testing.T) {
 		options := &SolutionOptions{
 			IOStreams: ioStreams,
 			CliParams: &settings.Run{NoColor: true},
-			Path:      "/path/to/solution.yaml",
+			File:      "/path/to/solution.yaml",
 		}
 
 		// Note: We can't easily inject the getter into Run() without refactoring,

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -30,18 +30,19 @@ type CmdOptionsVersion struct {
 	IOStreams *terminal.IOStreams
 	CliParams *settings.Run
 	Output    string
-	Path      string
+	File      string
 	NoCache   bool
 }
 
 func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	options := &CmdOptionsVersion{}
 	cCmd := &cobra.Command{
-		Use:     "solution",
+		Use:     "solution [name[@version]]",
 		Aliases: []string{"sol", "SOL", "Solution", "solutions"},
 		Short:   fmt.Sprintf("Gets %s solutions", settings.CliBinaryName),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cCmd *cobra.Command, args []string) error {
-			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Name())
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
 
 			lgr := logger.FromContext(ctx)
@@ -50,19 +51,21 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
 
-			err := output.ValidateCommands(args)
-			if err != nil {
-				output.NewWriteMessageOptions(
-					options.IOStreams,
-					output.MessageTypeError,
-					options.CliParams.NoColor,
-					options.CliParams.ExitOnError,
-				).WriteMessage(err.Error())
-
-				return exitcode.WithCode(err, exitcode.InvalidInput)
+			// Handle positional catalog name argument
+			if len(args) > 0 {
+				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl get solution"); err != nil {
+					output.NewWriteMessageOptions(
+						options.IOStreams,
+						output.MessageTypeError,
+						options.CliParams.NoColor,
+						options.CliParams.ExitOnError,
+					).WriteMessage(err.Error())
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				options.File = args[0]
 			}
 
-			err = output.ValidateOutputType(options.Output, ValidOutputTypes)
+			err := output.ValidateOutputType(options.Output, ValidOutputTypes)
 			if err != nil {
 				output.NewWriteMessageOptions(
 					options.IOStreams,
@@ -78,7 +81,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		SilenceUsage: true,
 	}
 	cCmd.PersistentFlags().StringVarP(&options.Output, "output", "o", "", fmt.Sprintf("Output format. One of: (%s)", strings.Join(ValidOutputTypes, ", ")))
-	cCmd.PersistentFlags().StringVarP(&options.Path, "path", "p", "", "Path to the solution. This can be a local file path or a URL. If not provided, the command will attempt to locate a solution file in default locations.")
+	cCmd.PersistentFlags().StringVarP(&options.File, "file", "f", "", "Path to the solution. This can be a local file path or a URL. If not provided, the command will attempt to locate a solution file in default locations.")
 	cCmd.PersistentFlags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
 	return cCmd
 }
@@ -113,7 +116,7 @@ func (o *CmdOptionsVersion) GetSolution(ctx context.Context) error {
 func (o *CmdOptionsVersion) GetSolutionWithGetter(ctx context.Context, getter get.Interface) error {
 	w := writer.FromContext(ctx)
 
-	sol, err := getter.Get(ctx, o.Path)
+	sol, err := getter.Get(ctx, o.File)
 	if err != nil {
 		if w != nil {
 			w.Errorf("%v", err)

--- a/pkg/cmd/scafctl/get/solution/solution_test.go
+++ b/pkg/cmd/scafctl/get/solution/solution_test.go
@@ -47,7 +47,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "json",
-			Path:   "/path/to/solution.yaml",
+			File:   "/path/to/solution.yaml",
 		}
 
 		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
@@ -84,7 +84,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "yaml",
-			Path:   "https://example.com/solution.yaml",
+			File:   "https://example.com/solution.yaml",
 		}
 
 		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
@@ -121,7 +121,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "json",
-			Path:   "",
+			File:   "",
 		}
 
 		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
@@ -152,7 +152,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "json",
-			Path:   "/invalid/path",
+			File:   "/invalid/path",
 		}
 
 		w := writer.New(ioStreams, options.CliParams)
@@ -194,7 +194,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "json",
-			Path:   "/path/to/solution.yaml",
+			File:   "/path/to/solution.yaml",
 		}
 
 		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
@@ -236,7 +236,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 			IOStreams: ioStreams,
 			CliParams: cliParams,
 			Output:    "json",
-			Path:      "/path/to/solution.yaml",
+			File:      "/path/to/solution.yaml",
 		}
 
 		err := options.GetSolutionWithGetter(ctx, mockGetter)
@@ -274,7 +274,7 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "yaml",
-			Path:   "/path/to/complex.yaml",
+			File:   "/path/to/complex.yaml",
 		}
 
 		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
@@ -303,10 +303,74 @@ func TestCmdOptionsVersion_GetSolution(t *testing.T) {
 				NoColor: true,
 			},
 			Output: "json",
-			Path:   "/nonexistent/solution.yaml",
+			File:   "/nonexistent/solution.yaml",
 		}
 
 		err := options.GetSolution(context.Background())
 		require.Error(t, err)
 	})
+}
+
+// TestCommandSolution_Validation tests the RunE validation branches in CommandSolution:
+// positional path rejection, -f+positional conflict, and invalid output type.
+func TestCommandSolution_Validation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "rejects relative path as positional arg",
+			args:    []string{"./solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "rejects yaml extension as positional arg",
+			args:    []string{"solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "rejects absolute path as positional arg",
+			args:    []string{"/tmp/my-solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "rejects both -f and positional arg",
+			args:    []string{"-f", "solution.yaml", "my-catalog"},
+			wantErr: "cannot use both -f/--file",
+		},
+		{
+			name:    "rejects invalid output type",
+			args:    []string{"-f", "solution.yaml", "-o", "xml"},
+			wantErr: "xml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outBuf := &bytes.Buffer{}
+			errBuf := &bytes.Buffer{}
+			ioStreams := &terminal.IOStreams{Out: outBuf, ErrOut: errBuf}
+			cliParams := &settings.Run{NoColor: true}
+			cmd := CommandSolution(cliParams, ioStreams, "get")
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			// Error may be in err.Error() or written to stderr
+			combinedOutput := err.Error() + errBuf.String()
+			assert.Contains(t, combinedOutput, tc.wantErr)
+		})
+	}
+}
+
+func BenchmarkCommandSolution_Structure(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandSolution(cliParams, ioStreams, "get")
+	}
 }

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -84,7 +84,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	options := &SolutionOptions{}
 
 	cCmd := &cobra.Command{
-		Use:     "solution",
+		Use:     "solution [name[@version]]",
 		Aliases: []string{"sol", "s", "solutions"},
 		Short:   "Render a solution's action graph or snapshot",
 		Long: `Render a solution as an executor-ready action graph or snapshot.
@@ -128,8 +128,12 @@ Examples:
   # Save snapshot with sensitive data redacted
   scafctl render solution -f ./solution.yaml --snapshot --snapshot-file=snapshot.json --redact
 
+  # Render solution from catalog by name
+  scafctl render solution my-app
+
   # Render with parameters
   scafctl render solution -f ./solution.yaml -r env=prod`,
+		Args: cobra.MaximumNArgs(1),
 		PreRun: func(cCmd *cobra.Command, _ []string) {
 			// Track which flags were explicitly set by the user
 			options.flagsChanged = make(map[string]bool)
@@ -138,7 +142,7 @@ Examples:
 			})
 		},
 		RunE: func(cCmd *cobra.Command, args []string) error {
-			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Name())
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
 
 			lgr := logger.FromContext(cCmd.Context())
@@ -154,10 +158,13 @@ Examples:
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
 
-			err := output.ValidateCommands(args)
-			if err != nil {
-				writeSolutionError(options, err.Error())
-				return exitcode.WithCode(err, exitcode.InvalidInput)
+			// Handle positional catalog name argument
+			if len(args) > 0 {
+				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl render solution"); err != nil {
+					writeSolutionError(options, err.Error())
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				options.File = args[0]
 			}
 
 			// Validate mutually exclusive modes
@@ -193,7 +200,7 @@ Examples:
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 			if options.Output != "" && !options.ActionGraph {
-				err = output.ValidateOutputType(options.Output, ValidOutputTypes)
+				err := output.ValidateOutputType(options.Output, ValidOutputTypes)
 				if err != nil {
 					writeSolutionError(options, err.Error())
 					return exitcode.WithCode(err, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/render/solution_test.go
+++ b/pkg/cmd/scafctl/render/solution_test.go
@@ -35,7 +35,7 @@ func TestCommandSolution(t *testing.T) {
 				cliParams := &settings.Run{}
 				cmd := CommandSolution(cliParams, ioStreams, "render")
 
-				assert.Equal(t, "solution", cmd.Use)
+				assert.Equal(t, "solution [name[@version]]", cmd.Use)
 				assert.Contains(t, cmd.Aliases, "sol")
 				assert.Contains(t, cmd.Aliases, "s")
 				assert.Contains(t, cmd.Aliases, "solutions")
@@ -518,4 +518,67 @@ func TestSolutionOptions_ModeValidation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+// TestCommandSolution_PositionalArgValidation covers the ValidatePositionalRef
+// branches added by the -f/--file standardisation work.
+func TestCommandSolution_PositionalArgValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "relative path rejected",
+			args:    []string{"./solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "yaml extension rejected",
+			args:    []string{"solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "absolute path rejected",
+			args:    []string{"/tmp/solution.yaml"},
+			wantErr: "local file paths must use -f/--file flag",
+		},
+		{
+			name:    "both -f and positional arg rejected",
+			args:    []string{"-f", "solution.yaml", "my-catalog-app"},
+			wantErr: "cannot use both -f/--file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ioStreams, _, _ := terminal.NewTestIOStreams()
+			cliParams := &settings.Run{}
+			cmd := CommandSolution(cliParams, ioStreams, "render")
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCommandSolution_InvalidOutputFormat(t *testing.T) {
+	t.Parallel()
+	solutionFile := "../../../../tests/integration/solutions/actions/auto-deps/solution.yaml"
+	if _, err := os.Stat(solutionFile); err != nil {
+		t.Skip("test fixture not available")
+	}
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := &settings.Run{}
+	cmd := CommandSolution(cliParams, ioStreams, "render")
+	cmd.SetArgs([]string{"-f", solutionFile, "-o", "invalid-format"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid-format")
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -63,6 +63,10 @@ type ResolverOptions struct {
 	// DynamicArgs are resolver parameters from positional key=value syntax
 	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
 	DynamicArgs []string
+
+	// positionalPathErr is set in PreRun when the user passes a local file
+	// path as a positional argument instead of using -f/--file.
+	positionalPathErr error
 }
 
 // CommandResolver creates the 'run resolver' subcommand
@@ -263,8 +267,8 @@ Examples:
 			// Split positional args: bare words are resolver names,
 			// args containing '=' or starting with '@' are dynamic parameters.
 			// When -f/--file is not explicitly set, the first bare word is
-			// treated as the solution reference (catalog name, file path, etc.),
-			// matching "run solution" behavior.
+			// treated as the solution reference (catalog name or registry ref).
+			// Local file paths must use -f/--file.
 			fileExplicit := options.flagsChanged["file"]
 			for _, arg := range args {
 				switch {
@@ -275,8 +279,13 @@ Examples:
 				case strings.Contains(arg, "=") || strings.HasPrefix(arg, "@"):
 					options.DynamicArgs = append(options.DynamicArgs, arg)
 				case !fileExplicit && options.File == "":
-					// First bare word becomes the solution reference
-					options.File = arg
+					// First bare word becomes the solution reference — must be
+					// a catalog name or registry ref, not a local file path.
+					if err := get.ValidatePositionalRef(arg, "", "scafctl run resolver"); err != nil {
+						options.positionalPathErr = err
+					} else {
+						options.File = arg
+					}
 					fileExplicit = true // only the first one
 				default:
 					options.Names = append(options.Names, arg)
@@ -306,6 +315,11 @@ Examples:
 
 // Run executes the resolver-only flow
 func (o *ResolverOptions) Run(ctx context.Context) error {
+	// Fail early if PreRun detected a local file path as positional arg
+	if o.positionalPathErr != nil {
+		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)
+	}
+
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("running resolver",
 		"file", o.File,

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -24,6 +24,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -59,6 +60,10 @@ type SolutionOptions struct {
 
 	// Backup enables .bak backup creation before mutating existing files.
 	Backup bool
+
+	// positionalPathErr is set in PreRun when the user passes a local file
+	// path as a positional argument instead of using -f/--file.
+	positionalPathErr error
 }
 
 // CommandSolution creates the 'run solution' subcommand
@@ -86,10 +91,14 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Long: `Execute a solution by running resolvers and then actions in dependency order.
 
 Solutions can be loaded from:
-- Local catalog: Use the solution name (e.g., "my-app" or "my-app@1.2.3")
-- Local file: Use -f flag or provide a path with separators (e.g., "./solution.yaml")
-- URL: Use -f flag with an HTTP(S) URL
+- Local catalog: Use the solution name as a positional argument (e.g., "my-app" or "my-app@1.2.3")
+- Local file: Use -f/--file flag (e.g., -f ./solution.yaml)
+- Stdin: Use -f - to read from stdin
+- URL: Use an HTTP(S) URL either as a positional argument or with -f/--file
 - Auto-discovery: If no source is specified, searches for solution.yaml in current directory
+
+NOTE: Positional arguments accept catalog names, remote registry refs, and URLs.
+Local file paths must use -f/--file.
 
 The solution MUST define a workflow with actions. If no workflow is defined,
 the command will error and suggest using 'scafctl run resolver' instead.
@@ -178,10 +187,15 @@ Examples:
 			cCmd.Flags().Visit(func(f *pflag.Flag) {
 				options.flagsChanged[f.Name] = true
 			})
-			// If a positional argument is provided (solution name), use it as the file
-			// unless -f/--file was explicitly set
-			if len(args) > 0 && options.File == "" {
-				options.File = args[0]
+			// If a positional argument is provided, it must be a catalog/registry
+			// reference. Local file paths require -f/--file. Providing both
+			// -f/--file and a positional arg is also an error.
+			if len(args) > 0 {
+				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl run solution"); err != nil {
+					options.positionalPathErr = err
+				} else {
+					options.File = args[0]
+				}
 			}
 		},
 		RunE:         makeRunEFunc(cfg, "solution"),
@@ -250,6 +264,11 @@ func (o *SolutionOptions) getEffectiveActionConfig(ctx context.Context) config.A
 
 // Run executes the solution
 func (o *SolutionOptions) Run(ctx context.Context) error {
+	// Fail early if PreRun detected a local file path as positional arg
+	if o.positionalPathErr != nil {
+		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	// Apply config default for output-dir when the CLI flag wasn't explicitly set

--- a/pkg/cmd/scafctl/solution/diff.go
+++ b/pkg/cmd/scafctl/solution/diff.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/lipgloss"
@@ -14,9 +16,11 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/soldiff"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,17 +34,21 @@ var (
 
 // DiffOptions holds options for the solution diff command.
 type DiffOptions struct {
-	FileA  string
-	FileB  string
+	Files  []string
 	Output string
 }
 
+// diffSource represents one of the two solutions to compare.
+type diffSource struct {
+	Value string // Path or catalog name
+}
+
 // CommandDiff creates the solution diff subcommand.
-func CommandDiff(_ *settings.Run, ioStreams terminal.IOStreams, binaryName string) *cobra.Command {
+func CommandDiff(cliParams *settings.Run, ioStreams terminal.IOStreams, binaryName string) *cobra.Command {
 	opts := &DiffOptions{}
 
 	cmd := &cobra.Command{
-		Use:          "diff [solution-a] [solution-b]",
+		Use:          "diff [catalog-ref-a] [catalog-ref-b]",
 		Short:        "Compare two solution files structurally",
 		SilenceUsage: true,
 		Long: heredoc.Doc(`
@@ -49,6 +57,13 @@ func CommandDiff(_ *settings.Run, ioStreams terminal.IOStreams, binaryName strin
 			Unlike text-based diff, this understands the solution schema and
 			reports meaningful changes to metadata, resolvers, actions,
 			and test cases.
+
+			Solutions can be specified using:
+			  - -f/--file for local file paths (repeatable, up to 2)
+			  - Positional arguments for catalog names, remote registry refs, and URLs
+
+			These can be combined in any order. The first source on the command
+			line becomes solution A, the second becomes solution B.
 
 			This is useful for:
 			  - Code review: See structural impact of YAML changes
@@ -62,35 +77,159 @@ func CommandDiff(_ *settings.Run, ioStreams terminal.IOStreams, binaryName strin
 			  - yaml: Machine-readable YAML
 		`),
 		Example: heredoc.Docf(`
-			# Compare two solutions
-			$ %[1]s solution diff solution-v1.yaml solution-v2.yaml
+			# Compare two local files
+			$ %[1]s solution diff -f solution-v1.yaml -f solution-v2.yaml
+
+			# Compare two catalog versions
+			$ %[1]s solution diff my-app@1.0.0 my-app@2.0.0
+
+			# Compare a local file with a catalog version
+			$ %[1]s solution diff -f modified.yaml my-app@1.0.0
 
 			# Output as JSON
-			$ %[1]s solution diff solution-v1.yaml solution-v2.yaml -o json
+			$ %[1]s solution diff -f solution-v1.yaml -f solution-v2.yaml -o json
 
 			# Output as YAML
-			$ %[1]s solution diff solution-v1.yaml solution-v2.yaml -o yaml
+			$ %[1]s solution diff -f solution-v1.yaml -f solution-v2.yaml -o yaml
 		`, binaryName),
-		Args: cobra.ExactArgs(2),
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.FileA = args[0]
-			opts.FileB = args[1]
-			return runDiff(cmd.Context(), opts, ioStreams)
+			// Ensure Writer is available in the context for output methods.
+			ctx := cmd.Context()
+			if writer.FromContext(ctx) == nil {
+				ctx = writer.WithWriter(ctx, writer.New(&ioStreams, cliParams))
+				cmd.SetContext(ctx)
+			}
+
+			w := writer.FromContext(ctx)
+
+			// Validate positional args are catalog references
+			for _, arg := range args {
+				if err := get.ValidatePositionalRef(arg, "", "scafctl solution diff"); err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+			}
+
+			totalSources := len(opts.Files) + len(args)
+			if totalSources != 2 {
+				err := fmt.Errorf("exactly 2 sources required (got %d); use -f for local files and positional args for catalog/registry refs", totalSources)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Resolve slot ordering by walking os.Args to preserve the
+			// user's intended A→B ordering when mixing -f and positional args.
+			sources := resolveDiffSlotOrder(os.Args, cmd.Flags(), opts.Files, args)
+
+			return runDiff(cmd.Context(), sources[0].Value, sources[1].Value, opts.Output)
 		},
 	}
 
+	cmd.Flags().StringArrayVarP(&opts.Files, "file", "f", nil, "Local solution file path (repeatable, up to 2)")
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, yaml")
 
 	return cmd
 }
 
-func runDiff(ctx context.Context, opts *DiffOptions, ioStreams terminal.IOStreams) error {
+// resolveDiffSlotOrder determines the declaration order of -f flags and
+// positional args, producing an ordered [2]diffSource slice that maps to
+// solution A and B respectively. It uses the FlagSet to auto-discover
+// value-bearing flags, avoiding a hard-coded maintenance list.
+//
+// Falls back to files-first ordering when osArgs cannot be parsed
+// (e.g., in unit tests using cmd.SetArgs).
+func resolveDiffSlotOrder(osArgs []string, flags *pflag.FlagSet, flagFiles, positionalArgs []string) []diffSource {
+	// Fast path: no mixing — ordering is trivial.
+	if len(flagFiles) == 2 {
+		return []diffSource{{Value: flagFiles[0]}, {Value: flagFiles[1]}}
+	}
+	if len(positionalArgs) == 2 {
+		return []diffSource{{Value: positionalArgs[0]}, {Value: positionalArgs[1]}}
+	}
+
+	// Mixed mode: walk osArgs to determine declaration order.
+	sources := make([]diffSource, 0, len(flagFiles)+len(positionalArgs))
+	fileIdx, posIdx := 0, 0
+
+	// Find the start of our args: skip past "diff" subcommand token.
+	startIdx := 0
+	for i, arg := range osArgs {
+		if arg == "diff" {
+			startIdx = i + 1
+			break
+		}
+	}
+
+	for i := startIdx; i < len(osArgs); i++ {
+		arg := osArgs[i]
+		switch {
+		case (arg == "-f" || arg == "--file") && i+1 < len(osArgs):
+			if fileIdx < len(flagFiles) {
+				sources = append(sources, diffSource{Value: flagFiles[fileIdx]})
+				fileIdx++
+			}
+			i++ // skip the value token
+		case strings.HasPrefix(arg, "-f=") || strings.HasPrefix(arg, "--file="):
+			if fileIdx < len(flagFiles) {
+				sources = append(sources, diffSource{Value: flagFiles[fileIdx]})
+				fileIdx++
+			}
+		case strings.HasPrefix(arg, "-"):
+			// Skip non-file flags. Use the FlagSet to determine whether
+			// the flag consumes a value token (NoOptDefVal == "").
+			name := strings.TrimLeft(arg, "-")
+			if strings.ContainsRune(name, '=') {
+				break // value is inline, nothing to skip
+			}
+			// Use ShorthandLookup for single-character names (e.g. "-o")
+			// because Lookup("o") resolves long names only and returns nil
+			// for shorthands, causing their value token to be misread as a
+			// positional argument.
+			var f *pflag.Flag
+			if len(name) == 1 {
+				f = flags.ShorthandLookup(name)
+			} else {
+				f = flags.Lookup(name)
+			}
+			if f != nil && f.NoOptDefVal == "" {
+				i++ // flag takes a value, skip the next token
+			}
+		default:
+			// Positional arg
+			if posIdx < len(positionalArgs) && arg == positionalArgs[posIdx] {
+				sources = append(sources, diffSource{Value: positionalArgs[posIdx]})
+				posIdx++
+			}
+		}
+	}
+
+	if len(sources) == 2 {
+		return sources
+	}
+
+	return filesThenPositional(flagFiles, positionalArgs)
+}
+
+// filesThenPositional returns sources ordered files-first, then positional args.
+func filesThenPositional(flagFiles, positionalArgs []string) []diffSource {
+	sources := make([]diffSource, 0, len(flagFiles)+len(positionalArgs))
+	for _, f := range flagFiles {
+		sources = append(sources, diffSource{Value: f})
+	}
+	for _, p := range positionalArgs {
+		sources = append(sources, diffSource{Value: p})
+	}
+	return sources
+}
+
+func runDiff(ctx context.Context, refA, refB, outputFmt string) error {
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
 
-	lgr.V(-1).Info("comparing solutions", "fileA", opts.FileA, "fileB", opts.FileB)
+	lgr.V(-1).Info("comparing solutions", "refA", refA, "refB", refB)
 
-	result, err := soldiff.CompareFiles(ctx, opts.FileA, opts.FileB)
+	result, err := soldiff.CompareFiles(ctx, refA, refB)
 	if err != nil {
 		if w != nil {
 			w.Errorf("%v", err)
@@ -98,30 +237,28 @@ func runDiff(ctx context.Context, opts *DiffOptions, ioStreams terminal.IOStream
 		return exitcode.WithCode(fmt.Errorf("diff failed: %w", err), exitcode.FileNotFound)
 	}
 
-	switch opts.Output {
+	switch outputFmt {
 	case "json":
-		enc := json.NewEncoder(ioStreams.Out)
+		out := w.IOStreams().Out
+		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(result); err != nil {
 			return exitcode.WithCode(fmt.Errorf("failed to encode JSON: %w", err), exitcode.GeneralError)
 		}
 
 	case "yaml":
-		enc := yaml.NewEncoder(ioStreams.Out)
+		out := w.IOStreams().Out
+		enc := yaml.NewEncoder(out)
 		enc.SetIndent(2)
 		if err := enc.Encode(result); err != nil {
 			return exitcode.WithCode(fmt.Errorf("failed to encode YAML: %w", err), exitcode.GeneralError)
 		}
 
 	case "table":
-		noColor := false
-		if w != nil {
-			noColor = w.CliParams().NoColor
-		}
-		formatHuman(ioStreams, result, noColor)
+		formatHuman(w, result)
 
 	default:
-		err := fmt.Errorf("unsupported output format: %s (supported: table, json, yaml)", opts.Output)
+		err := fmt.Errorf("unsupported output format: %s (supported: table, json, yaml)", outputFmt)
 		if w != nil {
 			w.Errorf("%v", err)
 		}
@@ -131,38 +268,37 @@ func runDiff(ctx context.Context, opts *DiffOptions, ioStreams terminal.IOStream
 	return nil
 }
 
-func formatHuman(ioStreams terminal.IOStreams, result *soldiff.Result, noColor bool) {
-	out := ioStreams.Out
-
+func formatHuman(w *writer.Writer, result *soldiff.Result) {
 	render := func(s lipgloss.Style, text string) string {
-		if noColor {
+		if w.NoColor() {
 			return text
 		}
 		return s.Render(text)
 	}
 
-	fmt.Fprintf(out, "%s\n\n", render(headerStyle, fmt.Sprintf("Solution Diff: %s ↔ %s", result.PathA, result.PathB)))
+	w.Plainlnf("%s", render(headerStyle, fmt.Sprintf("Solution Diff: %s ↔ %s", result.PathA, result.PathB)))
+	w.Plainln("")
 
 	if len(result.Changes) == 0 {
-		fmt.Fprintln(out, "No structural differences found.")
+		w.Plainln("No structural differences found.")
 		return
 	}
 
-	fmt.Fprintf(out, "%s\n", render(headerStyle, fmt.Sprintf("Changes (%d):", result.Summary.Total)))
+	w.Plainlnf("%s", render(headerStyle, fmt.Sprintf("Changes (%d):", result.Summary.Total)))
 	for _, c := range result.Changes {
 		switch c.Type {
 		case "added":
-			fmt.Fprintf(out, "  %s %s\n", render(addedStyle, "+ added   "), c.Field)
+			w.Plainlnf("  %s %s", render(addedStyle, "+ added   "), c.Field)
 		case "removed":
-			fmt.Fprintf(out, "  %s %s\n", render(removedStyle, "- removed "), c.Field)
+			w.Plainlnf("  %s %s", render(removedStyle, "- removed "), c.Field)
 		case "changed":
-			fmt.Fprintf(out, "  %s %s: %s → %s\n", render(changedStyle, "~ changed "), c.Field, render(removedStyle, fmt.Sprintf("%q", fmtValue(c.OldValue))), render(addedStyle, fmt.Sprintf("%q", fmtValue(c.NewValue))))
+			w.Plainlnf("  %s %s: %s → %s", render(changedStyle, "~ changed "), c.Field, render(removedStyle, fmt.Sprintf("%q", fmtValue(c.OldValue))), render(addedStyle, fmt.Sprintf("%q", fmtValue(c.NewValue))))
 		}
 	}
 
 	summary := fmt.Sprintf("\nSummary: %d total | %d added | %d removed | %d changed",
 		result.Summary.Total, result.Summary.Added, result.Summary.Removed, result.Summary.Changed)
-	fmt.Fprintln(out, render(summaryStyle, summary))
+	w.Plainln(render(summaryStyle, summary))
 }
 
 func fmtValue(v any) string {

--- a/pkg/cmd/scafctl/solution/diff_test.go
+++ b/pkg/cmd/scafctl/solution/diff_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +85,7 @@ func TestCommandDiff_TableOutput(t *testing.T) {
 
 	out, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, fileB})
+	cmd.SetArgs([]string{"-f", fileA, "-f", fileB})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -105,7 +106,7 @@ func TestCommandDiff_JSONOutput(t *testing.T) {
 
 	out, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, fileB, "-o", "json"})
+	cmd.SetArgs([]string{"-f", fileA, "-f", fileB, "-o", "json"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -126,7 +127,7 @@ func TestCommandDiff_YAMLOutput(t *testing.T) {
 
 	out, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, fileB, "-o", "yaml"})
+	cmd.SetArgs([]string{"-f", fileA, "-f", fileB, "-o", "yaml"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -144,7 +145,7 @@ func TestCommandDiff_InvalidFormat(t *testing.T) {
 
 	_, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, fileB, "-o", "invalid"})
+	cmd.SetArgs([]string{"-f", fileA, "-f", fileB, "-o", "invalid"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -157,7 +158,7 @@ func TestCommandDiff_MissingFile(t *testing.T) {
 
 	_, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, "/nonexistent/file.yaml"})
+	cmd.SetArgs([]string{"-f", fileA, "-f", "/nonexistent/file.yaml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -171,7 +172,7 @@ func TestCommandDiff_IdenticalSolutions(t *testing.T) {
 
 	out, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{fileA, fileB})
+	cmd.SetArgs([]string{"-f", fileA, "-f", fileB})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -183,7 +184,7 @@ func TestCommandDiff_WrongArgCount(t *testing.T) {
 	t.Parallel()
 	_, ioStreams := makeIOStreams()
 	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-	cmd.SetArgs([]string{"only-one.yaml"})
+	cmd.SetArgs([]string{"-f", "only-one.yaml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -213,11 +214,13 @@ func BenchmarkCommandDiff_Table(b *testing.B) {
 	require.NoError(b, os.WriteFile(fileA, []byte(solutionV1), 0o644))
 	require.NoError(b, os.WriteFile(fileB, []byte(solutionV2), 0o644))
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for b.Loop() {
 		out := &bytes.Buffer{}
 		ioStreams := terminal.IOStreams{In: os.Stdin, Out: out, ErrOut: out}
 		cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-		cmd.SetArgs([]string{fileA, fileB})
+		cmd.SetArgs([]string{"-f", fileA, "-f", fileB})
 		_ = cmd.Execute()
 	}
 }
@@ -229,11 +232,105 @@ func BenchmarkCommandDiff_JSON(b *testing.B) {
 	require.NoError(b, os.WriteFile(fileA, []byte(solutionV1), 0o644))
 	require.NoError(b, os.WriteFile(fileB, []byte(solutionV2), 0o644))
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for b.Loop() {
 		out := &bytes.Buffer{}
 		ioStreams := terminal.IOStreams{In: os.Stdin, Out: out, ErrOut: out}
 		cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
-		cmd.SetArgs([]string{fileA, fileB, "-o", "json"})
+		cmd.SetArgs([]string{"-f", fileA, "-f", fileB, "-o", "json"})
 		_ = cmd.Execute()
 	}
+}
+
+// ── resolveDiffSlotOrder tests ──────────────────────────────────────
+
+// newTestDiffFlags builds a FlagSet that mirrors the diff command's flags.
+func newTestDiffFlags() *pflag.FlagSet {
+	fs := pflag.NewFlagSet("diff", pflag.ContinueOnError)
+	fs.StringArrayP("file", "f", nil, "")
+	fs.StringP("output", "o", "table", "")
+	return fs
+}
+
+func TestResolveDiffSlotOrder(t *testing.T) {
+	fs := newTestDiffFlags()
+
+	tests := []struct {
+		name    string
+		osArgs  []string
+		files   []string
+		posArgs []string
+		wantA   string
+		wantB   string
+	}{
+		{
+			name:   "two -f flags",
+			osArgs: []string{"scafctl", "solution", "diff", "-f", "old.yaml", "-f", "new.yaml"},
+			files:  []string{"old.yaml", "new.yaml"},
+			wantA:  "old.yaml",
+			wantB:  "new.yaml",
+		},
+		{
+			name:    "two positional catalog refs",
+			osArgs:  []string{"scafctl", "solution", "diff", "my-app@1.0.0", "my-app@2.0.0"},
+			posArgs: []string{"my-app@1.0.0", "my-app@2.0.0"},
+			wantA:   "my-app@1.0.0",
+			wantB:   "my-app@2.0.0",
+		},
+		{
+			name:    "file first then catalog",
+			osArgs:  []string{"scafctl", "solution", "diff", "-f", "modified.yaml", "my-app@1.0.0"},
+			files:   []string{"modified.yaml"},
+			posArgs: []string{"my-app@1.0.0"},
+			wantA:   "modified.yaml",
+			wantB:   "my-app@1.0.0",
+		},
+		{
+			name:    "catalog first then file",
+			osArgs:  []string{"scafctl", "solution", "diff", "my-app@1.0.0", "-f", "modified.yaml"},
+			files:   []string{"modified.yaml"},
+			posArgs: []string{"my-app@1.0.0"},
+			wantA:   "my-app@1.0.0",
+			wantB:   "modified.yaml",
+		},
+		{
+			name:   "with output flag",
+			osArgs: []string{"scafctl", "solution", "diff", "-f", "a.yaml", "-f", "b.yaml", "-o", "json"},
+			files:  []string{"a.yaml", "b.yaml"},
+			wantA:  "a.yaml",
+			wantB:  "b.yaml",
+		},
+		{
+			// Regression: shorthand -o was not looked up via ShorthandLookup,
+			// so its value token could be misread as a positional source,
+			// inverting the A/B order when the catalog ref shared the flag value.
+			name:    "shorthand output flag before mixed file and catalog",
+			osArgs:  []string{"scafctl", "solution", "diff", "-o", "json", "-f", "a.yaml", "json"},
+			files:   []string{"a.yaml"},
+			posArgs: []string{"json"},
+			wantA:   "a.yaml",
+			wantB:   "json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources := resolveDiffSlotOrder(tt.osArgs, fs, tt.files, tt.posArgs)
+			require.Len(t, sources, 2)
+			assert.Equal(t, tt.wantA, sources[0].Value, "slot A")
+			assert.Equal(t, tt.wantB, sources[1].Value, "slot B")
+		})
+	}
+}
+
+func TestCommandDiff_RejectsPositionalFilePaths(t *testing.T) {
+	t.Parallel()
+	_, ioStreams := makeIOStreams()
+	cmd := CommandDiff(&settings.Run{}, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"./solution.yaml", "my-app@1.0.0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local file paths must use -f/--file flag")
 }

--- a/pkg/cmd/scafctl/solution/solution.go
+++ b/pkg/cmd/scafctl/solution/solution.go
@@ -26,11 +26,14 @@ func CommandSolution(cliParams *settings.Run, ioStreams terminal.IOStreams, bina
 		`),
 		Example: heredoc.Docf(`
 			# Compare two solution files
-			$ %s solution diff v1.yaml v2.yaml
+			$ %s solution diff -f v1.yaml -f v2.yaml
 
 			# Compare with JSON output
-			$ %s solution diff v1.yaml v2.yaml -o json
-		`, binaryName, binaryName),
+			$ %s solution diff -f v1.yaml -f v2.yaml -o json
+
+			# Compare catalog versions
+			$ %s solution diff my-app@1.0.0 my-app@2.0.0
+		`, binaryName, binaryName, binaryName),
 	}
 
 	cmd.AddCommand(CommandDiff(cliParams, ioStreams, binaryName))

--- a/pkg/cmd/scafctl/vendor/update.go
+++ b/pkg/cmd/scafctl/vendor/update.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -40,7 +41,7 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 	}
 
 	cmd := &cobra.Command{
-		Use:          "update [solution-path]",
+		Use:          "update",
 		Short:        "Update vendored dependencies",
 		SilenceUsage: true,
 		Long: heredoc.Doc(`
@@ -55,11 +56,11 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			Use --lock-only to update the lock file without re-vendoring files.
 
 			Examples:
-			  # Update all vendored dependencies
+			  # Update all vendored dependencies (auto-discover solution)
 			  scafctl vendor update
 
 			  # Update from a specific solution file
-			  scafctl vendor update ./my-solution.yaml
+			  scafctl vendor update -f ./my-solution.yaml
 
 			  # Preview updates without making changes
 			  scafctl vendor update --dry-run
@@ -70,17 +71,20 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			  # Update lock file only (don't re-vendor files)
 			  scafctl vendor update --lock-only
 		`),
-		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.SolutionPath = args[0]
-			} else {
-				opts.SolutionPath = "./solution.yaml"
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.SolutionPath == "" {
+				getter := get.NewGetter()
+				opts.SolutionPath = getter.FindSolution()
+				if opts.SolutionPath == "" {
+					opts.SolutionPath = "./solution.yaml"
+				}
 			}
 			return runVendorUpdate(cmd.Context(), opts)
 		},
 	}
 
+	cmd.Flags().StringVarP(&opts.SolutionPath, "file", "f", "", "Path to the solution file (auto-discovered if not provided)")
 	cmd.Flags().StringSliceVar(&opts.Dependencies, "dependency", nil, "Update only this dependency (repeatable)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be updated without making changes")
 	cmd.Flags().BoolVar(&opts.LockOnly, "lock-only", false, "Update lock file without re-vendoring files")
@@ -90,6 +94,20 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 }
 
 func runVendorUpdate(ctx context.Context, opts *UpdateOptions) error {
+	lgr := logger.FromContext(ctx)
+
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err != nil {
+		w := writer.FromContext(ctx)
+		w.Errorf("failed to open catalog: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	fetcher := &bundler.LocalCatalogFetcherAdapter{Catalog: localCatalog}
+	return runVendorUpdateWithFetcher(ctx, opts, fetcher)
+}
+
+func runVendorUpdateWithFetcher(ctx context.Context, opts *UpdateOptions, fetcher bundler.CatalogFetcher) error {
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
 
@@ -128,15 +146,6 @@ func runVendorUpdate(ctx context.Context, opts *UpdateOptions) error {
 	lgr.V(1).Info("loaded lock file", "path", lockPath,
 		"deps", len(existingLock.Dependencies),
 		"plugins", len(existingLock.Plugins))
-
-	// Create catalog fetcher
-	localCatalog, err := catalog.NewLocalCatalog(*lgr)
-	if err != nil {
-		w.Errorf("failed to open catalog: %v", err)
-		return exitcode.WithCode(err, exitcode.CatalogError)
-	}
-
-	fetcher := &bundler.LocalCatalogFetcherAdapter{Catalog: localCatalog}
 
 	// Filter dependencies if --dependency was specified
 	deps := existingLock.Dependencies

--- a/pkg/cmd/scafctl/vendor/vendor_test.go
+++ b/pkg/cmd/scafctl/vendor/vendor_test.go
@@ -4,10 +4,18 @@
 package vendor
 
 import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +39,7 @@ func TestCommandUpdate(t *testing.T) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
 	require.NotNil(t, cmd)
-	assert.Equal(t, "update [solution-path]", cmd.Use)
+	assert.Equal(t, "update", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 }
@@ -56,6 +64,392 @@ func TestCommandUpdate_Flags(t *testing.T) {
 			require.NotNil(t, f, "flag %q should exist", tt.flagName)
 			assert.Equal(t, tt.defVal, f.DefValue, "flag %q default value", tt.flagName)
 		})
+	}
+}
+
+func TestCommandUpdate_FileFlag(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
+
+	f := cmd.Flags().Lookup("file")
+	require.NotNil(t, f, "file flag should exist")
+	assert.Equal(t, "f", f.Shorthand)
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestCommandUpdate_RejectsPositionalArgs(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
+	cmd.SetArgs([]string{"solution.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestCommandUpdate_FileNotFound(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
+	cmd.SetArgs([]string{"-f", "/nonexistent/solution.yaml"})
+	cmd.SetContext(writer.WithWriter(context.Background(), writer.New(ioStreams, cliParams)))
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCommandUpdate_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	solPath := dir + "/solution.yaml"
+	require.NoError(t, writeTestFile(solPath, "not: valid: solution: yaml: ["))
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
+	cmd.SetArgs([]string{"-f", solPath})
+	cmd.SetContext(writer.WithWriter(context.Background(), writer.New(ioStreams, cliParams)))
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCommandUpdate_ValidSolutionNoLock(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := dir + "/solution.yaml"
+	solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, writeTestFile(solPath, solContent))
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/vendor")
+	cmd.SetArgs([]string{"-f", solPath})
+	cmd.SetContext(writer.WithWriter(context.Background(), writer.New(ioStreams, cliParams)))
+
+	// Should fail due to missing lock file, not due to parsing or flag issues
+	err := cmd.Execute()
+	require.Error(t, err)
+	// Verify it got past the file/parse stage
+	assert.NotContains(t, err.Error(), "failed to read solution file")
+	assert.NotContains(t, err.Error(), "failed to parse solution")
+}
+
+// writeTestFile is a helper that writes content to a file path.
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+// --- mock and helpers for runVendorUpdateWithFetcher tests ---
+
+type mockCatalogFetcher struct {
+	fetchFn func(ctx context.Context, ref string) ([]byte, catalog.ArtifactInfo, error)
+}
+
+func (m *mockCatalogFetcher) FetchSolution(ctx context.Context, ref string) ([]byte, catalog.ArtifactInfo, error) {
+	if m.fetchFn != nil {
+		return m.fetchFn(ctx, ref)
+	}
+	return nil, catalog.ArtifactInfo{}, fmt.Errorf("fetch not configured")
+}
+
+func (m *mockCatalogFetcher) ListSolutions(_ context.Context, _ string) ([]catalog.ArtifactInfo, error) {
+	return nil, nil
+}
+
+const minimalSolutionYAML = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+
+func makeTestCtx(t *testing.T) context.Context {
+	t.Helper()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	return writer.WithWriter(context.Background(), writer.New(ioStreams, cliParams))
+}
+
+func makeTestOpts(solPath string) *UpdateOptions {
+	return &UpdateOptions{
+		SolutionPath: solPath,
+		CliParams:    settings.NewCliParams(),
+	}
+}
+
+func writeTestLockFile(t *testing.T, dir string, lf *bundler.LockFile) {
+	t.Helper()
+	require.NoError(t, bundler.WriteLockFile(filepath.Join(dir, bundler.DefaultLockFileName), lf))
+}
+
+func contentDigest(data []byte) string {
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", h)
+}
+
+// --- runVendorUpdateWithFetcher tests ---
+
+func TestRunVendorUpdateWithFetcher_FileNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := makeTestCtx(t)
+	opts := makeTestOpts("/nonexistent/solution.yaml")
+	err := runVendorUpdateWithFetcher(ctx, opts, &mockCatalogFetcher{})
+	require.Error(t, err)
+}
+
+func TestRunVendorUpdateWithFetcher_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, "not: valid: ["))
+
+	ctx := makeTestCtx(t)
+	err := runVendorUpdateWithFetcher(ctx, makeTestOpts(solPath), &mockCatalogFetcher{})
+	require.Error(t, err)
+}
+
+func TestRunVendorUpdateWithFetcher_NoLockFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+
+	ctx := makeTestCtx(t)
+	err := runVendorUpdateWithFetcher(ctx, makeTestOpts(solPath), &mockCatalogFetcher{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no lock file")
+}
+
+func TestRunVendorUpdateWithFetcher_InvalidLockFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	// version: 2 triggers the unsupported version error in LoadLockFile
+	require.NoError(t, writeTestFile(filepath.Join(dir, bundler.DefaultLockFileName), "version: 2\n"))
+
+	ctx := makeTestCtx(t)
+	err := runVendorUpdateWithFetcher(ctx, makeTestOpts(solPath), &mockCatalogFetcher{})
+	require.Error(t, err)
+}
+
+func TestRunVendorUpdateWithFetcher_FilterDependencyNotFound(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:abc", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	ctx := makeTestCtx(t)
+	opts := makeTestOpts(solPath)
+	opts.Dependencies = []string{"unknown-dep@9.9.9"}
+	err := runVendorUpdateWithFetcher(ctx, opts, &mockCatalogFetcher{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown-dep@9.9.9")
+}
+
+func TestRunVendorUpdateWithFetcher_DryRun_AllUpToDate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+
+	depContent := []byte("dep content v1")
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: contentDigest(depContent), ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return depContent, catalog.ArtifactInfo{}, nil
+		},
+	}
+	opts := makeTestOpts(solPath)
+	opts.DryRun = true
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, fetcher))
+}
+
+func TestRunVendorUpdateWithFetcher_DryRun_NeedsUpdate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:oldhash", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return []byte("updated content"), catalog.ArtifactInfo{}, nil
+		},
+	}
+	opts := makeTestOpts(solPath)
+	opts.DryRun = true
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, fetcher))
+}
+
+func TestRunVendorUpdateWithFetcher_ApplyUpdates_Success(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:oldhash", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return []byte("updated content"), catalog.ArtifactInfo{}, nil
+		},
+	}
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), makeTestOpts(solPath), fetcher))
+
+	// Lock file should be rewritten with a valid format
+	newLock, err := bundler.LoadLockFile(filepath.Join(dir, bundler.DefaultLockFileName))
+	require.NoError(t, err)
+	require.NotNil(t, newLock)
+	require.Len(t, newLock.Dependencies, 1)
+	assert.NotEqual(t, "sha256:oldhash", newLock.Dependencies[0].Digest)
+}
+
+func TestRunVendorUpdateWithFetcher_LockOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:oldhash", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return []byte("updated content"), catalog.ArtifactInfo{}, nil
+		},
+	}
+	opts := makeTestOpts(solPath)
+	opts.LockOnly = true
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, fetcher))
+
+	// Vendor dir must NOT be created in lock-only mode
+	_, statErr := os.Stat(filepath.Join(dir, ".scafctl", "vendor"))
+	assert.True(t, os.IsNotExist(statErr), "vendor dir should not be created in lock-only mode")
+}
+
+func TestRunVendorUpdateWithFetcher_WithPlugins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Plugins: []bundler.LockPlugin{
+			{Name: "azure", Kind: "provider", Version: "1.2.3", Digest: "sha256:pluginhash"},
+		},
+	})
+
+	opts := makeTestOpts(solPath)
+	opts.DryRun = true
+	// No deps means no fetch calls; plugin messages should still be printed
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, &mockCatalogFetcher{}))
+}
+
+func TestRunVendorUpdateWithFetcher_FetcherError_EntrySkipped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:abc", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return nil, catalog.ArtifactInfo{}, fmt.Errorf("catalog unavailable")
+		},
+	}
+	opts := makeTestOpts(solPath)
+	opts.DryRun = true
+	// CheckForUpdates swallows fetch errors; overall call should succeed
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, fetcher))
+}
+
+func TestRunVendorUpdateWithFetcher_FilteredDependency(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, writeTestFile(solPath, minimalSolutionYAML))
+
+	newContent := []byte("new content")
+	writeTestLockFile(t, dir, &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: "sha256:oldhash", ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+			{Ref: "dep-b@2.0.0", Digest: contentDigest(newContent), ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-b@2.0.0.yaml"},
+		},
+	})
+
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return newContent, catalog.ArtifactInfo{}, nil
+		},
+	}
+	opts := makeTestOpts(solPath)
+	opts.DryRun = true
+	opts.Dependencies = []string{"dep-a@1.0.0"} // only check dep-a
+	require.NoError(t, runVendorUpdateWithFetcher(makeTestCtx(t), opts, fetcher))
+}
+
+func BenchmarkRunVendorUpdateWithFetcher(b *testing.B) {
+	dir := b.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	if err := writeTestFile(solPath, minimalSolutionYAML); err != nil {
+		b.Fatal(err)
+	}
+	depContent := []byte("bench content")
+	if err := bundler.WriteLockFile(filepath.Join(dir, bundler.DefaultLockFileName), &bundler.LockFile{
+		Dependencies: []bundler.LockDependency{
+			{Ref: "dep-a@1.0.0", Digest: contentDigest(depContent), ResolvedFrom: "local", VendoredAt: ".scafctl/vendor/dep-a@1.0.0.yaml"},
+		},
+	}); err != nil {
+		b.Fatal(err)
+	}
+	fetcher := &mockCatalogFetcher{
+		fetchFn: func(_ context.Context, _ string) ([]byte, catalog.ArtifactInfo, error) {
+			return depContent, catalog.ArtifactInfo{}, nil
+		},
+	}
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := writer.WithWriter(context.Background(), writer.New(ioStreams, cliParams))
+	opts := &UpdateOptions{SolutionPath: solPath, DryRun: true, CliParams: cliParams}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = runVendorUpdateWithFetcher(ctx, opts, fetcher)
 	}
 }
 

--- a/pkg/soldiff/README.md
+++ b/pkg/soldiff/README.md
@@ -85,10 +85,10 @@ The `soldiff` package powers the `solution diff` CLI command:
 
 ```bash
 # Compare two solution files
-scafctl solution diff v1/solution.yaml v2/solution.yaml
+scafctl solution diff -f v1/solution.yaml -f v2/solution.yaml
 
 # Output as JSON
-scafctl solution diff v1/solution.yaml v2/solution.yaml -o json
+scafctl solution diff -f v1/solution.yaml -f v2/solution.yaml -o json
 ```
 
 ## Testing

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -310,6 +310,77 @@ func (o *Getter) fromCatalogWithBundle(ctx context.Context, nameWithVersion stri
 	return &sol, nil, nil
 }
 
+// ValidatePositionalRef validates a positional CLI argument intended to be a
+// catalog or registry reference. Returns an error if:
+//   - fileFlag is non-empty (both -f/--file and a positional arg were provided)
+//   - arg looks like a local file path rather than a catalog/registry name
+//
+// cmdUsage is included in the error message to suggest the correct invocation
+// (e.g., "scafctl explain solution").
+func ValidatePositionalRef(arg, fileFlag, cmdUsage string) error {
+	if fileFlag != "" {
+		return fmt.Errorf("cannot use both -f/--file and a positional argument")
+	}
+	if !IsCatalogReference(arg) {
+		return fmt.Errorf("local file paths must use -f/--file flag: %s -f %s", cmdUsage, arg)
+	}
+	return nil
+}
+
+// IsCatalogReference returns true when s looks like a catalog name or remote
+// registry reference rather than a local file path. The check is intentionally
+// conservative: when in doubt it returns false so callers are guided to use
+// -f/--file instead of silently treating a filesystem path as a catalog lookup.
+//
+// Returns false (local file path) when:
+//   - s starts with "/" (absolute path)
+//   - s starts with "." (relative path like ./foo or ../bar)
+//   - s ends with ".yaml", ".yml", or ".json" (file extension)
+//   - s starts with a Windows drive letter (e.g., "C:\dir\sol" or "C:/dir/sol")
+//   - s contains a backslash (Windows path separator)
+//   - s contains "/" but the first path segment does not look like a hostname
+//     (i.e., does not contain "." or ":") — catches relative paths like
+//     "configs/solution" that lack a leading "./" but are still local
+//
+// Returns true (catalog / remote reference) for:
+//   - bare names ("my-app"), versioned names ("my-app@1.0.0")
+//   - registry refs where the first segment is hostname-like ("ghcr.io/org/sol:v1",
+//     "localhost:5000/sol")
+//   - URLs ("https://...", "oci://...")
+func IsCatalogReference(s string) bool {
+	if strings.HasPrefix(s, "/") || strings.HasPrefix(s, ".") {
+		return false
+	}
+	// URLs are not local file paths — they are handled by get.Getter.
+	if strings.Contains(s, "://") {
+		return true
+	}
+	lower := strings.ToLower(s)
+	if strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".json") {
+		return false
+	}
+	// Windows absolute paths (e.g., "C:\dir\sol" or "C:/dir/sol").
+	if len(s) >= 2 && s[1] == ':' {
+		return false
+	}
+	// Any remaining backslash is a Windows path separator → local path.
+	if strings.Contains(s, "\\") {
+		return false
+	}
+	// Strings containing "/" without "://" are either registry refs or relative
+	// local paths. Distinguish them by the first path segment: registry hostnames
+	// always contain "." (ghcr.io) or ":" (localhost:5000), while plain directory
+	// names (configs, relative, mydir) do not.
+	if strings.Contains(s, "/") {
+		firstSegment := strings.SplitN(s, "/", 2)[0]
+		if strings.Contains(firstSegment, ".") || strings.Contains(firstSegment, ":") {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
 // isBareName returns true if the path is a bare name suitable for catalog lookup.
 // A bare name has no path separators (/, \) and is not a URL.
 func (o *Getter) isBareName(path string) bool {

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -912,3 +912,110 @@ func TestGetter_GetWithBundle_EmptyPath(t *testing.T) {
 	assert.Nil(t, sol)
 	assert.Nil(t, bundleData)
 }
+
+func TestValidatePositionalRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		fileFlag string
+		wantErr  string
+	}{
+		{"catalog name passes", "my-app", "", ""},
+		{"versioned name passes", "my-app@1.0.0", "", ""},
+		{"file flag conflict", "my-app", "existing.yaml", "cannot use both -f/--file"},
+		{"local path rejected", "./solution.yaml", "", "local file paths must use -f/--file flag"},
+		{"yaml extension rejected", "solution.yaml", "", "local file paths must use -f/--file flag"},
+		{"error includes cmd usage", "../foo.yaml", "", "scafctl test cmd -f ../foo.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePositionalRef(tt.arg, tt.fileFlag, "scafctl test cmd")
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func BenchmarkValidatePositionalRef(b *testing.B) {
+	args := []string{"my-app", "./solution.yaml", "solution.yaml", "my-app@1.0.0"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		for _, arg := range args {
+			_ = ValidatePositionalRef(arg, "", "scafctl run solution")
+		}
+	}
+}
+
+func TestIsCatalogReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Catalog/registry refs (should return true)
+		{"bare name", "my-app", true},
+		{"versioned name", "my-app@1.0.0", true},
+		{"registry ref", "ghcr.io/myorg/solutions/app:2.0", true},
+		{"https URL", "https://example.com/solution.yaml", true},
+		{"stdin marker", "-", true},
+		{"bare name with dash", "deploy-to-k8s", true},
+		{"name with underscore", "my_app", true},
+		{"localhost registry", "localhost:5000/sol", true},
+		{"oci URL", "oci://registry.example.com/sol:v1", true},
+		{"nested registry ref", "registry.example.com/org/sol:v1", true},
+
+		// Local file paths (should return false)
+		{"absolute path", "/tmp/solution.yaml", false},
+		{"relative dot path", "./solution.yaml", false},
+		{"relative parent path", "../sol.yaml", false},
+		{"yaml extension", "solution.yaml", false},
+		{"yml extension", "solution.yml", false},
+		{"json extension", "config.json", false},
+		{"uppercase yaml", "Solution.YAML", false},
+		{"dot only start", ".", false},
+		{"dot-dot start", "..", false},
+
+		// Relative paths without leading "./" — still local (not catalog refs)
+		{"relative path no dot", "configs/solution", false},
+		{"relative path nested", "relative/path/to/solution", false},
+		{"relative path with yaml", "configs/solution.yaml", false},
+
+		// Windows paths (should return false)
+		{"windows absolute backslash", `C:\dir\sol`, false},
+		{"windows absolute slash", "C:/dir/sol", false},
+		{"bare backslash path", `dir\sol`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCatalogReference(tt.input)
+			assert.Equal(t, tt.expected, got, "IsCatalogReference(%q)", tt.input)
+		})
+	}
+}
+
+func BenchmarkIsCatalogReference(b *testing.B) {
+	inputs := []string{
+		"my-app",
+		"my-app@1.0.0",
+		"ghcr.io/myorg/solutions/app:2.0",
+		"./solution.yaml",
+		"/tmp/solution.yaml",
+		"solution.yaml",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		for _, input := range inputs {
+			IsCatalogReference(input)
+		}
+	}
+}

--- a/pkg/solution/inspect/run_command.go
+++ b/pkg/solution/inspect/run_command.go
@@ -16,7 +16,7 @@ import (
 // CLI, MCP, and future API consumers.
 type RunCommandInfo struct {
 	// Command is the full CLI command string with all flags.
-	Command string `json:"command" yaml:"command" doc:"Full CLI command to run the solution" maxLength:"2048" example:"scafctl run solution ./my-solution.yaml -r name=hello"`
+	Command string `json:"command" yaml:"command" doc:"Full CLI command to run the solution" maxLength:"2048" example:"scafctl run solution -f ./my-solution.yaml -r name=hello"`
 
 	// Subcommand is the base command (e.g., "scafctl run solution").
 	Subcommand string `json:"subcommand" yaml:"subcommand" doc:"Base CLI subcommand" maxLength:"128" example:"scafctl run solution"`

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2209,7 +2209,7 @@ func TestIntegration_BuildSolution_UsesMetadataVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build without --version flag - should use metadata version (1.0.0)
-	stdout, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml")
+	stdout, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml")
 
 	assert.Equal(t, 0, exitCode)
 	// Should report the version from metadata
@@ -2223,7 +2223,7 @@ func TestIntegration_BuildSolution_VersionOverrideWarning(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build with different version than metadata - should warn
-	stdout, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "9.9.9")
+	stdout, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "9.9.9")
 
 	assert.Equal(t, 0, exitCode)
 	// Should warn about overriding metadata version
@@ -2233,7 +2233,7 @@ func TestIntegration_BuildSolution_VersionOverrideWarning(t *testing.T) {
 
 func TestIntegration_BuildSolution_FileNotFound(t *testing.T) {
 	t.Parallel()
-	_, stderr, exitCode := runScafctl(t, "build", "solution", "nonexistent.yaml", "--version", "1.0.0")
+	_, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "nonexistent.yaml", "--version", "1.0.0")
 
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "failed to read")
@@ -2245,7 +2245,7 @@ func TestIntegration_BuildSolution_Success(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)
@@ -2262,7 +2262,7 @@ func TestIntegration_BuildSolution_WithName(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)
@@ -2279,16 +2279,16 @@ func TestIntegration_BuildSolution_ForceOverwrite(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// First build
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Second build without force should fail
-	_, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
+	_, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "exists")
 
 	// Third build with force should succeed
-	stdout, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--force", "--no-cache")
+	stdout, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--force", "--no-cache")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "Built")
 }
@@ -2298,7 +2298,7 @@ func TestIntegration_BuildSolution_DryRun(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--dry-run")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--dry-run")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)
@@ -2313,7 +2313,7 @@ func TestIntegration_BuildSolution_NoBundle(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-bundle")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-bundle")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)
@@ -2369,7 +2369,7 @@ func TestIntegration_CatalogList_WithArtifacts(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// List should show the artifact
@@ -2386,7 +2386,7 @@ func TestIntegration_CatalogList_FilterByKind(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// List with filter should work
@@ -2423,7 +2423,7 @@ func TestIntegration_CatalogInspect_Success(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Inspect the artifact
@@ -2441,9 +2441,9 @@ func TestIntegration_CatalogInspect_SpecificVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build multiple versions
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
-	_, _, exitCode = runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "2.0.0")
+	_, _, exitCode = runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "2.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Inspect specific version
@@ -2467,7 +2467,7 @@ func TestIntegration_CatalogDelete_RequiresVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Delete without version should fail
@@ -2495,7 +2495,7 @@ func TestIntegration_CatalogDelete_Success(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Delete the artifact
@@ -2555,7 +2555,7 @@ func TestIntegration_CatalogPrune_AfterDelete(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Delete the artifact (leaves orphaned blobs)
@@ -2595,7 +2595,7 @@ func TestIntegration_RunSolution_FromCatalog_ByName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build a solution into the catalog
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Run the solution from catalog by name (should pick latest version)
@@ -2613,9 +2613,9 @@ func TestIntegration_RunSolution_FromCatalog_ByNameVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build two versions
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
-	_, _, exitCode = runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "2.0.0")
+	_, _, exitCode = runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "2.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Run the solution from catalog by name@version
@@ -2647,11 +2647,11 @@ func TestIntegration_RunSolution_FromCatalog_PathNotBareName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// A path with a separator should not be treated as a bare name
-	// This should try to open a file, not lookup in catalog
+	// The new validation rejects positional file paths and directs users to use -f
 	_, stderr, exitCode := runScafctl(t, "run", "solution", "./nonexistent.yaml")
 	assert.NotEqual(t, 0, exitCode)
-	// Should report file not found, not catalog not found
-	assert.Contains(t, stderr, "Failed reading file")
+	// Should reject positional file path and suggest -f flag
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
 }
 
 // Render Solution from Catalog Tests
@@ -2664,7 +2664,7 @@ func TestIntegration_RenderSolution_FromCatalog_ByName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build a solution into the catalog
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Render the resolver graph from catalog by name
@@ -2685,7 +2685,7 @@ func TestIntegration_ExplainSolution_FromCatalog_ByName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build a solution into the catalog
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Explain the solution from catalog by name
@@ -2705,7 +2705,7 @@ func TestIntegration_Lint_FromCatalog_ByName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build a solution into the catalog
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Lint the solution from catalog by name
@@ -2725,11 +2725,11 @@ func TestIntegration_GetSolution_FromCatalog_ByName(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build a solution into the catalog
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
-	// Get the solution from catalog by name
-	stdout, _, exitCode := runScafctl(t, "get", "solution", "-p", "resolver-demo", "-o", "yaml")
+	// Get the solution from catalog by name (positional arg for catalog refs)
+	stdout, _, exitCode := runScafctl(t, "get", "solution", "resolver-demo", "-o", "yaml")
 	assert.Equal(t, 0, exitCode)
 	// Should have solution YAML
 	assert.Contains(t, stdout, "resolver-demo")
@@ -2753,7 +2753,7 @@ func TestIntegration_CatalogSave_RequiresOutput(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Try to save without output flag
@@ -2779,7 +2779,7 @@ func TestIntegration_CatalogSave_Success(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Save to tar
@@ -2801,9 +2801,9 @@ func TestIntegration_CatalogSave_SpecificVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build multiple versions
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
-	_, _, exitCode = runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "2.0.0")
+	_, _, exitCode = runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "2.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Save specific version
@@ -2849,7 +2849,7 @@ func TestIntegration_CatalogLoad_Success(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", srcDir)
 
 	// Build and save an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	tarPath := srcDir + "/export.tar"
@@ -2879,7 +2879,7 @@ func TestIntegration_CatalogLoad_AlreadyExists(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Save it
@@ -2899,7 +2899,7 @@ func TestIntegration_CatalogLoad_ForceOverwrite(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Save it
@@ -2924,7 +2924,7 @@ func TestIntegration_CatalogSaveLoad_RoundTrip(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", srcDir)
 
 	// Build an artifact
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Save to tar
@@ -3086,7 +3086,7 @@ func TestIntegration_CatalogTag_Success(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build an artifact first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Tag it
@@ -3102,9 +3102,9 @@ func TestIntegration_CatalogTag_MoveAlias(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build two versions
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
-	_, _, exitCode = runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "2.0.0", "--force", "--no-cache")
+	_, _, exitCode = runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "2.0.0", "--force", "--no-cache")
 	require.Equal(t, 0, exitCode)
 
 	// Tag v1 as stable
@@ -3231,7 +3231,7 @@ func TestIntegration_BuildSolution_NoCacheFlag(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)
@@ -3247,7 +3247,7 @@ func TestIntegration_BuildSolution_BuildCacheHit(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// First build
-	stdout1, stderr1, exitCode1 := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	stdout1, stderr1, exitCode1 := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	if exitCode1 != 0 {
 		t.Logf("stdout: %s", stdout1)
 		t.Logf("stderr: %s", stderr1)
@@ -3256,7 +3256,7 @@ func TestIntegration_BuildSolution_BuildCacheHit(t *testing.T) {
 	assert.Contains(t, stdout1, "Built")
 
 	// Second build with same inputs — should be a cache hit
-	stdout2, stderr2, exitCode2 := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	stdout2, stderr2, exitCode2 := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	if exitCode2 != 0 {
 		t.Logf("stdout: %s", stdout2)
 		t.Logf("stderr: %s", stderr2)
@@ -3271,11 +3271,11 @@ func TestIntegration_BuildSolution_NoCacheBypassesCacheHit(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// First build (populates cache)
-	_, _, exitCode1 := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode1 := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode1)
 
 	// Second build with --no-cache — should NOT be a cache hit, should fail with "already exists" since --force is not set
-	stdout2, _, exitCode2 := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
+	stdout2, _, exitCode2 := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--no-cache")
 	// Without --force, re-building same version should fail or succeed with --force
 	// It should at least NOT say "cache hit"
 	assert.NotContains(t, stdout2, "cache hit")
@@ -3652,7 +3652,7 @@ func TestIntegration_BundleVerify_AfterBuild(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Verify the built artifact
@@ -3668,7 +3668,7 @@ func TestIntegration_BundleExtract_AfterBuild(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Extract the built artifact
@@ -3685,7 +3685,7 @@ func TestIntegration_BundleExtract_ListOnly(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build first
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// List files — may have no bundle layer if the solution has no bundle config
@@ -3704,10 +3704,10 @@ func TestIntegration_BundleDiff_SameVersion(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build two versions
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
-	_, _, exitCode = runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "2.0.0", "--no-cache")
+	_, _, exitCode = runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "2.0.0", "--no-cache")
 	require.Equal(t, 0, exitCode)
 
 	// Diff them
@@ -3725,7 +3725,7 @@ func TestIntegration_BuildSolution_NestedBundle(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
 	// Build the nested-bundle example — should discover sub-solution files recursively
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/solutions/nested-bundle/parent.yaml", "--version", "1.0.0", "--dry-run")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/solutions/nested-bundle/parent.yaml", "--version", "1.0.0", "--dry-run")
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
 	assert.Equal(t, 0, exitCode)
@@ -3783,7 +3783,7 @@ spec:
 	solPath := filepath.Join(tmpDir, "solution.yaml")
 	require.NoError(t, os.WriteFile(solPath, []byte(solContent), 0o644))
 
-	_, stderr, exitCode := runScafctl(t, "vendor", "update", solPath)
+	_, stderr, exitCode := runScafctl(t, "vendor", "update", "-f", solPath)
 
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "lock file")
@@ -3807,7 +3807,7 @@ func TestIntegration_BuildSolution_WithDedupe(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml",
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml",
 		"--version", "1.0.0", "--dedupe")
 
 	if exitCode != 0 {
@@ -3823,7 +3823,7 @@ func TestIntegration_BuildSolution_WithDedupeDisabled(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml",
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml",
 		"--version", "1.0.0", "--dedupe=false")
 
 	if exitCode != 0 {
@@ -3839,7 +3839,7 @@ func TestIntegration_BuildSolution_DryRunShowsDetails(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml",
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml",
 		"--version", "1.0.0", "--dry-run")
 
 	if exitCode != 0 {
@@ -5480,7 +5480,7 @@ func TestIntegration_RunSolution_CatalogWritesToCallerCWD(t *testing.T) {
 
 	// Build the catalog-cwd solution into the local catalog
 	_, stderr, exitCode := runScafctlInDir(t, filepath.Join(projectRoot, "tests/integration/solutions/catalog-cwd"),
-		"build", "solution", "solution.yaml", "--version", "1.0.0", "--force",
+		"build", "solution", "-f", "solution.yaml", "--version", "1.0.0", "--force",
 	)
 	require.Equalf(t, 0, exitCode, "build failed: %s", stderr)
 
@@ -5538,7 +5538,7 @@ func TestIntegration_RunSolution_CatalogOutputDirOverridesCWD(t *testing.T) {
 
 	// Build the catalog-cwd solution into the local catalog
 	_, stderr, exitCode := runScafctlInDir(t, filepath.Join(projectRoot, "tests/integration/solutions/catalog-cwd"),
-		"build", "solution", "solution.yaml", "--version", "1.0.0", "--force",
+		"build", "solution", "-f", "solution.yaml", "--version", "1.0.0", "--force",
 	)
 	require.Equalf(t, 0, exitCode, "build failed: %s", stderr)
 
@@ -6485,8 +6485,8 @@ func TestIntegration_SolutionDiff_Table(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"solution", "diff",
-		"examples/soldiff/solution-v1.yaml",
-		"examples/soldiff/solution-v2.yaml",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"-f", "examples/soldiff/solution-v2.yaml",
 	)
 	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
 	assert.Contains(t, stdout, "Solution Diff:")
@@ -6498,8 +6498,8 @@ func TestIntegration_SolutionDiff_JSON(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"solution", "diff",
-		"examples/soldiff/solution-v1.yaml",
-		"examples/soldiff/solution-v2.yaml",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"-f", "examples/soldiff/solution-v2.yaml",
 		"-o", "json",
 	)
 	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
@@ -6514,8 +6514,8 @@ func TestIntegration_SolutionDiff_YAML(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"solution", "diff",
-		"examples/soldiff/solution-v1.yaml",
-		"examples/soldiff/solution-v2.yaml",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"-f", "examples/soldiff/solution-v2.yaml",
 		"-o", "yaml",
 	)
 	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
@@ -6529,7 +6529,7 @@ func TestIntegration_CacheInfo_ShowsArtifactCache(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 
 	// Build a solution to populate the artifact cache
-	_, _, exitCode := runScafctl(t, "build", "solution", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	_, _, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
 	require.Equal(t, 0, exitCode)
 
 	// Cache info should report artifact data
@@ -6543,8 +6543,8 @@ func TestIntegration_SolutionDiff_MissingFile(t *testing.T) {
 	t.Parallel()
 	_, _, exitCode := runScafctl(t,
 		"solution", "diff",
-		"examples/soldiff/solution-v1.yaml",
-		"/nonexistent/solution.yaml",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"-f", "/nonexistent/solution.yaml",
 	)
 	assert.NotEqual(t, 0, exitCode)
 }
@@ -6559,11 +6559,78 @@ func TestIntegration_SolutionDiff_Alias(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,
 		"sol", "diff",
-		"examples/soldiff/solution-v1.yaml",
-		"examples/soldiff/solution-v2.yaml",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"-f", "examples/soldiff/solution-v2.yaml",
 	)
 	assert.Equal(t, 0, exitCode, "stderr: %s", stderr)
 	assert.Contains(t, stdout, "Solution Diff:")
+}
+
+// ============================================================================
+// Positional Path Rejection Tests — Uniform -f/--file Input
+// ============================================================================
+
+func TestIntegration_ExplainSolution_PositionalPathRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "explain", "solution", "./my-solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+}
+
+func TestIntegration_GetSolution_PositionalPathRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "get", "solution", "./my-solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+}
+
+func TestIntegration_RenderSolution_PositionalPathRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "render", "solution", "./my-solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+}
+
+func TestIntegration_RunResolver_PositionalPathRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "run", "resolver", "./my-solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+}
+
+func TestIntegration_SolutionDiff_PositionalPathRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "solution", "diff", "./v1.yaml", "./v2.yaml")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+}
+
+func TestIntegration_BuildSolution_RejectsPositionalArgs(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "build", "solution", "solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_VendorUpdate_RejectsPositionalArgs(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "vendor", "update", "solution.yaml")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_SolutionDiff_MixedFlagAndPositional(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"solution", "diff",
+		"-f", "examples/soldiff/solution-v1.yaml",
+		"my-app@1.0.0",
+	)
+	// This should fail because my-app@1.0.0 doesn't exist in catalog,
+	// but the command should accept the mixed input without argument validation errors.
+	// Verify that the failure is from catalog resolution, not input validation.
+	_ = stdout
+	assert.NotEqual(t, 0, exitCode)
+	assert.NotContains(t, stderr, "local file paths must use -f/--file flag", "should not fail on arg validation")
+	assert.NotContains(t, stderr, "cannot use both -f/--file", "should not fail on conflict detection")
 }
 
 // ============================================================================

--- a/tests/integration/solutions/input-flag-validation/solution.yaml
+++ b/tests/integration/solutions/input-flag-validation/solution.yaml
@@ -1,0 +1,48 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: input-flag-validation
+  version: 1.0.0
+  description: |
+    Tests that the uniform -f/--file input pattern works correctly.
+    Verifies auto-discovery, explicit -f flag, and positional arg rejection.
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting for input flag validation
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: validated
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      resolve-with-auto-inject:
+        description: Verify resolver works with auto-injected -f flag
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [input-flag, smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.greeting == "validated"
+
+      lint-with-auto-inject:
+        description: Verify lint works with auto-injected -f flag
+        command: [lint]
+        tags: [input-flag, smoke]
+        assertions:
+          - expression: __exitCode == 0
+
+      explain-with-auto-inject:
+        description: Verify explain works with auto-injected -f flag
+        command: [explain, solution]
+        tags: [input-flag]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "input-flag-validation"


### PR DESCRIPTION
Refactor Copilot customization to reduce always-on context usage, add agent handoffs, enforce rules via hooks, and add layer-specific instructions:

- Slim copilot-instructions.md from ~250 to ~70 lines by extracting Go-specific rules into 9 targeted .instructions.md files with applyTo globs (go-conventions, go-testing, integration-tests, docs-examples, cli-commands, mcp-tools, providers, go-modules, markdown)
- Add handoffs to 4 agents: planner->issue-creator, go-reviewer->go-build-resolver, go-build-resolver->commit-message, pr-reviewer->go-build-resolver+commit-message
- Add PostToolUse hook for auto-formatting .go files via goimports
- Add PreToolUse hook to require approval for git write operations
- Add read tool to commit-message agent, agent tool to planner
- Remove unknown tools from planner (search/searchResults, search/searchSubagent)
- Add /completeness-check prompt for verifying docs, tutorials, examples, integration tests, and MCP tools
- Rewrite /pr-review prompt with GraphQL-first workflow and discuss-before-dismiss policy
- Update go-test prompt description to clarify build-resolver routing
- Remove trailing newline from golang-testing SKILL.md
