### PR TITLE
chore: optimize AI customization files for best practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,5 @@ Closes #
 - [ ] My commits follow conventional commit format
 - [ ] I have added/updated tests for my changes
 - [ ] `go test ./...` passes
-- [ ] `golangci-lint run` passes
+- [ ] `task lint` passes
 - [ ] I have signed off my commits (`git commit -s -S`)

--- a/.github/agents/commit-message.agent.md
+++ b/.github/agents/commit-message.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Generates conventional commit messages from staged or recent changes. Analyzes git diff to produce well-structured messages following the project's conventional commits spec. Does NOT execute git commit — only outputs the message. Use when preparing commit messages."
 name: "commit-message"
-tools: [execute]
+tools: [read, execute]
 ---
 You are a commit message generator for the **scafctl** project. You analyze changes and produce conventional commit messages. You **never** execute `git commit` — you only output the message for the user to copy.
 

--- a/.github/agents/go-build-resolver.agent.md
+++ b/.github/agents/go-build-resolver.agent.md
@@ -2,6 +2,10 @@
 description: "Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail."
 name: "go-build-resolver"
 tools: [read, edit, search, execute, todo]
+handoffs:
+  - label: "Generate commit message"
+    prompt: "Generate a commit message for the fixes just applied."
+    agent: "commit-message"
 ---
 You are an expert Go build error resolution specialist for the **scafctl** project. Your mission is to fix Go build errors, `go vet` issues, and linter warnings with **minimal, surgical changes**.
 
@@ -9,7 +13,7 @@ You are an expert Go build error resolution specialist for the **scafctl** proje
 
 - scafctl is a Go CLI tool using CEL expressions, Go templates, and a provider-based architecture
 - Build: `go build -o dist/scafctl ./cmd/scafctl/scafctl.go`
-- Lint: `golangci-lint run --fix`
+- Lint: `task lint:fix`
 - Test: `go test ./...`
 - Business logic lives in `pkg/`, never in `pkg/cmd/scafctl/...` or `pkg/mcp/tools_*.go`
 
@@ -20,7 +24,7 @@ Run these in order (all read-only):
 ```bash
 go build ./...
 go vet ./...
-golangci-lint run 2>/dev/null || echo "golangci-lint not installed"
+task lint
 go mod verify
 ```
 

--- a/.github/agents/go-reviewer.agent.md
+++ b/.github/agents/go-reviewer.agent.md
@@ -2,12 +2,16 @@
 description: "Expert Go code reviewer for scafctl. Checks for idiomatic Go, security, error handling, concurrency patterns, and scafctl-specific conventions. Use for all Go code reviews."
 name: "go-reviewer"
 tools: [read, search, execute]
+handoffs:
+  - label: "Fix reported issues"
+    prompt: "Fix the issues identified in the code review."
+    agent: "go-build-resolver"
 ---
 You are a senior Go code reviewer for the **scafctl** project ensuring high standards of idiomatic Go and project-specific best practices.
 
 When invoked:
 1. Run `git diff -- '*.go'` to see recent Go file changes
-2. Run `go vet ./...` and `golangci-lint run` if available
+2. Run `go vet ./...` and `task lint`
 3. Focus on modified `.go` files
 4. Begin review immediately
 
@@ -57,7 +61,7 @@ In addition to standard Go review, check for:
 
 ```bash
 go vet ./...
-golangci-lint run
+task lint
 go build -race ./...
 go test -race ./...
 ```

--- a/.github/agents/issue-creator.agent.md
+++ b/.github/agents/issue-creator.agent.md
@@ -85,3 +85,9 @@ Use `gh issue create` with:
 ```
 
 Use `--body-file` for complex markdown to avoid shell escaping issues.
+
+## Markdown Rules
+
+When writing issue bodies:
+- Use tilde fences (`~~~`) instead of backtick fences when code blocks contain backticks
+- Use only ASCII characters -- `--` not em dashes, straight quotes not curly quotes, `...` not ellipsis characters

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,8 +1,20 @@
 ---
 description: "Feature implementation planner for scafctl. Creates structured implementation blueprints with architecture decisions, task breakdown, and dependency analysis. Use for complex features and refactoring."
 name: "planner"
-tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/searchResults, search/textSearch, search/searchSubagent, web]
+tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, web, agent]
 argument-hint: "Describe the feature or change to plan"
+handoffs:
+  - label: "File GitHub issue"
+    prompt: "Create a GitHub issue from the implementation plan just produced."
+    agent: "issue-creator"
+  - label: "Start implementation"
+    prompt: "Start implementing the plan just produced."
+    agent: "agent"
+    send: true
+  - label: "Generate markdown plan"
+    prompt: "Generate a markdown file with the detailed implementation plan."
+    agent: "agent"
+    send: true
 ---
 You are a senior Go architect and implementation planner for the **scafctl** project. You create structured implementation blueprints before any code is written.
 

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -3,6 +3,13 @@ description: "Fetch PR review comments for the current branch, triage them, fix 
 name: "pr-reviewer"
 tools: [read, edit, search, execute, todo]
 argument-hint: "Optional: PR number or 'resolve' to auto-resolve addressed comments"
+handoffs:
+  - label: "Apply fixes"
+    prompt: "Apply the approved code fixes from the triage above. After fixing, run go build ./... and go vet ./... to verify no errors were introduced. Then run task test:e2e to make sure everything passes. Finally, reply to each addressed PR review thread confirming the fix and mark it resolved. Skip threads we disagree with. Do not commit."
+    agent: "pr-reviewer"
+  - label: "Generate commit message"
+    prompt: "Generate a commit message for the fixes just applied."
+    agent: "pr-reviewer"
 ---
 You are a PR review comment handler for the **scafctl** project. You fetch review comments from the PR matching the current branch, triage them, implement fixes, and respond/resolve threads.
 
@@ -49,12 +56,12 @@ For each unresolved review thread, classify it:
 
 | Category | Action |
 |----------|--------|
-| **Actionable** | Code change needed — fix it |
-| **Question** | Reviewer asked a question — answer it |
-| **Nit/Style** | Minor style preference — fix if trivial, otherwise explain |
-| **Already addressed** | Fixed in a subsequent commit — respond and resolve |
+| **Actionable** | Code change needed -- fix it |
+| **Question** | Reviewer asked a question -- answer it |
+| **Nit/Style** | Minor style preference -- fix if trivial, otherwise explain |
+| **Already addressed** | Fixed in a subsequent commit -- respond and resolve |
 | **Disagree** | Explain reasoning, suggest alternative |
-| **Outdated** | Code has changed, comment no longer applies — note and resolve |
+| **Outdated** | Code has changed, comment no longer applies -- note and resolve |
 
 Present the triage summary to the user:
 ```
@@ -63,25 +70,33 @@ Review Decision: <CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED>
 
 Unresolved threads: N
 
-1. [Actionable] path/to/file.go:42 — @reviewer: "should use Writer here"
-2. [Question]   pkg/auth/handler.go:15 — @reviewer: "why not use interfaces?"
-3. [Nit]        pkg/config/config.go:8 — @reviewer: "prefer constants"
-4. [Outdated]   pkg/resolver/resolver.go:30 — @reviewer: "missing error wrap"
+1. [Actionable] path/to/file.go:42 -- @reviewer: "should use Writer here"
+2. [Question]   pkg/auth/handler.go:15 -- @reviewer: "why not use interfaces?"
+3. [Nit]        pkg/config/config.go:8 -- @reviewer: "prefer constants"
+4. [Outdated]   pkg/resolver/resolver.go:30 -- @reviewer: "missing error wrap"
 ```
 
 **Wait for user approval** before making any changes or responding to comments.
 
-### Phase 3: Address Comments
+### Phase 3: Apply Fixes
 
 For each approved actionable comment:
 1. Read the file and understand the context
 2. Make the fix
-3. Run `go build ./...` and `go vet ./...` to verify
-4. Report what was fixed
+3. Report what was fixed
 
-### Phase 4: Respond & Resolve
+**Do not respond to threads yet** -- all code changes must be verified first.
 
-After fixes are made, respond to review threads:
+### Phase 4: Verify
+
+After all fixes are applied:
+1. Run `go build ./...` and `go vet ./...`
+2. Run `task test:e2e`
+3. Fix any errors introduced by the changes
+
+### Phase 5: Respond & Resolve
+
+**Only after all fixes pass verification**, respond to review threads:
 
 **To reply to a thread:**
 ```bash
@@ -108,13 +123,13 @@ Response templates:
 - **Question answered**: "<answer>"
 - **Nit accepted**: "Good catch, fixed."
 - **Disagree**: "<reasoning>. Happy to discuss further."
-- **Outdated**: "This was addressed in a subsequent change — the code now does X."
+- **Outdated**: "This was addressed in a subsequent change -- the code now does X."
 
 ## Hard Constraints
 
 - **NEVER** resolve threads without user approval
 - **NEVER** respond to comments without user approval
 - **NEVER** dismiss reviews
-- **NEVER** run `git commit` or `git push` — only make code changes
+- **NEVER** run `git commit` or `git push` -- only make code changes
 - Always present the triage summary and wait for the user before acting
 - When fixing code, follow all scafctl conventions (Writer, kvx, struct tags, etc.)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 
 ### CLI Output (`pkg/terminal/writer/`)
 
-Use **Writer** for all terminal output—**never** use `fmt.Fprintf` directly.
+Use **Writer** for all terminal output -- **never** use `fmt.Fprintf` directly.
 - Get via `writer.FromContext(ctx)`
 - Respects `--quiet` and `--no-color` flags automatically
 - For testing, use `writer.WithExitFunc()` to capture exit calls
@@ -21,72 +21,25 @@ Commands returning structured data should use **kvx** with `OutputOptions`:
 ### HTTP Client
 See `pkg/httpc/README.md`
 
-### Docs, Examples, and Tutorials
-
-- Use `pkg/docs/` for generating and managing documentation and tutorials.
-- Use `pkg/examples/` for storing example configurations and usage scenarios.
-- Always create documentation, tutorials, and examples for new features, providers and commands.
-- Always update documentation, tutorials, and examples when features, providers or commands change.
-
-
 ### Paths
-
-- Use xdg paths via the pkg/paths package
+- Use xdg paths via the `pkg/paths` package
 
 ### Configuration
+- Use `pkg/settings` for storing defaults and managing settings
+- Use `pkg/config/` for storing, loading, and managing application configuration
 
-- Use `pkg/settings` for storing defaults and managing settings.
-- Use `pkg/config/` for storing, loading and managing application configuration. Services should store their config in this package when it makes sense.
-
-### CLI integration tests
-
-- Use `tests/integration/cli_test.go` for integration tests of CLI commands.
-- Always add new commands to the CLI integration tests.
-
-### Solution integration tests
-
-- Use `tests/integration/solutions/` for integration tests of **non-API** features (providers, resolvers, actions, plugins, solutions, etc.).
-- Always create solution integration tests whenever a non-API feature, provider, or command is added or updated.
-- Solution integration tests **cannot** test API/server features — use API integration tests instead.
-
-### API integration tests
-
-- Use `tests/integration/api_test.go` for integration tests of **API/server** features (REST endpoints, middleware, auth, rate limiting, etc.).
-- Always add new API endpoints to the API integration tests.
-- API features must **only** be tested here, not in solution integration tests.
-
-### `settings` Package
+### CEL
+Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`. For CEL provider, prefer the `expression` field over `expr`.
 
 ## Conventions
 
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
 - **Signing**: All commits must be GPG/SSH signed (`-S`) and include DCO sign-off (`-s`)
 - **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
-- **Testing**: Use `testify/assert`, mocks in `mock.go` files
-- **Breaking changes**: Allowed—this app is not in production. Note when doing so.
+- **Breaking changes**: Allowed -- this app is not in production. Note when doing so.
 - **Backward compatibility**: Do not do it, see Breaking changes above.
 
-## Struct Tags
-
-Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
-- All fields: `doc`
-- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
-- Integers: `maximum`, `example`
-- Arrays: `maxItems` (no `example`)
-- Objects/maps: no `example` tag
-
-## Special Field Types
-
-| Field | Type | Package |
-|-------|------|---------|
-| `expr` | `Expression` | `pkg/celexp` |
-| `tmpl` | `GoTemplatingContent` | `pkg/gotmpl` |
-
-## CEL
-Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`. For CEL provider, prefer the `expression` field over `expr`.
-
 ## Build & Test Commands
-Standard Go commands for development (task runner available but use raw commands for AI agents):
 
 ```bash
 # Build
@@ -96,126 +49,25 @@ go build -ldflags "-s -w -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X mai
 go test ./...                    # Run all tests
 
 # Linting
-golangci-lint run --fix          # Run Linter and auto-fix issues
-
+task lint                        # Run Linter (uses pinned golangci-lint version)
+task lint:fix                    # Run Linter and auto-fix issues
 ```
 
-**IMPORTANT**: Never include business logic in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`) or API packages (future) instead, put it into proper shared domain packages (`pkg/...`)
+The project uses `task` (go-task/task) for builds and linting. **Always use `task lint` instead of running `golangci-lint` directly** to ensure the correct pinned version is used.
 
-**Note**: The project uses `task` (go-task/task) as a convenience wrapper, but AI agents should use raw Go commands for clarity and portability.
+## Critical Rules
 
-**IMPORTANT**: Always update documentation, tutorials, examples, mcp server tools (if applicable) when features, providers or commands change or added.
-**IMPORTANT**: Add benchmark tests for any new features or providers in `*_test.go` files using Go's `testing` package.
-**IMPORTANT**: After any change, run `task test:e2e` to ensure everything passes.
-**IMPORTANT**: Never use magic strings or numbers; always define constants or use settings for configuration values.
-**IMPORTANT**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Only generate commit messages — let the user execute the commit.
-**IMPORTANT**: Never commit or push any code without approval first
-
----
-paths:
-  - "**/*.go"
-  - "**/go.mod"
-  - "**/go.sum"
----
-- **gofmt/goimports**: Auto-format `.go` files after edit
-- **go vet**: Run static analysis after editing `.go` files
-- **staticcheck**: Run extended static checks on modified packages
-
-## Formatting
-
-- **gofmt** and **goimports** are mandatory — no style debates
-
-## Design Principles
-
-- Accept interfaces, return structs
-- Keep interfaces small (1-3 methods)
-
-## Error Handling
-
-Always wrap errors with context:
-
-```go
-if err != nil {
-    return fmt.Errorf("failed to create user: %w", err)
-}
-```
-
-## Functional Options
-
-```go
-type Option func(*Server)
-
-func WithPort(port int) Option {
-    return func(s *Server) { s.port = port }
-}
-
-func NewServer(opts ...Option) *Server {
-    s := &Server{port: 8080}
-    for _, opt := range opts {
-        opt(s)
-    }
-    return s
-}
-```
-
-## Small Interfaces
-
-Define interfaces where they are used, not where they are implemented.
-
-## Dependency Injection
-
-Use constructor functions to inject dependencies:
-
-```go
-func NewUserService(repo UserRepository, logger Logger) *UserService {
-    return &UserService{repo: repo, logger: logger}
-}
-```
-
-## Secret Management
-
-```go
-apiKey := os.Getenv("OPENAI_API_KEY")
-if apiKey == "" {
-    log.Fatal("OPENAI_API_KEY not configured")
-}
-```
+- **Business logic placement**: Never in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`), or API packages -- put it in shared domain packages (`pkg/...`)
+- **After any change**: Run `task test:e2e` to ensure everything passes
+- **No magic values**: Always define constants or use settings for configuration values
+- **Git safety**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Never commit or push without approval first
 
 ## Security Scanning
 
-- Use **gosec** for static security analysis:
-  ```bash
-  gosec ./...
-  ```
-
-## Context & Timeouts
-
-Always use `context.Context` for timeout control:
-
-```go
-ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-defer cancel()
-```
-
-## Framework
-
-Use the standard `go test` with **table-driven tests**.
-
-## Race Detection
-
-Always run with the `-race` flag:
-
 ```bash
-go test -race ./...
+gosec ./...
 ```
 
-## Coverage
+## Additional Conventions
 
-```bash
-go test -cover ./...
-```
-
-## Reference
-
-See skill: `golang-patterns` for comprehensive Go idioms and patterns.
-See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.
+Go coding conventions (struct tags, error handling, design patterns), testing rules, integration test scoping, and documentation requirements are in `.github/instructions/*.instructions.md` files -- they load automatically when editing relevant files.

--- a/.github/hooks/git-safety.json
+++ b/.github/hooks/git-safety.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/scripts/git-safety.sh",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/go-format.json
+++ b/.github/hooks/go-format.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/scripts/go-format.sh",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.github/hooks/scripts/git-safety.sh
+++ b/.github/hooks/scripts/git-safety.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block git commit/push/amend unless user explicitly approves.
+# Reads JSON from stdin, checks if the command is a git write operation.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the command being run
+cmd=$(echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' || true)
+
+# Check for git write operations
+# No command found -- not a tool invocation we care about
+if [[ -z "$cmd" ]]; then exit 0; fi
+
+if echo "$cmd" | grep -qE 'git\s+(commit|push|amend|reset\s+--hard|rebase|force-push)'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Git write operation detected. This project requires explicit user approval before committing, pushing, or rewriting history."
+  }
+}
+EOF
+  exit 0
+fi

--- a/.github/hooks/scripts/go-format.sh
+++ b/.github/hooks/scripts/go-format.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format .go files after edits
+# Reads JSON from stdin, checks if a .go file was edited, runs goimports.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the file path from the tool input (handles replace_string_in_file, create_file, etc.)
+file=$(echo "$input" | grep -o '"filePath"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"filePath"[[:space:]]*:[[:space:]]*"//;s/"$//' || true)
+
+# Only proceed for .go files
+if [[ -z "$file" || "$file" != *.go ]]; then
+  exit 0
+fi
+
+# Only format if the file exists
+if [[ ! -f "$file" ]]; then
+  exit 0
+fi
+
+# Run goimports if available, fall back to gofmt
+if command -v goimports &>/dev/null; then
+  goimports -w "$file"
+elif command -v gofmt &>/dev/null; then
+  gofmt -w "$file"
+fi

--- a/.github/instructions/cli-commands.instructions.md
+++ b/.github/instructions/cli-commands.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "CLI command layer rules for scafctl. Commands are thin wiring -- no business logic. Use Writer for output, kvx for data, cobra for flags. Use when editing CLI command packages."
+applyTo: "pkg/cmd/scafctl/**/*.go"
+---
+
+# CLI Command Layer
+
+Commands are **thin wiring only** -- they parse flags, call domain packages, and render output.
+
+## Rules
+
+- **No business logic** -- delegate to packages in `pkg/`
+- Use `writer.FromContext(ctx)` for all terminal output, never `fmt.Fprintf`
+- Use `kvx.OutputOptions` for structured data (table/json/yaml/quiet)
+- Use `cobra.Command` for command definition and flag binding
+- Wire up `settings.Run` parameters from flags
+- Always add new commands to CLI integration tests (`tests/integration/cli_test.go`)

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Documentation and examples conventions for scafctl. Use when creating or updating docs, tutorials, or examples."
+applyTo: "**/*.go"
+---
+
+# Documentation & Examples
+
+- Use `pkg/docs/` for generating and managing documentation and tutorials
+- Use `pkg/examples/` for storing example configurations and usage scenarios
+- Always create documentation, tutorials, and examples for new features, providers, and commands
+- Always update documentation, tutorials, and examples when features, providers, or commands change
+- Always update MCP server tools (if applicable) when features, providers, or commands change

--- a/.github/instructions/go-conventions.instructions.md
+++ b/.github/instructions/go-conventions.instructions.md
@@ -1,0 +1,93 @@
+---
+description: "Go coding conventions for scafctl: struct tags, Huma validation, error handling, design principles, functional options, context/timeouts, and formatting. Use when writing or editing Go code."
+applyTo: "**/*.go"
+---
+
+# Go Conventions
+
+## Struct Tags
+
+Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
+- All fields: `doc`
+- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
+- Integers: `maximum`, `example`
+- Arrays: `maxItems` (no `example`)
+- Objects/maps: no `example` tag
+
+## Special Field Types
+
+| Field | Type | Package |
+|-------|------|---------|
+| `expr` | `Expression` | `pkg/celexp` |
+| `tmpl` | `GoTemplatingContent` | `pkg/gotmpl` |
+
+## Error Handling
+
+Always wrap errors with context:
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to create user: %w", err)
+}
+```
+
+## Design Principles
+
+- Accept interfaces, return structs
+- Keep interfaces small (1-3 methods)
+- Define interfaces where they are used, not where they are implemented
+
+## Dependency Injection
+
+Use constructor functions to inject dependencies:
+
+```go
+func NewUserService(repo UserRepository, logger Logger) *UserService {
+    return &UserService{repo: repo, logger: logger}
+}
+```
+
+## Functional Options
+
+```go
+type Option func(*Server)
+
+func WithPort(port int) Option {
+    return func(s *Server) { s.port = port }
+}
+
+func NewServer(opts ...Option) *Server {
+    s := &Server{port: 8080}
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+## Context & Timeouts
+
+Always use `context.Context` for timeout control:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+defer cancel()
+```
+
+## Secret Management
+
+```go
+apiKey := os.Getenv("OPENAI_API_KEY")
+if apiKey == "" {
+    log.Fatal("OPENAI_API_KEY not configured")
+}
+```
+
+## Formatting
+
+- **gofmt** and **goimports** are mandatory -- no style debates
+- Never use magic strings or numbers; always define constants or use settings
+
+## Reference
+
+See skill: `golang-patterns` for comprehensive Go idioms and patterns.

--- a/.github/instructions/go-modules.instructions.md
+++ b/.github/instructions/go-modules.instructions.md
@@ -1,0 +1,11 @@
+---
+description: "Go module rules for scafctl. Run go mod tidy after dependency changes. Never edit go.sum manually. Use when editing go.mod."
+applyTo: "**/go.mod"
+---
+
+# Go Modules
+
+- Run `go mod tidy -v` after adding or removing dependencies
+- Never edit `go.sum` manually -- it is auto-generated
+- Pin dependencies to specific versions, not branches
+- Use `go mod verify` to check module integrity

--- a/.github/instructions/go-testing.instructions.md
+++ b/.github/instructions/go-testing.instructions.md
@@ -1,0 +1,45 @@
+---
+description: "Go testing conventions for scafctl: table-driven tests, testify/assert, benchmarks, race detection, and coverage. Use when writing or editing Go test files."
+applyTo: "**/*_test.go"
+---
+
+# Go Testing Conventions
+
+## Framework
+
+- Use standard `go test` with **table-driven tests**
+- Use `testify/assert` for assertions
+- Place mocks in `mock.go` files
+
+## Race Detection
+
+Always run with the `-race` flag:
+
+```bash
+go test -race ./...
+```
+
+## Coverage
+
+```bash
+go test -cover ./...
+```
+
+## Benchmarks
+
+Add benchmark tests for any new features or providers:
+
+```go
+func BenchmarkMyFeature(b *testing.B) {
+    b.ReportAllocs()
+    b.ResetTimer()
+
+    for b.Loop() {
+        // benchmark code
+    }
+}
+```
+
+## Reference
+
+See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Integration test rules for scafctl: CLI, solution, and API test scope boundaries. Use when writing or editing integration tests."
+applyTo: "tests/integration/**"
+---
+
+# Integration Test Rules
+
+## CLI Integration Tests (`tests/integration/cli_test.go`)
+
+- Always add new commands to the CLI integration tests
+- Tests CLI command behavior and output
+
+## Solution Integration Tests (`tests/integration/solutions/`)
+
+- For **non-API** features: providers, resolvers, actions, plugins, solutions
+- Always create solution integration tests when a non-API feature, provider, or command is added or updated
+- **Cannot** test API/server features -- use API integration tests instead
+
+## API Integration Tests (`tests/integration/api_test.go`)
+
+- For **API/server** features: REST endpoints, middleware, auth, rate limiting
+- Always add new API endpoints to the API integration tests
+- API features must **only** be tested here, not in solution integration tests
+
+## Scope Boundaries
+
+| Feature Type | Test Location |
+|-------------|---------------|
+| CLI commands | `tests/integration/cli_test.go` |
+| Providers, resolvers, actions, plugins | `tests/integration/solutions/` |
+| REST endpoints, middleware, auth | `tests/integration/api_test.go` |

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -1,0 +1,22 @@
+---
+description: "Markdown formatting rules: tilde fences for nested backticks, ASCII-only characters. Use when writing or editing markdown."
+applyTo: "**/*.md"
+---
+
+# Markdown Authoring Rules
+
+## Code Blocks
+
+When a markdown code block contains backticks (Go raw strings, heredocs, shell, template literals), use tilde fences instead of backtick fences to avoid delimiter collisions.
+
+If tilde fences are not suitable, use 4+ backtick fences as the outer delimiter.
+
+## Characters
+
+Use only ASCII characters in markdown files:
+
+- Use `--` instead of em dashes
+- Use `---` for horizontal rules
+- Use straight quotes (`"`, `'`) instead of curly/smart quotes
+- Use `...` instead of ellipsis characters
+- Use standard hyphens (`-`) instead of en dashes

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "MCP tool handler rules for scafctl. Handlers are thin wrappers -- no business logic. Parse inputs, call domain packages, format output. Use when editing MCP tool files."
+applyTo: "pkg/mcp/tools_*.go"
+---
+
+# MCP Tool Handlers
+
+MCP tool handlers are **thin wrappers** -- they parse tool inputs, call domain packages, and format results.
+
+## Rules
+
+- **No business logic** -- delegate to packages in `pkg/`
+- Register tools in `register*Tools()` methods on `*Server`
+- Use `mcp.NewTool()` with descriptive names, descriptions, and typed parameters
+- Use `mcp.With*HintAnnotation()` for tool metadata (read-only, destructive, idempotent)
+- Return `mcp.NewToolResultText()` or `mcp.NewToolResultError()` -- never panic
+- Always add Huma-style parameter descriptions and constraints

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Provider implementation rules for scafctl. Providers implement the Provider interface with Descriptor() and Execute(). Must include benchmarks, tests, and mock.go. Use when creating or editing providers."
+applyTo: "pkg/provider/**/*.go"
+---
+
+# Provider Layer
+
+Providers are **stateless execution primitives** that implement the Provider interface.
+
+## Interface
+
+Implement both methods:
+- `Descriptor()` returns provider metadata, schema, and capabilities
+- `Execute(ctx, input)` runs the provider logic
+
+## Rules
+
+- Define `ProviderName` and `Version` constants
+- Implement `Descriptor()` returning name, version, API version, schema, and capabilities
+- Use `schemahelper` for JSON schema generation
+- Define a testable ops interface (e.g., `EnvOps`) and inject via constructor for mockability
+- Provide `DefaultXxxOps` struct for real implementations
+- Place mocks in `mock.go`
+- Always include benchmark tests (`*_benchmark_test.go`)
+- Register in `pkg/provider/builtin/builtin.go`
+- Add struct tags with Huma validation on all Descriptor fields
+
+## Package naming
+
+- `pkg/provider/builtin/<name>provider/` (e.g., `envprovider`, `httpprovider`)
+- Main file matches the provider name (e.g., `env.go`, `http.go`)

--- a/.github/prompts/commit.prompt.md
+++ b/.github/prompts/commit.prompt.md
@@ -1,8 +1,8 @@
 ---
-description: "Generate a conventional commit message from staged or recent changes. Outputs the message only — does not run git commit."
+description: "scafctl: Generate a conventional commit message from staged or recent changes. Outputs the message only -- does not run git commit."
 agent: "commit-message"
 ---
-Analyze the current changes and generate a conventional commit message. **Output the message only — do not commit.**
+Analyze the current changes and generate a conventional commit message. **Output the message only -- do not commit.**
 
 1. Check `git diff --cached --stat` for staged changes (fall back to `git diff --stat`)
 2. Read the actual diff to understand what changed

--- a/.github/prompts/completeness-check.prompt.md
+++ b/.github/prompts/completeness-check.prompt.md
@@ -1,0 +1,19 @@
+---
+description: "scafctl: Check if staged changes have corresponding docs, tutorials, examples, integration tests, and MCP tools."
+agent: "agent"
+argument-hint: "Optional: specific area to check"
+---
+Review staged changes and check if supporting artifacts exist:
+
+1. Run `git diff --cached --stat` to identify staged changes
+2. If nothing is staged, fall back to `git log origin/main..HEAD --stat` to check pushed commits on the branch
+3. For each feature, provider, or command, verify:
+   - Docs in `docs/` or `pkg/docs/`
+   - Tutorials in `docs/tutorials/` for user-facing features
+   - Examples in `examples/`
+   - Solution integration tests in `tests/integration/solutions/`
+   - CLI integration tests in `tests/integration/cli_test.go`
+   - API integration tests in `tests/integration/api_test.go`
+   - MCP server tools in `pkg/mcp/tools_*.go`
+3. Report present vs missing as a checklist
+4. Do not create anything, just report the gaps

--- a/.github/prompts/go-build.prompt.md
+++ b/.github/prompts/go-build.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Fix Go build errors, go vet warnings, and linter issues with minimal surgical changes."
+description: "scafctl: Fix Go build errors, go vet warnings, and linter issues with minimal surgical changes."
 agent: "go-build-resolver"
 ---
 Diagnose and fix the current Go build errors:

--- a/.github/prompts/go-review.prompt.md
+++ b/.github/prompts/go-review.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Run Go code review on recent changes. Checks for idiomatic Go, security, error handling, concurrency, and scafctl conventions."
+description: "scafctl: Run Go code review on recent changes. Checks for idiomatic Go, security, error handling, concurrency, and scafctl conventions."
 agent: "go-reviewer"
 ---
 Review the current Go code changes for:
@@ -9,4 +9,4 @@ Review the current Go code changes for:
 - Code quality (function length, nesting depth, idiomatic patterns)
 - scafctl conventions (Writer usage, kvx output, struct tags, business logic placement)
 
-Run `go vet ./...` and `golangci-lint run` first, then review the code.
+Run `go vet ./...` and `task lint` first, then review the code.

--- a/.github/prompts/go-test.prompt.md
+++ b/.github/prompts/go-test.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Run Go tests with race detection and check coverage. Reports failures and coverage gaps."
+description: "scafctl: Run Go tests with race detection, check coverage, and diagnose failures via go-build-resolver."
 agent: "go-build-resolver"
 ---
 Run the Go test suite and report results:

--- a/.github/prompts/issue.prompt.md
+++ b/.github/prompts/issue.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "File a GitHub issue with codebase exploration and feasibility assessment."
+description: "scafctl: File a GitHub issue with codebase exploration and feasibility assessment."
 agent: "issue-creator"
 argument-hint: "Describe the change, bug, or feature (e.g., 'Add pagination to catalog list')"
 ---

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Create an implementation plan for a scafctl feature. Produces a structured blueprint with architecture decisions, task breakdown, interface design, and testing strategy."
+description: "scafctl: Create an implementation plan for a scafctl feature. Produces a structured blueprint with architecture decisions, task breakdown, interface design, and testing strategy."
 agent: "planner"
 argument-hint: "Describe the feature to plan (e.g., 'Add OAuth auth handler')"
 ---

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,14 +1,14 @@
 ---
-description: "Fetch and triage PR review comments for the current branch. Analyzes comments, fixes issues, and responds/resolves threads via gh CLI."
+description: "scafctl: Fetch and triage PR review comments for the current branch. Analyzes comments, fixes issues, and responds/resolves threads via gh CLI."
 agent: "pr-reviewer"
-argument-hint: "Optional: 'resolve' to also respond and resolve addressed threads"
+argument-hint: "Optional: PR number or leave blank to use current branch"
 ---
-Fetch review comments from the PR for the current branch and triage them:
+Address unresolved PR review comments. Use `gh` CLI and the **GitHub GraphQL API (v4)** to fetch review threads -- the REST API does not expose the `isResolved` field.
 
-1. Get current branch and find the matching PR via `gh pr view`
-2. Fetch all unresolved review threads via GitHub GraphQL API
-3. Classify each thread: actionable, question, nit, already addressed, disagree, outdated
-4. Present the triage summary and wait for approval
-5. Fix actionable items, then respond to and resolve threads
+Follow these phases **in order** -- do not skip ahead:
 
-**Always waits for approval before making changes or responding to comments.**
+1. **Fetch**: Fetch all review threads via GraphQL; **skip comments that are already resolved**
+2. **Triage**: For each unresolved comment, assess whether it's a legit problem with the code. Present the triage summary with recommendations and **stop here** -- the user will click "Apply fixes" to approve
+3. **Apply fixes**: Fix the code, verify build (`go build ./...`, `go vet ./...`), run tests (`task test:e2e`), then respond to and resolve each addressed thread
+4. If you disagree with a comment: **discuss it with me before deciding** -- don't resolve or dismiss it
+5. **Do not commit** -- I will handle that


### PR DESCRIPTION
Refactor Copilot customization to reduce always-on context usage, add agent handoffs, enforce rules via hooks, and add layer-specific instructions:

- Slim copilot-instructions.md from ~250 to ~70 lines by extracting Go-specific rules into 9 targeted .instructions.md files with applyTo globs (go-conventions, go-testing, integration-tests, docs-examples, cli-commands, mcp-tools, providers, go-modules, markdown)
- Add handoffs to 4 agents: planner->issue-creator, go-reviewer->go-build-resolver, go-build-resolver->commit-message, pr-reviewer->go-build-resolver+commit-message
- Add PostToolUse hook for auto-formatting .go files via goimports
- Add PreToolUse hook to require approval for git write operations
- Add read tool to commit-message agent, agent tool to planner
- Remove unknown tools from planner (search/searchResults, search/searchSubagent)
- Add /completeness-check prompt for verifying docs, tutorials, examples, integration tests, and MCP tools
- Rewrite /pr-review prompt with GraphQL-first workflow and discuss-before-dismiss policy
- Update go-test prompt description to clarify build-resolver routing
- Remove trailing newline from golang-testing SKILL.md