### PR TITLE
feat!: inject __plan and __execution as first-class CEL variables

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -827,11 +827,11 @@ scafctl run resolver -f solution.yaml
 # Run specific resolvers (with their transitive dependencies)
 scafctl run resolver db config -f solution.yaml
 
-# JSON output (includes __execution metadata by default)
+# JSON output (resolver values only, no execution metadata)
 scafctl run resolver -f solution.yaml -o json
 
-# JSON output without __execution metadata
-scafctl run resolver -f solution.yaml -o json --hide-execution
+# JSON output with __execution metadata (phases, timing, providers)
+scafctl run resolver -f solution.yaml -o json
 
 # Skip transform and validation phases
 scafctl run resolver --skip-transform -f solution.yaml

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -594,6 +594,109 @@ With the alias `config`, you can write `config.results.region` instead of `__act
 
 ---
 
+## Resolver Execution Metadata (`__execution`)
+
+After resolvers run and before any action executes, the full resolver execution metadata is available in every action's CEL context as `__execution`. This lets actions gate on resolver outcomes, surface timing data, or adapt behavior based on how the resolver phase completed.
+
+### Shape of `__execution`
+
+`__execution` mirrors the `--show-execution` output structure:
+
+| Field | Description |
+|---|---|
+| `__execution["resolvers"]["name"].status` | Resolver outcome: `"success"`, `"failed"`, or `"skipped"` |
+| `__execution["resolvers"]["name"].phase` | Execution phase number (int) |
+| `__execution["resolvers"]["name"].duration` | Duration string, e.g. `"3ms"` |
+| `__execution["resolvers"]["name"].dependencyCount` | Number of dependencies |
+| `__execution["summary"].phaseCount` | Total number of resolver phases |
+| `__execution["summary"].resolverCount` | Number of resolvers that executed |
+| `__execution["summary"].totalDuration` | Total resolver execution duration |
+
+### Gate an Action on Resolver Success
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: execution-aware-demo
+  version: 1.0.0
+spec:
+  resolvers:
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: staging
+
+    deploy_target:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.environment + '-cluster'"
+
+  workflow:
+    actions:
+      print-summary:
+        provider: message
+        inputs:
+          message:
+            expr: >
+              'Deploying to ' + _.environment +
+              ' -- resolver phases: ' + string(__execution['summary']['phaseCount'])
+          type: info
+
+      non-prod-deploy:
+        provider: message
+        dependsOn: [print-summary]
+        when:
+          expr: "_.environment != 'production'"
+        inputs:
+          message:
+            expr: >
+              'Deploying to ' + _.deploy_target +
+              ' (phase 1 resolver: environment, phase 2: deploy_target)'
+          type: success
+~~~
+
+Run it:
+
+{{< tabs "actions-tutorial-execution-1" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run solution -f execution-aware-demo.yaml
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution -f execution-aware-demo.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output (staging environment, non-production path):
+
+```
+Deploying to staging -- resolver phases: 2
+Deploying to staging-cluster (phase 1 resolver: environment, phase 2: deploy_target)
+Resolver phases: 2 | environment resolved in phase 1, deploy_target in phase 2
+```
+
+### `__execution` vs `__actions`
+
+| Variable | Available | Contents |
+|---|---|---|
+| `__execution` | All actions (always) | Resolver execution metadata |
+| `__actions["name"]` | Downstream actions only | Results from previously completed actions |
+
+> [!NOTE]
+> See `examples/solutions/execution-aware-actions/solution.yaml` for a complete working example.
+
+---
+
 ## Retry
 
 Actions can automatically retry on failure with configurable backoff strategies.
@@ -1022,10 +1125,10 @@ scafctl run solution -f foreach-demo.yaml --max-action-concurrency=2
 scafctl run solution -f hello-world.yaml --dry-run
 
 # Run resolvers only (skip actions, for debugging)
-scafctl run resolver -f conditional-demo.yaml -r environment=staging --hide-execution
+scafctl run resolver -f conditional-demo.yaml -r environment=staging
 
 # Run specific resolvers for inspection
-scafctl run resolver config -f conditional-demo.yaml -r environment=staging --hide-execution
+scafctl run resolver config -f conditional-demo.yaml -r environment=staging
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
@@ -1049,10 +1152,10 @@ scafctl run solution -f foreach-demo.yaml --max-action-concurrency=2
 scafctl run solution -f hello-world.yaml --dry-run
 
 # Run resolvers only (skip actions, for debugging)
-scafctl run resolver -f conditional-demo.yaml -r environment=staging --hide-execution
+scafctl run resolver -f conditional-demo.yaml -r environment=staging
 
 # Run specific resolvers for inspection
-scafctl run resolver config -f conditional-demo.yaml -r environment=staging --hide-execution
+scafctl run resolver config -f conditional-demo.yaml -r environment=staging
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -1711,7 +1711,7 @@ Run it (requires prior authentication via `scafctl auth login entra`):
 scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 
 # Then run the resolver
-scafctl run resolver -f graph-example.yaml -o json --hide-execution
+scafctl run resolver -f graph-example.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
@@ -1720,7 +1720,7 @@ scafctl run resolver -f graph-example.yaml -o json --hide-execution
 scafctl auth login entra --scope https://graph.microsoft.com/User.Read
 
 # Then run the resolver
-scafctl run resolver -f graph-example.yaml -o json --hide-execution
+scafctl run resolver -f graph-example.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1825,7 +1825,7 @@ Run it (requires prior authentication):
 scafctl auth login github
 
 # Run the resolver
-scafctl run resolver -f github-repos.yaml -o json --hide-execution
+scafctl run resolver -f github-repos.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
@@ -1834,7 +1834,7 @@ scafctl run resolver -f github-repos.yaml -o json --hide-execution
 scafctl auth login github
 
 # Run the resolver
-scafctl run resolver -f github-repos.yaml -o json --hide-execution
+scafctl run resolver -f github-repos.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -138,12 +138,12 @@ Once a solution is in the catalog, you can run it by name instead of providing a
 {{< tabs "catalog-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting -o yaml --hide-execution
+scafctl run resolver -f greeting -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting -o yaml --hide-execution
+scafctl run resolver -f greeting -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -162,12 +162,12 @@ No file path needed -- scafctl looked up `greeting` in the catalog and found the
 {{< tabs "catalog-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -186,12 +186,12 @@ When you have multiple versions, you can pin to a specific one:
 {{< tabs "catalog-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Bob
+scafctl run resolver -f greeting@1.0.0 -o yaml -r name=Bob
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Bob
+scafctl run resolver -f greeting@1.0.0 -o yaml -r name=Bob
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -463,12 +463,12 @@ Expected output:
 {{< tabs "catalog-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -488,12 +488,12 @@ Without a version, scafctl runs the **highest semantic version** -- in this case
 {{< tabs "catalog-tutorial-cmd-14" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting@1.0.0 -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting@1.0.0 -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting@1.0.0 -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -827,7 +827,7 @@ cp deploy-v1.tar /Volumes/USB/
 
 # Transfer USB to the air-gapped machine, then:
 scafctl catalog load --input /Volumes/USB/deploy-v1.tar
-scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
+scafctl run resolver -f deploy -o yaml -r env=prod
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
@@ -839,7 +839,7 @@ Copy-Item deploy-v1.tar /Volumes/USB/
 
 # Transfer USB to the air-gapped machine, then:
 scafctl catalog load --input /Volumes/USB/deploy-v1.tar
-scafctl run resolver -f deploy -o yaml --hide-execution -r env=prod
+scafctl run resolver -f deploy -o yaml -r env=prod
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1113,12 +1113,12 @@ The artifact is now in your local catalog. You can run it with:
 {{< tabs "catalog-tutorial-cmd-36" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f greeting -o yaml --hide-execution -r name=Alice
+scafctl run resolver -f greeting -o yaml -r name=Alice
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -55,12 +55,12 @@ Run it:
 {{< tabs "cel-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f cel-basics.yaml -o json --hide-execution
+scafctl run resolver -f cel-basics.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f cel-basics.yaml -o json --hide-execution
+scafctl run resolver -f cel-basics.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -74,13 +74,13 @@ Output:
 ```
 
 > [!NOTE]
-> **Tip**: `run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details.
+> **Tip**: `run resolver -o json` outputs only resolver values by default. Pass `--show-execution` to include `__execution` metadata (phases, timing, provider info). See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details.
 
 {{% details "▶ Try it" %}}
 The complete example with more expressions is at [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json
 ```
 {{% /details %}}
 
@@ -137,12 +137,12 @@ Run it:
 {{< tabs "cel-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f cel-refs.yaml -o json --hide-execution
+scafctl run resolver -f cel-refs.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f cel-refs.yaml -o json --hide-execution
+scafctl run resolver -f cel-refs.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -293,7 +293,7 @@ size("hello")                         // 5
 All the operators, string, list, and map operations above are runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json
 ```
 {{% /details %}}
 
@@ -307,7 +307,7 @@ scafctl extends CEL with project-specific functions for arrays, maps, strings, r
 All custom extension functions are demonstrated in a single runnable file — [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json
 ```
 {{% /details %}}
 
@@ -817,7 +817,7 @@ cel.bind(base, _.host + ":" + string(_.port),
 Encoders, math, optionals, sets, and bindings are all runnable in [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json
 ```
 {{% /details %}}
 
@@ -829,7 +829,7 @@ scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-exec
 All the patterns below are combined into one runnable file — [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json
 ```
 {{% /details %}}
 
@@ -938,7 +938,7 @@ deployments:
 For more data transformation patterns (filtering, aggregation, enrichment, serialization), see [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml)
 
 ```bash
-scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution
+scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json
 ```
 {{% /details %}}
 
@@ -999,11 +999,11 @@ scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-ex
 
 | Example | Description | Run |
 |---------|-------------|-----|
-| [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) | Literals, resolver refs, operators, strings, lists | `scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution` |
-| [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml) | Math, encoders, sets, optionals, bindings, string/list ops | `scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution` |
-| [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml) | Conditionals, map building, filtering, merging, resource generation | `scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution` |
-| [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml) | All custom CEL extension functions (arrays, map, strings, etc.) | `scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json --hide-execution` |
-| [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml) | Data transformation patterns (filter, aggregate, enrich) | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json --hide-execution` |
+| [cel-basics.yaml](../../examples/resolvers/cel-basics.yaml) | Literals, resolver refs, operators, strings, lists | `scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json` |
+| [cel-builtins.yaml](../../examples/resolvers/cel-builtins.yaml) | Math, encoders, sets, optionals, bindings, string/list ops | `scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json` |
+| [cel-common-patterns.yaml](../../examples/resolvers/cel-common-patterns.yaml) | Conditionals, map building, filtering, merging, resource generation | `scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json` |
+| [cel-extensions.yaml](../../examples/resolvers/cel-extensions.yaml) | All custom CEL extension functions (arrays, map, strings, etc.) | `scafctl run resolver -f examples/resolvers/cel-extensions.yaml -o json` |
+| [cel-transforms.yaml](../../examples/resolvers/cel-transforms.yaml) | Data transformation patterns (filter, aggregate, enrich) | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json` |
 
 ## Next Steps
 

--- a/docs/tutorials/directory-provider-tutorial.md
+++ b/docs/tutorials/directory-provider-tutorial.md
@@ -56,12 +56,12 @@ Run it:
 {{< tabs "directory-provider-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f list-dir.yaml -o json --hide-execution
+scafctl run resolver -f list-dir.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f list-dir.yaml -o json --hide-execution
+scafctl run resolver -f list-dir.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/file-provider-tutorial.md
+++ b/docs/tutorials/file-provider-tutorial.md
@@ -57,12 +57,12 @@ Run it:
 {{< tabs "file-provider-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f read-file.yaml -o json --hide-execution
+scafctl run resolver -f read-file.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f read-file.yaml -o json --hide-execution
+scafctl run resolver -f read-file.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -98,12 +98,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml --hide-execution
+scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml --hide-execution
+scafctl run resolver -f template-basics.yaml -e _.greeting -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -204,12 +204,12 @@ Run without passing any parameters — the environment defaults to `development`
 {{< tabs "go-templates-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -239,12 +239,12 @@ Pass `-r env=staging` to override the environment:
 {{< tabs "go-templates-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -r env=staging -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -269,12 +269,12 @@ The `{{ else if eq .environment "staging" }}` branch is now active.
 {{< tabs "go-templates-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml --hide-execution
+scafctl run resolver -f template-conditionals.yaml -r env=production -e _.deployment_config -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -361,12 +361,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml --hide-execution
+scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml --hide-execution
+scafctl run resolver -f template-loops.yaml -e _.service_report -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -473,12 +473,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-6" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml --hide-execution
+scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml --hide-execution
+scafctl run resolver -f template-maps.yaml -e _.feature_summary -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -575,12 +575,12 @@ First, check the untrimmed version:
 {{< tabs "go-templates-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml --hide-execution
+scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml --hide-execution
+scafctl run resolver -f template-whitespace.yaml -e _.without_trim -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -590,12 +590,12 @@ Then compare with the trimmed version:
 {{< tabs "go-templates-tutorial-cmd-8" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml --hide-execution
+scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml --hide-execution
+scafctl run resolver -f template-whitespace.yaml -e _.with_trim -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -910,12 +910,12 @@ First, comment out or remove the `strict_mode` resolver (it will cause a failure
 {{< tabs "go-templates-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.silent_mode -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -935,12 +935,12 @@ Now add back the `strict_mode` resolver and run:
 {{< tabs "go-templates-tutorial-cmd-12" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -968,12 +968,12 @@ Re-run and both resolvers now succeed:
 {{< tabs "go-templates-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml --hide-execution
+scafctl run resolver -f template-missing-keys.yaml -e _.strict_mode -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1052,12 +1052,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-14" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml --hide-execution
+scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml --hide-execution
+scafctl run resolver -f template-extra-data.yaml -e _.release_notes -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1138,12 +1138,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-15" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml --hide-execution
+scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml --hide-execution
+scafctl run resolver -f template-delimiters.yaml -e _.helm_values -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1774,12 +1774,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-23" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.greeting -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1797,12 +1797,12 @@ Try the other resolvers:
 {{< tabs "go-templates-tutorial-cmd-24" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-sprig.yaml -e _.config -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.config -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-sprig.yaml -e _.config -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.config -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1814,12 +1814,12 @@ port=8080, tls=true, debug=false
 {{< tabs "go-templates-tutorial-cmd-25" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml --hide-execution
+scafctl run resolver -f template-sprig.yaml -e _.formatted -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1890,12 +1890,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-26" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml --hide-execution
+scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml --hide-execution
+scafctl run resolver -f template-tohcl.yaml -e _.hclOutput -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1982,12 +1982,12 @@ spec:
 {{< tabs "go-templates-tutorial-cmd-27" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml --hide-execution
+scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml --hide-execution
+scafctl run resolver -f template-yaml.yaml -e _.yamlOutput -o yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -398,12 +398,12 @@ Run it:
 {{< tabs "resolver-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f transform.yaml -o json --hide-execution
+scafctl run resolver -f transform.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f transform.yaml -o json --hide-execution
+scafctl run resolver -f transform.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -417,7 +417,7 @@ Output:
 ```
 
 > [!NOTE]
-> **Tip**: `scafctl run resolver -o json` includes `__execution` metadata by default. Use `--hide-execution` for cleaner output. All examples in this tutorial use `--hide-execution`. See the [Run Resolver Tutorial](run-resolver-tutorial.md) for details on the execution metadata.
+> **Tip**: `scafctl run resolver -o json` outputs only resolver values by default. Pass `--show-execution` to include `__execution` metadata (phases, timing, provider info). 
 
 The value was trimmed of whitespace, then lowercased — each transform step feeds into the next.
 
@@ -460,12 +460,12 @@ Run it:
 {{< tabs "resolver-tutorial-cmd-6" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f enrich.yaml -o json --hide-execution
+scafctl run resolver -f enrich.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f enrich.yaml -o json --hide-execution
+scafctl run resolver -f enrich.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -527,12 +527,12 @@ Run it with a valid port:
 {{< tabs "resolver-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f validated-config.yaml -r port=8080 -o json --hide-execution
+scafctl run resolver -f validated-config.yaml -r port=8080 -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f validated-config.yaml -r port=8080 -o json --hide-execution
+scafctl run resolver -f validated-config.yaml -r port=8080 -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -609,12 +609,12 @@ Run it:
 {{< tabs "resolver-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f email-validator.yaml -o json --hide-execution
+scafctl run resolver -f email-validator.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f email-validator.yaml -o json --hide-execution
+scafctl run resolver -f email-validator.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -632,12 +632,12 @@ Now try an invalid value that fails **both** validations — not a valid email f
 {{< tabs "resolver-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json --hide-execution
+scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json --hide-execution
+scafctl run resolver -f email-validator.yaml -r email="not-an-email.test" -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -700,12 +700,12 @@ Run it with `development` (default) — the `prod_secrets` resolver is skipped:
 {{< tabs "resolver-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f conditional.yaml -o json --hide-execution
+scafctl run resolver -f conditional.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f conditional.yaml -o json --hide-execution
+scafctl run resolver -f conditional.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -723,12 +723,12 @@ Run it with `production` — the `prod_secrets` resolver executes:
 {{< tabs "resolver-tutorial-cmd-12" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f conditional.yaml -r env=production -o json --hide-execution
+scafctl run resolver -f conditional.yaml -r env=production -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f conditional.yaml -r env=production -o json --hide-execution
+scafctl run resolver -f conditional.yaml -r env=production -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -777,12 +777,12 @@ Run it:
 {{< tabs "resolver-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f phase-condition.yaml -o json --hide-execution
+scafctl run resolver -f phase-condition.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f phase-condition.yaml -o json --hide-execution
+scafctl run resolver -f phase-condition.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -844,12 +844,12 @@ Run it (the HTTP and file providers will fail, so it falls back to static):
 {{< tabs "resolver-tutorial-cmd-14" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f fallback.yaml -o json --hide-execution
+scafctl run resolver -f fallback.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f fallback.yaml -o json --hide-execution
+scafctl run resolver -f fallback.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -959,12 +959,12 @@ Run it:
 {{< tabs "resolver-tutorial-cmd-15" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f http-example.yaml -o json --hide-execution
+scafctl run resolver -f http-example.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f http-example.yaml -o json --hide-execution
+scafctl run resolver -f http-example.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1108,12 +1108,12 @@ Structured output (JSON, YAML) reveals sensitive values for machine consumption:
 {{< tabs "resolver-tutorial-cmd-18" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f env-config.yaml -o json --hide-execution
+scafctl run resolver -f env-config.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f env-config.yaml -o json --hide-execution
+scafctl run resolver -f env-config.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1279,12 +1279,12 @@ Structured output reveals the actual values:
 {{< tabs "resolver-tutorial-cmd-22" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f secrets.yaml -o json --hide-execution
+scafctl run resolver -f secrets.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f secrets.yaml -o json --hide-execution
+scafctl run resolver -f secrets.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -29,7 +29,7 @@ This tutorial covers the `scafctl run resolver` command — a debugging and insp
 ---
 
 > [!NOTE]
-> **A note on `__execution` metadata**: When using JSON or YAML output, `run resolver` automatically includes an `__execution` key containing execution metadata (timing, dependency graph, provider stats). Throughout this tutorial, examples use `--hide-execution` to keep output focused on resolver values. See [Execution Metadata](#execution-metadata) for details on this feature.
+> **A note on `__execution` metadata**: By default, `run resolver` output contains only resolver values. Pass `--show-execution` to include an `__execution` key with execution metadata (timing, dependency graph, provider stats). For `run solution`, execution metadata is also opt-in via `--show-execution`. See [Execution Metadata](#execution-metadata) for details on this feature.
 
 ## Run All Resolvers
 
@@ -75,12 +75,12 @@ spec:
 {{< tabs "run-resolver-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f demo.yaml --hide-execution
+scafctl run resolver -f demo.yaml
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f demo.yaml --hide-execution
+scafctl run resolver -f demo.yaml
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -100,12 +100,12 @@ region       us-west-2
 {{< tabs "run-resolver-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f demo.yaml -o json --hide-execution
+scafctl run resolver -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f demo.yaml -o json --hide-execution
+scafctl run resolver -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -134,12 +134,12 @@ Pass resolver names as positional arguments to execute only those resolvers (plu
 {{< tabs "run-resolver-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver environment -f demo.yaml -o json --hide-execution
+scafctl run resolver environment -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver environment -f demo.yaml -o json --hide-execution
+scafctl run resolver environment -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -157,12 +157,12 @@ Output:
 {{< tabs "run-resolver-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver environment region -f demo.yaml -o json --hide-execution
+scafctl run resolver environment region -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver environment region -f demo.yaml -o json --hide-execution
+scafctl run resolver environment region -f demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -222,12 +222,12 @@ Running just `endpoint` automatically includes `base_url` (its dependency):
 {{< tabs "run-resolver-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -270,17 +270,17 @@ Output:
 
 ## Execution Metadata
 
-By default, `run resolver` includes a `__execution` key in the output alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions (e.g. timeline). Use `--hide-execution` to suppress it when you only need the resolved values.
+By default, `run resolver` outputs only resolver values. Pass `--show-execution` to add a `__execution` key alongside the resolver values. The `__execution` key is a structured object with named sections, designed to be extensible for future additions.
 
 {{< tabs "run-resolver-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f dep-demo.yaml -o json
+scafctl run resolver -f dep-demo.yaml -o json --show-execution
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f dep-demo.yaml -o json
+scafctl run resolver -f dep-demo.yaml -o json --show-execution
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -353,7 +353,104 @@ scafctl run resolver endpoint -f dep-demo.yaml -o json
 The `__execution` section only includes metadata for the requested resolvers and their dependencies.
 
 > [!NOTE]
-> **Tip**: Use `--hide-execution` to suppress `__execution` when you only need the resolved values. For `run solution`, execution metadata is opt-in via `--show-execution`.
+> **Tip**: Pass `--show-execution` to include `__execution` metadata when you need timing, dependency graph, or provider stats. For `run solution`, execution metadata is also opt-in via `--show-execution`.
+
+---
+
+## Pre-Execution Plan (`__plan`)
+
+Before any resolver runs, `scafctl` builds an execution plan from the dependency graph and injects it into the resolver context as `__plan`. This gives every resolver access to topology data -- phase assignment, effective dependencies, and dependency count -- for every other resolver, **before execution begins**.
+
+This is useful for:
+
+- Conditional execution based on topology (e.g., skip a resolver if another has no deps)
+- Validating expected dependency structure (guard against misconfiguration)
+- Including phase metadata in resolver output for observability
+
+### Shape of `__plan`
+
+`__plan` is a map keyed by resolver name. Each entry has three fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `phase` | int | Execution phase number (1-based) |
+| `dependsOn` | list(string) | Effective dependency names |
+| `dependencyCount` | int | Number of effective dependencies |
+
+### Using `__plan` in a `when` Condition
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: plan-aware
+  version: 1.0.0
+spec:
+  resolvers:
+    base_url:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: https://api.example.com
+
+    endpoint:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.base_url + '/v2/data'"
+
+    # Only resolve if endpoint actually has dependencies
+    # (guards against misconfiguration where endpoint was made standalone)
+    endpoint_info:
+      type: string
+      when:
+        expr: "__plan['endpoint'].dependencyCount > 0"
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >-
+                'endpoint runs in phase ' + string(__plan['endpoint'].phase) +
+                ' and depends on: ' + __plan['endpoint'].dependsOn[0]
+~~~
+
+Run it:
+
+{{< tabs "run-resolver-tutorial-plan-1" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f plan-aware.yaml -o json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f plan-aware.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output:
+
+```json
+{
+  "base_url": "https://api.example.com",
+  "endpoint": "https://api.example.com/v2/data",
+  "endpoint_info": "endpoint runs in phase 2 and depends on: base_url"
+}
+```
+
+`endpoint_info` resolved because `__plan['endpoint'].dependencyCount > 0` was `true`.
+
+### `__plan` is Pre-Execution
+
+`__plan` is computed from the static dependency graph **before any resolver runs** -- it reflects the declared structure, not runtime values. Use it for topology checks. For runtime values from other resolvers, use `_` (e.g., `_.base_url`).
+
+> [!NOTE]
+> See `examples/resolvers/plan-aware.yaml` for a complete working example.
 
 ---
 
@@ -396,12 +493,12 @@ Running the resolver fails because the transformed value (`68000`) exceeds the v
 {{< tabs "run-resolver-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -421,12 +518,12 @@ Use `--skip-validation` to bypass the validation phase and see the actual value:
 {{< tabs "run-resolver-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver --skip-validation -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-validation -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver --skip-validation -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-validation -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -448,12 +545,12 @@ Use `--skip-transform` to see the raw resolved value before any transformations:
 {{< tabs "run-resolver-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver --skip-transform -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-transform -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver --skip-transform -f phases-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-transform -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -736,13 +833,13 @@ The command supports all standard output formats:
 {{% tab "Bash" %}}
 ```bash
 # Table (default) — human-readable bordered table
-scafctl run resolver -f demo.yaml --hide-execution
+scafctl run resolver -f demo.yaml
 
 # JSON — for scripting and piping
-scafctl run resolver -f demo.yaml -o json --hide-execution
+scafctl run resolver -f demo.yaml -o json
 
 # YAML — for configuration contexts
-scafctl run resolver -f demo.yaml -o yaml --hide-execution
+scafctl run resolver -f demo.yaml -o yaml
 
 # Quiet — suppress output (useful for exit code checks)
 scafctl run resolver -f demo.yaml -o quiet
@@ -757,13 +854,13 @@ scafctl run resolver -f demo.yaml -e '_.environment'
 {{% tab "PowerShell" %}}
 ```powershell
 # Table (default) — human-readable bordered table
-scafctl run resolver -f demo.yaml --hide-execution
+scafctl run resolver -f demo.yaml
 
 # JSON — for scripting and piping
-scafctl run resolver -f demo.yaml -o json --hide-execution
+scafctl run resolver -f demo.yaml -o json
 
 # YAML — for configuration contexts
-scafctl run resolver -f demo.yaml -o yaml --hide-execution
+scafctl run resolver -f demo.yaml -o yaml
 
 # Quiet — suppress output (useful for exit code checks)
 scafctl run resolver -f demo.yaml -o quiet
@@ -838,12 +935,12 @@ scafctl run resolver --graph -f dep-demo.yaml
 {{< tabs "run-resolver-tutorial-cmd-20" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -853,12 +950,12 @@ scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
 {{< tabs "run-resolver-tutorial-cmd-21" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver base_url -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver base_url -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver base_url -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver base_url -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1010,12 +1107,12 @@ spec:
 {{< tabs "run-resolver-tutorial-cmd-23" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f param-demo.yaml environment=staging -o json --hide-execution
+scafctl run resolver -f param-demo.yaml environment=staging -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f param-demo.yaml environment=staging -o json --hide-execution
+scafctl run resolver -f param-demo.yaml environment=staging -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1090,12 +1187,12 @@ Isolate a failing resolver and its dependencies:
 {{< tabs "run-resolver-tutorial-cmd-26" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver endpoint -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver endpoint -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1107,12 +1204,12 @@ Skip transforms to see what providers actually return:
 {{< tabs "run-resolver-tutorial-cmd-27" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver --skip-transform -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-transform -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver --skip-transform -f dep-demo.yaml -o json --hide-execution
+scafctl run resolver --skip-transform -f dep-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -1140,20 +1237,20 @@ scafctl run resolver --graph -f dep-demo.yaml
 {{% tab "Bash" %}}
 ```bash
 # Get current values
-scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide-execution > current.json
+scafctl run resolver -f param-demo.yaml -r environment=production -o json > current.json
 
 # Change parameters and compare
-scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution > staging.json
+scafctl run resolver -f param-demo.yaml -r environment=staging -o json > staging.json
 diff current.json staging.json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
 # Get current values
-scafctl run resolver -f param-demo.yaml -r environment=production -o json --hide-execution > current.json
+scafctl run resolver -f param-demo.yaml -r environment=production -o json > current.json
 
 # Change parameters and compare
-scafctl run resolver -f param-demo.yaml -r environment=staging -o json --hide-execution > staging.json
+scafctl run resolver -f param-demo.yaml -r environment=staging -o json > staging.json
 diff current.json staging.json
 ```
 {{% /tab %}}
@@ -1193,16 +1290,16 @@ Metrics are displayed on stderr after execution completes.
 {{% tab "Bash" %}}
 ```bash
 # All resolvers
-scafctl run resolver -f solution.yaml --hide-execution
+scafctl run resolver -f solution.yaml
 
 # Named resolvers (with dependencies)
-scafctl run resolver db config -f solution.yaml --hide-execution
+scafctl run resolver db config -f solution.yaml
 
-# JSON output (includes __execution metadata by default)
+# JSON output (resolver values only, no execution metadata)
 scafctl run resolver -f solution.yaml -o json
 
-# JSON output without __execution metadata
-scafctl run resolver -f solution.yaml -o json --hide-execution
+# JSON output with __execution metadata (phases, timing, providers)
+scafctl run resolver -f solution.yaml -o json
 
 # Skip transform and validation phases
 scafctl run resolver --skip-transform -f solution.yaml
@@ -1234,16 +1331,16 @@ scafctl run res -f solution.yaml
 {{% tab "PowerShell" %}}
 ```powershell
 # All resolvers
-scafctl run resolver -f solution.yaml --hide-execution
+scafctl run resolver -f solution.yaml
 
 # Named resolvers (with dependencies)
-scafctl run resolver db config -f solution.yaml --hide-execution
+scafctl run resolver db config -f solution.yaml
 
-# JSON output (includes __execution metadata by default)
+# JSON output (resolver values only, no execution metadata)
 scafctl run resolver -f solution.yaml -o json
 
-# JSON output without __execution metadata
-scafctl run resolver -f solution.yaml -o json --hide-execution
+# JSON output with __execution metadata (phases, timing, providers)
+scafctl run resolver -f solution.yaml -o json
 
 # Skip transform and validation phases
 scafctl run resolver --skip-transform -f solution.yaml

--- a/examples/resolvers/cel-basics.yaml
+++ b/examples/resolvers/cel-basics.yaml
@@ -2,8 +2,8 @@
 # Demonstrates basic CEL expressions, literal types, and resolver references.
 # This is the "Quick Start" companion for the CEL tutorial.
 #
-# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json --hide-execution
-# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o yaml --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/cel-basics.yaml -o yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/cel-builtins.yaml
+++ b/examples/resolvers/cel-builtins.yaml
@@ -2,8 +2,8 @@
 # Demonstrates built-in CEL functions: math, encoders, sets, optionals,
 # bindings, string operations, and list comprehensions.
 #
-# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json --hide-execution
-# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o yaml --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/cel-common-patterns.yaml
+++ b/examples/resolvers/cel-common-patterns.yaml
@@ -2,8 +2,8 @@
 # Demonstrates real-world patterns: conditionals, string interpolation,
 # map building, default merging, list transforms, and resource generation.
 #
-# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json --hide-execution
-# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o yaml --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/foreach-filter.yaml
+++ b/examples/resolvers/foreach-filter.yaml
@@ -11,7 +11,7 @@
 # Setting `keepSkipped: true` retains nil entries so the output array remains
 # index-aligned with the input array.
 #
-# Run: scafctl run resolver -f examples/resolvers/foreach-filter.yaml -o json --hide-execution
+# Run: scafctl run resolver -f examples/resolvers/foreach-filter.yaml -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/resolvers/plan-aware.yaml
+++ b/examples/resolvers/plan-aware.yaml
@@ -1,0 +1,80 @@
+# Plan-Aware Resolvers Example
+# Demonstrates using __plan to conditionally execute resolvers based on
+# pre-execution topology data (phase, dependencies, dependency count).
+#
+# __plan is injected before any resolver executes. Each resolver can access
+# its own or any other resolver's topology using __plan["resolverName"]:
+#
+#   __plan["resolverName"].phase           -- execution phase number (1-based)
+#   __plan["resolverName"].dependsOn       -- effective dependency list
+#   __plan["resolverName"].dependencyCount -- number of dependencies
+#
+# Run: scafctl run resolver -f plan-aware.yaml -o json
+# Run with debug: scafctl run resolver -f plan-aware.yaml -o json --show-execution
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: plan-aware-example
+  version: 1.0.0
+  description: Shows how resolvers can reference __plan topology data
+
+spec:
+  resolvers:
+    # Phase 1: no dependencies
+    base_url:
+      description: Base API URL
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: https://api.example.com
+
+    # Phase 1: no dependencies
+    region:
+      description: Deployment region
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-east-1
+
+    # Phase 2: depends on base_url
+    endpoint:
+      description: Full API endpoint
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.base_url + '/v2/data'"
+
+    # Only resolves when it has at least one dependency (guards against
+    # misconfiguration where this resolver was inadvertently made standalone)
+    dependent_check:
+      description: Verifies that this resolver executes after its dependencies
+      type: string
+      when:
+        expr: "__plan['endpoint'].dependencyCount > 0"
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >-
+                'endpoint is in phase ' + string(__plan['endpoint'].phase) +
+                ' with ' + string(__plan['endpoint'].dependencyCount) + ' dep(s)'
+
+    # Only resolve expensive config when running in a late phase
+    # (i.e., only when other resolvers actually depend on this one)
+    phase_summary:
+      description: Summary of the execution plan phases
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >-
+                'base_url: phase ' + string(__plan['base_url'].phase) +
+                ', endpoint: phase ' + string(__plan['endpoint'].phase)

--- a/examples/solutions/execution-aware-actions/solution.yaml
+++ b/examples/solutions/execution-aware-actions/solution.yaml
@@ -1,0 +1,108 @@
+# Execution-Aware Actions Example
+# Demonstrates using __execution in action when conditions and inputs.
+#
+# After resolvers run, the full execution metadata is available in actions as
+# __execution. This lets you gate actions on resolver execution outcomes:
+#
+#   __execution["resolvers"]["name"].status   -- "success" | "failed" | "skipped"
+#   __execution["resolvers"]["name"].phase    -- execution phase number
+#   __execution["resolvers"]["name"].duration -- duration string e.g. "3ms"
+#   __execution["summary"].phaseCount        -- total number of phases
+#   __execution["summary"].resolverCount     -- number of resolvers that ran
+#
+# Run: scafctl run solution -f examples/solutions/execution-aware-actions/solution.yaml
+# With show-execution output: add --show-execution to see the full metadata
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: execution-aware-actions
+  version: 1.0.0
+  description: Shows how to use __execution metadata in action when conditions and inputs
+
+spec:
+  resolvers:
+    environment:
+      description: Target deployment environment
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: environment
+          - provider: static
+            inputs:
+              value: staging
+
+    app_version:
+      description: Application version
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "2.5.0"
+
+    # A second-phase resolver that depends on environment
+    deploy_target:
+      description: Deployment target derived from environment
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.environment + '-cluster'"
+
+  workflow:
+    actions:
+      # Always runs -- shows basic resolver info from __execution
+      print-summary:
+        description: Print a deployment summary using resolver execution metadata
+        provider: message
+        inputs:
+          message:
+            expr: >
+              'Deploying ' + _.app_version + ' to ' + _.environment +
+              ' -- resolver phases: ' + string(__execution['summary']['phaseCount'])
+          type: info
+
+      # Only runs in the 'production' environment
+      prod-gate:
+        description: Gate that only runs when environment is production
+        provider: message
+        dependsOn: [print-summary]
+        when:
+          expr: "_.environment == 'production'"
+        inputs:
+          message: "Running production-only checks..."
+          type: warning
+
+      # Runs when prod-gate was SKIPPED (i.e., non-production)
+      # Demonstrates __execution combined with action status
+      non-prod-deploy:
+        description: Deploy to non-production target
+        provider: message
+        dependsOn: [print-summary]
+        when:
+          expr: "_.environment != 'production'"
+        inputs:
+          message:
+            expr: >
+              'Deploying to ' + _.deploy_target +
+              ' (resolver phase count: ' + string(__execution['summary']['phaseCount']) + ')'
+          type: success
+
+      # Show resolver phase metadata from __execution
+      show-phases:
+        description: Display resolver execution phase information
+        provider: message
+        dependsOn: [prod-gate, non-prod-deploy]
+        inputs:
+          message:
+            expr: >
+              'environment resolved in phase ' +
+              string(__execution['resolvers']['environment']['phase']) +
+              ', deploy_target in phase ' +
+              string(__execution['resolvers']['deploy_target']['phase'])
+          type: info

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -30,6 +30,11 @@ type Executor struct {
 	// resolverData contains resolved data from the resolver phase
 	resolverData map[string]any
 
+	// executionData contains resolver execution metadata (phases, timing, providers).
+	// When set, it is injected as __execution into action when conditions and inputs,
+	// allowing actions to inspect how resolvers ran (status, duration, phase, etc.).
+	executionData map[string]any
+
 	// actionContext manages the __actions namespace
 	actionContext *Context
 
@@ -71,6 +76,15 @@ func WithRegistry(registry RegistryInterface) ExecutorOption {
 func WithResolverData(data map[string]any) ExecutorOption {
 	return func(e *Executor) {
 		e.resolverData = data
+	}
+}
+
+// WithExecutionData sets the resolver execution metadata for action contexts.
+// When set, the data is injected as __execution into action when conditions and
+// provider inputs, allowing actions to read resolver status, duration, and phase.
+func WithExecutionData(data map[string]any) ExecutorOption {
+	return func(e *Executor) {
+		e.executionData = data
 	}
 }
 
@@ -665,6 +679,12 @@ func (e *Executor) buildAdditionalVars(aliasMap map[string]string) map[string]an
 	additionalVars := map[string]any{
 		celexp.VarActions: namespace,
 		celexp.VarCwd:     e.cwd,
+	}
+
+	// Inject resolver execution metadata when available so action when conditions
+	// and provider inputs can read __execution.resolvers.<name>.status, duration, etc.
+	if e.executionData != nil {
+		additionalVars[celexp.VarExecution] = e.executionData
 	}
 
 	// Add aliases as top-level variables

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -1099,3 +1099,64 @@ func TestExecutor_GetContext(t *testing.T) {
 	assert.NotNil(t, ctx)
 	assert.Equal(t, e.actionContext, ctx)
 }
+
+func TestWithExecutionData(t *testing.T) {
+	t.Parallel()
+
+	execData := map[string]any{
+		"resolvers": map[string]any{
+			"myResolver": map[string]any{
+				"status":   "success",
+				"duration": "1.2s",
+				"phase":    float64(1),
+			},
+		},
+	}
+
+	e := NewExecutor(WithExecutionData(execData))
+	assert.Equal(t, execData, e.executionData)
+}
+
+func TestWithExecutionData_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	e := NewExecutor()
+	assert.Nil(t, e.executionData)
+
+	// buildAdditionalVars should not include __execution when nil
+	vars := e.buildAdditionalVars(nil)
+	_, hasExecution := vars["__execution"]
+	assert.False(t, hasExecution, "__execution should not be injected when executionData is nil")
+}
+
+func TestBuildAdditionalVars_InjectsExecution(t *testing.T) {
+	t.Parallel()
+
+	execData := map[string]any{
+		"resolvers": map[string]any{
+			"build": map[string]any{"status": "success"},
+		},
+	}
+
+	e := NewExecutor(WithExecutionData(execData))
+	vars := e.buildAdditionalVars(nil)
+
+	execution, ok := vars["__execution"]
+	assert.True(t, ok, "__execution should be present when executionData is set")
+	assert.Equal(t, execData, execution)
+}
+
+func TestBuildAdditionalVars_ExecutionDoesNotOverrideActions(t *testing.T) {
+	t.Parallel()
+
+	execData := map[string]any{"resolvers": map[string]any{}}
+
+	e := NewExecutor(WithExecutionData(execData))
+	vars := e.buildAdditionalVars(nil)
+
+	// both __actions and __execution must coexist
+	_, hasActions := vars["__actions"]
+	_, hasExecution := vars["__execution"]
+	assert.True(t, hasActions)
+	assert.True(t, hasExecution)
+}

--- a/pkg/action/graph.go
+++ b/pkg/action/graph.go
@@ -812,19 +812,23 @@ func buildAliasNames(sections ...map[string]*Action) []string {
 	return aliases
 }
 
-// referencesActionsOrAlias checks if a ValueRef references __actions, __cwd, or any action alias.
+// referencesActionsOrAlias checks if a ValueRef references __actions, __cwd, __execution, or any action alias.
 // If any is true, the value must be deferred until runtime when action results and executor context are available.
 func referencesActionsOrAlias(v *spec.ValueRef, aliasNames []string) bool {
-	if v.ReferencesVariable(celexp.VarActions) {
+	vars := v.ReferencedVariables()
+
+	if _, ok := vars[celexp.VarActions]; ok {
 		return true
 	}
-
-	if v.ReferencesVariable(celexp.VarCwd) {
+	if _, ok := vars[celexp.VarCwd]; ok {
+		return true
+	}
+	if _, ok := vars[celexp.VarExecution]; ok {
 		return true
 	}
 
 	for _, alias := range aliasNames {
-		if v.ReferencesVariable(alias) {
+		if _, ok := vars[alias]; ok {
 			return true
 		}
 	}

--- a/pkg/celexp/context.go
+++ b/pkg/celexp/context.go
@@ -37,6 +37,17 @@ const (
 	// VarCwd is the variable name for the original working directory in action contexts.
 	// Access via __cwd in CEL expressions when --output-dir redirects action output.
 	VarCwd = "__cwd"
+
+	// VarExecution is the variable name for resolver execution metadata in action contexts.
+	// Available via __execution when --show-execution was used or when injected explicitly.
+	// Example: __execution.resolvers.myResolver.status
+	VarExecution = "__execution"
+
+	// VarPlan is the variable name for pre-execution resolver topology data.
+	// Injected before any resolver runs so resolvers can reference phase, dependsOn,
+	// and dependencyCount for any resolver in when conditions and provider inputs.
+	// Example: __plan["myResolver"].phase
+	VarPlan = "__plan"
 )
 
 // BuildCELContext creates CEL environment options and variables for evaluation.

--- a/pkg/cmd/scafctl/root_coverage_test.go
+++ b/pkg/cmd/scafctl/root_coverage_test.go
@@ -317,6 +317,7 @@ func TestRoot_BinaryName_EnvPrefix_Hyphen(t *testing.T) {
 
 // TestRoot_PreRunHook_Called verifies that PreRunHook is invoked during PersistentPreRun.
 func TestRoot_PreRunHook_Called(t *testing.T) {
+	t.Parallel()
 	hookCalled := false
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	cmd := Root(&RootOptions{
@@ -335,6 +336,7 @@ func TestRoot_PreRunHook_Called(t *testing.T) {
 
 // TestRoot_PreRunHook_Nil verifies that nil PreRunHook is a no-op.
 func TestRoot_PreRunHook_Nil(t *testing.T) {
+	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	cmd := Root(&RootOptions{IOStreams: ioStreams, PreRunHook: nil})
 	cmd.SetArgs([]string{"version"})
@@ -345,6 +347,7 @@ func TestRoot_PreRunHook_Nil(t *testing.T) {
 
 // TestRoot_VersionExtra verifies that VersionExtra is passed to the version command.
 func TestRoot_VersionExtra(t *testing.T) {
+	t.Parallel()
 	ioStreams, out, _ := terminal.NewTestIOStreams()
 	cmd := Root(&RootOptions{
 		IOStreams:  ioStreams,
@@ -375,6 +378,7 @@ func TestNewRootOptions_NewFields(t *testing.T) {
 
 // TestRoot_PreRunHook_Error verifies that PreRunHook errors are surfaced.
 func TestRoot_PreRunHook_Error(t *testing.T) {
+	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	exitCalled := false
 	cmd := Root(&RootOptions{

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -57,8 +57,8 @@ type ResolverOptions struct {
 	// Redact redacts sensitive values in the snapshot.
 	Redact bool
 
-	// HideExecution suppresses the __execution metadata from output.
-	HideExecution bool
+	// ShowExecution includes the __execution metadata in output.
+	ShowExecution bool
 
 	// DynamicArgs are resolver parameters from positional key=value syntax
 	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
@@ -97,10 +97,10 @@ This command is designed for debugging and inspecting resolver execution.
 It loads a solution file and executes only the resolvers, skipping the
 action/workflow phase entirely.
 
-By default, the output includes a __execution key containing per-resolver
-execution metadata: phase numbers, timing, provider info, dependencies, the
-resolver dependency graph, provider usage summary, and an aggregate summary.
-Use --hide-execution to suppress this metadata for cleaner output.
+By default, output contains only the resolved values. Pass --show-execution
+to include a __execution key with per-resolver metadata: phase numbers,
+timing, provider info, dependencies, the resolver dependency graph, provider
+usage summary, and an aggregate summary.
 
 SOLUTION SOURCE:
   Solutions can be loaded from:
@@ -306,7 +306,7 @@ Examples:
 	cCmd.Flags().BoolVar(&options.Snapshot, "snapshot", false, "Save execution snapshot instead of normal output")
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
-	cCmd.Flags().BoolVar(&options.HideExecution, "hide-execution", false, "Suppress __execution metadata from output")
+	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
 
 	setResolverHelpFunc(cCmd)
 
@@ -330,7 +330,8 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		"snapshot", o.Snapshot,
 		"resolveAll", o.ResolveAll,
 		"progress", o.Progress,
-		"showMetrics", o.ShowMetrics)
+		"showMetrics", o.ShowMetrics,
+		"showExecution", o.ShowExecution)
 
 	// Validate mutually exclusive modes
 	if o.Graph && o.Snapshot {
@@ -456,8 +457,8 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
 	}
 
-	// Include __execution metadata unless --hide-execution is set
-	if !o.HideExecution {
+	// Include __execution metadata only when --show-execution is set
+	if o.ShowExecution {
 		executionData := execute.BuildExecutionData(resolverCtx, resolvers, elapsed)
 
 		// Build and embed the resolver dependency graph

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -55,7 +55,6 @@ func TestCommandResolver(t *testing.T) {
 
 	// Should NOT have solution-specific flags
 	assert.Nil(t, ff.Lookup("action-timeout"))
-	assert.Nil(t, ff.Lookup("show-execution"))
 }
 
 func TestCommandResolver_FlagDefaults(t *testing.T) {
@@ -477,6 +476,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -522,7 +522,7 @@ spec:
 	assert.Equal(t, float64(1), summary["resolverCount"])
 }
 
-func TestResolverOptions_Run_HideExecution(t *testing.T) {
+func TestResolverOptions_Run_ShowExecution(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -530,7 +530,7 @@ func TestResolverOptions_Run_HideExecution(t *testing.T) {
 	solutionContent := `apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: hide-execution-test
+  name: show-execution-test
   version: 1.0.0
 spec:
   resolvers:
@@ -563,7 +563,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		HideExecution: true,
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -574,7 +574,7 @@ spec:
 
 	output := stdout.String()
 	assert.Contains(t, output, "hello")
-	assert.NotContains(t, output, "__execution", "__execution should not be present when --hide-execution is set")
+	assert.Contains(t, output, "__execution", "__execution should be present when --show-execution is set")
 
 	// Parse JSON to validate structure
 	var result map[string]any
@@ -582,7 +582,7 @@ spec:
 	require.NoError(t, err)
 
 	_, hasExecution := result["__execution"]
-	assert.False(t, hasExecution, "__execution key should not exist in output")
+	assert.True(t, hasExecution, "__execution key should exist in output when --show-execution is set")
 
 	// Resolver values should still be present
 	assert.Equal(t, "hello", result["greeting"])
@@ -681,7 +681,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		HideExecution: true,
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -762,7 +762,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		HideExecution: true,
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -826,7 +826,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		HideExecution: true,
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -1287,6 +1287,7 @@ spec:
 			registry:        testRegistry(),
 		},
 		SkipTransform: true,
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)
@@ -1456,6 +1457,7 @@ spec:
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
+		ShowExecution: true,
 	}
 
 	lgr := logger.Get(0)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -421,9 +421,15 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Get effective action config (CLI flags override app config)
 	actionCfg := o.getEffectiveActionConfig(ctx)
 
+	// Build execution metadata before constructing the action executor so it can be
+	// injected as __execution into action when conditions and provider inputs,
+	// regardless of whether --show-execution is set for resolver output display.
+	resolverExecutionData := execute.BuildExecutionData(resolverCtx, resolvers, resolverElapsed)
+
 	actionExecutor := action.NewExecutor(
 		action.WithRegistry(actionAdapter),
 		action.WithResolverData(resolverData),
+		action.WithExecutionData(resolverExecutionData),
 		action.WithProgressCallback(actionProgressCallback),
 		action.WithDefaultTimeout(actionCfg.DefaultTimeout),
 		action.WithGracePeriod(actionCfg.GracePeriod),
@@ -437,10 +443,10 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 	}
 
-	// Build and write output
+	// Build and write output — only include __execution in output when --show-execution is set
 	var executionData map[string]any
 	if o.ShowExecution {
-		executionData = execute.BuildExecutionData(resolverCtx, resolvers, resolverElapsed)
+		executionData = resolverExecutionData
 	}
 	return o.writeActionOutput(ctx, result, executionData)
 }

--- a/pkg/cmd/scafctl/test/test.go
+++ b/pkg/cmd/scafctl/test/test.go
@@ -5,7 +5,6 @@ package test
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -28,7 +27,7 @@ SUBCOMMANDS:
 Functional tests validate that solutions behave correctly by executing
 scafctl commands against them and checking the output. Tests are defined
 inline in solution YAML under spec.testing.cases or in separate test files
-under a tests/ directory.`, strings.SplitN(path, "/", 2)[0]),
+under a tests/ directory.`, path),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/version/version.go
+++ b/pkg/cmd/scafctl/version/version.go
@@ -111,7 +111,7 @@ func (options *CmdOptionsVersion) PrintVersion(ctx context.Context) error {
 		}
 	}
 	if outOfDate {
-		lgr.V(0).Info(fmt.Sprintf("A newer version of %s is available. Please consider updating to the latest version.", options.BinaryName))
+		lgr.V(0).Info("a newer version is available, consider updating", "binary", options.BinaryName)
 	}
 	verDetails := newVersionDetails(latestVersion, options.BinaryName, options.VersionExtra)
 	customOutputFn := func(_ *terminal.IOStreams, data map[string]any) error {

--- a/pkg/cmd/scafctl/version/version_test.go
+++ b/pkg/cmd/scafctl/version/version_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionCmdOptions_PrintVersion(t *testing.T) {
@@ -161,25 +163,13 @@ func TestVersionCmdOptions_PrintVersion_WithVersionExtra(t *testing.T) {
 	}
 
 	err := options.PrintVersion(ctx)
-	if err != nil {
-		t.Fatalf("PrintVersion() error = %v", err)
-	}
+	require.NoError(t, err)
 
 	output := out.String()
-	// Should contain embedder info
-	if !strings.Contains(output, "mycli") {
-		t.Errorf("output should contain embedder binary name 'mycli', got: %s", output)
-	}
-	if !strings.Contains(output, "v2.0.0") {
-		t.Errorf("output should contain embedder version 'v2.0.0', got: %s", output)
-	}
-	if !strings.Contains(output, "embed789") {
-		t.Errorf("output should contain embedder commit 'embed789', got: %s", output)
-	}
-	// Should still contain scafctl version info
-	if !strings.Contains(output, "1.0.0") {
-		t.Errorf("output should contain scafctl version '1.0.0', got: %s", output)
-	}
+	assert.Contains(t, output, "mycli")
+	assert.Contains(t, output, "v2.0.0")
+	assert.Contains(t, output, "embed789")
+	assert.Contains(t, output, "1.0.0")
 }
 
 func TestVersionCmdOptions_PrintVersion_JSONWithVersionExtra(t *testing.T) {
@@ -212,18 +202,11 @@ func TestVersionCmdOptions_PrintVersion_JSONWithVersionExtra(t *testing.T) {
 	}
 
 	err := options.PrintVersion(ctx)
-	if err != nil {
-		t.Fatalf("PrintVersion() error = %v", err)
-	}
+	require.NoError(t, err)
 
 	output := out.String()
-	// JSON output should contain embedder block
-	if !strings.Contains(output, "embedder") {
-		t.Errorf("JSON output should contain 'embedder' key, got: %s", output)
-	}
-	if !strings.Contains(output, "mycli") {
-		t.Errorf("JSON output should contain embedder name 'mycli', got: %s", output)
-	}
+	assert.Contains(t, output, "embedder")
+	assert.Contains(t, output, "mycli")
 }
 
 func TestNewVersionDetails_WithVersionExtra(t *testing.T) {
@@ -236,31 +219,20 @@ func TestNewVersionDetails_WithVersionExtra(t *testing.T) {
 	details := newVersionDetails("1.0.0", "mycli", extra)
 
 	embedder, ok := details["embedder"].(map[string]any)
-	if !ok {
-		t.Fatal("expected 'embedder' key in details")
-	}
-	if embedder["name"] != "mycli" {
-		t.Errorf("embedder name = %v, want 'mycli'", embedder["name"])
-	}
-	if embedder["version"] != "v2.0.0" {
-		t.Errorf("embedder version = %v, want 'v2.0.0'", embedder["version"])
-	}
+	require.True(t, ok, "expected 'embedder' key in details")
+	assert.Equal(t, "mycli", embedder["name"])
+	assert.Equal(t, "v2.0.0", embedder["version"])
 }
 
 func TestNewVersionDetails_WithoutVersionExtra(t *testing.T) {
 	t.Parallel()
 	details := newVersionDetails("1.0.0", "scafctl", nil)
-
-	if _, ok := details["embedder"]; ok {
-		t.Error("expected no 'embedder' key when VersionExtra is nil")
-	}
+	assert.NotContains(t, details, "embedder")
 }
 
 func TestCommandVersion_UsesPath(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	cmd := CommandVersion(&settings.Run{}, ioStreams, "mycli", nil)
-	if !strings.Contains(cmd.Short, "mycli") {
-		t.Errorf("Short should contain path 'mycli', got: %s", cmd.Short)
-	}
+	assert.Contains(t, cmd.Short, "mycli")
 }

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -293,6 +293,11 @@ Follow these rules when creating the solution:
 - Always validate user inputs using the validate phase with the validation provider
 - Use dependsOn for ordering (both resolvers and actions)
 - Use when clauses (CEL expressions) for conditional execution
+- CEL context variables available in resolver when/inputs: _ (resolved values), __plan (pre-execution topology)
+  - __plan["resolverName"].phase, __plan["resolverName"].dependsOn, __plan["resolverName"].dependencyCount
+- CEL context variables available in action when/inputs: _ (resolved values), __execution (resolver metadata), __actions (prior action results)
+  - Gate actions on resolver outcomes: __execution["resolvers"]["name"]["status"] == "success"
+  - Access phase count: __execution["summary"]["phaseCount"]
 - For exec provider actions: the input field is "command" (string), NOT "cmd". Always use get_provider_schema to verify required fields.
 
 NEVER invent fields that don't exist in the schema. Only use fields documented in the JSON Schema.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -253,6 +253,31 @@ CLI Usage Reference (use these exact flags when suggesting commands to users):
   Run tests:            scafctl test functional -f ./solution.yaml
   Run tests (verbose):  scafctl test functional -f ./solution.yaml -v
 
+Execution Metadata Flags:
+  Both 'run resolver' and 'run solution' support --show-execution to include
+  structured metadata in output. Off by default (clean output is the default).
+    --show-execution     Add '__execution' key with timing, phases, providers
+  Examples:
+    scafctl run resolver -f ./solution.yaml -o json --show-execution
+    scafctl run solution -f ./solution.yaml --show-execution
+
+CEL Context Variables (available in resolver conditions, inputs, and action when/inputs):
+  _            Map of resolved resolver values (e.g., _.environment, _.config.port)
+  __plan       Pre-execution resolver topology (available in resolvers, populated before any resolver runs):
+                 __plan["resolverName"].phase           -- execution phase (1-based int)
+                 __plan["resolverName"].dependsOn       -- dependency list (list of strings)
+                 __plan["resolverName"].dependencyCount -- number of dependencies (int)
+  __execution  Resolver execution metadata (available in actions, populated after resolvers complete):
+                 __execution["resolvers"]["name"].status   -- "success", "failed", or "skipped"
+                 __execution["resolvers"]["name"].phase    -- phase number (int)
+                 __execution["resolvers"]["name"].duration -- e.g. "3ms"
+                 __execution["summary"].phaseCount        -- total resolver phases
+                 __execution["summary"].resolverCount     -- number of resolvers that ran
+                 __execution["summary"].totalDuration     -- total resolver execution time
+  __actions    Downstream action results (available in actions, keyed by action name):
+                 __actions["name"].results -- action output
+                 __actions["name"].status  -- "succeeded", "failed", "skipped"
+
 File Conflict Strategies:
   When a solution writes files (file provider), use --on-conflict to control
   behavior when targets already exist:

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
@@ -205,6 +206,9 @@ func (s *Server) registerSolutionTools() {
 		),
 		mcp.WithBoolean("backup",
 			mcp.Description("Include --backup flag in the generated command. Creates .bak backups before overwriting existing files."),
+		),
+		mcp.WithBoolean("show_execution",
+			mcp.Description("Include --show-execution flag in the generated command. Adds __execution metadata (timing, phases, providers) to the output. Useful when debugging resolver performance or building execution-aware pipelines."),
 		),
 		mcp.WithString("cwd",
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
@@ -932,6 +936,11 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	if outputDir != "" {
 		response["outputDir"] = outputDir
 	}
+	// Include __plan topology: phase, dependsOn, dependencyCount for each resolver.
+	// This lets AI agents understand execution order without re-parsing the YAML.
+	if planRaw, ok := result.Context.Get(celexp.VarPlan); ok {
+		response["plan"] = planRaw
+	}
 
 	result2, err := mcp.NewToolResultJSON(response)
 	if err != nil {
@@ -1178,6 +1187,9 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 				WithSuggestion("Remove backup, or use a solution that has a workflow with file provider actions."),
 			), nil
 		}
+	}
+	if request.GetBool("show_execution", false) {
+		cmdInfo.Command += " --show-execution"
 	}
 
 	// Build result with content annotations.

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -570,6 +570,71 @@ spec:
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
 	})
+
+	t.Run("response includes __plan topology", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "plan-preview.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: plan-preview
+  version: 1.0.0
+spec:
+  resolvers:
+    base:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: root
+    derived:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.base + '-derived'"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		// __plan topology should be present in the response
+		plan, ok := parsed["plan"]
+		assert.True(t, ok, "plan should be present in preview_resolvers response")
+		require.NotNil(t, plan)
+
+		planMap, ok := plan.(map[string]any)
+		require.True(t, ok, "plan should be map[string]any")
+		assert.Contains(t, planMap, "base", "plan should contain base resolver")
+		assert.Contains(t, planMap, "derived", "plan should contain derived resolver")
+
+		basePlan, ok := planMap["base"].(map[string]any)
+		require.True(t, ok, "base plan entry should be map[string]any")
+		assert.Equal(t, float64(1), basePlan["phase"], "base should be in phase 1")
+		assert.Equal(t, float64(0), basePlan["dependencyCount"], "base should have no dependencies")
+
+		derivedPlan, ok := planMap["derived"].(map[string]any)
+		require.True(t, ok, "derived plan entry should be map[string]any")
+		assert.Equal(t, float64(2), derivedPlan["phase"], "derived should be in phase 2")
+		assert.Equal(t, float64(1), derivedPlan["dependencyCount"], "derived should have 1 dependency")
+	})
 }
 
 func TestHandleGetRunCommand(t *testing.T) {
@@ -978,6 +1043,90 @@ spec:
 		result, err := srv.handleGetRunCommand(context.Background(), request)
 		require.NoError(t, err)
 		assert.True(t, result.IsError, "should return error for backup with resolver-only solution")
+	})
+
+	t.Run("show_execution flag appended to command", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "show-execution-test.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: show-execution-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path":           solFile,
+			"show_execution": true,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		cmd, ok := parsed["command"].(string)
+		require.True(t, ok, "command should be a string")
+		assert.Contains(t, cmd, "--show-execution", "show_execution=true should add --show-execution flag")
+	})
+
+	t.Run("show_execution false omits flag", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "no-show-execution.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-show-execution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_run_command"
+		request.Params.Arguments = map[string]any{
+			"path":           solFile,
+			"show_execution": false,
+		}
+
+		result, err := srv.handleGetRunCommand(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		cmd, ok := parsed["command"].(string)
+		require.True(t, ok, "command should be a string")
+		assert.NotContains(t, cmd, "--show-execution", "show_execution=false should not add --show-execution flag")
 	})
 }
 

--- a/pkg/provider/builtin/celprovider/cel.go
+++ b/pkg/provider/builtin/celprovider/cel.go
@@ -148,9 +148,9 @@ func (p *CelProvider) Execute(ctx context.Context, input any) (*provider.Output,
 	}
 
 	// Extract standard special variables from resolver data and make them top-level CEL variables.
-	// These include __self, __item, __index.
+	// These include __self, __item, __index, and __plan (pre-execution topology).
 	if resolverData != nil {
-		for _, key := range []string{celexp.VarSelf, celexp.VarItem, celexp.VarIndex} {
+		for _, key := range []string{celexp.VarSelf, celexp.VarItem, celexp.VarIndex, celexp.VarPlan} {
 			if value, ok := resolverData[key]; ok {
 				additionalVars[key] = value
 				delete(resolverData, key)

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -228,18 +228,23 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 	lookup := e.registry.DescriptorLookup()
 
 	// Build execution phases
-	phases, err := BuildPhases(resolvers, lookup)
+	buildResult, err := BuildPhases(resolvers, lookup)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return ctx, fmt.Errorf("failed to build execution phases: %w", err)
 	}
 
-	lgr.V(1).Info("resolver execution plan", "phases", len(phases))
+	lgr.V(1).Info("resolver execution plan", "phases", len(buildResult.Phases))
 
 	// Create resolver context
 	resolverCtx := NewContext()
 	ctx = WithContext(ctx, resolverCtx)
+
+	// Inject pre-execution plan topology as __plan so resolvers can reference
+	// phase number, dependency list, and dependency count in when conditions
+	// and provider inputs before any resolver executes.
+	resolverCtx.Set(celexp.VarPlan, buildResult.Plan.ToMap())
 
 	// Add parameters to context for parameter provider
 	ctx = provider.WithParameters(ctx, params)
@@ -256,16 +261,12 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 		aggregatedError = &AggregatedExecutionError{}
 	}
 
-	// Build dependency map for all resolvers (used in validate-all mode)
-	depsMap := make(map[string][]string)
-	for _, phase := range phases {
-		for _, r := range phase.Resolvers {
-			depsMap[r.Name] = extractDependencies(r, lookup)
-		}
-	}
+	// Build dependency map for all resolvers (used in validate-all mode).
+	// Re-use the deps map already computed by BuildPhases.
+	depsMap := buildResult.Deps
 
 	// Execute phases sequentially
-	for _, phase := range phases {
+	for _, phase := range buildResult.Phases {
 		lgr.V(1).Info("executing resolver phase",
 			"phase", phase.Phase,
 			"resolvers", len(phase.Resolvers))
@@ -293,7 +294,7 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 		}
 	}
 
-	lgr.V(1).Info("resolver execution complete", "total_phases", len(phases))
+	lgr.V(1).Info("resolver execution complete", "total_phases", len(buildResult.Phases))
 
 	// In validate-all mode, return aggregated error if there were any failures
 	if e.validateAll && aggregatedError != nil && aggregatedError.HasErrors() {
@@ -724,8 +725,16 @@ func (e *Executor) evaluateCondition(ctx context.Context, cond *Condition) (bool
 	// Get resolver data for CEL evaluation
 	data := resolverCtx.ToMap()
 
+	// Promote __plan to a top-level CEL variable so when conditions can use
+	// __plan["resolverName"].phase rather than _["__plan"]["resolverName"]["phase"].
+	additionalVars := map[string]any{}
+	if plan, ok := data[celexp.VarPlan]; ok {
+		additionalVars[celexp.VarPlan] = plan
+		delete(data, celexp.VarPlan)
+	}
+
 	// Evaluate the CEL expression
-	result, err := celexp.EvaluateExpression(ctx, string(*cond.Expr), data, nil)
+	result, err := celexp.EvaluateExpression(ctx, string(*cond.Expr), data, additionalVars)
 	if err != nil {
 		return false, fmt.Errorf("condition evaluation failed: %w", err)
 	}
@@ -752,9 +761,14 @@ func (e *Executor) evaluateConditionWithSelf(ctx context.Context, cond *Conditio
 	// Get resolver data for CEL evaluation
 	data := resolverCtx.ToMap()
 
-	// Pass __self as an additional variable so it's available as a top-level CEL variable
+	// Pass __self as an additional variable so it's available as a top-level CEL variable.
+	// Also promote __plan so until: conditions can reference topology data.
 	additionalVars := map[string]any{
 		celexp.VarSelf: self,
+	}
+	if plan, ok := data[celexp.VarPlan]; ok {
+		additionalVars[celexp.VarPlan] = plan
+		delete(data, celexp.VarPlan)
 	}
 
 	// Evaluate the CEL expression

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -450,10 +450,11 @@ type GraphStats struct {
 // when available for more accurate dependency detection.
 func BuildGraph(resolvers []*Resolver, lookup DescriptorLookup) (*Graph, error) {
 	// Build phases first
-	phases, err := BuildPhases(resolvers, lookup)
+	buildResult, err := BuildPhases(resolvers, lookup)
 	if err != nil {
 		return nil, fmt.Errorf("build phases: %w", err)
 	}
+	phases := buildResult.Phases
 
 	graph := &Graph{
 		Nodes:  make([]*GraphNode, 0, len(resolvers)),

--- a/pkg/resolver/phase.go
+++ b/pkg/resolver/phase.go
@@ -16,6 +16,46 @@ type PhaseGroup struct {
 	Resolvers []*Resolver `json:"resolvers" yaml:"resolvers" doc:"Resolvers in this phase" minItems:"1"`
 }
 
+// Plan holds pre-execution static topology data for a single resolver.
+// It is populated after DAG construction and before any resolver executes.
+type Plan struct {
+	Phase           int      `json:"phase"           yaml:"phase"           doc:"Execution phase number (1-based)" minimum:"1"`
+	DependsOn       []string `json:"dependsOn"       yaml:"dependsOn"       doc:"Effective dependencies after provider extraction" maxItems:"1000"`
+	DependencyCount int      `json:"dependencyCount" yaml:"dependencyCount" doc:"Number of effective dependencies" minimum:"0"`
+}
+
+// PlanData is a pre-execution snapshot of resolver topology, keyed by resolver name.
+// It is injected into the resolver context as __plan before any resolver executes,
+// making topology data available in when conditions and provider inputs.
+type PlanData map[string]Plan
+
+// ToMap converts PlanData into a map[string]any suitable for injection into the
+// resolver CEL context. Each Plan is converted to a map[string]any with
+// keys "phase", "dependsOn", and "dependencyCount".
+func (p PlanData) ToMap() map[string]any {
+	out := make(map[string]any, len(p))
+	for name, rp := range p {
+		deps := rp.DependsOn
+		if deps == nil {
+			deps = []string{}
+		}
+		out[name] = map[string]any{
+			"phase":           rp.Phase,
+			"dependsOn":       deps,
+			"dependencyCount": rp.DependencyCount,
+		}
+	}
+	return out
+}
+
+// BuildResult is the output of BuildPhases, bundling the phase groups with the
+// pre-execution plan topology so callers can inject __plan without re-computing deps.
+type BuildResult struct {
+	Phases []*PhaseGroup       `json:"phases" yaml:"phases" doc:"Execution phase groups"`
+	Plan   PlanData            `json:"plan"   yaml:"plan"   doc:"Pre-execution resolver topology snapshot"`
+	Deps   map[string][]string `json:"-"      yaml:"-"      doc:"Effective dependency map (reusable by callers)"`
+}
+
 // resolverDagObject implements the dag.Object interface for resolvers
 type resolverDagObject struct {
 	resolver *Resolver
@@ -56,9 +96,14 @@ func (r *resolverObjectsWithLookup) DagItems() []dag.Object {
 // Phase numbers are 1-based, with phase 1 being root resolvers (no dependencies).
 // If lookup is provided, provider-specific ExtractDependencies functions will be used
 // when available for more accurate dependency detection.
-func BuildPhases(resolvers []*Resolver, lookup DescriptorLookup) ([]*PhaseGroup, error) {
+// The returned BuildResult includes both the phase groups and PlanData — a static
+// topology snapshot that can be injected as __plan before execution begins.
+func BuildPhases(resolvers []*Resolver, lookup DescriptorLookup) (*BuildResult, error) {
 	if len(resolvers) == 0 {
-		return []*PhaseGroup{}, nil
+		return &BuildResult{
+			Phases: []*PhaseGroup{},
+			Plan:   PlanData{},
+		}, nil
 	}
 
 	// Build dependency map
@@ -131,7 +176,27 @@ func BuildPhases(resolvers []*Resolver, lookup DescriptorLookup) ([]*PhaseGroup,
 		return nil, fmt.Errorf("not all resolvers were grouped into phases; missing: %v", missing)
 	}
 
-	return phases, nil
+	// Build PlanData from the computed phases and deps map
+	plan := make(PlanData, len(resolvers))
+	for _, pg := range phases {
+		for _, r := range pg.Resolvers {
+			d := deps[r.Name]
+			if d == nil {
+				d = []string{}
+			}
+			plan[r.Name] = Plan{
+				Phase:           pg.Phase,
+				DependsOn:       d,
+				DependencyCount: len(d),
+			}
+		}
+	}
+
+	return &BuildResult{
+		Phases: phases,
+		Plan:   plan,
+		Deps:   deps,
+	}, nil
 }
 
 // GetPhaseForResolver returns the phase number for a given resolver name

--- a/pkg/resolver/phase_test.go
+++ b/pkg/resolver/phase_test.go
@@ -4,6 +4,7 @@
 package resolver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -511,7 +512,7 @@ func TestBuildPhases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			phases, err := BuildPhases(tt.resolvers, nil)
+			result, err := BuildPhases(tt.resolvers, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -519,12 +520,206 @@ func TestBuildPhases(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, phases)
+			require.NotNil(t, result)
 
 			if tt.validate != nil {
-				tt.validate(t, phases)
+				tt.validate(t, result.Phases)
 			}
 		})
+	}
+}
+
+func TestBuildPhases_PlanData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		resolvers []*Resolver
+		wantErr   bool
+		validate  func(t *testing.T, plan PlanData)
+	}{
+		{
+			name:      "empty resolvers returns empty plan",
+			resolvers: []*Resolver{},
+			validate: func(t *testing.T, plan PlanData) {
+				assert.Empty(t, plan)
+			},
+		},
+		{
+			name: "root resolver has phase 1 and no deps",
+			resolvers: []*Resolver{
+				{
+					Name: "root",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "v"}}},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, plan PlanData) {
+				require.Contains(t, plan, "root")
+				rp := plan["root"]
+				assert.Equal(t, 1, rp.Phase)
+				assert.Empty(t, rp.DependsOn)
+				assert.Equal(t, 0, rp.DependencyCount)
+			},
+		},
+		{
+			name: "dependent resolver reflects correct phase and deps",
+			resolvers: []*Resolver{
+				{
+					Name: "base",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "b"}}},
+						},
+					},
+				},
+				{
+					Name: "child",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("base")}}},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, plan PlanData) {
+				require.Contains(t, plan, "base")
+				require.Contains(t, plan, "child")
+
+				basePlan := plan["base"]
+				assert.Equal(t, 1, basePlan.Phase)
+				assert.Empty(t, basePlan.DependsOn)
+				assert.Equal(t, 0, basePlan.DependencyCount)
+
+				childPlan := plan["child"]
+				assert.Equal(t, 2, childPlan.Phase)
+				assert.Equal(t, []string{"base"}, childPlan.DependsOn)
+				assert.Equal(t, 1, childPlan.DependencyCount)
+			},
+		},
+		{
+			name: "three-level chain phases are correct",
+			resolvers: []*Resolver{
+				{
+					Name: "l1",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "l1"}}},
+						},
+					},
+				},
+				{
+					Name: "l2",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("l1")}}},
+						},
+					},
+				},
+				{
+					Name: "l3",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: stringPtr("l2")}}},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, plan PlanData) {
+				assert.Equal(t, 1, plan["l1"].Phase)
+				assert.Equal(t, 2, plan["l2"].Phase)
+				assert.Equal(t, 3, plan["l3"].Phase)
+				assert.Equal(t, 0, plan["l1"].DependencyCount)
+				assert.Equal(t, 1, plan["l2"].DependencyCount)
+				assert.Equal(t, 1, plan["l3"].DependencyCount)
+			},
+		},
+		{
+			name: "parallel resolvers share the same phase in plan",
+			resolvers: []*Resolver{
+				{
+					Name: "a",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "a"}}},
+						},
+					},
+				},
+				{
+					Name: "b",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "b"}}},
+						},
+					},
+				},
+				{
+					Name: "c",
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{
+								Provider: "cel",
+								Inputs: map[string]*ValueRef{
+									"a": {Resolver: stringPtr("a")},
+									"b": {Resolver: stringPtr("b")},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, plan PlanData) {
+				assert.Equal(t, 1, plan["a"].Phase)
+				assert.Equal(t, 1, plan["b"].Phase)
+				assert.Equal(t, 2, plan["c"].Phase)
+				assert.Equal(t, 2, plan["c"].DependencyCount)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := BuildPhases(tt.resolvers, nil)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			tt.validate(t, result.Plan)
+		})
+	}
+}
+
+func BenchmarkBuildPhases_WithPlan(b *testing.B) {
+	resolvers := make([]*Resolver, 0, 10)
+	resolvers = append(resolvers, &Resolver{
+		Name: "root",
+		Resolve: &ResolvePhase{
+			With: []ProviderSource{{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: "v"}}}},
+		},
+	})
+	for i := 1; i < 10; i++ {
+		prev := resolvers[i-1].Name
+		resolvers = append(resolvers, &Resolver{
+			Name: fmt.Sprintf("r%d", i),
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{Provider: "cel", Inputs: map[string]*ValueRef{"value": {Resolver: &prev}}},
+				},
+			},
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = BuildPhases(resolvers, nil)
 	}
 }
 
@@ -669,9 +864,9 @@ func TestGetResolversInPhase(t *testing.T) {
 }
 
 func TestBuildPhases_EmptyResolvers(t *testing.T) {
-	phases, err := BuildPhases([]*Resolver{}, nil)
+	result, err := BuildPhases([]*Resolver{}, nil)
 	require.NoError(t, err)
-	assert.Empty(t, phases)
+	assert.Empty(t, result.Phases)
 }
 
 func TestBuildPhases_StandaloneResolver(t *testing.T) {
@@ -682,11 +877,11 @@ func TestBuildPhases_StandaloneResolver(t *testing.T) {
 		},
 	}
 
-	phases, err := BuildPhases(resolvers, nil)
+	result, err := BuildPhases(resolvers, nil)
 	require.NoError(t, err)
-	assert.Len(t, phases, 1)
-	assert.Equal(t, 1, phases[0].Phase)
-	assert.Len(t, phases[0].Resolvers, 1)
+	assert.Len(t, result.Phases, 1)
+	assert.Equal(t, 1, result.Phases[0].Phase)
+	assert.Len(t, result.Phases[0].Resolvers, 1)
 }
 
 func TestResolverDagObject_GetDependencyKeys(t *testing.T) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -28,7 +28,7 @@ func SanitizeBinaryName(raw string) string {
 	name = strings.TrimSuffix(name, filepath.Ext(name))
 	name = safeNameRe.ReplaceAllString(name, "_")
 	name = strings.Trim(name, "_")
-	if name == "" || name == "." {
+	if name == "" || name == "." || name == ".." {
 		return CliBinaryName
 	}
 	return name
@@ -93,9 +93,7 @@ const (
 // HTTPCacheDirFor returns the HTTP cache directory for the given binary name.
 // An empty binaryName defaults to CliBinaryName.
 func HTTPCacheDirFor(binaryName string) string {
-	if binaryName == "" {
-		binaryName = CliBinaryName
-	}
+	binaryName = SanitizeBinaryName(binaryName)
 	return filepath.Join(xdg.CacheHome, binaryName, "http-cache")
 }
 
@@ -233,9 +231,7 @@ const (
 // BuildCacheDirFor returns the build cache directory for the given binary name.
 // An empty binaryName defaults to CliBinaryName.
 func BuildCacheDirFor(binaryName string) string {
-	if binaryName == "" {
-		binaryName = CliBinaryName
-	}
+	binaryName = SanitizeBinaryName(binaryName)
 	return filepath.Join(xdg.CacheHome, binaryName, "build-cache")
 }
 
@@ -251,9 +247,7 @@ func DefaultBuildCacheDir() string {
 // PluginCacheDirFor returns the plugin cache directory for the given binary name.
 // An empty binaryName defaults to CliBinaryName.
 func PluginCacheDirFor(binaryName string) string {
-	if binaryName == "" {
-		binaryName = CliBinaryName
-	}
+	binaryName = SanitizeBinaryName(binaryName)
 	return filepath.Join(xdg.CacheHome, binaryName, "plugins")
 }
 

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -180,6 +180,7 @@ func TestSanitizeBinaryName(t *testing.T) {
 		{name: "spaces replaced", raw: "my cli", want: "my_cli"},
 		{name: "empty string", raw: "", want: CliBinaryName},
 		{name: "dot only", raw: ".", want: CliBinaryName},
+		{name: "double dot", raw: "..", want: CliBinaryName},
 		{name: "path separators only", raw: "///", want: CliBinaryName},
 	}
 	for _, tt := range tests {

--- a/pkg/spec/valueref.go
+++ b/pkg/spec/valueref.go
@@ -304,52 +304,52 @@ func (v *ValueRef) ResolveWithIterationContext(ctx context.Context, resolverData
 	return nil, fmt.Errorf("empty value reference")
 }
 
-// ReferencesVariable checks if the ValueRef references a specific variable name.
-// This is useful for detecting references to __actions, __self, __item, etc.
-// For expressions, it checks both top-level variables (like __actions, __self)
-// and underscore-prefixed variables (like _.environment).
-func (v *ValueRef) ReferencesVariable(varName string) bool {
+// ReferencedVariables returns the set of all variable names referenced by this ValueRef.
+// It collects top-level variables, underscore-prefixed variables, and template references
+// in a single pass. Use this instead of calling ReferencesVariable multiple times to
+// avoid redundant expression parsing.
+func (v *ValueRef) ReferencedVariables() map[string]struct{} {
+	vars := make(map[string]struct{})
 	if v == nil {
-		return false
+		return vars
 	}
 
 	if v.Expr != nil {
-		// Check top-level variables (for __actions, __self, __item, __index)
-		topLevelVars, err := v.Expr.RequiredVariables(context.TODO())
-		if err == nil {
-			for _, vn := range topLevelVars {
-				if vn == varName {
-					return true
-				}
+		if topLevel, err := v.Expr.RequiredVariables(context.TODO()); err == nil {
+			for _, vn := range topLevel {
+				vars[vn] = struct{}{}
 			}
 		}
-
-		// Also check underscore-prefixed variables (for _.resolver references)
-		underscoreVars, err := v.Expr.GetUnderscoreVariables(context.TODO())
-		if err == nil {
-			for _, vn := range underscoreVars {
-				if vn == varName {
-					return true
-				}
+		if underscore, err := v.Expr.GetUnderscoreVariables(context.TODO()); err == nil {
+			for _, vn := range underscore {
+				vars[vn] = struct{}{}
 			}
 		}
 	}
 
 	if v.Tmpl != nil {
-		refs, err := gotmpl.GetGoTemplateReferences(string(*v.Tmpl), "", "")
-		if err == nil {
+		if refs, err := gotmpl.GetGoTemplateReferences(string(*v.Tmpl), "", ""); err == nil {
 			for _, ref := range refs {
-				// Template paths start with "." (e.g., ".__actions.build.results")
-				// Strip the leading dot for comparison
 				path := strings.TrimPrefix(ref.Path, ".")
-				// Check if the path equals the variable name or starts with it followed by a dot
-				// e.g., for varName "__actions", match paths like "__actions" or "__actions.build.results"
-				if path == varName || strings.HasPrefix(path, varName+".") {
-					return true
+				// Extract the root variable name (before the first dot)
+				if idx := strings.Index(path, "."); idx >= 0 {
+					vars[path[:idx]] = struct{}{}
+				} else {
+					vars[path] = struct{}{}
 				}
 			}
 		}
 	}
 
-	return false
+	return vars
+}
+
+// ReferencesVariable checks if the ValueRef references a specific variable name.
+// This is useful for detecting references to __actions, __self, __item, etc.
+// For expressions, it checks both top-level variables (like __actions, __self)
+// and underscore-prefixed variables (like _.environment).
+func (v *ValueRef) ReferencesVariable(varName string) bool {
+	vars := v.ReferencedVariables()
+	_, ok := vars[varName]
+	return ok
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -986,25 +986,26 @@ func TestIntegration_RunResolver_ExecutionMetadataAlwaysIncluded(t *testing.T) {
 	)
 
 	assert.Equal(t, 0, exitCode)
-	// __execution metadata is always included in run resolver output
+	// By default, __execution is NOT included (clean output is the default)
+	assert.NotContains(t, stdout, "__execution")
+}
+
+func TestIntegration_RunResolver_ShowExecution(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"--show-execution",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	// --show-execution adds __execution metadata to output
 	assert.Contains(t, stdout, "__execution")
 	assert.Contains(t, stdout, "resolvers")
 	assert.Contains(t, stdout, "summary")
 	assert.Contains(t, stdout, "totalDuration")
 	assert.Contains(t, stdout, "phaseCount")
-}
-
-func TestIntegration_RunResolver_HideExecution(t *testing.T) {
-	t.Parallel()
-	stdout, _, exitCode := runScafctl(t,
-		"run", "resolver",
-		"-f", "examples/resolver-demo.yaml",
-		"--hide-execution",
-		"-o", "json",
-	)
-
-	assert.Equal(t, 0, exitCode)
-	assert.NotContains(t, stdout, "__execution")
 }
 
 func TestIntegration_RunResolver_SkipTransform(t *testing.T) {
@@ -1017,7 +1018,38 @@ func TestIntegration_RunResolver_SkipTransform(t *testing.T) {
 	)
 
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "__execution")
+	// skip-transform should not affect whether __execution is present (it is not, by default)
+	assert.NotContains(t, stdout, "__execution")
+}
+
+func TestIntegration_RunResolver_PlanDataInjected(t *testing.T) {
+	t.Parallel()
+	// plan-aware.yaml uses __plan in a when: condition and in a CEL expression.
+	// The resolver 'endpoint_info' only resolves when __plan['endpoint'].dependencyCount > 0.
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/plan-aware.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0\nstdout: %s", stdout)
+	// __plan-conditional resolver should have resolved
+	assert.Contains(t, stdout, "dependent_check")
+	// The resolved value embeds phase info from __plan
+	assert.Contains(t, stdout, "phase")
+}
+
+func TestIntegration_RunResolver_PlanDataNotInOutput(t *testing.T) {
+	t.Parallel()
+	// __plan is an internal injection variable -- it must not appear in the clean output
+	stdout, _, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/plan-aware.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.NotContains(t, stdout, `"__plan"`)
 }
 
 func TestIntegration_RunResolver_GraphASCII(t *testing.T) {
@@ -1080,6 +1112,7 @@ func TestIntegration_RunResolver_ExecutionIncludesGraphAndProviderSummary(t *tes
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
 		"-o", "json",
+		"--show-execution",
 	)
 
 	assert.Equal(t, 0, exitCode)
@@ -1203,7 +1236,6 @@ spec:
 		"run", "resolver",
 		"-f", solutionPath,
 		"-o", "json",
-		"--hide-execution",
 	)
 
 	assert.Equal(t, 0, exitCode)
@@ -1263,12 +1295,29 @@ func TestIntegration_RunSolution_ShowExecution(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolver-demo.yaml",
 		"-o", "json",
+		"--show-execution",
 	)
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "__execution")
 	assert.Contains(t, stdout, "resolvers")
 	assert.Contains(t, stdout, "summary")
+}
+
+func TestIntegration_RunSolution_ExecutionContextInActions(t *testing.T) {
+	t.Parallel()
+	// execution-aware-actions uses __execution in action when: conditions and inputs.
+	// non-prod-deploy runs (staging != production) and its message input uses __execution.
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "solution",
+		"-f", "examples/solutions/execution-aware-actions/solution.yaml",
+	)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0\nstdout: %s\nstderr: %s", stdout, stderr)
+	// non-prod-deploy should have run (default environment is staging != production)
+	assert.Contains(t, stdout, "staging-cluster")
+	// prod-gate should have been skipped
+	assert.NotContains(t, stdout, "production-only checks")
 }
 
 func TestIntegration_RunSolution_ConditionalRetry(t *testing.T) {
@@ -5869,7 +5918,7 @@ spec:
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
-	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.meta", "-o", "json", "--hide-execution")
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.meta", "-o", "json")
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
 
@@ -5920,7 +5969,7 @@ spec:
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
-	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.slugified", "-o", "json", "--hide-execution")
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.slugified", "-o", "json")
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
 
@@ -5967,7 +6016,7 @@ spec:
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
-	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.count", "-o", "json", "--hide-execution")
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.count", "-o", "json")
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
 
@@ -6016,7 +6065,7 @@ spec:
 `
 	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
 
-	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.names", "-o", "json", "--hide-execution")
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-e", "_.names", "-o", "json")
 	t.Logf("stdout: %s", stdout)
 	t.Logf("stderr: %s", stderr)
 
@@ -6031,7 +6080,6 @@ func TestIntegration_RunResolver_PositionalParams(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"name=Alice",
 		"count=5",
 	)
@@ -6048,7 +6096,6 @@ func TestIntegration_RunResolver_PositionalMixedWithFlags(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "name=Bob",
 		"count=3",
 	)
@@ -6066,7 +6113,6 @@ func TestIntegration_RunResolver_PositionalWithResolverNames(t *testing.T) {
 		"name",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"name=Charlie",
 	)
 	t.Logf("stdout: %s", stdout)
@@ -6977,7 +7023,6 @@ func TestIntegration_RunResolver_StdinParamsYAML(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "@-",
 	)
 	t.Logf("stdout: %s", stdout)
@@ -6994,7 +7039,6 @@ func TestIntegration_RunResolver_StdinParamsJSON(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "@-",
 	)
 	t.Logf("stdout: %s", stdout)
@@ -7011,7 +7055,6 @@ func TestIntegration_RunResolver_StdinParamsPositional(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"@-",
 	)
 	t.Logf("stdout: %s", stdout)
@@ -7084,7 +7127,6 @@ func TestIntegration_RunResolver_StdinMixedWithFileRef(t *testing.T) {
 		"run", "resolver",
 		"-f", "examples/resolvers/parameters.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "@"+paramFile,
 		"-r", "@-",
 	)
@@ -7106,7 +7148,6 @@ func TestIntegration_RunResolver_RawStdinParam(t *testing.T) {
 		"run", "resolver",
 		"-f", "tests/integration/solutions/resolvers/stdin-params/solution.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "greeting=Hello",
 		"-r", "name=@-",
 	)
@@ -7129,7 +7170,6 @@ func TestIntegration_RunResolver_RawFileParam(t *testing.T) {
 		"run", "resolver",
 		"-f", "tests/integration/solutions/resolvers/stdin-params/solution.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "greeting=Hi",
 		"-r", "name=@"+contentFile,
 	)
@@ -7178,7 +7218,6 @@ func TestIntegration_RunResolver_RawStdinConflictWithStandaloneAt(t *testing.T) 
 		"run", "resolver",
 		"-f", "tests/integration/solutions/resolvers/stdin-params/solution.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "name=@-",
 		"-r", "@-",
 	)
@@ -7194,7 +7233,6 @@ func TestIntegration_RunResolver_RawStdinWithOtherParams(t *testing.T) {
 		"run", "resolver",
 		"-f", "tests/integration/solutions/resolvers/stdin-params/solution.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "greeting=Hey",
 		"-r", "name=@-",
 	)
@@ -7218,7 +7256,6 @@ func TestIntegration_RunResolver_RawFileAndStdinMixed(t *testing.T) {
 		"run", "resolver",
 		"-f", "tests/integration/solutions/resolvers/stdin-params/solution.yaml",
 		"-o", "json",
-		"--hide-execution",
 		"-r", "greeting=@"+contentFile,
 		"-r", "name=@-",
 	)

--- a/tests/integration/solutions/actions/execution-context/solution.yaml
+++ b/tests/integration/solutions/actions/execution-context/solution.yaml
@@ -1,0 +1,117 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-execution-context
+  version: 1.0.0
+  description: |
+    Functional tests for __execution metadata in action CEL context.
+    Verifies that __execution is injected after resolver execution and
+    that actions can gate on resolver status, phase, and summary fields.
+    Uses expr: ValueRefs in action inputs (the correct access pattern
+    for __execution -- the cel provider only has resolver data scope).
+
+spec:
+  resolvers:
+    static_value:
+      description: Always-succeeding resolver (phase 1)
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+    dep_value:
+      description: Resolver depending on static_value (phase 2)
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.static_value + '-world'"
+
+  workflow:
+    actions:
+      # Prints phase count from __execution to stdout
+      capture-summary:
+        description: Print resolver phase count and resolver count
+        provider: exec
+        inputs:
+          command:
+            expr: >
+              'echo phase_count=' + string(__execution['summary']['phaseCount']) +
+              ' resolver_count=' + string(__execution['summary']['resolverCount'])
+
+      # Only runs when static_value succeeded (status == "success")
+      on-success:
+        description: Runs when static_value resolved successfully
+        provider: exec
+        dependsOn: [capture-summary]
+        when:
+          expr: "__execution['resolvers']['static_value']['status'] == 'success'"
+        inputs:
+          command: "echo on_success=ran"
+
+      # Only runs when static_value did NOT succeed (should be skipped)
+      on-failure:
+        description: Skipped because static_value always succeeds
+        provider: exec
+        dependsOn: [capture-summary]
+        when:
+          expr: "__execution['resolvers']['static_value']['status'] != 'success'"
+        inputs:
+          command: "echo on_failure=ran"
+
+      # Prints static_value's phase from __execution
+      capture-phase:
+        description: Print static_value phase from __execution
+        provider: exec
+        dependsOn: [on-success, on-failure]
+        inputs:
+          command:
+            expr: "'echo static_value_phase=' + string(__execution['resolvers']['static_value']['phase'])"
+
+  testing:
+    config:
+      skipBuiltins: []
+
+    cases:
+      _base:
+        description: Base template for __execution action tests
+        command: [run, solution]
+        args: []
+        tags: [action, execution]
+        assertions:
+          - expression: __exitCode == 0
+
+      execution-summary-fields:
+        description: __execution.summary contains phaseCount and resolverCount
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __stdout.contains("phase_count=2")
+            message: "__execution summary.phaseCount should be 2 (2 resolver phases)"
+          - expression: __stdout.contains("resolver_count=2")
+            message: "__execution summary.resolverCount should be 2"
+
+      execution-gate-on-success:
+        description: on-success action runs when resolver succeeded
+        extends: [_base]
+        assertions:
+          - expression: __stdout.contains("on_success=ran")
+            message: "on-success should run because static_value always succeeds"
+
+      execution-gate-on-failure-skipped:
+        description: on-failure action is skipped when resolver succeeded
+        extends: [_base]
+        assertions:
+          - expression: "!(__stdout.contains(\"on_failure=ran\"))"
+            message: "on-failure should be skipped because static_value succeeded"
+
+      execution-phase-available:
+        description: static_value phase is accessible from __execution in actions
+        extends: [_base]
+        assertions:
+          - expression: __stdout.contains("static_value_phase=1")
+            message: "static_value should be in phase 1 (no dependencies)"

--- a/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
@@ -41,7 +41,7 @@ spec:
       _base:
         description: Base template
         command: [run, resolver]
-        args: ["-o", "json", "--hide-execution"]
+        args: ["-o", "json"]
         tags: [validation, parameter]
         assertions:
           - expression: __exitCode == 0
@@ -49,7 +49,7 @@ spec:
       valid-params:
         description: Valid parameter keys are accepted
         extends: [_base]
-        args: ["-o", "json", "--hide-execution", "-r", "name=Alice", "-r", "region=eu-west-1"]
+        args: ["-o", "json", "-r", "name=Alice", "-r", "region=eu-west-1"]
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "Alice"
@@ -58,7 +58,7 @@ spec:
       unknown-param-with-suggestion:
         description: Unknown parameter key close to a valid one produces did-you-mean error
         command: [run, resolver]
-        args: ["-o", "json", "--hide-execution", "-r", "namee=Alice"]
+        args: ["-o", "json", "-r", "namee=Alice"]
         tags: [validation, parameter]
         assertions:
           - expression: __exitCode != 0
@@ -70,7 +70,7 @@ spec:
       unknown-param-no-suggestion:
         description: Completely unknown parameter key produces error without suggestion
         command: [run, resolver]
-        args: ["-o", "json", "--hide-execution", "-r", "zzzzz=value"]
+        args: ["-o", "json", "-r", "zzzzz=value"]
         tags: [validation, parameter]
         assertions:
           - expression: __exitCode != 0

--- a/tests/integration/solutions/resolvers/plan/solution.yaml
+++ b/tests/integration/solutions/resolvers/plan/solution.yaml
@@ -1,0 +1,144 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-plan
+  version: 1.0.0
+  description: |
+    Functional tests for __plan pre-execution topology data.
+    Verifies that __plan is injected before execution and contains
+    correct phase, dependsOn, and dependencyCount for each resolver.
+
+spec:
+  resolvers:
+    base_url:
+      description: Base URL (phase 1, no dependencies)
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: https://api.example.com
+
+    region:
+      description: Region (phase 1, no dependencies)
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-east-1
+
+    endpoint:
+      description: Full endpoint (phase 2, depends on base_url)
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.base_url + '/v2'"
+
+    # Uses __plan to verify topology before resolving
+    plan_phase:
+      description: Phase number of 'endpoint' from __plan
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__plan['endpoint'].phase"
+
+    plan_dep_count:
+      description: Dependency count of 'endpoint' from __plan
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__plan['endpoint'].dependencyCount"
+
+    plan_base_url_phase:
+      description: Phase of base_url from __plan (should be 1 -- no deps)
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__plan['base_url'].phase"
+
+    # Conditional resolver: only runs when endpoint has dependencies
+    conditional_on_plan:
+      description: Only resolves when endpoint has at least one dependency
+      type: string
+      when:
+        expr: "__plan['endpoint'].dependencyCount > 0"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "endpoint-has-deps"
+
+    # Conditional resolver: only runs when base_url has NO dependencies
+    standalone_check:
+      description: Only resolves when base_url has no dependencies
+      type: string
+      when:
+        expr: "__plan['base_url'].dependencyCount == 0"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base_url-is-standalone"
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      _base:
+        description: Base template for __plan tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, plan]
+        assertions:
+          - expression: __exitCode == 0
+
+      plan-phase-assignment:
+        description: endpoint should be in phase 2 (depends on base_url which is phase 1)
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.plan_phase == 2
+            message: "endpoint should be assigned to phase 2"
+          - expression: __output.plan_base_url_phase == 1
+            message: "base_url should be assigned to phase 1 (no dependencies)"
+
+      plan-dependency-count:
+        description: endpoint.dependencyCount should be 1
+        extends: [_base]
+        assertions:
+          - expression: __output.plan_dep_count == 1
+            message: "endpoint should report 1 dependency"
+
+      plan-conditional-with-deps:
+        description: conditional_on_plan resolves when endpoint has deps
+        extends: [_base]
+        assertions:
+          - expression: __output.conditional_on_plan == "endpoint-has-deps"
+            message: "conditional_on_plan should resolve when dependencyCount > 0"
+
+      plan-conditional-standalone:
+        description: standalone_check resolves when base_url has no deps
+        extends: [_base]
+        assertions:
+          - expression: __output.standalone_check == "base_url-is-standalone"
+            message: "standalone_check should resolve when base_url.dependencyCount == 0"
+
+      plan-available-pre-execution:
+        description: Verify __plan values are available even for phase-1 resolvers
+        extends: [_base]
+        assertions:
+          - expression: __output.plan_base_url_phase == 1
+            message: "__plan should be available before base_url runs (phase 1)"
+          - expression: __output.plan_dep_count == 1
+            message: "__plan dependency count should reflect static topology"

--- a/tests/integration/solutions/resolvers/stdin-params/solution.yaml
+++ b/tests/integration/solutions/resolvers/stdin-params/solution.yaml
@@ -45,7 +45,7 @@ spec:
       _base:
         description: Base template for stdin-params tests
         command: [run, resolver]
-        args: ["-o", "json", "--hide-execution"]
+        args: ["-o", "json"]
         tags: [parameter, stdin]
         assertions:
           - expression: __exitCode == 0


### PR DESCRIPTION
Add pre-execution resolver topology (__plan) and post-execution metadata (__execution) as first-class CEL variables in resolver and action contexts:

- __plan: injected before any resolver runs; exposes phase, dependsOn, and dependencyCount per resolver so when conditions and provider inputs can gate on topology before execution
- __execution: injected into action contexts after resolvers complete; exposes resolver status, phase, and duration so actions can gate on resolver outcomes
- BuildPhases now returns BuildResult{Phases, Plan} instead of []*PhaseGroup; executor reuses PlanData to avoid recomputing deps
- action/graph.go defers inputs referencing __execution to runtime
- VarExecution and VarPlan constants added to pkg/celexp/context.go
- MCP preview_resolvers response now includes __plan topology
- MCP get_run_command gains show_execution boolean parameter
- MCP system prompt documents __plan, __execution, and __actions
- SanitizeBinaryName handles ".." edge case; HTTPCacheDirFor, BuildCacheDirFor, PluginCacheDirFor delegate to SanitizeBinaryName
- New examples: examples/resolvers/plan-aware.yaml, examples/solutions/execution-aware-actions/solution.yaml
- New integration solutions: tests/integration/solutions/resolvers/plan/, tests/integration/solutions/actions/execution-context/

BREAKING CHANGE: --hide-execution flag removed; replaced by --show-execution. Clean output (no __execution key) is now the default. Pass --show-execution to include execution metadata.

Closes #177 