### PR TITLE
refactor: replace hardcoded binary name with configurable settings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,16 @@ The project uses `task` (go-task/task) for builds and linting. **Always use `tas
 - **No magic values**: Always define constants or use settings for configuration values
 - **Git safety**: Never run `git commit`, `git push`, or `git commit --amend` unless the user explicitly asks. Never commit or push without approval first
 
+## Embedder Contract
+
+scafctl is used as a **library by external CLIs**. Every new feature must be consumable by embedders via `RootOptions` or domain package APIs.
+
+- **No hardcoded "scafctl"**: Use `settings.CliBinaryName` constant or read from `settings.Run.BinaryName` in context. Never hardcode the binary name in user-facing strings (descriptions, error messages, paths, env var prefixes)
+- **`RootOptions` is the embedder API surface**: New CLI-level capabilities must be exposed as fields on `RootOptions` with sensible defaults that preserve existing behavior when unset
+- **Domain packages must be binary-name-aware**: Functions that produce paths, env vars, cache keys, or display strings must accept a name parameter or read from context -- never assume the binary is called "scafctl"
+- **MCP server must respect embedder identity**: The MCP server name, tool descriptions, and capabilities must use the configured binary name
+- **Test embedder scenarios**: When adding new configurable behavior, include a test that exercises it with a non-default binary name (e.g., `"mycli"`)
+
 ## Security Scanning
 
 ```bash

--- a/.github/instructions/cli-commands.instructions.md
+++ b/.github/instructions/cli-commands.instructions.md
@@ -15,3 +15,13 @@ Commands are **thin wiring only** -- they parse flags, call domain packages, and
 - Use `cobra.Command` for command definition and flag binding
 - Wire up `settings.Run` parameters from flags
 - Always add new commands to CLI integration tests (`tests/integration/cli_test.go`)
+
+## Embedder Awareness
+
+scafctl is used as a library by external CLIs. Commands must not assume the binary is called "scafctl".
+
+- Read the binary name from `settings.Run.BinaryName` (via context), not a hardcoded string
+- Subcommand `Short`/`Long` descriptions must use the configured app name, not "scafctl"
+- New `RootOptions` fields need doc comments explaining the default behavior when unset
+- Environment variable prefixes come from `settings.SafeEnvPrefix()` -- never hardcode `SCAFCTL_`
+- New CLI-level features (config layers, hooks, customization points) must be wirable through `RootOptions`

--- a/.github/instructions/go-conventions.instructions.md
+++ b/.github/instructions/go-conventions.instructions.md
@@ -88,6 +88,14 @@ if apiKey == "" {
 - **gofmt** and **goimports** are mandatory -- no style debates
 - Never use magic strings or numbers; always define constants or use settings
 
+## Embedder-Safe Design
+
+scafctl is consumed as a library by external CLIs. Code must not assume the binary name.
+
+- Use `settings.CliBinaryName` or `settings.Run.BinaryName` instead of hardcoding `"scafctl"`
+- Functions producing paths, cache keys, or env vars must accept a name parameter or read from context
+- When adding `settings.*For(binaryName)` helpers, guard against empty `binaryName` by falling back to `CliBinaryName`
+
 ## Reference
 
 See skill: `golang-patterns` for comprehensive Go idioms and patterns.

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -15,3 +15,4 @@ MCP tool handlers are **thin wrappers** -- they parse tool inputs, call domain p
 - Use `mcp.With*HintAnnotation()` for tool metadata (read-only, destructive, idempotent)
 - Return `mcp.NewToolResultText()` or `mcp.NewToolResultError()` -- never panic
 - Always add Huma-style parameter descriptions and constraints
+- Tool descriptions and server name must use the configured binary name (`s.name`), not hardcoded "scafctl"

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -7,8 +7,9 @@ Address unresolved PR review comments. Use `gh` CLI and the **GitHub GraphQL API
 
 Follow these phases **in order** -- do not skip ahead:
 
-1. **Fetch**: Fetch all review threads via GraphQL; **skip comments that are already resolved**
-2. **Triage**: For each unresolved comment, assess whether it's a legit problem with the code. Present the triage summary with recommendations and **stop here** -- the user will click "Apply fixes" to approve
-3. **Apply fixes**: Fix the code, verify build (`go build ./...`, `go vet ./...`), run tests (`task test:e2e`), then respond to and resolve each addressed thread
-4. If you disagree with a comment: **discuss it with me before deciding** -- don't resolve or dismiss it
-5. **Do not commit** -- I will handle that
+1. **Fetch**: Fetch all review threads via GraphQL; **skip comments that are already resolved or outdated**
+2. **Early exit**: If there are **zero unresolved threads**, report that and stop -- do not triage or apply fixes
+3. **Triage**: For each unresolved comment, assess whether it's a legit problem with the code. Present the triage summary with recommendations and **stop here** -- the user will click "Apply fixes" to approve
+4. **Apply fixes**: Fix the code, verify build (`go build ./...`, `go vet ./...`), run tests (`task test:e2e`), then respond to and resolve each addressed thread
+5. If you disagree with a comment: **discuss it with me before deciding** -- don't resolve or dismiss it
+6. **Do not commit** -- I will handle that

--- a/pkg/auth/entra/token.go
+++ b/pkg/auth/entra/token.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // TokenMetadata stores information about the stored credentials.
@@ -62,7 +63,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 	// This ensures the refresh token is always paired with the client ID
 	// that originally obtained it. If missing, the user must re-login.
 	if metadata.ClientID == "" {
-		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with 'scafctl auth login entra': %w", auth.ErrNotAuthenticated)
+		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with '%s auth login entra': %w", settings.BinaryNameFromContext(ctx), auth.ErrNotAuthenticated)
 	}
 
 	data := url.Values{}

--- a/pkg/auth/gcp/gcloud_adc.go
+++ b/pkg/auth/gcp/gcloud_adc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 const (
@@ -34,22 +35,21 @@ var ErrNoGcloudADCConfigured = errors.New("no gcloud ADC credentials configured"
 
 // formatGcloudTokenError converts a raw OAuth error response into a clear, actionable error.
 // It handles well-known error codes (e.g. invalid_grant / invalid_rapt) with remediation hints.
-func formatGcloudTokenError(errResp TokenErrorResponse) error {
+func formatGcloudTokenError(errResp TokenErrorResponse, binaryName string) error {
 	if errResp.Error == "invalid_grant" {
-		// invalid_rapt means Google requires re-authentication (Re-Authentication Proof Token).
-		// This is common with corporate/org accounts that enforce periodic re-auth or
-		// conditional access policies.
 		if strings.Contains(errResp.ErrorDescription, "invalid_rapt") {
 			return fmt.Errorf(
-				"gcloud ADC credentials require re-authentication (invalid_rapt): " +
-					"a security policy requires you to reauthenticate. " +
-					"Run: scafctl auth login gcp",
+				"gcloud ADC credentials require re-authentication (invalid_rapt): "+
+					"a security policy requires you to reauthenticate. "+
+					"Run: %s auth login gcp",
+				binaryName,
 			)
 		}
 		return fmt.Errorf(
 			"gcloud ADC credentials have expired or been revoked (%s). "+
-				"Run: scafctl auth login gcp",
+				"Run: %s auth login gcp",
 			errResp.ErrorDescription,
+			binaryName,
 		)
 	}
 	return fmt.Errorf("gcloud ADC token refresh failed: %s - %s", errResp.Error, errResp.ErrorDescription)
@@ -131,7 +131,7 @@ func (h *Handler) gcloudADCLogin(ctx context.Context, opts auth.LoginOptions) (*
 	creds, err := LoadGcloudADCCredentials()
 	if err != nil {
 		if errors.Is(err, ErrNoGcloudADCConfigured) {
-			return nil, fmt.Errorf("no gcloud ADC credentials found; run 'gcloud auth application-default login' or configure a client ID for scafctl")
+			return nil, fmt.Errorf("no gcloud ADC credentials found; run 'gcloud auth application-default login' or configure a client ID for %s", settings.BinaryNameFromContext(ctx))
 		}
 		return nil, fmt.Errorf("loading gcloud ADC credentials: %w", err)
 	}
@@ -152,7 +152,7 @@ func (h *Handler) gcloudADCLogin(ctx context.Context, opts auth.LoginOptions) (*
 	if resp.StatusCode != 200 {
 		var errResp TokenErrorResponse
 		_ = json.NewDecoder(resp.Body).Decode(&errResp)
-		return nil, formatGcloudTokenError(errResp)
+		return nil, formatGcloudTokenError(errResp, settings.BinaryNameFromContext(ctx))
 	}
 
 	var tokenResp TokenResponse
@@ -244,7 +244,7 @@ func (h *Handler) getGcloudADCToken(ctx context.Context, opts auth.TokenOptions)
 	if resp.StatusCode != 200 {
 		var errResp TokenErrorResponse
 		_ = json.NewDecoder(resp.Body).Decode(&errResp)
-		return nil, formatGcloudTokenError(errResp)
+		return nil, formatGcloudTokenError(errResp, settings.BinaryNameFromContext(ctx))
 	}
 
 	var tokenResp TokenResponse
@@ -261,7 +261,9 @@ func (h *Handler) getGcloudADCToken(ctx context.Context, opts auth.TokenOptions)
 		Flow:        auth.FlowGcloudADC,
 	}
 
-	lgr.V(1).Info("acquired token via gcloud ADC fallback; to use scafctl-managed credentials run: scafctl auth login gcp")
+	binaryName := settings.BinaryNameFromContext(ctx)
+	lgr.V(1).Info("acquired token via gcloud ADC fallback",
+		"hint", fmt.Sprintf("to use %s-managed credentials run: %s auth login gcp", binaryName, binaryName))
 	if err := h.tokenCache.Set(ctx, auth.FlowGcloudADC, fingerprint, opts.Scope, token); err != nil {
 		lgr.V(1).Info("failed to cache gcloud ADC token", "error", err)
 	}

--- a/pkg/auth/gcp/gcloud_adc_test.go
+++ b/pkg/auth/gcp/gcloud_adc_test.go
@@ -123,7 +123,7 @@ func TestFormatGcloudTokenError_InvalidRapt(t *testing.T) {
 	err := formatGcloudTokenError(TokenErrorResponse{
 		Error:            "invalid_grant",
 		ErrorDescription: "reauth related error (invalid_rapt)",
-	})
+	}, "scafctl")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "re-authentication")
 	assert.Contains(t, err.Error(), "invalid_rapt")
@@ -136,7 +136,7 @@ func TestFormatGcloudTokenError_InvalidGrantOther(t *testing.T) {
 	err := formatGcloudTokenError(TokenErrorResponse{
 		Error:            "invalid_grant",
 		ErrorDescription: "Token has been expired or revoked",
-	})
+	}, "scafctl")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expired or been revoked")
 	assert.Contains(t, err.Error(), "Token has been expired or revoked")
@@ -148,7 +148,7 @@ func TestFormatGcloudTokenError_OtherError(t *testing.T) {
 	err := formatGcloudTokenError(TokenErrorResponse{
 		Error:            "access_denied",
 		ErrorDescription: "the client is not authorized",
-	})
+	}, "scafctl")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access_denied")
 	assert.Contains(t, err.Error(), "the client is not authorized")

--- a/pkg/auth/github/token.go
+++ b/pkg/auth/github/token.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // TokenMetadata stores information about the stored credentials.
@@ -65,7 +66,7 @@ func (h *Handler) mintToken(ctx context.Context, scope string) (*auth.Token, err
 
 	// Use the client ID that was used during login
 	if metadata.ClientID == "" {
-		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with 'scafctl auth login github': %w", auth.ErrNotAuthenticated)
+		return nil, fmt.Errorf("stored credentials are missing client ID, please re-authenticate with '%s auth login github': %w", settings.BinaryNameFromContext(ctx), auth.ErrNotAuthenticated)
 	}
 
 	// Refresh the token

--- a/pkg/catalog/url.go
+++ b/pkg/catalog/url.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // ParseCatalogURL parses a catalog URL into registry and repository parts,
@@ -106,7 +107,8 @@ func ResolveCatalogURL(ctx context.Context, catalogFlag string) (string, error) 
 
 	cat, ok := cfg.GetDefaultCatalog()
 	if !ok {
-		return "", fmt.Errorf("no --catalog specified and no default catalog configured\n\nTo set a default catalog:\n  scafctl config add-catalog <name> --type oci --url <registry-url> --default\n\nOr specify one explicitly:\n  scafctl catalog push <artifact> --catalog <registry-url>")
+		bin := settings.BinaryNameFromContext(ctx)
+		return "", fmt.Errorf("no --catalog specified and no default catalog configured\n\nTo set a default catalog:\n  %s config add-catalog <name> --type oci --url <registry-url> --default\n\nOr specify one explicitly:\n  %s catalog push <artifact> --catalog <registry-url>", bin, bin)
 	}
 
 	url := catalogURLFromCatalogConfig(cat)
@@ -126,7 +128,7 @@ func lookupCatalogURLFromConfig(ctx context.Context, name string) (string, error
 
 	cat, ok := cfg.GetCatalog(name)
 	if !ok {
-		return "", fmt.Errorf("catalog %q not found in configuration\n\nTo add it:\n  scafctl config add-catalog %s --type oci --url <registry-url>", name, name)
+		return "", fmt.Errorf("catalog %q not found in configuration\n\nTo add it:\n  %s config add-catalog %s --type oci --url <registry-url>", name, settings.BinaryNameFromContext(ctx), name)
 	}
 
 	url := catalogURLFromCatalogConfig(cat)

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -18,7 +19,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 		Use:     "auth",
 		Aliases: []string{"authenticate"},
 		Short:   "Manage authentication",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Manage authentication for scafctl.
 
 			Authentication handlers manage identity verification and token acquisition
@@ -35,7 +36,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			Use 'scafctl auth logout <handler>' to clear credentials.
 			Use 'scafctl auth token <handler>' to retrieve a token value (for debugging).
 			Use 'scafctl auth diagnose' to run health checks and troubleshoot issues.
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -34,7 +35,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 		Use:     "diagnose",
 		Aliases: []string{"doctor"},
 		Short:   "Run auth diagnostics and report any issues",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Run a series of diagnostic checks on the authentication configuration
 			and report any issues found.
 
@@ -64,7 +65,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 
 			  # Output diagnostics as JSON
 			  scafctl auth diagnose -o json
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -211,7 +212,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 						Category: "handler",
 						Name:     fmt.Sprintf("%s: authenticated", name),
 						Status:   diagnose.StatusWarn,
-						Message:  fmt.Sprintf("not authenticated — run 'scafctl auth login %s'", name),
+						Message:  fmt.Sprintf("not authenticated — run '%s auth login %s'", cliParams.BinaryName, name),
 					})
 					continue
 				}
@@ -270,7 +271,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 						Category: "live",
 						Name:     fmt.Sprintf("%s: live token", name),
 						Status:   diagnose.StatusInfo,
-						Message:  "handler requires --scope for token fetch; use 'scafctl auth token " + name + " --scope <scope>' to test manually",
+						Message:  "handler requires --scope for token fetch; use '" + cliParams.BinaryName + " auth token " + name + " --scope <scope>' to test manually",
 					})
 				} else if liveToken {
 					_, err := handler.GetToken(ctx, authpkg.TokenOptions{
@@ -340,7 +341,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 					outputFlags.Expression,
 					kvx.WithOutputContext(ctx),
 					kvx.WithOutputNoColor(cliParams.NoColor),
-					kvx.WithOutputAppName("scafctl auth diagnose"),
+					kvx.WithOutputAppName(cliParams.BinaryName+" auth diagnose"),
 				)
 				outputOpts.IOStreams = ioStreams
 				return outputOpts.Write(results)

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -37,7 +37,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	cmd := &cobra.Command{
 		Use:   "list [handler]",
 		Short: "Show cached refresh and access token metadata",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Show metadata for all cached tokens (refresh and minted access tokens).
 
 			By default all registered auth handlers are queried. When a handler name
@@ -79,7 +79,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			  # Remove expired access tokens from the cache (keeps valid tokens and the refresh token)
 			  scafctl auth list --purge-expired
 			  scafctl auth list entra --purge-expired
-			`),
+			`), settings.CliBinaryName, cliParams.BinaryName),
 		Aliases:      []string{"ls"},
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
@@ -176,7 +176,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				}
 
 				for _, t := range tokens {
-					results = append(results, cachedTokenInfoToMap(t))
+					results = append(results, cachedTokenInfoToMap(t, cliParams.BinaryName))
 				}
 			}
 
@@ -218,7 +218,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				outputFlags.Expression,
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
-				kvx.WithOutputAppName("scafctl auth list"),
+				kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
 			)
 			outputOpts.IOStreams = ioStreams
 
@@ -269,7 +269,7 @@ func sortTokenResults(results []map[string]any, field string) error {
 }
 
 // cachedTokenInfoToMap converts a CachedTokenInfo into a map suitable for kvx output.
-func cachedTokenInfoToMap(t *auth.CachedTokenInfo) map[string]any {
+func cachedTokenInfoToMap(t *auth.CachedTokenInfo, binaryName string) map[string]any {
 	row := map[string]any{
 		"handler":   t.Handler,
 		"tokenKind": t.TokenKind,
@@ -302,9 +302,9 @@ func cachedTokenInfoToMap(t *auth.CachedTokenInfo) map[string]any {
 	// used internally and have no direct retrieval command.
 	if t.TokenKind == "access" {
 		if t.Scope != "" {
-			row["getTokenCommand"] = fmt.Sprintf("scafctl auth token %s --scope %q --raw", t.Handler, t.Scope)
+			row["getTokenCommand"] = fmt.Sprintf("%s auth token %s --scope %q --raw", binaryName, t.Handler, t.Scope)
 		} else {
-			row["getTokenCommand"] = fmt.Sprintf("scafctl auth token %s --raw", t.Handler)
+			row["getTokenCommand"] = fmt.Sprintf("%s auth token %s --raw", binaryName, t.Handler)
 		}
 	}
 

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -27,7 +28,7 @@ import (
 )
 
 // CommandLogin creates the 'auth login' command.
-func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
 	var (
 		tenantID                  string
 		clientID                  string
@@ -48,7 +49,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "login <handler>",
 		Short: "Authenticate with an auth handler",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Authenticate with an authentication handler.
 
 			For the 'entra' handler, this supports multiple authentication flows:
@@ -157,7 +158,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 
 			  # Login with GCP and specific scopes
 			  scafctl auth login gcp --scope https://www.googleapis.com/auth/bigquery
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -229,16 +230,16 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			var loginErr error
 			switch handlerName {
 			case "github":
-				loginErr = loginGitHub(ctx, w, flow, hostname, clientID, callbackPort, timeout, scopes, force, skipIfAuthenticated)
+				loginErr = loginGitHub(ctx, w, cliParams.BinaryName, flow, hostname, clientID, callbackPort, timeout, scopes, force, skipIfAuthenticated)
 			case "gcp":
-				loginErr = loginGCP(ctx, w, flow, clientID, impersonateServiceAccount, callbackPort, timeout, scopes, force, skipIfAuthenticated)
+				loginErr = loginGCP(ctx, w, cliParams.BinaryName, flow, clientID, impersonateServiceAccount, callbackPort, timeout, scopes, force, skipIfAuthenticated)
 			case "entra":
-				loginErr = loginEntra(ctx, w, flow, tenantID, clientID, callbackPort, timeout, federatedToken, flowStr, scopes, force, skipIfAuthenticated)
+				loginErr = loginEntra(ctx, w, cliParams.BinaryName, flow, tenantID, clientID, callbackPort, timeout, federatedToken, flowStr, scopes, force, skipIfAuthenticated)
 			default:
 				// Generic custom OAuth2 handler (e.g. quay, custom IdP).
 				// Use the handler already resolved from the registry; no built-in
 				// flow-detection or provider-specific overrides apply.
-				loginErr = loginGeneric(ctx, w, handler, handlerName, flow, callbackPort, timeout, scopes, force, skipIfAuthenticated)
+				loginErr = loginGeneric(ctx, w, cliParams.BinaryName, handler, handlerName, flow, callbackPort, timeout, scopes, force, skipIfAuthenticated)
 			}
 
 			if loginErr != nil {
@@ -293,7 +294,7 @@ func CommandLogin(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 }
 
 // loginGitHub handles the login flow for the GitHub auth handler.
-func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname, clientID string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
+func loginGitHub(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, hostname, clientID string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
 	// Auto-detect flow from available credentials.
 	// Skip PAT auto-detection when user provides --scope flags, since scopes
 	// only apply to the device code / interactive flows (PAT scopes are fixed at creation).
@@ -333,15 +334,15 @@ func loginGitHub(ctx context.Context, w *writer.Writer, flow auth.Flow, hostname
 		return nil
 	case auth.PreLoginAlreadyAuthenticated:
 		w.Warningf("Already authenticated as %s.", preLogin.Identity)
-		w.Warning("Use 'scafctl auth logout github' to sign out first, or use --force to re-authenticate.")
+		w.Warningf("Use '%s auth logout github' to sign out first, or use --force to re-authenticate.", binaryName)
 		w.Info("")
 	}
 
-	return executeLogin(ctx, w, handler, flow, "", callbackPort, timeout, scopes)
+	return executeLogin(ctx, w, binaryName, handler, flow, "", callbackPort, timeout, scopes)
 }
 
 // loginGCP handles the login flow for the GCP auth handler.
-func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, impersonateServiceAccount string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
+func loginGCP(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, clientID, impersonateServiceAccount string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
 	// Auto-detect flow based on available credentials (highest priority first)
 	detection := auth.DetectFlow(flow, []auth.CredentialDetector{
 		{
@@ -383,15 +384,15 @@ func loginGCP(ctx context.Context, w *writer.Writer, flow auth.Flow, clientID, i
 		return nil
 	case auth.PreLoginAlreadyAuthenticated:
 		w.Warningf("Already authenticated as %s.", preLogin.Identity)
-		w.Warning("Use 'scafctl auth logout gcp' to sign out first, or use --force to re-authenticate.")
+		w.Warningf("Use '%s auth logout gcp' to sign out first, or use --force to re-authenticate.", binaryName)
 		w.Info("")
 	}
 
-	return executeLogin(ctx, w, handler, flow, "", callbackPort, timeout, scopes)
+	return executeLogin(ctx, w, binaryName, handler, flow, "", callbackPort, timeout, scopes)
 }
 
 // loginEntra handles the login flow for the Entra auth handler.
-func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID, clientID string, callbackPort int, timeout time.Duration, federatedToken, flowStr string, scopes []string, force, skipIfAuthenticated bool) error {
+func loginEntra(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, tenantID, clientID string, callbackPort int, timeout time.Duration, federatedToken, flowStr string, scopes []string, force, skipIfAuthenticated bool) error {
 	// If --federated-token is provided, set the env var for workload identity
 	if federatedToken != "" {
 		if err := os.Setenv(entra.EnvAzureFederatedToken, federatedToken); err != nil {
@@ -445,17 +446,17 @@ func loginEntra(ctx context.Context, w *writer.Writer, flow auth.Flow, tenantID,
 		return nil
 	case auth.PreLoginAlreadyAuthenticated:
 		w.Warningf("Already authenticated as %s.", preLogin.Identity)
-		w.Warning("Use 'scafctl auth logout entra' to sign out first, or use --force to re-authenticate.")
+		w.Warningf("Use '%s auth logout entra' to sign out first, or use --force to re-authenticate.", binaryName)
 		w.Info("")
 	}
 
-	return executeLogin(ctx, w, handler, flow, tenantID, callbackPort, timeout, scopes)
+	return executeLogin(ctx, w, binaryName, handler, flow, tenantID, callbackPort, timeout, scopes)
 }
 
 // loginGeneric handles the login flow for custom (non-built-in) OAuth2 handlers.
 // It uses the handler already resolved from the auth registry so provider-specific
 // overrides (tenantID, hostname, etc.) do not apply.
-func loginGeneric(ctx context.Context, w *writer.Writer, handler auth.Handler, handlerName string, flow auth.Flow, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
+func loginGeneric(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, handlerName string, flow auth.Flow, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
 	// Pre-login check; skip for client_credentials since it is non-interactive.
 	preLogin, err := auth.PreLoginCheck(ctx, handler, flow, force, skipIfAuthenticated, auth.FlowClientCredentials)
 	if err != nil {
@@ -470,17 +471,17 @@ func loginGeneric(ctx context.Context, w *writer.Writer, handler auth.Handler, h
 		return nil
 	case auth.PreLoginAlreadyAuthenticated:
 		w.Warningf("Already authenticated as %s.", preLogin.Identity)
-		w.Warningf("Use 'scafctl auth logout %s' to sign out first, or use --force to re-authenticate.", handlerName)
+		w.Warningf("Use '%s auth logout %s' to sign out first, or use --force to re-authenticate.", binaryName, handlerName)
 		w.Info("")
 	}
 
-	return executeLogin(ctx, w, handler, flow, "", callbackPort, timeout, scopes)
+	return executeLogin(ctx, w, binaryName, handler, flow, "", callbackPort, timeout, scopes)
 }
 
 // executeLogin runs the common login logic for any auth handler.
 // For device-code flows on a terminal, it uses the kvx status screen TUI.
 // All other flows (and non-terminal output) use plain text output.
-func executeLogin(ctx context.Context, w *writer.Writer, handler auth.Handler, flow auth.Flow, tenantID string, callbackPort int, timeout time.Duration, scopes []string) error {
+func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, flow auth.Flow, tenantID string, callbackPort int, timeout time.Duration, scopes []string) error {
 	// Set up cancellation handling
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -499,7 +500,7 @@ func executeLogin(ctx context.Context, w *writer.Writer, handler auth.Handler, f
 
 	// Use kvx status TUI for device-code flows when running in a terminal.
 	if flow == auth.FlowDeviceCode && skvx.IsTerminal(ioStreams.Out) {
-		return executeLoginWithStatusTUI(ctx, w, handler, flow, tenantID, callbackPort, timeout, scopes, ioStreams)
+		return executeLoginWithStatusTUI(ctx, w, binaryName, handler, flow, tenantID, callbackPort, timeout, scopes, ioStreams)
 	}
 
 	// Plain-text login path (non-terminal, or non-device-code flows).
@@ -544,6 +545,7 @@ func executeLogin(ctx context.Context, w *writer.Writer, handler auth.Handler, f
 func executeLoginWithStatusTUI(
 	ctx context.Context,
 	w *writer.Writer,
+	binaryName string,
 	handler auth.Handler,
 	flow auth.Flow,
 	tenantID string,
@@ -662,7 +664,7 @@ func executeLoginWithStatusTUI(
 	}
 
 	cfg := tui.DefaultConfig()
-	cfg.AppName = "scafctl"
+	cfg.AppName = binaryName
 	cfg.DisplaySchema = schema
 	cfg.Done = done
 

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -27,7 +28,7 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 	cmd := &cobra.Command{
 		Use:   "logout [handler]",
 		Short: "Clear authentication credentials",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Clear stored authentication credentials for an auth handler.
 
 			This removes the stored refresh token, clears any cached access tokens,
@@ -61,7 +62,7 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 		  scafctl auth logout --all --dry-run
 
 		  # Log out from all handlers, skipping the confirmation prompt
-		  scafctl auth logout --all --yes	`),
+		  scafctl auth logout --all --yes	`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args: func(_ *cobra.Command, args []string) error {
 			if all && len(args) > 0 {

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -27,7 +28,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 	cmd := &cobra.Command{
 		Use:   "status [handler]",
 		Short: "Show authentication status",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Show the current authentication status for auth handlers.
 
 			If no handler is specified, shows status for all registered handlers.
@@ -56,7 +57,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			  # Exit non-zero if any token expires within 10 minutes (pre-flight check)
 			  scafctl auth status --warn-within 10m
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,7 +99,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				}
 
 				if !status.Authenticated {
-					result["hint"] = fmt.Sprintf("run 'scafctl auth login %s' to authenticate", handlerName)
+					result["hint"] = fmt.Sprintf("run '%s auth login %s' to authenticate", cliParams.BinaryName, handlerName)
 				}
 
 				// Add identity type
@@ -166,7 +167,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				outputFlags.Expression,
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
-				kvx.WithOutputAppName("scafctl auth status"),
+				kvx.WithOutputAppName(cliParams.BinaryName+" auth status"),
 			)
 			outputOpts.IOStreams = ioStreams
 

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -42,7 +42,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd := &cobra.Command{
 		Use:   "token <handler>",
 		Short: "Get an access token (for debugging)",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Get an access token from an auth handler.
 
 			This command is primarily for debugging and testing. It retrieves
@@ -97,7 +97,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Export the token as a shell variable (eval-compatible)
 			  eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -132,8 +132,8 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			if len(scopes) > 0 && !auth.HasCapability(caps, auth.CapScopesOnTokenRequest) {
 				err := fmt.Errorf(
 					"the %q auth handler does not support per-request scopes; "+
-						"scopes are fixed at login time. Use 'scafctl auth login %s --scope <scope>' to change scopes",
-					handlerName, handlerName,
+						"scopes are fixed at login time. Use '%s auth login %s --scope <scope>' to change scopes",
+					handlerName, cliParams.BinaryName, handlerName,
 				)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -236,7 +236,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 					outputFlags.Expression,
 					kvx.WithOutputContext(ctx),
 					kvx.WithOutputNoColor(cliParams.NoColor),
-					kvx.WithOutputAppName("scafctl auth token --decode"),
+					kvx.WithOutputAppName(cliParams.BinaryName+" auth token --decode"),
 				)
 				outputOpts.IOStreams = ioStreams
 				return outputOpts.Write(decoded)
@@ -262,7 +262,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				outputFlags.Expression,
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
-				kvx.WithOutputAppName("scafctl auth token"),
+				kvx.WithOutputAppName(cliParams.BinaryName+" auth token"),
 			)
 			outputOpts.IOStreams = ioStreams
 
@@ -279,7 +279,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().BoolVar(&decode, "decode", false, "Decode and display JWT header and claims from the access token (no signature validation); use -o json for full structured output")
 	cmd.Flags().BoolVar(&curl, "curl", false, "Emit a ready-to-run curl command with the token injected")
 	cmd.Flags().StringVar(&curlURL, "curl-url", "", "URL to embed in the --curl output (default: '<URL>' placeholder)")
-	cmd.Flags().BoolVar(&exportToken, "export", false, "Output a shell export statement: eval $(scafctl auth token ... --export)")
+	cmd.Flags().BoolVar(&exportToken, "export", false, fmt.Sprintf("Output a shell export statement: eval $(%s auth token ... --export)", cliParams.BinaryName))
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd

--- a/pkg/cmd/scafctl/bundle/extract.go
+++ b/pkg/cmd/scafctl/bundle/extract.go
@@ -24,6 +24,7 @@ import (
 
 // ExtractOptions holds options for the bundle extract command.
 type ExtractOptions struct {
+	BinaryName  string
 	ArtifactRef string
 	OutputDir   string
 	Resolvers   []string
@@ -46,7 +47,7 @@ func CommandExtract(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 		Use:          "extract <artifact-ref>",
 		Short:        "Extract files from a bundled solution artifact",
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Extract files from a bundled solution artifact, optionally filtering
 			by resolver, action, or glob patterns.
 
@@ -72,10 +73,11 @@ func CommandExtract(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 
 			  # Flatten directory structure
 			  scafctl bundle extract my-solution@1.0.0 --flatten
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ArtifactRef = args[0]
+			opts.BinaryName = cliParams.BinaryName
 			return runExtract(cmd.Context(), opts)
 		},
 	}
@@ -91,6 +93,10 @@ func CommandExtract(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 }
 
 func runExtract(ctx context.Context, opts *ExtractOptions) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
 
@@ -124,7 +130,7 @@ func runExtract(ctx context.Context, opts *ExtractOptions) error {
 	}
 
 	// Extract to temp dir first
-	tmpDir, err := os.MkdirTemp("", "scafctl-extract-*")
+	tmpDir, err := os.MkdirTemp("", opts.BinaryName+"-extract-*")
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
 	}

--- a/pkg/cmd/scafctl/cache/cache.go
+++ b/pkg/cmd/scafctl/cache/cache.go
@@ -6,6 +6,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -19,7 +20,7 @@ func CommandCache(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 		Use:          "cache",
 		Short:        fmt.Sprintf("Manage the %s cache", path),
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Manage the scafctl cache.
 
 			The cache stores HTTP responses to reduce network requests.
@@ -28,7 +29,7 @@ func CommandCache(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 			  - Linux: ~/.cache/scafctl/
 			  - macOS: ~/.cache/scafctl/
 			  - Windows: %LOCALAPPDATA%\cache\scafctl\
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 	}
 
 	cmd.AddCommand(CommandClear(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/catalog/login.go
+++ b/pkg/cmd/scafctl/catalog/login.go
@@ -24,6 +24,7 @@ import (
 
 // LoginOptions holds options for the catalog login command.
 type LoginOptions struct {
+	BinaryName        string
 	Registry          string
 	AuthProvider      string
 	Scope             string
@@ -45,7 +46,7 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd := &cobra.Command{
 		Use:   "login <registry>",
 		Short: "Authenticate to an OCI registry",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Authenticate to an OCI registry for catalog operations.
 
 			This command stores credentials for registry access without requiring
@@ -91,10 +92,11 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Login and also write to container auth file (Docker/Podman interop)
 			  scafctl catalog login ghcr.io --write-registry-auth
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			options.BinaryName = cliParams.BinaryName
 			options.Registry = args[0]
 			return runCatalogLogin(cmd.Context(), options)
 		},
@@ -111,6 +113,10 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 }
 
 func runCatalogLogin(ctx context.Context, opts *LoginOptions) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -185,7 +191,7 @@ func runAuthHandlerLogin(ctx context.Context, w *writer.Writer, opts *LoginOptio
 	// Get handler from registry
 	handler, err := auth.GetHandler(ctx, handlerName)
 	if err != nil {
-		err = fmt.Errorf("auth handler %q not available (did you run 'scafctl auth login %s'?): %w", handlerName, handlerName, err)
+		err = fmt.Errorf("auth handler %q not available (did you run '%s auth login %s'?): %w", handlerName, opts.BinaryName, handlerName, err)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}

--- a/pkg/cmd/scafctl/catalog/push.go
+++ b/pkg/cmd/scafctl/catalog/push.go
@@ -6,6 +6,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
@@ -43,7 +44,7 @@ func CommandPush(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	cmd := &cobra.Command{
 		Use:   "push <name[@version]>",
 		Short: "Push an artifact to a remote registry",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Push a catalog artifact to a remote OCI registry.
 
 			The artifact must exist in the local catalog. Use 'scafctl build'
@@ -73,7 +74,7 @@ func CommandPush(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			  # Force overwrite existing
 			  scafctl catalog push my-solution@1.0.0 --force
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,

--- a/pkg/cmd/scafctl/config/config.go
+++ b/pkg/cmd/scafctl/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -19,7 +20,10 @@ func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 		Use:     "config",
 		Aliases: []string{"cfg"},
 		Short:   fmt.Sprintf("Manage %s configuration", path),
-		Long: heredoc.Doc(`
+		Long: strings.NewReplacer(
+			settings.CliBinaryName, cliParams.BinaryName,
+			settings.SafeEnvPrefix(settings.CliBinaryName), settings.SafeEnvPrefix(cliParams.BinaryName),
+		).Replace(heredoc.Doc(`
 			View and manage scafctl configuration.
 
 			Configuration follows the XDG Base Directory Specification:
@@ -33,7 +37,7 @@ func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 			For nested keys, use underscores (e.g., SCAFCTL_SETTINGS_NOCOLOR).
 
 			Use 'scafctl config paths' to see all resolved paths.
-		`),
+		`)),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/config/get.go
+++ b/pkg/cmd/scafctl/config/get.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -22,6 +23,7 @@ import (
 
 // GetOptions holds options for the config get command.
 type GetOptions struct {
+	BinaryName string
 	IOStreams  *terminal.IOStreams
 	CliParams  *settings.Run
 	ConfigPath string
@@ -34,12 +36,14 @@ type GetOptions struct {
 //
 //nolint:dupl // Cobra command boilerplate is intentionally similar across commands
 func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	opts := &GetOptions{}
+	opts := &GetOptions{
+		BinaryName: cliParams.BinaryName,
+	}
 
 	cCmd := &cobra.Command{
 		Use:   "get <key>",
 		Short: "Get a configuration value",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Get a specific configuration value by key.
 
 			Uses dot notation for nested values (e.g., settings.noColor).
@@ -53,7 +57,7 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 
 			  # Get all catalogs as JSON
 			  scafctl config get catalogs -o json
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
@@ -90,12 +94,16 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 
 // Run executes the config get command.
 func (o *GetOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
 	}
 
-	mgr := appconfig.NewManager(o.ConfigPath)
+	mgr := appconfig.NewManager(o.ConfigPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	_, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)
@@ -119,7 +127,7 @@ func (o *GetOptions) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl config get"),
+		kvx.WithOutputAppName(o.BinaryName+" config get"),
 	)
 	kvxOpts.IOStreams = o.IOStreams
 

--- a/pkg/cmd/scafctl/config/init.go
+++ b/pkg/cmd/scafctl/config/init.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -25,6 +26,7 @@ var configTemplates embed.FS
 
 // InitOptions holds options for the config init command.
 type InitOptions struct {
+	BinaryName string
 	IOStreams  *terminal.IOStreams
 	CliParams  *settings.Run
 	ConfigPath string
@@ -43,7 +45,7 @@ func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	cCmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a configuration file",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Initialize a scafctl configuration file.
 
 			By default, creates a minimal configuration file at ~/.scafctl/config.yaml.
@@ -66,7 +68,7 @@ func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			  # Overwrite existing config
 			  scafctl config init --force
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.NoArgs,
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
@@ -84,6 +86,7 @@ func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			opts.IOStreams = ioStreams
 			opts.CliParams = cliParams
+			opts.BinaryName = cliParams.BinaryName
 
 			// Get config path from parent command context
 			if configFlag := cCmd.Root().Flag("config"); configFlag != nil && configFlag.Value.String() != "" {
@@ -97,7 +100,7 @@ func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 	cCmd.Flags().BoolVar(&opts.Full, "full", false, "Generate full config with all options documented")
 	cCmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview config without writing to file")
-	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output file path (default: ~/.scafctl/config.yaml)")
+	cCmd.Flags().StringVarP(&opts.Output, "output", "o", "", fmt.Sprintf("Output file path (default: ~/.%s/config.yaml)", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite existing config file")
 
 	return cCmd
@@ -105,6 +108,10 @@ func CommandInit(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 // Run executes the config init command.
 func (o *InitOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -174,7 +181,7 @@ func (o *InitOptions) Run(ctx context.Context) error {
 	if o.Full {
 		w.Infof("Full config with all options. Edit as needed.\n")
 	} else {
-		w.Infof("Minimal config created. Use 'scafctl config init --full' for all options.\n")
+		w.Infof("Minimal config created. Use '%s config init --full' for all options.\n", o.BinaryName)
 	}
 
 	return nil

--- a/pkg/cmd/scafctl/config/paths.go
+++ b/pkg/cmd/scafctl/config/paths.go
@@ -28,6 +28,7 @@ var supportedPlatforms = paths.SupportedPlatforms
 
 // PathsOptions holds options for the config paths command.
 type PathsOptions struct {
+	BinaryName     string
 	IOStreams      *terminal.IOStreams
 	CliParams      *settings.Run
 	KvxOutputFlags flags.KvxOutputFlags
@@ -41,7 +42,10 @@ func CommandPaths(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 	cCmd := &cobra.Command{
 		Use:   "paths",
 		Short: fmt.Sprintf("Show XDG-compliant paths used by %s", strings.SplitN(path, "/", 2)[0]),
-		Long: heredoc.Doc(`
+		Long: strings.NewReplacer(
+			settings.CliBinaryName, cliParams.BinaryName,
+			settings.SafeEnvPrefix(settings.CliBinaryName), settings.SafeEnvPrefix(cliParams.BinaryName),
+		).Replace(heredoc.Doc(`
 			Display all paths used by scafctl.
 
 			scafctl follows the XDG Base Directory Specification for storing
@@ -73,7 +77,7 @@ func CommandPaths(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 
 			  # Output as YAML
 			  scafctl config paths -o yaml
-		`),
+		`)),
 		Args: cobra.NoArgs,
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
@@ -91,6 +95,7 @@ func CommandPaths(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 
 			opts.IOStreams = ioStreams
 			opts.CliParams = cliParams
+			opts.BinaryName = cliParams.BinaryName
 
 			return opts.Run(ctx)
 		},
@@ -105,6 +110,10 @@ func CommandPaths(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 
 // Run executes the config paths command.
 func (o *PathsOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -153,7 +162,7 @@ func (o *PathsOptions) Run(ctx context.Context) error {
 	}
 
 	// Table output
-	w.Infof("scafctl Paths")
+	w.Infof("%s Paths", o.BinaryName)
 	w.Plain("")
 
 	if isIllustrative {

--- a/pkg/cmd/scafctl/config/view.go
+++ b/pkg/cmd/scafctl/config/view.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -22,6 +23,7 @@ import (
 
 // ViewOptions holds options for the config view command.
 type ViewOptions struct {
+	BinaryName string
 	IOStreams  *terminal.IOStreams
 	CliParams  *settings.Run
 	ConfigPath string
@@ -30,13 +32,15 @@ type ViewOptions struct {
 }
 
 // CommandView creates the 'config view' command.
+//
+//nolint:dupl // Cobra command boilerplate is intentionally similar across commands
 func CommandView(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	opts := &ViewOptions{}
 
 	cCmd := &cobra.Command{
 		Use:   "view",
 		Short: "View current configuration",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Display the current configuration.
 
 			Shows all settings from the config file merged with environment overrides.
@@ -50,7 +54,7 @@ func CommandView(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			  # View specific section using CEL
 			  scafctl config view -e '_.catalogs'
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
@@ -67,6 +71,7 @@ func CommandView(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			opts.IOStreams = ioStreams
 			opts.CliParams = cliParams
+			opts.BinaryName = cliParams.BinaryName
 
 			// Get config path from parent command context
 			if configFlag := cCmd.Root().Flag("config"); configFlag != nil && configFlag.Value.String() != "" {
@@ -87,12 +92,16 @@ func CommandView(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 // Run executes the config view command.
 func (o *ViewOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
 	}
 
-	mgr := appconfig.NewManager(o.ConfigPath)
+	mgr := appconfig.NewManager(o.ConfigPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	cfg, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)
@@ -116,7 +125,7 @@ func (o *ViewOptions) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl config view"),
+		kvx.WithOutputAppName(o.BinaryName+" config view"),
 	)
 	kvxOpts.IOStreams = o.IOStreams
 

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
@@ -23,27 +23,27 @@ import (
 )
 
 // CommandCredentialHelper returns the credential-helper command group.
-func CommandCredentialHelper(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+func CommandCredentialHelper(_ *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "credential-helper",
 		Short: "Docker/Podman credential helper protocol",
-		Long: `Implements the Docker credential helper protocol, exposing scafctl's
+		Long: fmt.Sprintf(`Implements the Docker credential helper protocol, exposing %[1]s's
 encrypted credential store (AES-256-GCM) to Docker, Podman, Buildah,
 and any OCI client.
 
-Configure Docker to use scafctl as a credential helper:
-  scafctl credential-helper install --docker
+Configure Docker to use %[1]s as a credential helper:
+  %[1]s credential-helper install --docker
 
 Or add manually to ~/.docker/config.json:
-  { "credsStore": "scafctl" }`,
+  { "credsStore": "%[1]s" }`, path),
 	}
 
 	cmd.AddCommand(commandGet())
 	cmd.AddCommand(commandStore())
 	cmd.AddCommand(commandErase())
 	cmd.AddCommand(commandList())
-	cmd.AddCommand(commandInstall(ioStreams))
-	cmd.AddCommand(commandUninstall(ioStreams))
+	cmd.AddCommand(commandInstall(ioStreams, path))
+	cmd.AddCommand(commandUninstall(ioStreams, path))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/credentialhelper/install.go
+++ b/pkg/cmd/scafctl/credentialhelper/install.go
@@ -14,20 +14,21 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 )
 
 const (
-	// symlinkName is the name of the Docker credential helper symlink.
-	symlinkName = "docker-credential-" + settings.CliBinaryName
-
 	// defaultBinDir is the default directory for the symlink.
 	defaultBinDir = "~/.local/bin"
 )
 
-func commandInstall(ioStreams *terminal.IOStreams) *cobra.Command {
+// credHelperName returns the Docker credential helper symlink name for the given binary.
+func credHelperName(binaryName string) string {
+	return "docker-credential-" + binaryName
+}
+
+func commandInstall(_ *terminal.IOStreams, path string) *cobra.Command {
 	var (
 		binDir   string
 		docker   bool
@@ -37,12 +38,12 @@ func commandInstall(ioStreams *terminal.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install scafctl as a Docker/Podman credential helper",
-		Long: `Creates a docker-credential-scafctl symlink and optionally configures
-Docker or Podman to use scafctl as the credential store.
+		Short: fmt.Sprintf("Install %s as a Docker/Podman credential helper", path),
+		Long: fmt.Sprintf(`Creates a %s symlink and optionally configures
+Docker or Podman to use %s as the credential store.
 
 The symlink is placed in --bin-dir (default ~/.local/bin) and must be on
-your PATH for Docker/Podman to discover it.`,
+your PATH for Docker/Podman to discover it.`, credHelperName(path), path),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -50,12 +51,13 @@ your PATH for Docker/Podman to discover it.`,
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)
 
+			helperName := credHelperName(path)
 			resolvedBinDir := expandHome(binDir)
 
 			// Find the scafctl binary
 			scafctlPath, err := findScafctlBinary()
 			if err != nil {
-				return fmt.Errorf("locate scafctl binary: %w", err)
+				return fmt.Errorf("locate %s binary: %w", path, err)
 			}
 
 			// Create bin dir if needed
@@ -64,7 +66,7 @@ your PATH for Docker/Podman to discover it.`,
 			}
 
 			// Create (or replace) the symlink
-			linkPath := filepath.Join(resolvedBinDir, symlinkName)
+			linkPath := filepath.Join(resolvedBinDir, helperName)
 			if err := createSymlink(scafctlPath, linkPath); err != nil {
 				return fmt.Errorf("create symlink: %w", err)
 			}
@@ -73,7 +75,7 @@ your PATH for Docker/Podman to discover it.`,
 			// Optionally configure Docker
 			if docker {
 				dockerConfig := dockerConfigPath()
-				if err := updateContainerConfig(dockerConfig, registry, ioStreams); err != nil {
+				if err := updateContainerConfig(dockerConfig, registry, path); err != nil {
 					return fmt.Errorf("update Docker config %s: %w", dockerConfig, err)
 				}
 				w.Successf("Updated %s\n", dockerConfig)
@@ -82,13 +84,13 @@ your PATH for Docker/Podman to discover it.`,
 			// Optionally configure Podman
 			if podman {
 				podmanConfig := podmanConfigPath()
-				if err := updateContainerConfig(podmanConfig, registry, ioStreams); err != nil {
+				if err := updateContainerConfig(podmanConfig, registry, path); err != nil {
 					return fmt.Errorf("update Podman config %s: %w", podmanConfig, err)
 				}
 				w.Successf("Updated %s\n", podmanConfig)
 			}
 
-			w.Infof("\nVerify with: %s list\n", symlinkName)
+			w.Infof("\nVerify with: %s list\n", helperName)
 			return nil
 		},
 	}
@@ -101,7 +103,7 @@ your PATH for Docker/Podman to discover it.`,
 	return cmd
 }
 
-func commandUninstall(ioStreams *terminal.IOStreams) *cobra.Command {
+func commandUninstall(_ *terminal.IOStreams, path string) *cobra.Command {
 	var (
 		binDir   string
 		docker   bool
@@ -111,9 +113,9 @@ func commandUninstall(ioStreams *terminal.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Remove scafctl credential helper integration",
-		Long: `Removes the docker-credential-scafctl symlink and optionally removes
-scafctl entries from Docker or Podman configuration.`,
+		Short: fmt.Sprintf("Remove %s credential helper integration", path),
+		Long: fmt.Sprintf(`Removes the %s symlink and optionally removes
+%s entries from Docker or Podman configuration.`, credHelperName(path), path),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -122,7 +124,7 @@ scafctl entries from Docker or Podman configuration.`,
 			w := writer.FromContext(ctx)
 
 			resolvedBinDir := expandHome(binDir)
-			linkPath := filepath.Join(resolvedBinDir, symlinkName)
+			linkPath := filepath.Join(resolvedBinDir, credHelperName(path))
 
 			// Remove symlink only when the path is actually a symlink.
 			// Refusing to remove regular files mirrors the safety checks in createSymlink.
@@ -145,7 +147,7 @@ scafctl entries from Docker or Podman configuration.`,
 			// Optionally clean Docker config
 			if docker {
 				dockerConfig := dockerConfigPath()
-				if err := removeFromContainerConfig(dockerConfig, registry, ioStreams); err != nil {
+				if err := removeFromContainerConfig(dockerConfig, registry, path); err != nil {
 					return fmt.Errorf("update Docker config %s: %w", dockerConfig, err)
 				}
 				w.Successf("Cleaned %s\n", dockerConfig)
@@ -154,7 +156,7 @@ scafctl entries from Docker or Podman configuration.`,
 			// Optionally clean Podman config
 			if podman {
 				podmanConfig := podmanConfigPath()
-				if err := removeFromContainerConfig(podmanConfig, registry, ioStreams); err != nil {
+				if err := removeFromContainerConfig(podmanConfig, registry, path); err != nil {
 					return fmt.Errorf("update Podman config %s: %w", podmanConfig, err)
 				}
 				w.Successf("Cleaned %s\n", podmanConfig)
@@ -165,8 +167,8 @@ scafctl entries from Docker or Podman configuration.`,
 	}
 
 	cmd.Flags().StringVar(&binDir, "bin-dir", defaultBinDir, "Directory where the symlink was installed")
-	cmd.Flags().BoolVar(&docker, "docker", false, "Remove scafctl entries from ~/.docker/config.json")
-	cmd.Flags().BoolVar(&podman, "podman", false, "Remove scafctl entries from Podman containers/auth.json")
+	cmd.Flags().BoolVar(&docker, "docker", false, fmt.Sprintf("Remove %s entries from ~/.docker/config.json", path))
+	cmd.Flags().BoolVar(&podman, "podman", false, fmt.Sprintf("Remove %s entries from Podman containers/auth.json", path))
 	cmd.Flags().StringVar(&registry, "registry", "", "Remove per-registry credHelper instead of global credsStore")
 
 	return cmd
@@ -239,8 +241,8 @@ func podmanConfigPath() string {
 	return filepath.Join(home, ".config", "containers", "auth.json")
 }
 
-// updateContainerConfig updates a Docker/Podman config file to use scafctl.
-func updateContainerConfig(configPath, registry string, _ *terminal.IOStreams) error {
+// updateContainerConfig updates a Docker/Podman config file to use the given binary as credential helper.
+func updateContainerConfig(configPath, registry, binaryName string) error {
 	cfg, err := readContainerConfig(configPath)
 	if err != nil {
 		return err
@@ -252,18 +254,18 @@ func updateContainerConfig(configPath, registry string, _ *terminal.IOStreams) e
 		if !ok {
 			credHelpers = make(map[string]interface{})
 		}
-		credHelpers[registry] = settings.CliBinaryName
+		credHelpers[registry] = binaryName
 		cfg["credHelpers"] = credHelpers
 	} else {
 		// Global credsStore
-		cfg["credsStore"] = settings.CliBinaryName
+		cfg["credsStore"] = binaryName
 	}
 
 	return writeContainerConfig(configPath, cfg)
 }
 
-// removeFromContainerConfig removes scafctl entries from a Docker/Podman config.
-func removeFromContainerConfig(configPath, registry string, _ *terminal.IOStreams) error {
+// removeFromContainerConfig removes credential helper entries from a Docker/Podman config.
+func removeFromContainerConfig(configPath, registry, binaryName string) error {
 	cfg, err := readContainerConfig(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -280,7 +282,7 @@ func removeFromContainerConfig(configPath, registry string, _ *terminal.IOStream
 			}
 		}
 	} else {
-		if store, ok := cfg["credsStore"].(string); ok && store == settings.CliBinaryName {
+		if store, ok := cfg["credsStore"].(string); ok && store == binaryName {
 			delete(cfg, "credsStore")
 		}
 	}

--- a/pkg/cmd/scafctl/credentialhelper/install_test.go
+++ b/pkg/cmd/scafctl/credentialhelper/install_test.go
@@ -137,7 +137,7 @@ func TestReadWriteContainerConfig(t *testing.T) {
 func TestUpdateContainerConfig(t *testing.T) {
 	t.Run("global credsStore", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.json")
-		require.NoError(t, updateContainerConfig(path, "", nil))
+		require.NoError(t, updateContainerConfig(path, "", settings.CliBinaryName))
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestUpdateContainerConfig(t *testing.T) {
 
 	t.Run("per-registry credHelper", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.json")
-		require.NoError(t, updateContainerConfig(path, "ghcr.io", nil))
+		require.NoError(t, updateContainerConfig(path, "ghcr.io", settings.CliBinaryName))
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestRemoveFromContainerConfig(t *testing.T) {
 		cfg := map[string]interface{}{"credsStore": settings.CliBinaryName}
 		require.NoError(t, writeContainerConfig(path, cfg))
 
-		require.NoError(t, removeFromContainerConfig(path, "", nil))
+		require.NoError(t, removeFromContainerConfig(path, "", settings.CliBinaryName))
 
 		got, err := readContainerConfig(path)
 		require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestRemoveFromContainerConfig(t *testing.T) {
 		cfg := map[string]interface{}{"credsStore": "desktop"}
 		require.NoError(t, writeContainerConfig(path, cfg))
 
-		require.NoError(t, removeFromContainerConfig(path, "", nil))
+		require.NoError(t, removeFromContainerConfig(path, "", settings.CliBinaryName))
 
 		got, err := readContainerConfig(path)
 		require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestRemoveFromContainerConfig(t *testing.T) {
 		}
 		require.NoError(t, writeContainerConfig(path, cfg))
 
-		require.NoError(t, removeFromContainerConfig(path, "ghcr.io", nil))
+		require.NoError(t, removeFromContainerConfig(path, "ghcr.io", settings.CliBinaryName))
 
 		got, err := readContainerConfig(path)
 		require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestRemoveFromContainerConfig(t *testing.T) {
 		}
 		require.NoError(t, writeContainerConfig(path, cfg))
 
-		require.NoError(t, removeFromContainerConfig(path, "ghcr.io", nil))
+		require.NoError(t, removeFromContainerConfig(path, "ghcr.io", settings.CliBinaryName))
 
 		got, err := readContainerConfig(path)
 		require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestRemoveFromContainerConfig(t *testing.T) {
 
 	t.Run("nonexistent file is no-op", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "nonexistent", "config.json")
-		err := removeFromContainerConfig(path, "", nil)
+		err := removeFromContainerConfig(path, "", settings.CliBinaryName)
 		assert.NoError(t, err)
 	})
 }
@@ -253,7 +253,7 @@ func TestPodmanConfigPath(t *testing.T) {
 
 func TestCommandInstall_Structure(t *testing.T) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := commandInstall(ioStreams)
+	cmd := commandInstall(ioStreams, "scafctl")
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, "install", cmd.Use)
@@ -267,7 +267,7 @@ func TestCommandInstall_Structure(t *testing.T) {
 
 func TestCommandUninstall_Structure(t *testing.T) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := commandUninstall(ioStreams)
+	cmd := commandUninstall(ioStreams, "scafctl")
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, "uninstall", cmd.Use)
@@ -279,13 +279,13 @@ func TestCommandUninstall_Structure(t *testing.T) {
 
 func TestCommandUninstall_RefusesNonSymlink(t *testing.T) {
 	dir := t.TempDir()
-	linkPath := filepath.Join(dir, symlinkName)
+	linkPath := filepath.Join(dir, credHelperName("scafctl"))
 
 	// Create a regular file at the symlink path
 	require.NoError(t, os.WriteFile(linkPath, []byte("not a symlink"), 0o644))
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := commandUninstall(ioStreams)
+	cmd := commandUninstall(ioStreams, "scafctl")
 	cmd.SetContext(newInstallTestCtx())
 	cmd.SetArgs([]string{"--bin-dir", dir})
 
@@ -302,7 +302,7 @@ func TestCommandUninstall_NonExistentSymlink(t *testing.T) {
 	dir := t.TempDir()
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := commandUninstall(ioStreams)
+	cmd := commandUninstall(ioStreams, "scafctl")
 	cmd.SetContext(newInstallTestCtx())
 	cmd.SetArgs([]string{"--bin-dir", dir})
 

--- a/pkg/cmd/scafctl/explain/solution.go
+++ b/pkg/cmd/scafctl/explain/solution.go
@@ -70,7 +70,7 @@ Examples:
 			w := writer.New(ioStreams, cliParams)
 
 			if len(args) > 0 {
-				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl explain solution"); err != nil {
+				if err := get.ValidatePositionalRef(args[0], options.File, cliParams.BinaryName+" explain solution"); err != nil {
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}

--- a/pkg/cmd/scafctl/get/authhandler/authhandler.go
+++ b/pkg/cmd/scafctl/get/authhandler/authhandler.go
@@ -56,8 +56,9 @@ var authHandlerSchema = []byte(`{
 
 // Options holds configuration for the get authhandler command.
 type Options struct {
-	IOStreams *terminal.IOStreams
-	CliParams *settings.Run
+	BinaryName string
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
 
 	flags.KvxOutputFlags
 }
@@ -70,7 +71,7 @@ func CommandAuthHandler(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 		Use:     "authhandler [name]",
 		Aliases: []string{"authhandlers", "ah", "auth-handler", "auth-handlers", "handlers", "handler"},
 		Short:   "List or get auth handler information",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			List all registered auth handlers or get details about a specific handler.
 
 			Without arguments, lists all registered authentication handlers
@@ -97,13 +98,14 @@ func CommandAuthHandler(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 
 			  # Get handler details as YAML
 			  scafctl get authhandler github -o yaml
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
+			options.BinaryName = cliParams.BinaryName
 
 			if len(args) > 0 {
 				return options.RunGetHandler(ctx, args[0])
@@ -119,6 +121,10 @@ func CommandAuthHandler(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 
 // RunListHandlers lists all registered auth handlers.
 func (o *Options) RunListHandlers(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	handlerNames := auth.ListHandlers(ctx)
 	if len(handlerNames) == 0 {
 		err := fmt.Errorf("no auth handlers registered")
@@ -227,8 +233,8 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl get authhandler"),
-		kvx.WithOutputHelp("scafctl get authhandler", []string{
+		kvx.WithOutputAppName(o.BinaryName+" get authhandler"),
+		kvx.WithOutputHelp(o.BinaryName+" get authhandler", []string{
 			"Auth Handler Viewer",
 			"",
 			"Navigate: ↑↓ arrows | Back: ← | Enter: →",

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -23,8 +23,9 @@ import (
 
 // Options holds configuration for the get cel-functions command
 type Options struct {
-	IOStreams *terminal.IOStreams
-	CliParams *settings.Run
+	BinaryName string
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
 
 	// kvx output integration
 	flags.KvxOutputFlags
@@ -82,6 +83,7 @@ Examples:
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
+			options.BinaryName = cliParams.BinaryName
 
 			if len(args) > 0 {
 				return options.RunGetFunction(ctx, args[0])
@@ -101,7 +103,7 @@ Examples:
 		"CEL expression to filter/transform output data")
 
 	// Filter flags
-	cCmd.Flags().BoolVar(&options.Custom, "custom", false, "Show only custom scafctl functions")
+	cCmd.Flags().BoolVar(&options.Custom, "custom", false, fmt.Sprintf("Show only custom %s functions", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&options.BuiltIn, "builtin", false, "Show only built-in cel-go functions")
 
 	return cCmd
@@ -136,6 +138,10 @@ func (o *Options) getFunctions() celexp.ExtFunctionList {
 
 // RunListFunctions lists all CEL extension functions
 func (o *Options) RunListFunctions(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	funcs := o.getFunctions()
 
 	// Populate function names via CEL env introspection
@@ -328,8 +334,8 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl get cel-functions"),
-		kvx.WithOutputHelp("scafctl get cel-functions", []string{
+		kvx.WithOutputAppName(o.BinaryName+" get cel-functions"),
+		kvx.WithOutputHelp(o.BinaryName+" get cel-functions", []string{
 			"CEL Extension Functions Viewer",
 			"",
 			"Navigate: ↑↓ arrows | Back: ← | Enter: →",

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -23,8 +23,9 @@ import (
 
 // Options holds configuration for the get go-template-functions command
 type Options struct {
-	IOStreams *terminal.IOStreams
-	CliParams *settings.Run
+	BinaryName string
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
 
 	// kvx output integration
 	flags.KvxOutputFlags
@@ -82,6 +83,7 @@ Examples:
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
+			options.BinaryName = cliParams.BinaryName
 
 			if len(args) > 0 {
 				return options.RunGetFunction(ctx, args[0])
@@ -101,7 +103,7 @@ Examples:
 		"CEL expression to filter/transform output data")
 
 	// Filter flags
-	cCmd.Flags().BoolVar(&options.Custom, "custom", false, "Show only custom scafctl functions")
+	cCmd.Flags().BoolVar(&options.Custom, "custom", false, fmt.Sprintf("Show only custom %s functions", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&options.Sprig, "sprig", false, "Show only sprig library functions")
 
 	return cCmd
@@ -136,6 +138,10 @@ func (o *Options) getFunctions() gotmpl.ExtFunctionList {
 
 // RunListFunctions lists all Go template extension functions
 func (o *Options) RunListFunctions(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	funcs := o.getFunctions()
 
 	// Interactive mode
@@ -305,8 +311,8 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl get go-template-functions"),
-		kvx.WithOutputHelp("scafctl get go-template-functions", []string{
+		kvx.WithOutputAppName(o.BinaryName+" get go-template-functions"),
+		kvx.WithOutputHelp(o.BinaryName+" get go-template-functions", []string{
 			"Go Template Extension Functions Viewer",
 			"",
 			"Navigate: ↑↓ arrows | Back: ← | Enter: →",

--- a/pkg/cmd/scafctl/get/provider/provider.go
+++ b/pkg/cmd/scafctl/get/provider/provider.go
@@ -31,8 +31,9 @@ var providerSchemaJSON []byte
 
 // Options holds configuration for the get provider command
 type Options struct {
-	IOStreams *terminal.IOStreams
-	CliParams *settings.Run
+	BinaryName string
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
 
 	// kvx output integration
 	flags.KvxOutputFlags
@@ -53,7 +54,7 @@ func CommandProvider(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Use:     "provider [name]",
 		Aliases: []string{"providers", "prov", "p"},
 		Short:   "List or get provider information",
-		Long: `List all registered providers or get details about a specific provider.
+		Long: strings.ReplaceAll(`List all registered providers or get details about a specific provider.
 
 Without arguments, prints a simple list of provider names and descriptions.
 Use -i/--interactive to launch a rich kvx TUI for browsing, filtering, and
@@ -90,13 +91,14 @@ Examples:
   scafctl get provider http
 
   # Get provider details as JSON
-  scafctl get provider http -o json`,
+  scafctl get provider http -o json`, settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
+			options.BinaryName = cliParams.BinaryName
 
 			if len(args) > 0 {
 				return options.RunGetProvider(ctx, args[0])
@@ -124,6 +126,10 @@ Examples:
 
 // RunListProviders lists all providers
 func (o *Options) RunListProviders(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	reg := o.getRegistry(ctx)
 	providers := reg.ListProviders()
 
@@ -468,7 +474,7 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl get provider"),
+		kvx.WithOutputAppName(o.BinaryName+" get provider"),
 		kvx.WithOutputDisplaySchemaJSON(providerSchemaJSON),
 	)
 	kvxOpts.IOStreams = o.IOStreams

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -53,7 +53,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 
 			// Handle positional catalog name argument
 			if len(args) > 0 {
-				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl get solution"); err != nil {
+				if err := get.ValidatePositionalRef(args[0], options.File, cliParams.BinaryName+" get solution"); err != nil {
 					output.NewWriteMessageOptions(
 						options.IOStreams,
 						output.MessageTypeError,

--- a/pkg/cmd/scafctl/lint/explain_cmd.go
+++ b/pkg/cmd/scafctl/lint/explain_cmd.go
@@ -21,6 +21,7 @@ import (
 
 // ExplainOptions holds options for the lint explain command.
 type ExplainOptions struct {
+	BinaryName     string
 	IOStreams      *terminal.IOStreams
 	CliParams      *settings.Run
 	KvxOutputFlags flags.KvxOutputFlags
@@ -62,6 +63,7 @@ func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 
 			opts.IOStreams = ioStreams
 			opts.CliParams = cliParams
+			opts.BinaryName = cliParams.BinaryName
 
 			return opts.Run(ctx, args[0])
 		},
@@ -75,6 +77,10 @@ func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 
 // Run executes the lint explain command.
 func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -82,7 +88,7 @@ func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
 
 	rule, found := GetRule(ruleName)
 	if !found {
-		err := fmt.Errorf("unknown rule %q; run 'scafctl lint rules' to see available rules", ruleName)
+		err := fmt.Errorf("unknown rule %q; run '%s lint rules' to see available rules", ruleName, o.BinaryName)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
@@ -56,11 +57,12 @@ func FilterBySeverity(result *Result, minSeverity string) *Result {
 
 // Options holds command flags and settings.
 type Options struct {
-	File      string
-	Output    string
-	Severity  string
-	CliParams *settings.Run
-	IOStreams *terminal.IOStreams
+	BinaryName string
+	File       string
+	Output     string
+	Severity   string
+	CliParams  *settings.Run
+	IOStreams  *terminal.IOStreams
 }
 
 // CommandLint creates the lint command.
@@ -106,7 +108,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			  yaml    YAML output
 			  quiet   Exit code only (0=clean, 1=issues found)
 		`),
-		Example: heredoc.Doc(`
+		Example: strings.ReplaceAll(heredoc.Doc(`
 			# Lint a solution file
 			scafctl lint -f ./solution.yaml
 
@@ -115,12 +117,14 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			# Output as JSON for CI integration
 			scafctl lint -f ./solution.yaml -o json
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)
 			lgr := logger.FromContext(cmd.Context())
 			ctx = logger.WithLogger(ctx, lgr)
+
+			options.BinaryName = cliParams.BinaryName
 
 			return runLint(ctx, options)
 		},
@@ -139,6 +143,10 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 }
 
 func runLint(ctx context.Context, opts *Options) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	// Set up getter with catalog resolver for bare name resolution
@@ -177,7 +185,7 @@ func runLint(ctx context.Context, opts *Options) error {
 		"",
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(opts.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl lint"),
+		kvx.WithOutputAppName(opts.BinaryName+" lint"),
 	)
 	kvxOpts.IOStreams = opts.IOStreams
 

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -42,10 +42,10 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the MCP server",
-		Long: heredoc.Doc(`
+		Long: fmt.Sprintf(heredoc.Doc(`
 			Start the Model Context Protocol (MCP) server for AI agent integration.
 
-			The MCP server exposes scafctl capabilities as tools that AI agents can discover
+			The MCP server exposes %[1]s capabilities as tools that AI agents can discover
 			and invoke programmatically. It supports multiple transport protocols:
 
 			  - stdio: JSON-RPC 2.0 over stdin/stdout (default)
@@ -56,9 +56,9 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  {
 			    "servers": {
-			      "scafctl": {
+			      "%[1]s": {
 			        "type": "stdio",
-			        "command": "scafctl",
+			        "command": "%[1]s",
 			        "args": ["mcp", "serve"]
 			      }
 			    }
@@ -66,27 +66,27 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			Use --info to print the server's capabilities and exit (useful for debugging):
 
-			  scafctl mcp serve --info
-		`),
-		Example: heredoc.Doc(`
+			  %[1]s mcp serve --info
+		`), cliParams.BinaryName),
+		Example: fmt.Sprintf(heredoc.Doc(`
 			# Start the MCP server (stdio transport)
-			scafctl mcp serve
+			%[1]s mcp serve
 
 			# Start with SSE transport on port 8080
-			scafctl mcp serve --transport sse --addr :8080
+			%[1]s mcp serve --transport sse --addr :8080
 
 			# Start with streamable HTTP transport
-			scafctl mcp serve --transport http --addr :8080
+			%[1]s mcp serve --transport http --addr :8080
 
 			# Print server capabilities as JSON and exit
-			scafctl mcp serve --info
+			%[1]s mcp serve --info
 
 			# Start with file-based logging for debugging
-			scafctl mcp serve --log-file /tmp/scafctl-mcp.log
+			%[1]s mcp serve --log-file /tmp/%[1]s-mcp.log
 
 			# Tune stdio worker pool and queue
-			scafctl mcp serve --worker-pool-size 4 --queue-size 200
-		`),
+			%[1]s mcp serve --worker-pool-size 4 --queue-size 200
+		`), cliParams.BinaryName),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runServe(cmd.Context(), opts)

--- a/pkg/cmd/scafctl/new/new.go
+++ b/pkg/cmd/scafctl/new/new.go
@@ -6,6 +6,7 @@ package newcmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -17,9 +18,9 @@ func CommandNew(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 	cCmd := &cobra.Command{
 		Use:   "new",
 		Short: fmt.Sprintf("Create new %s resources", path),
-		Long: `Create new solutions, templates, and other scafctl resources from scratch.
+		Long: strings.ReplaceAll(`Create new solutions, templates, and other scafctl resources from scratch.
 
-Generates well-structured YAML scaffolds with best practices built in.`,
+Generates well-structured YAML scaffolds with best practices built in.`, settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/plugins/install.go
+++ b/pkg/cmd/scafctl/plugins/install.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/go-logr/logr"
@@ -36,7 +37,7 @@ type InstallOptions struct {
 }
 
 // CommandInstall creates the install subcommand.
-func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	opts := &InstallOptions{
 		CliParams: cliParams,
 		IOStreams: ioStreams,
@@ -46,7 +47,7 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 		Use:          "install",
 		Short:        "Pre-fetch plugin binaries declared in a solution",
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Pre-fetch and cache plugin binaries declared in a solution's
 			bundle.plugins section.
 
@@ -64,7 +65,7 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 
 			  # Use a custom cache directory
 			  scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := writer.FromContext(cmd.Context())
 			if w == nil {
@@ -83,7 +84,7 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ st
 
 	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Path to solution file (auto-discovered if not provided)")
 	cmd.Flags().StringVar(&opts.Platform, "platform", "", "Target platform (default: current, e.g., linux/amd64)")
-	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", "Plugin cache directory (default: $XDG_CACHE_HOME/scafctl/plugins/)")
+	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/plugins/list.go
+++ b/pkg/cmd/scafctl/plugins/list.go
@@ -6,6 +6,7 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -19,14 +20,15 @@ import (
 
 // ListOptions holds options for the list command.
 type ListOptions struct {
-	CliParams *settings.Run
-	IOStreams *terminal.IOStreams
-	CacheDir  string
+	BinaryName string
+	CliParams  *settings.Run
+	IOStreams  *terminal.IOStreams
+	CacheDir   string
 	flags.KvxOutputFlags
 }
 
 // CommandList creates the list subcommand.
-func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	opts := &ListOptions{
 		CliParams: cliParams,
 		IOStreams: ioStreams,
@@ -37,7 +39,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 		Aliases:      []string{"ls"},
 		Short:        "List cached plugin binaries",
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			List all plugin binaries stored in the local plugin cache.
 
 			Shows the name, version, platform, size, and path for each
@@ -49,7 +51,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			  # List in JSON format
 			  scafctl plugins list -o json
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := writer.FromContext(cmd.Context())
 			if w == nil {
@@ -58,17 +60,23 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			ctx := writer.WithWriter(cmd.Context(), w)
 			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
 
+			opts.BinaryName = cliParams.BinaryName
+
 			return runList(ctx, opts, kvxOpts)
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", "Plugin cache directory (default: $XDG_CACHE_HOME/scafctl/plugins/)")
+	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
 	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
 
 	return cmd
 }
 
 func runList(ctx context.Context, opts *ListOptions, kvxOpts *kvx.OutputOptions) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -82,7 +90,7 @@ func runList(ctx context.Context, opts *ListOptions, kvxOpts *kvx.OutputOptions)
 	}
 
 	if len(cached) == 0 {
-		w.Infof("No plugins cached. Use 'scafctl plugins install' to fetch plugins.")
+		w.Infof("No plugins cached. Use '%s plugins install' to fetch plugins.", opts.BinaryName)
 		return nil
 	}
 

--- a/pkg/cmd/scafctl/plugins/plugins.go
+++ b/pkg/cmd/scafctl/plugins/plugins.go
@@ -6,6 +6,7 @@ package plugins
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -19,7 +20,7 @@ func CommandPlugins(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 		Use:          "plugins",
 		Short:        fmt.Sprintf("Manage %s plugins", path),
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Manage scafctl plugins.
 
 			Plugins extend scafctl with additional providers and auth handlers
@@ -28,7 +29,7 @@ func CommandPlugins(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			Commands:
 			  install  - Pre-fetch plugin binaries declared in a solution
 			  list     - List cached plugin binaries
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 	}
 
 	cmd.AddCommand(CommandInstall(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/render/render.go
+++ b/pkg/cmd/scafctl/render/render.go
@@ -5,6 +5,7 @@ package render
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -17,7 +18,7 @@ func CommandRender(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 		Use:     "render",
 		Aliases: []string{"rn"},
 		Short:   fmt.Sprintf("Renders %s artifacts for external execution", path),
-		Long: `Render produces executor-ready artifacts from solutions.
+		Long: strings.ReplaceAll(`Render produces executor-ready artifacts from solutions.
 
 The render command outputs action graphs as JSON or YAML that can be consumed
 by external execution engines. This enables decoupled architecture where
@@ -32,7 +33,7 @@ The rendered artifact includes:
   - Deferred expressions (referencing __actions) preserved for runtime
   - Execution order phases for parallel execution
   - Dependency information for each action
-  - Metadata including generation timestamp and statistics`,
+  - Metadata including generation timestamp and statistics`, settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -87,7 +87,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Use:     "solution [name[@version]]",
 		Aliases: []string{"sol", "s", "solutions"},
 		Short:   "Render a solution's action graph or snapshot",
-		Long: `Render a solution as an executor-ready action graph or snapshot.
+		Long: strings.ReplaceAll(`Render a solution as an executor-ready action graph or snapshot.
 
 NOTE: Resolver dependency graph visualization has moved to 'scafctl run resolver --graph'.
 
@@ -132,7 +132,7 @@ Examples:
   scafctl render solution my-app
 
   # Render with parameters
-  scafctl render solution -f ./solution.yaml -r env=prod`,
+  scafctl render solution -f ./solution.yaml -r env=prod`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.MaximumNArgs(1),
 		PreRun: func(cCmd *cobra.Command, _ []string) {
 			// Track which flags were explicitly set by the user
@@ -160,7 +160,7 @@ Examples:
 
 			// Handle positional catalog name argument
 			if len(args) > 0 {
-				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl render solution"); err != nil {
+				if err := get.ValidatePositionalRef(args[0], options.File, cliParams.BinaryName+" render solution"); err != nil {
 					writeSolutionError(options, err.Error())
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -137,6 +137,19 @@ type RootOptions struct {
 	// own version. When non-nil, the version command shows both the
 	// embedder's and scafctl's versions.
 	VersionExtra *settings.VersionInfo
+
+	// ConfigDefaults is an optional YAML byte slice providing embedder-level
+	// configuration defaults. These are merged after scafctl's built-in
+	// defaults but before the user's config file, environment variables,
+	// and CLI flags.
+	//
+	// Merge precedence (lowest to highest):
+	//  1. scafctl built-in defaults (setDefaults)
+	//  2. ConfigDefaults (this field)
+	//  3. User config file (~/.config/<binary>/config.yaml)
+	//  4. Environment variables
+	//  5. CLI flags
+	ConfigDefaults []byte
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -200,7 +213,15 @@ func Root(opts *RootOptions) *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRun: func(cCmd *cobra.Command, args []string) {
 			// Load configuration first (before logger setup so config can influence log level)
-			mgr := config.NewManager(configPath)
+			// Build config manager options from RootOptions.
+			var configOpts []config.ManagerOption
+			if len(opts.ConfigDefaults) > 0 {
+				configOpts = append(configOpts, config.WithBaseConfig(opts.ConfigDefaults))
+			}
+			if envPrefix != config.EnvPrefix {
+				configOpts = append(configOpts, config.WithEnvPrefix(envPrefix))
+			}
+			mgr := config.NewManager(configPath, configOpts...)
 			cfg, err := mgr.Load()
 			if err != nil {
 				// Use stderr directly since writer isn't set up yet
@@ -327,6 +348,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			ctx = writer.WithWriter(ctx, w)
 			ctx = input.WithInput(ctx, in)
 			ctx = config.WithConfig(ctx, cfg)
+			ctx = config.WithManagerOptions(ctx, configOpts)
 
 			// ── Resolve --cwd flag and inject into context ──
 			// This must happen before any path resolution so that downstream

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -29,8 +29,9 @@ import (
 
 // ProviderOptions holds configuration for the run provider command
 type ProviderOptions struct {
-	IOStreams *terminal.IOStreams
-	CliParams *settings.Run
+	BinaryName string
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
 
 	// kvx output integration
 	cmdflags.KvxOutputFlags
@@ -88,6 +89,7 @@ func CommandProvider(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		setIOStreamFn: func(ios *terminal.IOStreams, cli *settings.Run) {
 			options.IOStreams = ios
 			options.CliParams = cli
+			options.BinaryName = cli.BinaryName
 		},
 	}
 
@@ -95,7 +97,7 @@ func CommandProvider(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Use:     "provider <name>",
 		Aliases: []string{"prov", "p"},
 		Short:   "Execute a single provider directly",
-		Long: `Execute a provider directly without a solution or resolver file.
+		Long: strings.ReplaceAll(`Execute a provider directly without a solution or resolver file.
 
 This command is useful for testing, debugging, and exploring individual
 providers in isolation. It accepts the provider name as a positional
@@ -167,7 +169,7 @@ Examples:
   scafctl run provider http url=https://example.com --show-metrics
 
   # Explore results interactively
-  scafctl run provider http url=https://api.example.com -i`,
+  scafctl run provider http url=https://api.example.com -i`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.MinimumNArgs(1),
 		PreRun: func(_ *cobra.Command, args []string) {
 			options.ProviderName = args[0]
@@ -281,6 +283,10 @@ func extractProviderNameFromOSArgs() string {
 
 // Run executes a single provider directly
 func (o *ProviderOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("running provider",
 		"name", o.ProviderName,
@@ -320,7 +326,7 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	// Look up the provider
 	prov, ok := reg.Get(o.ProviderName)
 	if !ok {
-		err := fmt.Errorf("provider %q not found (use 'scafctl get providers' to list available providers)", o.ProviderName)
+		err := fmt.Errorf("provider %q not found (use '%s get providers' to list available providers)", o.ProviderName, o.BinaryName)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.FileNotFound)
 	}
@@ -543,8 +549,8 @@ func (o *ProviderOptions) writeOutput(ctx context.Context, output map[string]any
 		o.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName("scafctl run provider"),
-		kvx.WithOutputHelp("scafctl run provider", []string{
+		kvx.WithOutputAppName(o.BinaryName+" run provider"),
+		kvx.WithOutputHelp(o.BinaryName+" run provider", []string{
 			"Provider Output Viewer",
 			"",
 			"Navigate: ↑↓ arrows | Back: ← | Enter: →",

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -32,6 +32,7 @@ import (
 
 // ResolverOptions holds configuration for the run resolver command
 type ResolverOptions struct {
+	BinaryName string
 	sharedResolverOptions
 
 	// Names is the list of resolver names to execute (positional args).
@@ -82,6 +83,7 @@ func CommandResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			return options.Output
 		},
 		setIOStreamFn: func(ios *terminal.IOStreams, cli *settings.Run) {
+			options.BinaryName = cli.BinaryName
 			options.IOStreams = ios
 			options.CliParams = cli
 		},
@@ -91,7 +93,7 @@ func CommandResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Use:     "resolver [name[@version]] [resolver-name...] [key=value...]",
 		Aliases: []string{"res", "resolvers"},
 		Short:   "Execute resolvers for debugging and inspection",
-		Long: `Execute resolvers from a solution without running actions.
+		Long: strings.ReplaceAll(`Execute resolvers from a solution without running actions.
 
 This command is designed for debugging and inspecting resolver execution.
 It loads a solution file and executes only the resolvers, skipping the
@@ -256,7 +258,7 @@ Examples:
   scafctl run resolver --progress -f ./my-solution.yaml
 
   # Show provider metrics
-  scafctl run resolver --show-metrics -f ./my-solution.yaml`,
+  scafctl run resolver --show-metrics -f ./my-solution.yaml`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.ArbitraryArgs,
 		PreRun: func(cCmd *cobra.Command, args []string) {
 			// Track which flags were explicitly set by the user
@@ -281,7 +283,7 @@ Examples:
 				case !fileExplicit && options.File == "":
 					// First bare word becomes the solution reference — must be
 					// a catalog name or registry ref, not a local file path.
-					if err := get.ValidatePositionalRef(arg, "", "scafctl run resolver"); err != nil {
+					if err := get.ValidatePositionalRef(arg, "", cliParams.BinaryName+" run resolver"); err != nil {
 						options.positionalPathErr = err
 					} else {
 						options.File = arg
@@ -315,6 +317,10 @@ Examples:
 
 // Run executes the resolver-only flow
 func (o *ResolverOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	// Fail early if PreRun detected a local file path as positional arg
 	if o.positionalPathErr != nil {
 		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)
@@ -493,7 +499,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		return o.generateTestOutput(ctx, []string{"run", "resolver"}, o.Names, results)
 	}
 
-	return o.writeResolverOutput(ctx, results, "scafctl run resolver")
+	return o.writeResolverOutput(ctx, results, o.BinaryName+" run resolver")
 }
 
 // showResolverGraph renders the resolver dependency graph without executing providers

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -39,6 +39,7 @@ var ValidOutputTypes = kvx.BaseOutputFormats()
 
 // SolutionOptions holds configuration for the run solution command
 type SolutionOptions struct {
+	BinaryName string
 	sharedResolverOptions
 
 	// Action execution options
@@ -79,6 +80,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			return options.Output
 		},
 		setIOStreamFn: func(ios *terminal.IOStreams, cli *settings.Run) {
+			options.BinaryName = cli.BinaryName
 			options.IOStreams = ios
 			options.CliParams = cli
 		},
@@ -88,7 +90,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 		Use:     "solution [name[@version]]",
 		Aliases: []string{"sol", "s", "solutions"},
 		Short:   "Run a solution by executing resolvers and actions",
-		Long: `Execute a solution by running resolvers and then actions in dependency order.
+		Long: strings.ReplaceAll(`Execute a solution by running resolvers and then actions in dependency order.
 
 Solutions can be loaded from:
 - Local catalog: Use the solution name as a positional argument (e.g., "my-app" or "my-app@1.2.3")
@@ -179,7 +181,7 @@ Examples:
   scafctl run solution --progress
 
   # Include resolver execution metadata in output
-  scafctl run solution --show-execution -f ./my-solution.yaml -o json`,
+  scafctl run solution --show-execution -f ./my-solution.yaml -o json`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.MaximumNArgs(1),
 		PreRun: func(cCmd *cobra.Command, args []string) {
 			// Track which flags were explicitly set by the user
@@ -191,7 +193,7 @@ Examples:
 			// reference. Local file paths require -f/--file. Providing both
 			// -f/--file and a positional arg is also an error.
 			if len(args) > 0 {
-				if err := get.ValidatePositionalRef(args[0], options.File, "scafctl run solution"); err != nil {
+				if err := get.ValidatePositionalRef(args[0], options.File, cliParams.BinaryName+" run solution"); err != nil {
 					options.positionalPathErr = err
 				} else {
 					options.File = args[0]
@@ -264,6 +266,10 @@ func (o *SolutionOptions) getEffectiveActionConfig(ctx context.Context) config.A
 
 // Run executes the solution
 func (o *SolutionOptions) Run(ctx context.Context) error {
+	if o.BinaryName == "" {
+		o.BinaryName = settings.CliBinaryName
+	}
+
 	// Fail early if PreRun detected a local file path as positional arg
 	if o.positionalPathErr != nil {
 		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)
@@ -332,7 +338,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Use 'scafctl run resolver' for resolver-only solutions.
 	if !sol.Spec.HasWorkflow() {
 		return o.exitWithCode(ctx,
-			fmt.Errorf("solution %q has no workflow defined; use 'scafctl run resolver' to execute resolvers without actions", sol.Metadata.Name),
+			fmt.Errorf("solution %q has no workflow defined; use '%s run resolver' to execute resolvers without actions", sol.Metadata.Name, o.BinaryName),
 			exitcode.InvalidInput)
 	}
 

--- a/pkg/cmd/scafctl/secrets/delete.go
+++ b/pkg/cmd/scafctl/secrets/delete.go
@@ -37,7 +37,8 @@ func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 			name := args[0]
 
 			// Validate name
-			if err := secrets.ValidateSecretName(name, allFlag); err != nil {
+			prefix := secrets.InternalSecretPrefixFor(cliParams.BinaryName)
+			if err := secrets.ValidateSecretNameFor(name, allFlag, prefix); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -63,8 +64,8 @@ func CommandDelete(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 			}
 
 			// Warn about internal secret deletion
-			if secrets.IsInternalSecret(name) {
-				w.Warning("⚠️  WARNING: This is an internal secret managed by scafctl.")
+			if secrets.IsInternalSecretFor(name, prefix) {
+				w.Warningf("⚠️  WARNING: This is an internal secret managed by %s.", cliParams.BinaryName)
 				w.Warning("   Deleting it may break authentication or other functionality.")
 			}
 

--- a/pkg/cmd/scafctl/secrets/exists.go
+++ b/pkg/cmd/scafctl/secrets/exists.go
@@ -32,7 +32,8 @@ func CommandExists(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *co
 			name := args[0]
 
 			// Validate name
-			if err := secrets.ValidateSecretName(name, allFlag); err != nil {
+			prefix := secrets.InternalSecretPrefixFor(cliParams.BinaryName)
+			if err := secrets.ValidateSecretNameFor(name, allFlag, prefix); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}

--- a/pkg/cmd/scafctl/secrets/get.go
+++ b/pkg/cmd/scafctl/secrets/get.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CommandGet creates the 'secrets get' command.
-func CommandGet(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	var (
 		outputFormat string
 		noNewline    bool
@@ -38,7 +38,8 @@ func CommandGet(_ *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra
 			name := args[0]
 
 			// Validate name
-			if err := secrets.ValidateSecretName(name, allFlag); err != nil {
+			prefix := secrets.InternalSecretPrefixFor(cliParams.BinaryName)
+			if err := secrets.ValidateSecretNameFor(name, allFlag, prefix); err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}

--- a/pkg/cmd/scafctl/secrets/list.go
+++ b/pkg/cmd/scafctl/secrets/list.go
@@ -29,7 +29,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets",
-		Long:  "List the names of all stored secrets. By default, internal scafctl.* secrets are excluded. Use --all to include them.",
+		Long:  fmt.Sprintf("List the names of all stored secrets. By default, internal %s.* secrets are excluded. Use --all to include them.", cliParams.BinaryName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)
@@ -52,7 +52,8 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			}
 
 			// Filter secrets based on --all flag
-			filtered := secrets.FilterSecrets(names, opts.All)
+			prefix := secrets.InternalSecretPrefixFor(cliParams.BinaryName)
+			filtered := secrets.FilterSecretsFor(names, opts.All, prefix)
 
 			// Prepare output with kvx flags
 			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))

--- a/pkg/cmd/scafctl/secrets/secrets.go
+++ b/pkg/cmd/scafctl/secrets/secrets.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -32,7 +33,7 @@ func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 		Use:     "secrets",
 		Aliases: []string{"secret"},
 		Short:   "Manage encrypted secrets",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Securely manage encrypted secrets for authentication and configuration.
 
 			Secrets are encrypted with AES-256-GCM and stored in XDG-compliant locations:
@@ -43,9 +44,9 @@ func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			The master encryption key is stored in your OS keychain for security.
 
 			Internal secrets:
-			  Secret names starting with "scafctl." are used internally (e.g. auth tokens).
+			  Secret names starting with the binary name followed by "." are used internally (e.g. auth tokens).
 			  By default they are hidden. Use --all on subcommands to include them.
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 	}
 

--- a/pkg/cmd/scafctl/snapshot/show.go
+++ b/pkg/cmd/scafctl/snapshot/show.go
@@ -20,6 +20,7 @@ import (
 
 // ShowOptions holds options for the show command
 type ShowOptions struct {
+	BinaryName   string
 	SnapshotFile string
 	Format       string
 	Verbose      bool
@@ -54,6 +55,7 @@ func CommandShow(_ *settings.Run, ioStreams terminal.IOStreams, binaryName strin
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.SnapshotFile = args[0]
+			opts.BinaryName = binaryName
 			return runShow(cmd.Context(), opts, ioStreams)
 		},
 	}
@@ -65,6 +67,10 @@ func CommandShow(_ *settings.Run, ioStreams terminal.IOStreams, binaryName strin
 }
 
 func runShow(ctx context.Context, opts *ShowOptions, ioStreams terminal.IOStreams) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
 
@@ -128,7 +134,7 @@ func showSummary(snapshot *resolver.Snapshot, opts *ShowOptions, w *writer.Write
 	// Metadata
 	w.Plainlnf("Solution:        %s (v%s)", snapshot.Metadata.Solution, snapshot.Metadata.Version)
 	w.Plainlnf("Timestamp:       %s", snapshot.Metadata.Timestamp.Format("2006-01-02 15:04:05"))
-	w.Plainlnf("scafctl Version: %s", snapshot.Metadata.ScafctlVersion)
+	w.Plainlnf("%s Version: %s", opts.BinaryName, snapshot.Metadata.ScafctlVersion)
 	w.Plainlnf("Total Duration:  %s", snapshot.Metadata.TotalDuration)
 	w.Plainlnf("Overall Status:  %s\n", snapshot.Metadata.Status)
 

--- a/pkg/cmd/scafctl/solution/diff.go
+++ b/pkg/cmd/scafctl/solution/diff.go
@@ -105,7 +105,7 @@ func CommandDiff(cliParams *settings.Run, ioStreams terminal.IOStreams, binaryNa
 
 			// Validate positional args are catalog references
 			for _, arg := range args {
-				if err := get.ValidatePositionalRef(arg, "", "scafctl solution diff"); err != nil {
+				if err := get.ValidatePositionalRef(arg, "", binaryName+" solution diff"); err != nil {
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}

--- a/pkg/cmd/scafctl/vendor/update.go
+++ b/pkg/cmd/scafctl/vendor/update.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
@@ -24,6 +25,7 @@ import (
 
 // UpdateOptions holds options for the vendor update command.
 type UpdateOptions struct {
+	BinaryName   string
 	SolutionPath string
 	Dependencies []string
 	DryRun       bool
@@ -44,7 +46,7 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 		Use:          "update",
 		Short:        "Update vendored dependencies",
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Re-resolve and update vendored dependencies without a full rebuild.
 
 			Parses the solution YAML and lock file, re-resolves catalog references
@@ -70,7 +72,7 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			  # Update lock file only (don't re-vendor files)
 			  scafctl vendor update --lock-only
-		`),
+		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.SolutionPath == "" {
@@ -80,6 +82,7 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					opts.SolutionPath = "./solution.yaml"
 				}
 			}
+			opts.BinaryName = cliParams.BinaryName
 			return runVendorUpdate(cmd.Context(), opts)
 		},
 	}
@@ -94,6 +97,10 @@ func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 }
 
 func runVendorUpdate(ctx context.Context, opts *UpdateOptions) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	localCatalog, err := catalog.NewLocalCatalog(*lgr)
@@ -139,7 +146,7 @@ func runVendorUpdateWithFetcher(ctx context.Context, opts *UpdateOptions, fetche
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 	if existingLock == nil {
-		w.Errorf("no lock file found at %s; run 'scafctl build solution' first", lockPath)
+		w.Errorf("no lock file found at %s; run '%s build solution' first", lockPath, opts.BinaryName)
 		return exitcode.Errorf("no lock file")
 	}
 

--- a/pkg/cmd/scafctl/version/version.go
+++ b/pkg/cmd/scafctl/version/version.go
@@ -53,7 +53,7 @@ func CommandVersion(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 
 			options.IOStreams = ioStreams
 			options.CliParams = cliParams
-			options.BinaryName = path
+			options.BinaryName = cliParams.BinaryName
 			options.VersionExtra = versionExtra
 
 			// Get writer from parent context or create new one

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -35,26 +36,55 @@ var (
 	globalConfigErr         error
 )
 
+// ManagerOption configures a Manager.
+type ManagerOption func(*Manager)
+
+// WithBaseConfig sets an embedded configuration layer that is merged after
+// built-in defaults but before the user's config file. This allows embedders
+// to ship organization-specific defaults without overwriting user config.
+// The bytes must be valid YAML.
+func WithBaseConfig(data []byte) ManagerOption {
+	return func(m *Manager) {
+		m.baseConfig = data
+	}
+}
+
+// WithEnvPrefix overrides the default environment variable prefix ("SCAFCTL").
+// The prefix is normalized to a safe env var format (upper-cased, hyphens/dots replaced with underscores).
+func WithEnvPrefix(prefix string) ManagerOption {
+	return func(m *Manager) {
+		m.envPrefix = settings.SafeEnvPrefix(prefix)
+	}
+}
+
 // Manager handles configuration loading and access.
 type Manager struct {
 	v          *viper.Viper
 	configPath string
+	baseConfig []byte
+	envPrefix  string
 	config     *Config
 }
 
 // NewManager creates a new configuration manager.
 // If configPath is empty, the XDG-compliant default path will be used.
-func NewManager(configPath string) *Manager {
+func NewManager(configPath string, opts ...ManagerOption) *Manager {
+	m := &Manager{
+		configPath: configPath,
+		envPrefix:  EnvPrefix,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+
 	v := viper.New()
 	v.SetConfigType(DefaultConfigFileType)
-	v.SetEnvPrefix(EnvPrefix)
+	v.SetEnvPrefix(m.envPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+	m.v = v
 
-	return &Manager{
-		v:          v,
-		configPath: configPath,
-	}
+	return m
 }
 
 // Load loads the configuration from file and environment.
@@ -75,14 +105,23 @@ func (m *Manager) Load() (*Config, error) {
 	// Set defaults
 	m.setDefaults()
 
-	// Try to read config file (not an error if it doesn't exist)
-	if err := m.v.ReadInConfig(); err != nil {
+	// Merge embedder base config (after defaults, before user file)
+	if len(m.baseConfig) > 0 {
+		if err := m.v.MergeConfig(bytes.NewReader(m.baseConfig)); err != nil {
+			return nil, fmt.Errorf("failed to merge base config: %w", err)
+		}
+	}
+
+	// Read user config file (not an error if it doesn't exist).
+	// MergeInConfig is used unconditionally so that when a base config layer
+	// is present the user file merges on top rather than replacing it.
+	// When no base config exists MergeInConfig behaves identically to
+	// ReadInConfig.
+	if err := m.v.MergeInConfig(); err != nil {
 		var configFileNotFoundError viper.ConfigFileNotFoundError
-		// Return error for parse errors but not for missing files
 		if !errors.As(err, &configFileNotFoundError) && !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
-		// File doesn't exist - that's OK, we'll use defaults
 	}
 
 	// Unmarshal into struct

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -629,3 +629,84 @@ func TestBuildConfig_IsAutoCacheRemoteArtifacts(t *testing.T) {
 	b.AutoCacheRemoteArtifacts = &tr
 	assert.True(t, b.IsAutoCacheRemoteArtifacts())
 }
+
+func TestManager_Load_WithBaseConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "nonexistent", "config.yaml")
+
+	baseConfig := []byte(`
+logging:
+  level: info
+settings:
+  quiet: true
+`)
+
+	mgr := NewManager(configPath, WithBaseConfig(baseConfig))
+	cfg, err := mgr.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.Logging.Level)
+	assert.True(t, cfg.Settings.Quiet)
+	// Built-in defaults should still be present for unset fields
+	assert.Equal(t, "local", cfg.Settings.DefaultCatalog)
+}
+
+func TestManager_Load_BaseConfig_UserFileOverrides(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	baseConfig := []byte(`
+logging:
+  level: info
+settings:
+  quiet: true
+`)
+
+	userConfig := `
+logging:
+  level: warn
+`
+	err := os.WriteFile(configPath, []byte(userConfig), 0o600)
+	require.NoError(t, err)
+
+	mgr := NewManager(configPath, WithBaseConfig(baseConfig))
+	cfg, err := mgr.Load()
+
+	require.NoError(t, err)
+	// User config wins over base config
+	assert.Equal(t, "warn", cfg.Logging.Level)
+	// Base config value preserved where user didn't override
+	assert.True(t, cfg.Settings.Quiet)
+}
+
+func TestManager_Load_BaseConfig_InvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "nonexistent", "config.yaml")
+
+	baseConfig := []byte(`{invalid: yaml: [`)
+
+	mgr := NewManager(configPath, WithBaseConfig(baseConfig))
+	_, err := mgr.Load()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to merge base config")
+}
+
+func TestManager_WithEnvPrefix(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "nonexistent", "config.yaml")
+
+	mgr := NewManager(configPath, WithEnvPrefix("MYCLI"))
+	cfg, err := mgr.Load()
+
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -10,6 +10,9 @@ import (
 // configContextKey is the context key for storing Config.
 type configContextKey struct{}
 
+// managerOptsContextKey is the context key for storing ManagerOptions.
+type managerOptsContextKey struct{}
+
 // WithConfig returns a new context with the Config stored in it.
 func WithConfig(ctx context.Context, cfg *Config) context.Context {
 	return context.WithValue(ctx, configContextKey{}, cfg)
@@ -20,4 +23,18 @@ func WithConfig(ctx context.Context, cfg *Config) context.Context {
 func FromContext(ctx context.Context) *Config {
 	cfg, _ := ctx.Value(configContextKey{}).(*Config)
 	return cfg
+}
+
+// WithManagerOptions stores ManagerOption values in the context so that
+// subcommands which create their own Manager can apply the same embedder
+// options (e.g., WithBaseConfig, WithEnvPrefix).
+func WithManagerOptions(ctx context.Context, opts []ManagerOption) context.Context {
+	return context.WithValue(ctx, managerOptsContextKey{}, opts)
+}
+
+// ManagerOptionsFromContext retrieves the ManagerOption slice from the context.
+// Returns nil when no options were stored.
+func ManagerOptionsFromContext(ctx context.Context) []ManagerOption {
+	opts, _ := ctx.Value(managerOptsContextKey{}).([]ManagerOption)
+	return opts
 }

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // resolvePathArg detects whether a prompt argument contains file content
@@ -44,12 +46,23 @@ Solution content provided inline:
 	return "<solution_file_path>", inlineNote
 }
 
+// replaceName substitutes the configured binary name for "scafctl" in prompt text.
+func (s *Server) replaceName(text string) string {
+	if s.name == settings.CliBinaryName {
+		return text
+	}
+
+	return strings.ReplaceAll(text, settings.CliBinaryName, s.name)
+}
+
 // registerPrompts registers all MCP prompts on the server.
 func (s *Server) registerPrompts() {
+	replaceName := s.replaceName
+
 	// create_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("create_solution",
-			mcp.WithPromptDescription("Guide for creating a new scafctl solution YAML file from scratch. Provides the solution schema, examples, and step-by-step instructions."),
+			mcp.WithPromptDescription(replaceName("Guide for creating a new scafctl solution YAML file from scratch. Provides the solution schema, examples, and step-by-step instructions.")),
 			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("name",
 				mcp.ArgumentDescription("Name for the new solution (lowercase, hyphens allowed, e.g., 'my-solution')"),
@@ -69,7 +82,7 @@ func (s *Server) registerPrompts() {
 	// debug_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("debug_solution",
-			mcp.WithPromptDescription("Help debug a scafctl solution that isn't working as expected. Inspects the solution, lints it, and suggests fixes."),
+			mcp.WithPromptDescription(replaceName("Help debug a scafctl solution that isn't working as expected. Inspects the solution, lints it, and suggests fixes.")),
 			mcp.WithPromptIcons(promptIcons["debug"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to debug"),
@@ -117,7 +130,7 @@ func (s *Server) registerPrompts() {
 	// update_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("update_solution",
-			mcp.WithPromptDescription("Guide for modifying an existing scafctl solution. Inspects the current state, makes targeted changes, then validates with lint and preview."),
+			mcp.WithPromptDescription(replaceName("Guide for modifying an existing scafctl solution. Inspects the current state, makes targeted changes, then validates with lint and preview.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the existing solution file to modify"),
@@ -134,7 +147,7 @@ func (s *Server) registerPrompts() {
 	// add_tests prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("add_tests",
-			mcp.WithPromptDescription("Guide for writing functional tests for a scafctl solution. Walks through test schema, assertions, snapshots, and test patterns."),
+			mcp.WithPromptDescription(replaceName("Guide for writing functional tests for a scafctl solution. Walks through test schema, assertions, snapshots, and test patterns.")),
 			mcp.WithPromptIcons(promptIcons["create"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to add tests to"),
@@ -150,7 +163,7 @@ func (s *Server) registerPrompts() {
 	// compose_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("compose_solution",
-			mcp.WithPromptDescription("Guide for designing a multi-file composed solution using scafctl's composition system. Breaks a solution into reusable partial YAML files that get merged at build time."),
+			mcp.WithPromptDescription(replaceName("Guide for designing a multi-file composed solution using scafctl's composition system. Breaks a solution into reusable partial YAML files that get merged at build time.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the root solution file (or directory for a new composed solution)"),
@@ -167,7 +180,7 @@ func (s *Server) registerPrompts() {
 	// fix_lint prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("fix_lint",
-			mcp.WithPromptDescription("Guide for fixing lint findings in a scafctl solution. Lints the solution, explains each finding, and applies targeted fixes in priority order (errors first, then warnings)."),
+			mcp.WithPromptDescription(replaceName("Guide for fixing lint findings in a scafctl solution. Lints the solution, explains each finding, and applies targeted fixes in priority order (errors first, then warnings).")),
 			mcp.WithPromptIcons(promptIcons["debug"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to fix"),
@@ -183,7 +196,7 @@ func (s *Server) registerPrompts() {
 	// prepare_execution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("prepare_execution",
-			mcp.WithPromptDescription("Prepare a scafctl solution for execution. Validates, previews, and generates the exact CLI command — without actually running it. Use this when you're ready to run a solution but want to verify everything first."),
+			mcp.WithPromptDescription(replaceName("Prepare a scafctl solution for execution. Validates, previews, and generates the exact CLI command — without actually running it. Use this when you're ready to run a solution but want to verify everything first.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to prepare for execution"),
@@ -199,7 +212,7 @@ func (s *Server) registerPrompts() {
 	// analyze_execution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("analyze_execution",
-			mcp.WithPromptDescription("Analyze a completed scafctl execution by inspecting the snapshot. Identifies failures, regressions, and suggests fixes. Optionally compares against a known-good snapshot."),
+			mcp.WithPromptDescription(replaceName("Analyze a completed scafctl execution by inspecting the snapshot. Identifies failures, regressions, and suggests fixes. Optionally compares against a known-good snapshot.")),
 			mcp.WithPromptIcons(promptIcons["analyze"]),
 			mcp.WithArgument("snapshot_path",
 				mcp.ArgumentDescription("Path to the snapshot JSON file from the failed or unexpected run"),
@@ -218,7 +231,7 @@ func (s *Server) registerPrompts() {
 	// migrate_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("migrate_solution",
-			mcp.WithPromptDescription("Guide for structurally refactoring a scafctl solution. Supports adding composition, extracting templates, splitting into multiple files, adding tests, and upgrading to newer patterns."),
+			mcp.WithPromptDescription(replaceName("Guide for structurally refactoring a scafctl solution. Supports adding composition, extracting templates, splitting into multiple files, adding tests, and upgrading to newer patterns.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to migrate"),
@@ -238,7 +251,7 @@ func (s *Server) registerPrompts() {
 	// optimize_solution prompt
 	s.mcpServer.AddPrompt(
 		mcp.NewPrompt("optimize_solution",
-			mcp.WithPromptDescription("Analyze a scafctl solution for performance, readability, and quality improvements. Identifies parallelization opportunities, unnecessary dependencies, naming issues, and missing test coverage."),
+			mcp.WithPromptDescription(replaceName("Analyze a scafctl solution for performance, readability, and quality improvements. Identifies parallelization opportunities, unnecessary dependencies, naming issues, and missing test coverage.")),
 			mcp.WithPromptIcons(promptIcons["analyze"]),
 			mcp.WithArgument("path",
 				mcp.ArgumentDescription("Path to the solution file to optimize"),
@@ -325,13 +338,13 @@ After creating the solution file:
 4. If the solution has tests, call run_solution_tests to verify they pass`)
 
 	return &mcp.GetPromptResult{
-		Description: fmt.Sprintf("Create a new scafctl solution: %s", name),
+		Description: s.replaceName(fmt.Sprintf("Create a new scafctl solution: %s", name)),
 		Messages: []mcp.PromptMessage{
 			{
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -384,7 +397,7 @@ Check for common issues:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -587,7 +600,7 @@ IMPORTANT:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -684,7 +697,7 @@ IMPORTANT:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -776,7 +789,7 @@ SUB-SOLUTION COMPOSITION (alternative to compose partials):
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -868,7 +881,7 @@ IMPORTANT:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -947,7 +960,7 @@ highlight them clearly so the user can make an informed decision.`, pathRef, inl
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -1112,7 +1125,7 @@ CRITICAL RULES:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},
@@ -1235,7 +1248,7 @@ IMPORTANT:
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: prompt,
+					Text: s.replaceName(prompt),
 				},
 			},
 		},

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // Server wraps the mcp-go MCPServer and holds shared dependencies
@@ -134,7 +136,7 @@ func WithErrorLog(lgr *log.Logger) ServerOption {
 	}
 }
 
-const serverInstructions = `scafctl is a CLI tool for managing infrastructure solutions using CEL expressions, 
+const serverInstructionsTemplate = `scafctl is a CLI tool for managing infrastructure solutions using CEL expressions, 
 Go templates, and a provider-based architecture. This MCP server exposes tools 
 for inspecting solutions, validating configurations, evaluating CEL expressions, 
 browsing the solution catalog, previewing resolver outputs, and running functional tests.
@@ -322,11 +324,20 @@ Tool Latency Guide (helps optimize tool selection):
     preview_resolvers, preview_action, dry_run_solution, render_solution,
     run_solution_tests`
 
+// serverInstructions returns the MCP server instructions with the binary name
+// substituted for all "scafctl" references.
+func serverInstructions(name string) string {
+	if name == settings.CliBinaryName {
+		return serverInstructionsTemplate
+	}
+	return strings.ReplaceAll(serverInstructionsTemplate, settings.CliBinaryName, name)
+}
+
 // NewServer creates a new MCP server with all tools and resources registered.
 func NewServer(opts ...ServerOption) (*Server, error) {
 	cfg := &serverConfig{
 		version: "dev",
-		name:    "scafctl",
+		name:    settings.CliBinaryName,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -334,7 +345,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 
 	// Guard against empty server name.
 	if strings.TrimSpace(cfg.name) == "" {
-		cfg.name = "scafctl"
+		cfg.name = settings.CliBinaryName
 	}
 
 	// Build the MCP context for tool handlers
@@ -348,6 +359,15 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	if cfg.authReg != nil {
 		ctxOpts = append(ctxOpts, WithAuthRegistry(cfg.authReg))
 	}
+	// Inject settings with BinaryName so domain packages can access the
+	// configured binary name via settings.BinaryNameFromContext.
+	// IsQuiet and NoColor are true because MCP output goes through JSON-RPC,
+	// not the terminal — terminal formatting must be suppressed.
+	ctxOpts = append(ctxOpts, WithSettings(&settings.Run{
+		IsQuiet:    true,
+		NoColor:    true,
+		BinaryName: cfg.name,
+	}))
 	mcpCtx := NewContext(ctxOpts...)
 
 	// If a parent context was provided, layer its cancellation
@@ -376,7 +396,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		server.WithPromptCapabilities(true),
 		server.WithRecovery(),
 		server.WithResourceRecovery(),
-		server.WithInstructions(serverInstructions),
+		server.WithInstructions(serverInstructions(cfg.name)),
 		// Enable advanced protocol capabilities
 		server.WithLogging(),
 		server.WithRoots(),

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/fileprovider"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
@@ -1137,7 +1138,7 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 		), nil
 	}
 
-	cmdInfo, err := inspect.BuildRunCommand(sol, path)
+	cmdInfo, err := inspect.BuildRunCommand(sol, path, settings.BinaryNameFromContext(ctx))
 	if err != nil {
 		return mcp.NewToolResultJSON(map[string]any{
 			"error":       err.Error(),
@@ -1156,24 +1157,24 @@ func (s *Server) handleGetRunCommand(_ context.Context, request mcp.CallToolRequ
 				WithSuggestion("Use one of: error, overwrite, skip, skip-unchanged, append"),
 			), nil
 		}
-		if cmdInfo.Subcommand == "scafctl run solution" {
+		if cmdInfo.HasWorkflow {
 			cmdInfo.Command += " --on-conflict " + onConflict
 		} else {
 			// The --on-conflict flag is not supported by 'run resolver'.
 			// Return a structured error so the caller knows the flag was ignored.
 			return newStructuredError(ErrCodeInvalidInput,
-				fmt.Sprintf("--on-conflict is not supported by %q; it only applies to 'scafctl run solution' (solutions with a workflow)", cmdInfo.Subcommand),
+				fmt.Sprintf("--on-conflict is not supported by %q; it only applies to 'run solution' (solutions with a workflow)", cmdInfo.Subcommand),
 				WithField("on_conflict"),
 				WithSuggestion("Remove on_conflict, or use a solution that has a workflow with file provider actions."),
 			), nil
 		}
 	}
 	if backup {
-		if cmdInfo.Subcommand == "scafctl run solution" {
+		if cmdInfo.HasWorkflow {
 			cmdInfo.Command += " --backup"
 		} else {
 			return newStructuredError(ErrCodeInvalidInput,
-				fmt.Sprintf("--backup is not supported by %q; it only applies to 'scafctl run solution' (solutions with a workflow)", cmdInfo.Subcommand),
+				fmt.Sprintf("--backup is not supported by %q; it only applies to 'run solution' (solutions with a workflow)", cmdInfo.Subcommand),
 				WithField("backup"),
 				WithSuggestion("Remove backup, or use a solution that has a workflow with file provider actions."),
 			), nil

--- a/pkg/mcp/tools_sprint7_test.go
+++ b/pkg/mcp/tools_sprint7_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // --- Phase 3B: migrate_solution prompt ---
@@ -254,9 +256,10 @@ func TestHandleGetVersion(t *testing.T) {
 // --- Phase 5C: Latency hints in serverInstructions ---
 
 func TestServerInstructionsContainLatencyGuide(t *testing.T) {
-	assert.Contains(t, serverInstructions, "Tool Latency Guide")
-	assert.Contains(t, serverInstructions, "Instant")
-	assert.Contains(t, serverInstructions, "Fast")
-	assert.Contains(t, serverInstructions, "Variable")
-	assert.Contains(t, serverInstructions, "get_version")
+	instructions := serverInstructions(settings.CliBinaryName)
+	assert.Contains(t, instructions, "Tool Latency Guide")
+	assert.Contains(t, instructions, "Instant")
+	assert.Contains(t, instructions, "Fast")
+	assert.Contains(t, instructions, "Variable")
+	assert.Contains(t, instructions, "get_version")
 }

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -47,6 +47,7 @@ func TestSearchConfigFile(t *testing.T) {
 	t.Run("returns error when file does not exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+		t.Setenv("XDG_CONFIG_DIRS", tmpDir)
 		xdg.Reload()
 		defer xdg.Reload()
 

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -81,7 +81,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 	}
 
 	// Initialize secrets store for the secret provider.
-	// The keyring chain tries: OS keyring → SCAFCTL_SECRET_KEY env var → file-based key.
+	// The keyring chain tries: OS keyring → env var → file-based key.
 	// If all backends fail, skip the secret provider but register everything else.
 	var secretOpts []secrets.Option
 	if cfg := config.FromContext(ctx); cfg != nil {
@@ -94,10 +94,10 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		// Warn the user if we fell back to a less-secure backend
 		backend := secretStore.KeyringBackend()
 		if backend == secrets.KeyringBackendFile {
-			warnUser(ctx, " Secret store using file-based key storage. For better security, configure an OS keyring or set SCAFCTL_SECRET_KEY.")
+			warnUser(ctx, fmt.Sprintf(" Secret store using file-based key storage. For better security, configure an OS keyring or set %s.", secrets.EnvSecretKey))
 		}
 	} else {
-		warnUser(ctx, fmt.Sprintf(" Secret provider unavailable: %v. Secret features will be disabled. Set SCAFCTL_SECRET_KEY to enable.", err))
+		warnUser(ctx, fmt.Sprintf(" Secret provider unavailable: %v. Secret features will be disabled. Set %s to enable.", err, secrets.EnvSecretKey))
 	}
 
 	var errs []error

--- a/pkg/secrets/filtering.go
+++ b/pkg/secrets/filtering.go
@@ -9,44 +9,73 @@ import (
 )
 
 const (
-	// InternalSecretPrefix is the prefix used for internal scafctl secrets (e.g. auth tokens).
+	// InternalSecretPrefix is the default prefix used for internal secrets (e.g. auth tokens).
 	InternalSecretPrefix = "scafctl." //nolint:gosec // Not a credential, just a naming prefix
 )
 
-// IsInternalSecret returns true if the secret name belongs to the internal namespace.
-func IsInternalSecret(name string) bool {
-	return strings.HasPrefix(name, InternalSecretPrefix)
+// InternalSecretPrefixFor returns the internal-secret prefix for the given binary name.
+// Falls back to the default prefix when binaryName is empty.
+func InternalSecretPrefixFor(binaryName string) string {
+	if binaryName == "" {
+		return InternalSecretPrefix
+	}
+	return binaryName + "."
 }
 
-// ValidateSecretName validates a secret name, optionally allowing internal secrets.
-// When includeInternal is false, names starting with "scafctl." are rejected.
+// IsInternalSecret returns true if the secret name belongs to the default internal namespace.
+func IsInternalSecret(name string) bool {
+	return IsInternalSecretFor(name, InternalSecretPrefix)
+}
+
+// IsInternalSecretFor returns true if the secret name starts with the given prefix.
+func IsInternalSecretFor(name, prefix string) bool {
+	return strings.HasPrefix(name, prefix)
+}
+
+// ValidateSecretName validates a secret name using the default internal prefix.
 func ValidateSecretName(name string, includeInternal bool) error {
-	if !includeInternal && IsInternalSecret(name) {
-		return fmt.Errorf("%w: cannot operate on internal secrets (scafctl.*); use --all to include them", ErrInvalidName)
+	return ValidateSecretNameFor(name, includeInternal, InternalSecretPrefix)
+}
+
+// ValidateSecretNameFor validates a secret name, optionally allowing internal secrets
+// identified by the given prefix.
+func ValidateSecretNameFor(name string, includeInternal bool, prefix string) error {
+	if !includeInternal && IsInternalSecretFor(name, prefix) {
+		return fmt.Errorf("%w: cannot operate on internal secrets (%s*); use --all to include them", ErrInvalidName, prefix)
 	}
 	return ValidateName(name)
 }
 
 // ValidateUserSecretName validates a secret name for user operations.
-// Returns an error if the name is invalid or uses the reserved "scafctl." prefix.
+// Returns an error if the name is invalid or uses the reserved internal prefix.
 func ValidateUserSecretName(name string) error {
 	return ValidateSecretName(name, false)
 }
 
-// FilterSecrets filters secret names, optionally including internal secrets (scafctl.*).
-// When includeInternal is false, internal secrets are excluded.
+// FilterSecrets filters secret names, optionally including internal secrets.
+// When includeInternal is false, internal secrets are excluded using the default prefix.
 func FilterSecrets(names []string, includeInternal bool) []string {
+	return FilterSecretsFor(names, includeInternal, InternalSecretPrefix)
+}
+
+// FilterSecretsFor filters secret names using the given internal-secret prefix.
+func FilterSecretsFor(names []string, includeInternal bool, prefix string) []string {
 	if includeInternal {
 		return names
 	}
-	return FilterUserSecrets(names)
+	return FilterUserSecretsFor(names, prefix)
 }
 
-// FilterUserSecrets filters out internal secrets (scafctl.*) from a list of secret names.
+// FilterUserSecrets filters out internal secrets from a list using the default prefix.
 func FilterUserSecrets(names []string) []string {
+	return FilterUserSecretsFor(names, InternalSecretPrefix)
+}
+
+// FilterUserSecretsFor filters out secrets matching the given prefix.
+func FilterUserSecretsFor(names []string, prefix string) []string {
 	result := make([]string, 0, len(names))
 	for _, name := range names {
-		if !IsInternalSecret(name) {
+		if !IsInternalSecretFor(name, prefix) {
 			result = append(result, name)
 		}
 	}

--- a/pkg/settings/context.go
+++ b/pkg/settings/context.go
@@ -24,3 +24,12 @@ func FromContext(ctx context.Context) (*Run, bool) {
 	s, ok := val.(*Run)
 	return s, ok
 }
+
+// BinaryNameFromContext returns the configured binary name from context.
+// Returns CliBinaryName when settings are absent or BinaryName is empty.
+func BinaryNameFromContext(ctx context.Context) string {
+	if s, ok := FromContext(ctx); ok && s.BinaryName != "" {
+		return s.BinaryName
+	}
+	return CliBinaryName
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -344,5 +344,6 @@ func NewCliParams() *Run {
 		IsQuiet:     false,
 		NoColor:     false,
 		ExitOnError: true,
+		BinaryName:  CliBinaryName,
 	}
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -28,6 +28,7 @@ func TestNewCliParams(t *testing.T) {
 				IsQuiet:     false,
 				NoColor:     false,
 				ExitOnError: true,
+				BinaryName:  CliBinaryName,
 			},
 		},
 	}

--- a/pkg/solution/inspect/run_command.go
+++ b/pkg/solution/inspect/run_command.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
 
@@ -44,18 +45,24 @@ type ParamInfo struct {
 
 // BuildRunCommand analyzes a solution and returns the exact CLI command to run it,
 // including any parameter-type resolvers that need values passed via -r flags.
+// The binaryName parameter is used in the generated command (e.g., "scafctl" or a
+// custom name when scafctl is embedded as a library).
 // Returns nil and an error message if the solution has nothing to run.
-func BuildRunCommand(sol *solution.Solution, path string) (*RunCommandInfo, error) {
+func BuildRunCommand(sol *solution.Solution, path, binaryName string) (*RunCommandInfo, error) {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
 	hasResolvers := sol.Spec.HasResolvers()
 	hasWorkflow := sol.Spec.HasWorkflow()
 
 	var command, explanation string
 	switch {
 	case hasWorkflow:
-		command = "scafctl run solution"
+		command = binaryName + " run solution"
 		explanation = "Solution has a workflow with actions — use 'run solution'"
 	case hasResolvers:
-		command = "scafctl run resolver"
+		command = binaryName + " run resolver"
 		explanation = "Solution has resolvers but no workflow — use 'run resolver'"
 	default:
 		return nil, fmt.Errorf("solution has neither resolvers nor a workflow")

--- a/pkg/solution/inspect/run_command_test.go
+++ b/pkg/solution/inspect/run_command_test.go
@@ -21,7 +21,7 @@ func TestBuildRunCommand_WorkflowSolution(t *testing.T) {
 		},
 	}
 
-	info, err := BuildRunCommand(sol, "solutions/deploy.yaml")
+	info, err := BuildRunCommand(sol, "solutions/deploy.yaml", "scafctl")
 	require.NoError(t, err)
 
 	assert.Equal(t, "scafctl run solution", info.Subcommand)
@@ -52,7 +52,7 @@ func TestBuildRunCommand_ResolverOnlySolution(t *testing.T) {
 		},
 	}
 
-	info, err := BuildRunCommand(sol, "/abs/path/solution.yaml")
+	info, err := BuildRunCommand(sol, "/abs/path/solution.yaml", "scafctl")
 	require.NoError(t, err)
 
 	assert.Equal(t, "scafctl run resolver", info.Subcommand)
@@ -75,7 +75,7 @@ func TestBuildRunCommand_ResolverOnlySolution(t *testing.T) {
 func TestBuildRunCommand_EmptySolution(t *testing.T) {
 	sol := &solution.Solution{}
 
-	info, err := BuildRunCommand(sol, "empty.yaml")
+	info, err := BuildRunCommand(sol, "empty.yaml", "scafctl")
 
 	assert.Nil(t, info)
 	assert.Error(t, err)
@@ -102,7 +102,7 @@ func TestBuildRunCommand_PathPrefixing(t *testing.T) {
 				"x": {Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "cel"}}}},
 			}
 
-			info, err := BuildRunCommand(sol, tt.path)
+			info, err := BuildRunCommand(sol, tt.path, "scafctl")
 			require.NoError(t, err)
 			assert.Contains(t, info.Command, tt.expectInCmd)
 		})
@@ -120,8 +120,9 @@ func BenchmarkBuildRunCommand(b *testing.B) {
 		Actions: map[string]*action.Action{"deploy": {}},
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		BuildRunCommand(sol, "solution.yaml") //nolint:errcheck
+	for b.Loop() {
+		BuildRunCommand(sol, "solution.yaml", "scafctl") //nolint:errcheck
 	}
 }


### PR DESCRIPTION
Parameterize all user-facing "scafctl" references so embedders using scafctl as a library see their own binary name:

Fixes #205, #206

- Add BinaryNameFromContext helper to pkg/settings/context.go
- Replace hardcoded "scafctl" in auth token errors (entra, github, gcp)
- Replace hardcoded "scafctl" in catalog URL error messages
- Replace hardcoded "scafctl.*" in secret filtering error message
- Replace hardcoded "SCAFCTL_SECRET_KEY" in builtin provider warnings
- Parameterize MCP server instructions, prompts, and tool output
- Add replaceName method on MCP Server for prompt text substitution
- Change BuildRunCommand to accept binaryName parameter
- Use HasWorkflow bool instead of string-comparing subcommand names
- Add configurable BinaryName to CLI command descriptions and flags
- Fix path vs binaryName confusion in secrets, get, and snapshot cmds
- Add WithBaseConfig and WithEnvPrefix options to config.Manager
- Add NewCliParams default for BinaryName field
- Inject settings.Run into MCP context for binary-name-aware tools
- Update tests for new function signatures and parameterized output
