### PR TITLE
docs: improve parameter passing and resolver naming documentation

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -328,8 +328,19 @@ Resolver names must follow these rules:
 
 - `camelCase` - **Recommended best practice**
 - `snake_case` - Acceptable
-- `kebab-case` - Acceptable
+- `kebab-case` - Acceptable (but see CEL note below)
 - Any combination of alphanumeric characters, underscores, and hyphens
+
+**CEL and naming:**
+
+Names with hyphens (e.g., `api-endpoint`) require bracket notation in CEL
+expressions because the hyphen is parsed as a minus operator. For example:
+
+- `_.apiEndpoint` -- dot notation works for camelCase and snake_case names
+- `_["api-endpoint"]` -- bracket notation is required for hyphenated names
+
+Bracket notation works for all names, but dot notation is simpler. To avoid
+this friction, prefer `camelCase` or `snake_case` for resolver names.
 
 **Examples:**
 

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -162,6 +162,46 @@ This example is also in [cel-basics.yaml](../../examples/resolvers/cel-basics.ya
 
 {{% /details %}}
 
+#### Bracket Notation for Hyphenated Names
+
+CEL supports two syntaxes for accessing resolver values:
+
+- **Dot notation:** `_.resolverName` -- works for camelCase and snake_case names
+- **Bracket notation:** `_["resolver-name"]` -- works for all names, required for hyphens
+
+Hyphens in resolver names conflict with the CEL minus operator, so dot notation
+(`_.api-endpoint`) will not work. Use bracket notation instead:
+
+~~~yaml
+spec:
+  resolvers:
+    api-endpoint:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://api.example.com"
+
+    url:
+      type: string
+      dependsOn: [api-endpoint]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # Bracket notation required for hyphenated names
+              expression: '_["api-endpoint"] + "/v1/users"'
+~~~
+
+Both notations can be mixed in a single expression:
+
+~~~yaml
+expression: '_["api-endpoint"] + "/" + _.version'
+~~~
+
+> **Tip:** Prefer `camelCase` or `snake_case` for resolver names to use the simpler dot notation everywhere.
+
 ### 3. Using `expr` in Inputs
 
 The `expr` field can be used on any provider input for dynamic values. For example, in your solution's `workflow.actions` section:

--- a/docs/tutorials/message-provider-tutorial.md
+++ b/docs/tutorials/message-provider-tutorial.md
@@ -249,7 +249,7 @@ spec:
 
 Output: `💡 Deploying my-service v2.0.0`
 
-> **Note:** Go templates access resolver data directly with `{{ .resolverName }}`. In CEL expressions, use the `_` prefix: `_.resolverName`.
+> **Note:** Go templates access resolver data directly with `{{ .resolverName }}`. In CEL expressions, use the `_` prefix: `_.resolverName` (dot notation) or `_["resolver-name"]` (bracket notation, required for hyphenated names).
 
 ### CEL Expressions via `expr:`
 

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -258,6 +258,8 @@ Output:
 ## Resolver Dependencies
 
 Resolvers can reference other resolvers using `_.resolver_name` syntax in CEL expressions.
+For names with hyphens, use bracket notation: `_["resolver-name"]`. See the
+[CEL tutorial](cel-tutorial.md) for details.
 
 ### Step 1: Create a Solution with Dependencies
 

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -1,9 +1,25 @@
 # Parameters Example
 # Demonstrates using CLI parameters with default values and type coercion.
 #
-# Run: scafctl run resolver -f parameters.yaml
-# Run: scafctl run resolver -f parameters.yaml name=Alice count=5
-# Run: scafctl run resolver -f parameters.yaml -r name=Alice -r count=5
+# Basic usage:
+#   scafctl run resolver -f parameters.yaml
+#   scafctl run resolver -f parameters.yaml name=Alice count=5
+#   scafctl run resolver -f parameters.yaml -r name=Alice -r count=5
+#
+# Load parameters from a YAML/JSON file:
+#   scafctl run resolver -f parameters.yaml @params.yaml
+#   scafctl run resolver -f parameters.yaml -r @params.yaml
+#
+# Read parameters from stdin (parsed as YAML or JSON):
+#   echo '{"name": "Alice", "count": 5}' | scafctl run resolver -f parameters.yaml @-
+#   echo '{"name": "Alice"}' | scafctl run resolver -f parameters.yaml -r @-
+#
+# Pipe raw stdin into a single parameter:
+#   echo Alice | scafctl run resolver -f parameters.yaml name=@-
+#
+# Read a file's raw content into a single parameter:
+#   scafctl run resolver -f parameters.yaml name=@name.txt
+#
 # Help: scafctl run resolver -f parameters.yaml --help
 
 apiVersion: scafctl.io/v1

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -100,6 +100,54 @@ func makeRunEFunc(cfg runCommandConfig, cmdUse string) func(*cobra.Command, []st
 	}
 }
 
+// ResolverParametersHelp is the help text block for resolver parameter
+// passing conventions including positional args, used by run resolver.
+const ResolverParametersHelp = `RESOLVER PARAMETERS:
+  Parameters can be passed in two equivalent ways:
+
+  1. Positional key=value (recommended):
+       key=value         After resolver names or on its own
+       key=@-            Read raw stdin as value for key
+       key=@file         Read raw file content as value for key
+       @file.yaml        Load parameters from a file (parsed as YAML/JSON)
+       @-                Read parameters from stdin (parsed as YAML/JSON)
+
+  2. Explicit -r/--resolver flag:
+       -r key=value      Repeatable flag
+       -r key=val1,val2  Multiple values become an array
+       -r key=@-         Read raw stdin as value for key
+       -r key=@file      Read raw file content as value for key
+       -r @file.yaml     Load parameters from a YAML file
+       -r @file.json     Load parameters from a JSON file
+       -r @-             Read parameters from stdin (YAML or JSON)
+
+  Both forms can be mixed. When the same key appears multiple
+  times, values are merged into an array rather than replaced.
+
+  Note: @- cannot be combined with -f - (both read from stdin).
+
+  Bare words (without '=') are treated as resolver names (or the solution
+  reference if -f is not provided — see SOLUTION SOURCE above).
+  Words containing '=' or starting with '@' are treated as parameters.`
+
+// ResolverParametersFlagHelp is the flag-only help text block for resolver
+// parameter passing, used by run solution (which does not accept positional
+// key=value parameters).
+const ResolverParametersFlagHelp = `RESOLVER PARAMETERS:
+  Parameters are passed using the -r/--resolver flag:
+    -r key=value      Repeatable flag
+    -r key=val1,val2  Multiple values become an array
+    -r key=@-         Read raw stdin as value for key
+    -r key=@file      Read raw file content as value for key
+    -r @file.yaml     Load parameters from a YAML file
+    -r @file.json     Load parameters from a JSON file
+    -r @-             Read parameters from stdin (YAML or JSON)
+
+  When the same key appears multiple times, values are merged
+  into an array rather than replaced.
+
+  Note: @- cannot be combined with -f - (both read from stdin).`
+
 // sharedResolverOptions holds the resolver-specific fields shared between
 // the run solution and run resolver commands.
 type sharedResolverOptions struct {

--- a/pkg/cmd/scafctl/run/common_coverage_test.go
+++ b/pkg/cmd/scafctl/run/common_coverage_test.go
@@ -505,3 +505,51 @@ func BenchmarkCheckValueSizes(b *testing.B) {
 		_ = opts.checkValueSizes(data, lgr)
 	}
 }
+
+// ── ResolverParametersHelp shared constant tests ──────────────────────────────
+
+func TestResolverParametersHelp_EmbeddedInCommands(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	resolverCmd := CommandResolver(cliParams, streams, "")
+	solutionCmd := CommandSolution(cliParams, streams, "")
+
+	// run resolver uses the full help (with positional params)
+	assert.Contains(t, resolverCmd.Long, ResolverParametersHelp,
+		"run resolver Long description should contain ResolverParametersHelp")
+
+	// run solution uses the flag-only help (no positional params)
+	assert.Contains(t, solutionCmd.Long, ResolverParametersFlagHelp,
+		"run solution Long description should contain ResolverParametersFlagHelp")
+	assert.NotContains(t, solutionCmd.Long, "Positional key=value",
+		"run solution should not advertise positional key=value parameters")
+}
+
+func TestResolverParametersHelp_ContainsStdinConventions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{"positional key=value", "key=value"},
+		{"stdin raw value", "key=@-"},
+		{"stdin parsed", "@-"},
+		{"file raw value", "key=@file"},
+		{"file parsed YAML", "@file.yaml"},
+		{"flag key=value", "-r key=value"},
+		{"flag stdin", "-r @-"},
+		{"array merge", "merged into an array"},
+		{"stdin conflict note", "@- cannot be combined with -f -"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Contains(t, ResolverParametersHelp, tt.pattern)
+		})
+	}
+}

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -147,33 +147,7 @@ SNAPSHOT MODE:
   capture resolver values, timing, phases, parameters, and metadata for
   debugging, testing, comparison, and audit trails.
 
-RESOLVER PARAMETERS:
-  Parameters can be passed in two equivalent ways:
-
-  1. Positional key=value (recommended):
-       key=value         After resolver names or on its own
-       key=@-            Read raw stdin as value for key
-       key=@file         Read raw file content as value for key
-       @file.yaml        Load parameters from a file (parsed as YAML/JSON)
-       @-                Read parameters from stdin (parsed as YAML/JSON)
-
-  2. Explicit -r/--resolver flag:
-       -r key=value      Repeatable flag
-       -r key=val1,val2  Multiple values become an array
-       -r key=@-         Read raw stdin as value for key
-       -r key=@file      Read raw file content as value for key
-       -r @file.yaml     Load parameters from a YAML file
-       -r @file.json     Load parameters from a JSON file
-       -r @-             Read parameters from stdin (YAML or JSON)
-
-  Both forms can be mixed. When the same key appears multiple
-  times, values are merged into an array rather than replaced.
-
-  Note: @- cannot be combined with -f - (both read from stdin).
-
-  Bare words (without '=') are treated as resolver names (or the solution
-  reference if -f is not provided — see SOLUTION SOURCE above).
-  Words containing '=' or starting with '@' are treated as parameters.
+` + ResolverParametersHelp + `
 
 OUTPUT FORMATS:
   table    Bordered table view (default when terminal)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -110,12 +110,7 @@ The execution proceeds in two phases:
 To execute resolvers only without actions (for debugging/inspection), use:
   scafctl run resolver
 
-RESOLVER PARAMETERS:
-  Parameters can be passed using -r/--resolver flag in several formats:
-    key=value         Simple key-value pair
-    @file.yaml        Load parameters from YAML file  
-    @file.json        Load parameters from JSON file
-    key=val1,val2     Multiple values become an array
+` + ResolverParametersFlagHelp + `
 
 EXECUTION ORDER:
   1. Parse and validate solution (must have workflow)
@@ -162,6 +157,18 @@ Examples:
 
   # Run with parameters
   scafctl run solution -r env=prod -r region=us-east1
+
+  # Load parameters from a YAML file
+  scafctl run solution -f ./my-solution.yaml -r @params.yaml
+
+  # Load parameters from stdin (pipe YAML or JSON)
+  echo '{"env": "prod"}' | scafctl run solution -f ./my-solution.yaml -r @-
+
+  # Pipe raw stdin into a single parameter
+  echo hello | scafctl run solution -f ./my-solution.yaml -r message=@-
+
+  # Read a file's raw content into a parameter
+  scafctl run solution -f ./my-solution.yaml -r body=@content.txt
 
   # Dry run (validate and show what would execute)
   scafctl run solution -f ./my-solution.yaml --dry-run


### PR DESCRIPTION
Address #214 and #215 with documentation and help text improvements:

- Extract shared ResolverParametersHelp constant in pkg/cmd/scafctl/run/common.go
- Replace inline help in run resolver and run solution with shared constant
- Add stdin/file parameter examples to run solution help text
- Add stdin/file parameter examples to examples/resolvers/parameters.yaml
- Document CEL bracket notation for hyphenated resolver names in docs/design/resolvers.md
- Add bracket notation section to docs/tutorials/cel-tutorial.md
- Update resolver and message-provider tutorials with bracket notation
- Add tests verifying shared help constant in both commands


