### PR TITLE
feat(mcp): add WithSupplementalInstructions server option for embedders

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -44,17 +44,18 @@ type Server struct {
 type ServerOption func(*serverConfig)
 
 type serverConfig struct {
-	logger          *logr.Logger
-	registry        *provider.Registry
-	authReg         *auth.Registry
-	config          *config.Config
-	version         string
-	name            string
-	ctx             context.Context
-	paginationLimit int
-	workerPoolSize  int
-	queueSize       int
-	errorLogger     *log.Logger
+	logger                   *logr.Logger
+	registry                 *provider.Registry
+	authReg                  *auth.Registry
+	config                   *config.Config
+	version                  string
+	name                     string
+	ctx                      context.Context
+	paginationLimit          int
+	workerPoolSize           int
+	queueSize                int
+	errorLogger              *log.Logger
+	supplementalInstructions string
 }
 
 // WithServerLogger sets the logger for the MCP server.
@@ -133,6 +134,30 @@ func WithQueueSize(size int) ServerOption {
 func WithErrorLog(lgr *log.Logger) ServerOption {
 	return func(c *serverConfig) {
 		c.errorLogger = lgr
+	}
+}
+
+// WithSupplementalInstructions appends additional instruction text to the
+// server instructions returned to AI agents during initialization.
+// Embedders use this to provide routing guidance for their custom tools.
+//
+// The supplemental text is appended after the base server instructions,
+// separated by a blank line. Binary-name substitution is automatically
+// applied when the server name differs from the default.
+//
+// Example:
+//
+//	srv, err := mcp.NewServer(
+//		mcp.WithServerName("mycli"),
+//		mcp.WithSupplementalInstructions(`
+//	This server includes domain-specific migration tools.
+//	Use migration tools ONLY when working with legacy solution files.
+//	For new solutions, use only the core tools above.
+//	`),
+//	)
+func WithSupplementalInstructions(instructions string) ServerOption {
+	return func(c *serverConfig) {
+		c.supplementalInstructions = instructions
 	}
 }
 
@@ -358,6 +383,20 @@ func serverInstructions(name string) string {
 	return strings.ReplaceAll(serverInstructionsTemplate, settings.CliBinaryName, name)
 }
 
+// buildInstructions combines the base server instructions with optional
+// supplemental instructions from embedders. Binary-name substitution is
+// applied to supplemental text when the server name differs from the default.
+func buildInstructions(name, supplemental string) string {
+	base := serverInstructions(name)
+	if supplemental == "" {
+		return base
+	}
+	if name != settings.CliBinaryName {
+		supplemental = strings.ReplaceAll(supplemental, settings.CliBinaryName, name)
+	}
+	return base + "\n\n" + supplemental
+}
+
 // NewServer creates a new MCP server with all tools and resources registered.
 func NewServer(opts ...ServerOption) (*Server, error) {
 	cfg := &serverConfig{
@@ -421,7 +460,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		server.WithPromptCapabilities(true),
 		server.WithRecovery(),
 		server.WithResourceRecovery(),
-		server.WithInstructions(serverInstructions(cfg.name)),
+		server.WithInstructions(buildInstructions(cfg.name, cfg.supplementalInstructions)),
 		// Enable advanced protocol capabilities
 		server.WithLogging(),
 		server.WithRoots(),

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -6,12 +6,14 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -198,5 +200,54 @@ func TestMergeContext(t *testing.T) {
 		default:
 			// expected
 		}
+	})
+}
+
+func TestBuildInstructions(t *testing.T) {
+	t.Run("empty supplemental returns base only", func(t *testing.T) {
+		result := buildInstructions(settings.CliBinaryName, "")
+		assert.Equal(t, serverInstructionsTemplate, result)
+	})
+
+	t.Run("supplemental is appended", func(t *testing.T) {
+		supplemental := "Use domain tools for legacy files."
+		result := buildInstructions(settings.CliBinaryName, supplemental)
+		assert.Contains(t, result, serverInstructionsTemplate)
+		assert.Contains(t, result, supplemental)
+		assert.True(t, strings.HasSuffix(result, supplemental))
+		assert.Contains(t, result, "\n\n"+supplemental)
+	})
+
+	t.Run("binary name substitution in supplemental", func(t *testing.T) {
+		supplemental := "Run " + settings.CliBinaryName + " solve to execute."
+		result := buildInstructions("mycli", supplemental)
+		assert.Contains(t, result, "Run mycli solve to execute.")
+		assert.NotContains(t, result, "Run "+settings.CliBinaryName+" solve to execute.")
+	})
+
+	t.Run("no substitution when using default name", func(t *testing.T) {
+		supplemental := "Run " + settings.CliBinaryName + " solve to execute."
+		result := buildInstructions(settings.CliBinaryName, supplemental)
+		assert.Contains(t, result, "Run "+settings.CliBinaryName+" solve to execute.")
+	})
+}
+
+func TestWithSupplementalInstructions(t *testing.T) {
+	t.Run("sets field on config", func(t *testing.T) {
+		cfg := &serverConfig{}
+		opt := WithSupplementalInstructions("extra guidance")
+		opt(cfg)
+		assert.Equal(t, "extra guidance", cfg.supplementalInstructions)
+	})
+
+	t.Run("server created with supplemental instructions", func(t *testing.T) {
+		supplemental := "Use migration tools for legacy solutions."
+		srv, err := NewServer(
+			WithServerName("mycli"),
+			WithSupplementalInstructions(supplemental),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, srv)
+		assert.Equal(t, "mycli", srv.name)
 	})
 }


### PR DESCRIPTION
Allow embedders to append routing guidance to MCP server instructions:
- Add supplementalInstructions field to serverConfig
- Add WithSupplementalInstructions server option
- Add buildInstructions helper with binary-name substitution
- Wire buildInstructions into NewServer replacing direct call

Closes #222