### PR TITLE
fix(ci): add missing gomarkdown dependency to scripts module

### DIFF
--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,3 +1,5 @@
 module github.com/oakwood-commons/scafctl/scripts
 
 go 1.26.1
+
+require github.com/gomarkdown/markdown v0.0.0-20260217112301-37c66b85d6ab // indirect

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -1,0 +1,2 @@
+github.com/gomarkdown/markdown v0.0.0-20260217112301-37c66b85d6ab h1:VYNivV7P8IRHUam2swVUNkhIdp0LRRFKe4hXNnoZKTc=
+github.com/gomarkdown/markdown v0.0.0-20260217112301-37c66b85d6ab/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=


### PR DESCRIPTION
- Add github.com/gomarkdown/markdown to scripts/go.mod
- Fixes release pipeline failure in generate-index task