### PR TITLE
feat(auth/oauth2): add disablePKCE and implicit grant flow for Quay-compatible servers

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -582,10 +582,12 @@ auth:
   customOAuth2:
     - name: quay              # unique handler name
       displayName: "Quay.io"  # human-readable label
-      tokenURL: "https://quay.io/oauth/token"
+      authorizeURL: "https://quay.io/oauth/authorize"
       clientID: "app-client-id"
       clientSecret: "app-client-secret"  # required for client_credentials
-      defaultFlow: client_credentials    # interactive | device_code | client_credentials
+      defaultFlow: interactive           # interactive | device_code | client_credentials
+      responseType: token                # implicit grant (Quay only supports response_type=token)
+      disablePKCE: true                  # auto-implied by responseType: token
       scopes: ["repo:read"]
       registry: "quay.io"               # auto-inferred for catalog login
       registryUsername: "$oauthtoken"    # OCI username convention

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -2771,10 +2771,11 @@ auth:
   customOAuth2:
     - name: quay
       displayName: "Quay.io"
-      tokenURL: "https://quay.io/oauth/token"
+      authorizeURL: "https://quay.io/oauth/authorize"
+      tokenURL: "https://quay.io/oauth/access_token"
       clientID: "your-app-client-id"
-      clientSecret: "your-app-client-secret"
-      defaultFlow: client_credentials
+      defaultFlow: interactive
+      responseType: token    # Quay only supports implicit grant (response_type=token)
       scopes:
         - "repo:read"
       registry: "quay.io"
@@ -2798,7 +2799,7 @@ scafctl catalog login quay.io
 ```
 
 Custom handlers support all three OAuth2 flows:
-- **Interactive** (authorization code + PKCE) -- requires `authorizeURL`
+- **Interactive** (authorization code + PKCE) -- requires `authorizeURL`. Set `responseType: token` for implicit grant servers. Set `disablePKCE: true` for servers that support auth code but reject PKCE parameters
 - **Device code** (RFC 8628) -- requires `deviceAuthURL`  
 - **Client credentials** -- requires `clientSecret`
 

--- a/pkg/auth/oauth/callback.go
+++ b/pkg/auth/oauth/callback.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"fmt"
 	"html"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"sync"
 	"time"
 )
 
@@ -16,6 +19,12 @@ import (
 type CallbackResult struct {
 	// Code is the authorization code received from the identity provider.
 	Code string
+	// AccessToken is the token received directly via implicit grant flow.
+	AccessToken string //nolint:gosec // struct field, not a hardcoded credential
+	// TokenType is the token type from an implicit grant response (e.g. "Bearer").
+	TokenType string
+	// ExpiresIn is the token lifetime in seconds from an implicit grant response.
+	ExpiresIn string
 	// Err is set if an error was received instead of a code.
 	Err error
 }
@@ -32,6 +41,7 @@ type CallbackServer struct {
 	resultCh chan CallbackResult
 
 	expectedState string
+	resultOnce    sync.Once
 }
 
 // StartCallbackServer creates and starts a local HTTP server on a localhost
@@ -83,7 +93,7 @@ func StartCallbackServer(ctx context.Context, port int, expectedState string) (*
 
 	go func() {
 		if sErr := cs.server.Serve(listener); sErr != nil && sErr != http.ErrServerClosed {
-			cs.resultCh <- CallbackResult{Err: fmt.Errorf("redirect server error: %w", sErr)}
+			cs.sendResult(CallbackResult{Err: fmt.Errorf("redirect server error: %w", sErr)})
 		}
 	}()
 
@@ -101,6 +111,15 @@ func (cs *CallbackServer) Close() error {
 	return cs.server.Close()
 }
 
+// sendResult delivers exactly one result to the channel. Subsequent calls are
+// no-ops, preventing goroutine leaks when duplicate requests or server errors
+// arrive after the first result has already been consumed.
+func (cs *CallbackServer) sendResult(r CallbackResult) {
+	cs.resultOnce.Do(func() {
+		cs.resultCh <- r
+	})
+}
+
 func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -112,7 +131,8 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		if errDesc != "" {
 			errMsg = fmt.Sprintf("%s: %s", errMsg, errDesc)
 		}
-		cs.resultCh <- CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)}
+		cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
+		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p><p>You can close this window.</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
 		return
 	}
@@ -123,12 +143,186 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 	if cs.expectedState != "" {
 		if r.URL.Query().Get("state") != cs.expectedState {
 			errMsg := "state parameter mismatch (possible CSRF attack)"
-			cs.resultCh <- CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)}
+			cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
+			w.WriteHeader(http.StatusForbidden)
 			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p><p>You can close this window.</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
 			return
 		}
 	}
 
-	cs.resultCh <- CallbackResult{Code: code}
+	cs.sendResult(CallbackResult{Code: code})
 	fmt.Fprint(w, "<html><body><h1>Authentication Successful</h1><p>You can close this window and return to the terminal.</p></body></html>")
 }
+
+// StartImplicitCallbackServer creates a local HTTP server for the OAuth2
+// implicit grant flow (response_type=token). The identity provider redirects
+// to the callback URL with the access token in the URL fragment
+// (#access_token=...). Because browsers do not send fragments to the server,
+// the server serves an HTML page with JavaScript that extracts the fragment
+// and POSTs the token back to a /token endpoint on the same server.
+//
+// If expectedState is non-empty, a provided state value must match it. Unlike
+// StartCallbackServer, the implicit flow accepts a missing state value and
+// only rejects explicit mismatches.
+func StartImplicitCallbackServer(ctx context.Context, port int, expectedState string) (*CallbackServer, error) {
+	addr := "localhost:0"
+	if port > 0 {
+		addr = fmt.Sprintf("localhost:%d", port)
+	}
+
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("starting local redirect server on %s: %w", addr, err)
+	}
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		listener.Close()
+		return nil, fmt.Errorf("unexpected listener address type: %T", listener.Addr())
+	}
+
+	cs := &CallbackServer{
+		RedirectURI:   fmt.Sprintf("http://localhost:%d", tcpAddr.Port),
+		listener:      listener,
+		resultCh:      make(chan CallbackResult, 1),
+		expectedState: expectedState,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", cs.handleImplicitCallback)
+	mux.HandleFunc("/token", cs.handleImplicitTokenPost)
+
+	cs.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		if sErr := cs.server.Serve(listener); sErr != nil && sErr != http.ErrServerClosed {
+			cs.sendResult(CallbackResult{Err: fmt.Errorf("redirect server error: %w", sErr)})
+		}
+	}()
+
+	return cs, nil
+}
+
+// handleImplicitCallback serves the HTML page that extracts the access token
+// from the URL fragment and POSTs it back to the local server.
+func (cs *CallbackServer) handleImplicitCallback(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// The JavaScript extracts fragment parameters and POSTs them as form data
+	// to /token on the same origin. This runs entirely on localhost.
+	fmt.Fprint(w, implicitCallbackHTML)
+}
+
+const maxImplicitTokenBody = 8192
+
+// handleImplicitTokenPost receives the token POSTed by the JavaScript on the
+// implicit grant callback page.
+func (cs *CallbackServer) handleImplicitTokenPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Reject cross-origin requests. A simple POST with application/x-www-form-urlencoded
+	// Content-Type is not subject to CORS preflight, so a malicious page could inject
+	// a forged token. When Origin is present it must match the local callback server.
+	if origin := r.Header.Get("Origin"); origin != "" && origin != cs.RedirectURI {
+		http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxImplicitTokenBody))
+	if err != nil {
+		cs.sendResult(CallbackResult{Err: fmt.Errorf("read implicit token POST: %w", err)})
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	params, err := url.ParseQuery(string(body))
+	if err != nil {
+		cs.sendResult(CallbackResult{Err: fmt.Errorf("parse implicit token POST: %w", err)})
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// Validate state parameter first to reject CSRF before processing any payload.
+	// Some OAuth2 servers omit state from the implicit grant fragment.
+	// Per RFC 6749 §4.2.2, state is only REQUIRED in the response if it was present
+	// in the request, but not all servers comply. Accept missing state (server didn't
+	// echo it back); reject only when the server returns a *different* state value.
+	if cs.expectedState != "" {
+		returnedState := params.Get("state")
+		if returnedState != "" && returnedState != cs.expectedState {
+			errMsg := "state parameter mismatch (possible CSRF attack)"
+			cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+			return
+		}
+	}
+
+	// Check for OAuth error in fragment
+	if errCode := params.Get("error"); errCode != "" {
+		errDesc := params.Get("error_description")
+		errMsg := errCode
+		if errDesc != "" {
+			errMsg = fmt.Sprintf("%s: %s", errCode, errDesc)
+		}
+		cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+		return
+	}
+
+	accessToken := params.Get("access_token")
+	if accessToken == "" {
+		cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: no access_token in redirect fragment")})
+		http.Error(w, "missing access_token", http.StatusBadRequest)
+		return
+	}
+
+	cs.sendResult(CallbackResult{
+		AccessToken: accessToken,
+		TokenType:   params.Get("token_type"),
+		ExpiresIn:   params.Get("expires_in"),
+	})
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, "<html><body><h1>Authentication Successful</h1><p>You can close this window and return to the terminal.</p></body></html>")
+}
+
+// implicitCallbackHTML is the HTML page served by the implicit grant callback
+// server. It extracts the access token from the URL fragment (#access_token=...)
+// and POSTs it to /token on the same localhost server.
+const implicitCallbackHTML = `<!DOCTYPE html>
+<html><head><title>Authentication</title></head>
+<body>
+<h1>Completing authentication...</h1>
+<p id="status">Processing...</p>
+<script>
+(function() {
+  var hash = window.location.hash.substring(1);
+  if (!hash) {
+    document.getElementById("status").textContent = "No token received.";
+    return;
+  }
+  var xhr = new XMLHttpRequest();
+  xhr.open("POST", "/token", true);
+  xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+  xhr.onload = function() {
+    if (xhr.status === 200) {
+      document.getElementById("status").textContent = "Authentication successful. You can close this window.";
+    } else {
+      document.getElementById("status").textContent = "Authentication failed: " + xhr.statusText;
+    }
+  };
+  xhr.onerror = function() {
+    document.getElementById("status").textContent = "Failed to communicate with local server.";
+  };
+  xhr.send(hash);
+  history.replaceState(null, "", window.location.pathname);
+})();
+</script>
+</body></html>`

--- a/pkg/auth/oauth/callback_test.go
+++ b/pkg/auth/oauth/callback_test.go
@@ -6,7 +6,9 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -244,6 +246,220 @@ func TestCallbackServer_NoExpectedState_SkipsValidation(t *testing.T) {
 	case result := <-cs.ResultChan():
 		assert.NoError(t, result.Err)
 		assert.Equal(t, "test-code", result.Code)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+// ---------- implicit grant callback tests ----------
+
+func TestStartImplicitCallbackServer(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	assert.Contains(t, cs.RedirectURI, "http://localhost:")
+}
+
+func TestImplicitCallbackServer_ServesHTMLPage(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	resp, err := http.Get(cs.RedirectURI + "/") //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), "window.location.hash")
+	assert.Contains(t, string(body), "/token")
+}
+
+func TestImplicitCallbackServer_ReceivesToken(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	// Simulate the JavaScript POSTing the fragment data
+	tokenData := "access_token=test-implicit-token&token_type=Bearer&expires_in=3600"
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.NoError(t, result.Err)
+		assert.Equal(t, "test-implicit-token", result.AccessToken)
+		assert.Equal(t, "Bearer", result.TokenType)
+		assert.Equal(t, "3600", result.ExpiresIn)
+		assert.Empty(t, result.Code)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_MissingToken(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	// POST with no access_token
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader("token_type=Bearer")) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.Error(t, result.Err)
+		assert.Contains(t, result.Err.Error(), "no access_token")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_OAuthError(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	errorData := "error=access_denied&error_description=user+cancelled"
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader(errorData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.Error(t, result.Err)
+		assert.Contains(t, result.Err.Error(), "access_denied")
+		assert.Contains(t, result.Err.Error(), "user cancelled")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_StateValidation_Matches(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "my-state-123")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	tokenData := "access_token=tok&token_type=Bearer&state=my-state-123"
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.NoError(t, result.Err)
+		assert.Equal(t, "tok", result.AccessToken)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_StateValidation_Mismatch(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "expected-state")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	tokenData := "access_token=tok&token_type=Bearer&state=wrong-state"
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.Error(t, result.Err)
+		assert.Contains(t, result.Err.Error(), "state parameter mismatch")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_StateOmittedByServer(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "my-state")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	// Server omits state from fragment — should be accepted per RFC 6749 §4.2.2
+	tokenData := "access_token=tok&token_type=Bearer"
+	resp, err := http.Post(cs.RedirectURI+"/token", "application/x-www-form-urlencoded", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.NoError(t, result.Err)
+		assert.Equal(t, "tok", result.AccessToken)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}
+
+func TestImplicitCallbackServer_RejectsGET(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	resp, err := http.Get(cs.RedirectURI + "/token?access_token=tok") //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestImplicitCallbackServer_RejectsCrossOrigin(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	tokenData := "access_token=tok&token_type=Bearer"
+	req, err := http.NewRequest(http.MethodPost, cs.RedirectURI+"/token", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestImplicitCallbackServer_AllowsSameOrigin(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartImplicitCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	tokenData := "access_token=tok&token_type=Bearer"
+	req, err := http.NewRequest(http.MethodPost, cs.RedirectURI+"/token", strings.NewReader(tokenData)) //nolint:noctx // test code
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", cs.RedirectURI)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.NoError(t, result.Err)
+		assert.Equal(t, "tok", result.AccessToken)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for callback result")
 	}

--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -69,6 +69,11 @@ func WithLogger(lgr logr.Logger) Option {
 
 // New creates a new generic OAuth2 auth handler from a CustomOAuth2Config.
 func New(cfg config.CustomOAuth2Config, opts ...Option) (*Handler, error) {
+	// Implicit grant flow does not use PKCE.
+	if cfg.ResponseType == "token" {
+		cfg.DisablePKCE = true
+	}
+
 	h := &Handler{
 		cfg:    cfg,
 		logger: logr.Discard(),
@@ -364,11 +369,19 @@ func (h *Handler) authCodeLogin(ctx context.Context, scopes []string, callbackPo
 		return nil, fmt.Errorf("authorizeURL is required for interactive flow")
 	}
 
-	verifier, err := oauth.GenerateCodeVerifier()
-	if err != nil {
-		return nil, fmt.Errorf("generate PKCE verifier: %w", err)
+	// Implicit grant flow (response_type=token) uses a different callback mechanism.
+	if h.cfg.ResponseType == "token" {
+		return h.implicitGrantLogin(ctx, scopes, callbackPort)
 	}
-	challenge := oauth.GenerateCodeChallenge(verifier)
+
+	var verifier string
+	if !h.cfg.DisablePKCE {
+		var err error
+		verifier, err = oauth.GenerateCodeVerifier()
+		if err != nil {
+			return nil, fmt.Errorf("generate PKCE verifier: %w", err)
+		}
+	}
 
 	state, err := oauth.GenerateCodeVerifier()
 	if err != nil {
@@ -390,8 +403,11 @@ func (h *Handler) authCodeLogin(ctx context.Context, scopes []string, callbackPo
 	q.Set("client_id", h.cfg.ClientID)
 	q.Set("redirect_uri", callbackServer.RedirectURI)
 	q.Set("state", state)
-	q.Set("code_challenge", challenge)
-	q.Set("code_challenge_method", "S256")
+	if !h.cfg.DisablePKCE {
+		challenge := oauth.GenerateCodeChallenge(verifier)
+		q.Set("code_challenge", challenge)
+		q.Set("code_challenge_method", "S256")
+	}
 	if len(scopes) > 0 {
 		q.Set("scope", strings.Join(scopes, " "))
 	}
@@ -414,11 +430,14 @@ func (h *Handler) authCodeLogin(ctx context.Context, scopes []string, callbackPo
 
 func (h *Handler) exchangeAuthCode(ctx context.Context, code, redirectURI, codeVerifier string, scopes []string) (*tokenResponse, error) {
 	data := url.Values{
-		"grant_type":    {"authorization_code"},
-		"code":          {code},
-		"redirect_uri":  {redirectURI},
-		"client_id":     {h.cfg.ClientID},
-		"code_verifier": {codeVerifier},
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {redirectURI},
+		"client_id":    {h.cfg.ClientID},
+	}
+	// codeVerifier is empty when h.cfg.DisablePKCE is true (set by authCodeLogin).
+	if codeVerifier != "" {
+		data.Set("code_verifier", codeVerifier)
 	}
 	if h.cfg.ClientSecret != "" {
 		data.Set("client_secret", h.cfg.ClientSecret)
@@ -427,6 +446,68 @@ func (h *Handler) exchangeAuthCode(ctx context.Context, code, redirectURI, codeV
 		data.Set("scope", strings.Join(scopes, " "))
 	}
 	return h.postTokenEndpoint(ctx, data)
+}
+
+// ---------- flow: implicit grant (response_type=token) ----------
+
+func (h *Handler) implicitGrantLogin(ctx context.Context, scopes []string, callbackPort int) (*tokenResponse, error) {
+	state, err := oauth.GenerateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("generate state: %w", err)
+	}
+
+	callbackServer, err := oauth.StartImplicitCallbackServer(ctx, callbackPort, state)
+	if err != nil {
+		return nil, fmt.Errorf("start callback server: %w", err)
+	}
+	defer callbackServer.Close()
+
+	authURL, err := url.Parse(h.cfg.AuthorizeURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse authorizeURL: %w", err)
+	}
+	q := authURL.Query()
+	q.Set("response_type", "token")
+	q.Set("client_id", h.cfg.ClientID)
+	q.Set("redirect_uri", callbackServer.RedirectURI)
+	q.Set("state", state)
+	if len(scopes) > 0 {
+		q.Set("scope", strings.Join(scopes, " "))
+	}
+	authURL.RawQuery = q.Encode()
+
+	if openErr := oauth.OpenBrowser(ctx, authURL.String()); openErr != nil {
+		h.logger.V(1).Info("failed to open browser", "url", authURL.String(), "error", openErr)
+	}
+
+	select {
+	case result := <-callbackServer.ResultChan():
+		if result.Err != nil {
+			return nil, fmt.Errorf("callback error: %w", result.Err)
+		}
+		resp := &tokenResponse{
+			AccessToken: result.AccessToken,
+			TokenType:   result.TokenType,
+		}
+		if resp.TokenType == "" {
+			resp.TokenType = defaultTokenType
+		}
+		if result.ExpiresIn != "" {
+			var expiresIn int
+			if _, scanErr := fmt.Sscanf(result.ExpiresIn, "%d", &expiresIn); scanErr == nil {
+				resp.ExpiresIn = expiresIn
+			} else {
+				h.logger.V(1).Info("failed to parse expires_in from implicit grant, defaulting to 3600", "value", result.ExpiresIn, "error", scanErr)
+				resp.ExpiresIn = 3600
+			}
+		} else {
+			h.logger.V(1).Info("expires_in not provided by implicit grant server, defaulting to 3600")
+			resp.ExpiresIn = 3600
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, auth.ErrTimeout
+	}
 }
 
 // ---------- flow: device code (RFC 8628) ----------
@@ -888,7 +969,24 @@ func ValidateConfig(cfg config.CustomOAuth2Config) error {
 	if cfg.Name == "" {
 		return fmt.Errorf("custom OAuth2 handler: name is required")
 	}
-	if cfg.TokenURL == "" {
+
+	// Validate responseType early so unknown values are rejected before
+	// field-presence checks that depend on the response type.
+	switch cfg.ResponseType {
+	case "", "code":
+		// default authorization code flow
+	case "token":
+		if cfg.AuthorizeURL == "" {
+			return fmt.Errorf("custom OAuth2 handler %q: authorizeURL is required when responseType is token", cfg.Name)
+		}
+		if cfg.DefaultFlow != "" && cfg.DefaultFlow != "interactive" {
+			return fmt.Errorf("custom OAuth2 handler %q: implicit grant (responseType=token) only supports interactive flow, got defaultFlow=%q", cfg.Name, cfg.DefaultFlow)
+		}
+	default:
+		return fmt.Errorf("custom OAuth2 handler %q: unknown responseType %q (valid: code, token)", cfg.Name, cfg.ResponseType)
+	}
+
+	if cfg.TokenURL == "" && cfg.ResponseType != "token" {
 		return fmt.Errorf("custom OAuth2 handler %q: tokenURL is required", cfg.Name)
 	}
 	if cfg.ClientID == "" {

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -430,6 +431,11 @@ func TestValidateConfig(t *testing.T) {
 		{name: "exchange bad method", cfg: config.CustomOAuth2Config{Name: "t", TokenURL: "https://x.com/token", ClientID: "c", ClientSecret: "s", DefaultFlow: "client_credentials", TokenExchange: &config.TokenExchangeConfig{URL: "https://x.com/e", TokenJSONPath: "t", Method: "DELETE"}}, wantErr: "tokenExchange.method must be"},
 		{name: "valid minimal", cfg: config.CustomOAuth2Config{Name: "t", TokenURL: "https://x.com/token", ClientID: "c", ClientSecret: "s"}},
 		{name: "valid full", cfg: config.CustomOAuth2Config{Name: "t", TokenURL: "https://x.com/token", ClientID: "c", AuthorizeURL: "https://x.com/a", DeviceAuthURL: "https://x.com/d", ClientSecret: "s", CallbackPort: 8080, TokenExchange: &config.TokenExchangeConfig{URL: "https://x.com/e", TokenJSONPath: "t", Method: "POST"}}},
+		{name: "responseType token valid", cfg: config.CustomOAuth2Config{Name: "t", TokenURL: "https://x.com/token", ClientID: "c", AuthorizeURL: "https://x.com/a", ResponseType: "token"}},
+		{name: "responseType token no authorizeURL", cfg: config.CustomOAuth2Config{Name: "t", ClientID: "c", ResponseType: "token"}, wantErr: "authorizeURL is required when responseType is token"},
+		{name: "responseType token no tokenURL ok", cfg: config.CustomOAuth2Config{Name: "t", ClientID: "c", AuthorizeURL: "https://x.com/a", ResponseType: "token"}},
+		{name: "responseType invalid", cfg: config.CustomOAuth2Config{Name: "t", TokenURL: "https://x.com/token", ClientID: "c", ResponseType: "bad"}, wantErr: "unknown responseType"},
+		{name: "responseType token with device_code flow", cfg: config.CustomOAuth2Config{Name: "t", ClientID: "c", AuthorizeURL: "https://x.com/a", ResponseType: "token", DefaultFlow: "device_code"}, wantErr: "implicit grant (responseType=token) only supports interactive flow"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -628,6 +634,135 @@ func TestHandler_Logout_ClearsDerivedUsername(t *testing.T) {
 	token, loadErr := h.loadDerivedToken(ctx)
 	assert.Nil(t, token)
 	assert.Error(t, loadErr)
+}
+
+func TestHandler_ExchangeAuthCode_PKCEEnabled(t *testing.T) {
+	var capturedForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		capturedForm = r.PostForm
+		writeJSON(w, tokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = srv.URL + "/authorize"
+	})
+
+	_, err := h.exchangeAuthCode(context.Background(), "test-code", "http://localhost:9999", "test-verifier", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-verifier", capturedForm.Get("code_verifier"), "code_verifier should be sent when PKCE is enabled")
+}
+
+func TestHandler_ExchangeAuthCode_PKCEDisabled(t *testing.T) {
+	var capturedForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		capturedForm = r.PostForm
+		writeJSON(w, tokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = srv.URL + "/authorize"
+		cfg.DisablePKCE = true
+	})
+
+	// When PKCE is disabled, verifier is empty string — exchangeAuthCode should skip code_verifier
+	_, err := h.exchangeAuthCode(context.Background(), "test-code", "http://localhost:9999", "", nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedForm.Get("code_verifier"), "code_verifier must not be sent when PKCE is disabled")
+	_, hasKey := capturedForm["code_verifier"]
+	assert.False(t, hasKey, "code_verifier key must be absent from form when PKCE is disabled")
+}
+
+func TestNew_ResponseTypeToken_ImpliesDisablePKCE(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = srv.URL + "/authorize"
+		cfg.ResponseType = "token"
+	})
+	assert.True(t, h.cfg.DisablePKCE, "DisablePKCE should be auto-implied when ResponseType is token")
+}
+
+func TestNew_ResponseTypeCode_PreservesDisablePKCE(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = srv.URL + "/authorize"
+		// ResponseType "" (default) should not force DisablePKCE
+	})
+	assert.False(t, h.cfg.DisablePKCE)
+}
+
+func TestHandler_ImplicitGrantLogin_RequiresAuthorizeURL(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.ResponseType = "token"
+		cfg.AuthorizeURL = "" // missing
+	})
+
+	_, err := h.authCodeLogin(context.Background(), nil, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authorizeURL is required")
+}
+
+func TestHandler_ImplicitGrantLogin_ContextCancelled(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = "https://example.com/authorize"
+		cfg.ResponseType = "token"
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := h.implicitGrantLogin(ctx, nil, 0)
+	// Should fail with context cancelled (server can't start or times out)
+	assert.Error(t, err)
+}
+
+func BenchmarkHandler_ExchangeAuthCode(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, tokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	store := secrets.NewMockStore()
+	cfg := config.CustomOAuth2Config{Name: "bench", TokenURL: srv.URL + "/token", ClientID: "bc", AuthorizeURL: srv.URL + "/auth"}
+	h, _ := New(cfg, WithSecretStore(store), WithHTTPClient(srv.Client()), WithLogger(logr.Discard()))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := h.exchangeAuthCode(ctx, "code", "http://localhost:9999", "verifier", nil); err != nil {
+			b.Fatalf("exchangeAuthCode failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkHandler_ExchangeAuthCode_PKCEDisabled(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, tokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	store := secrets.NewMockStore()
+	cfg := config.CustomOAuth2Config{Name: "bench", TokenURL: srv.URL + "/token", ClientID: "bc", AuthorizeURL: srv.URL + "/auth", DisablePKCE: true}
+	h, _ := New(cfg, WithSecretStore(store), WithHTTPClient(srv.Client()), WithLogger(logr.Discard()))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := h.exchangeAuthCode(ctx, "code", "http://localhost:9999", "", nil); err != nil {
+			b.Fatalf("exchangeAuthCode failed: %v", err)
+		}
+	}
 }
 
 func BenchmarkHandler_ClientCredentialsLogin(b *testing.B) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -569,6 +569,8 @@ type CustomOAuth2Config struct {
 	DefaultFlow            string   `json:"defaultFlow,omitempty" yaml:"defaultFlow,omitempty" mapstructure:"defaultFlow" doc:"Default OAuth2 flow (interactive, device_code, client_credentials)" enum:"interactive,device_code,client_credentials" maxLength:"32" example:"interactive"`
 	CallbackPort           int      `json:"callbackPort,omitempty" yaml:"callbackPort,omitempty" mapstructure:"callbackPort" doc:"Local callback port for interactive flow (0 = random)" minimum:"0" maximum:"65535" example:"8080"`
 	DeviceCodePollInterval int      `json:"deviceCodePollInterval,omitempty" yaml:"deviceCodePollInterval,omitempty" mapstructure:"deviceCodePollInterval" doc:"Polling interval in seconds for device_code flow (0 = server default)" minimum:"0" maximum:"30" example:"5"`
+	DisablePKCE            bool     `json:"disablePKCE,omitempty" yaml:"disablePKCE,omitempty" mapstructure:"disablePKCE" doc:"Disable PKCE for servers that reject code_challenge parameters"`
+	ResponseType           string   `json:"responseType,omitempty" yaml:"responseType,omitempty" mapstructure:"responseType" doc:"OAuth2 response type: code (default) or token (implicit grant)" enum:"code,token" maxLength:"16" example:"token"`
 
 	// Token verification
 	VerifyURL      string                `json:"verifyURL,omitempty" yaml:"verifyURL,omitempty" mapstructure:"verifyURL" doc:"Token verification endpoint (optional)" maxLength:"2048" example:"https://quay.io/api/v1/user/"`


### PR DESCRIPTION
feat(auth/oauth2): add disablePKCE and implicit grant flow for Quay-compatible servers

Add DisablePKCE option and implicit grant (response_type=token) support
for OAuth2 servers like Quay that reject PKCE and only support implicit
grant:

disablePKCE:
- New DisablePKCE bool field on CustomOAuth2Config
- Conditionally skip PKCE verifier/challenge in authCodeLogin()
- Skip code_verifier in exchangeAuthCode() when verifier is empty

Implicit grant (response_type=token):
- New ResponseType field on CustomOAuth2Config (code or token)
- StartImplicitCallbackServer in pkg/auth/oauth/callback.go serves
  HTML+JS page that extracts access_token from URL fragment and
  POSTs it to the local callback server
- Origin header validation on /token POST to prevent cross-origin
  token injection
- Lenient state validation: accept missing state (Quay omits it),
  reject only mismatched state per RFC 6749 §4.2.2
- Auto-implies DisablePKCE when ResponseType is token
- ValidateConfig rejects non-interactive flows with responseType=token
- Default ExpiresIn to 3600 with warning when parsing fails
- Proper HTTP status codes on error responses (403/400)

Tests:
- Unit tests for PKCE-enabled and PKCE-disabled exchange paths
- Implicit callback server tests (token, error, state, CSRF, origin)
- State-omitted-by-server test for Quay compatibility
- ValidateConfig tests for responseType validation
- Benchmarks for exchangeAuthCode with and without PKCE

Docs:
- Updated Quay examples in auth tutorial and design docs

Closes #226
Closes #229
Fixes #232