### PR TITLE
feat(plugin)!: upgrade plugin protocol to v2 with diagnostics, exit codes, and auth token callbacks

### DIFF
--- a/docs/design/implementation-gaps.md
+++ b/docs/design/implementation-gaps.md
@@ -93,7 +93,7 @@ Phases 9–10 of the MCP server design — executing solutions through the MCP s
 - Catalog chain resolution — local-first, then remote OCI catalogs (`pkg/catalog/chain.go`, `pkg/catalog/chain_builder.go`)
 - `scafctl plugins install` and `scafctl plugins list` CLI commands (`pkg/cmd/scafctl/plugins/`)
 - Wired into solution execution via `prepare.Solution()` options
-- Auth handler plugin runtime: `AuthHandlerPlugin` interface, gRPC service (`AuthHandlerService` with 7 RPCs), client/server/wrapper (`pkg/plugin/grpc_auth.go`, `pkg/plugin/wrapper_auth.go`), fetcher integration (`RegisterFetchedAuthHandlerPlugins`), preparation pipeline (`prepare.WithAuthRegistry`)
+- Auth handler plugin runtime: `AuthHandlerPlugin` interface (9 methods), gRPC service (`AuthHandlerService` with 9 RPCs including `ConfigureAuthHandler` and `StopAuthHandler`), client/server/wrapper (`pkg/plugin/grpc_auth.go`, `pkg/plugin/wrapper_auth.go`), fetcher integration (`RegisterFetchedAuthHandlerPlugins`), preparation pipeline (`prepare.WithAuthRegistry`), HostService broker access, protocol version negotiation
 
 ### GCP Auth Handler Documentation
 

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -133,6 +133,20 @@ service PluginService {
   rpc ExecuteProviderStream(ExecuteProviderRequest) returns (stream ExecuteProviderStreamChunk);
   rpc DescribeWhatIf(DescribeWhatIfRequest) returns (DescribeWhatIfResponse);
   rpc ExtractDependencies(ExtractDependenciesRequest) returns (ExtractDependenciesResponse);
+  rpc StopProvider(StopProviderRequest) returns (StopProviderResponse);
+}
+
+// AuthHandlerService is the auth handler plugin service.
+service AuthHandlerService {
+  rpc GetAuthHandlers(GetAuthHandlersRequest) returns (GetAuthHandlersResponse);
+  rpc ConfigureAuthHandler(ConfigureAuthHandlerRequest) returns (ConfigureAuthHandlerResponse);
+  rpc Login(LoginRequest) returns (LoginResponse);
+  rpc Logout(LogoutRequest) returns (LogoutResponse);
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+  rpc GetToken(GetTokenRequest) returns (GetTokenResponse);
+  rpc ListCachedTokens(ListCachedTokensRequest) returns (ListCachedTokensResponse);
+  rpc PurgeExpiredTokens(PurgeExpiredTokensRequest) returns (PurgeExpiredTokensResponse);
+  rpc StopAuthHandler(StopAuthHandlerRequest) returns (StopAuthHandlerResponse);
 }
 
 // HostService is a callback service that plugins can invoke on the host.
@@ -145,6 +159,7 @@ service HostService {
   rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse);
   rpc GetAuthIdentity(GetAuthIdentityRequest) returns (GetAuthIdentityResponse);
   rpc ListAuthHandlers(ListAuthHandlersRequest) returns (ListAuthHandlersResponse);
+  rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
 }
 ```
 
@@ -159,7 +174,23 @@ service HostService {
 | Streaming | `ExecuteProviderStream` | host -> plugin | When IOStreams are available |
 | Dry-run | `DescribeWhatIf` | host -> plugin | During `run solution --dry-run` |
 | Dependencies | `ExtractDependencies` | host -> plugin | During DAG construction |
+| Shutdown | `StopProvider` | host -> plugin | During cancellation or cleanup |
 | Callbacks | `HostService.*` | plugin -> host | Anytime during execution |
+
+### Auth Handler RPC Lifecycle
+
+| Phase | RPC | Direction | When |
+|-------|-----|-----------|------|
+| Discovery | `GetAuthHandlers` | host -> plugin | On plugin load |
+| Configuration | `ConfigureAuthHandler` | host -> plugin | Once after load, before any auth calls |
+| Authentication | `Login` | host -> plugin | On `auth login` |
+| Authentication | `Logout` | host -> plugin | On `auth logout` |
+| Authentication | `GetStatus` | host -> plugin | On `auth status` |
+| Token | `GetToken` | host -> plugin | On token request |
+| Token | `ListCachedTokens` | host -> plugin | On cache listing |
+| Token | `PurgeExpiredTokens` | host -> plugin | On cache cleanup |
+| Shutdown | `StopAuthHandler` | host -> plugin | During cancellation or cleanup |
+| Callbacks | `HostService.*` | plugin -> host | Anytime during handler operations |
 
 ### ConfigureProvider
 
@@ -169,6 +200,24 @@ Called once after plugin load with host-side configuration:
 - `binary_name` -- the CLI binary name (e.g. "scafctl" or an embedder name)
 - `settings` -- extensible key-value JSON settings
 - `host_service_id` -- GRPCBroker service ID for HostService callbacks
+- `protocol_version` -- the host's plugin protocol version for feature detection
+
+### ConfigureAuthHandler
+
+Called once after auth handler plugin load, using the same configuration model as `ConfigureProvider`:
+
+- `handler_name` -- which auth handler to configure (multi-handler plugins)
+- `quiet` / `no_color` -- terminal output preferences
+- `binary_name` -- the CLI binary name (e.g. "scafctl" or an embedder name)
+- `settings` -- extensible key-value JSON settings
+- `host_service_id` -- GRPCBroker service ID for HostService callbacks
+- `protocol_version` -- the host's plugin protocol version for feature detection
+
+The response includes a `protocol_version` field and optional `diagnostics` (repeated `Diagnostic` messages) for structured warning/error reporting.
+
+### StopAuthHandler
+
+Called during CLI shutdown or context cancellation to allow auth handler plugins to release resources gracefully. The RPC carries only the `handler_name`. If the plugin does not implement `StopAuthHandler` (older plugins), the host silently ignores the `Unimplemented` gRPC status.
 
 ### HostService Callbacks
 
@@ -178,9 +227,30 @@ Plugins that need host-side resources (secrets, auth tokens) use the `HostServic
 |----------|---------|
 | `GetSecret` / `SetSecret` / `DeleteSecret` / `ListSecrets` | Access the host's secret store |
 | `GetAuthIdentity` | Retrieve identity claims from the host's auth registry |
-| `ListAuthHandlers` | List available auth handlers on the host |
+| `ListAuthHandlers` | List available auth handlers (filtered by AllowedAuthHandlers) |
+| `GetAuthToken` | Retrieve a valid access token from the host's auth registry |
 
 Plugins access HostService via a client injected during `ConfigureProvider`.
+
+### Diagnostics and Exit Codes
+
+The `ExecuteProviderResponse` carries structured `Diagnostic` messages alongside the output. Each diagnostic includes a severity level, a summary, an optional detail string, and an optional attribute path. This allows plugins to report multiple warnings or errors in a single response.
+
+An `exit_code` field on the response enables plugins to propagate typed exit codes back to the host. The host maps these to scafctl's `exitcode.ExitError` type so that callers can distinguish between different failure modes.
+
+### Streaming Fallback
+
+When IOStreams are available in the execution context, scafctl attempts `ExecuteProviderStream` first. If the plugin returns `ErrStreamingNotSupported`, the host transparently falls back to unary `ExecuteProvider`. This allows plugins to opt into streaming incrementally without breaking non-streaming hosts.
+
+### Protocol Version Negotiation
+
+scafctl sends a `protocol_version` field in both the `ConfigureProvider` and `ConfigureAuthHandler` requests. The current version is defined by the `PluginProtocolVersion` constant. Plugins can inspect this value to enable or disable features based on the host's capabilities. The plugin may return its own protocol version in the response for the host to check.
+
+This is separate from the hashicorp/go-plugin handshake `ProtocolVersion`, which gates basic RPC compatibility. The plugin protocol version enables finer-grained feature detection after the connection is established.
+
+### Descriptor Caching
+
+The plugin client caches provider descriptors after the first `GetProviderDescriptor` call to avoid repeated gRPC round-trips. The cache is protected by a `sync.RWMutex` for safe concurrent access. Descriptors are immutable once loaded.
 
 ### Schema Round-Trip
 
@@ -211,7 +281,9 @@ The plugin process lifecycle is managed entirely by scafctl.
 
 ## Plugin Capabilities
 
-Plugins expose providers that support the full provider lifecycle:
+Plugins expose providers or auth handlers that support full lifecycles:
+
+**Provider plugins** support:
 
 - **Discovery**: Advertise provider names and descriptors
 - **Configuration**: Receive host-side settings (quiet, color, binary name)
@@ -219,6 +291,14 @@ Plugins expose providers that support the full provider lifecycle:
 - **Dry-run**: Describe what would happen without executing (WhatIf)
 - **Dependency extraction**: Custom dependency graph participation
 - **Host callbacks**: Access secrets and auth tokens from the host
+
+**Auth handler plugins** support:
+
+- **Discovery**: Advertise handler names, flows, and capabilities
+- **Configuration**: Receive host-side settings and HostService access
+- **Authentication**: Login, logout, and status checking
+- **Token management**: Token retrieval, cache listing, and expiry purging
+- **Host callbacks**: Access secrets and auth identity from the host
 
 Future capability types may include:
 

--- a/docs/tutorials/auth-handler-development.md
+++ b/docs/tutorials/auth-handler-development.md
@@ -16,7 +16,7 @@ Auth handlers can be delivered in two ways:
 | **Credential storage** | Uses `pkg/secrets` (OS keychain) | Plugin manages its own credential storage |
 | **Crash isolation** | Shares process with scafctl | Isolated process — plugin crash doesn't take down CLI |
 | **Distribution** | Ships with scafctl releases | OCI catalog artifact (`kind: auth-handler`) or standalone binary |
-| **Interface** | `auth.Handler` (8 methods) | `plugin.AuthHandlerPlugin` (7 methods) |
+| **Interface** | `auth.Handler` (8 methods) | `plugin.AuthHandlerPlugin` (9 methods) |
 
 > [!WARNING]
 > **Prerequisite**: Read the [Extension Concepts](extension-concepts.md) page for terminology (provider vs auth handler vs plugin).
@@ -644,6 +644,11 @@ type AuthHandlerPlugin interface {
     // GetAuthHandlers returns metadata for all auth handlers in this plugin.
     GetAuthHandlers(ctx context.Context) ([]AuthHandlerInfo, error)
 
+    // ConfigureAuthHandler sends host-side configuration to a named handler
+    // once after plugin load. Receives quiet/noColor/binaryName/settings,
+    // the HostService broker ID, and protocol version.
+    ConfigureAuthHandler(ctx context.Context, handlerName string, cfg ProviderConfig) error
+
     // Login initiates authentication. The callback relays device-code prompts.
     Login(ctx context.Context, handlerName string, req LoginRequest,
           deviceCodeCb func(DeviceCodePrompt)) (*LoginResponse, error)
@@ -662,6 +667,10 @@ type AuthHandlerPlugin interface {
 
     // PurgeExpiredTokens removes expired tokens. Returns count removed.
     PurgeExpiredTokens(ctx context.Context, handlerName string) (int, error)
+
+    // StopAuthHandler requests graceful shutdown of a named handler.
+    // Return nil if not implemented.
+    StopAuthHandler(ctx context.Context, handlerName string) error
 }
 ```
 
@@ -740,6 +749,16 @@ func (p *OktaPlugin) ListCachedTokens(ctx context.Context, name string) ([]*auth
 
 func (p *OktaPlugin) PurgeExpiredTokens(ctx context.Context, name string) (int, error) {
     return 0, nil
+}
+
+func (p *OktaPlugin) ConfigureAuthHandler(ctx context.Context, name string, cfg plugin.ProviderConfig) error {
+    // Store host-side config (binary name, settings, etc.) for later use
+    return nil
+}
+
+func (p *OktaPlugin) StopAuthHandler(ctx context.Context, name string) error {
+    // Release resources for the named handler
+    return nil
 }
 
 func main() {

--- a/docs/tutorials/plugin-development.md
+++ b/docs/tutorials/plugin-development.md
@@ -16,8 +16,8 @@ scafctl supports two types of plugins:
 
 | Plugin Type | Artifact Kind | Interface | Guide |
 |-------------|---------------|-----------|-------|
-| **Provider Plugin** | `provider` | `plugin.ProviderPlugin` (7 methods) | [Provider Development Guide -- Delivering as a Plugin](provider-development.md#delivering-as-a-plugin) |
-| **Auth Handler Plugin** | `auth-handler` | `plugin.AuthHandlerPlugin` (7 methods) | [Auth Handler Development Guide -- Delivering as a Plugin](auth-handler-development.md#delivering-as-a-plugin) |
+| **Provider Plugin** | `provider` | `plugin.ProviderPlugin` (8 methods) | [Provider Development Guide -- Delivering as a Plugin](provider-development.md#delivering-as-a-plugin) |
+| **Auth Handler Plugin** | `auth-handler` | `plugin.AuthHandlerPlugin` (9 methods) | [Auth Handler Development Guide -- Delivering as a Plugin](auth-handler-development.md#delivering-as-a-plugin) |
 
 ## Architecture
 

--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -15,7 +15,7 @@ Providers can be delivered in two ways:
 | **Registration** | `registry.Register(...)` in `builtin.go` | Discovered at runtime from plugin cache or catalog |
 | **Crash isolation** | Shares process with scafctl | Isolated process -- plugin crash doesn't take down CLI |
 | **Distribution** | Ships with scafctl releases | OCI catalog artifact (`kind: provider`) or standalone binary |
-| **Interface** | `provider.Provider` (2 methods) | `plugin.ProviderPlugin` (3 methods) |
+| **Interface** | `provider.Provider` (2 methods) | `plugin.ProviderPlugin` (8 methods) |
 
 > [!WARNING]
 > **Prerequisite**: Read the [Extension Concepts](extension-concepts.md) page for terminology (provider vs plugin vs auth handler).
@@ -958,7 +958,7 @@ Plugins use [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin) with g
 
 ### Plugin Interface
 
-Plugins implement `plugin.ProviderPlugin` (7 methods):
+Plugins implement `plugin.ProviderPlugin` (8 methods):
 
 ```go
 type ProviderPlugin interface {
@@ -986,6 +986,10 @@ type ProviderPlugin interface {
     // ExtractDependencies returns resolver dependency names from inputs.
     // Return nil to let the host use generic extraction.
     ExtractDependencies(ctx context.Context, name string, inputs map[string]any) ([]string, error)
+
+    // StopProvider requests graceful shutdown of a running provider execution.
+    // providerName may be empty to stop all providers. Return nil if not implemented.
+    StopProvider(ctx context.Context, providerName string) error
 }
 ```
 
@@ -1008,7 +1012,8 @@ Plugins that need host-side resources can access the **HostService** callback se
 - **GetSecret / SetSecret / DeleteSecret** -- access the host's secret store
 - **ListSecrets(pattern)** -- list secret names, optionally filtered by a regex pattern (max 256 characters)
 - **GetAuthIdentity** -- retrieve identity claims from the host's auth registry
-- **ListAuthHandlers** -- list available auth handlers
+- **ListAuthHandlers** -- list available auth handlers (filtered by AllowedAuthHandlers)
+- **GetAuthToken** -- retrieve a valid access token from the host's auth registry
 
 The host registers HostService via the go-plugin GRPCBroker during plugin startup. Plugins receive the broker service ID in `ProviderConfig.HostServiceID` from the `ConfigureProvider` call. Use this ID to dial the HostService via the broker.
 
@@ -1125,6 +1130,10 @@ func (p *MyPlugin) DescribeWhatIf(_ context.Context, name string, input map[stri
 
 func (p *MyPlugin) ExtractDependencies(_ context.Context, _ string, _ map[string]any) ([]string, error) {
     return nil, nil // Use generic extraction
+}
+
+func (p *MyPlugin) StopProvider(_ context.Context, _ string) error {
+    return nil // No graceful shutdown needed
 }
 
 func main() {

--- a/examples/plugins/echo/main.go
+++ b/examples/plugins/echo/main.go
@@ -130,6 +130,13 @@ func (p *EchoPlugin) ExtractDependencies(_ context.Context, _ string, _ map[stri
 	return nil, nil
 }
 
+// StopProvider is a no-op for the echo plugin.
+//
+//nolint:revive // all params required by interface
+func (p *EchoPlugin) StopProvider(_ context.Context, _ string) error {
+	return nil
+}
+
 func main() {
 	plugin.Serve(&EchoPlugin{})
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -46,6 +46,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/profiler"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -151,6 +152,11 @@ type RootOptions struct {
 	//  4. Environment variables
 	//  5. CLI flags
 	ConfigDefaults []byte
+
+	// AuthPluginDirs specifies directories to scan for auth handler plugin
+	// binaries. Discovered plugins are registered in the auth.Registry
+	// alongside built-in handlers during PersistentPreRunE.
+	AuthPluginDirs []string
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -175,13 +181,14 @@ func Root(opts *RootOptions) *cobra.Command {
 	// Per-invocation state — no package-level mutable variables.
 	cliParams := settings.NewCliParams()
 	var (
-		configPath   = opts.ConfigPath
-		cwdFlag      string
-		debugFlag    bool
-		logFormat    = "console"
-		logFile      string
-		otelInsecure bool
-		telShutdown  func(context.Context) error
+		configPath        = opts.ConfigPath
+		cwdFlag           string
+		debugFlag         bool
+		logFormat         = "console"
+		logFile           string
+		otelInsecure      bool
+		telShutdown       func(context.Context) error
+		authPluginClients []*plugin.AuthHandlerClient
 	)
 
 	// Resolve binary name: use caller-provided or default to settings.CliBinaryName ("scafctl").
@@ -491,6 +498,21 @@ func Root(opts *RootOptions) *cobra.Command {
 				}
 			}
 
+			// Register auth handler plugins if directories are configured
+			if len(opts.AuthPluginDirs) > 0 {
+				lgr.V(1).Info("loading auth handler plugins", "dirs", opts.AuthPluginDirs)
+				pluginCfg := &plugin.ProviderConfig{
+					Quiet:      cliParams.IsQuiet,
+					NoColor:    cliParams.NoColor,
+					BinaryName: binaryName,
+				}
+				authClients, authPluginErr := plugin.RegisterAuthHandlerPlugins(ctx, authRegistry, opts.AuthPluginDirs, pluginCfg)
+				if authPluginErr != nil {
+					w.Warningf("failed to load some auth handler plugins: %v", authPluginErr)
+				}
+				authPluginClients = authClients
+			}
+
 			ctx = auth.WithRegistry(ctx, authRegistry)
 
 			cCmd.SetContext(ctx)
@@ -499,6 +521,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			if cCmd.Use == binaryName {
 				err := output.ValidateCommands(args)
 				if err != nil {
+					plugin.KillAllAuthHandlers(authPluginClients)
 					w.ErrorWithExit(err.Error())
 					return
 				}
@@ -514,6 +537,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			// Call embedder's pre-run hook after all standard setup is complete.
 			if opts.PreRunHook != nil {
 				if hookErr := opts.PreRunHook(cCmd, args); hookErr != nil {
+					plugin.KillAllAuthHandlers(authPluginClients)
 					w.ErrorWithExit(hookErr.Error())
 					return
 				}
@@ -524,6 +548,7 @@ func Root(opts *RootOptions) *cobra.Command {
 				profilePath, _ := cCmd.Flags().GetString("pprof-output-dir")
 				p, err := profiler.GetProfiler(profileType, profilePath, lgr)
 				if err != nil {
+					plugin.KillAllAuthHandlers(authPluginClients)
 					w.ErrorWithExitf("Error starting profiler: %v", err)
 					return
 				}
@@ -539,6 +564,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			}
 		},
 		PersistentPostRun: func(_ *cobra.Command, _ []string) {
+			plugin.KillAllAuthHandlers(authPluginClients)
 			if telShutdown != nil {
 				shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -323,9 +323,11 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 			NoColor:    o.CliParams.NoColor,
 			BinaryName: o.CliParams.BinaryName,
 		}
-		if err := plugin.RegisterPluginProviders(ctx, reg, o.PluginDirs, pluginCfg); err != nil {
+		clients, err := plugin.RegisterPluginProviders(ctx, reg, o.PluginDirs, pluginCfg)
+		if err != nil {
 			w.Warningf("failed to load some plugins: %v", err)
 		}
+		defer plugin.KillAll(clients)
 	}
 
 	// Look up the provider

--- a/pkg/plugin/README.md
+++ b/pkg/plugin/README.md
@@ -6,24 +6,131 @@ The scafctl plugin system allows extending the provider framework with external 
 
 - **hashicorp/go-plugin**: Manages plugin lifecycle, process isolation, and crash recovery
 - **gRPC**: Communication protocol between scafctl and plugins
-- **Protocol Buffers**: Interface definitions
+- **Protocol Buffers**: Interface definitions in `proto/plugin.proto`
 
 ## Plugin Interface
 
-Plugins must implement the `ProviderPlugin` interface:
+Plugins must implement the `ProviderPlugin` interface (8 methods):
 
 ```go
 type ProviderPlugin interface {
-    // GetProviders returns all provider names exposed by this plugin
+    // GetProviders returns all provider names exposed by this plugin.
     GetProviders(ctx context.Context) ([]string, error)
 
-    // GetProviderDescriptor returns metadata for a specific provider
+    // GetProviderDescriptor returns metadata for a specific provider.
     GetProviderDescriptor(ctx context.Context, providerName string) (*provider.Descriptor, error)
 
-    // ExecuteProvider executes a provider with the given input
+    // ConfigureProvider sends host-side configuration to a named provider once
+    // after plugin load. Implementations store the config internally for
+    // subsequent Execute calls.
+    ConfigureProvider(ctx context.Context, providerName string, cfg ProviderConfig) error
+
+    // ExecuteProvider executes a provider with the given input.
     ExecuteProvider(ctx context.Context, providerName string, input map[string]any) (*provider.Output, error)
+
+    // ExecuteProviderStream executes a provider that produces incremental
+    // output. The callback is invoked for each chunk; the final chunk carries
+    // the Result (or Error). Return ErrStreamingNotSupported if not implemented.
+    ExecuteProviderStream(ctx context.Context, providerName string, input map[string]any, cb func(StreamChunk)) error
+
+    // DescribeWhatIf returns a human-readable description of what the provider
+    // would do with the given inputs, without executing.
+    DescribeWhatIf(ctx context.Context, providerName string, input map[string]any) (string, error)
+
+    // ExtractDependencies returns resolver dependency names from the given
+    // inputs. Return nil to let the host use generic extraction.
+    ExtractDependencies(ctx context.Context, providerName string, inputs map[string]any) ([]string, error)
+
+    // StopProvider requests graceful shutdown of a running provider execution.
+    // providerName may be empty to stop all providers. Return nil if not implemented.
+    StopProvider(ctx context.Context, providerName string) error
 }
 ```
+
+## ProviderConfig
+
+After plugin load, scafctl calls `ConfigureProvider` once per provider with host-side settings:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Quiet` | `bool` | Suppress non-essential output |
+| `NoColor` | `bool` | Disable colored output |
+| `BinaryName` | `string` | CLI binary name (e.g. "scafctl" or an embedder name) |
+| `HostServiceID` | `uint32` | GRPCBroker service ID for HostService callbacks |
+| `Settings` | `map[string]json.RawMessage` | Extensible key-value settings |
+
+The `ConfigureProvider` request also carries a `protocol_version` field for
+feature detection. The current version is defined by `PluginProtocolVersion`.
+
+## Auth Handler Plugin Interface
+
+Auth handler plugins implement the `AuthHandlerPlugin` interface (9 methods):
+
+```go
+type AuthHandlerPlugin interface {
+    GetAuthHandlers(ctx context.Context) ([]AuthHandlerInfo, error)
+    ConfigureAuthHandler(ctx context.Context, handlerName string, cfg ProviderConfig) error
+    Login(ctx context.Context, handlerName string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
+    Logout(ctx context.Context, handlerName string) error
+    GetStatus(ctx context.Context, handlerName string) (*auth.Status, error)
+    GetToken(ctx context.Context, handlerName string, req TokenRequest) (*TokenResponse, error)
+    ListCachedTokens(ctx context.Context, handlerName string) ([]*auth.CachedTokenInfo, error)
+    PurgeExpiredTokens(ctx context.Context, handlerName string) (int, error)
+    StopAuthHandler(ctx context.Context, handlerName string) error
+}
+```
+
+After plugin load, scafctl calls `ConfigureAuthHandler` once per handler. The
+request uses the same `ProviderConfig` fields as `ConfigureProvider` (quiet,
+no_color, binary_name, settings, host_service_id, protocol_version). The
+response includes optional `diagnostics` for structured warnings/errors.
+
+Auth handler plugins have full access to `HostService` callbacks (secrets, auth
+identity) via the GRPCBroker, mirroring the provider plugin pattern.
+
+`RegisterAuthHandlerPlugins` returns `[]*AuthHandlerClient`. The caller should
+defer `KillAllAuthHandlers(clients)` for cleanup.
+
+## HostService Callbacks
+
+Plugins that need host-side resources use the HostService callback service,
+accessed via the GRPCBroker using the service ID from `ProviderConfig.HostServiceID`.
+
+| Callback | Purpose |
+|----------|---------|
+| `GetSecret` / `SetSecret` / `DeleteSecret` / `ListSecrets` | Access the host's secret store |
+| `GetAuthIdentity` | Retrieve identity claims from the host's auth registry |
+| `ListAuthHandlers` | List available auth handlers (filtered by AllowedAuthHandlers) |
+| `GetAuthToken` | Retrieve a valid access token from the host's auth registry |
+
+Secret names are scoped by a plugin-specific prefix. Auth handler access is
+restricted to the set declared in `AllowedAuthHandlers`.
+
+## Streaming Execution
+
+`ExecuteProviderStream` delivers incremental output (stdout/stderr chunks) to
+the host in real time. The callback receives `StreamChunk` values:
+
+- `Stdout` / `Stderr` -- incremental output bytes
+- `Result` -- final `*provider.Output` on success
+- `Error` -- terminal error string on failure
+
+Plugins that do not support streaming should return `ErrStreamingNotSupported`.
+The host automatically falls back to unary `ExecuteProvider`.
+
+## Diagnostics and Exit Codes
+
+The `ExecuteProviderResponse` proto carries structured `Diagnostic` messages
+alongside the output. Each diagnostic has a severity, summary, detail, and
+optional attribute path. An `exit_code` field enables plugins to propagate
+typed exit codes back to the host.
+
+## Protocol Version Negotiation
+
+scafctl sends `PluginProtocolVersion` in the `ConfigureProvider` request. Plugins
+can inspect this to enable or disable features based on the host's capabilities.
+The plugin may return its own protocol version in the response for the host to
+check.
 
 ## Creating a Plugin
 
@@ -32,7 +139,7 @@ type ProviderPlugin interface {
 import "github.com/oakwood-commons/scafctl/pkg/plugin"
 ```
 
-2. Implement the `ProviderPlugin` interface
+2. Implement the `ProviderPlugin` interface (all 8 methods)
 
 3. Call `plugin.Serve()` in your main function:
 ```go
@@ -42,9 +149,15 @@ func main() {
 ```
 
 4. Build your plugin as an executable:
-```go
+```bash
 go build -o my-plugin main.go
 ```
+
+## Descriptor Caching
+
+The plugin client caches provider descriptors after the first `GetProviderDescriptor`
+call to avoid repeated gRPC round-trips. The cache is protected by a `sync.RWMutex`
+for concurrent access.
 
 ## Plugin Discovery
 
@@ -54,6 +167,30 @@ Plugins are discovered by scanning configured plugin directories for executable 
 2. Attempts to connect to each potential plugin
 3. Registers providers from successfully loaded plugins
 4. Skips plugins that fail to load
+
+`RegisterPluginProviders` returns all created `*Client` instances so the caller
+can clean up with `KillAll` on shutdown.
+
+## Plugin Lifecycle
+
+### Provider Plugins
+
+1. **Discovery**: scafctl finds plugin binaries
+2. **Handshake**: Protocol version and magic cookie are validated
+3. **GetProviders**: Plugin advertises provider names
+4. **GetProviderDescriptor**: scafctl fetches and caches descriptors
+5. **ConfigureProvider**: Host sends config + protocol version + HostService ID
+6. **Execution**: `ExecuteProvider` or `ExecuteProviderStream` on invocation
+7. **Shutdown**: `StopProvider` for graceful cleanup, then `Kill()` the process
+
+### Auth Handler Plugins
+
+1. **Discovery**: scafctl finds plugin binaries
+2. **Handshake**: Protocol version and magic cookie are validated
+3. **GetAuthHandlers**: Plugin advertises handler names, flows, and capabilities
+4. **ConfigureAuthHandler**: Host sends config + protocol version + HostService ID
+5. **Authentication**: `Login`, `Logout`, `GetStatus`, `GetToken` on user request
+6. **Shutdown**: `StopAuthHandler` for graceful cleanup, then `Kill()` the process
 
 ## Example Plugin
 
@@ -65,6 +202,8 @@ See `examples/plugins/echo/` for a complete example plugin implementation.
 - Communication over gRPC provides clear security boundaries
 - Plugins are validated using handshake configuration
 - Failed plugins don't crash the main process
+- Secret access is scoped by plugin-specific prefix
+- Auth handler access restricted by AllowedAuthHandlers allowlist
 
 ## Testing
 

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -1,0 +1,1095 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/plugin/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- Mock AuthHandlerServiceClient ---
+
+type mockAuthHandlerServiceClient struct {
+	proto.AuthHandlerServiceClient
+
+	getAuthHandlersResp      *proto.GetAuthHandlersResponse
+	getAuthHandlersErr       error
+	configureAuthHandlerResp *proto.ConfigureAuthHandlerResponse
+	configureAuthHandlerErr  error
+	loginFunc                func(ctx context.Context, req *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error)
+	logoutResp               *proto.LogoutResponse
+	logoutErr                error
+	getStatusResp            *proto.GetStatusResponse
+	getStatusErr             error
+	getTokenResp             *proto.GetTokenResponse
+	getTokenErr              error
+	listCachedTokensResp     *proto.ListCachedTokensResponse
+	listCachedTokensErr      error
+	purgeExpiredTokensResp   *proto.PurgeExpiredTokensResponse
+	purgeExpiredTokensErr    error
+	stopAuthHandlerResp      *proto.StopAuthHandlerResponse
+	stopAuthHandlerErr       error
+}
+
+func (m *mockAuthHandlerServiceClient) GetAuthHandlers(_ context.Context, _ *proto.GetAuthHandlersRequest, _ ...grpc.CallOption) (*proto.GetAuthHandlersResponse, error) {
+	return m.getAuthHandlersResp, m.getAuthHandlersErr
+}
+
+func (m *mockAuthHandlerServiceClient) ConfigureAuthHandler(_ context.Context, req *proto.ConfigureAuthHandlerRequest, _ ...grpc.CallOption) (*proto.ConfigureAuthHandlerResponse, error) {
+	return m.configureAuthHandlerResp, m.configureAuthHandlerErr
+}
+
+func (m *mockAuthHandlerServiceClient) Login(ctx context.Context, req *proto.LoginRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+	if m.loginFunc != nil {
+		return m.loginFunc(ctx, req)
+	}
+	return nil, fmt.Errorf("login not configured")
+}
+
+func (m *mockAuthHandlerServiceClient) Logout(_ context.Context, _ *proto.LogoutRequest, _ ...grpc.CallOption) (*proto.LogoutResponse, error) {
+	return m.logoutResp, m.logoutErr
+}
+
+func (m *mockAuthHandlerServiceClient) GetStatus(_ context.Context, _ *proto.GetStatusRequest, _ ...grpc.CallOption) (*proto.GetStatusResponse, error) {
+	return m.getStatusResp, m.getStatusErr
+}
+
+func (m *mockAuthHandlerServiceClient) GetToken(_ context.Context, _ *proto.GetTokenRequest, _ ...grpc.CallOption) (*proto.GetTokenResponse, error) {
+	return m.getTokenResp, m.getTokenErr
+}
+
+func (m *mockAuthHandlerServiceClient) ListCachedTokens(_ context.Context, _ *proto.ListCachedTokensRequest, _ ...grpc.CallOption) (*proto.ListCachedTokensResponse, error) {
+	return m.listCachedTokensResp, m.listCachedTokensErr
+}
+
+func (m *mockAuthHandlerServiceClient) PurgeExpiredTokens(_ context.Context, _ *proto.PurgeExpiredTokensRequest, _ ...grpc.CallOption) (*proto.PurgeExpiredTokensResponse, error) {
+	return m.purgeExpiredTokensResp, m.purgeExpiredTokensErr
+}
+
+func (m *mockAuthHandlerServiceClient) StopAuthHandler(_ context.Context, _ *proto.StopAuthHandlerRequest, _ ...grpc.CallOption) (*proto.StopAuthHandlerResponse, error) {
+	return m.stopAuthHandlerResp, m.stopAuthHandlerErr
+}
+
+// --- Mock login stream ---
+
+type mockLoginStreamClient struct {
+	grpc.ClientStream
+	messages []*proto.LoginStreamMessage
+	idx      int
+}
+
+func (s *mockLoginStreamClient) Recv() (*proto.LoginStreamMessage, error) {
+	if s.idx >= len(s.messages) {
+		return nil, io.EOF
+	}
+	msg := s.messages[s.idx]
+	s.idx++
+	return msg, nil
+}
+
+// =====================================================================
+// AuthHandlerGRPCClient tests
+// =====================================================================
+
+func TestAuthHandlerGRPCClient_GetAuthHandlers_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		getAuthHandlersResp: &proto.GetAuthHandlersResponse{
+			Handlers: []*proto.AuthHandlerInfo{
+				{
+					Name:         "azure",
+					DisplayName:  "Azure AD",
+					Flows:        []string{"device_code", "service_principal"},
+					Capabilities: []string{"scopes_on_login", "tenant_id"},
+				},
+				{
+					Name:        "github",
+					DisplayName: "GitHub OAuth",
+					Flows:       []string{"interactive"},
+				},
+			},
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	handlers, err := client.GetAuthHandlers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, handlers, 2)
+
+	assert.Equal(t, "azure", handlers[0].Name)
+	assert.Equal(t, "Azure AD", handlers[0].DisplayName)
+	assert.Equal(t, []auth.Flow{"device_code", "service_principal"}, handlers[0].Flows)
+	assert.Equal(t, []auth.Capability{"scopes_on_login", "tenant_id"}, handlers[0].Capabilities)
+
+	assert.Equal(t, "github", handlers[1].Name)
+	assert.Len(t, handlers[1].Capabilities, 0)
+}
+
+func TestAuthHandlerGRPCClient_GetAuthHandlers_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		getAuthHandlersErr: fmt.Errorf("connection error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.GetAuthHandlers(context.Background())
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_Login_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return &mockLoginStreamClient{
+				messages: []*proto.LoginStreamMessage{
+					{
+						Payload: &proto.LoginStreamMessage_Result{
+							Result: &proto.LoginResult{
+								Claims: &proto.Claims{
+									Email:         "user@example.com",
+									Name:          "Test User",
+									ExpiresAtUnix: now.Add(time.Hour).Unix(),
+								},
+								ExpiresAtUnix: now.Add(time.Hour).Unix(),
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	resp, err := client.Login(context.Background(), "azure", LoginRequest{
+		TenantID: "tenant-123",
+		Scopes:   []string{"openid"},
+		Flow:     auth.FlowDeviceCode,
+		Timeout:  30 * time.Second,
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", resp.Claims.Email)
+	assert.Equal(t, now.Add(time.Hour).Unix(), resp.ExpiresAt.Unix())
+}
+
+func TestAuthHandlerGRPCClient_Login_WithDeviceCodePrompt(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return &mockLoginStreamClient{
+				messages: []*proto.LoginStreamMessage{
+					{
+						Payload: &proto.LoginStreamMessage_DeviceCodePrompt{
+							DeviceCodePrompt: &proto.DeviceCodePrompt{
+								UserCode:        "ABCD-1234",
+								VerificationUri: "https://device.login.example.com",
+								Message:         "Go to the URL and enter the code",
+							},
+						},
+					},
+					{
+						Payload: &proto.LoginStreamMessage_Result{
+							Result: &proto.LoginResult{
+								Claims: &proto.Claims{
+									Email: "user@example.com",
+								},
+								ExpiresAtUnix: time.Now().Add(time.Hour).Unix(),
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	var receivedPrompt DeviceCodePrompt
+	cb := func(p DeviceCodePrompt) {
+		receivedPrompt = p
+	}
+
+	resp, err := client.Login(context.Background(), "azure", LoginRequest{}, cb)
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", resp.Claims.Email)
+	assert.Equal(t, "ABCD-1234", receivedPrompt.UserCode)
+	assert.Equal(t, "https://device.login.example.com", receivedPrompt.VerificationURI)
+}
+
+func TestAuthHandlerGRPCClient_Login_DeviceCodeNilCallback(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return &mockLoginStreamClient{
+				messages: []*proto.LoginStreamMessage{
+					{
+						Payload: &proto.LoginStreamMessage_DeviceCodePrompt{
+							DeviceCodePrompt: &proto.DeviceCodePrompt{UserCode: "CODE"},
+						},
+					},
+					{
+						Payload: &proto.LoginStreamMessage_Result{
+							Result: &proto.LoginResult{
+								Claims:        &proto.Claims{Email: "u@e.com"},
+								ExpiresAtUnix: time.Now().Add(time.Hour).Unix(),
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	// nil callback should not panic
+	resp, err := client.Login(context.Background(), "h", LoginRequest{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "u@e.com", resp.Claims.Email)
+}
+
+func TestAuthHandlerGRPCClient_Login_StreamError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return nil, fmt.Errorf("stream setup failed")
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.Login(context.Background(), "h", LoginRequest{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "login RPC failed")
+}
+
+func TestAuthHandlerGRPCClient_Login_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return &mockLoginStreamClient{
+				messages: []*proto.LoginStreamMessage{
+					{
+						Payload: &proto.LoginStreamMessage_Error{
+							Error: "auth failed: invalid credentials",
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.Login(context.Background(), "h", LoginRequest{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid credentials")
+}
+
+func TestAuthHandlerGRPCClient_Login_EOFWithoutResult(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, _ *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			return &mockLoginStreamClient{messages: nil}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.Login(context.Background(), "h", LoginRequest{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "login stream ended without result")
+}
+
+func TestAuthHandlerGRPCClient_Logout_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		logoutResp: &proto.LogoutResponse{},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.Logout(context.Background(), "azure")
+	require.NoError(t, err)
+}
+
+func TestAuthHandlerGRPCClient_Logout_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		logoutErr: fmt.Errorf("logout failed"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.Logout(context.Background(), "azure")
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_GetStatus_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	mock := &mockAuthHandlerServiceClient{
+		getStatusResp: &proto.GetStatusResponse{
+			Authenticated: true,
+			Claims: &proto.Claims{
+				Email: "user@example.com",
+				Name:  "Test User",
+			},
+			ExpiresAtUnix:   now.Add(time.Hour).Unix(),
+			LastRefreshUnix: now.Unix(),
+			TenantId:        "tenant-abc",
+			IdentityType:    "user",
+			ClientId:        "client-123",
+			TokenFile:       "/tmp/token",
+			Scopes:          []string{"read", "write"},
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	s, err := client.GetStatus(context.Background(), "azure")
+	require.NoError(t, err)
+	assert.True(t, s.Authenticated)
+	assert.Equal(t, "user@example.com", s.Claims.Email)
+	assert.Equal(t, "tenant-abc", s.TenantID)
+	assert.Equal(t, auth.IdentityType("user"), s.IdentityType)
+	assert.Equal(t, []string{"read", "write"}, s.Scopes)
+}
+
+func TestAuthHandlerGRPCClient_GetStatus_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		getStatusErr: fmt.Errorf("status error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.GetStatus(context.Background(), "azure")
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_GetToken_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	mock := &mockAuthHandlerServiceClient{
+		getTokenResp: &proto.GetTokenResponse{
+			AccessToken:   "eyJtoken123",
+			TokenType:     "Bearer",
+			ExpiresAtUnix: now.Add(time.Hour).Unix(),
+			Scope:         "read write",
+			CachedAtUnix:  now.Unix(),
+			Flow:          "device_code",
+			SessionId:     "session-abc",
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	resp, err := client.GetToken(context.Background(), "azure", TokenRequest{
+		Scope:        "read write",
+		MinValidFor:  5 * time.Minute,
+		ForceRefresh: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "eyJtoken123", resp.AccessToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "read write", resp.Scope)
+	assert.Equal(t, auth.Flow("device_code"), resp.Flow)
+	assert.Equal(t, "session-abc", resp.SessionID)
+}
+
+func TestAuthHandlerGRPCClient_GetToken_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		getTokenErr: fmt.Errorf("token error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.GetToken(context.Background(), "azure", TokenRequest{})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_ListCachedTokens_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	mock := &mockAuthHandlerServiceClient{
+		listCachedTokensResp: &proto.ListCachedTokensResponse{
+			Tokens: []*proto.CachedTokenInfo{
+				{
+					Handler:       "azure",
+					TokenKind:     "access",
+					Scope:         "read",
+					TokenType:     "Bearer",
+					Flow:          "device_code",
+					ExpiresAtUnix: now.Add(time.Hour).Unix(),
+					CachedAtUnix:  now.Unix(),
+					IsExpired:     false,
+					SessionId:     "s1",
+				},
+				{
+					Handler:       "azure",
+					TokenKind:     "refresh",
+					Scope:         "openid",
+					TokenType:     "Bearer",
+					Flow:          "interactive",
+					ExpiresAtUnix: now.Add(-time.Hour).Unix(),
+					IsExpired:     true,
+					SessionId:     "s2",
+				},
+			},
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	tokens, err := client.ListCachedTokens(context.Background(), "azure")
+	require.NoError(t, err)
+	require.Len(t, tokens, 2)
+	assert.Equal(t, "azure", tokens[0].Handler)
+	assert.Equal(t, "access", tokens[0].TokenKind)
+	assert.False(t, tokens[0].IsExpired)
+	assert.True(t, tokens[1].IsExpired)
+}
+
+func TestAuthHandlerGRPCClient_ListCachedTokens_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		listCachedTokensErr: fmt.Errorf("list error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.ListCachedTokens(context.Background(), "azure")
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_PurgeExpiredTokens_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		purgeExpiredTokensResp: &proto.PurgeExpiredTokensResponse{PurgedCount: 5},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	count, err := client.PurgeExpiredTokens(context.Background(), "azure")
+	require.NoError(t, err)
+	assert.Equal(t, 5, count)
+}
+
+func TestAuthHandlerGRPCClient_PurgeExpiredTokens_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		purgeExpiredTokensErr: fmt.Errorf("purge error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.PurgeExpiredTokens(context.Background(), "azure")
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerResp: &proto.ConfigureAuthHandlerResponse{
+			ProtocolVersion: PluginProtocolVersion,
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock, hostServiceID: 42}
+
+	err := client.ConfigureAuthHandler(context.Background(), "azure", ProviderConfig{
+		Quiet:      true,
+		NoColor:    true,
+		BinaryName: "mycli",
+	})
+	require.NoError(t, err)
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_ResponseError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerResp: &proto.ConfigureAuthHandlerResponse{
+			Error: "configuration rejected",
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.ConfigureAuthHandler(context.Background(), "azure", ProviderConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configuration rejected")
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_Unimplemented(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerErr: status.Error(codes.Unimplemented, "not supported"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.ConfigureAuthHandler(context.Background(), "azure", ProviderConfig{})
+	require.NoError(t, err) // should swallow Unimplemented
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_OtherGRPCError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerErr: status.Error(codes.Internal, "server error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.ConfigureAuthHandler(context.Background(), "azure", ProviderConfig{})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_WithSettings(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerResp: &proto.ConfigureAuthHandlerResponse{
+			ProtocolVersion: PluginProtocolVersion,
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.ConfigureAuthHandler(context.Background(), "azure", ProviderConfig{
+		Settings: map[string]json.RawMessage{
+			"timeout": json.RawMessage(`30`),
+			"region":  json.RawMessage(`"us-west-2"`),
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestAuthHandlerGRPCClient_StopAuthHandler_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		stopAuthHandlerResp: &proto.StopAuthHandlerResponse{},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.StopAuthHandler(context.Background(), "azure")
+	require.NoError(t, err)
+}
+
+func TestAuthHandlerGRPCClient_StopAuthHandler_ResponseError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		stopAuthHandlerResp: &proto.StopAuthHandlerResponse{
+			Error: "stop failed: handler busy",
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.StopAuthHandler(context.Background(), "azure")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handler busy")
+}
+
+func TestAuthHandlerGRPCClient_StopAuthHandler_Unimplemented(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		stopAuthHandlerErr: status.Error(codes.Unimplemented, "not supported"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.StopAuthHandler(context.Background(), "azure")
+	require.NoError(t, err) // should swallow Unimplemented
+}
+
+func TestAuthHandlerGRPCClient_StopAuthHandler_OtherError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		stopAuthHandlerErr: errors.New("transport error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	err := client.StopAuthHandler(context.Background(), "azure")
+	require.Error(t, err)
+}
+
+// =====================================================================
+// AuthHandlerGRPCServer tests for uncovered server methods
+// =====================================================================
+
+func TestAuthHandlerGRPCServer_GetAuthHandlers_Error(t *testing.T) {
+	t.Parallel()
+
+	errPlugin := &errAuthPlugin{err: fmt.Errorf("plugin error")}
+	server := &AuthHandlerGRPCServer{Impl: errPlugin}
+
+	_, err := server.GetAuthHandlers(context.Background(), &proto.GetAuthHandlersRequest{})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_Logout_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	resp, err := server.Logout(context.Background(), &proto.LogoutRequest{HandlerName: "test"})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestAuthHandlerGRPCServer_Logout_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		logoutFunc: func(_ context.Context, _ string) error {
+			return fmt.Errorf("logout error")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	_, err := server.Logout(context.Background(), &proto.LogoutRequest{HandlerName: "test"})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_GetStatus_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		statusFunc: func(_ context.Context, _ string) (*auth.Status, error) {
+			return nil, fmt.Errorf("status error")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	_, err := server.GetStatus(context.Background(), &proto.GetStatusRequest{HandlerName: "test"})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_GetToken_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(_ context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			return nil, fmt.Errorf("token error")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	_, err := server.GetToken(context.Background(), &proto.GetTokenRequest{
+		HandlerName: "test",
+		Scope:       "read",
+	})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_ListCachedTokens_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		listFunc: func(_ context.Context, _ string) ([]*auth.CachedTokenInfo, error) {
+			return nil, fmt.Errorf("list error")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	_, err := server.ListCachedTokens(context.Background(), &proto.ListCachedTokensRequest{HandlerName: "test"})
+	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_PurgeExpiredTokens_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		purgeFunc: func(_ context.Context, _ string) (int, error) {
+			return 0, fmt.Errorf("purge error")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	_, err := server.PurgeExpiredTokens(context.Background(), &proto.PurgeExpiredTokensRequest{HandlerName: "test"})
+	require.Error(t, err)
+}
+
+// =====================================================================
+// AuthHandlerClient delegation tests
+// =====================================================================
+
+func TestAuthHandlerClient_Delegation(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	client := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+		path:   "/usr/local/bin/test-plugin",
+	}
+
+	// GetAuthHandlers
+	handlers, err := client.GetAuthHandlers(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, handlers, 1)
+
+	// Login
+	resp, err := client.Login(context.Background(), "test-handler", LoginRequest{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "test@example.com", resp.Claims.Email)
+
+	// Logout
+	err = client.Logout(context.Background(), "test-handler")
+	require.NoError(t, err)
+
+	// GetStatus
+	s, err := client.GetStatus(context.Background(), "test-handler")
+	require.NoError(t, err)
+	assert.True(t, s.Authenticated)
+
+	// GetToken
+	tok, err := client.GetToken(context.Background(), "test-handler", TokenRequest{Scope: "read"})
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-token", tok.AccessToken)
+
+	// ConfigureAuthHandler
+	err = client.ConfigureAuthHandler(context.Background(), "test-handler", ProviderConfig{BinaryName: "cli"})
+	require.NoError(t, err)
+
+	// StopAuthHandler
+	err = client.StopAuthHandler(context.Background(), "test-handler")
+	require.NoError(t, err)
+
+	// Name / Path
+	assert.Equal(t, "test-plugin", client.Name())
+	assert.Equal(t, "/usr/local/bin/test-plugin", client.Path())
+}
+
+func TestAuthHandlerClient_Kill_NilPluginClient(t *testing.T) {
+	t.Parallel()
+
+	client := &AuthHandlerClient{
+		plugin: &MockAuthHandlerPlugin{},
+	}
+	// Should not panic with nil pluginClient
+	client.Kill()
+}
+
+// =====================================================================
+// NewAuthHandlerWrapper tests
+// =====================================================================
+
+func TestNewAuthHandlerWrapper(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	info := AuthHandlerInfo{
+		Name:         "azure",
+		DisplayName:  "Azure AD",
+		Flows:        []auth.Flow{auth.FlowDeviceCode},
+		Capabilities: []auth.Capability{auth.CapScopesOnLogin},
+	}
+
+	wrapper := NewAuthHandlerWrapper(ahClient, info)
+	require.NotNil(t, wrapper)
+
+	assert.Equal(t, "azure", wrapper.Name())
+	assert.Equal(t, "Azure AD", wrapper.DisplayName())
+	assert.Equal(t, []auth.Flow{auth.FlowDeviceCode}, wrapper.SupportedFlows())
+	assert.Equal(t, []auth.Capability{auth.CapScopesOnLogin}, wrapper.Capabilities())
+	assert.Equal(t, ahClient, wrapper.Client())
+}
+
+// =====================================================================
+// configureAndRegisterAuthHandlers tests
+// =====================================================================
+
+func TestConfigureAndRegisterAuthHandlers_WithConfig(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	registry := auth.NewRegistry()
+	handlers := []AuthHandlerInfo{
+		{
+			Name:        "handler-a",
+			DisplayName: "Handler A",
+			Flows:       []auth.Flow{auth.FlowDeviceCode},
+		},
+		{
+			Name:        "handler-b",
+			DisplayName: "Handler B",
+			Flows:       []auth.Flow{auth.FlowServicePrincipal},
+		},
+	}
+	cfg := &ProviderConfig{
+		Quiet:      true,
+		BinaryName: "mycli",
+	}
+
+	configureAndRegisterAuthHandlers(context.Background(), registry, ahClient, handlers, cfg)
+
+	// Verify both handlers are registered
+	h, err := registry.Get("handler-a")
+	require.NoError(t, err)
+	assert.Equal(t, "handler-a", h.Name())
+
+	h, err = registry.Get("handler-b")
+	require.NoError(t, err)
+	assert.Equal(t, "handler-b", h.Name())
+}
+
+func TestConfigureAndRegisterAuthHandlers_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	registry := auth.NewRegistry()
+	handlers := []AuthHandlerInfo{
+		{
+			Name:        "handler-a",
+			DisplayName: "Handler A",
+		},
+	}
+
+	configureAndRegisterAuthHandlers(context.Background(), registry, ahClient, handlers, nil)
+
+	h, err := registry.Get("handler-a")
+	require.NoError(t, err)
+	assert.Equal(t, "handler-a", h.Name())
+}
+
+func TestConfigureAndRegisterAuthHandlers_DuplicateSkipped(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	registry := auth.NewRegistry()
+
+	// Pre-register a handler
+	preWrapper := NewAuthHandlerWrapper(ahClient, AuthHandlerInfo{Name: "handler-a", DisplayName: "Pre"})
+	require.NoError(t, registry.Register(preWrapper))
+
+	// Try to register duplicate
+	handlers := []AuthHandlerInfo{
+		{Name: "handler-a", DisplayName: "Dup"},
+	}
+	configureAndRegisterAuthHandlers(context.Background(), registry, ahClient, handlers, nil)
+
+	// Original should still be there
+	h, err := registry.Get("handler-a")
+	require.NoError(t, err)
+	assert.Equal(t, "Pre", h.DisplayName())
+}
+
+func TestConfigureAndRegisterAuthHandlers_ConfigureError(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		configureErr: fmt.Errorf("configure failed"),
+	}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	registry := auth.NewRegistry()
+	handlers := []AuthHandlerInfo{
+		{Name: "handler-a", DisplayName: "A"},
+	}
+	cfg := &ProviderConfig{BinaryName: "cli"}
+
+	// Should log error but still register the handler
+	configureAndRegisterAuthHandlers(context.Background(), registry, ahClient, handlers, cfg)
+
+	h, err := registry.Get("handler-a")
+	require.NoError(t, err)
+	assert.Equal(t, "handler-a", h.Name())
+}
+
+// =====================================================================
+// KillAll / KillAllAuthHandlers additional tests
+// =====================================================================
+
+func TestKillAll_WithNilEntries(t *testing.T) {
+	t.Parallel()
+
+	clients := []*Client{nil, nil}
+	KillAll(clients) // should not panic
+}
+
+func TestKillAllAuthHandlers_WithNilEntries(t *testing.T) {
+	t.Parallel()
+
+	clients := []*AuthHandlerClient{nil, nil}
+	KillAllAuthHandlers(clients) // should not panic
+}
+
+func TestKillAllAuthHandlers_WithMockClients(t *testing.T) {
+	t.Parallel()
+
+	clients := []*AuthHandlerClient{
+		{plugin: &MockAuthHandlerPlugin{}, name: "a"},
+		{plugin: &MockAuthHandlerPlugin{}, name: "b"},
+	}
+	KillAllAuthHandlers(clients) // should not panic
+}
+
+// =====================================================================
+// AuthHandlerWrapper error paths
+// =====================================================================
+
+func TestAuthHandlerWrapper_Login_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, _ func(DeviceCodePrompt)) (*LoginResponse, error) {
+			return nil, fmt.Errorf("login failed")
+		},
+	}
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "h",
+		info:        AuthHandlerInfo{Name: "h"},
+	}
+
+	_, err := w.Login(context.Background(), auth.LoginOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "login failed")
+}
+
+func TestAuthHandlerWrapper_GetToken_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(_ context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			return nil, fmt.Errorf("token error")
+		},
+	}
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "h",
+		info:        AuthHandlerInfo{Name: "h"},
+	}
+
+	_, err := w.GetToken(context.Background(), auth.TokenOptions{Scope: "read"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token error")
+}
+
+func TestAuthHandlerWrapper_InjectAuth_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(_ context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			return nil, fmt.Errorf("inject token error")
+		},
+	}
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "h",
+		info:        AuthHandlerInfo{Name: "h"},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com", nil)
+	err := w.InjectAuth(context.Background(), req, auth.TokenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inject-auth")
+}
+
+func TestAuthHandlerWrapper_InjectAuth_EmptyTokenType(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(_ context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			return &TokenResponse{
+				AccessToken: "my-token",
+				TokenType:   "", // empty
+			}, nil
+		},
+	}
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "h",
+		info:        AuthHandlerInfo{Name: "h"},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com", nil)
+	err := w.InjectAuth(context.Background(), req, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
+}
+
+// =====================================================================
+// errAuthPlugin helper for error-path server tests
+// =====================================================================
+
+type errAuthPlugin struct {
+	err error
+}
+
+func (e *errAuthPlugin) GetAuthHandlers(_ context.Context) ([]AuthHandlerInfo, error) {
+	return nil, e.err
+}
+
+func (e *errAuthPlugin) Login(_ context.Context, _ string, _ LoginRequest, _ func(DeviceCodePrompt)) (*LoginResponse, error) {
+	return nil, e.err
+}
+
+func (e *errAuthPlugin) Logout(_ context.Context, _ string) error {
+	return e.err
+}
+
+func (e *errAuthPlugin) GetStatus(_ context.Context, _ string) (*auth.Status, error) {
+	return nil, e.err
+}
+
+func (e *errAuthPlugin) GetToken(_ context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+	return nil, e.err
+}
+
+func (e *errAuthPlugin) ListCachedTokens(_ context.Context, _ string) ([]*auth.CachedTokenInfo, error) {
+	return nil, e.err
+}
+
+func (e *errAuthPlugin) PurgeExpiredTokens(_ context.Context, _ string) (int, error) {
+	return 0, e.err
+}
+
+func (e *errAuthPlugin) ConfigureAuthHandler(_ context.Context, _ string, _ ProviderConfig) error {
+	return e.err
+}
+
+func (e *errAuthPlugin) StopAuthHandler(_ context.Context, _ string) error {
+	return e.err
+}

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -122,6 +123,11 @@ type Client struct {
 	plugin       ProviderPlugin
 	path         string
 	name         string
+
+	// descriptorCache caches GetProviderDescriptor results to avoid redundant
+	// RPCs for the same provider within a single client lifecycle.
+	mu              sync.RWMutex
+	descriptorCache map[string]*provider.Descriptor
 }
 
 // ClientOption configures plugin client creation.
@@ -174,9 +180,33 @@ func (c *Client) GetProviders(ctx context.Context) ([]string, error) {
 	return c.plugin.GetProviders(ctx)
 }
 
-// GetProviderDescriptor returns metadata for a specific provider
+// GetProviderDescriptor returns metadata for a specific provider.
+// The result is cached for the lifetime of the client.
+//
+// Note: concurrent callers for the same uncached provider may both issue an
+// RPC (classic check-then-act). This is benign because descriptors are
+// immutable — the second writer simply overwrites with an identical value.
 func (c *Client) GetProviderDescriptor(ctx context.Context, providerName string) (*provider.Descriptor, error) {
-	return c.plugin.GetProviderDescriptor(ctx, providerName)
+	c.mu.RLock()
+	if desc, ok := c.descriptorCache[providerName]; ok {
+		c.mu.RUnlock()
+		return desc, nil
+	}
+	c.mu.RUnlock()
+
+	desc, err := c.plugin.GetProviderDescriptor(ctx, providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	if c.descriptorCache == nil {
+		c.descriptorCache = make(map[string]*provider.Descriptor)
+	}
+	c.descriptorCache[providerName] = desc
+	c.mu.Unlock()
+
+	return desc, nil
 }
 
 // ExecuteProvider executes a provider with the given input
@@ -239,11 +269,16 @@ type AuthHandlerClient struct {
 }
 
 // NewAuthHandlerClient creates a new auth handler plugin client.
-func NewAuthHandlerClient(pluginPath string) (*AuthHandlerClient, error) {
+func NewAuthHandlerClient(pluginPath string, opts ...ClientOption) (*AuthHandlerClient, error) {
+	var o clientOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	raw, client, err := connectPlugin(pluginPath, pluginConfig{
 		handshake:  AuthHandlerHandshakeConfig,
 		pluginName: AuthHandlerPluginName,
-		grpcPlugin: &AuthHandlerGRPCPlugin{},
+		grpcPlugin: &AuthHandlerGRPCPlugin{HostDeps: o.hostDeps},
 	})
 	if err != nil {
 		return nil, err
@@ -288,6 +323,25 @@ func (c *AuthHandlerClient) GetToken(ctx context.Context, handlerName string, re
 	return c.plugin.GetToken(ctx, handlerName, req)
 }
 
+// ConfigureAuthHandler delegates to the plugin's ConfigureAuthHandler.
+func (c *AuthHandlerClient) ConfigureAuthHandler(ctx context.Context, handlerName string, cfg ProviderConfig) error {
+	return c.plugin.ConfigureAuthHandler(ctx, handlerName, cfg)
+}
+
+// StopAuthHandler delegates to the plugin's StopAuthHandler.
+func (c *AuthHandlerClient) StopAuthHandler(ctx context.Context, handlerName string) error {
+	return c.plugin.StopAuthHandler(ctx, handlerName)
+}
+
+// HostServiceID returns the broker service ID of the HostService callback server.
+// Returns 0 if no HostService was registered.
+func (c *AuthHandlerClient) HostServiceID() uint32 {
+	if gc, ok := c.plugin.(*AuthHandlerGRPCClient); ok {
+		return gc.hostServiceID
+	}
+	return 0
+}
+
 // Kill terminates the plugin process.
 func (c *AuthHandlerClient) Kill() {
 	if c.pluginClient != nil {
@@ -306,6 +360,8 @@ func (c *AuthHandlerClient) Path() string {
 }
 
 // DiscoverAuthHandlers discovers auth handler plugins from the given directories.
-func DiscoverAuthHandlers(pluginDirs []string) ([]*AuthHandlerClient, error) {
-	return discoverExecutables(pluginDirs, NewAuthHandlerClient)
+func DiscoverAuthHandlers(pluginDirs []string, opts ...ClientOption) ([]*AuthHandlerClient, error) {
+	return discoverExecutables(pluginDirs, func(path string) (*AuthHandlerClient, error) {
+		return NewAuthHandlerClient(path, opts...)
+	})
 }

--- a/pkg/plugin/coverage_test.go
+++ b/pkg/plugin/coverage_test.go
@@ -40,6 +40,8 @@ type mockPluginServiceClient struct {
 	describeWhatIfErr         error
 	extractDependenciesResp   *proto.ExtractDependenciesResponse
 	extractDependenciesErr    error
+	stopProviderResp          *proto.StopProviderResponse
+	stopProviderErr           error
 	executeProviderStreamFunc func(ctx context.Context, req *proto.ExecuteProviderRequest) (proto.PluginService_ExecuteProviderStreamClient, error)
 }
 
@@ -73,6 +75,10 @@ func (m *mockPluginServiceClient) ExecuteProviderStream(ctx context.Context, req
 		return m.executeProviderStreamFunc(ctx, req)
 	}
 	return nil, status.Error(codes.Unimplemented, "streaming not supported")
+}
+
+func (m *mockPluginServiceClient) StopProvider(_ context.Context, _ *proto.StopProviderRequest, _ ...grpc.CallOption) (*proto.StopProviderResponse, error) {
+	return m.stopProviderResp, m.stopProviderErr
 }
 
 // --- Mock gRPC stream client ---
@@ -142,6 +148,8 @@ type mockHostServiceClient struct {
 	getAuthIdentityErr   error
 	listAuthHandlersResp *proto.ListAuthHandlersResponse
 	listAuthHandlersErr  error
+	getAuthTokenResp     *proto.GetAuthTokenResponse
+	getAuthTokenErr      error
 }
 
 func (m *mockHostServiceClient) GetSecret(_ context.Context, _ *proto.GetSecretRequest, _ ...grpc.CallOption) (*proto.GetSecretResponse, error) {
@@ -166,6 +174,10 @@ func (m *mockHostServiceClient) GetAuthIdentity(_ context.Context, _ *proto.GetA
 
 func (m *mockHostServiceClient) ListAuthHandlers(_ context.Context, _ *proto.ListAuthHandlersRequest, _ ...grpc.CallOption) (*proto.ListAuthHandlersResponse, error) {
 	return m.listAuthHandlersResp, m.listAuthHandlersErr
+}
+
+func (m *mockHostServiceClient) GetAuthToken(_ context.Context, _ *proto.GetAuthTokenRequest, _ ...grpc.CallOption) (*proto.GetAuthTokenResponse, error) {
+	return m.getAuthTokenResp, m.getAuthTokenErr
 }
 
 // --- streamingMockPlugin wraps MockProviderPlugin with real streaming ---
@@ -1618,4 +1630,298 @@ func BenchmarkGRPCClient_ExecuteProvider(b *testing.B) {
 	for b.Loop() {
 		_, _ = client.ExecuteProvider(ctx, "test", map[string]any{"k": "v"})
 	}
+}
+
+// --- StopProvider tests ---
+
+func TestGRPCClient_StopProvider_Success(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		stopProviderResp: &proto.StopProviderResponse{},
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.StopProvider(context.Background(), "test-provider")
+	assert.NoError(t, err)
+}
+
+func TestGRPCClient_StopProvider_Error(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		stopProviderResp: &proto.StopProviderResponse{Error: "shutdown failed"},
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.StopProvider(context.Background(), "test-provider")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "shutdown failed")
+}
+
+func TestGRPCClient_StopProvider_Unimplemented(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		stopProviderErr: status.Error(codes.Unimplemented, "not implemented"),
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.StopProvider(context.Background(), "test-provider")
+	assert.NoError(t, err, "unimplemented should be treated as no-op")
+}
+
+func TestGRPCClient_StopProvider_RPCError(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		stopProviderErr: status.Error(codes.Unavailable, "connection lost"),
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.StopProvider(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestGRPCServer_StopProvider(t *testing.T) {
+	mock := &MockProviderPlugin{}
+	server := &GRPCServer{Impl: mock}
+
+	resp, err := server.StopProvider(context.Background(), &proto.StopProviderRequest{
+		ProviderName: "test-provider",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+}
+
+// --- GetAuthToken tests ---
+
+func TestHostServiceServer_GetAuthToken_Success(t *testing.T) {
+	deps := HostServiceDeps{
+		AllowedAuthHandlers: []string{"github"},
+		AuthTokenFunc: func(_ context.Context, handler, scope string, minValidFor int64, forceRefresh bool) (*proto.GetAuthTokenResponse, error) {
+			return &proto.GetAuthTokenResponse{
+				AccessToken:   "tok-123",
+				TokenType:     "Bearer",
+				ExpiresAtUnix: 1700000000,
+				Scope:         scope,
+			}, nil
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName:        "github",
+		Scope:              "repo",
+		MinValidForSeconds: 60,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "tok-123", resp.AccessToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Empty(t, resp.Error)
+}
+
+func TestHostServiceServer_GetAuthToken_NotAvailable(t *testing.T) {
+	server := &HostServiceServer{Deps: HostServiceDeps{}}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "github",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "not available")
+}
+
+func TestHostServiceServer_GetAuthToken_Denied(t *testing.T) {
+	deps := HostServiceDeps{
+		AllowedAuthHandlers: []string{"azure"},
+		AuthTokenFunc: func(_ context.Context, _, _ string, _ int64, _ bool) (*proto.GetAuthTokenResponse, error) {
+			t.Fatal("should not be called")
+			return nil, nil
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "github",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "access denied")
+}
+
+func TestHostServiceServer_GetAuthToken_FuncError(t *testing.T) {
+	deps := HostServiceDeps{
+		AllowedAuthHandlers: []string{"github"},
+		AuthTokenFunc: func(_ context.Context, _, _ string, _ int64, _ bool) (*proto.GetAuthTokenResponse, error) {
+			return nil, errors.New("token refresh failed")
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "github",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "token refresh failed")
+}
+
+func TestHostServiceServer_GetAuthToken_EmptyHandlerDeniedWithAllowlist(t *testing.T) {
+	deps := HostServiceDeps{
+		AllowedAuthHandlers: []string{"github"},
+		AuthTokenFunc: func(_ context.Context, _, _ string, _ int64, _ bool) (*proto.GetAuthTokenResponse, error) {
+			t.Fatal("should not be called for empty handler when allowlist is configured")
+			return nil, nil
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "",
+		Scope:       "repo",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "access denied")
+}
+
+func TestHostServiceServer_GetAuthToken_EmptyHandlerAllowedWithoutAllowlist(t *testing.T) {
+	deps := HostServiceDeps{
+		AuthTokenFunc: func(_ context.Context, handler, scope string, _ int64, _ bool) (*proto.GetAuthTokenResponse, error) {
+			return &proto.GetAuthTokenResponse{
+				AccessToken: "default-tok",
+				TokenType:   "Bearer",
+				Scope:       scope,
+			}, nil
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "",
+		Scope:       "repo",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "default-tok", resp.AccessToken)
+}
+
+func TestHostServiceClient_GetAuthToken_Success(t *testing.T) {
+	mock := &mockHostServiceClient{
+		getAuthTokenResp: &proto.GetAuthTokenResponse{
+			AccessToken: "tok-456",
+			TokenType:   "Bearer",
+		},
+	}
+	client := &HostServiceClient{client: mock}
+
+	resp, err := client.GetAuthToken(context.Background(), "github", "repo", 60, false)
+	require.NoError(t, err)
+	assert.Equal(t, "tok-456", resp.AccessToken)
+}
+
+func TestHostServiceClient_GetAuthToken_RPCError(t *testing.T) {
+	mock := &mockHostServiceClient{
+		getAuthTokenErr: status.Error(codes.Unavailable, "connection lost"),
+	}
+	client := &HostServiceClient{client: mock}
+
+	_, err := client.GetAuthToken(context.Background(), "github", "repo", 0, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "host GetAuthToken")
+}
+
+func TestHostServiceClient_GetAuthToken_ResponseError(t *testing.T) {
+	mock := &mockHostServiceClient{
+		getAuthTokenResp: &proto.GetAuthTokenResponse{
+			Error: "access denied",
+		},
+	}
+	client := &HostServiceClient{client: mock}
+
+	_, err := client.GetAuthToken(context.Background(), "github", "repo", 0, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+// --- KillAll tests ---
+
+func TestKillAll_NilSlice(t *testing.T) {
+	// Should not panic on nil
+	KillAll(nil)
+}
+
+func TestKillAll_EmptySlice(t *testing.T) {
+	// Should not panic on empty
+	KillAll([]*Client{})
+}
+
+// --- Protocol version tests ---
+
+func TestGRPCClient_ConfigureProvider_SendsProtocolVersion(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		configureProviderResp: &proto.ConfigureProviderResponse{},
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.ConfigureProvider(context.Background(), "test", ProviderConfig{
+		BinaryName: "scafctl",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfigureReq)
+	assert.Equal(t, PluginProtocolVersion, mock.lastConfigureReq.ProtocolVersion)
+}
+
+// --- WrapperOption tests ---
+
+func TestNewProviderWrapper_WithContext(t *testing.T) {
+	mock := &MockProviderPlugin{}
+	client := &Client{plugin: mock, name: "test-plugin"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wrapper, err := NewProviderWrapper(client, "test-provider", WithContext(ctx))
+	require.NoError(t, err)
+	assert.Equal(t, "test-provider", wrapper.Descriptor().Name)
+}
+
+func TestNewProviderWrapper_WithContext_Nil(t *testing.T) {
+	mock := &MockProviderPlugin{}
+	client := &Client{plugin: mock, name: "test-plugin"}
+
+	// Verify the nil guard: a nil context should not panic; falls back to context.Background().
+	var nilCtx context.Context //nolint:staticcheck // intentionally testing nil context guard
+	wrapper, err := NewProviderWrapper(client, "test-provider", WithContext(nilCtx))
+	require.NoError(t, err)
+	assert.Equal(t, "test-provider", wrapper.Descriptor().Name)
+}
+
+// --- Descriptor caching tests ---
+
+func TestClient_DescriptorCache_HitOnSecondCall(t *testing.T) {
+	callCount := 0
+	mock := &MockProviderPlugin{
+		descriptors: map[string]*provider.Descriptor{
+			"test-provider": {
+				Name: "test-provider",
+			},
+		},
+	}
+	// Wrap the mock to count calls
+	wrapper := &descriptorCountingPlugin{MockProviderPlugin: mock, count: &callCount}
+	client := &Client{plugin: wrapper, name: "test-plugin"}
+
+	ctx := context.Background()
+
+	desc1, err := client.GetProviderDescriptor(ctx, "test-provider")
+	require.NoError(t, err)
+	assert.Equal(t, "test-provider", desc1.Name)
+	assert.Equal(t, 1, callCount)
+
+	// Second call should hit cache
+	desc2, err := client.GetProviderDescriptor(ctx, "test-provider")
+	require.NoError(t, err)
+	assert.Equal(t, desc1, desc2)
+	assert.Equal(t, 1, callCount, "second call should hit cache, not invoke RPC")
+}
+
+// descriptorCountingPlugin wraps MockProviderPlugin and counts GetProviderDescriptor calls.
+type descriptorCountingPlugin struct {
+	*MockProviderPlugin
+	count *int
+}
+
+func (d *descriptorCountingPlugin) GetProviderDescriptor(ctx context.Context, name string) (*provider.Descriptor, error) {
+	*d.count++
+	return d.MockProviderPlugin.GetProviderDescriptor(ctx, name)
 }

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -284,7 +284,7 @@ func RegisterFetchedPlugins(ctx context.Context, registry *provider.Registry, re
 		}
 
 		for _, providerName := range providers {
-			wrapper, err := NewProviderWrapper(client, providerName)
+			wrapper, err := NewProviderWrapper(client, providerName, WithContext(ctx))
 			if err != nil {
 				continue
 			}
@@ -310,7 +310,7 @@ func RegisterFetchedPlugins(ctx context.Context, registry *provider.Registry, re
 // RegisterFetchedAuthHandlerPlugins loads and registers fetched auth handler
 // plugin binaries into the auth registry. Returns the created clients
 // (caller should Kill() them on cleanup).
-func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Registry, results []FetchResult) ([]*AuthHandlerClient, error) {
+func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Registry, results []FetchResult, cfg *ProviderConfig, clientOpts ...ClientOption) ([]*AuthHandlerClient, error) {
 	var clients []*AuthHandlerClient
 
 	for _, r := range results {
@@ -318,7 +318,7 @@ func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Regis
 			continue
 		}
 
-		client, err := NewAuthHandlerClient(r.Path)
+		client, err := NewAuthHandlerClient(r.Path, clientOpts...)
 		if err != nil {
 			for _, c := range clients {
 				c.Kill()
@@ -335,12 +335,7 @@ func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Regis
 			return nil, fmt.Errorf("getting auth handlers from plugin %s: %w", r.Name, err)
 		}
 
-		for _, info := range handlers {
-			wrapper := NewAuthHandlerWrapper(client, info)
-			if err := registry.Register(wrapper); err != nil {
-				continue
-			}
-		}
+		configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
 
 		clients = append(clients, client)
 	}

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -9,11 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/hashicorp/go-plugin"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin/proto"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -131,9 +133,12 @@ func (s *GRPCServer) ExecuteProvider(ctx context.Context, req *proto.ExecuteProv
 	output, err := s.Impl.ExecuteProvider(ctx, req.ProviderName, input)
 	if err != nil {
 		//nolint:nilerr // Error is communicated via response, not gRPC error
-		return &proto.ExecuteProviderResponse{
-			Error: err.Error(),
-		}, nil
+		resp := &proto.ExecuteProviderResponse{
+			Error:    err.Error(),
+			ExitCode: safeIntToInt32(exitcode.GetCode(err)),
+		}
+		resp.Diagnostics = errorToDiagnostics(err)
+		return resp, nil
 	}
 
 	// Encode output
@@ -171,7 +176,9 @@ func (s *GRPCServer) ConfigureProvider(ctx context.Context, req *proto.Configure
 		}, nil
 	}
 
-	return &proto.ConfigureProviderResponse{}, nil
+	return &proto.ConfigureProviderResponse{
+		ProtocolVersion: PluginProtocolVersion,
+	}, nil
 }
 
 // unmarshalIterationContext deserializes a proto.IterationContext and injects
@@ -208,6 +215,69 @@ func unmarshalSolutionMeta(ctx context.Context, meta *proto.SolutionMeta) contex
 		Category:    meta.Category,
 		Tags:        meta.Tags,
 	})
+}
+
+// safeIntToInt32 converts an int to int32 with clamping to prevent overflow.
+func safeIntToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v) //nolint:gosec // bounds checked above
+}
+
+// errorToDiagnostics converts an error into a slice of proto Diagnostics.
+// If the error is an ExitError, the summary includes the exit code description.
+func errorToDiagnostics(err error) []*proto.Diagnostic {
+	if err == nil {
+		return nil
+	}
+	d := &proto.Diagnostic{
+		Severity: proto.Diagnostic_ERROR,
+		Summary:  err.Error(),
+	}
+	var exitErr *exitcode.ExitError
+	if errors.As(err, &exitErr) {
+		d.Detail = fmt.Sprintf("exit code %d: %s", exitErr.Code, exitcode.Description(exitErr.Code))
+	}
+	return []*proto.Diagnostic{d}
+}
+
+// diagnosticsToError converts proto Diagnostics into a Go error. Returns nil
+// when there are no ERROR-level diagnostics. Warnings are logged but do not
+// produce an error.
+func diagnosticsToError(ctx context.Context, diags []*proto.Diagnostic) error {
+	if len(diags) == 0 {
+		return nil
+	}
+	var errs []error
+	lgr := logger.FromContext(ctx)
+	for _, d := range diags {
+		switch d.Severity {
+		case proto.Diagnostic_ERROR:
+			summary := d.Summary
+			if summary == "" {
+				summary = "unknown error (empty diagnostic summary)"
+			}
+			switch {
+			case d.Attribute != "" && d.Detail != "":
+				errs = append(errs, fmt.Errorf("%s: %s (attribute: %s)", summary, d.Detail, d.Attribute))
+			case d.Attribute != "":
+				errs = append(errs, fmt.Errorf("%s (attribute: %s)", summary, d.Attribute))
+			case d.Detail != "":
+				errs = append(errs, fmt.Errorf("%s: %s", summary, d.Detail))
+			default:
+				errs = append(errs, errors.New(summary))
+			}
+		case proto.Diagnostic_WARNING:
+			lgr.V(1).Info("plugin warning", "summary", d.Summary, "detail", d.Detail, "attribute", d.Attribute)
+		case proto.Diagnostic_INVALID:
+			lgr.V(1).Info("plugin diagnostic with invalid severity", "summary", d.Summary, "detail", d.Detail, "attribute", d.Attribute)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // applyRequestContext decodes context data, iteration context, parameters,
@@ -357,7 +427,9 @@ func (s *GRPCServer) ExecuteProviderStream(req *proto.ExecuteProviderRequest, st
 		return stream.Send(&proto.ExecuteProviderStreamChunk{
 			Chunk: &proto.ExecuteProviderStreamChunk_Result{
 				Result: &proto.ExecuteProviderResponse{
-					Error: err.Error(),
+					Error:       err.Error(),
+					ExitCode:    safeIntToInt32(exitcode.GetCode(err)),
+					Diagnostics: errorToDiagnostics(err),
 				},
 			},
 		})
@@ -416,6 +488,15 @@ func (s *GRPCServer) ExtractDependencies(ctx context.Context, req *proto.Extract
 	}, nil
 }
 
+// StopProvider implements the StopProvider RPC
+func (s *GRPCServer) StopProvider(ctx context.Context, req *proto.StopProviderRequest) (*proto.StopProviderResponse, error) {
+	if err := s.Impl.StopProvider(ctx, req.ProviderName); err != nil {
+		//nolint:nilerr // Error is communicated via response, not gRPC error
+		return &proto.StopProviderResponse{Error: err.Error()}, nil
+	}
+	return &proto.StopProviderResponse{}, nil
+}
+
 // GRPCClient implements the gRPC client for the plugin
 type GRPCClient struct {
 	client        proto.PluginServiceClient
@@ -469,7 +550,16 @@ func (c *GRPCClient) ExecuteProvider(ctx context.Context, providerName string, i
 	}
 
 	if resp.Error != "" {
-		return nil, fmt.Errorf("provider execution failed: %s", resp.Error)
+		err := fmt.Errorf("provider execution failed: %s", resp.Error)
+		// Prefer diagnostics for richer context, fall back to plain error
+		if diagErr := diagnosticsToError(ctx, resp.Diagnostics); diagErr != nil {
+			err = diagErr
+		}
+		// Reconstruct ExitError when the plugin transmitted a non-zero exit code
+		if resp.ExitCode != 0 {
+			return nil, exitcode.WithCode(err, int(resp.ExitCode))
+		}
+		return nil, err
 	}
 
 	// Decode output
@@ -489,12 +579,13 @@ func (c *GRPCClient) ConfigureProvider(ctx context.Context, providerName string,
 	}
 
 	resp, err := c.client.ConfigureProvider(ctx, &proto.ConfigureProviderRequest{
-		ProviderName:  providerName,
-		HostServiceId: c.hostServiceID,
-		Quiet:         cfg.Quiet,
-		NoColor:       cfg.NoColor,
-		BinaryName:    cfg.BinaryName,
-		Settings:      protoSettings,
+		ProviderName:    providerName,
+		HostServiceId:   c.hostServiceID,
+		Quiet:           cfg.Quiet,
+		NoColor:         cfg.NoColor,
+		BinaryName:      cfg.BinaryName,
+		Settings:        protoSettings,
+		ProtocolVersion: PluginProtocolVersion,
 	})
 	if err != nil {
 		// Older plugins may not implement ConfigureProvider.
@@ -554,7 +645,16 @@ func (c *GRPCClient) ExecuteProviderStream(ctx context.Context, providerName str
 		case *proto.ExecuteProviderStreamChunk_Result:
 			if v.Result.Error != "" {
 				cb(StreamChunk{Error: v.Result.Error})
-				return fmt.Errorf("provider execution failed: %s", v.Result.Error)
+				err := fmt.Errorf("provider execution failed: %s", v.Result.Error)
+				// Prefer diagnostics for richer context, fall back to plain error
+				if diagErr := diagnosticsToError(ctx, v.Result.Diagnostics); diagErr != nil {
+					err = diagErr
+				}
+				// Reconstruct ExitError when the plugin transmitted a non-zero exit code
+				if v.Result.ExitCode != 0 {
+					return exitcode.WithCode(err, int(v.Result.ExitCode))
+				}
+				return err
 			}
 			var output provider.Output
 			if err := json.Unmarshal(v.Result.Output, &output); err != nil {
@@ -721,6 +821,24 @@ func (c *GRPCClient) ExtractDependencies(ctx context.Context, providerName strin
 	}
 
 	return resp.Dependencies, nil
+}
+
+// StopProvider implements ProviderPlugin.StopProvider
+func (c *GRPCClient) StopProvider(ctx context.Context, providerName string) error {
+	resp, err := c.client.StopProvider(ctx, &proto.StopProviderRequest{
+		ProviderName: providerName,
+	})
+	if err != nil {
+		// Older plugins may not implement StopProvider.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return nil
+		}
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("stop provider failed: %s", resp.Error)
+	}
+	return nil
 }
 
 // protoSchemaToJSON converts a proto.Schema to a jsonschema.Schema (structured

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,8 +13,11 @@ import (
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -26,21 +30,44 @@ const (
 type AuthHandlerGRPCPlugin struct {
 	plugin.Plugin
 	Impl AuthHandlerPlugin
+	// HostDeps holds host-side dependencies for the HostService callback server.
+	// Set by the host before starting the plugin. Nil on the plugin side.
+	HostDeps *HostServiceDeps
 }
 
 // GRPCServer registers the auth handler gRPC server.
 //
 //nolint:revive // broker is required by go-plugin interface
 func (p *AuthHandlerGRPCPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
-	proto.RegisterAuthHandlerServiceServer(s, &AuthHandlerGRPCServer{Impl: p.Impl})
+	proto.RegisterAuthHandlerServiceServer(s, &AuthHandlerGRPCServer{Impl: p.Impl, broker: broker})
 	return nil
 }
 
 // GRPCClient returns the auth handler gRPC client.
-//
-//nolint:revive // ctx and broker are required by go-plugin interface
+// If HostDeps is non-nil, a HostService gRPC server is started via the broker.
 func (p *AuthHandlerGRPCPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
-	return &AuthHandlerGRPCClient{client: proto.NewAuthHandlerServiceClient(c)}, nil
+	var hostServiceID uint32
+	if p.HostDeps != nil {
+		hostServiceID = broker.NextId()
+		deps := p.HostDeps
+		lgr := logger.FromContext(ctx)
+		// AcceptAndServe blocks until the broker connection is closed, which
+		// happens automatically when the plugin client is killed (Kill()).
+		// The goroutine therefore does not leak.
+		go func() {
+			broker.AcceptAndServe(hostServiceID, func(opts []grpc.ServerOption) *grpc.Server {
+				s := grpc.NewServer(opts...)
+				proto.RegisterHostServiceServer(s, &HostServiceServer{Deps: *deps})
+				return s
+			})
+			lgr.V(1).Info("auth handler HostService broker stopped", "serviceID", hostServiceID)
+		}()
+	}
+	return &AuthHandlerGRPCClient{
+		client:        proto.NewAuthHandlerServiceClient(c),
+		broker:        broker,
+		hostServiceID: hostServiceID,
+	}, nil
 }
 
 // ---- gRPC Server (runs inside the plugin process) ----
@@ -48,7 +75,8 @@ func (p *AuthHandlerGRPCPlugin) GRPCClient(ctx context.Context, broker *plugin.G
 // AuthHandlerGRPCServer implements the gRPC server for auth handler plugins.
 type AuthHandlerGRPCServer struct {
 	proto.UnimplementedAuthHandlerServiceServer
-	Impl AuthHandlerPlugin
+	Impl   AuthHandlerPlugin
+	broker *plugin.GRPCBroker
 }
 
 // GetAuthHandlers implements the GetAuthHandlers RPC.
@@ -185,11 +213,48 @@ func (s *AuthHandlerGRPCServer) PurgeExpiredTokens(ctx context.Context, req *pro
 	}, nil
 }
 
+// ConfigureAuthHandler implements the ConfigureAuthHandler RPC.
+func (s *AuthHandlerGRPCServer) ConfigureAuthHandler(ctx context.Context, req *proto.ConfigureAuthHandlerRequest) (*proto.ConfigureAuthHandlerResponse, error) {
+	settings := make(map[string]json.RawMessage, len(req.Settings))
+	for k, v := range req.Settings {
+		settings[k] = json.RawMessage(v)
+	}
+
+	cfg := ProviderConfig{
+		Quiet:      req.Quiet,
+		NoColor:    req.NoColor,
+		BinaryName: req.BinaryName,
+		Settings:   settings,
+	}
+	if req.HostServiceId != 0 && s.broker != nil {
+		cfg.HostServiceID = req.HostServiceId
+	}
+
+	if err := s.Impl.ConfigureAuthHandler(ctx, req.HandlerName, cfg); err != nil {
+		//nolint:nilerr // Error is communicated via response, not gRPC error
+		return &proto.ConfigureAuthHandlerResponse{Error: err.Error()}, nil
+	}
+	return &proto.ConfigureAuthHandlerResponse{
+		ProtocolVersion: PluginProtocolVersion,
+	}, nil
+}
+
+// StopAuthHandler implements the StopAuthHandler RPC.
+func (s *AuthHandlerGRPCServer) StopAuthHandler(ctx context.Context, req *proto.StopAuthHandlerRequest) (*proto.StopAuthHandlerResponse, error) {
+	if err := s.Impl.StopAuthHandler(ctx, req.HandlerName); err != nil {
+		//nolint:nilerr // Error is communicated via response, not gRPC error
+		return &proto.StopAuthHandlerResponse{Error: err.Error()}, nil
+	}
+	return &proto.StopAuthHandlerResponse{}, nil
+}
+
 // ---- gRPC Client (runs in the scafctl host process) ----
 
 // AuthHandlerGRPCClient implements AuthHandlerPlugin by calling the gRPC service.
 type AuthHandlerGRPCClient struct {
-	client proto.AuthHandlerServiceClient
+	client        proto.AuthHandlerServiceClient
+	broker        *plugin.GRPCBroker
+	hostServiceID uint32
 }
 
 // GetAuthHandlers implements AuthHandlerPlugin.GetAuthHandlers.
@@ -310,6 +375,53 @@ func (c *AuthHandlerGRPCClient) PurgeExpiredTokens(ctx context.Context, handlerN
 		return 0, err
 	}
 	return int(resp.PurgedCount), nil
+}
+
+// ConfigureAuthHandler implements AuthHandlerPlugin.ConfigureAuthHandler.
+func (c *AuthHandlerGRPCClient) ConfigureAuthHandler(ctx context.Context, handlerName string, cfg ProviderConfig) error {
+	protoSettings := make(map[string][]byte, len(cfg.Settings))
+	for k, v := range cfg.Settings {
+		protoSettings[k] = []byte(v)
+	}
+
+	resp, err := c.client.ConfigureAuthHandler(ctx, &proto.ConfigureAuthHandlerRequest{
+		HandlerName:     handlerName,
+		Quiet:           cfg.Quiet,
+		NoColor:         cfg.NoColor,
+		BinaryName:      cfg.BinaryName,
+		HostServiceId:   c.hostServiceID,
+		Settings:        protoSettings,
+		ProtocolVersion: PluginProtocolVersion,
+	})
+	if err != nil {
+		// Older plugins may not implement ConfigureAuthHandler.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return nil
+		}
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("configure auth handler failed: %s", resp.Error)
+	}
+	return nil
+}
+
+// StopAuthHandler implements AuthHandlerPlugin.StopAuthHandler.
+func (c *AuthHandlerGRPCClient) StopAuthHandler(ctx context.Context, handlerName string) error {
+	resp, err := c.client.StopAuthHandler(ctx, &proto.StopAuthHandlerRequest{
+		HandlerName: handlerName,
+	})
+	if err != nil {
+		// Older plugins may not implement StopAuthHandler.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return nil
+		}
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("stop auth handler failed: %s", resp.Error)
+	}
+	return nil
 }
 
 // ---- Conversion helpers ----

--- a/pkg/plugin/grpc_host.go
+++ b/pkg/plugin/grpc_host.go
@@ -60,6 +60,10 @@ type HostServiceDeps struct {
 	// AuthHandlersFunc returns available auth handler names and the default handler.
 	// May be nil if auth is unavailable.
 	AuthHandlersFunc func(ctx context.Context) (handlers []string, defaultHandler string, err error) `json:"-" yaml:"-" doc:"Auth handlers callback (not serialized)."`
+	// AuthTokenFunc retrieves a valid access token from the host's auth registry.
+	// Plugins call this for authenticated HTTP requests and token refresh on 401.
+	// May be nil if auth is unavailable.
+	AuthTokenFunc func(ctx context.Context, handler, scope string, minValidFor int64, forceRefresh bool) (*proto.GetAuthTokenResponse, error) `json:"-" yaml:"-" doc:"Auth token callback (not serialized)."`
 }
 
 // isSecretAllowed checks whether the given secret name is within the allowed
@@ -72,11 +76,15 @@ func (d *HostServiceDeps) isSecretAllowed(name string) bool {
 }
 
 // isAuthHandlerAllowed checks whether the given handler name is in the
-// AllowedAuthHandlers list. Returns true when no restriction is configured
-// or when handler is empty (default handler).
+// AllowedAuthHandlers list. Returns true when no restriction is configured.
+// When an allowlist is configured, an empty handler name is rejected to
+// prevent bypassing the restriction via the default handler.
 func (d *HostServiceDeps) isAuthHandlerAllowed(handler string) bool {
-	if len(d.AllowedAuthHandlers) == 0 || handler == "" {
+	if len(d.AllowedAuthHandlers) == 0 {
 		return true
+	}
+	if handler == "" {
+		return false
 	}
 	for _, h := range d.AllowedAuthHandlers {
 		if h == handler {
@@ -274,10 +282,54 @@ func (h *HostServiceServer) ListAuthHandlers(ctx context.Context, _ *proto.ListA
 		return &proto.ListAuthHandlersResponse{}, nil
 	}
 
+	// Filter handlers to only those allowed for this plugin. This prevents
+	// plugins from discovering handler names they are not permitted to use.
+	if len(h.Deps.AllowedAuthHandlers) > 0 {
+		allowed := make(map[string]struct{}, len(h.Deps.AllowedAuthHandlers))
+		for _, a := range h.Deps.AllowedAuthHandlers {
+			allowed[a] = struct{}{}
+		}
+		filtered := make([]string, 0, len(handlers))
+		for _, name := range handlers {
+			if _, ok := allowed[name]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		handlers = filtered
+		// Redact default handler if not in allowed set
+		if _, ok := allowed[defaultHandler]; !ok {
+			defaultHandler = ""
+		}
+	}
+
 	return &proto.ListAuthHandlersResponse{
 		HandlerNames:   handlers,
 		DefaultHandler: defaultHandler,
 	}, nil
+}
+
+// GetAuthToken implements HostService.GetAuthToken
+func (h *HostServiceServer) GetAuthToken(ctx context.Context, req *proto.GetAuthTokenRequest) (*proto.GetAuthTokenResponse, error) {
+	if h.Deps.AuthTokenFunc == nil {
+		return &proto.GetAuthTokenResponse{
+			Error: "auth token service not available",
+		}, nil
+	}
+
+	if !h.Deps.isAuthHandlerAllowed(req.HandlerName) {
+		return &proto.GetAuthTokenResponse{
+			Error: fmt.Sprintf("access denied: auth handler %q is not in the allowed set", req.HandlerName),
+		}, nil
+	}
+
+	resp, err := h.Deps.AuthTokenFunc(ctx, req.HandlerName, req.Scope, req.MinValidForSeconds, req.ForceRefresh)
+	if err != nil {
+		return &proto.GetAuthTokenResponse{
+			Error: fmt.Sprintf("get auth token: %v", err),
+		}, nil
+	}
+
+	return resp, nil
 }
 
 // HostServiceClient wraps the HostService gRPC client (used by plugins).
@@ -361,4 +413,21 @@ func (c *HostServiceClient) ListAuthHandlers(ctx context.Context) (handlers []st
 		return nil, "", fmt.Errorf("host ListAuthHandlers: %w", err)
 	}
 	return resp.HandlerNames, resp.DefaultHandler, nil
+}
+
+// GetAuthToken retrieves a valid access token from the host's auth registry.
+func (c *HostServiceClient) GetAuthToken(ctx context.Context, handler, scope string, minValidFor int64, forceRefresh bool) (*proto.GetAuthTokenResponse, error) {
+	resp, err := c.client.GetAuthToken(ctx, &proto.GetAuthTokenRequest{
+		HandlerName:        handler,
+		Scope:              scope,
+		MinValidForSeconds: minValidFor,
+		ForceRefresh:       forceRefresh,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("host GetAuthToken: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("host GetAuthToken: %s", resp.Error)
+	}
+	return resp, nil
 }

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/plugin/proto"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
@@ -810,12 +811,13 @@ func TestHostServiceServer_AuthHandlerRestriction(t *testing.T) {
 	assert.Contains(t, resp.Error, "access denied")
 	assert.False(t, called)
 
-	// Empty handler (default) is always allowed
+	// Empty handler is denied when an allowlist is configured (prevents
+	// bypassing the restriction via the default handler).
 	called = false
 	resp, err = server.GetAuthIdentity(ctx, &proto.GetAuthIdentityRequest{HandlerName: "", Scope: "read"})
 	require.NoError(t, err)
-	assert.Empty(t, resp.Error)
-	assert.True(t, called)
+	assert.Contains(t, resp.Error, "access denied")
+	assert.False(t, called)
 }
 
 func TestHostServiceServer_SecretNameValidation(t *testing.T) {
@@ -980,4 +982,314 @@ func BenchmarkValidateSecretName(b *testing.B) {
 			_ = validateSecretName("../etc/passwd")
 		}
 	})
+}
+
+func TestExitCode_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name         string
+		execErr      error
+		wantExitCode int32
+		wantErrMsg   string
+	}{
+		{
+			name:         "ExitError with ActionFailed code",
+			execErr:      exitcode.WithCode(fmt.Errorf("deploy failed"), exitcode.ActionFailed),
+			wantExitCode: int32(exitcode.ActionFailed),
+			wantErrMsg:   "deploy failed",
+		},
+		{
+			name:         "ExitError with ValidationFailed code",
+			execErr:      exitcode.WithCode(fmt.Errorf("bad input"), exitcode.ValidationFailed),
+			wantExitCode: int32(exitcode.ValidationFailed),
+			wantErrMsg:   "bad input",
+		},
+		{
+			name:         "plain error gets GeneralError code",
+			execErr:      fmt.Errorf("something went wrong"),
+			wantExitCode: int32(exitcode.GeneralError),
+			wantErrMsg:   "something went wrong",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockProviderPlugin{
+				execFunc: func(_ context.Context, _ string, _ map[string]any) (*provider.Output, error) {
+					return nil, tt.execErr
+				},
+			}
+			server := &GRPCServer{Impl: mock}
+
+			inputBytes, err := json.Marshal(map[string]any{"key": "value"})
+			require.NoError(t, err)
+
+			resp, err := server.ExecuteProvider(context.Background(), &proto.ExecuteProviderRequest{
+				ProviderName: "test-provider",
+				Input:        inputBytes,
+			})
+			require.NoError(t, err, "gRPC-level error should be nil")
+			assert.NotEmpty(t, resp.Error)
+			assert.Equal(t, tt.wantExitCode, resp.ExitCode)
+			assert.Contains(t, resp.Error, tt.wantErrMsg)
+			assert.NotEmpty(t, resp.Diagnostics, "diagnostics should be populated")
+			assert.Equal(t, proto.Diagnostic_ERROR, resp.Diagnostics[0].Severity)
+		})
+	}
+}
+
+func TestExitCode_ClientReconstruction(t *testing.T) {
+	// Test that the client reconstructs ExitError from the response
+	mock := &MockProviderPlugin{
+		execFunc: func(_ context.Context, _ string, _ map[string]any) (*provider.Output, error) {
+			return nil, exitcode.WithCode(fmt.Errorf("action failed"), exitcode.ActionFailed)
+		},
+	}
+	server := &GRPCServer{Impl: mock}
+
+	inputBytes, err := json.Marshal(map[string]any{"key": "value"})
+	require.NoError(t, err)
+
+	resp, err := server.ExecuteProvider(context.Background(), &proto.ExecuteProviderRequest{
+		ProviderName: "test-provider",
+		Input:        inputBytes,
+	})
+	require.NoError(t, err)
+
+	// Simulate client-side reconstruction
+	assert.NotEmpty(t, resp.Error)
+	assert.Equal(t, int32(exitcode.ActionFailed), resp.ExitCode)
+
+	// Verify the client would reconstruct an ExitError
+	clientErr := fmt.Errorf("provider execution failed: %s", resp.Error)
+	if resp.ExitCode != 0 {
+		clientErr = exitcode.WithCode(clientErr, int(resp.ExitCode))
+	}
+	assert.Equal(t, exitcode.ActionFailed, exitcode.GetCode(clientErr))
+}
+
+func TestDiagnostics_ErrorConversion(t *testing.T) {
+	tests := []struct {
+		name  string
+		diags []*proto.Diagnostic
+		want  string
+	}{
+		{
+			name:  "nil diagnostics",
+			diags: nil,
+			want:  "",
+		},
+		{
+			name: "error with detail",
+			diags: []*proto.Diagnostic{
+				{
+					Severity: proto.Diagnostic_ERROR,
+					Summary:  "validation failed",
+					Detail:   "field 'url' is required",
+				},
+			},
+			want: "validation failed: field 'url' is required",
+		},
+		{
+			name: "error with attribute and detail",
+			diags: []*proto.Diagnostic{
+				{
+					Severity:  proto.Diagnostic_ERROR,
+					Summary:   "invalid value",
+					Detail:    "must be a valid URL",
+					Attribute: "config.url",
+				},
+			},
+			want: "invalid value: must be a valid URL (attribute: config.url)",
+		},
+		{
+			name: "error with attribute but no detail",
+			diags: []*proto.Diagnostic{
+				{
+					Severity:  proto.Diagnostic_ERROR,
+					Summary:   "missing field",
+					Attribute: "config.url",
+				},
+			},
+			want: "missing field (attribute: config.url)",
+		},
+		{
+			name: "warnings only produce no error",
+			diags: []*proto.Diagnostic{
+				{
+					Severity: proto.Diagnostic_WARNING,
+					Summary:  "deprecated field",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "multiple errors joined",
+			diags: []*proto.Diagnostic{
+				{
+					Severity: proto.Diagnostic_ERROR,
+					Summary:  "error one",
+				},
+				{
+					Severity: proto.Diagnostic_ERROR,
+					Summary:  "error two",
+				},
+			},
+			want: "error one\nerror two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := diagnosticsToError(context.Background(), tt.diags)
+			if tt.want == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tt.want, err.Error())
+			}
+		})
+	}
+}
+
+func TestDiagnostics_ErrorToDiagnostics(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.Nil(t, errorToDiagnostics(nil))
+	})
+
+	t.Run("plain error", func(t *testing.T) {
+		diags := errorToDiagnostics(fmt.Errorf("something failed"))
+		require.Len(t, diags, 1)
+		assert.Equal(t, proto.Diagnostic_ERROR, diags[0].Severity)
+		assert.Equal(t, "something failed", diags[0].Summary)
+		assert.Empty(t, diags[0].Detail)
+	})
+
+	t.Run("ExitError includes code description", func(t *testing.T) {
+		diags := errorToDiagnostics(exitcode.WithCode(fmt.Errorf("timeout"), exitcode.TimeoutError))
+		require.Len(t, diags, 1)
+		assert.Equal(t, proto.Diagnostic_ERROR, diags[0].Severity)
+		assert.Contains(t, diags[0].Detail, "exit code 9")
+		assert.Contains(t, diags[0].Detail, "timeout")
+	})
+}
+
+func TestListAuthHandlers_Filtered(t *testing.T) {
+	tests := []struct {
+		name            string
+		allHandlers     []string
+		defaultHandler  string
+		allowedHandlers []string
+		wantHandlers    []string
+		wantDefault     string
+	}{
+		{
+			name:            "no restrictions returns all",
+			allHandlers:     []string{"entra", "gcp", "github"},
+			defaultHandler:  "entra",
+			allowedHandlers: nil,
+			wantHandlers:    []string{"entra", "gcp", "github"},
+			wantDefault:     "entra",
+		},
+		{
+			name:            "filters to allowed set",
+			allHandlers:     []string{"entra", "gcp", "github"},
+			defaultHandler:  "entra",
+			allowedHandlers: []string{"entra", "github"},
+			wantHandlers:    []string{"entra", "github"},
+			wantDefault:     "entra",
+		},
+		{
+			name:            "redacts default when not allowed",
+			allHandlers:     []string{"entra", "gcp", "github"},
+			defaultHandler:  "gcp",
+			allowedHandlers: []string{"entra"},
+			wantHandlers:    []string{"entra"},
+			wantDefault:     "",
+		},
+		{
+			name:            "empty allowed with restrictions returns none",
+			allHandlers:     []string{"entra", "gcp"},
+			defaultHandler:  "entra",
+			allowedHandlers: []string{"nonexistent"},
+			wantHandlers:    []string{},
+			wantDefault:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &HostServiceServer{
+				Deps: HostServiceDeps{
+					AllowedAuthHandlers: tt.allowedHandlers,
+					AuthHandlersFunc: func(_ context.Context) ([]string, string, error) {
+						return tt.allHandlers, tt.defaultHandler, nil
+					},
+				},
+			}
+
+			resp, err := server.ListAuthHandlers(context.Background(), &proto.ListAuthHandlersRequest{})
+			require.NoError(t, err)
+
+			if len(tt.wantHandlers) == 0 {
+				assert.Empty(t, resp.HandlerNames)
+			} else {
+				assert.Equal(t, tt.wantHandlers, resp.HandlerNames)
+			}
+			assert.Equal(t, tt.wantDefault, resp.DefaultHandler)
+		})
+	}
+}
+
+func TestDescriptorCache(t *testing.T) {
+	callCount := 0
+	mock := &MockProviderPlugin{
+		descriptors: map[string]*provider.Descriptor{
+			"cached-provider": {
+				Name:        "cached-provider",
+				DisplayName: "Cached",
+				Description: "Test descriptor caching",
+				APIVersion:  "v1",
+			},
+		},
+	}
+	// Wrap mock to count calls
+	originalGetDesc := mock.GetProviderDescriptor
+	countingPlugin := &countingDescriptorPlugin{
+		ProviderPlugin: mock,
+		getDescFn:      originalGetDesc,
+		callCount:      &callCount,
+	}
+
+	client := &Client{
+		plugin: countingPlugin,
+		name:   "test",
+	}
+
+	// First call should hit the plugin
+	desc1, err := client.GetProviderDescriptor(context.Background(), "cached-provider")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-provider", desc1.Name)
+	assert.Equal(t, 1, callCount)
+
+	// Second call should return cached result
+	desc2, err := client.GetProviderDescriptor(context.Background(), "cached-provider")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-provider", desc2.Name)
+	assert.Equal(t, 1, callCount, "second call should use cache")
+
+	// Different provider should still call plugin
+	_, _ = client.GetProviderDescriptor(context.Background(), "other-provider")
+	assert.Equal(t, 2, callCount, "different provider should hit plugin")
+}
+
+// countingDescriptorPlugin wraps ProviderPlugin to count GetProviderDescriptor calls.
+type countingDescriptorPlugin struct {
+	ProviderPlugin
+	getDescFn func(ctx context.Context, name string) (*provider.Descriptor, error)
+	callCount *int
+}
+
+func (c *countingDescriptorPlugin) GetProviderDescriptor(ctx context.Context, name string) (*provider.Descriptor, error) {
+	*c.callCount++
+	return c.getDescFn(ctx, name)
 }

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -75,6 +75,11 @@ type ProviderPlugin interface {
 	// inputs. Plugins that do not implement custom extraction should return
 	// nil. The host falls back to generic extraction when the result is nil.
 	ExtractDependencies(ctx context.Context, providerName string, inputs map[string]any) ([]string, error)
+
+	// StopProvider requests graceful shutdown of a running provider execution.
+	// providerName may be empty to stop all providers. Plugins that do not
+	// support graceful shutdown may return nil immediately.
+	StopProvider(ctx context.Context, providerName string) error
 }
 
 // ErrStreamingNotSupported is returned by ExecuteProviderStream when the plugin
@@ -142,6 +147,11 @@ type AuthHandlerPlugin interface {
 	// GetAuthHandlers returns metadata for all auth handlers exposed by this plugin.
 	GetAuthHandlers(ctx context.Context) ([]AuthHandlerInfo, error)
 
+	// ConfigureAuthHandler sends host-side configuration to the plugin once
+	// after load. Implementations store the config internally for subsequent
+	// calls. Plugins that do not need configuration may return nil.
+	ConfigureAuthHandler(ctx context.Context, handlerName string, cfg ProviderConfig) error
+
 	// Login initiates authentication for the named handler.
 	// The callback, if non-nil, is invoked when the plugin sends a device-code prompt.
 	Login(ctx context.Context, handlerName string, req LoginRequest, deviceCodeCb func(DeviceCodePrompt)) (*LoginResponse, error)
@@ -163,6 +173,11 @@ type AuthHandlerPlugin interface {
 	// Returns the number of tokens removed and an error if the handler
 	// does not support token purging.
 	PurgeExpiredTokens(ctx context.Context, handlerName string) (int, error)
+
+	// StopAuthHandler requests graceful shutdown of a running auth handler
+	// operation. handlerName may be empty to stop all handlers. Plugins that
+	// do not support graceful shutdown may return nil immediately.
+	StopAuthHandler(ctx context.Context, handlerName string) error
 }
 
 // HandshakeConfig is used to verify provider plugin compatibility.
@@ -171,6 +186,10 @@ var HandshakeConfig = &HandshakeConfigData{
 	MagicCookieKey:   "SCAFCTL_PLUGIN",
 	MagicCookieValue: "scafctl_provider_plugin",
 }
+
+// PluginProtocolVersion is the current plugin protocol version exchanged
+// during ConfigureProvider. Plugins compare this to detect feature availability.
+const PluginProtocolVersion int32 = 2
 
 // AuthHandlerHandshakeConfig is used to verify auth handler plugin compatibility.
 var AuthHandlerHandshakeConfig = &HandshakeConfigData{

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -17,13 +17,18 @@ import (
 
 // MockAuthHandlerPlugin implements AuthHandlerPlugin for testing.
 type MockAuthHandlerPlugin struct {
-	handlers   []AuthHandlerInfo
-	loginFunc  func(ctx context.Context, name string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
-	logoutFunc func(ctx context.Context, name string) error
-	statusFunc func(ctx context.Context, name string) (*auth.Status, error)
-	tokenFunc  func(ctx context.Context, name string, req TokenRequest) (*TokenResponse, error)
-	listFunc   func(ctx context.Context, name string) ([]*auth.CachedTokenInfo, error)
-	purgeFunc  func(ctx context.Context, name string) (int, error)
+	handlers     []AuthHandlerInfo
+	loginFunc    func(ctx context.Context, name string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
+	logoutFunc   func(ctx context.Context, name string) error
+	statusFunc   func(ctx context.Context, name string) (*auth.Status, error)
+	tokenFunc    func(ctx context.Context, name string, req TokenRequest) (*TokenResponse, error)
+	listFunc     func(ctx context.Context, name string) ([]*auth.CachedTokenInfo, error)
+	purgeFunc    func(ctx context.Context, name string) (int, error)
+	configureErr error
+	lastConfig   *ProviderConfig
+	stopErr      error
+	stopCalled   bool
+	stopHandler  string
 }
 
 func (m *MockAuthHandlerPlugin) GetAuthHandlers(ctx context.Context) ([]AuthHandlerInfo, error) {
@@ -120,6 +125,19 @@ func (m *MockAuthHandlerPlugin) PurgeExpiredTokens(ctx context.Context, handlerN
 		return m.purgeFunc(ctx, handlerName)
 	}
 	return 0, nil
+}
+
+//nolint:revive // all params required by interface
+func (m *MockAuthHandlerPlugin) ConfigureAuthHandler(_ context.Context, _ string, cfg ProviderConfig) error {
+	m.lastConfig = &cfg
+	return m.configureErr
+}
+
+//nolint:revive // all params required by interface
+func (m *MockAuthHandlerPlugin) StopAuthHandler(_ context.Context, handlerName string) error {
+	m.stopCalled = true
+	m.stopHandler = handlerName
+	return m.stopErr
 }
 
 func TestAuthHandlerGRPC_GetAuthHandlers(t *testing.T) {
@@ -513,4 +531,160 @@ func TestAuthHandlerWrapper_Interface(t *testing.T) {
 func TestNilClaimsConversion(t *testing.T) {
 	assert.Nil(t, claimsToProto(nil))
 	assert.Nil(t, protoToClaims(nil))
+}
+
+// ── ConfigureAuthHandler gRPC server/client tests ─────────────────────────────
+
+func TestAuthHandlerGRPCServer_ConfigureAuthHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		configureErr error
+		wantErr      string
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:         "plugin returns error",
+			configureErr: assert.AnError,
+			wantErr:      assert.AnError.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &MockAuthHandlerPlugin{
+				configureErr: tt.configureErr,
+			}
+			server := &AuthHandlerGRPCServer{Impl: mock}
+
+			resp, err := server.ConfigureAuthHandler(context.Background(), &proto.ConfigureAuthHandlerRequest{
+				HandlerName:     "test-handler",
+				Quiet:           true,
+				NoColor:         true,
+				BinaryName:      "mycli",
+				ProtocolVersion: PluginProtocolVersion,
+				Settings: map[string][]byte{
+					"timeout": []byte(`30`),
+				},
+			})
+			require.NoError(t, err)
+
+			if tt.wantErr != "" {
+				assert.Contains(t, resp.Error, tt.wantErr)
+				return
+			}
+
+			assert.Empty(t, resp.Error)
+			assert.Equal(t, PluginProtocolVersion, resp.ProtocolVersion)
+			require.NotNil(t, mock.lastConfig)
+			assert.True(t, mock.lastConfig.Quiet)
+			assert.True(t, mock.lastConfig.NoColor)
+			assert.Equal(t, "mycli", mock.lastConfig.BinaryName)
+			assert.Contains(t, mock.lastConfig.Settings, "timeout")
+		})
+	}
+}
+
+func TestAuthHandlerGRPCServer_ConfigureAuthHandler_NoBroker(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	resp, err := server.ConfigureAuthHandler(context.Background(), &proto.ConfigureAuthHandlerRequest{
+		HandlerName:   "test-handler",
+		HostServiceId: 99,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+	// Without a broker, HostServiceID should not be passed through.
+	require.NotNil(t, mock.lastConfig)
+	assert.Equal(t, uint32(0), mock.lastConfig.HostServiceID)
+}
+
+// ── StopAuthHandler gRPC server/client tests ──────────────────────────────────
+
+func TestAuthHandlerGRPCServer_StopAuthHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stopErr error
+		wantErr string
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:    "plugin returns error",
+			stopErr: assert.AnError,
+			wantErr: assert.AnError.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &MockAuthHandlerPlugin{
+				stopErr: tt.stopErr,
+			}
+			server := &AuthHandlerGRPCServer{Impl: mock}
+
+			resp, err := server.StopAuthHandler(context.Background(), &proto.StopAuthHandlerRequest{
+				HandlerName: "test-handler",
+			})
+			require.NoError(t, err)
+
+			if tt.wantErr != "" {
+				assert.Contains(t, resp.Error, tt.wantErr)
+				return
+			}
+
+			assert.Empty(t, resp.Error)
+			assert.True(t, mock.stopCalled)
+			assert.Equal(t, "test-handler", mock.stopHandler)
+		})
+	}
+}
+
+// ── KillAllAuthHandlers tests ─────────────────────────────────────────────────
+
+func TestKillAllAuthHandlers_NilSlice(t *testing.T) {
+	t.Parallel()
+	KillAllAuthHandlers(nil)
+}
+
+func TestKillAllAuthHandlers_EmptySlice(t *testing.T) {
+	t.Parallel()
+	KillAllAuthHandlers([]*AuthHandlerClient{})
+}
+
+// ── AuthHandlerClient.HostServiceID tests ─────────────────────────────────────
+
+func TestAuthHandlerClient_HostServiceID_NonGRPC(t *testing.T) {
+	t.Parallel()
+
+	// When the underlying plugin is not a GRPCClient, HostServiceID returns 0.
+	client := &AuthHandlerClient{
+		plugin: &MockAuthHandlerPlugin{},
+	}
+	assert.Equal(t, uint32(0), client.HostServiceID())
+}
+
+func TestAuthHandlerClient_HostServiceID_GRPCClient(t *testing.T) {
+	t.Parallel()
+
+	grpcClient := &AuthHandlerGRPCClient{
+		hostServiceID: 42,
+	}
+	client := &AuthHandlerClient{
+		plugin: grpcClient,
+	}
+	assert.Equal(t, uint32(42), client.HostServiceID())
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -95,6 +95,10 @@ func (m *MockProviderPlugin) ExtractDependencies(ctx context.Context, name strin
 	return nil, nil
 }
 
+func (m *MockProviderPlugin) StopProvider(_ context.Context, _ string) error {
+	return nil
+}
+
 func TestGRPCPlugin_ServerClient(t *testing.T) {
 	mock := &MockProviderPlugin{}
 

--- a/pkg/plugin/proto/plugin.pb.go
+++ b/pkg/plugin/proto/plugin.pb.go
@@ -21,6 +21,55 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type Diagnostic_Severity int32
+
+const (
+	Diagnostic_INVALID Diagnostic_Severity = 0
+	Diagnostic_ERROR   Diagnostic_Severity = 1
+	Diagnostic_WARNING Diagnostic_Severity = 2
+)
+
+// Enum value maps for Diagnostic_Severity.
+var (
+	Diagnostic_Severity_name = map[int32]string{
+		0: "INVALID",
+		1: "ERROR",
+		2: "WARNING",
+	}
+	Diagnostic_Severity_value = map[string]int32{
+		"INVALID": 0,
+		"ERROR":   1,
+		"WARNING": 2,
+	}
+)
+
+func (x Diagnostic_Severity) Enum() *Diagnostic_Severity {
+	p := new(Diagnostic_Severity)
+	*p = x
+	return p
+}
+
+func (x Diagnostic_Severity) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Diagnostic_Severity) Descriptor() protoreflect.EnumDescriptor {
+	return file_pkg_plugin_proto_plugin_proto_enumTypes[0].Descriptor()
+}
+
+func (Diagnostic_Severity) Type() protoreflect.EnumType {
+	return &file_pkg_plugin_proto_plugin_proto_enumTypes[0]
+}
+
+func (x Diagnostic_Severity) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Diagnostic_Severity.Descriptor instead.
+func (Diagnostic_Severity) EnumDescriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{16, 0}
+}
+
 type GetProvidersRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -949,8 +998,11 @@ type ConfigureProviderRequest struct {
 	BinaryName    string                 `protobuf:"bytes,4,opt,name=binary_name,json=binaryName,proto3" json:"binary_name,omitempty"`
 	HostServiceId uint32                 `protobuf:"varint,5,opt,name=host_service_id,json=hostServiceId,proto3" json:"host_service_id,omitempty"`                                         // GRPCBroker service ID for HostService callbacks
 	Settings      map[string][]byte      `protobuf:"bytes,6,rep,name=settings,proto3" json:"settings,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Extensible JSON-encoded key-value settings
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// protocol_version is the host's plugin protocol version. Plugins can use
+	// this to detect feature availability and fail clearly on incompatible hosts.
+	ProtocolVersion int32 `protobuf:"varint,7,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ConfigureProviderRequest) Reset() {
@@ -1025,11 +1077,22 @@ func (x *ConfigureProviderRequest) GetSettings() map[string][]byte {
 	return nil
 }
 
+func (x *ConfigureProviderRequest) GetProtocolVersion() int32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
 type ConfigureProviderResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Error         string                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"` // Empty if no error
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Error       string                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"` // Empty if no error
+	Diagnostics []*Diagnostic          `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	// protocol_version is the plugin's protocol version. The host can use this
+	// to detect feature availability. If unset (0), the plugin predates version negotiation.
+	ProtocolVersion int32 `protobuf:"varint,3,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ConfigureProviderResponse) Reset() {
@@ -1067,6 +1130,20 @@ func (x *ConfigureProviderResponse) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *ConfigureProviderResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+func (x *ConfigureProviderResponse) GetProtocolVersion() int32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
 }
 
 // SolutionMeta carries solution-level metadata to plugin providers.
@@ -1323,17 +1400,95 @@ func (*ExecuteProviderStreamChunk_Stderr) isExecuteProviderStreamChunk_Chunk() {
 
 func (*ExecuteProviderStreamChunk_Result) isExecuteProviderStreamChunk_Chunk() {}
 
-type ExecuteProviderResponse struct {
+// Diagnostic represents a single warning or error from a provider execution,
+// following the Terraform diagnostic pattern. Providers can return multiple
+// diagnostics alongside a result.
+type Diagnostic struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Output        []byte                 `protobuf:"bytes,1,opt,name=output,proto3" json:"output,omitempty"` // JSON-encoded output (ProviderOutput)
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`   // Empty if no error
+	Severity      Diagnostic_Severity    `protobuf:"varint,1,opt,name=severity,proto3,enum=plugin.Diagnostic_Severity" json:"severity,omitempty"`
+	Summary       string                 `protobuf:"bytes,2,opt,name=summary,proto3" json:"summary,omitempty"`     // Short one-line description (always present)
+	Detail        string                 `protobuf:"bytes,3,opt,name=detail,proto3" json:"detail,omitempty"`       // Optional multi-line explanation
+	Attribute     string                 `protobuf:"bytes,4,opt,name=attribute,proto3" json:"attribute,omitempty"` // Optional dotted attribute path (e.g. "config.url")
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Diagnostic) Reset() {
+	*x = Diagnostic{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Diagnostic) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Diagnostic) ProtoMessage() {}
+
+func (x *Diagnostic) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Diagnostic.ProtoReflect.Descriptor instead.
+func (*Diagnostic) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *Diagnostic) GetSeverity() Diagnostic_Severity {
+	if x != nil {
+		return x.Severity
+	}
+	return Diagnostic_INVALID
+}
+
+func (x *Diagnostic) GetSummary() string {
+	if x != nil {
+		return x.Summary
+	}
+	return ""
+}
+
+func (x *Diagnostic) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+func (x *Diagnostic) GetAttribute() string {
+	if x != nil {
+		return x.Attribute
+	}
+	return ""
+}
+
+type ExecuteProviderResponse struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Output []byte                 `protobuf:"bytes,1,opt,name=output,proto3" json:"output,omitempty"` // JSON-encoded output (ProviderOutput)
+	Error  string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`   // Empty if no error (DEPRECATED: prefer diagnostics)
+	// exit_code carries the provider's exit code so that ExitError semantics
+	// survive the RPC boundary. 0 = success, non-zero mirrors exitcode constants.
+	// Only meaningful when error is non-empty.
+	ExitCode int32 `protobuf:"varint,3,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	// diagnostics carries structured warnings and errors from the provider.
+	// When present, prefer these over the flat error string.
+	Diagnostics   []*Diagnostic `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecuteProviderResponse) Reset() {
 	*x = ExecuteProviderResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[16]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1345,7 +1500,7 @@ func (x *ExecuteProviderResponse) String() string {
 func (*ExecuteProviderResponse) ProtoMessage() {}
 
 func (x *ExecuteProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[16]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1358,7 +1513,7 @@ func (x *ExecuteProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteProviderResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteProviderResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{16}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ExecuteProviderResponse) GetOutput() []byte {
@@ -1375,6 +1530,20 @@ func (x *ExecuteProviderResponse) GetError() string {
 	return ""
 }
 
+func (x *ExecuteProviderResponse) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+func (x *ExecuteProviderResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
 type DescribeWhatIfRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProviderName  string                 `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"`
@@ -1385,7 +1554,7 @@ type DescribeWhatIfRequest struct {
 
 func (x *DescribeWhatIfRequest) Reset() {
 	*x = DescribeWhatIfRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[17]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1397,7 +1566,7 @@ func (x *DescribeWhatIfRequest) String() string {
 func (*DescribeWhatIfRequest) ProtoMessage() {}
 
 func (x *DescribeWhatIfRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[17]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1410,7 +1579,7 @@ func (x *DescribeWhatIfRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DescribeWhatIfRequest.ProtoReflect.Descriptor instead.
 func (*DescribeWhatIfRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{17}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DescribeWhatIfRequest) GetProviderName() string {
@@ -1431,13 +1600,14 @@ type DescribeWhatIfResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Description   string                 `protobuf:"bytes,1,opt,name=description,proto3" json:"description,omitempty"` // Human-readable WhatIf description (empty if not implemented)
 	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`             // Empty if no error
+	Diagnostics   []*Diagnostic          `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DescribeWhatIfResponse) Reset() {
 	*x = DescribeWhatIfResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[18]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1449,7 +1619,7 @@ func (x *DescribeWhatIfResponse) String() string {
 func (*DescribeWhatIfResponse) ProtoMessage() {}
 
 func (x *DescribeWhatIfResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[18]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1462,7 +1632,7 @@ func (x *DescribeWhatIfResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DescribeWhatIfResponse.ProtoReflect.Descriptor instead.
 func (*DescribeWhatIfResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{18}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DescribeWhatIfResponse) GetDescription() string {
@@ -1479,6 +1649,13 @@ func (x *DescribeWhatIfResponse) GetError() string {
 	return ""
 }
 
+func (x *DescribeWhatIfResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
 type ExtractDependenciesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProviderName  string                 `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"`
@@ -1489,7 +1666,7 @@ type ExtractDependenciesRequest struct {
 
 func (x *ExtractDependenciesRequest) Reset() {
 	*x = ExtractDependenciesRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[19]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1501,7 +1678,7 @@ func (x *ExtractDependenciesRequest) String() string {
 func (*ExtractDependenciesRequest) ProtoMessage() {}
 
 func (x *ExtractDependenciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[19]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1514,7 +1691,7 @@ func (x *ExtractDependenciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtractDependenciesRequest.ProtoReflect.Descriptor instead.
 func (*ExtractDependenciesRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{19}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ExtractDependenciesRequest) GetProviderName() string {
@@ -1535,13 +1712,14 @@ type ExtractDependenciesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Dependencies  []string               `protobuf:"bytes,1,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
 	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	Diagnostics   []*Diagnostic          `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExtractDependenciesResponse) Reset() {
 	*x = ExtractDependenciesResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[20]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1731,7 @@ func (x *ExtractDependenciesResponse) String() string {
 func (*ExtractDependenciesResponse) ProtoMessage() {}
 
 func (x *ExtractDependenciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[20]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1744,7 @@ func (x *ExtractDependenciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtractDependenciesResponse.ProtoReflect.Descriptor instead.
 func (*ExtractDependenciesResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{20}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ExtractDependenciesResponse) GetDependencies() []string {
@@ -1583,6 +1761,104 @@ func (x *ExtractDependenciesResponse) GetError() string {
 	return ""
 }
 
+func (x *ExtractDependenciesResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+// StopProviderRequest asks the plugin to gracefully stop any in-flight
+// execution for the named provider.
+type StopProviderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ProviderName  string                 `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"` // Empty means stop all providers
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopProviderRequest) Reset() {
+	*x = StopProviderRequest{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopProviderRequest) ProtoMessage() {}
+
+func (x *StopProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopProviderRequest.ProtoReflect.Descriptor instead.
+func (*StopProviderRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *StopProviderRequest) GetProviderName() string {
+	if x != nil {
+		return x.ProviderName
+	}
+	return ""
+}
+
+// StopProviderResponse acknowledges the stop request.
+type StopProviderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Error         string                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"` // Empty if no error
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopProviderResponse) Reset() {
+	*x = StopProviderResponse{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopProviderResponse) ProtoMessage() {}
+
+func (x *StopProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopProviderResponse.ProtoReflect.Descriptor instead.
+func (*StopProviderResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *StopProviderResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 type GetAuthHandlersRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -1591,7 +1867,7 @@ type GetAuthHandlersRequest struct {
 
 func (x *GetAuthHandlersRequest) Reset() {
 	*x = GetAuthHandlersRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[21]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1603,7 +1879,7 @@ func (x *GetAuthHandlersRequest) String() string {
 func (*GetAuthHandlersRequest) ProtoMessage() {}
 
 func (x *GetAuthHandlersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[21]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1616,7 +1892,7 @@ func (x *GetAuthHandlersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuthHandlersRequest.ProtoReflect.Descriptor instead.
 func (*GetAuthHandlersRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{21}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{24}
 }
 
 type GetAuthHandlersResponse struct {
@@ -1628,7 +1904,7 @@ type GetAuthHandlersResponse struct {
 
 func (x *GetAuthHandlersResponse) Reset() {
 	*x = GetAuthHandlersResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[22]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1640,7 +1916,7 @@ func (x *GetAuthHandlersResponse) String() string {
 func (*GetAuthHandlersResponse) ProtoMessage() {}
 
 func (x *GetAuthHandlersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[22]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1653,7 +1929,7 @@ func (x *GetAuthHandlersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuthHandlersResponse.ProtoReflect.Descriptor instead.
 func (*GetAuthHandlersResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{22}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetAuthHandlersResponse) GetHandlers() []*AuthHandlerInfo {
@@ -1675,7 +1951,7 @@ type AuthHandlerInfo struct {
 
 func (x *AuthHandlerInfo) Reset() {
 	*x = AuthHandlerInfo{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[23]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1687,7 +1963,7 @@ func (x *AuthHandlerInfo) String() string {
 func (*AuthHandlerInfo) ProtoMessage() {}
 
 func (x *AuthHandlerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[23]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1700,7 +1976,7 @@ func (x *AuthHandlerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthHandlerInfo.ProtoReflect.Descriptor instead.
 func (*AuthHandlerInfo) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{23}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *AuthHandlerInfo) GetName() string {
@@ -1744,7 +2020,7 @@ type LoginRequest struct {
 
 func (x *LoginRequest) Reset() {
 	*x = LoginRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[24]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1756,7 +2032,7 @@ func (x *LoginRequest) String() string {
 func (*LoginRequest) ProtoMessage() {}
 
 func (x *LoginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[24]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1769,7 +2045,7 @@ func (x *LoginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginRequest.ProtoReflect.Descriptor instead.
 func (*LoginRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{24}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LoginRequest) GetHandlerName() string {
@@ -1823,7 +2099,7 @@ type LoginStreamMessage struct {
 
 func (x *LoginStreamMessage) Reset() {
 	*x = LoginStreamMessage{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[25]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +2111,7 @@ func (x *LoginStreamMessage) String() string {
 func (*LoginStreamMessage) ProtoMessage() {}
 
 func (x *LoginStreamMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[25]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +2124,7 @@ func (x *LoginStreamMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginStreamMessage.ProtoReflect.Descriptor instead.
 func (*LoginStreamMessage) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{25}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LoginStreamMessage) GetPayload() isLoginStreamMessage_Payload {
@@ -1918,7 +2194,7 @@ type DeviceCodePrompt struct {
 
 func (x *DeviceCodePrompt) Reset() {
 	*x = DeviceCodePrompt{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[26]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1930,7 +2206,7 @@ func (x *DeviceCodePrompt) String() string {
 func (*DeviceCodePrompt) ProtoMessage() {}
 
 func (x *DeviceCodePrompt) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[26]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1943,7 +2219,7 @@ func (x *DeviceCodePrompt) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceCodePrompt.ProtoReflect.Descriptor instead.
 func (*DeviceCodePrompt) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{26}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DeviceCodePrompt) GetUserCode() string {
@@ -1977,7 +2253,7 @@ type LoginResult struct {
 
 func (x *LoginResult) Reset() {
 	*x = LoginResult{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[27]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1989,7 +2265,7 @@ func (x *LoginResult) String() string {
 func (*LoginResult) ProtoMessage() {}
 
 func (x *LoginResult) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[27]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2002,7 +2278,7 @@ func (x *LoginResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginResult.ProtoReflect.Descriptor instead.
 func (*LoginResult) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{27}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *LoginResult) GetClaims() *Claims {
@@ -2037,7 +2313,7 @@ type Claims struct {
 
 func (x *Claims) Reset() {
 	*x = Claims{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[28]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2049,7 +2325,7 @@ func (x *Claims) String() string {
 func (*Claims) ProtoMessage() {}
 
 func (x *Claims) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[28]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2062,7 +2338,7 @@ func (x *Claims) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Claims.ProtoReflect.Descriptor instead.
 func (*Claims) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{28}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *Claims) GetIssuer() string {
@@ -2144,7 +2420,7 @@ type LogoutRequest struct {
 
 func (x *LogoutRequest) Reset() {
 	*x = LogoutRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[29]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2156,7 +2432,7 @@ func (x *LogoutRequest) String() string {
 func (*LogoutRequest) ProtoMessage() {}
 
 func (x *LogoutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[29]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2169,7 +2445,7 @@ func (x *LogoutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogoutRequest.ProtoReflect.Descriptor instead.
 func (*LogoutRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{29}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LogoutRequest) GetHandlerName() string {
@@ -2187,7 +2463,7 @@ type LogoutResponse struct {
 
 func (x *LogoutResponse) Reset() {
 	*x = LogoutResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[30]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2199,7 +2475,7 @@ func (x *LogoutResponse) String() string {
 func (*LogoutResponse) ProtoMessage() {}
 
 func (x *LogoutResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[30]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2212,7 +2488,7 @@ func (x *LogoutResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogoutResponse.ProtoReflect.Descriptor instead.
 func (*LogoutResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{30}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{33}
 }
 
 type GetStatusRequest struct {
@@ -2224,7 +2500,7 @@ type GetStatusRequest struct {
 
 func (x *GetStatusRequest) Reset() {
 	*x = GetStatusRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[31]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2236,7 +2512,7 @@ func (x *GetStatusRequest) String() string {
 func (*GetStatusRequest) ProtoMessage() {}
 
 func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[31]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2249,7 +2525,7 @@ func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetStatusRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{31}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetStatusRequest) GetHandlerName() string {
@@ -2276,7 +2552,7 @@ type GetStatusResponse struct {
 
 func (x *GetStatusResponse) Reset() {
 	*x = GetStatusResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[32]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2288,7 +2564,7 @@ func (x *GetStatusResponse) String() string {
 func (*GetStatusResponse) ProtoMessage() {}
 
 func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[32]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2301,7 +2577,7 @@ func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetStatusResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{32}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetStatusResponse) GetAuthenticated() bool {
@@ -2379,7 +2655,7 @@ type GetTokenRequest struct {
 
 func (x *GetTokenRequest) Reset() {
 	*x = GetTokenRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[33]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2391,7 +2667,7 @@ func (x *GetTokenRequest) String() string {
 func (*GetTokenRequest) ProtoMessage() {}
 
 func (x *GetTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[33]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2404,7 +2680,7 @@ func (x *GetTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTokenRequest.ProtoReflect.Descriptor instead.
 func (*GetTokenRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{33}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetTokenRequest) GetHandlerName() string {
@@ -2450,7 +2726,7 @@ type GetTokenResponse struct {
 
 func (x *GetTokenResponse) Reset() {
 	*x = GetTokenResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[34]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2462,7 +2738,7 @@ func (x *GetTokenResponse) String() string {
 func (*GetTokenResponse) ProtoMessage() {}
 
 func (x *GetTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[34]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2475,7 +2751,7 @@ func (x *GetTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTokenResponse.ProtoReflect.Descriptor instead.
 func (*GetTokenResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{34}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetTokenResponse) GetAccessToken() string {
@@ -2536,7 +2812,7 @@ type ListCachedTokensRequest struct {
 
 func (x *ListCachedTokensRequest) Reset() {
 	*x = ListCachedTokensRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[35]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2548,7 +2824,7 @@ func (x *ListCachedTokensRequest) String() string {
 func (*ListCachedTokensRequest) ProtoMessage() {}
 
 func (x *ListCachedTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[35]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2561,7 +2837,7 @@ func (x *ListCachedTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachedTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListCachedTokensRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{35}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListCachedTokensRequest) GetHandlerName() string {
@@ -2580,7 +2856,7 @@ type ListCachedTokensResponse struct {
 
 func (x *ListCachedTokensResponse) Reset() {
 	*x = ListCachedTokensResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[36]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2592,7 +2868,7 @@ func (x *ListCachedTokensResponse) String() string {
 func (*ListCachedTokensResponse) ProtoMessage() {}
 
 func (x *ListCachedTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[36]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2605,7 +2881,7 @@ func (x *ListCachedTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachedTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListCachedTokensResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{36}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListCachedTokensResponse) GetTokens() []*CachedTokenInfo {
@@ -2632,7 +2908,7 @@ type CachedTokenInfo struct {
 
 func (x *CachedTokenInfo) Reset() {
 	*x = CachedTokenInfo{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[37]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2644,7 +2920,7 @@ func (x *CachedTokenInfo) String() string {
 func (*CachedTokenInfo) ProtoMessage() {}
 
 func (x *CachedTokenInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[37]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2657,7 +2933,7 @@ func (x *CachedTokenInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CachedTokenInfo.ProtoReflect.Descriptor instead.
 func (*CachedTokenInfo) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{37}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CachedTokenInfo) GetHandler() string {
@@ -2732,7 +3008,7 @@ type PurgeExpiredTokensRequest struct {
 
 func (x *PurgeExpiredTokensRequest) Reset() {
 	*x = PurgeExpiredTokensRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[38]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2744,7 +3020,7 @@ func (x *PurgeExpiredTokensRequest) String() string {
 func (*PurgeExpiredTokensRequest) ProtoMessage() {}
 
 func (x *PurgeExpiredTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[38]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2757,7 +3033,7 @@ func (x *PurgeExpiredTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeExpiredTokensRequest.ProtoReflect.Descriptor instead.
 func (*PurgeExpiredTokensRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{38}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PurgeExpiredTokensRequest) GetHandlerName() string {
@@ -2776,7 +3052,7 @@ type PurgeExpiredTokensResponse struct {
 
 func (x *PurgeExpiredTokensResponse) Reset() {
 	*x = PurgeExpiredTokensResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[39]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2788,7 +3064,7 @@ func (x *PurgeExpiredTokensResponse) String() string {
 func (*PurgeExpiredTokensResponse) ProtoMessage() {}
 
 func (x *PurgeExpiredTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[39]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2801,7 +3077,7 @@ func (x *PurgeExpiredTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeExpiredTokensResponse.ProtoReflect.Descriptor instead.
 func (*PurgeExpiredTokensResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{39}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *PurgeExpiredTokensResponse) GetPurgedCount() int32 {
@@ -2809,6 +3085,250 @@ func (x *PurgeExpiredTokensResponse) GetPurgedCount() int32 {
 		return x.PurgedCount
 	}
 	return 0
+}
+
+// ConfigureAuthHandlerRequest carries host-side configuration to auth handler plugins.
+type ConfigureAuthHandlerRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	HandlerName     string                 `protobuf:"bytes,1,opt,name=handler_name,json=handlerName,proto3" json:"handler_name,omitempty"`                                                  // Auth handler to configure (empty = all)
+	Quiet           bool                   `protobuf:"varint,2,opt,name=quiet,proto3" json:"quiet,omitempty"`                                                                                // Suppress non-essential output
+	NoColor         bool                   `protobuf:"varint,3,opt,name=no_color,json=noColor,proto3" json:"no_color,omitempty"`                                                             // Disable colored output
+	BinaryName      string                 `protobuf:"bytes,4,opt,name=binary_name,json=binaryName,proto3" json:"binary_name,omitempty"`                                                     // CLI binary name (e.g. "scafctl" or embedder name)
+	Settings        map[string][]byte      `protobuf:"bytes,5,rep,name=settings,proto3" json:"settings,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Extensible JSON key-value settings
+	HostServiceId   uint32                 `protobuf:"varint,6,opt,name=host_service_id,json=hostServiceId,proto3" json:"host_service_id,omitempty"`                                         // GRPCBroker service ID for HostService callbacks
+	ProtocolVersion int32                  `protobuf:"varint,7,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`                                     // Host plugin protocol version for feature detection
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ConfigureAuthHandlerRequest) Reset() {
+	*x = ConfigureAuthHandlerRequest{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureAuthHandlerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureAuthHandlerRequest) ProtoMessage() {}
+
+func (x *ConfigureAuthHandlerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureAuthHandlerRequest.ProtoReflect.Descriptor instead.
+func (*ConfigureAuthHandlerRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *ConfigureAuthHandlerRequest) GetHandlerName() string {
+	if x != nil {
+		return x.HandlerName
+	}
+	return ""
+}
+
+func (x *ConfigureAuthHandlerRequest) GetQuiet() bool {
+	if x != nil {
+		return x.Quiet
+	}
+	return false
+}
+
+func (x *ConfigureAuthHandlerRequest) GetNoColor() bool {
+	if x != nil {
+		return x.NoColor
+	}
+	return false
+}
+
+func (x *ConfigureAuthHandlerRequest) GetBinaryName() string {
+	if x != nil {
+		return x.BinaryName
+	}
+	return ""
+}
+
+func (x *ConfigureAuthHandlerRequest) GetSettings() map[string][]byte {
+	if x != nil {
+		return x.Settings
+	}
+	return nil
+}
+
+func (x *ConfigureAuthHandlerRequest) GetHostServiceId() uint32 {
+	if x != nil {
+		return x.HostServiceId
+	}
+	return 0
+}
+
+func (x *ConfigureAuthHandlerRequest) GetProtocolVersion() int32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
+// ConfigureAuthHandlerResponse acknowledges configuration.
+type ConfigureAuthHandlerResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Error           string                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`                                             // Non-empty on failure
+	ProtocolVersion int32                  `protobuf:"varint,2,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"` // Plugin's own protocol version
+	Diagnostics     []*Diagnostic          `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`                                 // Structured diagnostics
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ConfigureAuthHandlerResponse) Reset() {
+	*x = ConfigureAuthHandlerResponse{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureAuthHandlerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureAuthHandlerResponse) ProtoMessage() {}
+
+func (x *ConfigureAuthHandlerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureAuthHandlerResponse.ProtoReflect.Descriptor instead.
+func (*ConfigureAuthHandlerResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *ConfigureAuthHandlerResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *ConfigureAuthHandlerResponse) GetProtocolVersion() int32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
+func (x *ConfigureAuthHandlerResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+// StopAuthHandlerRequest asks the plugin to gracefully stop operations.
+type StopAuthHandlerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HandlerName   string                 `protobuf:"bytes,1,opt,name=handler_name,json=handlerName,proto3" json:"handler_name,omitempty"` // Handler to stop (empty = all)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopAuthHandlerRequest) Reset() {
+	*x = StopAuthHandlerRequest{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopAuthHandlerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopAuthHandlerRequest) ProtoMessage() {}
+
+func (x *StopAuthHandlerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopAuthHandlerRequest.ProtoReflect.Descriptor instead.
+func (*StopAuthHandlerRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *StopAuthHandlerRequest) GetHandlerName() string {
+	if x != nil {
+		return x.HandlerName
+	}
+	return ""
+}
+
+// StopAuthHandlerResponse acknowledges shutdown.
+type StopAuthHandlerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Error         string                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"` // Non-empty on failure
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopAuthHandlerResponse) Reset() {
+	*x = StopAuthHandlerResponse{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopAuthHandlerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopAuthHandlerResponse) ProtoMessage() {}
+
+func (x *StopAuthHandlerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopAuthHandlerResponse.ProtoReflect.Descriptor instead.
+func (*StopAuthHandlerResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *StopAuthHandlerResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
 }
 
 type GetSecretRequest struct {
@@ -2820,7 +3340,7 @@ type GetSecretRequest struct {
 
 func (x *GetSecretRequest) Reset() {
 	*x = GetSecretRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[40]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2832,7 +3352,7 @@ func (x *GetSecretRequest) String() string {
 func (*GetSecretRequest) ProtoMessage() {}
 
 func (x *GetSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[40]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2845,7 +3365,7 @@ func (x *GetSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSecretRequest.ProtoReflect.Descriptor instead.
 func (*GetSecretRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{40}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetSecretRequest) GetName() string {
@@ -2866,7 +3386,7 @@ type GetSecretResponse struct {
 
 func (x *GetSecretResponse) Reset() {
 	*x = GetSecretResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[41]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2878,7 +3398,7 @@ func (x *GetSecretResponse) String() string {
 func (*GetSecretResponse) ProtoMessage() {}
 
 func (x *GetSecretResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[41]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2891,7 +3411,7 @@ func (x *GetSecretResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSecretResponse.ProtoReflect.Descriptor instead.
 func (*GetSecretResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{41}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetSecretResponse) GetValue() string {
@@ -2925,7 +3445,7 @@ type SetSecretRequest struct {
 
 func (x *SetSecretRequest) Reset() {
 	*x = SetSecretRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[42]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2937,7 +3457,7 @@ func (x *SetSecretRequest) String() string {
 func (*SetSecretRequest) ProtoMessage() {}
 
 func (x *SetSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[42]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2950,7 +3470,7 @@ func (x *SetSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSecretRequest.ProtoReflect.Descriptor instead.
 func (*SetSecretRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{42}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SetSecretRequest) GetName() string {
@@ -2976,7 +3496,7 @@ type SetSecretResponse struct {
 
 func (x *SetSecretResponse) Reset() {
 	*x = SetSecretResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[43]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2988,7 +3508,7 @@ func (x *SetSecretResponse) String() string {
 func (*SetSecretResponse) ProtoMessage() {}
 
 func (x *SetSecretResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[43]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3001,7 +3521,7 @@ func (x *SetSecretResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSecretResponse.ProtoReflect.Descriptor instead.
 func (*SetSecretResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{43}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SetSecretResponse) GetError() string {
@@ -3020,7 +3540,7 @@ type DeleteSecretRequest struct {
 
 func (x *DeleteSecretRequest) Reset() {
 	*x = DeleteSecretRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[44]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3032,7 +3552,7 @@ func (x *DeleteSecretRequest) String() string {
 func (*DeleteSecretRequest) ProtoMessage() {}
 
 func (x *DeleteSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[44]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3045,7 +3565,7 @@ func (x *DeleteSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSecretRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{44}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DeleteSecretRequest) GetName() string {
@@ -3064,7 +3584,7 @@ type DeleteSecretResponse struct {
 
 func (x *DeleteSecretResponse) Reset() {
 	*x = DeleteSecretResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[45]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3076,7 +3596,7 @@ func (x *DeleteSecretResponse) String() string {
 func (*DeleteSecretResponse) ProtoMessage() {}
 
 func (x *DeleteSecretResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[45]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3089,7 +3609,7 @@ func (x *DeleteSecretResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSecretResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{45}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteSecretResponse) GetError() string {
@@ -3108,7 +3628,7 @@ type ListSecretsRequest struct {
 
 func (x *ListSecretsRequest) Reset() {
 	*x = ListSecretsRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[46]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3120,7 +3640,7 @@ func (x *ListSecretsRequest) String() string {
 func (*ListSecretsRequest) ProtoMessage() {}
 
 func (x *ListSecretsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[46]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3133,7 +3653,7 @@ func (x *ListSecretsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsRequest.ProtoReflect.Descriptor instead.
 func (*ListSecretsRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{46}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListSecretsRequest) GetPattern() string {
@@ -3153,7 +3673,7 @@ type ListSecretsResponse struct {
 
 func (x *ListSecretsResponse) Reset() {
 	*x = ListSecretsResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[47]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3165,7 +3685,7 @@ func (x *ListSecretsResponse) String() string {
 func (*ListSecretsResponse) ProtoMessage() {}
 
 func (x *ListSecretsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[47]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3178,7 +3698,7 @@ func (x *ListSecretsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsResponse.ProtoReflect.Descriptor instead.
 func (*ListSecretsResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{47}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ListSecretsResponse) GetNames() []string {
@@ -3205,7 +3725,7 @@ type GetAuthIdentityRequest struct {
 
 func (x *GetAuthIdentityRequest) Reset() {
 	*x = GetAuthIdentityRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[48]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3217,7 +3737,7 @@ func (x *GetAuthIdentityRequest) String() string {
 func (*GetAuthIdentityRequest) ProtoMessage() {}
 
 func (x *GetAuthIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[48]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3230,7 +3750,7 @@ func (x *GetAuthIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuthIdentityRequest.ProtoReflect.Descriptor instead.
 func (*GetAuthIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{48}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetAuthIdentityRequest) GetHandlerName() string {
@@ -3257,7 +3777,7 @@ type GetAuthIdentityResponse struct {
 
 func (x *GetAuthIdentityResponse) Reset() {
 	*x = GetAuthIdentityResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[49]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3269,7 +3789,7 @@ func (x *GetAuthIdentityResponse) String() string {
 func (*GetAuthIdentityResponse) ProtoMessage() {}
 
 func (x *GetAuthIdentityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[49]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3282,7 +3802,7 @@ func (x *GetAuthIdentityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuthIdentityResponse.ProtoReflect.Descriptor instead.
 func (*GetAuthIdentityResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{49}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetAuthIdentityResponse) GetClaims() *Claims {
@@ -3307,7 +3827,7 @@ type ListAuthHandlersRequest struct {
 
 func (x *ListAuthHandlersRequest) Reset() {
 	*x = ListAuthHandlersRequest{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[50]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3319,7 +3839,7 @@ func (x *ListAuthHandlersRequest) String() string {
 func (*ListAuthHandlersRequest) ProtoMessage() {}
 
 func (x *ListAuthHandlersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[50]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3332,7 +3852,7 @@ func (x *ListAuthHandlersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAuthHandlersRequest.ProtoReflect.Descriptor instead.
 func (*ListAuthHandlersRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{50}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{57}
 }
 
 type ListAuthHandlersResponse struct {
@@ -3345,7 +3865,7 @@ type ListAuthHandlersResponse struct {
 
 func (x *ListAuthHandlersResponse) Reset() {
 	*x = ListAuthHandlersResponse{}
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[51]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3357,7 +3877,7 @@ func (x *ListAuthHandlersResponse) String() string {
 func (*ListAuthHandlersResponse) ProtoMessage() {}
 
 func (x *ListAuthHandlersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[51]
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3370,7 +3890,7 @@ func (x *ListAuthHandlersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAuthHandlersResponse.ProtoReflect.Descriptor instead.
 func (*ListAuthHandlersResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{51}
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListAuthHandlersResponse) GetHandlerNames() []string {
@@ -3383,6 +3903,153 @@ func (x *ListAuthHandlersResponse) GetHandlerNames() []string {
 func (x *ListAuthHandlersResponse) GetDefaultHandler() string {
 	if x != nil {
 		return x.DefaultHandler
+	}
+	return ""
+}
+
+// GetAuthTokenRequest asks the host for a valid access token. Plugins use
+// this for authenticated HTTP requests and transparent token refresh.
+type GetAuthTokenRequest struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	HandlerName        string                 `protobuf:"bytes,1,opt,name=handler_name,json=handlerName,proto3" json:"handler_name,omitempty"`                           // Auth handler name (empty for default)
+	Scope              string                 `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`                                                          // OAuth scope
+	MinValidForSeconds int64                  `protobuf:"varint,3,opt,name=min_valid_for_seconds,json=minValidForSeconds,proto3" json:"min_valid_for_seconds,omitempty"` // Minimum remaining validity (0 = any valid token)
+	ForceRefresh       bool                   `protobuf:"varint,4,opt,name=force_refresh,json=forceRefresh,proto3" json:"force_refresh,omitempty"`                       // Force a token refresh
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *GetAuthTokenRequest) Reset() {
+	*x = GetAuthTokenRequest{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAuthTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAuthTokenRequest) ProtoMessage() {}
+
+func (x *GetAuthTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAuthTokenRequest.ProtoReflect.Descriptor instead.
+func (*GetAuthTokenRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *GetAuthTokenRequest) GetHandlerName() string {
+	if x != nil {
+		return x.HandlerName
+	}
+	return ""
+}
+
+func (x *GetAuthTokenRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *GetAuthTokenRequest) GetMinValidForSeconds() int64 {
+	if x != nil {
+		return x.MinValidForSeconds
+	}
+	return 0
+}
+
+func (x *GetAuthTokenRequest) GetForceRefresh() bool {
+	if x != nil {
+		return x.ForceRefresh
+	}
+	return false
+}
+
+// GetAuthTokenResponse carries the token back to the plugin.
+type GetAuthTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccessToken   string                 `protobuf:"bytes,1,opt,name=access_token,json=accessToken,proto3" json:"access_token,omitempty"`
+	TokenType     string                 `protobuf:"bytes,2,opt,name=token_type,json=tokenType,proto3" json:"token_type,omitempty"`                // e.g. "Bearer"
+	ExpiresAtUnix int64                  `protobuf:"varint,3,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"` // When the token expires (unix seconds)
+	Scope         string                 `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	Error         string                 `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetAuthTokenResponse) Reset() {
+	*x = GetAuthTokenResponse{}
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAuthTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAuthTokenResponse) ProtoMessage() {}
+
+func (x *GetAuthTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugin_proto_plugin_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAuthTokenResponse.ProtoReflect.Descriptor instead.
+func (*GetAuthTokenResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_plugin_proto_plugin_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *GetAuthTokenResponse) GetAccessToken() string {
+	if x != nil {
+		return x.AccessToken
+	}
+	return ""
+}
+
+func (x *GetAuthTokenResponse) GetTokenType() string {
+	if x != nil {
+		return x.TokenType
+	}
+	return ""
+}
+
+func (x *GetAuthTokenResponse) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *GetAuthTokenResponse) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *GetAuthTokenResponse) GetError() string {
+	if x != nil {
+		return x.Error
 	}
 	return ""
 }
@@ -3493,7 +4160,7 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\n" +
 	"parameters\x18\v \x01(\fR\n" +
 	"parameters\x12A\n" +
-	"\x11solution_metadata\x18\f \x01(\v2\x14.plugin.SolutionMetaR\x10solutionMetadata\"\xc2\x02\n" +
+	"\x11solution_metadata\x18\f \x01(\v2\x14.plugin.SolutionMetaR\x10solutionMetadata\"\xed\x02\n" +
 	"\x18ConfigureProviderRequest\x12#\n" +
 	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\x12\x14\n" +
 	"\x05quiet\x18\x02 \x01(\bR\x05quiet\x12\x19\n" +
@@ -3501,12 +4168,15 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\vbinary_name\x18\x04 \x01(\tR\n" +
 	"binaryName\x12&\n" +
 	"\x0fhost_service_id\x18\x05 \x01(\rR\rhostServiceId\x12J\n" +
-	"\bsettings\x18\x06 \x03(\v2..plugin.ConfigureProviderRequest.SettingsEntryR\bsettings\x1a;\n" +
+	"\bsettings\x18\x06 \x03(\v2..plugin.ConfigureProviderRequest.SettingsEntryR\bsettings\x12)\n" +
+	"\x10protocol_version\x18\a \x01(\x05R\x0fprotocolVersion\x1a;\n" +
 	"\rSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"1\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x92\x01\n" +
 	"\x19ConfigureProviderResponse\x12\x14\n" +
-	"\x05error\x18\x01 \x01(\tR\x05error\"\xb1\x01\n" +
+	"\x05error\x18\x01 \x01(\tR\x05error\x124\n" +
+	"\vdiagnostics\x18\x02 \x03(\v2\x12.plugin.DiagnosticR\vdiagnostics\x12)\n" +
+	"\x10protocol_version\x18\x03 \x01(\x05R\x0fprotocolVersion\"\xb1\x01\n" +
 	"\fSolutionMeta\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12!\n" +
@@ -3525,22 +4195,40 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\x06stdout\x18\x01 \x01(\fH\x00R\x06stdout\x12\x18\n" +
 	"\x06stderr\x18\x02 \x01(\fH\x00R\x06stderr\x129\n" +
 	"\x06result\x18\x03 \x01(\v2\x1f.plugin.ExecuteProviderResponseH\x00R\x06resultB\a\n" +
-	"\x05chunk\"G\n" +
+	"\x05chunk\"\xc6\x01\n" +
+	"\n" +
+	"Diagnostic\x127\n" +
+	"\bseverity\x18\x01 \x01(\x0e2\x1b.plugin.Diagnostic.SeverityR\bseverity\x12\x18\n" +
+	"\asummary\x18\x02 \x01(\tR\asummary\x12\x16\n" +
+	"\x06detail\x18\x03 \x01(\tR\x06detail\x12\x1c\n" +
+	"\tattribute\x18\x04 \x01(\tR\tattribute\"/\n" +
+	"\bSeverity\x12\v\n" +
+	"\aINVALID\x10\x00\x12\t\n" +
+	"\x05ERROR\x10\x01\x12\v\n" +
+	"\aWARNING\x10\x02\"\x9a\x01\n" +
 	"\x17ExecuteProviderResponse\x12\x16\n" +
 	"\x06output\x18\x01 \x01(\fR\x06output\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"R\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x12\x1b\n" +
+	"\texit_code\x18\x03 \x01(\x05R\bexitCode\x124\n" +
+	"\vdiagnostics\x18\x04 \x03(\v2\x12.plugin.DiagnosticR\vdiagnostics\"R\n" +
 	"\x15DescribeWhatIfRequest\x12#\n" +
 	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\x12\x14\n" +
-	"\x05input\x18\x02 \x01(\fR\x05input\"P\n" +
+	"\x05input\x18\x02 \x01(\fR\x05input\"\x86\x01\n" +
 	"\x16DescribeWhatIfResponse\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"Y\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x124\n" +
+	"\vdiagnostics\x18\x03 \x03(\v2\x12.plugin.DiagnosticR\vdiagnostics\"Y\n" +
 	"\x1aExtractDependenciesRequest\x12#\n" +
 	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\x12\x16\n" +
-	"\x06inputs\x18\x02 \x01(\fR\x06inputs\"W\n" +
+	"\x06inputs\x18\x02 \x01(\fR\x06inputs\"\x8d\x01\n" +
 	"\x1bExtractDependenciesResponse\x12\"\n" +
 	"\fdependencies\x18\x01 \x03(\tR\fdependencies\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\x18\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x124\n" +
+	"\vdiagnostics\x18\x03 \x03(\v2\x12.plugin.DiagnosticR\vdiagnostics\":\n" +
+	"\x13StopProviderRequest\x12#\n" +
+	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\",\n" +
+	"\x14StopProviderResponse\x12\x14\n" +
+	"\x05error\x18\x01 \x01(\tR\x05error\"\x18\n" +
 	"\x16GetAuthHandlersRequest\"N\n" +
 	"\x17GetAuthHandlersResponse\x123\n" +
 	"\bhandlers\x18\x01 \x03(\v2\x17.plugin.AuthHandlerInfoR\bhandlers\"\x82\x01\n" +
@@ -3631,7 +4319,27 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\x19PurgeExpiredTokensRequest\x12!\n" +
 	"\fhandler_name\x18\x01 \x01(\tR\vhandlerName\"?\n" +
 	"\x1aPurgeExpiredTokensResponse\x12!\n" +
-	"\fpurged_count\x18\x01 \x01(\x05R\vpurgedCount\"&\n" +
+	"\fpurged_count\x18\x01 \x01(\x05R\vpurgedCount\"\xf1\x02\n" +
+	"\x1bConfigureAuthHandlerRequest\x12!\n" +
+	"\fhandler_name\x18\x01 \x01(\tR\vhandlerName\x12\x14\n" +
+	"\x05quiet\x18\x02 \x01(\bR\x05quiet\x12\x19\n" +
+	"\bno_color\x18\x03 \x01(\bR\anoColor\x12\x1f\n" +
+	"\vbinary_name\x18\x04 \x01(\tR\n" +
+	"binaryName\x12M\n" +
+	"\bsettings\x18\x05 \x03(\v21.plugin.ConfigureAuthHandlerRequest.SettingsEntryR\bsettings\x12&\n" +
+	"\x0fhost_service_id\x18\x06 \x01(\rR\rhostServiceId\x12)\n" +
+	"\x10protocol_version\x18\a \x01(\x05R\x0fprotocolVersion\x1a;\n" +
+	"\rSettingsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x95\x01\n" +
+	"\x1cConfigureAuthHandlerResponse\x12\x14\n" +
+	"\x05error\x18\x01 \x01(\tR\x05error\x12)\n" +
+	"\x10protocol_version\x18\x02 \x01(\x05R\x0fprotocolVersion\x124\n" +
+	"\vdiagnostics\x18\x03 \x03(\v2\x12.plugin.DiagnosticR\vdiagnostics\";\n" +
+	"\x16StopAuthHandlerRequest\x12!\n" +
+	"\fhandler_name\x18\x01 \x01(\tR\vhandlerName\"/\n" +
+	"\x17StopAuthHandlerResponse\x12\x14\n" +
+	"\x05error\x18\x01 \x01(\tR\x05error\"&\n" +
 	"\x10GetSecretRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"U\n" +
 	"\x11GetSecretResponse\x12\x14\n" +
@@ -3661,7 +4369,19 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\x17ListAuthHandlersRequest\"h\n" +
 	"\x18ListAuthHandlersResponse\x12#\n" +
 	"\rhandler_names\x18\x01 \x03(\tR\fhandlerNames\x12'\n" +
-	"\x0fdefault_handler\x18\x02 \x01(\tR\x0edefaultHandler2\xfe\x04\n" +
+	"\x0fdefault_handler\x18\x02 \x01(\tR\x0edefaultHandler\"\xa6\x01\n" +
+	"\x13GetAuthTokenRequest\x12!\n" +
+	"\fhandler_name\x18\x01 \x01(\tR\vhandlerName\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\x121\n" +
+	"\x15min_valid_for_seconds\x18\x03 \x01(\x03R\x12minValidForSeconds\x12#\n" +
+	"\rforce_refresh\x18\x04 \x01(\bR\fforceRefresh\"\xac\x01\n" +
+	"\x14GetAuthTokenResponse\x12!\n" +
+	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12\x1d\n" +
+	"\n" +
+	"token_type\x18\x02 \x01(\tR\ttokenType\x12&\n" +
+	"\x0fexpires_at_unix\x18\x03 \x01(\x03R\rexpiresAtUnix\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error2\xc9\x05\n" +
 	"\rPluginService\x12I\n" +
 	"\fGetProviders\x12\x1b.plugin.GetProvidersRequest\x1a\x1c.plugin.GetProvidersResponse\x12d\n" +
 	"\x15GetProviderDescriptor\x12$.plugin.GetProviderDescriptorRequest\x1a%.plugin.GetProviderDescriptorResponse\x12X\n" +
@@ -3669,22 +4389,26 @@ const file_pkg_plugin_proto_plugin_proto_rawDesc = "" +
 	"\x0fExecuteProvider\x12\x1e.plugin.ExecuteProviderRequest\x1a\x1f.plugin.ExecuteProviderResponse\x12]\n" +
 	"\x15ExecuteProviderStream\x12\x1e.plugin.ExecuteProviderRequest\x1a\".plugin.ExecuteProviderStreamChunk0\x01\x12O\n" +
 	"\x0eDescribeWhatIf\x12\x1d.plugin.DescribeWhatIfRequest\x1a\x1e.plugin.DescribeWhatIfResponse\x12^\n" +
-	"\x13ExtractDependencies\x12\".plugin.ExtractDependenciesRequest\x1a#.plugin.ExtractDependenciesResponse2\xcf\x03\n" +
+	"\x13ExtractDependencies\x12\".plugin.ExtractDependenciesRequest\x1a#.plugin.ExtractDependenciesResponse\x12I\n" +
+	"\fStopProvider\x12\x1b.plugin.StopProviderRequest\x1a\x1c.plugin.StopProviderResponse2\x9a\x04\n" +
 	"\vHostService\x12@\n" +
 	"\tGetSecret\x12\x18.plugin.GetSecretRequest\x1a\x19.plugin.GetSecretResponse\x12@\n" +
 	"\tSetSecret\x12\x18.plugin.SetSecretRequest\x1a\x19.plugin.SetSecretResponse\x12I\n" +
 	"\fDeleteSecret\x12\x1b.plugin.DeleteSecretRequest\x1a\x1c.plugin.DeleteSecretResponse\x12F\n" +
 	"\vListSecrets\x12\x1a.plugin.ListSecretsRequest\x1a\x1b.plugin.ListSecretsResponse\x12R\n" +
 	"\x0fGetAuthIdentity\x12\x1e.plugin.GetAuthIdentityRequest\x1a\x1f.plugin.GetAuthIdentityResponse\x12U\n" +
-	"\x10ListAuthHandlers\x12\x1f.plugin.ListAuthHandlersRequest\x1a .plugin.ListAuthHandlersResponse2\x93\x04\n" +
+	"\x10ListAuthHandlers\x12\x1f.plugin.ListAuthHandlersRequest\x1a .plugin.ListAuthHandlersResponse\x12I\n" +
+	"\fGetAuthToken\x12\x1b.plugin.GetAuthTokenRequest\x1a\x1c.plugin.GetAuthTokenResponse2\xca\x05\n" +
 	"\x12AuthHandlerService\x12R\n" +
-	"\x0fGetAuthHandlers\x12\x1e.plugin.GetAuthHandlersRequest\x1a\x1f.plugin.GetAuthHandlersResponse\x12;\n" +
+	"\x0fGetAuthHandlers\x12\x1e.plugin.GetAuthHandlersRequest\x1a\x1f.plugin.GetAuthHandlersResponse\x12a\n" +
+	"\x14ConfigureAuthHandler\x12#.plugin.ConfigureAuthHandlerRequest\x1a$.plugin.ConfigureAuthHandlerResponse\x12;\n" +
 	"\x05Login\x12\x14.plugin.LoginRequest\x1a\x1a.plugin.LoginStreamMessage0\x01\x127\n" +
 	"\x06Logout\x12\x15.plugin.LogoutRequest\x1a\x16.plugin.LogoutResponse\x12@\n" +
 	"\tGetStatus\x12\x18.plugin.GetStatusRequest\x1a\x19.plugin.GetStatusResponse\x12=\n" +
 	"\bGetToken\x12\x17.plugin.GetTokenRequest\x1a\x18.plugin.GetTokenResponse\x12U\n" +
 	"\x10ListCachedTokens\x12\x1f.plugin.ListCachedTokensRequest\x1a .plugin.ListCachedTokensResponse\x12[\n" +
-	"\x12PurgeExpiredTokens\x12!.plugin.PurgeExpiredTokensRequest\x1a\".plugin.PurgeExpiredTokensResponseB5Z3github.com/oakwood-commons/scafctl/pkg/plugin/protob\x06proto3"
+	"\x12PurgeExpiredTokens\x12!.plugin.PurgeExpiredTokensRequest\x1a\".plugin.PurgeExpiredTokensResponse\x12R\n" +
+	"\x0fStopAuthHandler\x12\x1e.plugin.StopAuthHandlerRequest\x1a\x1f.plugin.StopAuthHandlerResponseB5Z3github.com/oakwood-commons/scafctl/pkg/plugin/protob\x06proto3"
 
 var (
 	file_pkg_plugin_proto_plugin_proto_rawDescOnce sync.Once
@@ -3698,132 +4422,159 @@ func file_pkg_plugin_proto_plugin_proto_rawDescGZIP() []byte {
 	return file_pkg_plugin_proto_plugin_proto_rawDescData
 }
 
-var file_pkg_plugin_proto_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
+var file_pkg_plugin_proto_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_pkg_plugin_proto_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
 var file_pkg_plugin_proto_plugin_proto_goTypes = []any{
-	(*GetProvidersRequest)(nil),           // 0: plugin.GetProvidersRequest
-	(*GetProvidersResponse)(nil),          // 1: plugin.GetProvidersResponse
-	(*GetProviderDescriptorRequest)(nil),  // 2: plugin.GetProviderDescriptorRequest
-	(*GetProviderDescriptorResponse)(nil), // 3: plugin.GetProviderDescriptorResponse
-	(*ProviderDescriptor)(nil),            // 4: plugin.ProviderDescriptor
-	(*Link)(nil),                          // 5: plugin.Link
-	(*Example)(nil),                       // 6: plugin.Example
-	(*Contact)(nil),                       // 7: plugin.Contact
-	(*Schema)(nil),                        // 8: plugin.Schema
-	(*Parameter)(nil),                     // 9: plugin.Parameter
-	(*ExecuteProviderRequest)(nil),        // 10: plugin.ExecuteProviderRequest
-	(*ConfigureProviderRequest)(nil),      // 11: plugin.ConfigureProviderRequest
-	(*ConfigureProviderResponse)(nil),     // 12: plugin.ConfigureProviderResponse
-	(*SolutionMeta)(nil),                  // 13: plugin.SolutionMeta
-	(*IterationContext)(nil),              // 14: plugin.IterationContext
-	(*ExecuteProviderStreamChunk)(nil),    // 15: plugin.ExecuteProviderStreamChunk
-	(*ExecuteProviderResponse)(nil),       // 16: plugin.ExecuteProviderResponse
-	(*DescribeWhatIfRequest)(nil),         // 17: plugin.DescribeWhatIfRequest
-	(*DescribeWhatIfResponse)(nil),        // 18: plugin.DescribeWhatIfResponse
-	(*ExtractDependenciesRequest)(nil),    // 19: plugin.ExtractDependenciesRequest
-	(*ExtractDependenciesResponse)(nil),   // 20: plugin.ExtractDependenciesResponse
-	(*GetAuthHandlersRequest)(nil),        // 21: plugin.GetAuthHandlersRequest
-	(*GetAuthHandlersResponse)(nil),       // 22: plugin.GetAuthHandlersResponse
-	(*AuthHandlerInfo)(nil),               // 23: plugin.AuthHandlerInfo
-	(*LoginRequest)(nil),                  // 24: plugin.LoginRequest
-	(*LoginStreamMessage)(nil),            // 25: plugin.LoginStreamMessage
-	(*DeviceCodePrompt)(nil),              // 26: plugin.DeviceCodePrompt
-	(*LoginResult)(nil),                   // 27: plugin.LoginResult
-	(*Claims)(nil),                        // 28: plugin.Claims
-	(*LogoutRequest)(nil),                 // 29: plugin.LogoutRequest
-	(*LogoutResponse)(nil),                // 30: plugin.LogoutResponse
-	(*GetStatusRequest)(nil),              // 31: plugin.GetStatusRequest
-	(*GetStatusResponse)(nil),             // 32: plugin.GetStatusResponse
-	(*GetTokenRequest)(nil),               // 33: plugin.GetTokenRequest
-	(*GetTokenResponse)(nil),              // 34: plugin.GetTokenResponse
-	(*ListCachedTokensRequest)(nil),       // 35: plugin.ListCachedTokensRequest
-	(*ListCachedTokensResponse)(nil),      // 36: plugin.ListCachedTokensResponse
-	(*CachedTokenInfo)(nil),               // 37: plugin.CachedTokenInfo
-	(*PurgeExpiredTokensRequest)(nil),     // 38: plugin.PurgeExpiredTokensRequest
-	(*PurgeExpiredTokensResponse)(nil),    // 39: plugin.PurgeExpiredTokensResponse
-	(*GetSecretRequest)(nil),              // 40: plugin.GetSecretRequest
-	(*GetSecretResponse)(nil),             // 41: plugin.GetSecretResponse
-	(*SetSecretRequest)(nil),              // 42: plugin.SetSecretRequest
-	(*SetSecretResponse)(nil),             // 43: plugin.SetSecretResponse
-	(*DeleteSecretRequest)(nil),           // 44: plugin.DeleteSecretRequest
-	(*DeleteSecretResponse)(nil),          // 45: plugin.DeleteSecretResponse
-	(*ListSecretsRequest)(nil),            // 46: plugin.ListSecretsRequest
-	(*ListSecretsResponse)(nil),           // 47: plugin.ListSecretsResponse
-	(*GetAuthIdentityRequest)(nil),        // 48: plugin.GetAuthIdentityRequest
-	(*GetAuthIdentityResponse)(nil),       // 49: plugin.GetAuthIdentityResponse
-	(*ListAuthHandlersRequest)(nil),       // 50: plugin.ListAuthHandlersRequest
-	(*ListAuthHandlersResponse)(nil),      // 51: plugin.ListAuthHandlersResponse
-	nil,                                   // 52: plugin.ProviderDescriptor.OutputSchemasEntry
-	nil,                                   // 53: plugin.ProviderDescriptor.RawOutputSchemasEntry
-	nil,                                   // 54: plugin.Schema.ParametersEntry
-	nil,                                   // 55: plugin.ConfigureProviderRequest.SettingsEntry
+	(Diagnostic_Severity)(0),              // 0: plugin.Diagnostic.Severity
+	(*GetProvidersRequest)(nil),           // 1: plugin.GetProvidersRequest
+	(*GetProvidersResponse)(nil),          // 2: plugin.GetProvidersResponse
+	(*GetProviderDescriptorRequest)(nil),  // 3: plugin.GetProviderDescriptorRequest
+	(*GetProviderDescriptorResponse)(nil), // 4: plugin.GetProviderDescriptorResponse
+	(*ProviderDescriptor)(nil),            // 5: plugin.ProviderDescriptor
+	(*Link)(nil),                          // 6: plugin.Link
+	(*Example)(nil),                       // 7: plugin.Example
+	(*Contact)(nil),                       // 8: plugin.Contact
+	(*Schema)(nil),                        // 9: plugin.Schema
+	(*Parameter)(nil),                     // 10: plugin.Parameter
+	(*ExecuteProviderRequest)(nil),        // 11: plugin.ExecuteProviderRequest
+	(*ConfigureProviderRequest)(nil),      // 12: plugin.ConfigureProviderRequest
+	(*ConfigureProviderResponse)(nil),     // 13: plugin.ConfigureProviderResponse
+	(*SolutionMeta)(nil),                  // 14: plugin.SolutionMeta
+	(*IterationContext)(nil),              // 15: plugin.IterationContext
+	(*ExecuteProviderStreamChunk)(nil),    // 16: plugin.ExecuteProviderStreamChunk
+	(*Diagnostic)(nil),                    // 17: plugin.Diagnostic
+	(*ExecuteProviderResponse)(nil),       // 18: plugin.ExecuteProviderResponse
+	(*DescribeWhatIfRequest)(nil),         // 19: plugin.DescribeWhatIfRequest
+	(*DescribeWhatIfResponse)(nil),        // 20: plugin.DescribeWhatIfResponse
+	(*ExtractDependenciesRequest)(nil),    // 21: plugin.ExtractDependenciesRequest
+	(*ExtractDependenciesResponse)(nil),   // 22: plugin.ExtractDependenciesResponse
+	(*StopProviderRequest)(nil),           // 23: plugin.StopProviderRequest
+	(*StopProviderResponse)(nil),          // 24: plugin.StopProviderResponse
+	(*GetAuthHandlersRequest)(nil),        // 25: plugin.GetAuthHandlersRequest
+	(*GetAuthHandlersResponse)(nil),       // 26: plugin.GetAuthHandlersResponse
+	(*AuthHandlerInfo)(nil),               // 27: plugin.AuthHandlerInfo
+	(*LoginRequest)(nil),                  // 28: plugin.LoginRequest
+	(*LoginStreamMessage)(nil),            // 29: plugin.LoginStreamMessage
+	(*DeviceCodePrompt)(nil),              // 30: plugin.DeviceCodePrompt
+	(*LoginResult)(nil),                   // 31: plugin.LoginResult
+	(*Claims)(nil),                        // 32: plugin.Claims
+	(*LogoutRequest)(nil),                 // 33: plugin.LogoutRequest
+	(*LogoutResponse)(nil),                // 34: plugin.LogoutResponse
+	(*GetStatusRequest)(nil),              // 35: plugin.GetStatusRequest
+	(*GetStatusResponse)(nil),             // 36: plugin.GetStatusResponse
+	(*GetTokenRequest)(nil),               // 37: plugin.GetTokenRequest
+	(*GetTokenResponse)(nil),              // 38: plugin.GetTokenResponse
+	(*ListCachedTokensRequest)(nil),       // 39: plugin.ListCachedTokensRequest
+	(*ListCachedTokensResponse)(nil),      // 40: plugin.ListCachedTokensResponse
+	(*CachedTokenInfo)(nil),               // 41: plugin.CachedTokenInfo
+	(*PurgeExpiredTokensRequest)(nil),     // 42: plugin.PurgeExpiredTokensRequest
+	(*PurgeExpiredTokensResponse)(nil),    // 43: plugin.PurgeExpiredTokensResponse
+	(*ConfigureAuthHandlerRequest)(nil),   // 44: plugin.ConfigureAuthHandlerRequest
+	(*ConfigureAuthHandlerResponse)(nil),  // 45: plugin.ConfigureAuthHandlerResponse
+	(*StopAuthHandlerRequest)(nil),        // 46: plugin.StopAuthHandlerRequest
+	(*StopAuthHandlerResponse)(nil),       // 47: plugin.StopAuthHandlerResponse
+	(*GetSecretRequest)(nil),              // 48: plugin.GetSecretRequest
+	(*GetSecretResponse)(nil),             // 49: plugin.GetSecretResponse
+	(*SetSecretRequest)(nil),              // 50: plugin.SetSecretRequest
+	(*SetSecretResponse)(nil),             // 51: plugin.SetSecretResponse
+	(*DeleteSecretRequest)(nil),           // 52: plugin.DeleteSecretRequest
+	(*DeleteSecretResponse)(nil),          // 53: plugin.DeleteSecretResponse
+	(*ListSecretsRequest)(nil),            // 54: plugin.ListSecretsRequest
+	(*ListSecretsResponse)(nil),           // 55: plugin.ListSecretsResponse
+	(*GetAuthIdentityRequest)(nil),        // 56: plugin.GetAuthIdentityRequest
+	(*GetAuthIdentityResponse)(nil),       // 57: plugin.GetAuthIdentityResponse
+	(*ListAuthHandlersRequest)(nil),       // 58: plugin.ListAuthHandlersRequest
+	(*ListAuthHandlersResponse)(nil),      // 59: plugin.ListAuthHandlersResponse
+	(*GetAuthTokenRequest)(nil),           // 60: plugin.GetAuthTokenRequest
+	(*GetAuthTokenResponse)(nil),          // 61: plugin.GetAuthTokenResponse
+	nil,                                   // 62: plugin.ProviderDescriptor.OutputSchemasEntry
+	nil,                                   // 63: plugin.ProviderDescriptor.RawOutputSchemasEntry
+	nil,                                   // 64: plugin.Schema.ParametersEntry
+	nil,                                   // 65: plugin.ConfigureProviderRequest.SettingsEntry
+	nil,                                   // 66: plugin.ConfigureAuthHandlerRequest.SettingsEntry
 }
 var file_pkg_plugin_proto_plugin_proto_depIdxs = []int32{
-	4,  // 0: plugin.GetProviderDescriptorResponse.descriptor:type_name -> plugin.ProviderDescriptor
-	8,  // 1: plugin.ProviderDescriptor.schema:type_name -> plugin.Schema
-	52, // 2: plugin.ProviderDescriptor.output_schemas:type_name -> plugin.ProviderDescriptor.OutputSchemasEntry
-	5,  // 3: plugin.ProviderDescriptor.links:type_name -> plugin.Link
-	6,  // 4: plugin.ProviderDescriptor.examples:type_name -> plugin.Example
-	7,  // 5: plugin.ProviderDescriptor.maintainers:type_name -> plugin.Contact
-	53, // 6: plugin.ProviderDescriptor.raw_output_schemas:type_name -> plugin.ProviderDescriptor.RawOutputSchemasEntry
-	54, // 7: plugin.Schema.parameters:type_name -> plugin.Schema.ParametersEntry
-	14, // 8: plugin.ExecuteProviderRequest.iteration_context:type_name -> plugin.IterationContext
-	13, // 9: plugin.ExecuteProviderRequest.solution_metadata:type_name -> plugin.SolutionMeta
-	55, // 10: plugin.ConfigureProviderRequest.settings:type_name -> plugin.ConfigureProviderRequest.SettingsEntry
-	16, // 11: plugin.ExecuteProviderStreamChunk.result:type_name -> plugin.ExecuteProviderResponse
-	23, // 12: plugin.GetAuthHandlersResponse.handlers:type_name -> plugin.AuthHandlerInfo
-	26, // 13: plugin.LoginStreamMessage.device_code_prompt:type_name -> plugin.DeviceCodePrompt
-	27, // 14: plugin.LoginStreamMessage.result:type_name -> plugin.LoginResult
-	28, // 15: plugin.LoginResult.claims:type_name -> plugin.Claims
-	28, // 16: plugin.GetStatusResponse.claims:type_name -> plugin.Claims
-	37, // 17: plugin.ListCachedTokensResponse.tokens:type_name -> plugin.CachedTokenInfo
-	28, // 18: plugin.GetAuthIdentityResponse.claims:type_name -> plugin.Claims
-	8,  // 19: plugin.ProviderDescriptor.OutputSchemasEntry.value:type_name -> plugin.Schema
-	9,  // 20: plugin.Schema.ParametersEntry.value:type_name -> plugin.Parameter
-	0,  // 21: plugin.PluginService.GetProviders:input_type -> plugin.GetProvidersRequest
-	2,  // 22: plugin.PluginService.GetProviderDescriptor:input_type -> plugin.GetProviderDescriptorRequest
-	11, // 23: plugin.PluginService.ConfigureProvider:input_type -> plugin.ConfigureProviderRequest
-	10, // 24: plugin.PluginService.ExecuteProvider:input_type -> plugin.ExecuteProviderRequest
-	10, // 25: plugin.PluginService.ExecuteProviderStream:input_type -> plugin.ExecuteProviderRequest
-	17, // 26: plugin.PluginService.DescribeWhatIf:input_type -> plugin.DescribeWhatIfRequest
-	19, // 27: plugin.PluginService.ExtractDependencies:input_type -> plugin.ExtractDependenciesRequest
-	40, // 28: plugin.HostService.GetSecret:input_type -> plugin.GetSecretRequest
-	42, // 29: plugin.HostService.SetSecret:input_type -> plugin.SetSecretRequest
-	44, // 30: plugin.HostService.DeleteSecret:input_type -> plugin.DeleteSecretRequest
-	46, // 31: plugin.HostService.ListSecrets:input_type -> plugin.ListSecretsRequest
-	48, // 32: plugin.HostService.GetAuthIdentity:input_type -> plugin.GetAuthIdentityRequest
-	50, // 33: plugin.HostService.ListAuthHandlers:input_type -> plugin.ListAuthHandlersRequest
-	21, // 34: plugin.AuthHandlerService.GetAuthHandlers:input_type -> plugin.GetAuthHandlersRequest
-	24, // 35: plugin.AuthHandlerService.Login:input_type -> plugin.LoginRequest
-	29, // 36: plugin.AuthHandlerService.Logout:input_type -> plugin.LogoutRequest
-	31, // 37: plugin.AuthHandlerService.GetStatus:input_type -> plugin.GetStatusRequest
-	33, // 38: plugin.AuthHandlerService.GetToken:input_type -> plugin.GetTokenRequest
-	35, // 39: plugin.AuthHandlerService.ListCachedTokens:input_type -> plugin.ListCachedTokensRequest
-	38, // 40: plugin.AuthHandlerService.PurgeExpiredTokens:input_type -> plugin.PurgeExpiredTokensRequest
-	1,  // 41: plugin.PluginService.GetProviders:output_type -> plugin.GetProvidersResponse
-	3,  // 42: plugin.PluginService.GetProviderDescriptor:output_type -> plugin.GetProviderDescriptorResponse
-	12, // 43: plugin.PluginService.ConfigureProvider:output_type -> plugin.ConfigureProviderResponse
-	16, // 44: plugin.PluginService.ExecuteProvider:output_type -> plugin.ExecuteProviderResponse
-	15, // 45: plugin.PluginService.ExecuteProviderStream:output_type -> plugin.ExecuteProviderStreamChunk
-	18, // 46: plugin.PluginService.DescribeWhatIf:output_type -> plugin.DescribeWhatIfResponse
-	20, // 47: plugin.PluginService.ExtractDependencies:output_type -> plugin.ExtractDependenciesResponse
-	41, // 48: plugin.HostService.GetSecret:output_type -> plugin.GetSecretResponse
-	43, // 49: plugin.HostService.SetSecret:output_type -> plugin.SetSecretResponse
-	45, // 50: plugin.HostService.DeleteSecret:output_type -> plugin.DeleteSecretResponse
-	47, // 51: plugin.HostService.ListSecrets:output_type -> plugin.ListSecretsResponse
-	49, // 52: plugin.HostService.GetAuthIdentity:output_type -> plugin.GetAuthIdentityResponse
-	51, // 53: plugin.HostService.ListAuthHandlers:output_type -> plugin.ListAuthHandlersResponse
-	22, // 54: plugin.AuthHandlerService.GetAuthHandlers:output_type -> plugin.GetAuthHandlersResponse
-	25, // 55: plugin.AuthHandlerService.Login:output_type -> plugin.LoginStreamMessage
-	30, // 56: plugin.AuthHandlerService.Logout:output_type -> plugin.LogoutResponse
-	32, // 57: plugin.AuthHandlerService.GetStatus:output_type -> plugin.GetStatusResponse
-	34, // 58: plugin.AuthHandlerService.GetToken:output_type -> plugin.GetTokenResponse
-	36, // 59: plugin.AuthHandlerService.ListCachedTokens:output_type -> plugin.ListCachedTokensResponse
-	39, // 60: plugin.AuthHandlerService.PurgeExpiredTokens:output_type -> plugin.PurgeExpiredTokensResponse
-	41, // [41:61] is the sub-list for method output_type
-	21, // [21:41] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	5,  // 0: plugin.GetProviderDescriptorResponse.descriptor:type_name -> plugin.ProviderDescriptor
+	9,  // 1: plugin.ProviderDescriptor.schema:type_name -> plugin.Schema
+	62, // 2: plugin.ProviderDescriptor.output_schemas:type_name -> plugin.ProviderDescriptor.OutputSchemasEntry
+	6,  // 3: plugin.ProviderDescriptor.links:type_name -> plugin.Link
+	7,  // 4: plugin.ProviderDescriptor.examples:type_name -> plugin.Example
+	8,  // 5: plugin.ProviderDescriptor.maintainers:type_name -> plugin.Contact
+	63, // 6: plugin.ProviderDescriptor.raw_output_schemas:type_name -> plugin.ProviderDescriptor.RawOutputSchemasEntry
+	64, // 7: plugin.Schema.parameters:type_name -> plugin.Schema.ParametersEntry
+	15, // 8: plugin.ExecuteProviderRequest.iteration_context:type_name -> plugin.IterationContext
+	14, // 9: plugin.ExecuteProviderRequest.solution_metadata:type_name -> plugin.SolutionMeta
+	65, // 10: plugin.ConfigureProviderRequest.settings:type_name -> plugin.ConfigureProviderRequest.SettingsEntry
+	17, // 11: plugin.ConfigureProviderResponse.diagnostics:type_name -> plugin.Diagnostic
+	18, // 12: plugin.ExecuteProviderStreamChunk.result:type_name -> plugin.ExecuteProviderResponse
+	0,  // 13: plugin.Diagnostic.severity:type_name -> plugin.Diagnostic.Severity
+	17, // 14: plugin.ExecuteProviderResponse.diagnostics:type_name -> plugin.Diagnostic
+	17, // 15: plugin.DescribeWhatIfResponse.diagnostics:type_name -> plugin.Diagnostic
+	17, // 16: plugin.ExtractDependenciesResponse.diagnostics:type_name -> plugin.Diagnostic
+	27, // 17: plugin.GetAuthHandlersResponse.handlers:type_name -> plugin.AuthHandlerInfo
+	30, // 18: plugin.LoginStreamMessage.device_code_prompt:type_name -> plugin.DeviceCodePrompt
+	31, // 19: plugin.LoginStreamMessage.result:type_name -> plugin.LoginResult
+	32, // 20: plugin.LoginResult.claims:type_name -> plugin.Claims
+	32, // 21: plugin.GetStatusResponse.claims:type_name -> plugin.Claims
+	41, // 22: plugin.ListCachedTokensResponse.tokens:type_name -> plugin.CachedTokenInfo
+	66, // 23: plugin.ConfigureAuthHandlerRequest.settings:type_name -> plugin.ConfigureAuthHandlerRequest.SettingsEntry
+	17, // 24: plugin.ConfigureAuthHandlerResponse.diagnostics:type_name -> plugin.Diagnostic
+	32, // 25: plugin.GetAuthIdentityResponse.claims:type_name -> plugin.Claims
+	9,  // 26: plugin.ProviderDescriptor.OutputSchemasEntry.value:type_name -> plugin.Schema
+	10, // 27: plugin.Schema.ParametersEntry.value:type_name -> plugin.Parameter
+	1,  // 28: plugin.PluginService.GetProviders:input_type -> plugin.GetProvidersRequest
+	3,  // 29: plugin.PluginService.GetProviderDescriptor:input_type -> plugin.GetProviderDescriptorRequest
+	12, // 30: plugin.PluginService.ConfigureProvider:input_type -> plugin.ConfigureProviderRequest
+	11, // 31: plugin.PluginService.ExecuteProvider:input_type -> plugin.ExecuteProviderRequest
+	11, // 32: plugin.PluginService.ExecuteProviderStream:input_type -> plugin.ExecuteProviderRequest
+	19, // 33: plugin.PluginService.DescribeWhatIf:input_type -> plugin.DescribeWhatIfRequest
+	21, // 34: plugin.PluginService.ExtractDependencies:input_type -> plugin.ExtractDependenciesRequest
+	23, // 35: plugin.PluginService.StopProvider:input_type -> plugin.StopProviderRequest
+	48, // 36: plugin.HostService.GetSecret:input_type -> plugin.GetSecretRequest
+	50, // 37: plugin.HostService.SetSecret:input_type -> plugin.SetSecretRequest
+	52, // 38: plugin.HostService.DeleteSecret:input_type -> plugin.DeleteSecretRequest
+	54, // 39: plugin.HostService.ListSecrets:input_type -> plugin.ListSecretsRequest
+	56, // 40: plugin.HostService.GetAuthIdentity:input_type -> plugin.GetAuthIdentityRequest
+	58, // 41: plugin.HostService.ListAuthHandlers:input_type -> plugin.ListAuthHandlersRequest
+	60, // 42: plugin.HostService.GetAuthToken:input_type -> plugin.GetAuthTokenRequest
+	25, // 43: plugin.AuthHandlerService.GetAuthHandlers:input_type -> plugin.GetAuthHandlersRequest
+	44, // 44: plugin.AuthHandlerService.ConfigureAuthHandler:input_type -> plugin.ConfigureAuthHandlerRequest
+	28, // 45: plugin.AuthHandlerService.Login:input_type -> plugin.LoginRequest
+	33, // 46: plugin.AuthHandlerService.Logout:input_type -> plugin.LogoutRequest
+	35, // 47: plugin.AuthHandlerService.GetStatus:input_type -> plugin.GetStatusRequest
+	37, // 48: plugin.AuthHandlerService.GetToken:input_type -> plugin.GetTokenRequest
+	39, // 49: plugin.AuthHandlerService.ListCachedTokens:input_type -> plugin.ListCachedTokensRequest
+	42, // 50: plugin.AuthHandlerService.PurgeExpiredTokens:input_type -> plugin.PurgeExpiredTokensRequest
+	46, // 51: plugin.AuthHandlerService.StopAuthHandler:input_type -> plugin.StopAuthHandlerRequest
+	2,  // 52: plugin.PluginService.GetProviders:output_type -> plugin.GetProvidersResponse
+	4,  // 53: plugin.PluginService.GetProviderDescriptor:output_type -> plugin.GetProviderDescriptorResponse
+	13, // 54: plugin.PluginService.ConfigureProvider:output_type -> plugin.ConfigureProviderResponse
+	18, // 55: plugin.PluginService.ExecuteProvider:output_type -> plugin.ExecuteProviderResponse
+	16, // 56: plugin.PluginService.ExecuteProviderStream:output_type -> plugin.ExecuteProviderStreamChunk
+	20, // 57: plugin.PluginService.DescribeWhatIf:output_type -> plugin.DescribeWhatIfResponse
+	22, // 58: plugin.PluginService.ExtractDependencies:output_type -> plugin.ExtractDependenciesResponse
+	24, // 59: plugin.PluginService.StopProvider:output_type -> plugin.StopProviderResponse
+	49, // 60: plugin.HostService.GetSecret:output_type -> plugin.GetSecretResponse
+	51, // 61: plugin.HostService.SetSecret:output_type -> plugin.SetSecretResponse
+	53, // 62: plugin.HostService.DeleteSecret:output_type -> plugin.DeleteSecretResponse
+	55, // 63: plugin.HostService.ListSecrets:output_type -> plugin.ListSecretsResponse
+	57, // 64: plugin.HostService.GetAuthIdentity:output_type -> plugin.GetAuthIdentityResponse
+	59, // 65: plugin.HostService.ListAuthHandlers:output_type -> plugin.ListAuthHandlersResponse
+	61, // 66: plugin.HostService.GetAuthToken:output_type -> plugin.GetAuthTokenResponse
+	26, // 67: plugin.AuthHandlerService.GetAuthHandlers:output_type -> plugin.GetAuthHandlersResponse
+	45, // 68: plugin.AuthHandlerService.ConfigureAuthHandler:output_type -> plugin.ConfigureAuthHandlerResponse
+	29, // 69: plugin.AuthHandlerService.Login:output_type -> plugin.LoginStreamMessage
+	34, // 70: plugin.AuthHandlerService.Logout:output_type -> plugin.LogoutResponse
+	36, // 71: plugin.AuthHandlerService.GetStatus:output_type -> plugin.GetStatusResponse
+	38, // 72: plugin.AuthHandlerService.GetToken:output_type -> plugin.GetTokenResponse
+	40, // 73: plugin.AuthHandlerService.ListCachedTokens:output_type -> plugin.ListCachedTokensResponse
+	43, // 74: plugin.AuthHandlerService.PurgeExpiredTokens:output_type -> plugin.PurgeExpiredTokensResponse
+	47, // 75: plugin.AuthHandlerService.StopAuthHandler:output_type -> plugin.StopAuthHandlerResponse
+	52, // [52:76] is the sub-list for method output_type
+	28, // [28:52] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_pkg_plugin_proto_plugin_proto_init() }
@@ -3836,7 +4587,7 @@ func file_pkg_plugin_proto_plugin_proto_init() {
 		(*ExecuteProviderStreamChunk_Stderr)(nil),
 		(*ExecuteProviderStreamChunk_Result)(nil),
 	}
-	file_pkg_plugin_proto_plugin_proto_msgTypes[25].OneofWrappers = []any{
+	file_pkg_plugin_proto_plugin_proto_msgTypes[28].OneofWrappers = []any{
 		(*LoginStreamMessage_DeviceCodePrompt)(nil),
 		(*LoginStreamMessage_Result)(nil),
 		(*LoginStreamMessage_Error)(nil),
@@ -3846,13 +4597,14 @@ func file_pkg_plugin_proto_plugin_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_plugin_proto_plugin_proto_rawDesc), len(file_pkg_plugin_proto_plugin_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   56,
+			NumEnums:      1,
+			NumMessages:   66,
 			NumExtensions: 0,
 			NumServices:   3,
 		},
 		GoTypes:           file_pkg_plugin_proto_plugin_proto_goTypes,
 		DependencyIndexes: file_pkg_plugin_proto_plugin_proto_depIdxs,
+		EnumInfos:         file_pkg_plugin_proto_plugin_proto_enumTypes,
 		MessageInfos:      file_pkg_plugin_proto_plugin_proto_msgTypes,
 	}.Build()
 	File_pkg_plugin_proto_plugin_proto = out.File

--- a/pkg/plugin/proto/plugin.proto
+++ b/pkg/plugin/proto/plugin.proto
@@ -31,6 +31,11 @@ service PluginService {
   // implement custom extraction should return an empty list (the host falls
   // back to generic extraction).
   rpc ExtractDependencies(ExtractDependenciesRequest) returns (ExtractDependenciesResponse);
+
+  // StopProvider requests graceful shutdown of a running provider execution.
+  // The host calls this when the user cancels an operation (e.g. Ctrl+C).
+  // Plugins should abort in-flight work and return promptly.
+  rpc StopProvider(StopProviderRequest) returns (StopProviderResponse);
 }
 
 // HostService is a callback service that plugins can invoke on the host.
@@ -50,12 +55,20 @@ service HostService {
   rpc GetAuthIdentity(GetAuthIdentityRequest) returns (GetAuthIdentityResponse);
   // ListAuthHandlers lists available auth handlers on the host.
   rpc ListAuthHandlers(ListAuthHandlersRequest) returns (ListAuthHandlersResponse);
+  // GetAuthToken retrieves a valid access token from the host's auth registry.
+  // Plugins use this for authenticated HTTP requests and token refresh on 401.
+  rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
 }
 
 // AuthHandlerService is the auth handler plugin service.
 service AuthHandlerService {
   // GetAuthHandlers returns metadata for all auth handlers exposed by this plugin.
   rpc GetAuthHandlers(GetAuthHandlersRequest) returns (GetAuthHandlersResponse);
+
+  // ConfigureAuthHandler sends host-side configuration to the plugin once after load.
+  // Carries quiet/noColor/binaryName, extensible settings, HostService broker ID,
+  // and the plugin protocol version for feature detection.
+  rpc ConfigureAuthHandler(ConfigureAuthHandlerRequest) returns (ConfigureAuthHandlerResponse);
 
   // Login initiates authentication. Returns a stream: zero or more DeviceCodePrompt
   // messages followed by exactly one LoginResult message.
@@ -75,6 +88,10 @@ service AuthHandlerService {
 
   // PurgeExpiredTokens removes expired tokens for the named handler.
   rpc PurgeExpiredTokens(PurgeExpiredTokensRequest) returns (PurgeExpiredTokensResponse);
+
+  // StopAuthHandler requests graceful shutdown of a running auth handler operation.
+  // handler_name may be empty to stop all handlers.
+  rpc StopAuthHandler(StopAuthHandlerRequest) returns (StopAuthHandlerResponse);
 }
 
 message GetProvidersRequest {}
@@ -194,10 +211,17 @@ message ConfigureProviderRequest {
   string binary_name = 4;
   uint32 host_service_id = 5; // GRPCBroker service ID for HostService callbacks
   map<string, bytes> settings = 6; // Extensible JSON-encoded key-value settings
+  // protocol_version is the host's plugin protocol version. Plugins can use
+  // this to detect feature availability and fail clearly on incompatible hosts.
+  int32 protocol_version = 7;
 }
 
 message ConfigureProviderResponse {
   string error = 1; // Empty if no error
+  repeated Diagnostic diagnostics = 2;
+  // protocol_version is the plugin's protocol version. The host can use this
+  // to detect feature availability. If unset (0), the plugin predates version negotiation.
+  int32 protocol_version = 3;
 }
 
 // SolutionMeta carries solution-level metadata to plugin providers.
@@ -228,9 +252,31 @@ message ExecuteProviderStreamChunk {
   }
 }
 
+// Diagnostic represents a single warning or error from a provider execution,
+// following the Terraform diagnostic pattern. Providers can return multiple
+// diagnostics alongside a result.
+message Diagnostic {
+  enum Severity {
+    INVALID = 0;
+    ERROR = 1;
+    WARNING = 2;
+  }
+  Severity severity = 1;
+  string summary = 2;     // Short one-line description (always present)
+  string detail = 3;      // Optional multi-line explanation
+  string attribute = 4;   // Optional dotted attribute path (e.g. "config.url")
+}
+
 message ExecuteProviderResponse {
   bytes output = 1; // JSON-encoded output (ProviderOutput)
-  string error = 2;  // Empty if no error
+  string error = 2;  // Empty if no error (DEPRECATED: prefer diagnostics)
+  // exit_code carries the provider's exit code so that ExitError semantics
+  // survive the RPC boundary. 0 = success, non-zero mirrors exitcode constants.
+  // Only meaningful when error is non-empty.
+  int32 exit_code = 3;
+  // diagnostics carries structured warnings and errors from the provider.
+  // When present, prefer these over the flat error string.
+  repeated Diagnostic diagnostics = 4;
 }
 
 message DescribeWhatIfRequest {
@@ -241,6 +287,7 @@ message DescribeWhatIfRequest {
 message DescribeWhatIfResponse {
   string description = 1; // Human-readable WhatIf description (empty if not implemented)
   string error = 2;       // Empty if no error
+  repeated Diagnostic diagnostics = 3;
 }
 
 message ExtractDependenciesRequest {
@@ -251,6 +298,18 @@ message ExtractDependenciesRequest {
 message ExtractDependenciesResponse {
   repeated string dependencies = 1;
   string error = 2;
+  repeated Diagnostic diagnostics = 3;
+}
+
+// StopProviderRequest asks the plugin to gracefully stop any in-flight
+// execution for the named provider.
+message StopProviderRequest {
+  string provider_name = 1; // Empty means stop all providers
+}
+
+// StopProviderResponse acknowledges the stop request.
+message StopProviderResponse {
+  string error = 1; // Empty if no error
 }
 
 // ---- Auth Handler Messages ----
@@ -376,7 +435,33 @@ message PurgeExpiredTokensRequest {
 message PurgeExpiredTokensResponse {
   int32 purged_count = 1;
 }
+// ConfigureAuthHandlerRequest carries host-side configuration to auth handler plugins.
+message ConfigureAuthHandlerRequest {
+  string handler_name = 1;         // Auth handler to configure (empty = all)
+  bool   quiet = 2;                // Suppress non-essential output
+  bool   no_color = 3;             // Disable colored output
+  string binary_name = 4;          // CLI binary name (e.g. "scafctl" or embedder name)
+  map<string, bytes> settings = 5; // Extensible JSON key-value settings
+  uint32 host_service_id = 6;      // GRPCBroker service ID for HostService callbacks
+  int32  protocol_version = 7;     // Host plugin protocol version for feature detection
+}
 
+// ConfigureAuthHandlerResponse acknowledges configuration.
+message ConfigureAuthHandlerResponse {
+  string error = 1;                // Non-empty on failure
+  int32  protocol_version = 2;     // Plugin's own protocol version
+  repeated Diagnostic diagnostics = 3; // Structured diagnostics
+}
+
+// StopAuthHandlerRequest asks the plugin to gracefully stop operations.
+message StopAuthHandlerRequest {
+  string handler_name = 1;         // Handler to stop (empty = all)
+}
+
+// StopAuthHandlerResponse acknowledges shutdown.
+message StopAuthHandlerResponse {
+  string error = 1;                // Non-empty on failure
+}
 // ---- Host Service Messages (plugin → host callbacks) ----
 
 message GetSecretRequest {
@@ -430,4 +515,22 @@ message ListAuthHandlersRequest {}
 message ListAuthHandlersResponse {
   repeated string handler_names = 1;
   string default_handler = 2;
+}
+
+// GetAuthTokenRequest asks the host for a valid access token. Plugins use
+// this for authenticated HTTP requests and transparent token refresh.
+message GetAuthTokenRequest {
+  string handler_name = 1;    // Auth handler name (empty for default)
+  string scope = 2;           // OAuth scope
+  int64 min_valid_for_seconds = 3; // Minimum remaining validity (0 = any valid token)
+  bool force_refresh = 4;     // Force a token refresh
+}
+
+// GetAuthTokenResponse carries the token back to the plugin.
+message GetAuthTokenResponse {
+  string access_token = 1;
+  string token_type = 2;      // e.g. "Bearer"
+  int64 expires_at_unix = 3;  // When the token expires (unix seconds)
+  string scope = 4;
+  string error = 5;
 }

--- a/pkg/plugin/proto/plugin_grpc.pb.go
+++ b/pkg/plugin/proto/plugin_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	PluginService_ExecuteProviderStream_FullMethodName = "/plugin.PluginService/ExecuteProviderStream"
 	PluginService_DescribeWhatIf_FullMethodName        = "/plugin.PluginService/DescribeWhatIf"
 	PluginService_ExtractDependencies_FullMethodName   = "/plugin.PluginService/ExtractDependencies"
+	PluginService_StopProvider_FullMethodName          = "/plugin.PluginService/StopProvider"
 )
 
 // PluginServiceClient is the client API for PluginService service.
@@ -55,6 +56,10 @@ type PluginServiceClient interface {
 	// implement custom extraction should return an empty list (the host falls
 	// back to generic extraction).
 	ExtractDependencies(ctx context.Context, in *ExtractDependenciesRequest, opts ...grpc.CallOption) (*ExtractDependenciesResponse, error)
+	// StopProvider requests graceful shutdown of a running provider execution.
+	// The host calls this when the user cancels an operation (e.g. Ctrl+C).
+	// Plugins should abort in-flight work and return promptly.
+	StopProvider(ctx context.Context, in *StopProviderRequest, opts ...grpc.CallOption) (*StopProviderResponse, error)
 }
 
 type pluginServiceClient struct {
@@ -144,6 +149,16 @@ func (c *pluginServiceClient) ExtractDependencies(ctx context.Context, in *Extra
 	return out, nil
 }
 
+func (c *pluginServiceClient) StopProvider(ctx context.Context, in *StopProviderRequest, opts ...grpc.CallOption) (*StopProviderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StopProviderResponse)
+	err := c.cc.Invoke(ctx, PluginService_StopProvider_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginServiceServer is the server API for PluginService service.
 // All implementations must embed UnimplementedPluginServiceServer
 // for forward compatibility.
@@ -171,6 +186,10 @@ type PluginServiceServer interface {
 	// implement custom extraction should return an empty list (the host falls
 	// back to generic extraction).
 	ExtractDependencies(context.Context, *ExtractDependenciesRequest) (*ExtractDependenciesResponse, error)
+	// StopProvider requests graceful shutdown of a running provider execution.
+	// The host calls this when the user cancels an operation (e.g. Ctrl+C).
+	// Plugins should abort in-flight work and return promptly.
+	StopProvider(context.Context, *StopProviderRequest) (*StopProviderResponse, error)
 	mustEmbedUnimplementedPluginServiceServer()
 }
 
@@ -201,6 +220,9 @@ func (UnimplementedPluginServiceServer) DescribeWhatIf(context.Context, *Describ
 }
 func (UnimplementedPluginServiceServer) ExtractDependencies(context.Context, *ExtractDependenciesRequest) (*ExtractDependenciesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ExtractDependencies not implemented")
+}
+func (UnimplementedPluginServiceServer) StopProvider(context.Context, *StopProviderRequest) (*StopProviderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopProvider not implemented")
 }
 func (UnimplementedPluginServiceServer) mustEmbedUnimplementedPluginServiceServer() {}
 func (UnimplementedPluginServiceServer) testEmbeddedByValue()                       {}
@@ -342,6 +364,24 @@ func _PluginService_ExtractDependencies_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginService_StopProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopProviderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginServiceServer).StopProvider(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginService_StopProvider_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginServiceServer).StopProvider(ctx, req.(*StopProviderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginService_ServiceDesc is the grpc.ServiceDesc for PluginService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -373,6 +413,10 @@ var PluginService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "ExtractDependencies",
 			Handler:    _PluginService_ExtractDependencies_Handler,
 		},
+		{
+			MethodName: "StopProvider",
+			Handler:    _PluginService_StopProvider_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -391,6 +435,7 @@ const (
 	HostService_ListSecrets_FullMethodName      = "/plugin.HostService/ListSecrets"
 	HostService_GetAuthIdentity_FullMethodName  = "/plugin.HostService/GetAuthIdentity"
 	HostService_ListAuthHandlers_FullMethodName = "/plugin.HostService/ListAuthHandlers"
+	HostService_GetAuthToken_FullMethodName     = "/plugin.HostService/GetAuthToken"
 )
 
 // HostServiceClient is the client API for HostService service.
@@ -413,6 +458,9 @@ type HostServiceClient interface {
 	GetAuthIdentity(ctx context.Context, in *GetAuthIdentityRequest, opts ...grpc.CallOption) (*GetAuthIdentityResponse, error)
 	// ListAuthHandlers lists available auth handlers on the host.
 	ListAuthHandlers(ctx context.Context, in *ListAuthHandlersRequest, opts ...grpc.CallOption) (*ListAuthHandlersResponse, error)
+	// GetAuthToken retrieves a valid access token from the host's auth registry.
+	// Plugins use this for authenticated HTTP requests and token refresh on 401.
+	GetAuthToken(ctx context.Context, in *GetAuthTokenRequest, opts ...grpc.CallOption) (*GetAuthTokenResponse, error)
 }
 
 type hostServiceClient struct {
@@ -483,6 +531,16 @@ func (c *hostServiceClient) ListAuthHandlers(ctx context.Context, in *ListAuthHa
 	return out, nil
 }
 
+func (c *hostServiceClient) GetAuthToken(ctx context.Context, in *GetAuthTokenRequest, opts ...grpc.CallOption) (*GetAuthTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetAuthTokenResponse)
+	err := c.cc.Invoke(ctx, HostService_GetAuthToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // HostServiceServer is the server API for HostService service.
 // All implementations must embed UnimplementedHostServiceServer
 // for forward compatibility.
@@ -503,6 +561,9 @@ type HostServiceServer interface {
 	GetAuthIdentity(context.Context, *GetAuthIdentityRequest) (*GetAuthIdentityResponse, error)
 	// ListAuthHandlers lists available auth handlers on the host.
 	ListAuthHandlers(context.Context, *ListAuthHandlersRequest) (*ListAuthHandlersResponse, error)
+	// GetAuthToken retrieves a valid access token from the host's auth registry.
+	// Plugins use this for authenticated HTTP requests and token refresh on 401.
+	GetAuthToken(context.Context, *GetAuthTokenRequest) (*GetAuthTokenResponse, error)
 	mustEmbedUnimplementedHostServiceServer()
 }
 
@@ -530,6 +591,9 @@ func (UnimplementedHostServiceServer) GetAuthIdentity(context.Context, *GetAuthI
 }
 func (UnimplementedHostServiceServer) ListAuthHandlers(context.Context, *ListAuthHandlersRequest) (*ListAuthHandlersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAuthHandlers not implemented")
+}
+func (UnimplementedHostServiceServer) GetAuthToken(context.Context, *GetAuthTokenRequest) (*GetAuthTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetAuthToken not implemented")
 }
 func (UnimplementedHostServiceServer) mustEmbedUnimplementedHostServiceServer() {}
 func (UnimplementedHostServiceServer) testEmbeddedByValue()                     {}
@@ -660,6 +724,24 @@ func _HostService_ListAuthHandlers_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _HostService_GetAuthToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetAuthTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostServiceServer).GetAuthToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostService_GetAuthToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostServiceServer).GetAuthToken(ctx, req.(*GetAuthTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // HostService_ServiceDesc is the grpc.ServiceDesc for HostService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -691,19 +773,25 @@ var HostService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "ListAuthHandlers",
 			Handler:    _HostService_ListAuthHandlers_Handler,
 		},
+		{
+			MethodName: "GetAuthToken",
+			Handler:    _HostService_GetAuthToken_Handler,
+		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "pkg/plugin/proto/plugin.proto",
 }
 
 const (
-	AuthHandlerService_GetAuthHandlers_FullMethodName    = "/plugin.AuthHandlerService/GetAuthHandlers"
-	AuthHandlerService_Login_FullMethodName              = "/plugin.AuthHandlerService/Login"
-	AuthHandlerService_Logout_FullMethodName             = "/plugin.AuthHandlerService/Logout"
-	AuthHandlerService_GetStatus_FullMethodName          = "/plugin.AuthHandlerService/GetStatus"
-	AuthHandlerService_GetToken_FullMethodName           = "/plugin.AuthHandlerService/GetToken"
-	AuthHandlerService_ListCachedTokens_FullMethodName   = "/plugin.AuthHandlerService/ListCachedTokens"
-	AuthHandlerService_PurgeExpiredTokens_FullMethodName = "/plugin.AuthHandlerService/PurgeExpiredTokens"
+	AuthHandlerService_GetAuthHandlers_FullMethodName      = "/plugin.AuthHandlerService/GetAuthHandlers"
+	AuthHandlerService_ConfigureAuthHandler_FullMethodName = "/plugin.AuthHandlerService/ConfigureAuthHandler"
+	AuthHandlerService_Login_FullMethodName                = "/plugin.AuthHandlerService/Login"
+	AuthHandlerService_Logout_FullMethodName               = "/plugin.AuthHandlerService/Logout"
+	AuthHandlerService_GetStatus_FullMethodName            = "/plugin.AuthHandlerService/GetStatus"
+	AuthHandlerService_GetToken_FullMethodName             = "/plugin.AuthHandlerService/GetToken"
+	AuthHandlerService_ListCachedTokens_FullMethodName     = "/plugin.AuthHandlerService/ListCachedTokens"
+	AuthHandlerService_PurgeExpiredTokens_FullMethodName   = "/plugin.AuthHandlerService/PurgeExpiredTokens"
+	AuthHandlerService_StopAuthHandler_FullMethodName      = "/plugin.AuthHandlerService/StopAuthHandler"
 )
 
 // AuthHandlerServiceClient is the client API for AuthHandlerService service.
@@ -714,6 +802,10 @@ const (
 type AuthHandlerServiceClient interface {
 	// GetAuthHandlers returns metadata for all auth handlers exposed by this plugin.
 	GetAuthHandlers(ctx context.Context, in *GetAuthHandlersRequest, opts ...grpc.CallOption) (*GetAuthHandlersResponse, error)
+	// ConfigureAuthHandler sends host-side configuration to the plugin once after load.
+	// Carries quiet/noColor/binaryName, extensible settings, HostService broker ID,
+	// and the plugin protocol version for feature detection.
+	ConfigureAuthHandler(ctx context.Context, in *ConfigureAuthHandlerRequest, opts ...grpc.CallOption) (*ConfigureAuthHandlerResponse, error)
 	// Login initiates authentication. Returns a stream: zero or more DeviceCodePrompt
 	// messages followed by exactly one LoginResult message.
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LoginStreamMessage], error)
@@ -727,6 +819,9 @@ type AuthHandlerServiceClient interface {
 	ListCachedTokens(ctx context.Context, in *ListCachedTokensRequest, opts ...grpc.CallOption) (*ListCachedTokensResponse, error)
 	// PurgeExpiredTokens removes expired tokens for the named handler.
 	PurgeExpiredTokens(ctx context.Context, in *PurgeExpiredTokensRequest, opts ...grpc.CallOption) (*PurgeExpiredTokensResponse, error)
+	// StopAuthHandler requests graceful shutdown of a running auth handler operation.
+	// handler_name may be empty to stop all handlers.
+	StopAuthHandler(ctx context.Context, in *StopAuthHandlerRequest, opts ...grpc.CallOption) (*StopAuthHandlerResponse, error)
 }
 
 type authHandlerServiceClient struct {
@@ -741,6 +836,16 @@ func (c *authHandlerServiceClient) GetAuthHandlers(ctx context.Context, in *GetA
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetAuthHandlersResponse)
 	err := c.cc.Invoke(ctx, AuthHandlerService_GetAuthHandlers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authHandlerServiceClient) ConfigureAuthHandler(ctx context.Context, in *ConfigureAuthHandlerRequest, opts ...grpc.CallOption) (*ConfigureAuthHandlerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ConfigureAuthHandlerResponse)
+	err := c.cc.Invoke(ctx, AuthHandlerService_ConfigureAuthHandler_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -816,6 +921,16 @@ func (c *authHandlerServiceClient) PurgeExpiredTokens(ctx context.Context, in *P
 	return out, nil
 }
 
+func (c *authHandlerServiceClient) StopAuthHandler(ctx context.Context, in *StopAuthHandlerRequest, opts ...grpc.CallOption) (*StopAuthHandlerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StopAuthHandlerResponse)
+	err := c.cc.Invoke(ctx, AuthHandlerService_StopAuthHandler_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AuthHandlerServiceServer is the server API for AuthHandlerService service.
 // All implementations must embed UnimplementedAuthHandlerServiceServer
 // for forward compatibility.
@@ -824,6 +939,10 @@ func (c *authHandlerServiceClient) PurgeExpiredTokens(ctx context.Context, in *P
 type AuthHandlerServiceServer interface {
 	// GetAuthHandlers returns metadata for all auth handlers exposed by this plugin.
 	GetAuthHandlers(context.Context, *GetAuthHandlersRequest) (*GetAuthHandlersResponse, error)
+	// ConfigureAuthHandler sends host-side configuration to the plugin once after load.
+	// Carries quiet/noColor/binaryName, extensible settings, HostService broker ID,
+	// and the plugin protocol version for feature detection.
+	ConfigureAuthHandler(context.Context, *ConfigureAuthHandlerRequest) (*ConfigureAuthHandlerResponse, error)
 	// Login initiates authentication. Returns a stream: zero or more DeviceCodePrompt
 	// messages followed by exactly one LoginResult message.
 	Login(*LoginRequest, grpc.ServerStreamingServer[LoginStreamMessage]) error
@@ -837,6 +956,9 @@ type AuthHandlerServiceServer interface {
 	ListCachedTokens(context.Context, *ListCachedTokensRequest) (*ListCachedTokensResponse, error)
 	// PurgeExpiredTokens removes expired tokens for the named handler.
 	PurgeExpiredTokens(context.Context, *PurgeExpiredTokensRequest) (*PurgeExpiredTokensResponse, error)
+	// StopAuthHandler requests graceful shutdown of a running auth handler operation.
+	// handler_name may be empty to stop all handlers.
+	StopAuthHandler(context.Context, *StopAuthHandlerRequest) (*StopAuthHandlerResponse, error)
 	mustEmbedUnimplementedAuthHandlerServiceServer()
 }
 
@@ -849,6 +971,9 @@ type UnimplementedAuthHandlerServiceServer struct{}
 
 func (UnimplementedAuthHandlerServiceServer) GetAuthHandlers(context.Context, *GetAuthHandlersRequest) (*GetAuthHandlersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAuthHandlers not implemented")
+}
+func (UnimplementedAuthHandlerServiceServer) ConfigureAuthHandler(context.Context, *ConfigureAuthHandlerRequest) (*ConfigureAuthHandlerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ConfigureAuthHandler not implemented")
 }
 func (UnimplementedAuthHandlerServiceServer) Login(*LoginRequest, grpc.ServerStreamingServer[LoginStreamMessage]) error {
 	return status.Error(codes.Unimplemented, "method Login not implemented")
@@ -867,6 +992,9 @@ func (UnimplementedAuthHandlerServiceServer) ListCachedTokens(context.Context, *
 }
 func (UnimplementedAuthHandlerServiceServer) PurgeExpiredTokens(context.Context, *PurgeExpiredTokensRequest) (*PurgeExpiredTokensResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PurgeExpiredTokens not implemented")
+}
+func (UnimplementedAuthHandlerServiceServer) StopAuthHandler(context.Context, *StopAuthHandlerRequest) (*StopAuthHandlerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopAuthHandler not implemented")
 }
 func (UnimplementedAuthHandlerServiceServer) mustEmbedUnimplementedAuthHandlerServiceServer() {}
 func (UnimplementedAuthHandlerServiceServer) testEmbeddedByValue()                            {}
@@ -903,6 +1031,24 @@ func _AuthHandlerService_GetAuthHandlers_Handler(srv interface{}, ctx context.Co
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AuthHandlerServiceServer).GetAuthHandlers(ctx, req.(*GetAuthHandlersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthHandlerService_ConfigureAuthHandler_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConfigureAuthHandlerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthHandlerServiceServer).ConfigureAuthHandler(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthHandlerService_ConfigureAuthHandler_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthHandlerServiceServer).ConfigureAuthHandler(ctx, req.(*ConfigureAuthHandlerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1008,6 +1154,24 @@ func _AuthHandlerService_PurgeExpiredTokens_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AuthHandlerService_StopAuthHandler_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopAuthHandlerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthHandlerServiceServer).StopAuthHandler(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthHandlerService_StopAuthHandler_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthHandlerServiceServer).StopAuthHandler(ctx, req.(*StopAuthHandlerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AuthHandlerService_ServiceDesc is the grpc.ServiceDesc for AuthHandlerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1018,6 +1182,10 @@ var AuthHandlerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetAuthHandlers",
 			Handler:    _AuthHandlerService_GetAuthHandlers_Handler,
+		},
+		{
+			MethodName: "ConfigureAuthHandler",
+			Handler:    _AuthHandlerService_ConfigureAuthHandler_Handler,
 		},
 		{
 			MethodName: "Logout",
@@ -1038,6 +1206,10 @@ var AuthHandlerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PurgeExpiredTokens",
 			Handler:    _AuthHandlerService_PurgeExpiredTokens_Handler,
+		},
+		{
+			MethodName: "StopAuthHandler",
+			Handler:    _AuthHandlerService_StopAuthHandler_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/plugin/wrapper.go
+++ b/pkg/plugin/wrapper.go
@@ -23,10 +23,34 @@ type ProviderWrapper struct {
 	mu           sync.RWMutex
 }
 
+// wrapperConfig holds configuration for NewProviderWrapper.
+type wrapperConfig struct {
+	ctx context.Context
+}
+
+// WrapperOption configures NewProviderWrapper.
+type WrapperOption func(*wrapperConfig)
+
+// WithContext sets the context used during wrapper initialisation (e.g. for
+// the initial GetProviderDescriptor RPC). Defaults to context.Background().
+// A nil context is silently replaced with context.Background().
+func WithContext(ctx context.Context) WrapperOption {
+	return func(c *wrapperConfig) {
+		if ctx != nil {
+			c.ctx = ctx
+		}
+	}
+}
+
 // NewProviderWrapper creates a new provider wrapper for a plugin provider
-func NewProviderWrapper(client *Client, providerName string) (*ProviderWrapper, error) {
+func NewProviderWrapper(client *Client, providerName string, opts ...WrapperOption) (*ProviderWrapper, error) {
+	wCfg := wrapperConfig{ctx: context.Background()}
+	for _, o := range opts {
+		o(&wCfg)
+	}
+
 	// Get the descriptor to validate the provider exists
-	desc, err := client.GetProviderDescriptor(context.Background(), providerName)
+	desc, err := client.GetProviderDescriptor(wCfg.ctx, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider descriptor: %w", err)
 	}
@@ -184,28 +208,34 @@ func (w *ProviderWrapper) ExecuteStream(ctx context.Context, input any, cb func(
 // RegisterPluginProviders discovers plugins and registers them with the provider registry.
 // After registration, each wrapper is configured with the provided ProviderConfig.
 // If cfg is nil, configuration is skipped (providers will use defaults).
-func RegisterPluginProviders(ctx context.Context, registry *provider.Registry, pluginDirs []string, cfg *ProviderConfig, clientOpts ...ClientOption) error {
+// Returns the created clients; the caller should defer calling KillAll(clients)
+// to clean up plugin processes on exit.
+func RegisterPluginProviders(ctx context.Context, registry *provider.Registry, pluginDirs []string, cfg *ProviderConfig, clientOpts ...ClientOption) ([]*Client, error) {
 	// Discover plugins
 	clients, err := Discover(pluginDirs, clientOpts...)
 	if err != nil {
-		return fmt.Errorf("failed to discover plugins: %w", err)
+		return nil, fmt.Errorf("failed to discover plugins: %w", err)
 	}
 
 	// Register providers from each plugin
 	for _, client := range clients {
 		providers, err := client.GetProviders(ctx)
 		if err != nil {
+			logger.FromContext(ctx).V(1).Info("failed to get providers from plugin", "plugin", client.Name(), "error", err)
 			client.Kill()
 			continue
 		}
 
+		lgr := logger.FromContext(ctx)
 		for _, providerName := range providers {
-			wrapper, err := NewProviderWrapper(client, providerName)
+			wrapper, err := NewProviderWrapper(client, providerName, WithContext(ctx))
 			if err != nil {
+				lgr.V(1).Info("failed to create provider wrapper", "provider", providerName, "plugin", client.Name(), "error", err)
 				continue
 			}
 
 			if err := registry.Register(wrapper); err != nil {
+				lgr.V(1).Info("failed to register plugin provider", "provider", providerName, "plugin", client.Name(), "error", err)
 				continue
 			}
 
@@ -221,5 +251,15 @@ func RegisterPluginProviders(ctx context.Context, registry *provider.Registry, p
 		}
 	}
 
-	return nil
+	return clients, nil
+}
+
+// KillAll terminates all plugin processes in the given client list.
+// This is safe to call with a nil or empty slice.
+func KillAll(clients []*Client) {
+	for _, c := range clients {
+		if c != nil {
+			c.Kill()
+		}
+	}
 }

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -163,28 +163,60 @@ func (w *AuthHandlerWrapper) Client() *AuthHandlerClient {
 	return w.client
 }
 
+// configureAndRegisterAuthHandlers configures each handler with host-side
+// settings (when cfg is non-nil) and registers it in the auth registry.
+func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Registry, client *AuthHandlerClient, handlers []AuthHandlerInfo, cfg *ProviderConfig) {
+	lgr := logger.FromContext(ctx)
+	for _, info := range handlers {
+		if cfg != nil {
+			hostCfg := *cfg
+			hostCfg.HostServiceID = client.HostServiceID()
+			if cfgErr := client.ConfigureAuthHandler(ctx, info.Name, hostCfg); cfgErr != nil {
+				lgr.Info("failed to configure auth handler plugin",
+					"handler", info.Name,
+					"error", cfgErr)
+			}
+		}
+
+		wrapper := NewAuthHandlerWrapper(client, info)
+		if err := registry.Register(wrapper); err != nil {
+			lgr.V(1).Info("failed to register auth handler", "handler", info.Name, "error", err)
+			continue
+		}
+	}
+}
+
 // RegisterAuthHandlerPlugins discovers auth handler plugins and registers them
-// with the auth registry.
-func RegisterAuthHandlerPlugins(registry *auth.Registry, pluginDirs []string) error {
-	clients, err := DiscoverAuthHandlers(pluginDirs)
+// with the auth registry. Returns the created clients (caller should Kill() them
+// on cleanup).
+func RegisterAuthHandlerPlugins(ctx context.Context, registry *auth.Registry, pluginDirs []string, cfg *ProviderConfig, clientOpts ...ClientOption) ([]*AuthHandlerClient, error) {
+	clients, err := DiscoverAuthHandlers(pluginDirs, clientOpts...)
 	if err != nil {
-		return fmt.Errorf("failed to discover auth handler plugins: %w", err)
+		return nil, fmt.Errorf("failed to discover auth handler plugins: %w", err)
 	}
 
+	var allClients []*AuthHandlerClient
+
 	for _, client := range clients {
-		handlers, err := client.GetAuthHandlers(context.Background())
+		handlers, err := client.GetAuthHandlers(ctx)
 		if err != nil {
 			client.Kill()
 			continue
 		}
 
-		for _, info := range handlers {
-			wrapper := NewAuthHandlerWrapper(client, info)
-			if err := registry.Register(wrapper); err != nil {
-				continue
-			}
-		}
+		configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		allClients = append(allClients, client)
 	}
 
-	return nil
+	return allClients, nil
+}
+
+// KillAllAuthHandlers terminates all auth handler plugin processes in the given client list.
+// This is safe to call with a nil or empty slice.
+func KillAllAuthHandlers(clients []*AuthHandlerClient) {
+	for _, c := range clients {
+		if c != nil {
+			c.Kill()
+		}
+	}
 }

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -252,7 +252,7 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 
 		// Register auth handler plugins if auth registry is available
 		if cfg.authRegistry != nil {
-			authClients, authRegErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, cfg.authRegistry, fetchResults)
+			authClients, authRegErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, cfg.authRegistry, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
 			if authRegErr != nil {
 				cleanup()
 				return nil, fmt.Errorf("registering fetched auth handler plugins: %w", authRegErr)


### PR DESCRIPTION
Upgrade the plugin gRPC protocol with several new capabilities:
- Add protocol version negotiation (PluginProtocolVersion = 2)
- Add Diagnostic message type for structured error/warning reporting
- Propagate exit codes across the gRPC boundary via ExitError
- Add StopProvider and StopAuthHandler RPCs for graceful shutdown
- Add GetAuthToken host callback so plugins can request auth tokens
- Add ConfigureAuthHandler RPC for host-to-plugin configuration
- Start HostService broker for auth handler plugins (secret/auth access)
- Filter ListAuthHandlers responses by AllowedAuthHandlers set
- Cache GetProviderDescriptor results per client lifecycle
- Return clients from RegisterPluginProviders/RegisterAuthHandlerPlugins for proper cleanup via KillAll/KillAllAuthHandlers
- Expose AuthPluginDirs on RootOptions for embedder auth plugin loading
- Update proto definitions, echo example plugin, and documentation
- Add comprehensive tests for all new RPCs and round-trip behaviors

BREAKING CHANGE: RegisterPluginProviders and RegisterAuthHandlerPlugins now return ([]*Client, error) and ([]*AuthHandlerClient, error) respectively. ProviderPlugin requires StopProvider; AuthHandlerPlugin requires ConfigureAuthHandler and StopAuthHandler.