### PR TITLE
feat: improve CLI arg validation, output, and lint accuracy

### DIFF
--- a/.github/agents/issue-creator.agent.md
+++ b/.github/agents/issue-creator.agent.md
@@ -30,7 +30,7 @@ Clarify what the user wants. Ask brief follow-up questions if the request is amb
 
 ### Phase 2: Explore
 
-Search the codebase to gather technical context:
+Search the codebase to gather technical context. Use the `Explore` subagent for fast, targeted searches when you need to find patterns across multiple packages:
 - Which files, packages, and layers would be affected?
 - Existing patterns, interfaces, or types that are relevant?
 - Similar implementations to reference?

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Feature implementation planner for scafctl. Creates structured implementation blueprints with architecture decisions, task breakdown, and dependency analysis. Use for complex features and refactoring."
 name: "planner"
-tools: [vscode/askQuestions, read, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, web, agent]
+tools: [vscode/askQuestions, read, search, web, agent]
 argument-hint: "Describe the feature or change to plan"
 handoffs:
   - label: "File GitHub issue"
@@ -31,10 +31,10 @@ You are a senior Go architect and implementation planner for the **scafctl** pro
 
 ## Planning Process
 
-1. **Understand** — Analyze the request, identify constraints
-2. **Research** — Search the codebase for existing patterns, interfaces, and conventions
-3. **Design** — Create the implementation blueprint
-4. **Review** — Identify risks, edge cases, and dependencies
+1. **Understand** -- Analyze the request, identify constraints
+2. **Research** -- Use the `Explore` subagent for fast codebase searches when you need to find patterns, interfaces, or conventions across multiple packages
+3. **Design** -- Create the implementation blueprint
+4. **Review** -- Identify risks, edge cases, and dependencies
 
 ## Blueprint Template
 

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -102,7 +102,7 @@ After all fixes are applied:
 ```bash
 gh api graphql -f query='
   mutation($threadId: ID!, $body: String!) {
-    addPullRequestReviewThread(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+    addPullRequestReviewComment(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
       comment { id }
     }
   }' -f threadId=<THREAD_ID> -f body="<response>"

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -101,11 +101,11 @@ After all fixes are applied:
 **To reply to a thread:**
 ```bash
 gh api graphql -f query='
-  mutation($threadId: ID!, $body: String!) {
-    addPullRequestReviewComment(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+  mutation($id: ID!, $body: String!) {
+    addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $id, body: $body}) {
       comment { id }
     }
-  }' -f threadId=<THREAD_ID> -f body="<response>"
+  }' -f id=<THREAD_ID> -f body="<response>"
 ```
 
 **To resolve a thread:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,31 +5,12 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 
 ## Key Patterns
 
-### CLI Output (`pkg/terminal/writer/`)
-
-Use **Writer** for all terminal output -- **never** use `fmt.Fprintf` directly.
-- Get via `writer.FromContext(ctx)`
-- Respects `--quiet` and `--no-color` flags automatically
-- For testing, use `writer.WithExitFunc()` to capture exit calls
-
-### Data Output (`pkg/terminal/kvx/`)
-Commands returning structured data should use **kvx** with `OutputOptions`:
-- Default to **table** view; support `-o` flag for `table`, `json`, `yaml`, `quiet`
-- Use `kvx.NewOutputOptions(ioStreams)` then `opts.Write(data)`
-- Supports `--interactive` for TUI and `--expression` for CEL filtering
-
-### HTTP Client
-See `pkg/httpc/README.md`
-
-### Paths
-- Use xdg paths via the `pkg/paths` package
-
-### Configuration
-- Use `pkg/settings` for storing defaults and managing settings
-- Use `pkg/config/` for storing, loading, and managing application configuration
-
-### CEL
-Use `celexp.EvaluateExpression()` from `pkg/celexp/context.go`. For CEL provider, prefer the `expression` field over `expr`.
+- **CLI Output**: Use `writer.FromContext(ctx)` -- never `fmt.Fprintf` directly. See `pkg/terminal/writer/`
+- **Data Output**: Use `kvx.OutputOptions` for structured table/json/yaml/quiet output. See `pkg/terminal/kvx/`
+- **HTTP Client**: See `pkg/httpc/README.md`
+- **Paths**: Use xdg paths via `pkg/paths`
+- **Configuration**: `pkg/settings` for defaults, `pkg/config/` for app configuration
+- **CEL**: Use `celexp.EvaluateExpression()`. Prefer `expression` field over `expr`
 
 ## Conventions
 
@@ -66,11 +47,9 @@ The project uses `task` (go-task/task) for builds and linting. **Always use `tas
 
 scafctl is used as a **library by external CLIs**. Every new feature must be consumable by embedders via `RootOptions` or domain package APIs.
 
-- **No hardcoded "scafctl"**: Use `settings.CliBinaryName` constant or read from `settings.Run.BinaryName` in context. Never hardcode the binary name in user-facing strings (descriptions, error messages, paths, env var prefixes)
-- **`RootOptions` is the embedder API surface**: New CLI-level capabilities must be exposed as fields on `RootOptions` with sensible defaults that preserve existing behavior when unset
-- **Domain packages must be binary-name-aware**: Functions that produce paths, env vars, cache keys, or display strings must accept a name parameter or read from context -- never assume the binary is called "scafctl"
-- **MCP server must respect embedder identity**: The MCP server name, tool descriptions, and capabilities must use the configured binary name
-- **Test embedder scenarios**: When adding new configurable behavior, include a test that exercises it with a non-default binary name (e.g., `"mycli"`)
+- **No hardcoded "scafctl"**: Use `settings.CliBinaryName` or `settings.Run.BinaryName` in context
+- **`RootOptions` is the embedder API surface**: New CLI-level capabilities must be exposed as fields with sensible defaults
+- **Test embedder scenarios**: Include a test with a non-default binary name (e.g., `"mycli"`)
 
 ## Security Scanning
 

--- a/.github/instructions/api-server.instructions.md
+++ b/.github/instructions/api-server.instructions.md
@@ -1,0 +1,24 @@
+---
+description: "API server layer rules for scafctl. Endpoints are thin handlers -- no business logic. Use chi+Huma, validate with struct tags, test in api_test.go. Use when editing API server packages."
+applyTo: "pkg/api/**/*.go"
+---
+
+# API Server Layer
+
+API endpoints are **thin handlers** -- they validate input, call domain packages, and return responses.
+
+## Rules
+
+- **No business logic** -- delegate to packages in `pkg/`
+- Use chi for routing and Huma for OpenAPI-driven request/response handling
+- Use Huma struct tags for request validation (`doc`, `maxLength`, `example`, `required`)
+- Use `ServerOption` functional options for server configuration
+- Return structured error responses via `pkg/api/errors.go` helpers
+- Always add new endpoints to API integration tests (`tests/integration/api_test.go`)
+- API features must **only** be tested in `tests/integration/api_test.go`, not in solution integration tests
+
+## Embedder Awareness
+
+- The API server is configurable via `ServerOption` functions
+- Use `settings.Run.BinaryName` for any user-facing strings, not hardcoded `"scafctl"`
+- Middleware must be composable -- embedders may add or replace middleware

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: "Documentation and examples conventions for scafctl. Use when creating or updating docs, tutorials, or examples."
-applyTo: "**/*.go"
+applyTo: "{docs,examples,pkg/docs,pkg/examples}/**"
 ---
 
 # Documentation & Examples

--- a/.github/instructions/settings.instructions.md
+++ b/.github/instructions/settings.instructions.md
@@ -1,0 +1,35 @@
+---
+description: "Settings and configuration conventions for scafctl. Binary name safety, xdg paths, env var prefixes, and timeout defaults. Use when editing settings or config packages."
+applyTo: "{pkg/settings,pkg/config}/**/*.go"
+---
+
+# Settings & Configuration
+
+## Binary Name Safety
+
+scafctl is embedded by external CLIs -- never assume the binary is called `"scafctl"`.
+
+- Use `settings.CliBinaryName` as the fallback constant
+- Use `settings.SanitizeBinaryName()` to normalize raw binary names
+- Use `settings.SafeEnvPrefix()` for environment variable prefixes -- never hardcode `SCAFCTL_`
+- Functions producing paths, cache keys, or display strings must accept a binary name parameter or read from `settings.Run.BinaryName` in context
+- Guard against empty binary names by falling back to `CliBinaryName`
+
+## XDG Paths
+
+Use `xdg` package paths for all file locations:
+- Config: `xdg.ConfigHome` / binary name
+- Cache: `xdg.CacheHome` / binary name
+- Data: `xdg.DataHome` / binary name
+
+## Constants
+
+- Define timeout defaults as named constants (e.g., `DefaultResolverTimeout`, `DefaultHTTPTimeout`)
+- Define conflict strategy defaults as constants
+- No magic values -- all defaults must be exported constants with doc comments
+
+## Configuration (`pkg/config/`)
+
+- Use `config.Config` for runtime application configuration
+- Configuration loading must support layered overrides (file, env, flags)
+- Always validate configuration after loading

--- a/.github/prompts/completeness-check.prompt.md
+++ b/.github/prompts/completeness-check.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "scafctl: Check if staged changes have corresponding docs, tutorials, examples, integration tests, and MCP tools."
-agent: "Explore"
+agent: "agent"
 argument-hint: "Optional: specific area to check"
 ---
 Review staged changes and check if supporting artifacts exist:

--- a/.github/prompts/completeness-check.prompt.md
+++ b/.github/prompts/completeness-check.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "scafctl: Check if staged changes have corresponding docs, tutorials, examples, integration tests, and MCP tools."
-agent: "agent"
+agent: "Explore"
 argument-hint: "Optional: specific area to check"
 ---
 Review staged changes and check if supporting artifacts exist:

--- a/.github/prompts/go-test.prompt.md
+++ b/.github/prompts/go-test.prompt.md
@@ -1,6 +1,6 @@
 ---
-description: "scafctl: Run Go tests with race detection, check coverage, and diagnose failures via go-build-resolver."
-agent: "go-build-resolver"
+description: "scafctl: Run Go tests with race detection, check coverage, and diagnose failures."
+agent: "go-reviewer"
 ---
 Run the Go test suite and report results:
 

--- a/.github/skills/golang-patterns/SKILL.md
+++ b/.github/skills/golang-patterns/SKILL.md
@@ -355,20 +355,7 @@ func join(parts []string) string {
 
 ## Struct Tags
 
-Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/features/request-validation/#validation-tags):
-- All fields: `doc`
-- Strings: `maxLength`, `example`, `pattern`, `patternDescription`
-- Integers: `maximum`, `example`
-- Arrays: `maxItems` (no `example`)
-- Objects/maps: no `example` tag
-
-```go
-type Provider struct {
-    Name    string `json:"name" yaml:"name" doc:"Provider name" maxLength:"128" example:"redis"`
-    Version string `json:"version" yaml:"version" doc:"Semantic version" pattern:"^v?\\d+\\.\\d+\\.\\d+$" patternDescription:"semver format" example:"1.0.0"`
-    Port    int    `json:"port" yaml:"port" doc:"Listen port" maximum:"65535" example:"8080"`
-}
-```
+See `.github/instructions/go-conventions.instructions.md` for the full struct tag and Huma validation tag rules.
 
 ## Anti-Patterns to Avoid
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ go.work.sum
 # .idea/
 .vscode/*
 !.vscode/*.example
+!.vscode/tasks.json
 
 /local
 /temp
@@ -43,6 +44,7 @@ go.work.sum
 /logs
 scafctl.log
 scafctl.exe~
+scafctl
 /modules
 /env
 **/ca-key.pem
@@ -64,3 +66,4 @@ __debug*
 .gocache/*
 .cache/*
 .tool/*
+issues/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,131 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "task",
+      "args": ["build"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": ["$go"],
+      "detail": "Build scafctl binary"
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "task",
+      "args": ["test"],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": ["$go"],
+      "detail": "Run all unit tests"
+    },
+    {
+      "label": "test:e2e",
+      "type": "shell",
+      "command": "task",
+      "args": ["test:e2e"],
+      "group": "test",
+      "problemMatcher": ["$go"],
+      "detail": "Run unit + integration tests"
+    },
+    {
+      "label": "test:race",
+      "type": "shell",
+      "command": "task",
+      "args": ["test:race"],
+      "group": "test",
+      "problemMatcher": ["$go"],
+      "detail": "Run tests with race detector"
+    },
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "task",
+      "args": ["lint"],
+      "problemMatcher": ["$go"],
+      "detail": "Run golangci-lint (pinned version)"
+    },
+    {
+      "label": "lint:fix",
+      "type": "shell",
+      "command": "task",
+      "args": ["lint:fix"],
+      "problemMatcher": ["$go"],
+      "detail": "Run golangci-lint with auto-fix"
+    },
+    {
+      "label": "vet",
+      "type": "shell",
+      "command": "task",
+      "args": ["vet"],
+      "problemMatcher": ["$go"],
+      "detail": "Run go vet"
+    },
+    {
+      "label": "format",
+      "type": "shell",
+      "command": "task",
+      "args": ["format"],
+      "detail": "Run gofumpt + goimports"
+    },
+    {
+      "label": "coverage",
+      "type": "shell",
+      "command": "task",
+      "args": ["coverage"],
+      "group": "test",
+      "problemMatcher": ["$go"],
+      "detail": "Run tests with coverage"
+    },
+    {
+      "label": "coverage:html",
+      "type": "shell",
+      "command": "task",
+      "args": ["coverage:html"],
+      "group": "test",
+      "detail": "Generate and open HTML coverage report"
+    },
+    {
+      "label": "bench",
+      "type": "shell",
+      "command": "task",
+      "args": ["bench"],
+      "problemMatcher": ["$go"],
+      "detail": "Run benchmarks"
+    },
+    {
+      "label": "vulncheck",
+      "type": "shell",
+      "command": "task",
+      "args": ["vulncheck"],
+      "detail": "Run govulncheck"
+    },
+    {
+      "label": "security:scan",
+      "type": "shell",
+      "command": "task",
+      "args": ["security:scan"],
+      "detail": "Run gosec security scanner"
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "task",
+      "args": ["clean"],
+      "detail": "Clean build artifacts and caches"
+    },
+    {
+      "label": "mod",
+      "type": "shell",
+      "command": "task",
+      "args": ["mod"],
+      "detail": "Run go mod tidy + verify"
+    }
+  ]
+}

--- a/pkg/catalog/auth_bridge.go
+++ b/pkg/catalog/auth_bridge.go
@@ -116,6 +116,18 @@ func InferAuthHandler(registryHost string, customHandlers []config.CustomOAuth2C
 	return ""
 }
 
+// InferDefaultScope returns the default OAuth scope for a known registry host.
+// Returns empty string if no default scope is known for the registry.
+func InferDefaultScope(registryHost string) string {
+	switch {
+	case strings.HasSuffix(registryHost, ".pkg.dev"),
+		registryHost == "gcr.io",
+		strings.HasSuffix(registryHost, ".gcr.io"):
+		return "https://www.googleapis.com/auth/cloud-platform"
+	}
+	return ""
+}
+
 // IsBuiltinHandlerName returns true if the name conflicts with a built-in handler.
 func IsBuiltinHandlerName(name string) bool {
 	for _, builtin := range builtinHandlerNames {

--- a/pkg/catalog/auth_bridge_test.go
+++ b/pkg/catalog/auth_bridge_test.go
@@ -214,3 +214,27 @@ func BenchmarkBridgeAuthToRegistry(b *testing.B) {
 		_, _, _ = BridgeAuthToRegistry(ctx, mock, "ghcr.io", "")
 	}
 }
+
+func TestInferDefaultScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		registry string
+		want     string
+	}{
+		{"us-central1-docker.pkg.dev", "https://www.googleapis.com/auth/cloud-platform"},
+		{"gcr.io", "https://www.googleapis.com/auth/cloud-platform"},
+		{"us.gcr.io", "https://www.googleapis.com/auth/cloud-platform"},
+		{"ghcr.io", ""},
+		{"myregistry.azurecr.io", ""},
+		{"docker.io", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.registry, func(t *testing.T) {
+			t.Parallel()
+			got := InferDefaultScope(tc.registry)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/cmd/flags/args.go
+++ b/pkg/cmd/flags/args.go
@@ -1,0 +1,41 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// RequireArg returns a cobra.PositionalArgs validator that requires exactly one
+// positional argument. If missing, it returns an error naming the expected
+// argument and showing an example usage. This replaces cobra.ExactArgs(1)
+// with a more descriptive error message.
+func RequireArg(argName, example string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("missing required argument: <%s>\n\n  Example: %s\n  Run '%s --help' for more information",
+				argName, example, cmd.CommandPath())
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("expected 1 argument <%s>, got %d\n\n  Example: %s\n  Run '%s --help' for more information",
+				argName, len(args), example, cmd.CommandPath())
+		}
+		return nil
+	}
+}
+
+// RequireArgs returns a cobra.PositionalArgs validator that requires exactly n
+// positional arguments with a descriptive error message naming the expected
+// arguments and showing an example.
+func RequireArgs(n int, argDesc, example string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("expected %d argument(s) %s, got %d\n\n  Example: %s\n  Run '%s --help' for more information",
+				n, argDesc, len(args), example, cmd.CommandPath())
+		}
+		return nil
+	}
+}

--- a/pkg/cmd/flags/args_test.go
+++ b/pkg/cmd/flags/args_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "one arg succeeds",
+			args: []string{"gcp"},
+		},
+		{
+			name:    "zero args fails with descriptive message",
+			args:    []string{},
+			wantErr: "missing required argument: <handler>",
+		},
+		{
+			name:    "two args fails",
+			args:    []string{"gcp", "extra"},
+			wantErr: "expected 1 argument <handler>, got 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			validator := RequireArg("handler", "scafctl auth token gcp")
+			cmd := &cobra.Command{Use: "token"}
+
+			err := validator(cmd, tc.args)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Contains(t, err.Error(), "Example:")
+			}
+		})
+	}
+}
+
+func TestRequireArgs(t *testing.T) {
+	t.Parallel()
+
+	validator := RequireArgs(2, "<name> <version>", "scafctl snapshot diff a.yaml b.yaml")
+	cmd := &cobra.Command{Use: "diff"}
+
+	t.Run("correct count succeeds", func(t *testing.T) {
+		t.Parallel()
+		err := validator(cmd, []string{"a.yaml", "b.yaml"})
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong count fails with descriptive message", func(t *testing.T) {
+		t.Parallel()
+		err := validator(cmd, []string{"a.yaml"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 2 argument(s)")
+		assert.Contains(t, err.Error(), "Example:")
+	})
+}

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -18,6 +18,7 @@ import (
 	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -160,7 +161,7 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 			  scafctl auth login gcp --scope https://www.googleapis.com/auth/bigquery
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args:         flags.RequireArg("handler", cliParams.BinaryName+" auth login gcp"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)

--- a/pkg/cmd/scafctl/auth/login_test.go
+++ b/pkg/cmd/scafctl/auth/login_test.go
@@ -54,7 +54,7 @@ func TestCommandLogin_MissingHandler(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+	assert.Contains(t, err.Error(), "missing required argument: <handler>")
 }
 
 func TestCommandLogin_Success(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -99,7 +99,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			  eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args:         flags.RequireArg("handler", cliParams.BinaryName+" auth token gcp"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -62,7 +62,7 @@ func TestCommandToken_MissingHandler(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+	assert.Contains(t, err.Error(), "missing required argument: <handler>")
 }
 
 func TestCommandToken_MissingScopeForEntra(t *testing.T) {

--- a/pkg/cmd/scafctl/build/plugin.go
+++ b/pkg/cmd/scafctl/build/plugin.go
@@ -79,6 +79,7 @@ func CommandBuildPlugin(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 			  scafctl build plugin --name aws-provider --kind provider --version 1.0.0 \
 			    --platform linux/amd64=./dist/aws-provider --force
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runBuildPlugin(cmd.Context(), options)
 		},

--- a/pkg/cmd/scafctl/cache/clear.go
+++ b/pkg/cmd/scafctl/cache/clear.go
@@ -87,6 +87,7 @@ func CommandClear(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			  # Show what would be cleared (JSON output)
 			  scafctl cache clear -o json
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			kvxOpts := flags.ToKvxOutputOptions(&options.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
 			return runClear(cmd.Context(), options, kvxOpts)

--- a/pkg/cmd/scafctl/cache/info.go
+++ b/pkg/cmd/scafctl/cache/info.go
@@ -51,6 +51,7 @@ func CommandInfo(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			  # Show cache info as JSON
 			  scafctl cache info -o json
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			kvxOpts := flags.ToKvxOutputOptions(&options.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
 			return runInfo(cmd.Context(), options, kvxOpts)

--- a/pkg/cmd/scafctl/catalog/delete.go
+++ b/pkg/cmd/scafctl/catalog/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -57,7 +58,7 @@ func CommandDelete(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			  # Delete from a configured catalog
 			  scafctl catalog delete my-solution@1.0.0 --catalog myregistry
 		`),
-		Args: cobra.ExactArgs(1),
+		Args: flags.RequireArg("name@version", cliParams.BinaryName+" catalog delete my-solution@1.0.0"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Reference = args[0]
 			return runDelete(cmd.Context(), options)

--- a/pkg/cmd/scafctl/catalog/delete_test.go
+++ b/pkg/cmd/scafctl/catalog/delete_test.go
@@ -73,7 +73,7 @@ func TestCommandDelete_RequiresExactlyOneArg(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+	assert.Contains(t, err.Error(), "missing required argument: <name@version>")
 }
 
 func TestCommandDelete_VersionRequired(t *testing.T) {

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -107,6 +107,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			  # Output as JSON
 			  %[1]s catalog list -o json
 		`, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			kvxOpts := flags.ToKvxOutputOptions(&options.KvxOutputFlags,
 				kvx.WithIOStreams(ioStreams),

--- a/pkg/cmd/scafctl/catalog/login.go
+++ b/pkg/cmd/scafctl/catalog/login.go
@@ -206,8 +206,9 @@ func runAuthHandlerLogin(ctx context.Context, w *writer.Writer, opts *LoginOptio
 		}
 	}
 
-	// Fall back to default scope for known registries (e.g. *.pkg.dev → cloud-platform)
-	if scope == "" {
+	// Fall back to default scope for known GCP registries (e.g. *.pkg.dev → cloud-platform).
+	// Only apply when the handler is "gcp" to avoid injecting GCP scopes into custom auth flows.
+	if scope == "" && handlerName == "gcp" {
 		scope = catalog.InferDefaultScope(opts.Registry)
 	}
 

--- a/pkg/cmd/scafctl/catalog/login.go
+++ b/pkg/cmd/scafctl/catalog/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -96,7 +97,7 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			  # Login and also write to container auth file (Docker/Podman interop)
 			  scafctl catalog login ghcr.io --write-registry-auth
 		`), settings.CliBinaryName, cliParams.BinaryName),
-		Args:         cobra.ExactArgs(1),
+		Args:         flags.RequireArg("registry", cliParams.BinaryName+" catalog login ghcr.io"),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.BinaryName = cliParams.BinaryName
@@ -203,6 +204,11 @@ func runAuthHandlerLogin(ctx context.Context, w *writer.Writer, opts *LoginOptio
 				}
 			}
 		}
+	}
+
+	// Fall back to default scope for known registries (e.g. *.pkg.dev → cloud-platform)
+	if scope == "" {
+		scope = catalog.InferDefaultScope(opts.Registry)
 	}
 
 	// Get handler from registry

--- a/pkg/cmd/scafctl/catalog/login_test.go
+++ b/pkg/cmd/scafctl/catalog/login_test.go
@@ -69,7 +69,7 @@ func TestCommandLogin_RequiresExactlyOneArg(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+	assert.Contains(t, err.Error(), "missing required argument: <registry>")
 }
 
 func TestReadPassword_BothStdinAndEnv(t *testing.T) {

--- a/pkg/cmd/scafctl/catalog/push.go
+++ b/pkg/cmd/scafctl/catalog/push.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/sbom"
@@ -86,7 +87,7 @@ func CommandPush(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			  scafctl catalog push my-solution@1.0.0 --force
 		`), settings.CliBinaryName, cliParams.BinaryName),
 
-		Args:         cobra.ExactArgs(1),
+		Args:         flags.RequireArg("name@version", cliParams.BinaryName+" catalog push my-solution@1.0.0"),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Reference = args[0]

--- a/pkg/cmd/scafctl/catalog/push_test.go
+++ b/pkg/cmd/scafctl/catalog/push_test.go
@@ -87,7 +87,7 @@ func TestCommandPush_RequiresExactlyOneArg(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+	assert.Contains(t, err.Error(), "missing required argument: <name@version>")
 }
 
 func TestCommandPush_InvalidKind(t *testing.T) {

--- a/pkg/cmd/scafctl/eval/cel.go
+++ b/pkg/cmd/scafctl/eval/cel.go
@@ -67,6 +67,7 @@ func CommandCEL(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 			  # Output as JSON
 			  scafctl eval cel --expression '1 + 2' -o json
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)

--- a/pkg/cmd/scafctl/eval/template.go
+++ b/pkg/cmd/scafctl/eval/template.go
@@ -69,6 +69,7 @@ func CommandTemplate(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			  # Output as JSON
 			  scafctl eval template -t '{{ .name }}' -v name=world -o json
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)

--- a/pkg/cmd/scafctl/eval/validate.go
+++ b/pkg/cmd/scafctl/eval/validate.go
@@ -61,6 +61,7 @@ func CommandValidate(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			  # Output as JSON
 			  scafctl eval validate --expression '{{ .name' --type go-template -o json
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)

--- a/pkg/cmd/scafctl/examples/list.go
+++ b/pkg/cmd/scafctl/examples/list.go
@@ -55,6 +55,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			  # List available categories
 			  scafctl examples list --category ""
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -134,8 +134,12 @@ func (o *CmdOptionsVersion) GetSolutionWithGetter(ctx context.Context, getter ge
 		err = output.WriteOutput(o.IOStreams, o.Output, sol, nil)
 	default:
 		// Default / table: use kvx for structured table output
+		format := o.Output
+		if format == "" {
+			format = "auto"
+		}
 		kvxOpts := flags.NewKvxOutputOptionsFromFlags(
-			"auto",
+			format,
 			false,
 			"",
 			kvx.WithOutputContext(ctx),

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -11,18 +11,21 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
 
-var ValidOutputTypes = []string{"json", "yaml"}
+var ValidOutputTypes = []string{"json", "yaml", "table"}
 
 type GetLatestVersionFunc func(ctx context.Context) (string, error)
 
@@ -124,7 +127,25 @@ func (o *CmdOptionsVersion) GetSolutionWithGetter(ctx context.Context, getter ge
 		return exitcode.WithCode(err, exitcode.FileNotFound)
 	}
 
-	err = output.WriteOutput(o.IOStreams, o.Output, sol, nil)
+	// For json/yaml, use the direct output writer. For table or default,
+	// use kvx which provides table rendering.
+	switch o.Output {
+	case "json", "yaml":
+		err = output.WriteOutput(o.IOStreams, o.Output, sol, nil)
+	default:
+		// Default / table: use kvx for structured table output
+		kvxOpts := flags.NewKvxOutputOptionsFromFlags(
+			"auto",
+			false,
+			"",
+			kvx.WithOutputContext(ctx),
+			kvx.WithOutputNoColor(o.CliParams.NoColor),
+			kvx.WithOutputAppName(o.CliParams.BinaryName+" get solution"),
+		)
+		kvxOpts.IOStreams = o.IOStreams
+		err = kvxOpts.Write(newSolutionSummary(sol))
+	}
+
 	if err != nil {
 		if w != nil {
 			w.Errorf("%v", err)
@@ -132,4 +153,37 @@ func (o *CmdOptionsVersion) GetSolutionWithGetter(ctx context.Context, getter ge
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
 	return nil
+}
+
+// solutionSummary is a display-friendly representation of a solution.
+type solutionSummary struct {
+	Name        string `json:"name" yaml:"name"`
+	Version     string `json:"version" yaml:"version"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Resolvers   int    `json:"resolvers" yaml:"resolvers"`
+	Actions     int    `json:"actions" yaml:"actions"`
+}
+
+func newSolutionSummary(sol *solution.Solution) *solutionSummary {
+	version := ""
+	if sol.Metadata.Version != nil {
+		version = sol.Metadata.Version.String()
+	}
+	resolverCount := 0
+	if sol.Spec.Resolvers != nil {
+		resolverCount = len(sol.Spec.Resolvers)
+	}
+	actionCount := 0
+	if sol.Spec.Workflow != nil && sol.Spec.Workflow.Actions != nil {
+		actionCount = len(sol.Spec.Workflow.Actions)
+	}
+	return &solutionSummary{
+		Name:        sol.Metadata.Name,
+		Version:     version,
+		DisplayName: sol.Metadata.DisplayName,
+		Description: sol.Metadata.Description,
+		Resolvers:   resolverCount,
+		Actions:     actionCount,
+	}
 }

--- a/pkg/cmd/scafctl/get/solution/solution_test.go
+++ b/pkg/cmd/scafctl/get/solution/solution_test.go
@@ -247,6 +247,82 @@ func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 		assert.Contains(t, outBuf.String(), "context-solution")
 	})
 
+	t.Run("default output does not crash", func(t *testing.T) {
+		mockGetter := &solutionget.MockGetter{}
+		expectedSolution := &solutionpkg.Solution{
+			APIVersion: "scafctl.io/v1",
+			Kind:       "Solution",
+			Metadata: solutionpkg.Metadata{
+				Name: "default-output-solution",
+			},
+		}
+
+		mockGetter.On("Get", mock.Anything, "/path/to/solution.yaml").
+			Return(expectedSolution, nil)
+
+		outBuf := &bytes.Buffer{}
+		errBuf := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{
+			Out:    outBuf,
+			ErrOut: errBuf,
+		}
+
+		options := &CmdOptionsVersion{
+			IOStreams: ioStreams,
+			CliParams: &settings.Run{
+				NoColor:    true,
+				BinaryName: "scafctl",
+			},
+			Output: "",
+			File:   "/path/to/solution.yaml",
+		}
+
+		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
+		require.NoError(t, err)
+		mockGetter.AssertExpectations(t)
+
+		assert.NotEmpty(t, outBuf.String())
+		assert.Contains(t, outBuf.String(), "default-output-solution")
+	})
+
+	t.Run("table output does not crash", func(t *testing.T) {
+		mockGetter := &solutionget.MockGetter{}
+		expectedSolution := &solutionpkg.Solution{
+			APIVersion: "scafctl.io/v1",
+			Kind:       "Solution",
+			Metadata: solutionpkg.Metadata{
+				Name: "table-output-solution",
+			},
+		}
+
+		mockGetter.On("Get", mock.Anything, "/path/to/solution.yaml").
+			Return(expectedSolution, nil)
+
+		outBuf := &bytes.Buffer{}
+		errBuf := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{
+			Out:    outBuf,
+			ErrOut: errBuf,
+		}
+
+		options := &CmdOptionsVersion{
+			IOStreams: ioStreams,
+			CliParams: &settings.Run{
+				NoColor:    true,
+				BinaryName: "scafctl",
+			},
+			Output: "table",
+			File:   "/path/to/solution.yaml",
+		}
+
+		err := options.GetSolutionWithGetter(context.Background(), mockGetter)
+		require.NoError(t, err)
+		mockGetter.AssertExpectations(t)
+
+		assert.NotEmpty(t, outBuf.String())
+		assert.Contains(t, outBuf.String(), "table-output-solution")
+	})
+
 	t.Run("solution with complex data", func(t *testing.T) {
 		mockGetter := &solutionget.MockGetter{}
 		expectedSolution := &solutionpkg.Solution{

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -61,6 +61,7 @@ type Options struct {
 	File       string
 	Output     string
 	Severity   string
+	Expression string
 	CliParams  *settings.Run
 	IOStreams  *terminal.IOStreams
 }
@@ -118,6 +119,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			# Output as JSON for CI integration
 			scafctl lint -f ./solution.yaml -o json
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)
@@ -133,6 +135,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
+	cmd.Flags().StringVarP(&options.Expression, "expression", "e", "", "CEL expression to filter/transform output data (e.g., '_.findings')")
 	cmd.Flags().StringVar(&options.Severity, "severity", "info", "Minimum severity to report: error, warning, info")
 
 	lintPath := fmt.Sprintf("%s/%s", path, cmd.Use)
@@ -182,7 +185,7 @@ func runLint(ctx context.Context, opts *Options) error {
 	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
 		opts.Output,
 		false,
-		"",
+		opts.Expression,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(opts.CliParams.NoColor),
 		kvx.WithOutputAppName(opts.BinaryName+" lint"),

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -43,6 +43,7 @@ func TestCommandLint_Flags(t *testing.T) {
 	}{
 		{"file", "file", ""},
 		{"output", "output", "table"},
+		{"expression", "expression", ""},
 		{"severity", "severity", "info"},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -87,6 +87,7 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			# Tune stdio worker pool and queue
 			%[1]s mcp serve --worker-pool-size 4 --queue-size 200
 		`), cliParams.BinaryName),
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runServe(cmd.Context(), opts)

--- a/pkg/cmd/scafctl/new/solution.go
+++ b/pkg/cmd/scafctl/new/solution.go
@@ -74,6 +74,7 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			  # Pipe to file
 			  scafctl new solution -n my-deploy -d "Deploy" > my-deploy.yaml
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Use)
 			ctx := settings.IntoContext(cmd.Context(), cliParams)

--- a/pkg/cmd/scafctl/plugins/install.go
+++ b/pkg/cmd/scafctl/plugins/install.go
@@ -66,6 +66,7 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			  # Use a custom cache directory
 			  scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := writer.FromContext(cmd.Context())
 			if w == nil {

--- a/pkg/cmd/scafctl/plugins/list.go
+++ b/pkg/cmd/scafctl/plugins/list.go
@@ -52,6 +52,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			  # List in JSON format
 			  scafctl plugins list -o json
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := writer.FromContext(cmd.Context())
 			if w == nil {

--- a/pkg/cmd/scafctl/secrets/rotate.go
+++ b/pkg/cmd/scafctl/secrets/rotate.go
@@ -36,6 +36,7 @@ This is useful for:
   - Periodic key rotation for security compliance
   - After suspected key compromise
   - Before sharing a device or system`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)

--- a/pkg/cmd/scafctl/serve/openapi.go
+++ b/pkg/cmd/scafctl/serve/openapi.go
@@ -49,6 +49,7 @@ func CommandOpenAPI(cliParams *settings.Run, _ *terminal.IOStreams) *cobra.Comma
 			# Export as JSON to a file
 			scafctl serve openapi --format json --output openapi.json
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runOpenAPI(cmd, format, output)

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -71,6 +71,7 @@ func CommandServe(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			# Export OpenAPI spec without starting the server
 			scafctl serve openapi --format yaml --output openapi.yaml
 		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runServe(cmd.Context(), opts)

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -52,6 +52,7 @@ Examples:
 
   # Pipe into a compose file
   scafctl test init -f solution.yaml >> solution-tests.yaml`,
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)

--- a/pkg/cmd/scafctl/test/list.go
+++ b/pkg/cmd/scafctl/test/list.go
@@ -62,6 +62,7 @@ Examples:
 
   # Output as JSON
   scafctl test list -f ./solution.yaml -o json`,
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cCmd *cobra.Command, _ []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)

--- a/pkg/cmd/scafctl/version/version.go
+++ b/pkg/cmd/scafctl/version/version.go
@@ -44,6 +44,7 @@ func CommandVersion(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 		Use:     "version",
 		Aliases: []string{"v"},
 		Short:   fmt.Sprintf("Prints the %s version", path),
+		Args:    cobra.NoArgs,
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -169,7 +169,11 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				"reserved-name")
 		}
 
-		if !referencedResolvers[name] {
+		// A resolver with a validate block exists for its side effect (aborting
+		// execution on validation failure), so it is "used" even if no other
+		// resolver or action references it.
+		hasValidation := res.Validate != nil && len(res.Validate.With) > 0
+		if !referencedResolvers[name] && !hasValidation {
 			result.addFinding(SeverityWarning, "usage", location,
 				fmt.Sprintf("resolver '%s' is defined but never referenced", name),
 				"Remove unused resolver or reference it in actions/other resolvers",

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
@@ -438,4 +439,67 @@ func TestAddFinding_NoSourceMap(t *testing.T) {
 	result.addFinding(SeverityWarning, "usage", "resolvers.foo", "msg", "", "test-rule")
 	require.Len(t, result.Findings, 1)
 	assert.Equal(t, 0, result.Findings[0].Line)
+}
+
+func TestLintResolvers_ValidateBlockNotFlaggedUnused(t *testing.T) {
+	// A resolver with a validate block should not be flagged as unused,
+	// even if it is not referenced by any other resolver or action.
+	reg := provider.NewRegistry()
+	fp := newFakeProvider("static", nil)
+	require.NoError(t, reg.Register(fp))
+	vp := newFakeProvider("validation", nil)
+	require.NoError(t, reg.Register(vp))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"versionValidated": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static"},
+				},
+			},
+			Validate: &resolver.ValidatePhase{
+				With: []resolver.ProviderValidation{
+					{Provider: "validation"},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "unused-resolver", f.RuleName,
+			"resolver with validate block should not be flagged as unused")
+	}
+}
+
+func TestLintResolvers_NoValidateBlockFlaggedUnused(t *testing.T) {
+	// A resolver without a validate block that is not referenced should be flagged.
+	reg := provider.NewRegistry()
+	fp := newFakeProvider("static", nil)
+	require.NoError(t, reg.Register(fp))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"unreferenced": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static"},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	rules := make([]string, 0, len(result.Findings))
+	for _, f := range result.Findings {
+		rules = append(rules, f.RuleName)
+	}
+	assert.Contains(t, rules, "unused-resolver")
 }

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -116,7 +116,7 @@ type ValidatePhase struct {
 // ProviderSource represents a single source in the resolve phase
 type ProviderSource struct {
 	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"parameter" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
-	Inputs   map[string]*ValueRef `json:"inputs" yaml:"inputs" doc:"Provider inputs"`
+	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
 	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Source-level condition"`
 	OnError  ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Behavior when provider fails (continue, fail). Defaults to continue (fallback chain semantics). Use fail to stop on first error." example:"continue" default:"continue"`
 }
@@ -124,7 +124,7 @@ type ProviderSource struct {
 // ProviderTransform represents a single transform step
 type ProviderTransform struct {
 	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"cel" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
-	Inputs   map[string]*ValueRef `json:"inputs" yaml:"inputs" doc:"Provider inputs"`
+	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
 	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Step-level condition"`
 	OnError  ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Behavior when provider fails (continue, fail)" example:"fail" default:"fail"`
 	ForEach  *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element"`
@@ -133,6 +133,6 @@ type ProviderTransform struct {
 // ProviderValidation represents a single validation rule
 type ProviderValidation struct {
 	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"validation" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
-	Inputs   map[string]*ValueRef `json:"inputs" yaml:"inputs" doc:"Provider inputs"`
+	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
 	Message  *ValueRef            `json:"message,omitempty" yaml:"message,omitempty" doc:"Error message on validation failure"`
 }

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -102,8 +102,9 @@ type Metadata struct {
 	// Name is the unique identifier for the solution (e.g., "gcp-basic")
 	Name string `json:"name" yaml:"name" doc:"The unique name of the solution" minLength:"3" maxLength:"60" example:"gcp-basic" pattern:"^[a-z0-9]([a-z0-9-]+[a-z0-9])?$"`
 
-	// Version is the semantic version of the solution
-	Version *semver.Version `json:"version" yaml:"version" doc:"The version of the solution" example:"1.0.0" pattern:"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"`
+	// Version is the semantic version of the solution.
+	// Optional for local development; required for catalog publishing (build/push).
+	Version *semver.Version `json:"version,omitempty" yaml:"version,omitempty" doc:"The version of the solution" example:"1.0.0" pattern:"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" required:"false"`
 
 	// DisplayName is the human-readable name of the solution
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"The display name of the solution" minLength:"3" maxLength:"80" example:"Basic GCP Solution" pattern:"^(.)+$" required:"false"`

--- a/pkg/solution/solution_test.go
+++ b/pkg/solution/solution_test.go
@@ -201,8 +201,8 @@ func TestSolution_ToJSON(t *testing.T) {
 						assert.Contains(t, string(data), tt.solution.Metadata.Version.String())
 					}
 				} else {
-					// When Version is nil, it should still be present in JSON (not omitempty)
-					assert.Contains(t, string(data), "version")
+					// When Version is nil and omitempty, it should be absent from JSON
+					assert.NotContains(t, string(data), "version")
 				}
 			}
 		})
@@ -345,9 +345,8 @@ func TestSolution_ToYAML(t *testing.T) {
 						assert.Contains(t, string(data), tt.solution.Metadata.Version.String())
 					}
 				} else {
-					// When Version is nil, check YAML representation
-					// YAML will show "version: null" or similar
-					assert.Contains(t, string(data), "version")
+					// When Version is nil and omitempty, it should be absent from YAML
+					assert.NotContains(t, string(data), "version")
 				}
 			}
 		})

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2409,7 +2409,7 @@ func TestIntegration_CatalogLoginRequiresArg(t *testing.T) {
 	_, stderr, exitCode := runScafctl(t, "catalog", "login")
 
 	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "accepts 1 arg(s)")
+	assert.Contains(t, stderr, "missing required argument: <registry>")
 }
 
 func TestIntegration_CatalogLogoutHelp(t *testing.T) {


### PR DESCRIPTION
Easy-win CLI improvements across multiple packages:
- Fix get solution crash on default output by adding kvx table view
- Fix unused-resolver false positive for validators in lint engine
- Make metadata.version optional in solution spec
- Add -e/--expression flag to lint command for CEL filtering
- Add cobra.NoArgs to 18 leaf commands missing arg validation
- Add flags.RequireArg() helper with descriptive error messages
- Apply RequireArg to auth login/token, catalog login/delete/push
- Infer default OAuth scope for *.pkg.dev registries in catalog login
- Make provider inputs optional when no required inputs exist

Also improve AI agent and Copilot customization files:
- Fix docs-examples instruction applyTo scope (was **/*.go)
- Deduplicate copilot-instructions.md with instruction files
- Fix go-test prompt routing to go-reviewer agent
- Fix pr-reviewer GraphQL mutation for thread replies
- Simplify planner agent tool list
- Add API server and settings instruction files
- Add Explore agent references to planner/issue-creator
- Replace duplicate struct tags in golang-patterns skill
- Add .vscode/tasks.json with 15 task runner commands