### PR TITLE
fix: add build preflight checks and tag-aware catalog delete

### DIFF
--- a/.github/prompts/go-review.prompt.md
+++ b/.github/prompts/go-review.prompt.md
@@ -8,5 +8,6 @@ Review the current Go code changes for:
 - Concurrency issues (goroutine leaks, race conditions, deadlocks)
 - Code quality (function length, nesting depth, idiomatic patterns)
 - scafctl conventions (Writer usage, kvx output, struct tags, business logic placement)
+- **Test coverage**: Run `go test -coverprofile` on changed packages and flag any changed file with patch coverage below 60%. List uncovered lines and recommend specific tests to add.
 
 Run `go vet ./...` and `task lint` first, then review the code.

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -11,5 +11,6 @@ Follow these phases **in order** -- do not skip ahead:
 2. **Early exit**: If there are **zero unresolved threads**, report that and stop -- do not triage or apply fixes
 3. **Triage**: For each unresolved comment, assess whether it's a legit problem with the code. Present the triage summary with recommendations and **stop here** -- the user will click "Apply fixes" to approve
 4. **Apply fixes**: Fix the code, verify build (`go build ./...`, `go vet ./...`), run tests (`task test:e2e`), then respond to and resolve each addressed thread
-5. If you disagree with a comment: **explain your reasoning in the reply and resolve it anyway** -- do not leave threads open
-6. **Do not commit** -- I will handle that
+5. **Coverage check**: After fixes pass, run coverage on changed packages (`go test -coverprofile=... ./pkg/changed/...`) and compare patch coverage. If any changed file has patch coverage below 60%, add tests to cover the new/modified lines before responding to threads
+6. If you disagree with a comment: **explain your reasoning in the reply and resolve it anyway** -- do not leave threads open
+7. **Do not commit** -- I will handle that

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -32,6 +33,7 @@ type RemoteCatalog struct {
 	registry   string
 	repository string
 	client     *auth.Client
+	insecure   bool
 	logger     logr.Logger
 }
 
@@ -137,6 +139,7 @@ func NewRemoteCatalog(cfg RemoteCatalogConfig) (*RemoteCatalog, error) {
 		registry:   cfg.Registry,
 		repository: cfg.Repository,
 		client:     client,
+		insecure:   cfg.Insecure,
 		logger:     cfg.Logger.WithName("remote-catalog").WithValues("catalog", cfg.Name),
 	}, nil
 }
@@ -618,6 +621,10 @@ func (c *RemoteCatalog) Exists(ctx context.Context, ref Reference) (bool, error)
 }
 
 // Delete removes an artifact from the catalog.
+//
+// The method first attempts a standard OCI delete by digest. If the registry
+// rejects it because the manifest still has tags (e.g., GCP Artifact Registry
+// returns 400 "dangling tag"), it retries by deleting via the tag reference.
 func (c *RemoteCatalog) Delete(ctx context.Context, ref Reference) error {
 	repo, err := c.getRepository(ref)
 	if err != nil {
@@ -633,14 +640,83 @@ func (c *RemoteCatalog) Delete(ctx context.Context, ref Reference) error {
 
 	// Delete the manifest (this may not be supported by all registries)
 	if err := repo.Delete(ctx, desc); err != nil {
+		errStr := err.Error()
+
+		// GCP Artifact Registry rejects digest-based DELETE when the manifest
+		// still has a tag. Retry by deleting via the tag reference, which
+		// removes both the tag and the manifest in one operation.
+		if (strings.Contains(errStr, "dangling tag") || strings.Contains(errStr, "still referenced")) && ref.Version != nil {
+			c.logger.V(1).Info("digest delete rejected (tagged manifest), retrying with tag reference",
+				"tag", tag, "digest", desc.Digest.String())
+
+			if deleteErr := c.deleteByTag(ctx, ref, tag); deleteErr != nil {
+				return fmt.Errorf("failed to delete artifact by tag after digest rejection: %w", deleteErr)
+			}
+
+			c.logger.V(1).Info("deleted artifact via tag reference",
+				"name", ref.Name,
+				"tag", tag)
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete artifact: %w", err)
 	}
 
 	c.logger.V(1).Info("deleted artifact",
 		"name", ref.Name,
-		"version", ref.Version.String())
+		"version", ref.VersionOrDigest())
 
 	return nil
+}
+
+// deleteByTag issues an HTTP DELETE using the tag reference instead of the
+// digest. Some registries (GCP Artifact Registry) require this when the
+// manifest is still tagged.
+func (c *RemoteCatalog) deleteByTag(ctx context.Context, ref Reference, tag string) error {
+	// Build the OCI repository name (without registry host).
+	parts := []string{}
+	if c.repository != "" {
+		parts = append(parts, c.repository)
+	}
+	if ref.Kind != "" {
+		parts = append(parts, ref.Kind.Plural())
+	}
+	parts = append(parts, ref.Name)
+	repoName := strings.Join(parts, "/")
+
+	// Try HTTPS first, fall back to HTTP if insecure.
+	schemes := []string{"https"}
+	if c.insecure {
+		schemes = append(schemes, "http")
+	}
+
+	var lastErr error
+	for _, scheme := range schemes {
+		deleteURL := fmt.Sprintf("%s://%s/v2/%s/manifests/%s", scheme, c.registry, repoName, tag)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deleteURL, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create delete request: %w", err)
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		status := resp.StatusCode
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if status == http.StatusOK || status == http.StatusAccepted || status == http.StatusNoContent {
+			return nil
+		}
+		return fmt.Errorf("delete by tag returned status %d", status)
+	}
+
+	return fmt.Errorf("delete by tag request failed: %w", lastErr)
 }
 
 // Tag creates an alias tag for an existing remote artifact.

--- a/pkg/catalog/remote_integration_test.go
+++ b/pkg/catalog/remote_integration_test.go
@@ -217,7 +217,14 @@ func (r *fakeOCIRegistry) handleManifests(w http.ResponseWriter, req *http.Reque
 
 	case http.MethodDelete:
 		r.mu.Lock()
-		key := repo + ":" + ref
+		// Resolve tag to digest if needed
+		resolvedRef := ref
+		if repoTags, ok := r.tags[repo]; ok {
+			if d, found := repoTags[ref]; found {
+				resolvedRef = d
+			}
+		}
+		key := repo + ":" + resolvedRef
 		if _, ok := r.manifests[key]; !ok {
 			r.mu.Unlock()
 			w.WriteHeader(http.StatusNotFound)
@@ -227,7 +234,7 @@ func (r *fakeOCIRegistry) handleManifests(w http.ResponseWriter, req *http.Reque
 		// Remove tag references pointing to this digest
 		if repoTags, ok := r.tags[repo]; ok {
 			for t, d := range repoTags {
-				if d == ref {
+				if d == resolvedRef {
 					delete(repoTags, t)
 				}
 			}
@@ -826,4 +833,184 @@ func BenchmarkRemoteCatalog_StoreAndFetch(b *testing.B) {
 		_, _ = cat.Store(ctx, ref, content, nil, nil, true)
 		_, _, _ = cat.Fetch(ctx, ref)
 	}
+}
+
+func TestInferKindFromRemote_Found(t *testing.T) {
+	t.Parallel()
+	cat, ts := newTestRemoteCatalog(t)
+	defer ts.Close()
+
+	ctx := t.Context()
+
+	// Store a solution artifact
+	ref := Reference{
+		Kind:    ArtifactKindSolution,
+		Name:    "my-sol",
+		Version: semver.MustParse("1.0.0"),
+	}
+	_, err := cat.Store(ctx, ref, []byte("sol data"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Infer kind from remote
+	kind, err := InferKindFromRemote(ctx, cat, "my-sol", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, ArtifactKindSolution, kind)
+}
+
+func TestInferKindFromRemote_NotFound(t *testing.T) {
+	t.Parallel()
+	cat, ts := newTestRemoteCatalog(t)
+	defer ts.Close()
+
+	_, err := InferKindFromRemote(t.Context(), cat, "ghost", "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in remote catalog")
+}
+
+func TestInferKindFromRemote_Provider(t *testing.T) {
+	t.Parallel()
+	cat, ts := newTestRemoteCatalog(t)
+	defer ts.Close()
+
+	ctx := t.Context()
+
+	// Store a provider artifact
+	ref := Reference{
+		Kind:    ArtifactKindProvider,
+		Name:    "my-provider",
+		Version: semver.MustParse("2.0.0"),
+	}
+	_, err := cat.Store(ctx, ref, []byte("provider data"), nil, nil, false)
+	require.NoError(t, err)
+
+	kind, err := InferKindFromRemote(ctx, cat, "my-provider", "2.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, ArtifactKindProvider, kind)
+}
+
+func TestRemoteCatalog_Delete_TagFallback(t *testing.T) {
+	t.Parallel()
+
+	// Create a fake registry that rejects DELETE-by-digest with a "dangling tag" error
+	// but accepts DELETE-by-tag.
+	reg := newFakeOCIRegistry()
+	origHandler := reg.handler()
+
+	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Intercept DELETE on manifests with a digest reference
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"errors":[{"code":"MANIFEST_INVALID","message":"google manifest dangling tag: Manifest is still referenced by one or more tags"}]}`)) //nolint:errcheck
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewTLSServer(wrapper)
+	defer ts.Close()
+
+	host := strings.TrimPrefix(ts.URL, "https://")
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "gcp-test",
+		Registry:   host,
+		Repository: "myorg/artifacts",
+		Insecure:   true,
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+	cat.client.Client = ts.Client()
+
+	ctx := t.Context()
+	ref := Reference{
+		Kind:    ArtifactKindSolution,
+		Name:    "tagged-sol",
+		Version: semver.MustParse("1.0.0"),
+	}
+
+	// Store an artifact
+	_, err = cat.Store(ctx, ref, []byte("tagged data"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Delete should succeed via tag fallback
+	err = cat.Delete(ctx, ref)
+	require.NoError(t, err)
+}
+
+func TestRemoteCatalog_Delete_DigestRef(t *testing.T) {
+	t.Parallel()
+	cat, ts := newTestRemoteCatalog(t)
+	defer ts.Close()
+
+	ctx := t.Context()
+	ref := Reference{
+		Kind:    ArtifactKindSolution,
+		Name:    "digest-sol",
+		Version: semver.MustParse("1.0.0"),
+	}
+
+	// Store an artifact
+	info, err := cat.Store(ctx, ref, []byte("digest data"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Delete using a digest-based reference (Version == nil)
+	digestRef := Reference{
+		Kind:   ArtifactKindSolution,
+		Name:   "digest-sol",
+		Digest: info.Digest,
+	}
+	err = cat.Delete(ctx, digestRef)
+	require.NoError(t, err)
+}
+
+func TestRemoteCatalog_Delete_DanglingTag_DigestRef_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	// Create a fake registry that rejects digest DELETE with "dangling tag".
+	// Since ref.Version is nil, the fallback should NOT fire and we get the original error.
+	reg := newFakeOCIRegistry()
+	origHandler := reg.handler()
+
+	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"errors":[{"code":"MANIFEST_INVALID","message":"dangling tag still referenced"}]}`)) //nolint:errcheck
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewTLSServer(wrapper)
+	defer ts.Close()
+
+	host := strings.TrimPrefix(ts.URL, "https://")
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:       "digest-test",
+		Registry:   host,
+		Repository: "myorg/artifacts",
+		Insecure:   true,
+		Logger:     logr.Discard(),
+	})
+	require.NoError(t, err)
+	cat.client.Client = ts.Client()
+
+	ctx := t.Context()
+
+	// Store with version
+	storeRef := Reference{
+		Kind:    ArtifactKindSolution,
+		Name:    "digest-sol",
+		Version: semver.MustParse("1.0.0"),
+	}
+	info, err := cat.Store(ctx, storeRef, []byte("data"), nil, nil, false)
+	require.NoError(t, err)
+
+	// Delete with digest-only ref (Version == nil) -- tag fallback should NOT fire
+	digestRef := Reference{
+		Kind:   ArtifactKindSolution,
+		Name:   "digest-sol",
+		Digest: info.Digest,
+	}
+	err = cat.Delete(ctx, digestRef)
+	require.Error(t, err, "digest-based delete should not trigger tag fallback")
+	assert.Contains(t, err.Error(), "failed to delete artifact")
 }

--- a/pkg/catalog/url.go
+++ b/pkg/catalog/url.go
@@ -102,6 +102,51 @@ func InferKindFromLocalCatalog(ctx context.Context, localCatalog *LocalCatalog, 
 	return "", fmt.Errorf("artifact %q not found in local catalog", name)
 }
 
+// InferKindFromRemote resolves an artifact's kind by trying each known kind
+// against the remote catalog. For each kind it attempts to resolve the tag;
+// the first successful resolve wins. This avoids fetching the full manifest
+// and works even when the artifact has no scafctl-specific annotations.
+//
+// If no known kind matches, it returns an error rather than guessing a
+// fallback kind.
+func InferKindFromRemote(ctx context.Context, remoteCatalog *RemoteCatalog, name, version string) (ArtifactKind, error) {
+	kinds := []ArtifactKind{
+		ArtifactKindSolution,
+		ArtifactKindProvider,
+		ArtifactKindAuthHandler,
+	}
+
+	var lastErr error
+	for _, kind := range kinds {
+		ref := Reference{
+			Kind: kind,
+			Name: name,
+		}
+
+		if version != "" {
+			parsedRef, err := ParseReference(kind, name+"@"+version)
+			if err != nil {
+				continue
+			}
+			ref = parsedRef
+		}
+
+		exists, err := remoteCatalog.Exists(ctx, ref)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if exists {
+			return kind, nil
+		}
+	}
+
+	if lastErr != nil {
+		return "", fmt.Errorf("failed to query remote catalog for %q: %w", name, lastErr)
+	}
+	return "", fmt.Errorf("artifact %q not found in remote catalog", name)
+}
+
 // ResolveCatalogURL resolves a catalog URL from a flag value or config defaults.
 //
 // Resolution order:

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
@@ -40,6 +41,10 @@ type SolutionOptions struct {
 	DryRun          bool
 	Dedupe          bool
 	DedupeThreshold string
+	SkipLint        bool
+	SkipTests       bool
+	IgnorePreflight bool
+	AllowDevVersion bool
 	CliParams       *settings.Run
 	IOStreams       *terminal.IOStreams
 
@@ -195,6 +200,10 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 	cmd.Flags().BoolVar(&options.Dedupe, "dedupe", true, "Enable content-addressable deduplication")
 	cmd.Flags().StringVar(&options.DedupeThreshold, "dedupe-threshold", "4KB", "Minimum file size for individual layer extraction (smaller files are tarred together)")
 	cmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Skip build cache and force a full rebuild")
+	cmd.Flags().BoolVar(&options.SkipLint, "skip-lint", false, "Skip lint pre-flight check")
+	cmd.Flags().BoolVar(&options.SkipTests, "skip-tests", false, "Skip functional test pre-flight check")
+	cmd.Flags().BoolVar(&options.IgnorePreflight, "ignore-preflight", false, "Run pre-flight checks but proceed even if they fail")
+	cmd.Flags().BoolVar(&options.AllowDevVersion, "allow-dev-version", false, "Allow build without metadata.version set")
 
 	return cmd
 }
@@ -239,6 +248,17 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
+	// Block dev version unless explicitly allowed
+	if version.Equal(solution.DefaultVersion()) && !opts.AllowDevVersion {
+		w.Errorf("metadata.version is not set (resolved to %s)", version.String())
+		binaryName := settings.BinaryNameFromContext(ctx)
+		if opts.CliParams != nil && opts.CliParams.BinaryName != "" {
+			binaryName = opts.CliParams.BinaryName
+		}
+		w.Infof("Set metadata.version, pass --version, or use %s build solution --allow-dev-version to build anyway", binaryName)
+		return exitcode.Errorf("dev version not allowed")
+	}
+
 	// Stamp resolved name and version into the solution so the stored
 	// artifact always carries the authoritative values.
 	needsReserialization := false
@@ -257,6 +277,45 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		if err != nil {
 			w.Errorf("failed to serialize stamped solution: %v", err)
 			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+	}
+
+	// === Pre-flight checks ===
+	if !opts.DryRun {
+		var reg *provider.Registry
+		if !opts.SkipLint {
+			var regErr error
+			reg, regErr = builtin.DefaultRegistry(ctx)
+			if regErr != nil {
+				reg = provider.GetGlobalRegistry()
+			}
+		}
+
+		var binaryPath string
+		if !opts.SkipTests {
+			binaryPath, _ = os.Executable()
+		}
+
+		pfResult, pfErr := builder.RunPreflight(ctx, &sol, opts.File, builder.PreflightOptions{
+			SkipLint:        opts.SkipLint,
+			SkipTests:       opts.SkipTests,
+			IgnorePreflight: opts.IgnorePreflight,
+			BinaryPath:      binaryPath,
+			Registry:        reg,
+			Logger:          *lgr,
+		})
+		if pfErr != nil {
+			w.Errorf("pre-flight checks failed: %v", pfErr)
+			return exitcode.WithCode(pfErr, exitcode.GeneralError)
+		}
+
+		for _, msg := range pfResult.Messages {
+			w.Infof("  %s", msg)
+		}
+
+		if pfResult.Blocked {
+			w.Error("build blocked by pre-flight checks (use --skip-lint/--skip-tests to skip, or --ignore-preflight to override)")
+			return exitcode.Errorf("pre-flight checks failed")
 		}
 	}
 

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/adrg/xdg"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
@@ -54,6 +55,10 @@ func TestCommandBuildSolution_Flags(t *testing.T) {
 		{"dedupe", "true"},
 		{"dedupe-threshold", "4KB"},
 		{"no-cache", "false"},
+		{"skip-lint", "false"},
+		{"skip-tests", "false"},
+		{"ignore-preflight", "false"},
+		{"allow-dev-version", "false"},
 	}
 
 	for _, tc := range flagTests {
@@ -187,6 +192,219 @@ spec: {}
 
 	err := runBuildSolution(ctx, opts)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dev version not allowed")
+}
+
+func TestRunBuildSolution_NoVersion_AllowDevVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:            solFile,
+		IOStreams:       ioStreams,
+		CliParams:       settings.NewCliParams(),
+		AllowDevVersion: true,
+		DryRun:          true, BundleMaxSize: "50MB",
+	}
+
+	// With AllowDevVersion + DryRun, the build should proceed past the version check
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+}
+
+func TestRunBuildSolution_PreflightBlocked(t *testing.T) {
+	t.Parallel()
+
+	// Create a solution with a version but an empty spec so lint blocks it.
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		SkipTests:     true,
+		BundleMaxSize: "50MB",
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-flight checks failed")
+}
+
+func TestRunBuildSolution_PreflightSkipLint(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		SkipLint:      true,
+		SkipTests:     true,
+		BundleMaxSize: "50MB",
+	}
+
+	// With lint and tests skipped, preflight runs but skips both checks.
+	// Subsequent pipeline steps may fail; we only care about the preflight path.
+	_ = runBuildSolution(ctx, opts)
+	output := buf.String()
+	assert.Contains(t, output, "lint: skipped")
+	assert.Contains(t, output, "tests: skipped")
+}
+
+func TestRunBuildSolution_PreflightIgnored(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:            solFile,
+		IOStreams:       ioStreams,
+		CliParams:       settings.NewCliParams(),
+		SkipTests:       true,
+		IgnorePreflight: true,
+		BundleMaxSize:   "50MB",
+	}
+
+	// With IgnorePreflight, lint errors become warnings and the build is not blocked.
+	// Subsequent pipeline steps may fail; we only care about the preflight path.
+	_ = runBuildSolution(ctx, opts)
+	output := buf.String()
+	assert.Contains(t, output, "lint:")
+	assert.NotContains(t, output, "build blocked")
+}
+
+func TestRunBuildSolution_DryRunSkipsPreflight(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+
+	// Dry-run should skip preflight entirely — no lint/tests messages in output.
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "lint:")
+	assert.NotContains(t, output, "tests:")
+	assert.Contains(t, output, "Dry run:")
+}
+
+func TestRunBuildSolution_DevVersionErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:      solFile,
+		IOStreams: ioStreams,
+		CliParams: cliParams,
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.Error(t, err)
+	// The error message should use the configured binary name, not "scafctl"
+	assert.Contains(t, buf.String(), "mycli build solution --allow-dev-version")
 }
 
 func TestPrintDryRunOutput_StaticFiles(t *testing.T) {

--- a/pkg/cmd/scafctl/catalog/delete.go
+++ b/pkg/cmd/scafctl/catalog/delete.go
@@ -201,27 +201,27 @@ func runDeleteRemote(ctx context.Context, opts *DeleteOptions) error {
 			}
 			artifactKind = kind
 		} else {
-			// Try to infer from local catalog
+			// Try to infer from local catalog first, then fall back to remote
 			localCatalog, localErr := catalog.NewLocalCatalog(*lgr)
 			if localErr == nil {
 				artifactKind, err = catalog.InferKindFromLocalCatalog(ctx, localCatalog, name, version)
-				if err != nil {
-					w.Errorf("could not infer artifact kind: %v", err)
-					w.Infof("Hint: use --kind to specify the artifact kind explicitly")
-					return exitcode.WithCode(err, exitcode.InvalidInput)
-				}
-			} else {
-				w.Errorf("could not infer artifact kind (local catalog unavailable)")
-				w.Infof("Hint: use --kind to specify the artifact kind explicitly")
-				return exitcode.Errorf("kind required")
+			}
+			if artifactKind == "" {
+				// Local inference failed or unavailable; defer to remote inference
+				// after the remote catalog is created (see below).
+				lgr.V(1).Info("local kind inference failed, will try remote",
+					"localErr", localErr, "inferErr", err)
 			}
 		}
 
-		ref, err = catalog.ParseReference(artifactKind, opts.Reference)
-		if err != nil {
-			w.Errorf("invalid reference: %v", err)
-			return exitcode.WithCode(err, exitcode.InvalidInput)
+		if artifactKind != "" {
+			ref, err = catalog.ParseReference(artifactKind, opts.Reference)
+			if err != nil {
+				w.Errorf("invalid reference: %v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
 		}
+		// When artifactKind is empty, ref will be set after remote inference below.
 	}
 
 	// Create credential store
@@ -247,6 +247,34 @@ func runDeleteRemote(ctx context.Context, opts *DeleteOptions) error {
 	if err != nil {
 		w.Errorf("failed to create remote catalog: %v", err)
 		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	// If kind is still unknown (short-reference path where ParseReference was
+	// skipped because no --kind was provided and local inference failed),
+	// infer from the remote catalog by probing each artifact kind.
+	if ref.Kind == "" {
+		// Use already-parsed ref fields when available (full remote ref path),
+		// otherwise parse from the raw reference string (short ref path).
+		infName, infVersion := ref.Name, ""
+		if ref.Version != nil {
+			infVersion = ref.Version.String()
+		} else if ref.Digest != "" {
+			infVersion = ref.Digest
+		}
+		if infName == "" {
+			infName, infVersion = catalog.ParseNameVersion(opts.Reference)
+		}
+		inferredKind, inferErr := catalog.InferKindFromRemote(ctx, remoteCatalog, infName, infVersion)
+		if inferErr != nil {
+			w.Errorf("could not infer artifact kind: %v", inferErr)
+			w.Infof("Hint: use --kind to specify the artifact kind explicitly")
+			return exitcode.WithCode(inferErr, exitcode.InvalidInput)
+		}
+		ref, err = catalog.ParseReference(inferredKind, opts.Reference)
+		if err != nil {
+			w.Errorf("invalid reference: %v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
 	}
 
 	// Delete from remote

--- a/pkg/solution/builder/preflight.go
+++ b/pkg/solution/builder/preflight.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+// PreflightOptions controls which pre-flight checks run before a build.
+type PreflightOptions struct {
+	// SkipLint skips the lint pre-flight check entirely.
+	SkipLint bool `json:"skipLint,omitempty" yaml:"skipLint,omitempty" doc:"Skip lint pre-flight check"`
+
+	// SkipTests skips the functional test pre-flight check entirely.
+	SkipTests bool `json:"skipTests,omitempty" yaml:"skipTests,omitempty" doc:"Skip functional test pre-flight check"`
+
+	// IgnorePreflight runs checks but treats errors as warnings instead of blocking.
+	IgnorePreflight bool `json:"ignorePreflight,omitempty" yaml:"ignorePreflight,omitempty" doc:"Run checks but treat errors as warnings"`
+
+	// BinaryPath is the CLI executable path used for test execution.
+	// When empty, functional test pre-flight checks are skipped.
+	BinaryPath string `json:"binaryPath,omitempty" yaml:"binaryPath,omitempty" doc:"Binary path for test execution"`
+
+	// Registry is the provider registry for lint to validate against.
+	// When nil, lint skips provider-specific checks.
+	Registry *provider.Registry `json:"-" yaml:"-"`
+
+	// Logger is used for structured logging.
+	Logger logr.Logger
+}
+
+// PreflightResult holds the outcome of pre-flight validation.
+type PreflightResult struct {
+	// LintResult contains lint findings. Nil if lint was skipped.
+	LintResult *lint.Result `json:"lintResult,omitempty" yaml:"lintResult,omitempty" doc:"Lint findings"`
+
+	// TestsPassed is true if tests passed or were skipped.
+	TestsPassed bool `json:"testsPassed" yaml:"testsPassed" doc:"Whether tests passed or were skipped"`
+
+	// Blocked is true if the build should be aborted.
+	Blocked bool `json:"blocked" yaml:"blocked" doc:"Whether the build should be aborted"`
+
+	// Messages collects human-readable status lines for display.
+	Messages []string `json:"messages,omitempty" yaml:"messages,omitempty" doc:"Human-readable status lines"`
+}
+
+// RunPreflight executes lint and (optionally) functional tests against the
+// parsed solution. Returns a result indicating whether the build should proceed.
+func RunPreflight(ctx context.Context, sol *solution.Solution, filePath string, opts PreflightOptions) (*PreflightResult, error) {
+	if opts.Logger.GetSink() == nil {
+		opts.Logger = logr.Discard()
+	}
+
+	result := &PreflightResult{
+		TestsPassed: true,
+	}
+
+	// --- Lint ---
+	if !opts.SkipLint {
+		opts.Logger.V(1).Info("running pre-flight lint check")
+		lintResult := lint.Solution(sol, filePath, opts.Registry)
+		result.LintResult = lintResult
+
+		// Count errors from findings (Result.ErrorCount may be zero for early-return paths).
+		lintErrors := lintResult.ErrorCount
+		if lintErrors == 0 {
+			for _, f := range lintResult.Findings {
+				if f.Severity == lint.SeverityError {
+					lintErrors++
+				}
+			}
+		}
+
+		warnings := lintResult.WarnCount
+		if warnings == 0 {
+			warnings = countBySeverity(lintResult.Findings, lint.SeverityWarning)
+		}
+
+		switch {
+		case lintErrors > 0:
+			msg := fmt.Sprintf("lint: %d error(s), %d warning(s)", lintErrors, warnings)
+			if opts.IgnorePreflight {
+				result.Messages = append(result.Messages, msg+" (ignored, preflight errors overridden)")
+			} else {
+				result.Messages = append(result.Messages, msg)
+				result.Blocked = true
+			}
+		case warnings > 0:
+			result.Messages = append(result.Messages,
+				fmt.Sprintf("lint: %d warning(s)", warnings))
+		default:
+			result.Messages = append(result.Messages, "lint: passed")
+		}
+	} else {
+		result.Messages = append(result.Messages, "lint: skipped")
+	}
+
+	// --- Functional Tests ---
+	switch {
+	case opts.SkipTests:
+		result.Messages = append(result.Messages, "tests: skipped")
+	case !sol.Spec.HasTests():
+		result.Messages = append(result.Messages, "tests: no tests defined")
+	case opts.BinaryPath == "":
+		result.Messages = append(result.Messages, "tests: skipped (no binary path)")
+	default:
+		opts.Logger.V(1).Info("running pre-flight functional tests")
+
+		tests, err := soltesting.DiscoverFromFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("pre-flight test discovery: %w", err)
+		}
+
+		if tests != nil && len(tests.Cases) > 0 {
+			ios := terminal.NewIOStreams(io.NopCloser(bytes.NewReader(nil)), io.Discard, io.Discard, false)
+			runner := &soltesting.Runner{
+				BinaryPath:  opts.BinaryPath,
+				Concurrency: 1,
+				FailFast:    true,
+				IOStreams:   ios,
+			}
+
+			results, err := runner.Run(ctx, []soltesting.SolutionTests{*tests})
+			if err != nil {
+				return nil, fmt.Errorf("pre-flight tests: %w", err)
+			}
+
+			var failures int
+			for _, tr := range results {
+				if tr.Status == soltesting.StatusFail || tr.Status == soltesting.StatusError {
+					failures++
+				}
+			}
+
+			if failures > 0 {
+				result.TestsPassed = false
+				msg := fmt.Sprintf("tests: %d of %d failed", failures, len(results))
+				if opts.IgnorePreflight {
+					result.Messages = append(result.Messages, msg+" (ignored, preflight errors overridden)")
+				} else {
+					result.Messages = append(result.Messages, msg)
+					result.Blocked = true
+				}
+			} else {
+				result.Messages = append(result.Messages,
+					fmt.Sprintf("tests: %d passed", len(results)))
+			}
+		} else {
+			result.Messages = append(result.Messages, "tests: no test cases found")
+		}
+	}
+
+	return result, nil
+}
+
+// countBySeverity counts findings at a given severity level.
+func countBySeverity(findings []*lint.Finding, severity lint.SeverityLevel) int {
+	count := 0
+	for _, f := range findings {
+		if f.Severity == severity {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/solution/builder/preflight_test.go
+++ b/pkg/solution/builder/preflight_test.go
@@ -1,0 +1,283 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPreflight_LintErrors_BlockBuild(t *testing.T) {
+	t.Parallel()
+
+	// A solution with no resolvers and no workflow triggers the
+	// "empty-solution" lint error.
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Blocked, "build should be blocked when lint has errors")
+	assert.NotNil(t, result.LintResult)
+	assert.NotEmpty(t, result.LintResult.Findings, "lint should report at least one finding")
+}
+
+func TestRunPreflight_LintErrors_IgnorePreflight(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipTests:       true,
+		IgnorePreflight: true,
+		Logger:          logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Blocked, "build should not be blocked when --ignore-preflight is set")
+	assert.NotEmpty(t, result.LintResult.Findings,
+		"lint errors should still be reported")
+	assert.Contains(t, result.Messages[0], "ignored, preflight errors overridden")
+}
+
+func TestRunPreflight_SkipLint(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipLint:  true,
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Blocked)
+	assert.Nil(t, result.LintResult)
+	assert.Contains(t, result.Messages[0], "lint: skipped")
+}
+
+func TestRunPreflight_SkipTests(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipLint:  true,
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.TestsPassed)
+	assert.Contains(t, result.Messages[1], "tests: skipped")
+}
+
+func TestRunPreflight_NoTests_Defined(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipLint: true,
+		Logger:   logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.TestsPassed)
+	assert.Contains(t, result.Messages[1], "tests: no tests defined")
+}
+
+func TestRunPreflight_LintClean(t *testing.T) {
+	t.Parallel()
+
+	// Create a minimal valid solution to pass lint.
+	sol := buildMinimalValidSolution(t)
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Blocked)
+	assert.NotNil(t, result.LintResult)
+	assert.Equal(t, 0, result.LintResult.ErrorCount)
+}
+
+func TestRunPreflight_AllSkipped_NotBlocked(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipLint:  true,
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Blocked)
+	assert.Len(t, result.Messages, 2)
+}
+
+func TestRunPreflight_LintWarnings_NotBlocked(t *testing.T) {
+	t.Parallel()
+
+	// Construct a result scenario: warnings only don't block.
+	// We test the logic by running with a valid solution that may produce warnings.
+	sol := buildMinimalValidSolution(t)
+
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Blocked, "warnings should not block the build")
+}
+
+func TestRunPreflight_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.ApplyDefaults()
+
+	// Zero-value logr.Logger (no sink) should not panic.
+	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
+		SkipTests: true,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Blocked, "empty solution should still block")
+}
+
+func TestRunPreflight_EmptyBinaryPath_TestsDefined(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      value: hello
+  testing:
+    cases:
+      basic:
+        resolvers:
+          greeting: world
+`
+	var sol solution.Solution
+	err := sol.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err)
+
+	result, err := RunPreflight(context.Background(), &sol, "test.yaml", PreflightOptions{
+		SkipLint:   true,
+		BinaryPath: "", // Empty -- should report "skipped (no binary path)"
+		Logger:     logr.Discard(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.TestsPassed)
+	assert.Contains(t, result.Messages[1], "tests: skipped (no binary path)")
+}
+
+func TestCountBySeverity_Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, countBySeverity(nil, lint.SeverityError))
+	assert.Equal(t, 0, countBySeverity([]*lint.Finding{}, lint.SeverityWarning))
+}
+
+func TestCountBySeverity_Mixed(t *testing.T) {
+	t.Parallel()
+
+	findings := []*lint.Finding{
+		{Severity: lint.SeverityError},
+		{Severity: lint.SeverityWarning},
+		{Severity: lint.SeverityError},
+		{Severity: lint.SeverityWarning},
+		{Severity: lint.SeverityWarning},
+	}
+
+	assert.Equal(t, 2, countBySeverity(findings, lint.SeverityError))
+	assert.Equal(t, 3, countBySeverity(findings, lint.SeverityWarning))
+}
+
+// buildMinimalValidSolution creates a solution that passes lint with zero errors.
+func buildMinimalValidSolution(t *testing.T) *solution.Solution {
+	t.Helper()
+
+	yaml := `
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      value: hello
+`
+	var sol solution.Solution
+	err := sol.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err)
+
+	// Verify it passes lint so the test is meaningful.
+	lintResult := lint.Solution(&sol, "test.yaml", nil)
+	require.Equal(t, 0, lintResult.ErrorCount,
+		"test fixture should pass lint; findings: %v", lintResult.Findings)
+
+	return &sol
+}
+
+func BenchmarkRunPreflight(b *testing.B) {
+	yaml := `
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bench-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      value: hello
+`
+	var sol solution.Solution
+	if err := sol.LoadFromBytes([]byte(yaml)); err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := context.Background()
+	opts := PreflightOptions{
+		SkipTests: true,
+		Logger:    logr.Discard(),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = RunPreflight(ctx, &sol, "bench.yaml", opts)
+	}
+}


### PR DESCRIPTION
Build preflight checks:
- Add RunPreflight domain logic in pkg/solution/builder/preflight.go with lint and functional test validation before builds
- Add --skip-lint, --skip-tests, --ignore-preflight, and --allow-dev-version flags to build solution command
- Block builds when metadata.version is unset unless --allow-dev-version is passed
- Skip preflight during --dry-run

Catalog remote delete improvements:
- Add tag-aware delete fallback in RemoteCatalog.Delete for registries that reject digest-based DELETE (e.g., GCP Artifact Registry "dangling tag" error)
- Add InferKindFromRemote to probe remote catalog when local kind inference fails
- Wire remote kind inference into catalog delete command as fallback when --kind is omitted and local catalog is unavailable
- Fix fake OCI registry DELETE handler to resolve tags to digests