### PR TITLE
feat(provider)!: add structured data rendering to message provider

### DIFF
--- a/examples/actions/hello-world.yaml
+++ b/examples/actions/hello-world.yaml
@@ -25,7 +25,8 @@ spec:
       greet:
         description: Display a greeting message
         displayName: Greeting Action
-        provider: exec
+        provider: message
         inputs:
-          command:
-            expr: "'echo ' + _.greeting"
+          message:
+            expr: "_.greeting"
+          type: success

--- a/pkg/provider/builtin/messageprovider/display.go
+++ b/pkg/provider/builtin/messageprovider/display.go
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package messageprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// displayKeyMapping maps solution YAML display keys to x-kvx-* vendor extension keys
+// used by kvx's ParseSchemaWithDisplay.
+var displayKeyMapping = map[string]string{
+	"list":            "x-kvx-list",
+	"detail":          "x-kvx-detail",
+	"collectionTitle": "x-kvx-collectionTitle",
+	"icon":            "x-kvx-icon",
+	"version":         "x-kvx-version",
+}
+
+// displaySchemaFromMap converts a display config map from solution YAML into JSON
+// with x-kvx-* vendor extensions suitable for kvx.WithDisplaySchemaJSON().
+//
+// Input keys map to x-kvx extensions:
+//
+//	display.list           -> x-kvx-list
+//	display.detail         -> x-kvx-detail
+//	display.collectionTitle -> x-kvx-collectionTitle
+//	display.icon           -> x-kvx-icon
+func displaySchemaFromMap(display map[string]any) ([]byte, error) {
+	if len(display) == 0 {
+		return nil, fmt.Errorf("display config must not be empty")
+	}
+
+	mapped := make(map[string]any, len(display))
+	for key, val := range display {
+		if xkvxKey, ok := displayKeyMapping[key]; ok {
+			mapped[xkvxKey] = val
+		} else if strings.HasPrefix(key, "x-kvx-") {
+			// Already prefixed -- pass through unchanged.
+			mapped[key] = val
+		} else {
+			// Pass through any unknown keys with the x-kvx- prefix
+			// to support future kvx extensions without code changes.
+			mapped["x-kvx-"+key] = val
+		}
+	}
+
+	data, err := json.Marshal(mapped)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal display schema: %w", err)
+	}
+	return data, nil
+}
+
+// columnHintsToJSON converts a columnHints map from solution YAML into a JSON Schema
+// document suitable for kvx.WithSchemaJSON(). The input shape is:
+//
+//	properties:
+//	  fieldName:
+//	    x-kvx-header: "Display Name"
+//	    x-kvx-maxWidth: 30
+//	    x-kvx-visible: false
+//
+// The output is a JSON Schema with those x-kvx-* extensions preserved, which
+// tui.ParseSchema uses to derive column hints.
+func columnHintsToJSON(hints map[string]any) ([]byte, error) {
+	if len(hints) == 0 {
+		return nil, fmt.Errorf("column hints must not be empty")
+	}
+
+	data, err := json.Marshal(hints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal column hints: %w", err)
+	}
+	return data, nil
+}

--- a/pkg/provider/builtin/messageprovider/display_test.go
+++ b/pkg/provider/builtin/messageprovider/display_test.go
@@ -1,0 +1,244 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package messageprovider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplaySchemaFromMap_ListConfig(t *testing.T) {
+	display := map[string]any{
+		"collectionTitle": "GCP Projects",
+		"list": map[string]any{
+			"titleField":      "name",
+			"subtitleField":   "type",
+			"badgeFields":     []any{"environmentCode"},
+			"secondaryFields": []any{"folderID", "number"},
+		},
+	}
+
+	result, err := displaySchemaFromMap(display)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "GCP Projects", parsed["x-kvx-collectionTitle"])
+	listConfig, ok := parsed["x-kvx-list"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "name", listConfig["titleField"])
+	assert.Equal(t, "type", listConfig["subtitleField"])
+}
+
+func TestDisplaySchemaFromMap_DetailConfig(t *testing.T) {
+	display := map[string]any{
+		"detail": map[string]any{
+			"titleField": "name",
+			"sections": []any{
+				map[string]any{
+					"title":  "Identity",
+					"fields": []any{"clientID", "name"},
+				},
+				map[string]any{
+					"title":  "Access",
+					"fields": []any{"adminGroup", "opsGroup"},
+					"layout": "inline",
+				},
+			},
+		},
+	}
+
+	result, err := displaySchemaFromMap(display)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	detailConfig, ok := parsed["x-kvx-detail"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "name", detailConfig["titleField"])
+
+	sections, ok := detailConfig["sections"].([]any)
+	require.True(t, ok)
+	assert.Len(t, sections, 2)
+}
+
+func TestDisplaySchemaFromMap_FullConfig(t *testing.T) {
+	display := map[string]any{
+		"icon":            "📦",
+		"collectionTitle": "Projects",
+		"version":         "v1",
+		"list": map[string]any{
+			"titleField": "name",
+		},
+		"detail": map[string]any{
+			"titleField": "name",
+		},
+	}
+
+	result, err := displaySchemaFromMap(display)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "📦", parsed["x-kvx-icon"])
+	assert.Equal(t, "Projects", parsed["x-kvx-collectionTitle"])
+	assert.Equal(t, "v1", parsed["x-kvx-version"])
+	assert.Contains(t, parsed, "x-kvx-list")
+	assert.Contains(t, parsed, "x-kvx-detail")
+}
+
+func TestDisplaySchemaFromMap_Empty(t *testing.T) {
+	_, err := displaySchemaFromMap(map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestDisplaySchemaFromMap_Nil(t *testing.T) {
+	_, err := displaySchemaFromMap(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestDisplaySchemaFromMap_UnknownKeysPassthrough(t *testing.T) {
+	display := map[string]any{
+		"list":       map[string]any{"titleField": "name"},
+		"futureFlag": true,
+	}
+
+	result, err := displaySchemaFromMap(display)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Contains(t, parsed, "x-kvx-list")
+	assert.Equal(t, true, parsed["x-kvx-futureFlag"])
+}
+
+func TestDisplaySchemaFromMap_AlreadyPrefixedKeys(t *testing.T) {
+	display := map[string]any{
+		"list":       map[string]any{"titleField": "name"},
+		"x-kvx-icon": "rocket",
+	}
+
+	result, err := displaySchemaFromMap(display)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	// Should NOT double-prefix to x-kvx-x-kvx-icon.
+	assert.Equal(t, "rocket", parsed["x-kvx-icon"])
+	assert.NotContains(t, parsed, "x-kvx-x-kvx-icon")
+}
+
+func TestColumnHintsToJSON_BasicProperties(t *testing.T) {
+	hints := map[string]any{
+		"properties": map[string]any{
+			"name": map[string]any{
+				"x-kvx-header":   "Full Name",
+				"x-kvx-maxWidth": 30,
+			},
+			"email": map[string]any{
+				"x-kvx-header": "Email Address",
+			},
+		},
+	}
+
+	result, err := columnHintsToJSON(hints)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	props, ok := parsed["properties"].(map[string]any)
+	require.True(t, ok)
+
+	nameHints, ok := props["name"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Full Name", nameHints["x-kvx-header"])
+}
+
+func TestColumnHintsToJSON_HiddenFields(t *testing.T) {
+	hints := map[string]any{
+		"properties": map[string]any{
+			"metadata": map[string]any{
+				"x-kvx-visible": false,
+			},
+		},
+	}
+
+	result, err := columnHintsToJSON(hints)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	props := parsed["properties"].(map[string]any)
+	meta := props["metadata"].(map[string]any)
+	assert.Equal(t, false, meta["x-kvx-visible"])
+}
+
+func TestColumnHintsToJSON_Empty(t *testing.T) {
+	_, err := columnHintsToJSON(map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestColumnHintsToJSON_Nil(t *testing.T) {
+	_, err := columnHintsToJSON(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func BenchmarkDisplaySchemaFromMap(b *testing.B) {
+	display := map[string]any{
+		"collectionTitle": "GCP Projects",
+		"icon":            "📦",
+		"list": map[string]any{
+			"titleField":    "name",
+			"subtitleField": "type",
+			"badgeFields":   []any{"environmentCode"},
+		},
+		"detail": map[string]any{
+			"titleField": "name",
+			"sections": []any{
+				map[string]any{
+					"title":  "Identity",
+					"fields": []any{"name", "number"},
+				},
+			},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = displaySchemaFromMap(display)
+	}
+}
+
+func BenchmarkColumnHintsToJSON(b *testing.B) {
+	hints := map[string]any{
+		"properties": map[string]any{
+			"name":     map[string]any{"x-kvx-header": "Full Name", "x-kvx-maxWidth": 30},
+			"email":    map[string]any{"x-kvx-header": "Email Address"},
+			"metadata": map[string]any{"x-kvx-visible": false},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = columnHintsToJSON(hints)
+	}
+}

--- a/pkg/provider/builtin/messageprovider/message.go
+++ b/pkg/provider/builtin/messageprovider/message.go
@@ -5,6 +5,7 @@ package messageprovider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 	"github.com/oakwood-commons/scafctl/pkg/ptrs"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"gopkg.in/yaml.v3"
 )
 
 // messageStyle holds the resolved styling attributes for rendering a message.
@@ -52,6 +55,14 @@ const (
 	fieldDestination = "destination"
 	fieldNewline     = "newline"
 
+	// Data mode fields.
+	fieldData        = "data"
+	fieldDisplay     = "display"
+	fieldFormat      = "format"
+	fieldColumnHints = "columnHints"
+	fieldColumnOrder = "columnOrder"
+	fieldExpand      = "expand"
+
 	// Style sub-fields.
 	fieldStyleColor  = "color"
 	fieldStyleBold   = "bold"
@@ -77,6 +88,18 @@ const (
 	destStderr = "stderr"
 )
 
+// Data mode format constants.
+const (
+	formatAuto    = "auto"
+	formatTable   = "table"
+	formatList    = "list"
+	formatTree    = "tree"
+	formatMermaid = "mermaid"
+	formatJSON    = "json"
+	formatYAML    = "yaml"
+	formatQuiet   = "quiet"
+)
+
 // Maximum message length to prevent abuse.
 const maxMessageLength = 8192
 
@@ -86,11 +109,14 @@ const maxLabelLength = 100
 // labelStyle renders the label prefix in dimmed text.
 var labelStyle = lipgloss.NewStyle().Faint(true)
 
-// messageOutputSchema defines the output shape for the message provider.
+// messageOutputSchema defines the output shape for text mode.
 var messageOutputSchema = schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 	"success": schemahelper.BoolProp("Whether the message was output successfully"),
 	"message": schemahelper.StringProp("The rendered message text (plain text, no ANSI codes)"),
 })
+
+// dataOnlyFields are input fields exclusive to data mode.
+var dataOnlyFields = []string{fieldDisplay, fieldFormat, fieldColumnHints, fieldColumnOrder, fieldExpand}
 
 // MessageProvider outputs styled, feature-rich terminal messages during solution execution.
 type MessageProvider struct {
@@ -99,48 +125,51 @@ type MessageProvider struct {
 
 // NewMessageProvider creates a new message provider instance.
 func NewMessageProvider() *MessageProvider {
-	version, _ := semver.NewVersion("1.0.0")
+	version, _ := semver.NewVersion("2.0.0")
 	return &MessageProvider{
 		descriptor: &provider.Descriptor{
 			Name:        ProviderName,
 			DisplayName: "Message Provider",
 			APIVersion:  "v1",
 			Version:     version,
-			Description: "Outputs styled, feature-rich terminal messages during solution execution. Supports message types (success, warning, error, info, debug, plain), custom formatting with colors and icons via lipgloss, and respects --quiet and --no-color flags. Use the framework's tmpl: or expr: ValueRef on the message input for dynamic interpolation.",
+			Description: "Outputs styled terminal messages or renders structured data using kvx during solution execution. Text mode supports message types (success, warning, error, info, debug, plain) with custom formatting. Data mode renders arrays and objects as tables, lists, trees, mermaid diagrams, or rich card-list/detail views via kvx DisplaySchema. Respects --quiet and --no-color flags.",
 			Category:    "utility",
-			Tags:        []string{"output", "message", "terminal", "logging", "display"},
-			WhatIf: func(_ context.Context, input any) (string, error) {
-				inputs, ok := input.(map[string]any)
-				if !ok {
-					return "", nil
-				}
-				msgType := stringField(inputs, fieldType, typeInfo)
-				dest := stringField(inputs, fieldDestination, destStdout)
-				label := stringField(inputs, fieldLabel, "")
-				msg := stringField(inputs, fieldMessage, "")
-				if msg == "" {
-					if label != "" {
-						return fmt.Sprintf("Would output %s message [%s] to %s", msgType, label, dest), nil
-					}
-					return fmt.Sprintf("Would output %s message to %s", msgType, dest), nil
-				}
-				// Truncate long messages in dry-run description.
-				if len(msg) > 80 {
-					msg = msg[:77] + "..."
-				}
-				if label != "" {
-					return fmt.Sprintf("Would output %s message [%s]: %q to %s", msgType, label, msg, dest), nil
-				}
-				return fmt.Sprintf("Would output %s message: %q to %s", msgType, msg, dest), nil
-			},
+			Tags:        []string{"output", "message", "terminal", "logging", "display", "data", "kvx"},
+			WhatIf:      whatIf,
 			Capabilities: []provider.Capability{
 				provider.CapabilityAction,
 			},
-			Schema: schemahelper.ObjectSchema([]string{fieldMessage}, map[string]*jsonschema.Schema{
+			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 				fieldMessage: schemahelper.StringProp(
-					"The message text to output. For dynamic interpolation, use tmpl: or expr: ValueRef on this input instead of passing templates directly.",
+					"The message text to output (text mode). Mutually exclusive with 'data'. For dynamic interpolation, use tmpl: or expr: ValueRef on this input instead of passing templates directly.",
 					schemahelper.WithExample("Deployment completed successfully"),
 					schemahelper.WithMaxLength(maxMessageLength),
+				),
+				fieldData: schemahelper.AnyProp(
+					"Structured data to render (data mode). Mutually exclusive with 'message'. Arrays render as tables or card lists; objects render as key-value views or sectioned detail views. Supports rslvr:/expr:/tmpl: ValueRef.",
+				),
+				fieldFormat: schemahelper.StringProp(
+					"Output format for data mode rendering. Controls the visual layout when 'data' is set. Defaults to 'auto' when used with 'data'.",
+					schemahelper.WithEnum(formatAuto, formatTable, formatList, formatTree, formatMermaid, formatJSON, formatYAML, formatQuiet),
+					schemahelper.WithMaxLength(*ptrs.IntPtr(10)),
+				),
+				fieldDisplay: schemahelper.ObjectProp(
+					"Display schema for rich card-list and detail views via kvx. Maps directly to kvx DisplaySchema: list (titleField, subtitleField, badgeFields, secondaryFields), detail (titleField, sections with fields and layout), collectionTitle, and icon. Requires 'data'.",
+					nil,
+					nil,
+				),
+				fieldColumnHints: schemahelper.ObjectProp(
+					"JSON Schema with x-kvx-* extensions for column-level rendering control. Supports x-kvx-header (rename), x-kvx-maxWidth, and x-kvx-visible (hide columns). Requires 'data'.",
+					nil,
+					nil,
+				),
+				fieldColumnOrder: schemahelper.ArrayProp(
+					"Preferred column display order for table rendering. Fields not listed are appended in their natural order. Recommended for deterministic column layout. Requires 'data'.",
+					schemahelper.WithItems(schemahelper.StringProp("Column field name")),
+					schemahelper.WithMaxItems(50),
+				),
+				fieldExpand: schemahelper.BoolProp(
+					"When true, the raw data is returned directly as the action output (for downstream action consumption). When false (default), output is wrapped as {success: true, data: <raw>}. Requires 'data'.",
 				),
 				fieldLabel: schemahelper.StringProp(
 					"Optional contextual prefix displayed in brackets before the message text (e.g., 'deploy', 'step 2/5'). Rendered as dimmed [label] between the icon and message. Supports tmpl: and expr: ValueRef for dynamic labels.",
@@ -234,6 +263,68 @@ inputs:
     bold: true
     icon: "🚀"`,
 				},
+				{
+					Name:        "Data table",
+					Description: "Render structured data as a default kvx table",
+					YAML: `name: show-admins
+provider: message
+inputs:
+  data:
+    rslvr: administrators
+  label: Administrators
+  columnOrder: [name, email, role]`,
+				},
+				{
+					Name:        "Data table with column hints",
+					Description: "Render data as a table with renamed headers and hidden columns",
+					YAML: `name: show-admins
+provider: message
+inputs:
+  data:
+    rslvr: administrators
+  label: Administrators
+  columnOrder: [name, email, role]
+  columnHints:
+    properties:
+      name:
+        x-kvx-header: "Full Name"
+      metadata:
+        x-kvx-visible: false`,
+				},
+				{
+					Name:        "Data card list with DisplaySchema",
+					Description: "Render an array as a rich card list with badge fields and sectioned detail view",
+					YAML: `name: show-projects
+provider: message
+inputs:
+  data:
+    rslvr: gcp_projects
+  display:
+    collectionTitle: GCP Projects
+    list:
+      titleField: name
+      subtitleField: type
+      badgeFields: [environmentCode]
+    detail:
+      titleField: name
+      sections:
+        - title: Identity
+          fields: [name, number, folderID]
+        - title: Environment
+          fields: [environment, environmentCode]
+          layout: inline`,
+				},
+				{
+					Name:        "Data tree view",
+					Description: "Render nested data as an ASCII tree",
+					YAML: `name: show-deps
+provider: message
+inputs:
+  data:
+    rslvr: dependency_tree
+  format: tree
+  label: Dependencies`,
+				},
 			},
 		},
 	}
@@ -244,23 +335,51 @@ func (p *MessageProvider) Descriptor() *provider.Descriptor {
 	return p.descriptor
 }
 
-// Execute outputs a styled message to the terminal.
+// Execute outputs a styled message or renders structured data to the terminal.
 func (p *MessageProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
 	inputs, ok := input.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%s: expected map[string]any, got %T", ProviderName, input)
 	}
-	lgr := logger.FromContext(ctx)
 
-	// Resolve the message text (required for both normal and dry-run execution).
-	msgStr, ok := inputs[fieldMessage].(string)
-	if !ok || msgStr == "" {
-		return nil, fmt.Errorf("%s: 'message' must be provided", ProviderName)
+	// Determine mode: data or text.
+	_, hasData := inputs[fieldData]
+	_, hasMessage := inputs[fieldMessage]
+
+	if hasData && hasMessage {
+		return nil, fmt.Errorf("%s: 'data' and 'message' are mutually exclusive", ProviderName)
+	}
+	if !hasData && !hasMessage {
+		return nil, fmt.Errorf("%s: either 'data' or 'message' must be provided", ProviderName)
+	}
+
+	// Validate that data-only fields are not used without data.
+	if !hasData {
+		for _, field := range dataOnlyFields {
+			if _, ok := inputs[field]; ok {
+				return nil, fmt.Errorf("%s: '%s' requires 'data' to be set", ProviderName, field)
+			}
+		}
 	}
 
 	// Check for dry-run mode.
 	if provider.DryRunFromContext(ctx) {
 		return p.executeDryRun(inputs)
+	}
+
+	if hasData {
+		return p.executeDataMode(ctx, inputs)
+	}
+	return p.executeTextMode(ctx, inputs)
+}
+
+// executeTextMode renders a styled text message to the terminal.
+func (p *MessageProvider) executeTextMode(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	msgStr, ok := inputs[fieldMessage].(string)
+	if !ok || msgStr == "" {
+		return nil, fmt.Errorf("%s: 'message' must be a non-empty string", ProviderName)
 	}
 
 	// Get configuration fields.
@@ -411,8 +530,254 @@ func (p *MessageProvider) writeToTerminal(ioStreams *provider.IOStreams, msg, de
 	return err
 }
 
+// whatIf generates a dry-run description for the message provider.
+func whatIf(_ context.Context, input any) (string, error) {
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+
+	// Data mode WhatIf.
+	if _, hasData := inputs[fieldData]; hasData {
+		format := stringField(inputs, fieldFormat, formatAuto)
+		label := stringField(inputs, fieldLabel, "")
+		hasDisplay := false
+		if _, ok := inputs[fieldDisplay].(map[string]any); ok {
+			hasDisplay = true
+		}
+		desc := fmt.Sprintf("Would render data as %s", format)
+		if hasDisplay {
+			desc += " with display schema"
+		}
+		if label != "" {
+			desc += fmt.Sprintf(" [%s]", label)
+		}
+		return desc, nil
+	}
+
+	// Text mode WhatIf.
+	msgType := stringField(inputs, fieldType, typeInfo)
+	dest := stringField(inputs, fieldDestination, destStdout)
+	label := stringField(inputs, fieldLabel, "")
+	msg := stringField(inputs, fieldMessage, "")
+	if msg == "" {
+		if label != "" {
+			return fmt.Sprintf("Would output %s message [%s] to %s", msgType, label, dest), nil
+		}
+		return fmt.Sprintf("Would output %s message to %s", msgType, dest), nil
+	}
+	// Truncate long messages in dry-run description.
+	if len(msg) > 80 {
+		msg = msg[:77] + "..."
+	}
+	if label != "" {
+		return fmt.Sprintf("Would output %s message [%s]: %q to %s", msgType, label, msg, dest), nil
+	}
+	return fmt.Sprintf("Would output %s message: %q to %s", msgType, msg, dest), nil
+}
+
+// executeDataMode renders structured data using kvx.
+func (p *MessageProvider) executeDataMode(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+	data := inputs[fieldData]
+
+	ioStreams, _ := provider.IOStreamsFromContext(ctx)
+
+	noColor := false
+	isQuiet := false
+	if runSettings, ok := settings.FromContext(ctx); ok {
+		noColor = runSettings.NoColor
+		isQuiet = runSettings.IsQuiet
+	}
+
+	format := stringField(inputs, fieldFormat, formatAuto)
+	expand := boolField(inputs, fieldExpand, false)
+
+	// Validate display and columnHints types early.
+	if v, exists := inputs[fieldDisplay]; exists {
+		if _, ok := v.(map[string]any); !ok {
+			return nil, fmt.Errorf("%s: 'display' must be an object, got %T", ProviderName, v)
+		}
+	}
+	if v, exists := inputs[fieldColumnHints]; exists {
+		if _, ok := v.(map[string]any); !ok {
+			return nil, fmt.Errorf("%s: 'columnHints' must be an object, got %T", ProviderName, v)
+		}
+	}
+
+	// Resolve the output writer based on destination, honoring stderr when requested.
+	dest := stringField(inputs, fieldDestination, destStdout)
+	out := resolveDataWriter(ioStreams, dest)
+	streamed := false
+	if out != nil && !isQuiet {
+		switch format {
+		case formatJSON:
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(data); err != nil {
+				return nil, fmt.Errorf("%s: failed to encode JSON: %w", ProviderName, err)
+			}
+			streamed = true
+		case formatYAML:
+			yEnc := yaml.NewEncoder(out)
+			if err := yEnc.Encode(data); err != nil {
+				return nil, fmt.Errorf("%s: failed to encode YAML: %w", ProviderName, err)
+			}
+			if err := yEnc.Close(); err != nil {
+				return nil, fmt.Errorf("%s: failed to flush YAML output: %w", ProviderName, err)
+			}
+			streamed = true
+		case formatQuiet:
+			// No output.
+		default:
+			if err := p.renderVisual(ctx, data, inputs, out, noColor, format); err != nil {
+				return nil, err
+			}
+			streamed = true
+		}
+	}
+
+	lgr.V(1).Info("Data output",
+		fieldFormat, format,
+		"expand", expand,
+		"written", streamed,
+	)
+
+	// Build output based on expand flag.
+	var outputData any
+	if expand {
+		outputData = data
+	} else {
+		outputData = map[string]any{
+			"success": true,
+			"data":    data,
+		}
+	}
+
+	return &provider.Output{
+		Data:     outputData,
+		Streamed: streamed,
+	}, nil
+}
+
+// resolveDataWriter selects the output writer for data mode based on the destination input.
+// Returns nil when IOStreams are unavailable (embedder/structured-output mode).
+func resolveDataWriter(ioStreams *provider.IOStreams, dest string) io.Writer {
+	if ioStreams == nil {
+		return nil
+	}
+	switch dest {
+	case destStderr:
+		return ioStreams.ErrOut
+	default:
+		return ioStreams.Out
+	}
+}
+
+// renderVisual renders structured data using kvx visual output (table, list, tree, mermaid,
+// or DisplaySchema-driven card-list/detail views). Writes directly to the provided writer.
+func (p *MessageProvider) renderVisual(ctx context.Context, data any, inputs map[string]any, out io.Writer, noColor bool, format string) error {
+	// Default AppName to the runtime binary name for embedder compatibility.
+	appName := settings.BinaryNameFromContext(ctx)
+	if label := stringField(inputs, fieldLabel, ""); label != "" {
+		appName = label
+	}
+
+	// If display schema is present, use Snapshot() for rich rendering.
+	if displayMap, ok := inputs[fieldDisplay].(map[string]any); ok {
+		displayJSON, err := displaySchemaFromMap(displayMap)
+		if err != nil {
+			return fmt.Errorf("%s: invalid display config: %w", ProviderName, err)
+		}
+		opts := []kvx.Option{
+			kvx.WithIO(nil, out),
+			kvx.WithNoColor(noColor),
+			kvx.WithDisplaySchemaJSON(displayJSON),
+			kvx.WithAppName(appName),
+		}
+		if hintsMap, ok := inputs[fieldColumnHints].(map[string]any); ok {
+			hintsJSON, err := columnHintsToJSON(hintsMap)
+			if err != nil {
+				return fmt.Errorf("%s: invalid column hints: %w", ProviderName, err)
+			}
+			opts = append(opts, kvx.WithSchemaJSON(hintsJSON))
+		}
+		snapshot, err := kvx.Snapshot(data, opts...)
+		if err != nil {
+			return fmt.Errorf("%s: failed to render display: %w", ProviderName, err)
+		}
+		_, err = fmt.Fprint(out, snapshot)
+		return err
+	}
+
+	// No display schema -- use View() for basic layout rendering.
+	opts := []kvx.Option{
+		kvx.WithIO(nil, out),
+		kvx.WithNoColor(noColor),
+		kvx.WithLayout(format),
+		kvx.WithAppName(appName),
+	}
+	if order, ok := inputs[fieldColumnOrder].([]any); ok {
+		strOrder := make([]string, 0, len(order))
+		for i, v := range order {
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("%s: columnOrder[%d] must be a string, got %T", ProviderName, i, v)
+			}
+			strOrder = append(strOrder, s)
+		}
+		opts = append(opts, kvx.WithColumnOrder(strOrder))
+	}
+	if hintsMap, ok := inputs[fieldColumnHints].(map[string]any); ok {
+		hintsJSON, err := columnHintsToJSON(hintsMap)
+		if err != nil {
+			return fmt.Errorf("%s: invalid column hints: %w", ProviderName, err)
+		}
+		opts = append(opts, kvx.WithSchemaJSON(hintsJSON))
+	}
+	return kvx.View(data, opts...)
+}
+
 // executeDryRun returns a simulated output for dry-run mode.
 func (p *MessageProvider) executeDryRun(inputs map[string]any) (*provider.Output, error) {
+	_, hasData := inputs[fieldData]
+
+	if hasData {
+		format := stringField(inputs, fieldFormat, formatAuto)
+		label := stringField(inputs, fieldLabel, "")
+		hasDisplay := false
+		if _, ok := inputs[fieldDisplay].(map[string]any); ok {
+			hasDisplay = true
+		}
+		desc := fmt.Sprintf("[dry-run] Would render data as %s", format)
+		if hasDisplay {
+			desc += " with display schema"
+		}
+		if label != "" {
+			desc += fmt.Sprintf(" [%s]", label)
+		}
+
+		// Return the same output shape as non-dry-run so downstream
+		// actions/resolvers see the correct structure during dry-run.
+		data := inputs[fieldData]
+		expand := boolField(inputs, fieldExpand, false)
+		var outputData any
+		if expand {
+			outputData = data
+		} else {
+			outputData = map[string]any{
+				"success": true,
+				"data":    data,
+			}
+		}
+		return &provider.Output{
+			Data: outputData,
+			Metadata: map[string]any{
+				"description": desc,
+			},
+		}, nil
+	}
+
 	msgType := stringField(inputs, fieldType, typeInfo)
 	dest := stringField(inputs, fieldDestination, destStdout)
 	label := stringField(inputs, fieldLabel, "")

--- a/pkg/provider/builtin/messageprovider/message_test.go
+++ b/pkg/provider/builtin/messageprovider/message_test.go
@@ -52,13 +52,13 @@ func TestMessageProvider_Execute_InvalidInput(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected map[string]any")
 }
 
-func TestMessageProvider_Execute_MissingMessage(t *testing.T) {
+func TestMessageProvider_Execute_MissingMessageAndData(t *testing.T) {
 	p := NewMessageProvider()
 	ctx, _, _ := testCtx(t, nil)
 
 	_, err := p.Execute(ctx, map[string]any{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "'message' must be provided")
+	assert.Contains(t, err.Error(), "either 'data' or 'message' must be provided")
 }
 
 func TestMessageProvider_Execute_PlainMessage(t *testing.T) {
@@ -507,7 +507,7 @@ func TestMessageProvider_Execute_DryRun(t *testing.T) {
 	assert.Contains(t, data["message"].(string), "stderr")
 }
 
-func TestMessageProvider_Execute_DryRun_NoMessage(t *testing.T) {
+func TestMessageProvider_Execute_DryRun_NoMessageOrData(t *testing.T) {
 	p := NewMessageProvider()
 	ctx, _, _ := testCtx(t, nil)
 	ctx = provider.WithDryRun(ctx, true)
@@ -516,7 +516,7 @@ func TestMessageProvider_Execute_DryRun_NoMessage(t *testing.T) {
 		"type": "info",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "'message' must be provided")
+	assert.Contains(t, err.Error(), "either 'data' or 'message' must be provided")
 }
 
 func TestMessageProvider_Execute_DryRun_WithLabel(t *testing.T) {
@@ -648,6 +648,28 @@ func TestMessageProvider_WhatIf(t *testing.T) {
 			name:     "invalid input type",
 			input:    "not-a-map",
 			contains: "",
+		},
+		{
+			name:     "data mode basic",
+			input:    map[string]any{"data": []any{"a", "b"}},
+			contains: "Would render data as auto",
+		},
+		{
+			name: "data mode with display",
+			input: map[string]any{
+				"data":    []any{"a"},
+				"display": map[string]any{"list": map[string]any{"titleField": "name"}},
+			},
+			contains: "with display schema",
+		},
+		{
+			name: "data mode with label",
+			input: map[string]any{
+				"data":   []any{"a"},
+				"format": "table",
+				"label":  "Results",
+			},
+			contains: "[Results]",
 		},
 	}
 	for _, tt := range tests {
@@ -781,6 +803,693 @@ func BenchmarkExecuteWithLabel(b *testing.B) {
 	}
 
 	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+// --- Data mode tests ---
+
+func TestMessageProvider_Execute_DataMode_DefaultTable(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin"},
+		{"name": "Bob", "role": "operator"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.True(t, out.Streamed)
+
+	// Default output wraps data.
+	outputMap, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.True(t, outputMap["success"].(bool))
+	assert.Equal(t, data, outputMap["data"])
+
+	// Should have rendered something to stdout.
+	assert.NotEmpty(t, stdout.String())
+	assert.Contains(t, stdout.String(), "Alice")
+	assert.Contains(t, stdout.String(), "Bob")
+}
+
+func TestMessageProvider_Execute_DataMode_WithLabel(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":  data,
+		"label": "Team Members",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), "Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_TableFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "table",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), "Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_ListFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := map[string]any{
+		"name": "Alice",
+		"role": "admin",
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "list",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_TreeFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := map[string]any{
+		"root": map[string]any{
+			"child1": "value1",
+			"child2": "value2",
+		},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "tree",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_MermaidFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := map[string]any{
+		"root": map[string]any{
+			"child": "value",
+		},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "mermaid",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_JSONFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "json",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), `"name"`)
+	assert.Contains(t, stdout.String(), `"Alice"`)
+}
+
+func TestMessageProvider_Execute_DataMode_YAMLFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "yaml",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), "name: Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_QuietFormat(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{{"name": "Alice"}}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"format": "quiet",
+	})
+	require.NoError(t, err)
+	assert.False(t, out.Streamed)
+	assert.Empty(t, stdout.String())
+
+	// Data is still in output even when quiet.
+	outputMap := out.Data.(map[string]any)
+	assert.True(t, outputMap["success"].(bool))
+}
+
+func TestMessageProvider_Execute_DataMode_QuietFromSettings(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{IsQuiet: true, NoColor: true})
+
+	data := []map[string]any{{"name": "Alice"}}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+	})
+	require.NoError(t, err)
+	assert.False(t, out.Streamed)
+	assert.Empty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_ExpandTrue(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"expand": true,
+	})
+	require.NoError(t, err)
+
+	// With expand: true, output IS the raw data.
+	outData, ok := out.Data.([]map[string]any)
+	require.True(t, ok)
+	assert.Len(t, outData, 1)
+	assert.Equal(t, "Alice", outData[0]["name"])
+}
+
+func TestMessageProvider_Execute_DataMode_ExpandFalse(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := map[string]any{"name": "Alice"}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   data,
+		"expand": false,
+	})
+	require.NoError(t, err)
+
+	// With expand: false, output is wrapped.
+	outputMap, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.True(t, outputMap["success"].(bool))
+	assert.Equal(t, data, outputMap["data"])
+}
+
+func TestMessageProvider_Execute_DataMode_ColumnOrder(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin", "email": "alice@test.com"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":        data,
+		"columnOrder": []any{"name", "email", "role"},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), "Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_WithDisplaySchema(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "my-project", "type": "compute", "env": "prod"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+		"display": map[string]any{
+			"collectionTitle": "Projects",
+			"list": map[string]any{
+				"titleField":    "name",
+				"subtitleField": "type",
+				"badgeFields":   []any{"env"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_DetailView(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := map[string]any{
+		"name":    "my-app",
+		"version": "1.0.0",
+		"status":  "running",
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+		"display": map[string]any{
+			"detail": map[string]any{
+				"titleField": "name",
+				"sections": []any{
+					map[string]any{
+						"title":  "Info",
+						"fields": []any{"name", "version"},
+					},
+					map[string]any{
+						"title":  "Status",
+						"fields": []any{"status"},
+						"layout": "inline",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_ColumnHints(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin", "secret": "hidden"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+		"columnHints": map[string]any{
+			"properties": map[string]any{
+				"name": map[string]any{
+					"x-kvx-header": "Full Name",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Contains(t, stdout.String(), "Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_DryRun(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	inputData := []map[string]any{{"name": "Alice"}}
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   inputData,
+		"format": "table",
+		"label":  "Users",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
+
+	outputMap := out.Data.(map[string]any)
+	assert.True(t, outputMap["success"].(bool))
+	assert.Equal(t, inputData, outputMap["data"])
+	assert.Contains(t, out.Metadata["description"].(string), "[dry-run]")
+	assert.Contains(t, out.Metadata["description"].(string), "table")
+	assert.Contains(t, out.Metadata["description"].(string), "[Users]")
+}
+
+func TestMessageProvider_Execute_DataMode_DryRunWithDisplay(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	inputData := []map[string]any{{"name": "Alice"}}
+	out, err := p.Execute(ctx, map[string]any{
+		"data": inputData,
+		"display": map[string]any{
+			"list": map[string]any{"titleField": "name"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out.Metadata["description"].(string), "display schema")
+	outputMap := out.Data.(map[string]any)
+	assert.Equal(t, inputData, outputMap["data"])
+}
+
+func TestMessageProvider_Execute_DataMode_DryRunExpand(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	inputData := []map[string]any{{"name": "Alice"}}
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   inputData,
+		"expand": true,
+	})
+	require.NoError(t, err)
+	// expand=true returns raw data directly, not wrapped.
+	assert.Equal(t, inputData, out.Data)
+}
+
+// --- Error cases for data mode ---
+
+func TestMessageProvider_Execute_DataAndMessage_MutuallyExclusive(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "hello",
+		"data":    []map[string]any{{"name": "Alice"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'data' and 'message' are mutually exclusive")
+}
+
+func TestMessageProvider_Execute_DisplayWithoutData(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "hello",
+		"display": map[string]any{"list": map[string]any{"titleField": "name"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'display' requires 'data' to be set")
+}
+
+func TestMessageProvider_Execute_FormatWithoutData(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "hello",
+		"format":  "table",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'format' requires 'data' to be set")
+}
+
+func TestMessageProvider_Execute_ColumnHintsWithoutData(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message":     "hello",
+		"columnHints": map[string]any{"properties": map[string]any{}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'columnHints' requires 'data' to be set")
+}
+
+func TestMessageProvider_Execute_ColumnOrderWithoutData(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message":     "hello",
+		"columnOrder": []any{"name"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'columnOrder' requires 'data' to be set")
+}
+
+func TestMessageProvider_Execute_ExpandWithoutData(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "hello",
+		"expand":  true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'expand' requires 'data' to be set")
+}
+
+func TestMessageProvider_Execute_DataMode_NoIOStreams(t *testing.T) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": []map[string]any{{"name": "Alice"}},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.False(t, out.Streamed, "should not stream when IOStreams are nil")
+	assert.Equal(t, map[string]any{
+		"success": true,
+		"data":    []map[string]any{{"name": "Alice"}},
+	}, out.Data)
+}
+
+func TestMessageProvider_Execute_DataMode_DisplayWrongType(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"data":    []map[string]any{{"name": "Alice"}},
+		"display": "not-a-map",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'display' must be an object")
+}
+
+func TestMessageProvider_Execute_DataMode_DestinationStderr(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, stderr := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"data":        []map[string]any{{"name": "Alice"}},
+		"format":      "json",
+		"destination": "stderr",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String(), "stdout should be empty when destination is stderr")
+	assert.Contains(t, stderr.String(), "Alice")
+}
+
+func TestMessageProvider_Execute_DataMode_AppNameEmbedder(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true, BinaryName: "mycli"})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"data": []map[string]any{{"name": "Alice"}},
+	})
+	require.NoError(t, err)
+	// The rendered output should use the embedder binary name, not hardcoded "scafctl".
+	output := stdout.String()
+	assert.NotContains(t, output, "scafctl")
+}
+
+func TestMessageProvider_Execute_DataMode_ColumnHintsWrongType(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"data":        []map[string]any{{"name": "Alice"}},
+		"columnHints": "not-a-map",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'columnHints' must be an object")
+}
+
+func TestMessageProvider_Execute_DataMode_NoIOStreams_WithExpand(t *testing.T) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":   []map[string]any{{"name": "Alice"}},
+		"expand": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]any{{"name": "Alice"}}, out.Data)
+	assert.False(t, out.Streamed)
+}
+
+func TestMessageProvider_Execute_DataMode_DisplayAndColumnHints(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{
+		{"name": "Alice", "role": "admin", "secret": "hidden"},
+	}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data": data,
+		"display": map[string]any{
+			"collectionTitle": "Users",
+			"list": map[string]any{
+				"titleField": "name",
+			},
+		},
+		"columnHints": map[string]any{
+			"properties": map[string]any{
+				"name": map[string]any{
+					"x-kvx-header": "Full Name",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+func TestMessageProvider_Execute_DataMode_ColumnOrderNonString(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	_, err := p.Execute(ctx, map[string]any{
+		"data":        []map[string]any{{"name": "Alice"}},
+		"columnOrder": []any{"name", 42},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "columnOrder[1] must be a string")
+}
+
+func TestMessageProvider_Execute_DataMode_DisplayWithLabel(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	data := []map[string]any{{"name": "Alice"}}
+
+	out, err := p.Execute(ctx, map[string]any{
+		"data":  data,
+		"label": "Team",
+		"display": map[string]any{
+			"list": map[string]any{"titleField": "name"},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.NotEmpty(t, stdout.String())
+}
+
+// --- Data mode benchmarks ---
+
+func BenchmarkExecute_DataMode_Table(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	data := make([]map[string]any, 10)
+	for i := range data {
+		data[i] = map[string]any{
+			"name":  "item-" + string(rune('A'+i)),
+			"value": i * 10,
+			"type":  "compute",
+		}
+	}
+	input := map[string]any{"data": data}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecute_DataMode_Display(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	data := make([]map[string]any, 10)
+	for i := range data {
+		data[i] = map[string]any{
+			"name":  "project-" + string(rune('A'+i)),
+			"type":  "compute",
+			"env":   "production",
+			"value": i * 10,
+		}
+	}
+	input := map[string]any{
+		"data": data,
+		"display": map[string]any{
+			"collectionTitle": "Projects",
+			"list": map[string]any{
+				"titleField":    "name",
+				"subtitleField": "type",
+				"badgeFields":   []any{"env"},
+			},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecute_DataMode_JSON(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: true})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	data := make([]map[string]any, 10)
+	for i := range data {
+		data[i] = map[string]any{
+			"name":  "item-" + string(rune('A'+i)),
+			"value": i * 10,
+		}
+	}
+	input := map[string]any{"data": data, "format": "json"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for b.Loop() {
 		stdout.Reset()
 		_, _ = p.Execute(ctx, input)


### PR DESCRIPTION
Add data mode to the message provider, enabling kvx-powered rendering of structured data (tables, lists, trees, mermaid, card-list/detail views) directly from solution actions:

- New inputs: data, format, display, columnHints, columnOrder, expand
- Three rendering tiers: basic kvx layout, column-controlled tables, and rich DisplaySchema card-list/detail views
- format supports auto/table/list/tree/mermaid/json/yaml/quiet
- expand flag controls output shape (raw data vs wrapped object)
- display maps directly to kvx x-kvx-* vendor extensions
- columnHints supports x-kvx-header, x-kvx-maxWidth, x-kvx-visible
- New display.go with displaySchemaFromMap and columnHintsToJSON helpers
- WhatIf and dry-run support for data mode
- 25 new unit tests, 3 data-mode benchmarks, 2 display helper benchmarks
- Bumped provider version to 2.0.0
- Update hello-world example to use message provider instead of exec

Closes #213
Closes #210

BREAKING CHANGE: message field is no longer unconditionally required; either message or data must be provided. Existing solutions with message set are unaffected.
