### PR TITLE
feat: condition shorthand, output formats, build ergonomics, auth TUI, and re-tag support

### DIFF
--- a/pkg/auth/entra/authcode_flow.go
+++ b/pkg/auth/entra/authcode_flow.go
@@ -93,6 +93,9 @@ func (h *Handler) authCodeLogin(ctx context.Context, opts auth.LoginOptions) (*a
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(authURL)
+	}
 	if err := BrowserOpener(ctx, authURL); err != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
 		// Notify via callback if available so the CLI can display the URL

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -72,6 +72,9 @@ func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.R
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(authURL)
+	}
 	if err := oauth.OpenBrowser(ctx, authURL); err != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
 	}

--- a/pkg/auth/github/authcode_flow.go
+++ b/pkg/auth/github/authcode_flow.go
@@ -76,6 +76,9 @@ func (h *Handler) authCodeLogin(ctx context.Context, opts auth.LoginOptions) (*a
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(authURL)
+	}
 	if err := BrowserOpener(ctx, authURL); err != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
 		// Notify via callback if available so the CLI can display the URL

--- a/pkg/auth/github/device_flow.go
+++ b/pkg/auth/github/device_flow.go
@@ -80,6 +80,9 @@ func (h *Handler) interactiveDeviceCodeLogin(ctx context.Context, opts auth.Logi
 	)
 
 	// Open browser to the device verification page
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(deviceCode.VerificationURI)
+	}
 	if err := BrowserOpener(ctx, deviceCode.VerificationURI); err != nil {
 		lgr.V(0).Info("could not open browser automatically", "url", deviceCode.VerificationURI)
 	}

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -95,12 +95,13 @@ const DefaultMinValidFor = 60 * time.Second
 
 // LoginOptions configures the login process.
 type LoginOptions struct {
-	TenantID           string                                          `json:"tenantId,omitempty" yaml:"tenantId,omitempty" doc:"Azure AD tenant ID override" maxLength:"128"`
-	Scopes             []string                                        `json:"scopes,omitempty" yaml:"scopes,omitempty" doc:"OAuth scopes to request" maxItems:"20"`
-	Flow               Flow                                            `json:"flow,omitempty" yaml:"flow,omitempty" doc:"Authentication flow to use" example:"device_code" maxLength:"64"`
-	Timeout            time.Duration                                   `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Maximum time to wait for authentication"`
-	CallbackPort       int                                             `json:"callbackPort,omitempty" yaml:"callbackPort,omitempty" doc:"Local port for OAuth callback server" minimum:"0" maximum:"65535"`
-	DeviceCodeCallback func(userCode, verificationURI, message string) `json:"-" yaml:"-"`
+	TenantID            string                                          `json:"tenantId,omitempty" yaml:"tenantId,omitempty" doc:"Azure AD tenant ID override" maxLength:"128"`
+	Scopes              []string                                        `json:"scopes,omitempty" yaml:"scopes,omitempty" doc:"OAuth scopes to request" maxItems:"20"`
+	Flow                Flow                                            `json:"flow,omitempty" yaml:"flow,omitempty" doc:"Authentication flow to use" example:"device_code" maxLength:"64"`
+	Timeout             time.Duration                                   `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Maximum time to wait for authentication"`
+	CallbackPort        int                                             `json:"callbackPort,omitempty" yaml:"callbackPort,omitempty" doc:"Local port for OAuth callback server" minimum:"0" maximum:"65535"`
+	DeviceCodeCallback  func(userCode, verificationURI, message string) `json:"-" yaml:"-"`
+	BrowserAuthCallback func(authURL string)                            `json:"-" yaml:"-"`
 }
 
 // TokenOptions configures token acquisition.

--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -174,7 +174,7 @@ func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Resu
 		if callbackPort == 0 {
 			callbackPort = h.cfg.CallbackPort
 		}
-		tokenResp, err = h.authCodeLogin(ctx, scopes, callbackPort)
+		tokenResp, err = h.authCodeLogin(ctx, opts, scopes, callbackPort)
 	case auth.FlowDeviceCode:
 		tokenResp, err = h.deviceCodeLogin(ctx, opts, scopes)
 	case auth.FlowClientCredentials:
@@ -364,14 +364,14 @@ func (e *tokenEndpointError) Error() string {
 
 // ---------- flow: authorization code + PKCE ----------
 
-func (h *Handler) authCodeLogin(ctx context.Context, scopes []string, callbackPort int) (*tokenResponse, error) {
+func (h *Handler) authCodeLogin(ctx context.Context, opts auth.LoginOptions, scopes []string, callbackPort int) (*tokenResponse, error) {
 	if h.cfg.AuthorizeURL == "" {
 		return nil, fmt.Errorf("authorizeURL is required for interactive flow")
 	}
 
 	// Implicit grant flow (response_type=token) uses a different callback mechanism.
 	if h.cfg.ResponseType == "token" {
-		return h.implicitGrantLogin(ctx, scopes, callbackPort)
+		return h.implicitGrantLogin(ctx, opts, scopes, callbackPort)
 	}
 
 	var verifier string
@@ -413,6 +413,9 @@ func (h *Handler) authCodeLogin(ctx context.Context, scopes []string, callbackPo
 	}
 	authURL.RawQuery = q.Encode()
 
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(authURL.String())
+	}
 	if openErr := oauth.OpenBrowser(ctx, authURL.String()); openErr != nil {
 		h.logger.V(1).Info("failed to open browser", "url", authURL.String(), "error", openErr)
 	}
@@ -450,7 +453,7 @@ func (h *Handler) exchangeAuthCode(ctx context.Context, code, redirectURI, codeV
 
 // ---------- flow: implicit grant (response_type=token) ----------
 
-func (h *Handler) implicitGrantLogin(ctx context.Context, scopes []string, callbackPort int) (*tokenResponse, error) {
+func (h *Handler) implicitGrantLogin(ctx context.Context, opts auth.LoginOptions, scopes []string, callbackPort int) (*tokenResponse, error) {
 	state, err := oauth.GenerateCodeVerifier()
 	if err != nil {
 		return nil, fmt.Errorf("generate state: %w", err)
@@ -476,6 +479,9 @@ func (h *Handler) implicitGrantLogin(ctx context.Context, scopes []string, callb
 	}
 	authURL.RawQuery = q.Encode()
 
+	if opts.BrowserAuthCallback != nil {
+		opts.BrowserAuthCallback(authURL.String())
+	}
 	if openErr := oauth.OpenBrowser(ctx, authURL.String()); openErr != nil {
 		h.logger.V(1).Info("failed to open browser", "url", authURL.String(), "error", openErr)
 	}

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -706,7 +706,7 @@ func TestHandler_ImplicitGrantLogin_RequiresAuthorizeURL(t *testing.T) {
 		cfg.AuthorizeURL = "" // missing
 	})
 
-	_, err := h.authCodeLogin(context.Background(), nil, 0)
+	_, err := h.authCodeLogin(context.Background(), auth.LoginOptions{}, nil, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authorizeURL is required")
 }
@@ -722,7 +722,7 @@ func TestHandler_ImplicitGrantLogin_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	_, err := h.implicitGrantLogin(ctx, nil, 0)
+	_, err := h.implicitGrantLogin(ctx, auth.LoginOptions{}, nil, 0)
 	// Should fail with context cancelled (server can't start or times out)
 	assert.Error(t, err)
 }

--- a/pkg/catalog/local.go
+++ b/pkg/catalog/local.go
@@ -720,6 +720,99 @@ func (c *LocalCatalog) Tag(ctx context.Context, ref Reference, alias string) (st
 	return oldVersion, nil
 }
 
+// CopyLocal copies an artifact to a new name and/or version within the same
+// local catalog. This is used for re-tagging (e.g., "catalog tag foo@1.0.0
+// bar@1.0.0"). The content blobs (layers, config) are shared via
+// content-addressing; only a new manifest is created with updated annotations.
+func (c *LocalCatalog) CopyLocal(ctx context.Context, src Reference, dstName string, dstVersion *semver.Version, dstKind ArtifactKind, force bool) (ArtifactInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Build the destination reference.
+	kind := src.Kind
+	if dstKind != "" {
+		kind = dstKind
+	}
+	dstRef := Reference{
+		Kind:    kind,
+		Name:    dstName,
+		Version: dstVersion,
+	}
+
+	// Check if destination already exists (unless force).
+	if !force {
+		if c.existsLocked(ctx, dstRef) {
+			return ArtifactInfo{}, fmt.Errorf("artifact %s@%s already exists; use --force to overwrite", dstName, dstVersion.String())
+		}
+	}
+
+	// Resolve the source manifest.
+	srcTag := c.tagForRef(src)
+	srcDesc, err := c.store.Resolve(ctx, srcTag)
+	if err != nil {
+		return ArtifactInfo{}, &ArtifactNotFoundError{Reference: src, Catalog: LocalCatalogName}
+	}
+
+	// Read source manifest to get layers and config.
+	srcManifestData, err := c.fetchBlob(ctx, srcDesc)
+	if err != nil {
+		return ArtifactInfo{}, fmt.Errorf("failed to read source manifest: %w", err)
+	}
+
+	var srcManifest ocispec.Manifest
+	if err := json.Unmarshal(srcManifestData, &srcManifest); err != nil {
+		return ArtifactInfo{}, fmt.Errorf("failed to parse source manifest: %w", err)
+	}
+
+	// Build new annotations with the destination name/version.
+	now := time.Now().UTC()
+	annotations := make(map[string]string)
+	for k, v := range srcManifest.Annotations {
+		annotations[k] = v
+	}
+	annotations[AnnotationArtifactType] = kind.String()
+	annotations[AnnotationArtifactName] = dstName
+	if dstVersion != nil {
+		annotations[AnnotationVersion] = dstVersion.String()
+	}
+	annotations[AnnotationCreated] = now.Format(time.RFC3339)
+
+	// Create a new manifest referencing the same layers and config but
+	// with updated annotations. Content-addressed blobs are re-used.
+	newManifest := ocispec.Manifest{
+		Versioned:   srcManifest.Versioned,
+		MediaType:   srcManifest.MediaType,
+		Config:      srcManifest.Config,
+		Layers:      srcManifest.Layers,
+		Annotations: annotations,
+	}
+
+	manifestData, err := json.Marshal(newManifest)
+	if err != nil {
+		return ArtifactInfo{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	manifestDesc, err := c.pushBlob(ctx, ocispec.MediaTypeImageManifest, manifestData)
+	if err != nil {
+		return ArtifactInfo{}, fmt.Errorf("failed to push manifest: %w", err)
+	}
+
+	dstTag := c.tagForRef(dstRef)
+	if err := c.store.Tag(ctx, manifestDesc, dstTag); err != nil {
+		return ArtifactInfo{}, fmt.Errorf("failed to tag artifact: %w", err)
+	}
+
+	c.logger.V(1).Info("copied artifact",
+		"src", srcTag,
+		"dst", dstTag)
+
+	return ArtifactInfo{
+		Reference: dstRef,
+		Digest:    manifestDesc.Digest.String(),
+		Size:      manifestDesc.Size,
+	}, nil
+}
+
 // PruneResult contains statistics from a prune operation.
 type PruneResult struct {
 	// RemovedManifests is the number of orphaned manifests removed

--- a/pkg/catalog/local_test.go
+++ b/pkg/catalog/local_test.go
@@ -840,3 +840,102 @@ func TestLocalCatalog_Prune_OrphanedManifest(t *testing.T) {
 	// The orphaned manifest entry should have been removed from index.json
 	assert.Equal(t, 1, result.RemovedManifests)
 }
+
+func TestLocalCatalog_CopyLocal(t *testing.T) {
+	t.Run("copies artifact to new name", func(t *testing.T) {
+		cat := newTestCatalog(t)
+		ctx := context.Background()
+
+		ref := Reference{Kind: ArtifactKindSolution, Name: "original", Version: semver.MustParse("1.0.0")}
+		_, err := cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+		require.NoError(t, err)
+
+		info, err := cat.CopyLocal(ctx, ref, "copied", semver.MustParse("2.0.0"), ArtifactKindSolution, false)
+		require.NoError(t, err)
+		assert.Equal(t, "copied", info.Reference.Name)
+		assert.Equal(t, "2.0.0", info.Reference.Version.String())
+		assert.NotEmpty(t, info.Digest)
+
+		// Verify the new artifact can be retrieved
+		list, err := cat.List(ctx, ArtifactKindSolution, "copied")
+		require.NoError(t, err)
+		assert.Len(t, list, 1)
+		assert.Equal(t, "2.0.0", list[0].Reference.Version.String())
+	})
+
+	t.Run("preserves original artifact", func(t *testing.T) {
+		cat := newTestCatalog(t)
+		ctx := context.Background()
+
+		ref := Reference{Kind: ArtifactKindSolution, Name: "source", Version: semver.MustParse("1.0.0")}
+		_, err := cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+		require.NoError(t, err)
+
+		_, err = cat.CopyLocal(ctx, ref, "dest", semver.MustParse("1.0.0"), ArtifactKindSolution, false)
+		require.NoError(t, err)
+
+		// Original should still exist
+		list, err := cat.List(ctx, ArtifactKindSolution, "source")
+		require.NoError(t, err)
+		assert.Len(t, list, 1)
+	})
+
+	t.Run("errors on existing destination without force", func(t *testing.T) {
+		cat := newTestCatalog(t)
+		ctx := context.Background()
+
+		src := Reference{Kind: ArtifactKindSolution, Name: "src", Version: semver.MustParse("1.0.0")}
+		dst := Reference{Kind: ArtifactKindSolution, Name: "dst", Version: semver.MustParse("1.0.0")}
+		_, err := cat.Store(ctx, src, []byte("source"), nil, nil, false)
+		require.NoError(t, err)
+		_, err = cat.Store(ctx, dst, []byte("dest"), nil, nil, false)
+		require.NoError(t, err)
+
+		_, err = cat.CopyLocal(ctx, src, "dst", semver.MustParse("1.0.0"), ArtifactKindSolution, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("overwrites with force", func(t *testing.T) {
+		cat := newTestCatalog(t)
+		ctx := context.Background()
+
+		src := Reference{Kind: ArtifactKindSolution, Name: "src", Version: semver.MustParse("1.0.0")}
+		dst := Reference{Kind: ArtifactKindSolution, Name: "dst", Version: semver.MustParse("1.0.0")}
+		_, err := cat.Store(ctx, src, []byte("source"), nil, nil, false)
+		require.NoError(t, err)
+		_, err = cat.Store(ctx, dst, []byte("dest"), nil, nil, false)
+		require.NoError(t, err)
+
+		info, err := cat.CopyLocal(ctx, src, "dst", semver.MustParse("1.0.0"), ArtifactKindSolution, true)
+		require.NoError(t, err)
+		assert.Equal(t, "dst", info.Reference.Name)
+	})
+
+	t.Run("errors on missing source", func(t *testing.T) {
+		cat := newTestCatalog(t)
+		ctx := context.Background()
+
+		ref := Reference{Kind: ArtifactKindSolution, Name: "nonexistent", Version: semver.MustParse("1.0.0")}
+		_, err := cat.CopyLocal(ctx, ref, "dst", semver.MustParse("1.0.0"), ArtifactKindSolution, false)
+		require.Error(t, err)
+		assert.True(t, IsNotFound(err))
+	})
+}
+
+func BenchmarkLocalCatalog_CopyLocal(b *testing.B) {
+	dir := b.TempDir()
+	cat, err := NewLocalCatalogAt(dir, logr.Discard())
+	require.NoError(b, err)
+	ctx := context.Background()
+
+	ref := Reference{Kind: ArtifactKindSolution, Name: "bench-src", Version: semver.MustParse("1.0.0")}
+	_, err = cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = cat.CopyLocal(ctx, ref, "bench-dst", semver.MustParse("2.0.0"), ArtifactKindSolution, true)
+	}
+}

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -499,12 +499,15 @@ func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, hand
 
 	ioStreams := w.IOStreams()
 
-	// Use kvx status TUI for device-code flows when running in a terminal.
-	if flow == auth.FlowDeviceCode && skvx.IsTerminal(ioStreams.Out) {
+	// Use kvx status TUI for interactive and device-code flows when running
+	// in a terminal. This provides consistent UX across all auth handlers:
+	// device code flows get copy/open actions, browser flows get "waiting" status.
+	isInteractiveFlow := flow == auth.FlowDeviceCode || flow == auth.FlowInteractive || flow == auth.FlowGcloudADC
+	if isInteractiveFlow && skvx.IsTerminal(ioStreams.Out) {
 		return executeLoginWithStatusTUI(ctx, w, binaryName, handler, flow, tenantID, callbackPort, timeout, scopes, ioStreams)
 	}
 
-	// Plain-text login path (non-terminal, or non-device-code flows).
+	// Plain-text login path (non-terminal, or non-interactive flows).
 	loginOpts := auth.LoginOptions{
 		TenantID:     tenantID,
 		Scopes:       scopes,
@@ -519,6 +522,11 @@ func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, hand
 			w.Infof("Enter the code: %s", userCode)
 			w.Info("")
 			w.Info("Waiting for authentication...")
+		},
+		BrowserAuthCallback: func(authURL string) {
+			w.Info("")
+			w.Infof("Opening browser for authentication: %s", authURL)
+			w.Info("Waiting for browser authentication...")
 		},
 	}
 
@@ -536,11 +544,14 @@ func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, hand
 	return displayLoginResult(w, result, flow)
 }
 
-// executeLoginWithStatusTUI runs the device-code login flow using the kvx status
-// screen TUI. It:
-//  1. Starts handler.Login in a goroutine with a DeviceCodeCallback that captures
-//     the verification URL and user code.
-//  2. Waits for the device code before launching the TUI (avoids empty-data start).
+// executeLoginWithStatusTUI runs the login flow using the kvx status screen TUI.
+// It supports both device-code flows (with copy code + open URL actions) and
+// browser-based flows (with "Waiting for browser..." status and re-open URL action).
+//
+// It:
+//  1. Starts handler.Login in a goroutine with callbacks that capture the
+//     verification URL/user code (device code) or auth URL (browser).
+//  2. Waits for either callback before launching the TUI (avoids empty-data start).
 //  3. Launches tui.Run with a DisplaySchema status view and a Done channel that
 //     receives the login outcome when the goroutine completes.
 func executeLoginWithStatusTUI(
@@ -559,12 +570,16 @@ func executeLoginWithStatusTUI(
 		userCode        string
 		verificationURI string
 	}
+	type browserAuthData struct {
+		authURL string
+	}
 	type loginOutcome struct {
 		result *auth.Result
 		err    error
 	}
 
 	deviceCodeChan := make(chan deviceCodeData, 1)
+	browserAuthChan := make(chan browserAuthData, 1)
 	outcomeChan := make(chan loginOutcome, 1)
 	done := make(chan tui.StatusResult, 1)
 
@@ -580,6 +595,12 @@ func executeLoginWithStatusTUI(
 			default:
 			}
 		},
+		BrowserAuthCallback: func(authURL string) {
+			select {
+			case browserAuthChan <- browserAuthData{authURL: authURL}:
+			default:
+			}
+		},
 	}
 
 	go func() {
@@ -587,14 +608,21 @@ func executeLoginWithStatusTUI(
 		outcomeChan <- loginOutcome{result: result, err: err}
 	}()
 
-	// Wait for the device code, an early completion, or cancellation.
+	// Wait for a device code, browser auth URL, an early completion, or cancellation.
 	w.Infof("Initiating authentication with %s...", handler.DisplayName())
-	var dci deviceCodeData
+
+	var data map[string]any
+	var schema *tui.DisplaySchema
+
 	select {
-	case dci = <-deviceCodeChan:
-		// Device code ready - proceed to TUI.
+	case dci := <-deviceCodeChan:
+		// Device code flow — show code + URL with copy/open actions.
+		data, schema = buildDeviceCodeTUI(handler.DisplayName(), dci.userCode, dci.verificationURI)
+	case bai := <-browserAuthChan:
+		// Browser auth flow — show "Waiting for browser..." with re-open action.
+		data, schema = buildBrowserAuthTUI(handler.DisplayName(), bai.authURL)
 	case outcome := <-outcomeChan:
-		// Login completed before device code was shown (unusual).
+		// Login completed before any callback (e.g., cached token, PAT).
 		if outcome.err != nil {
 			if ctx.Err() != nil {
 				return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
@@ -629,41 +657,6 @@ func executeLoginWithStatusTUI(
 		close(outcomeReady)
 	}()
 
-	data := map[string]any{
-		"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-		"url":   dci.verificationURI,
-		"code":  dci.userCode,
-	}
-
-	schema := &tui.DisplaySchema{
-		Version: "v1",
-		Status: &tui.StatusDisplayConfig{
-			TitleField:     "title",
-			WaitMessage:    "Waiting for authentication...",
-			SuccessMessage: "Authenticated successfully!",
-			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-			DoneDelay:      "2s",
-			DisplayFields: []tui.StatusFieldDisplay{
-				{Label: "URL", Field: "url"},
-				{Label: "Code", Field: "code"},
-			},
-			Actions: []tui.StatusActionConfig{
-				{
-					Label: "Copy code",
-					Type:  "copy-value",
-					Field: "code",
-					Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
-				},
-				{
-					Label: "Open URL",
-					Type:  "open-url",
-					Field: "url",
-					Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
-				},
-			},
-		},
-	}
-
 	cfg := tui.DefaultConfig()
 	cfg.AppName = binaryName
 	cfg.DisplaySchema = schema
@@ -697,6 +690,78 @@ func executeLoginWithStatusTUI(
 	}
 
 	return displayLoginResult(w, capturedOutcome.result, flow)
+}
+
+// buildDeviceCodeTUI returns the data map and DisplaySchema for a device-code
+// based authentication flow. The TUI shows the verification URL and user code
+// with copy-code and open-URL actions.
+func buildDeviceCodeTUI(displayName, userCode, verificationURI string) (map[string]any, *tui.DisplaySchema) {
+	data := map[string]any{
+		"title": fmt.Sprintf("Sign in to %s", displayName),
+		"url":   verificationURI,
+		"code":  userCode,
+	}
+	schema := &tui.DisplaySchema{
+		Version: "v1",
+		Status: &tui.StatusDisplayConfig{
+			TitleField:     "title",
+			WaitMessage:    "Waiting for authentication...",
+			SuccessMessage: "Authenticated successfully!",
+			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+			DoneDelay:      "2s",
+			DisplayFields: []tui.StatusFieldDisplay{
+				{Label: "URL", Field: "url"},
+				{Label: "Code", Field: "code"},
+			},
+			Actions: []tui.StatusActionConfig{
+				{
+					Label: "Copy code",
+					Type:  "copy-value",
+					Field: "code",
+					Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
+				},
+				{
+					Label: "Open URL",
+					Type:  "open-url",
+					Field: "url",
+					Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+				},
+			},
+		},
+	}
+	return data, schema
+}
+
+// buildBrowserAuthTUI returns the data map and DisplaySchema for a browser-based
+// authentication flow. The TUI shows the auth URL with a re-open action while
+// waiting for the browser callback.
+func buildBrowserAuthTUI(displayName, authURL string) (map[string]any, *tui.DisplaySchema) {
+	data := map[string]any{
+		"title": fmt.Sprintf("Sign in to %s", displayName),
+		"url":   authURL,
+	}
+	schema := &tui.DisplaySchema{
+		Version: "v1",
+		Status: &tui.StatusDisplayConfig{
+			TitleField:     "title",
+			WaitMessage:    "Waiting for browser authentication...",
+			SuccessMessage: "Authenticated successfully!",
+			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+			DoneDelay:      "2s",
+			DisplayFields: []tui.StatusFieldDisplay{
+				{Label: "URL", Field: "url"},
+			},
+			Actions: []tui.StatusActionConfig{
+				{
+					Label: "Re-open URL",
+					Type:  "open-url",
+					Field: "url",
+					Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+				},
+			},
+		},
+	}
+	return data, schema
 }
 
 // displayLoginResult prints the authentication success header and claim details.

--- a/pkg/cmd/scafctl/auth/login_test.go
+++ b/pkg/cmd/scafctl/auth/login_test.go
@@ -247,3 +247,66 @@ func TestCommandLogin_DeviceCodeCallback(t *testing.T) {
 	// Re-execute to test callback behavior (it was captured above)
 	capturedCallback("ABC123", "https://microsoft.com/devicelogin", "Test message")
 }
+
+func TestBuildDeviceCodeTUI(t *testing.T) {
+	data, schema := buildDeviceCodeTUI("Entra ID", "ABC123", "https://microsoft.com/devicelogin")
+
+	assert.Equal(t, "Sign in to Entra ID", data["title"])
+	assert.Equal(t, "https://microsoft.com/devicelogin", data["url"])
+	assert.Equal(t, "ABC123", data["code"])
+
+	require.NotNil(t, schema.Status)
+	assert.Equal(t, "title", schema.Status.TitleField)
+	assert.Equal(t, "Waiting for authentication...", schema.Status.WaitMessage)
+	assert.Len(t, schema.Status.DisplayFields, 2)
+	assert.Len(t, schema.Status.Actions, 2)
+	assert.Equal(t, "copy-value", schema.Status.Actions[0].Type)
+	assert.Equal(t, "open-url", schema.Status.Actions[1].Type)
+}
+
+func TestBuildBrowserAuthTUI(t *testing.T) {
+	data, schema := buildBrowserAuthTUI("GitHub", "https://github.com/login/oauth/authorize?...")
+
+	assert.Equal(t, "Sign in to GitHub", data["title"])
+	assert.Equal(t, "https://github.com/login/oauth/authorize?...", data["url"])
+	_, hasCode := data["code"]
+	assert.False(t, hasCode, "browser auth TUI should not have a code field")
+
+	require.NotNil(t, schema.Status)
+	assert.Equal(t, "title", schema.Status.TitleField)
+	assert.Equal(t, "Waiting for browser authentication...", schema.Status.WaitMessage)
+	assert.Len(t, schema.Status.DisplayFields, 1)
+	assert.Equal(t, "url", schema.Status.DisplayFields[0].Field)
+	assert.Len(t, schema.Status.Actions, 1)
+	assert.Equal(t, "open-url", schema.Status.Actions[0].Type)
+	assert.Equal(t, "Re-open URL", schema.Status.Actions[0].Label)
+}
+
+func TestCommandLogin_BrowserAuthCallback(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("github")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+	}
+	mock.SetNotAuthenticated()
+
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{Email: "user@example.com"},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	require.Len(t, mock.LoginCalls, 1)
+	assert.NotNil(t, mock.LoginCalls[0].BrowserAuthCallback, "browser auth callback should be set")
+}

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -278,11 +278,17 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	// Determine version (priority: --version flag > metadata.version)
+	// Determine version (priority: --version flag > metadata.version > auto-increment)
 	version, _, err := solution.ResolveArtifactVersion(opts.Version, sol.Metadata.Version)
 	if err != nil {
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+		// No explicit version and no metadata.version — auto-increment from local catalog.
+		localCatalog, catErr := catalog.NewLocalCatalog(*lgr)
+		if catErr != nil {
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+		version = solution.NextPatchVersion(ctx, localCatalog, name)
+		w.Infof("No version specified; auto-incremented to %s", version.String())
 	}
 
 	// Block dev version unless explicitly allowed
@@ -298,13 +304,27 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 
 	// Stamp resolved name and version into the solution so the stored
 	// artifact always carries the authoritative values.
+	// Error on mismatch unless --force is set.
 	needsReserialization := false
-	if sol.Metadata.Name != name {
+	if sol.Metadata.Name != "" && sol.Metadata.Name != name {
+		if !opts.Force {
+			err := fmt.Errorf("build target name %q does not match metadata.name %q -- update the solution or use --force to override", name, sol.Metadata.Name)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+		w.Warningf("overriding metadata.name %q with build target name %q (--force)", sol.Metadata.Name, name)
+		sol.Metadata.Name = name
+		needsReserialization = true
+	} else if sol.Metadata.Name != name {
 		lgr.V(1).Info("stamping artifact name into solution", "from", sol.Metadata.Name, "to", name)
 		sol.Metadata.Name = name
 		needsReserialization = true
 	}
-	if sol.Metadata.Version == nil || !sol.Metadata.Version.Equal(version) {
+	if sol.Metadata.Version != nil && !sol.Metadata.Version.Equal(version) {
+		w.Warningf("overriding metadata.version %q with build target version %q", sol.Metadata.Version.String(), version.String())
+		sol.Metadata.Version = version
+		needsReserialization = true
+	} else if sol.Metadata.Version == nil || !sol.Metadata.Version.Equal(version) {
 		lgr.V(1).Info("stamping artifact version into solution", "from", sol.Metadata.Version, "to", version.String())
 		sol.Metadata.Version = version
 		needsReserialization = true

--- a/pkg/cmd/scafctl/catalog/tag.go
+++ b/pkg/cmd/scafctl/catalog/tag.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/Masterminds/semver/v3"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -20,9 +21,10 @@ import (
 // TagOptions holds options for the tag command.
 type TagOptions struct {
 	Reference string // Source artifact reference (name@version)
-	Alias     string // Alias tag to create (e.g., "stable", "latest")
+	Alias     string // Alias tag or target reference (e.g., "stable" or "newname@1.0.0")
 	Catalog   string // Target catalog for remote tagging (URL or config name, --catalog)
 	Kind      string // Artifact kind override (--kind)
+	Force     bool   // Overwrite existing artifact (--force)
 	Insecure  bool   // Allow HTTP (--insecure)
 	CliParams *settings.Run
 	IOStreams *terminal.IOStreams
@@ -36,19 +38,21 @@ func CommandTag(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 	}
 
 	cmd := &cobra.Command{
-		Use:   "tag <name@version> <alias>",
-		Short: "Create an alias tag for an artifact",
+		Use:   "tag <name@version> <target>",
+		Short: "Create an alias tag or re-tag an artifact under a new name",
 		Long: heredoc.Doc(`
-			Create an alias tag for an existing catalog artifact.
+			Create an alias tag for an existing catalog artifact, or re-tag it
+			under a new name.
 
-			Tags are freeform aliases that point to a specific version of an artifact.
-			Common uses include marking releases as "stable" or "production".
+			If the target is a plain string (e.g., "stable"), it creates a freeform
+			alias tag that points to the source version.
+
+			If the target is a name@version reference (e.g., "new-name@1.0.0"),
+			it copies the artifact under the new name and version. This is useful
+			for renaming artifacts before pushing to a registry (like docker tag).
 
 			Note: "latest" is reserved and auto-resolves to the highest semver version.
 			It cannot be used as a manual alias.
-
-			The source artifact must exist and have a version specified.
-			The alias must not be a valid semver version (use 'scafctl build' for that).
 
 			By default, tags the artifact in the local catalog. Use --catalog to
 			tag an artifact in a remote registry.
@@ -60,7 +64,10 @@ func CommandTag(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 			  # Tag for production
 			  scafctl catalog tag my-solution@1.0.0 production
 
-			  # Tag in a remote registry
+			  # Re-tag under a new name (like docker tag)
+			  scafctl catalog tag my-solution@1.0.0 production-solution@1.0.0
+
+			  # Re-tag in a remote registry
 			  scafctl catalog tag my-solution@1.0.0 production --catalog ghcr.io/myorg
 
 			  # Tag with explicit kind
@@ -77,6 +84,7 @@ func CommandTag(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 
 	cmd.Flags().StringVarP(&options.Catalog, "catalog", "c", "", catalogFlagUsage)
 	cmd.Flags().StringVar(&options.Kind, "kind", "", "Artifact kind override (solution, provider, auth-handler)")
+	cmd.Flags().BoolVar(&options.Force, "force", false, "Overwrite existing artifact when re-tagging")
 	cmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Allow insecure HTTP connections")
 
 	return cmd
@@ -85,12 +93,6 @@ func CommandTag(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 func runTag(ctx context.Context, opts *TagOptions) error {
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
-
-	// Validate alias - must not be a valid semver version
-	if err := catalog.ValidateAlias(opts.Alias); err != nil {
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
-	}
 
 	// Parse reference - require version
 	name, version := catalog.ParseNameVersion(opts.Reference)
@@ -116,10 +118,24 @@ func runTag(ctx context.Context, opts *TagOptions) error {
 		artifactKind = kind
 	}
 
-	// Build reference
+	// Build source reference
 	ref, err := catalog.ParseReference(artifactKind, opts.Reference)
 	if err != nil {
 		w.Errorf("invalid reference %q: %v", opts.Reference, err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Detect re-tag: if the target looks like "name@version", treat it as a
+	// copy-under-new-name operation instead of an alias tag.
+	dstName, dstVersion := catalog.ParseNameVersion(opts.Alias)
+	isRetag := dstVersion != "" && !catalog.IsValidDigest(dstVersion)
+	if isRetag {
+		return runRetagLocal(ctx, opts, ref, artifactKind, name, version, dstName, dstVersion)
+	}
+
+	// Alias path: validate that the alias is not a semver version.
+	if err := catalog.ValidateAlias(opts.Alias); err != nil {
+		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
@@ -163,9 +179,71 @@ func runTag(ctx context.Context, opts *TagOptions) error {
 	}
 
 	if oldVersion != "" {
-		w.Warningf("Moved %q from %s → %s", opts.Alias, oldVersion, ref.Version.String())
+		w.Warningf("Moved %q from %s \u2192 %s", opts.Alias, oldVersion, ref.Version.String())
 	}
 	w.Successf("Tagged %s@%s as %q", ref.Name, ref.Version.String(), opts.Alias)
+
+	return nil
+}
+
+// runRetagLocal copies an artifact under a new name and version in the local catalog.
+func runRetagLocal(ctx context.Context, opts *TagOptions, ref catalog.Reference, artifactKind catalog.ArtifactKind, srcName, srcVersion, dstName, dstVersion string) error {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
+	// Validate destination name
+	if !catalog.IsValidName(dstName) {
+		w.Errorf("invalid target name %q: must be lowercase alphanumeric with hyphens", dstName)
+		return exitcode.Errorf("invalid target name")
+	}
+
+	// Parse destination version
+	dstSemver, err := semver.NewVersion(dstVersion)
+	if err != nil {
+		w.Errorf("invalid target version %q: %v", dstVersion, err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Remote re-tag is not supported (use push instead).
+	if opts.Catalog != "" {
+		w.Error("re-tagging to a new name is only supported locally; push the re-tagged artifact instead")
+		return exitcode.Errorf("remote re-tag not supported")
+	}
+
+	// Open local catalog and infer kind if needed.
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err != nil {
+		err = fmt.Errorf("failed to open local catalog: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	if artifactKind == "" {
+		artifactKind, err = catalog.InferKindFromLocalCatalog(ctx, localCatalog, srcName, srcVersion)
+		if err != nil {
+			w.Errorf("failed to infer artifact kind: %v", err)
+			w.Infof("Hint: use --kind to specify the artifact kind explicitly")
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+		// Re-parse reference with the inferred kind.
+		ref, err = catalog.ParseReference(artifactKind, opts.Reference)
+		if err != nil {
+			w.Errorf("invalid reference %q: %v", opts.Reference, err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	}
+
+	info, err := localCatalog.CopyLocal(ctx, ref, dstName, dstSemver, artifactKind, opts.Force)
+	if err != nil {
+		if catalog.IsNotFound(err) {
+			w.Errorf("artifact %q not found in local catalog", opts.Reference)
+			return exitcode.WithCode(err, exitcode.FileNotFound)
+		}
+		w.Errorf("failed to re-tag artifact: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	w.Successf("Re-tagged %s@%s as %s@%s (digest: %s)", ref.Name, ref.Version.String(), dstName, dstSemver.String(), info.Digest)
 
 	return nil
 }

--- a/pkg/cmd/scafctl/catalog/tag_test.go
+++ b/pkg/cmd/scafctl/catalog/tag_test.go
@@ -33,7 +33,7 @@ func TestCommandTag(t *testing.T) {
 	cmd := CommandTag(cliParams, ioStreams, "scafctl/catalog")
 
 	require.NotNil(t, cmd)
-	assert.Equal(t, "tag <name@version> <alias>", cmd.Use)
+	assert.Equal(t, "tag <name@version> <target>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 }
@@ -51,6 +51,7 @@ func TestCommandTag_Flags(t *testing.T) {
 	}{
 		{"catalog", ""},
 		{"kind", ""},
+		{"force", "false"},
 		{"insecure", "false"},
 	}
 
@@ -200,6 +201,51 @@ func TestCommandTag_InvalidCharAlias(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid character")
+}
+
+func TestCommandTag_RetagToNewName(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandTag(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	// Target is name@version — this is a re-tag operation.
+	// Will fail because source doesn't exist in catalog, but validates the re-tag path.
+	cmd.SetArgs([]string{"my-solution@1.0.0", "new-name@2.0.0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	// Should NOT contain "alias" errors — it should go through the re-tag path
+	assert.NotContains(t, err.Error(), "alias")
+}
+
+func TestCommandTag_RetagInvalidTargetName(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandTag(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	cmd.SetArgs([]string{"my-solution@1.0.0", "INVALID@1.0.0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid target name")
+}
+
+func TestCommandTag_RetagRemoteNotSupported(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandTag(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	cmd.SetArgs([]string{"my-solution@1.0.0", "new-name@1.0.0", "--catalog", "ghcr.io/myorg"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote re-tag not supported")
 }
 
 func BenchmarkCommandTag(b *testing.B) {

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -96,7 +96,8 @@ func NewExecProvider() *ExecProvider {
 					schemahelper.WithDefault("auto"),
 					schemahelper.WithExample("auto"),
 					schemahelper.WithMaxLength(10)),
-				"expand": schemahelper.BoolProp("Return full result map (stdout, stderr, exitCode, etc.) instead of trimmed stdout string. Default: false in resolver/transform mode, always true in action mode"),
+				"expand":      schemahelper.BoolProp("Return full result map (stdout, stderr, exitCode, etc.) instead of trimmed stdout string. Default: false in resolver/transform mode, always true in action mode"),
+				"passthrough": schemahelper.BoolProp("Stream stdout/stderr directly to the user's terminal in real-time instead of capturing. Colors, formatting, and TTY features are preserved. Result stdout/stderr fields will be empty. Default: false"),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom:      schemahelper.AnyProp("Trimmed stdout string by default; full result map (stdout, stderr, exitCode, success, command, shell) when expand: true"),
@@ -308,14 +309,27 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 	}
 
 	// Capture stdout and stderr into buffers.
+	// If passthrough: true, stream directly to terminal without capturing.
 	// If IOStreams are available in context, also stream to the terminal in real-time
 	// using io.MultiWriter so output appears immediately while still being captured
 	// for inter-action dependencies.
 	var stdout, stderr bytes.Buffer
 	var stdoutWriter, stderrWriter io.Writer = &stdout, &stderr
 	streamed := false
+	passthrough, _ := inputs["passthrough"].(bool)
 
-	if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
+	if passthrough {
+		// Passthrough mode: stream directly to terminal, don't capture
+		if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
+			if ioStreams.Out != nil {
+				stdoutWriter = ioStreams.Out
+			}
+			if ioStreams.ErrOut != nil {
+				stderrWriter = ioStreams.ErrOut
+			}
+			streamed = true
+		}
+	} else if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
 		if ioStreams.Out != nil {
 			stdoutWriter = io.MultiWriter(&stdout, ioStreams.Out)
 			streamed = true

--- a/pkg/provider/builtin/execprovider/exec_test.go
+++ b/pkg/provider/builtin/execprovider/exec_test.go
@@ -4,6 +4,7 @@
 package execprovider
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -731,4 +732,89 @@ func TestExecProvider_Execute_NoExecutionMode_ReturnsFullMap(t *testing.T) {
 	data, ok := output.Data.(map[string]any)
 	require.True(t, ok, "expected map, got %T", output.Data)
 	assert.Equal(t, "hello\n", data["stdout"])
+}
+
+func TestExecProvider_Execute_Passthrough(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	var termErr bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termErr,
+	})
+
+	inputs := map[string]any{
+		"command":     "echo",
+		"args":        []any{"passthrough-test"},
+		"passthrough": true,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	// Passthrough: output streamed to terminal, not captured in result
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	assert.Empty(t, data["stdout"], "passthrough should not capture stdout")
+	assert.Equal(t, 0, data["exitCode"])
+	assert.Equal(t, true, data["success"])
+
+	// Terminal should have received the output
+	assert.Contains(t, termOut.String(), "passthrough-test")
+}
+
+func TestExecProvider_Execute_Passthrough_ExitCode(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termOut,
+	})
+
+	inputs := map[string]any{
+		"command":     "exit 42",
+		"passthrough": true,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	assert.Equal(t, 42, data["exitCode"])
+	assert.Equal(t, false, data["success"])
+}
+
+func TestExecProvider_Execute_PassthroughFalse_StillCaptures(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termOut,
+	})
+
+	inputs := map[string]any{
+		"command":     "echo",
+		"args":        []any{"captured"},
+		"passthrough": false,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	// Default behavior: stdout is captured
+	assert.Contains(t, data["stdout"], "captured")
+	// Also streamed to terminal
+	assert.Contains(t, termOut.String(), "captured")
 }

--- a/pkg/provider/builtin/hclprovider/hcl.go
+++ b/pkg/provider/builtin/hclprovider/hcl.go
@@ -111,7 +111,7 @@ func NewHCLProvider(opts ...Option) *HCLProvider {
 		descriptor: &provider.Descriptor{
 			Name:        ProviderName,
 			DisplayName: "HCL",
-			Description: "Processes HCL (HashiCorp Configuration Language) content. Supports parsing into structured data, formatting to canonical style, validating syntax, and generating HCL from structured input. Accepts single files, multiple paths, or a directory of .tf files.",
+			Description: "Parse, format, validate, and generate Terraform/OpenTofu HCL configuration. Operations: 'parse' extracts structured blocks (variables, resources, data sources, modules, outputs, locals, providers, terraform, moved, import, check) into typed maps; 'format' rewrites content to canonical HCL style; 'validate' checks syntax and returns diagnostics with source positions; 'generate' produces HCL (.tf) or Terraform JSON (.tf.json) from structured block data. Accepts inline content, a single file path, multiple file paths, or a directory of .tf/.tf.json files.",
 			APIVersion:  "v1",
 			Version:     version,
 			Category:    "data",

--- a/pkg/resolver/README.md
+++ b/pkg/resolver/README.md
@@ -334,7 +334,7 @@ Built-in providers available in the default registry:
 | `file` | File contents | `path: ./config.json` |
 | `exec` | Command execution | `command: echo hello` |
 | `git` | Git operations | `operation: branch` |
-| `hcl` | Parse HCL files | `content: 'variable "x" { default = 1 }'` |
+| `hcl` | Parse, format, validate, and generate Terraform/OpenTofu HCL | `content: 'variable "x" { default = 1 }'` |
 | `identity` | Auth identity info | `operation: status, handler: entra` |
 | `secret` | Encrypted secrets | `operation: get, name: api-key` |
 | `validation` | Value validation | `pattern: ^[a-z]+$` |

--- a/pkg/solution/build.go
+++ b/pkg/solution/build.go
@@ -4,12 +4,15 @@
 package solution
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
 // ResolveArtifactName determines the artifact name using the following priority:
@@ -63,4 +66,38 @@ func ResolveArtifactVersion(explicitVersion string, metadataVersion *semver.Vers
 	}
 
 	return nil, false, fmt.Errorf("no version: solution has no version in metadata; provide --version or set metadata.version")
+}
+
+// NextPatchVersion queries the local catalog for existing versions of the named
+// artifact and returns the next patch increment. If no versions exist, it returns
+// 0.0.1. This is used as the fallback when neither --version nor metadata.version
+// is provided.
+func NextPatchVersion(ctx context.Context, localCatalog *catalog.LocalCatalog, name string) *semver.Version {
+	lgr := logger.FromContext(ctx)
+
+	artifacts, err := localCatalog.List(ctx, catalog.ArtifactKindSolution, name)
+	if err != nil {
+		lgr.V(1).Info("failed to list artifacts for auto-increment", "name", name, "error", err)
+		return semver.MustParse("0.0.1")
+	}
+
+	var versions []*semver.Version
+	for _, a := range artifacts {
+		if a.Reference.Version != nil {
+			versions = append(versions, a.Reference.Version)
+		}
+	}
+
+	if len(versions) == 0 {
+		return semver.MustParse("0.0.1")
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].LessThan(versions[j])
+	})
+
+	latest := versions[len(versions)-1]
+	next := semver.New(latest.Major(), latest.Minor(), latest.Patch()+1, "", "")
+	lgr.V(1).Info("auto-incremented version", "latest", latest.String(), "next", next.String())
+	return next
 }

--- a/pkg/solution/build_test.go
+++ b/pkg/solution/build_test.go
@@ -4,9 +4,12 @@
 package solution
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -105,5 +108,68 @@ func BenchmarkResolveArtifactVersion(b *testing.B) {
 	metadata := semver.MustParse("1.0.0")
 	for b.Loop() {
 		_, _, _ = ResolveArtifactVersion("2.0.0", metadata)
+	}
+}
+
+func TestNextPatchVersion(t *testing.T) {
+	t.Run("no existing versions returns 0.0.1", func(t *testing.T) {
+		dir := t.TempDir()
+		lgr := logr.Discard()
+		lc, err := catalog.NewLocalCatalogAt(dir, lgr)
+		require.NoError(t, err)
+
+		v := NextPatchVersion(context.Background(), lc, "my-solution")
+		assert.Equal(t, "0.0.1", v.String())
+	})
+
+	t.Run("increments highest existing version", func(t *testing.T) {
+		dir := t.TempDir()
+		lgr := logr.Discard()
+		lc, err := catalog.NewLocalCatalogAt(dir, lgr)
+		require.NoError(t, err)
+
+		// Store two versions
+		ref1 := catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "my-solution", Version: semver.MustParse("1.0.0")}
+		ref2 := catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "my-solution", Version: semver.MustParse("1.2.3")}
+		_, err = lc.Store(context.Background(), ref1, []byte("solution: v1"), nil, nil, false)
+		require.NoError(t, err)
+		_, err = lc.Store(context.Background(), ref2, []byte("solution: v2"), nil, nil, false)
+		require.NoError(t, err)
+
+		v := NextPatchVersion(context.Background(), lc, "my-solution")
+		assert.Equal(t, "1.2.4", v.String())
+	})
+
+	t.Run("different name returns 0.0.1", func(t *testing.T) {
+		dir := t.TempDir()
+		lgr := logr.Discard()
+		lc, err := catalog.NewLocalCatalogAt(dir, lgr)
+		require.NoError(t, err)
+
+		// Store under a different name
+		ref := catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "other", Version: semver.MustParse("5.0.0")}
+		_, err = lc.Store(context.Background(), ref, []byte("solution: other"), nil, nil, false)
+		require.NoError(t, err)
+
+		v := NextPatchVersion(context.Background(), lc, "my-solution")
+		assert.Equal(t, "0.0.1", v.String())
+	})
+}
+
+func BenchmarkNextPatchVersion(b *testing.B) {
+	dir := b.TempDir()
+	lgr := logr.Discard()
+	lc, err := catalog.NewLocalCatalogAt(dir, lgr)
+	require.NoError(b, err)
+
+	ref := catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "bench", Version: semver.MustParse("1.0.0")}
+	_, err = lc.Store(context.Background(), ref, []byte("solution"), nil, nil, false)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		NextPatchVersion(ctx, lc, "bench")
 	}
 }

--- a/pkg/spec/condition.go
+++ b/pkg/spec/condition.go
@@ -5,15 +5,142 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"gopkg.in/yaml.v3"
 )
 
 // Condition represents a conditional execution clause.
 // It wraps a CEL expression that must evaluate to a boolean value.
+//
+// Supported YAML forms:
+//   - Boolean literal:  when: true / when: false
+//   - String shorthand: when: "_.environment == 'prod'"
+//   - Explicit object:  when: { expr: "_.environment == 'prod'" }
 type Condition struct {
 	Expr *celexp.Expression `json:"expr" yaml:"expr" doc:"CEL expression that must evaluate to boolean" example:"_.environment == 'prod'"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshalling for Condition.
+// It supports boolean literals, string shorthand, and the explicit {expr: ...} form.
+func (c *Condition) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return c.unmarshalScalarYAML(node)
+	case yaml.MappingNode:
+		// Explicit object form: {expr: "..."}
+		type conditionRaw Condition
+		var raw conditionRaw
+		if err := node.Decode(&raw); err != nil {
+			return fmt.Errorf("invalid condition at line %d, column %d: %w", node.Line, node.Column, err)
+		}
+		*c = Condition(raw)
+		return nil
+	case yaml.AliasNode:
+		return c.UnmarshalYAML(node.Alias)
+	case yaml.DocumentNode, yaml.SequenceNode:
+		return fmt.Errorf("invalid condition at line %d, column %d: expected boolean, string, or object {expr: \"...\"}, got unsupported node kind", node.Line, node.Column)
+	default:
+		return fmt.Errorf("invalid condition at line %d, column %d: expected boolean, string, or object {expr: \"...\"}, got unsupported node kind", node.Line, node.Column)
+	}
+}
+
+func (c *Condition) unmarshalScalarYAML(node *yaml.Node) error {
+	switch node.Tag {
+	case "!!bool":
+		// Boolean literal: when: true / false → stored as CEL expression "true"/"false"
+		expr := celexp.Expression(node.Value)
+		c.Expr = &expr
+		return nil
+	case "!!str":
+		if node.Value == "" {
+			return fmt.Errorf("invalid condition at line %d, column %d: empty string is not a valid CEL expression", node.Line, node.Column)
+		}
+		expr := celexp.Expression(node.Value)
+		c.Expr = &expr
+		return nil
+	case "!!null":
+		return fmt.Errorf("invalid condition at line %d, column %d: null is not a valid condition; use true, false, a CEL expression string, or {expr: \"...\"}", node.Line, node.Column)
+	default:
+		return fmt.Errorf("invalid condition at line %d, column %d: unsupported type %s; use true, false, a CEL expression string, or {expr: \"...\"}", node.Line, node.Column, node.Tag)
+	}
+}
+
+// MarshalYAML implements custom YAML marshalling for Condition.
+// If the expression is a literal "true" or "false", it marshals as a boolean.
+// Otherwise it uses the string shorthand form for compact output.
+func (c Condition) MarshalYAML() (any, error) {
+	if c.Expr == nil {
+		return nil, nil
+	}
+	s := string(*c.Expr)
+	switch s {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return s, nil
+	}
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for Condition.
+// It supports boolean literals, string shorthand, and the explicit {"expr": "..."} form.
+func (c *Condition) UnmarshalJSON(data []byte) error {
+	*c = Condition{}
+
+	// Null → zero-value Condition (nil Expr), consistent with YAML null handling.
+	if string(data) == "null" {
+		return nil
+	}
+
+	// Try boolean
+	var b bool
+	if json.Unmarshal(data, &b) == nil {
+		s := fmt.Sprintf("%t", b)
+		expr := celexp.Expression(s)
+		c.Expr = &expr
+		return nil
+	}
+
+	// Try string
+	var s string
+	if json.Unmarshal(data, &s) == nil {
+		if s == "" {
+			return fmt.Errorf("invalid condition: empty string is not a valid CEL expression")
+		}
+		expr := celexp.Expression(s)
+		c.Expr = &expr
+		return nil
+	}
+
+	// Try object
+	var obj struct {
+		Expr *celexp.Expression `json:"expr"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("invalid condition: expected boolean, string, or object {\"expr\": \"...\"}: %w", err)
+	}
+	c.Expr = obj.Expr
+	return nil
+}
+
+// MarshalJSON implements custom JSON marshalling for Condition.
+func (c Condition) MarshalJSON() ([]byte, error) {
+	if c.Expr == nil {
+		return []byte("null"), nil
+	}
+	s := string(*c.Expr)
+	switch s {
+	case "true":
+		return []byte("true"), nil
+	case "false":
+		return []byte("false"), nil
+	default:
+		return json.Marshal(s)
+	}
 }
 
 // Evaluate evaluates the condition with the given resolver data.

--- a/pkg/spec/condition_test.go
+++ b/pkg/spec/condition_test.go
@@ -5,11 +5,13 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCondition_Evaluate_NilCondition(t *testing.T) {
@@ -96,6 +98,267 @@ func TestCondition_Evaluate_Simple(t *testing.T) {
 				assert.Equal(t, tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestCondition_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantExpr    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			wantExpr: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			wantExpr: "false",
+		},
+		{
+			name:     "string shorthand",
+			input:    `"_.environment == 'prod'"`,
+			wantExpr: "_.environment == 'prod'",
+		},
+		{
+			name:     "explicit object form",
+			input:    `expr: "_.count > 5"`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:        "empty string",
+			input:       `""`,
+			wantErr:     true,
+			errContains: "empty string",
+		},
+		{
+			name:     "null value unmarshals to zero condition",
+			input:    "null",
+			wantExpr: "",
+		},
+		{
+			name:        "integer value",
+			input:       "42",
+			wantErr:     true,
+			errContains: "unsupported type",
+		},
+		{
+			name:        "float value",
+			input:       "3.14",
+			wantErr:     true,
+			errContains: "unsupported type",
+		},
+		{
+			name:        "sequence value",
+			input:       "- foo\n- bar",
+			wantErr:     true,
+			errContains: "unsupported node kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := yaml.Unmarshal([]byte(tt.input), &c)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantExpr == "" {
+				assert.Nil(t, c.Expr)
+			} else {
+				require.NotNil(t, c.Expr)
+				assert.Equal(t, tt.wantExpr, string(*c.Expr))
+			}
+		})
+	}
+}
+
+func TestCondition_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantExpr    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			wantExpr: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			wantExpr: "false",
+		},
+		{
+			name:     "string shorthand",
+			input:    `"_.environment == 'prod'"`,
+			wantExpr: "_.environment == 'prod'",
+		},
+		{
+			name:     "explicit object form",
+			input:    `{"expr": "_.count > 5"}`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:        "empty string",
+			input:       `""`,
+			wantErr:     true,
+			errContains: "empty string",
+		},
+		{
+			name:  "null value",
+			input: "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := json.Unmarshal([]byte(tt.input), &c)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantExpr == "" {
+				assert.Nil(t, c.Expr)
+			} else {
+				require.NotNil(t, c.Expr)
+				assert.Equal(t, tt.wantExpr, string(*c.Expr))
+			}
+		})
+	}
+}
+
+func TestCondition_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{name: "true", expr: "true", expected: "true\n"},
+		{name: "false", expr: "false", expected: "false\n"},
+		{name: "expression", expr: "_.env == 'prod'", expected: "_.env == 'prod'\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := celexp.Expression(tt.expr)
+			c := Condition{Expr: &expr}
+			data, err := yaml.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestCondition_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{name: "true", expr: "true", expected: "true"},
+		{name: "false", expr: "false", expected: "false"},
+		{name: "expression", expr: "_.env == 'prod'", expected: `"_.env == 'prod'"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := celexp.Expression(tt.expr)
+			c := Condition{Expr: &expr}
+			data, err := json.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestCondition_MarshalJSON_Nil(t *testing.T) {
+	c := Condition{Expr: nil}
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestCondition_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "bool true", input: "true\n"},
+		{name: "bool false", input: "false\n"},
+		{name: "string expr", input: "_.env == 'prod'\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := yaml.Unmarshal([]byte(tt.input), &c)
+			require.NoError(t, err)
+
+			data, err := yaml.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, string(data))
+		})
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_Bool(b *testing.B) {
+	data := []byte("true")
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_String(b *testing.B) {
+	data := []byte(`"_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_Object(b *testing.B) {
+	data := []byte(`expr: "_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalJSON(b *testing.B) {
+	data := []byte(`"_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = json.Unmarshal(data, &c)
 	}
 }
 

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -5,9 +5,13 @@ package kvx
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
+
+	toml "github.com/pelletier/go-toml/v2"
 
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -47,6 +51,12 @@ const (
 
 	// OutputFormatMermaid renders data as a Mermaid flowchart diagram
 	OutputFormatMermaid OutputFormat = "mermaid"
+
+	// OutputFormatCSV outputs as comma-separated values (for spreadsheets/scripting)
+	OutputFormatCSV OutputFormat = "csv"
+
+	// OutputFormatTOML outputs as TOML (for config files/scripting)
+	OutputFormatTOML OutputFormat = "toml"
 )
 
 // String returns the string representation of the output format.
@@ -65,6 +75,8 @@ func BaseOutputFormats() []string {
 		string(OutputFormatMermaid),
 		string(OutputFormatJSON),
 		string(OutputFormatYAML),
+		string(OutputFormatCSV),
+		string(OutputFormatTOML),
 		string(OutputFormatQuiet),
 		string(OutputFormatTest),
 	}
@@ -75,7 +87,7 @@ func BaseOutputFormats() []string {
 // bordered table output. Mermaid is included because it is a piping-friendly
 // plain-text format even though Write() routes it through the kvx renderer.
 func IsStructuredFormat(format OutputFormat) bool {
-	return format == OutputFormatJSON || format == OutputFormatYAML || format == OutputFormatMermaid
+	return format == OutputFormatJSON || format == OutputFormatYAML || format == OutputFormatMermaid || format == OutputFormatCSV || format == OutputFormatTOML
 }
 
 // IsKvxFormat returns true if the format uses kvx visual output (auto, table, list, or tree).
@@ -121,6 +133,10 @@ func ParseOutputFormat(s string) (OutputFormat, bool) {
 		return OutputFormatTree, true
 	case "mermaid":
 		return OutputFormatMermaid, true
+	case "csv":
+		return OutputFormatCSV, true
+	case "toml":
+		return OutputFormatTOML, true
 	default:
 		return "", false
 	}
@@ -362,6 +378,11 @@ func (o *OutputOptions) writeKvx(data any) error {
 				return fmt.Errorf("expression evaluation failed: %w", err)
 			}
 		}
+		// Print scalar values as plain text instead of JSON wrapping.
+		if isScalarValue(outputData) {
+			fmt.Fprintln(o.IOStreams.Out, outputData)
+			return nil
+		}
 		return o.writeJSON(outputData)
 	}
 
@@ -371,6 +392,36 @@ func (o *OutputOptions) writeKvx(data any) error {
 		WithIO(o.IOStreams.In, o.IOStreams.Out),
 		WithInteractive(o.Interactive),
 	)
+
+	// Pre-evaluate expression for scalar detection: if Where + Expression
+	// resolve to a scalar value (string, number, bool), print it directly
+	// instead of wrapping it in a table view.
+	if !o.Interactive && (o.Expression != "" || o.Where != "") {
+		preData := data
+		var preErr error
+		preData, preErr = applyWhereFilter(o.Where, preData)
+		if preErr != nil {
+			return preErr
+		}
+		if o.Expression != "" {
+			ctx := o.Ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			preData, preErr = EvaluateExpression(ctx, o.Expression, preData)
+			if preErr != nil {
+				return fmt.Errorf("expression evaluation failed: %w", preErr)
+			}
+		}
+		if isScalarValue(preData) {
+			fmt.Fprintln(o.IOStreams.Out, preData)
+			return nil
+		}
+		// Not a scalar — pass pre-evaluated data to viewer without re-evaluating.
+		// Remove expression/where from options to avoid double evaluation.
+		kvxOpts = removeExpressionOptions(kvxOpts)
+		data = preData
+	}
 
 	// Pass layout based on output format
 	switch o.Format {
@@ -382,10 +433,10 @@ func (o *OutputOptions) writeKvx(data any) error {
 		kvxOpts = append(kvxOpts, WithLayout("tree"))
 	case OutputFormatMermaid:
 		kvxOpts = append(kvxOpts, WithLayout("mermaid"))
-	case OutputFormatAuto, OutputFormatJSON, OutputFormatYAML, OutputFormatQuiet, OutputFormatTest:
+	case OutputFormatAuto, OutputFormatJSON, OutputFormatYAML, OutputFormatCSV, OutputFormatTOML, OutputFormatQuiet, OutputFormatTest:
 		// Auto and empty use default layout (auto).
-		// JSON/YAML/Quiet/Test are handled upstream and should not reach here,
-		// but are listed for exhaustiveness.
+		// Structured formats (JSON/YAML/CSV/TOML), Quiet, and Test are handled
+		// upstream and should not reach here, but are listed for exhaustiveness.
 	}
 
 	return View(data, kvxOpts...)
@@ -464,6 +515,10 @@ func (o *OutputOptions) writeStructured(data any) error {
 		return o.writeJSON(outputData)
 	case OutputFormatYAML:
 		return o.writeYAML(outputData)
+	case OutputFormatCSV:
+		return o.writeCSV(outputData)
+	case OutputFormatTOML:
+		return o.writeTOML(outputData)
 	case OutputFormatTable, OutputFormatAuto, OutputFormatList, OutputFormatTree, OutputFormatMermaid, OutputFormatQuiet, OutputFormatTest:
 		// These formats are handled upstream (writeKvx or command-level test generation),
 		// and should not reach writeStructured.
@@ -501,6 +556,124 @@ func (o *OutputOptions) writeYAML(data any) error {
 	return nil
 }
 
+// writeTOML writes data as TOML.
+func (o *OutputOptions) writeTOML(data any) error {
+	tomlData, err := toml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal TOML: %w", err)
+	}
+	fmt.Fprint(o.IOStreams.Out, string(tomlData))
+	return nil
+}
+
+// writeCSV writes data as comma-separated values.
+// For a slice of maps, column headers are derived from the union of all keys.
+// For a single map, it writes a two-row CSV (header + values).
+// Scalar values are written as a single cell.
+func (o *OutputOptions) writeCSV(data any) error {
+	w := csv.NewWriter(o.IOStreams.Out)
+	defer w.Flush()
+
+	switch v := data.(type) {
+	case []any:
+		return o.writeCSVSlice(w, v)
+	case []map[string]any:
+		items := make([]any, len(v))
+		for i, m := range v {
+			items[i] = m
+		}
+		return o.writeCSVSlice(w, items)
+	case map[string]any:
+		return o.writeCSVSlice(w, []any{v})
+	default:
+		// Scalar or unsupported type — write as single value
+		return w.Write([]string{fmt.Sprintf("%v", data)})
+	}
+}
+
+// writeCSVSlice writes a slice of items as CSV rows with a header row.
+func (o *OutputOptions) writeCSVSlice(w *csv.Writer, items []any) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Collect all keys across all items for consistent columns
+	keySet := make(map[string]struct{})
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			for k := range m {
+				keySet[k] = struct{}{}
+			}
+		}
+	}
+
+	headers := make([]string, 0, len(keySet))
+	for k := range keySet {
+		headers = append(headers, k)
+	}
+	sort.Strings(headers)
+
+	// Apply column order if configured
+	if len(o.ColumnOrder) > 0 {
+		headers = applyColumnOrder(headers, o.ColumnOrder)
+	}
+
+	// Write header row
+	if err := w.Write(headers); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	// Write data rows
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			// Non-map item — write as single column
+			if err := w.Write([]string{fmt.Sprintf("%v", item)}); err != nil {
+				return fmt.Errorf("failed to write CSV row: %w", err)
+			}
+			continue
+		}
+		row := make([]string, len(headers))
+		for i, h := range headers {
+			if v, exists := m[h]; exists {
+				row[i] = fmt.Sprintf("%v", v)
+			}
+		}
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("failed to write CSV row: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// applyColumnOrder reorders headers based on the preferred column order.
+// Fields in the order list come first; remaining fields are appended in their original order.
+func applyColumnOrder(headers, order []string) []string {
+	orderSet := make(map[string]struct{}, len(order))
+	for _, o := range order {
+		orderSet[o] = struct{}{}
+	}
+
+	result := make([]string, 0, len(headers))
+	// Add ordered columns first (preserving order list sequence)
+	for _, o := range order {
+		for _, h := range headers {
+			if h == o {
+				result = append(result, h)
+				break
+			}
+		}
+	}
+	// Append remaining columns not in order list
+	for _, h := range headers {
+		if _, ok := orderSet[h]; !ok {
+			result = append(result, h)
+		}
+	}
+	return result
+}
+
 // WriteTo writes data to a specific writer with the configured format.
 // This is useful when you need to write to a different output than the configured IOStreams.
 func (o *OutputOptions) WriteTo(w io.Writer, data any) error {
@@ -528,4 +701,25 @@ func StructToMap(v any) (any, error) {
 		return nil, fmt.Errorf("failed to unmarshal from JSON: %w", err)
 	}
 	return result, nil
+}
+
+// isScalarValue returns true if the value is a scalar type (string, number, bool)
+// that should be printed directly rather than rendered in a table.
+func isScalarValue(v any) bool {
+	switch v.(type) {
+	case string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// removeExpressionOptions appends overrides that clear expression and where
+// options. Since Option is an opaque func, we cannot filter the original slice;
+// instead we append empty-value overrides so the viewer skips re-evaluation.
+func removeExpressionOptions(opts []Option) []Option {
+	return append(opts, WithExpression(""), WithWhere(""))
 }

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -47,7 +47,9 @@ func TestBaseOutputFormats(t *testing.T) {
 	assert.Contains(t, formats, "test")
 	assert.Contains(t, formats, "tree")
 	assert.Contains(t, formats, "mermaid")
-	assert.Len(t, formats, 9)
+	assert.Contains(t, formats, "csv")
+	assert.Contains(t, formats, "toml")
+	assert.Len(t, formats, 11)
 }
 
 func TestIsStructuredFormat(t *testing.T) {
@@ -986,4 +988,291 @@ func TestOutputOptions_Write_KvxNonTTY_InvalidWhere(t *testing.T) {
 	err := opts.Write(data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "where filter failed")
+}
+
+func TestOutputOptions_Write_ScalarExpressionNonTTY(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       any
+		expression string
+		expected   string
+	}{
+		{
+			name:       "string scalar",
+			data:       map[string]any{"name": "abaker9"},
+			expression: "_.name",
+			expected:   "abaker9\n",
+		},
+		{
+			name:       "integer scalar",
+			data:       map[string]any{"count": 42},
+			expression: "_.count",
+			expected:   "42\n",
+		},
+		{
+			name:       "boolean scalar",
+			data:       map[string]any{"enabled": true},
+			expression: "_.enabled",
+			expected:   "true\n",
+		},
+		{
+			name:       "float scalar",
+			data:       map[string]any{"ratio": 3.14},
+			expression: "_.ratio",
+			expected:   "3.14\n",
+		},
+		{
+			name:       "map result stays structured",
+			data:       map[string]any{"nested": map[string]any{"a": 1}},
+			expression: "_.nested",
+			expected:   "\"a\": 1", // should be JSON, not plain text
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			ioStreams := &terminal.IOStreams{Out: out}
+
+			opts := NewOutputOptions(ioStreams)
+			opts.Format = OutputFormatAuto
+			opts.Expression = tt.expression
+
+			err := opts.Write(tt.data)
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), tt.expected)
+		})
+	}
+}
+
+func TestOutputOptions_Write_CSV(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := []map[string]any{
+		{"name": "alice", "age": 30},
+		{"name": "bob", "age": 25},
+	}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	// Header row should contain both columns
+	assert.Contains(t, lines, "age")
+	assert.Contains(t, lines, "name")
+	// Data rows
+	assert.Contains(t, lines, "alice")
+	assert.Contains(t, lines, "bob")
+}
+
+func TestOutputOptions_Write_CSV_SingleMap(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := map[string]any{"name": "alice", "role": "admin"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	assert.Contains(t, lines, "name")
+	assert.Contains(t, lines, "alice")
+}
+
+func TestOutputOptions_Write_CSV_WithExpression(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+	opts.Expression = "_"
+
+	data := []map[string]any{{"key": "value"}}
+	err := opts.Write(data)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "key")
+	assert.Contains(t, out.String(), "value")
+}
+
+func TestOutputOptions_Write_CSV_Empty(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := []any{}
+	err := opts.Write(data)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func TestOutputOptions_Write_CSV_ColumnOrder(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+	opts.ColumnOrder = []string{"name", "age"}
+
+	data := []map[string]any{{"age": 30, "name": "alice"}}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	// First line should be header with name before age
+	lines := out.String()
+	headerEnd := lines[:len("name,age")]
+	assert.Equal(t, "name,age", headerEnd)
+}
+
+func TestIsScalarValue(t *testing.T) {
+	assert.True(t, isScalarValue("hello"))
+	assert.True(t, isScalarValue(42))
+	assert.True(t, isScalarValue(3.14))
+	assert.True(t, isScalarValue(true))
+	assert.True(t, isScalarValue(false))
+	assert.False(t, isScalarValue(map[string]any{"a": 1}))
+	assert.False(t, isScalarValue([]any{1, 2}))
+	assert.False(t, isScalarValue(nil))
+}
+
+func TestRemoveExpressionOptions(t *testing.T) {
+	opts := []Option{WithExpression("_.name"), WithWhere("_.age > 10")}
+	cleared := removeExpressionOptions(opts)
+	// Should have original opts + 2 override opts
+	assert.Len(t, cleared, 4)
+}
+
+func TestOutputOptions_Write_NonScalarExpressionNonTTY(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatAuto
+	opts.Expression = "_.nested"
+
+	data := map[string]any{"nested": map[string]any{"a": 1, "b": 2}}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	// Non-scalar expression result should fall through to JSON output
+	output := out.String()
+	assert.Contains(t, output, "\"a\"")
+	assert.Contains(t, output, "\"b\"")
+}
+
+func TestParseOutputFormat_CSV(t *testing.T) {
+	format, ok := ParseOutputFormat("csv")
+	assert.True(t, ok)
+	assert.Equal(t, OutputFormatCSV, format)
+}
+
+func TestIsStructuredFormat_CSV(t *testing.T) {
+	assert.True(t, IsStructuredFormat(OutputFormatCSV))
+}
+
+func BenchmarkOutputOptions_Write_CSV(b *testing.B) {
+	data := []map[string]any{
+		{"name": "alice", "age": 30, "role": "admin"},
+		{"name": "bob", "age": 25, "role": "user"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		out := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{Out: out}
+		opts := NewOutputOptions(ioStreams)
+		opts.Format = OutputFormatCSV
+		_ = opts.Write(data)
+	}
+}
+
+func TestOutputOptions_Write_TOML(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatTOML
+
+	data := map[string]any{"name": "alice", "role": "admin"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "name = 'alice'")
+	assert.Contains(t, output, "role = 'admin'")
+}
+
+func TestOutputOptions_Write_TOML_Nested(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatTOML
+
+	data := map[string]any{
+		"name": "test",
+		"settings": map[string]any{
+			"verbose": true,
+			"timeout": 30,
+		},
+	}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "name = 'test'")
+	assert.Contains(t, output, "[settings]")
+	assert.Contains(t, output, "verbose = true")
+	assert.Contains(t, output, "timeout = 30")
+}
+
+func TestOutputOptions_Write_TOML_WithExpression(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatTOML
+	opts.Expression = "_"
+
+	data := map[string]any{"key": "value"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "key = 'value'")
+}
+
+func TestParseOutputFormat_TOML(t *testing.T) {
+	format, ok := ParseOutputFormat("toml")
+	assert.True(t, ok)
+	assert.Equal(t, OutputFormatTOML, format)
+}
+
+func TestIsStructuredFormat_TOML(t *testing.T) {
+	assert.True(t, IsStructuredFormat(OutputFormatTOML))
+}
+
+func BenchmarkOutputOptions_Write_TOML(b *testing.B) {
+	data := map[string]any{
+		"name": "alice",
+		"age":  30,
+		"settings": map[string]any{
+			"verbose": true,
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		out := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{Out: out}
+		opts := NewOutputOptions(ioStreams)
+		opts.Format = OutputFormatTOML
+		_ = opts.Write(data)
+	}
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2419,7 +2419,7 @@ func TestIntegration_BuildSolution_WithName(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name", "--force")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)


### PR DESCRIPTION
- add YAML/JSON shorthand for Condition (when) fields: bare string, bool, and map with expr/expression keys
- add CSV and TOML output formats to kvx, print scalar values as literals instead of single-cell tables
- add passthrough input to exec provider for streaming command output directly to the terminal
- add BrowserAuthCallback to LoginOptions and wire consistent TUI status display across all browser and device-code auth flows (entra, github, gcp, oauth2)
- auto-increment patch version in build solution when neither --version nor metadata.version is provided
- error on name mismatch between build target and metadata unless --force is set; warn on version override
- add CopyLocal to LocalCatalog for re-tagging artifacts under a new name and version
- extend catalog tag to support name@version targets for Docker-style re-tagging (e.g., tag foo@1.0.0 bar@1.0.0)
- fix HCL provider descriptor description typo

Closes #168
Closes #258
Closes #165
Closes #169
Closes #236