### PR TITLE
feat(provider)!: add repository management operations to github provider

### DIFF
--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -1019,7 +1019,72 @@ The host registers HostService via the go-plugin GRPCBroker during plugin startu
 
 ### Quick Start
 
-#### 1. Create Plugin Directory
+The fastest way to scaffold a complete plugin project is with the **plugin-template** solution. It creates the full project structure -- source code, tests, CI/CD pipelines, linter config, and optionally a GitHub repository with branch protection and security settings.
+
+#### Option A: Scaffold with GitHub Repository
+
+{{< tabs "provider-development-cmd-0a" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run solution \
+  -f examples/solutions/plugin-template/solution.yaml \
+  -r name=scafctl-plugin-echo \
+  -r module=github.com/myorg/scafctl-plugin-echo \
+  -r "description=Echoes input values" \
+  -r capabilities=from \
+  -r create_repo=true \
+  -r repo_visibility=private
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution `
+  -f examples/solutions/plugin-template/solution.yaml `
+  -r name=scafctl-plugin-echo `
+  -r module=github.com/myorg/scafctl-plugin-echo `
+  -r "description=Echoes input values" `
+  -r capabilities=from `
+  -r create_repo=true `
+  -r repo_visibility=private
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+This creates the GitHub repository, pushes a GPG-signed initial commit with all scaffolded files, configures branch/tag rulesets, and enables Dependabot.
+
+> [!WARNING]
+> The initial commit does not include `go.sum`. Run `go mod tidy` locally and push the result before CI pipelines will pass.
+
+#### Option B: Scaffold Locally
+
+{{< tabs "provider-development-cmd-0b" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run solution \
+  -f examples/solutions/plugin-template/solution.yaml \
+  -r name=scafctl-plugin-echo \
+  -r module=github.com/myorg/scafctl-plugin-echo \
+  -r "description=Echoes input values" \
+  -r capabilities=from
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run solution `
+  -f examples/solutions/plugin-template/solution.yaml `
+  -r name=scafctl-plugin-echo `
+  -r module=github.com/myorg/scafctl-plugin-echo `
+  -r "description=Echoes input values" `
+  -r capabilities=from
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+This writes the project files to `scafctl-plugin-echo/` in the current directory.
+
+#### Option C: Manual Setup
+
+If you prefer to set up the project manually:
 
 {{< tabs "provider-development-cmd-1" >}}
 {{% tab "Bash" %}}

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -559,7 +559,7 @@ The git provider enforces several security measures:
 
 ## github
 
-Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, tags) and REST (releases). Uses the configured GitHub auth handler automatically. Commit operations use `createCommitOnBranch` for GPG-signed multi-file atomic commits.
+Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, tags, repos) and REST (releases, rulesets, security settings). Uses the configured GitHub auth handler automatically. Commit operations use `createCommitOnBranch` for GPG-signed multi-file atomic commits.
 
 > For arbitrary HTTP requests to GitHub, use the `http` provider with `auth: github`.
 
@@ -571,9 +571,9 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `operation` | string | ✅ | API operation (see operations table below) |
-| `owner` | string | ✅ | Repository owner (user or organization) |
-| `repo` | string | ✅ | Repository name |
+| `operation` | string | Yes | API operation (see operations table below) |
+| `owner` | string | Conditional | Repository owner (user or organization). Required for all operations except `create_repo` (defaults to authenticated user). |
+| `repo` | string | Yes | Repository name. Required for all operations. |
 | `api_base` | string | ❌ | GitHub API base URL (default: `https://api.github.com`). Set for GitHub Enterprise. |
 | `path` | string | ❌ | File path within the repository (for `get_file`) |
 | `ref` | string | ❌ | Git reference (branch, tag, or commit SHA). Defaults to repo's default branch |
@@ -600,6 +600,19 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 | `release_id` | int | ❌ | Release ID for update/delete |
 | `prerelease` | bool | ❌ | Whether release is a prerelease |
 | `target_commitish` | string | ❌ | Branch/SHA target for release tag |
+| `visibility` | string | ❌ | Repository visibility for `create_repo`: `public` or `private` (default: `public`) |
+| `auto_init` | bool | ❌ | Initialize repo with a README (uses REST Contents API) |
+| `ruleset_name` | string | ❌ | Name for the repository ruleset |
+| `target` | string | ❌ | Ruleset target type: `branch` or `tag` (default: `branch`) |
+| `enforcement` | string | ❌ | Ruleset enforcement level: `active`, `disabled`, `evaluate` (default: `active`) |
+| `include_refs` | array | ❌ | Ref patterns to include (e.g. `refs/heads/main`, `refs/tags/v*`) |
+| `exclude_refs` | array | ❌ | Ref patterns to exclude |
+| `required_status_checks_contexts` | array | ❌ | Required status check context names |
+| `required_approving_review_count` | int | ❌ | Minimum approving reviews required (0--10) |
+| `required_linear_history` | bool | ❌ | Require linear commit history |
+| `allow_force_pushes` | bool | ❌ | Allow force pushes to matching refs |
+| `allow_deletions` | bool | ❌ | Allow deletion of matching refs |
+| `requires_commit_signatures` | bool | ❌ | Require signed commits |
 
 ### Operations
 
@@ -640,6 +653,10 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 | `create_release` | REST | Create a release |
 | `update_release` | REST | Update a release |
 | `delete_release` | REST | Delete a release |
+| `create_repo` | GraphQL | Create a repository (REST fallback for EMU) |
+| `create_ruleset` | REST | Create a repository ruleset (branch or tag protection) |
+| `enable_vulnerability_alerts` | REST | Enable Dependabot vulnerability alerts |
+| `enable_automated_security_fixes` | REST | Enable Dependabot automated security fixes |
 
 ### Output
 
@@ -653,10 +670,14 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `success` | bool | Whether the operation succeeded |
+| `success` | bool | Always `true` on success (failures return a Go error) |
 | `operation` | string | The operation that was performed |
 | `result` | any | API response data |
-| `error` | string | Error message if the operation failed |
+
+> Write operations return a Go error on failure, which stops dependent workflow actions and respects `onError` handling.
+
+> [!NOTE]
+> The `create_commit` result includes `additions` and `deletions` as integer counts (e.g., `"additions": 3`), not nested objects.
 
 ### Examples
 
@@ -723,7 +744,54 @@ action:
         tag_name: v1.0.0
         name: "Release 1.0.0"
         body: "First stable release"
+
+# Create a repository with auto-init
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_repo
+        owner: my-org
+        repo: my-new-repo
+        description: "A scaffolded project"
+        visibility: private
+        auto_init: true
+
+# Create a branch protection ruleset
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_ruleset
+        owner: my-org
+        repo: my-repo
+        ruleset_name: main branch protection
+        target: branch
+        enforcement: active
+        include_refs:
+          - refs/heads/main
+        required_status_checks_contexts:
+          - test
+          - lint
+        required_approving_review_count: 1
+        required_linear_history: true
+        requires_commit_signatures: true
+        allow_force_pushes: false
+        allow_deletions: false
+
+# Enable Dependabot security features
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: enable_vulnerability_alerts
+        owner: my-org
+        repo: my-repo
 ```
+
+> [!TIP]
+> For a complete end-to-end example of repo creation with rulesets and security settings,
+> see the [plugin-template solution](../../examples/solutions/plugin-template/solution.yaml).
 
 ---
 

--- a/examples/providers/github-write-operations.yaml
+++ b/examples/providers/github-write-operations.yaml
@@ -12,7 +12,8 @@ metadata:
   version: 1.0.0
   description: |
     GitHub provider write operations: issues, PRs, commits, branches, tags,
-    and releases. Commits are automatically GPG-signed via createCommitOnBranch.
+    releases, repo management, rulesets, and security settings.
+    Commits are automatically GPG-signed via createCommitOnBranch.
 
 spec:
   resolvers:
@@ -94,3 +95,81 @@ spec:
     #             body: "First stable release"
     #             prerelease: false
     #             target_commitish: main
+    #
+    # Create a repository (GraphQL, REST fallback for EMU):
+    #   new-repo:
+    #     type: any
+    #     resolve:
+    #       with:
+    #         - provider: github
+    #           inputs:
+    #             operation: create_repo
+    #             owner: my-org
+    #             repo: my-new-repo
+    #             description: "A new project"
+    #             visibility: private
+    #             auto_init: true
+    #
+    # Create a branch protection ruleset (REST):
+    #   branch-ruleset:
+    #     type: any
+    #     resolve:
+    #       with:
+    #         - provider: github
+    #           inputs:
+    #             operation: create_ruleset
+    #             owner: my-org
+    #             repo: my-repo
+    #             ruleset_name: main branch protection
+    #             target: branch
+    #             enforcement: active
+    #             include_refs:
+    #               - refs/heads/main
+    #             required_status_checks_contexts:
+    #               - test
+    #               - lint
+    #             required_approving_review_count: 1
+    #             required_linear_history: true
+    #             requires_commit_signatures: true
+    #             allow_force_pushes: false
+    #             allow_deletions: false
+    #
+    # Create a tag protection ruleset (REST):
+    #   tag-ruleset:
+    #     type: any
+    #     resolve:
+    #       with:
+    #         - provider: github
+    #           inputs:
+    #             operation: create_ruleset
+    #             owner: my-org
+    #             repo: my-repo
+    #             ruleset_name: version tag protection
+    #             target: tag
+    #             enforcement: active
+    #             include_refs:
+    #               - "refs/tags/v*"
+    #             allow_deletions: false
+    #             allow_force_pushes: false
+    #
+    # Enable vulnerability alerts (REST):
+    #   vuln-alerts:
+    #     type: any
+    #     resolve:
+    #       with:
+    #         - provider: github
+    #           inputs:
+    #             operation: enable_vulnerability_alerts
+    #             owner: my-org
+    #             repo: my-repo
+    #
+    # Enable automated security fixes (REST):
+    #   auto-security-fixes:
+    #     type: any
+    #     resolve:
+    #       with:
+    #         - provider: github
+    #           inputs:
+    #             operation: enable_automated_security_fixes
+    #             owner: my-org
+    #             repo: my-repo

--- a/examples/solutions/plugin-template/solution.yaml
+++ b/examples/solutions/plugin-template/solution.yaml
@@ -1,0 +1,587 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: plugin-template
+  version: 1.0.0
+  displayName: Plugin Project Template
+  description: >-
+    Scaffolds a complete scafctl plugin project (provider or auth-handler) with
+    source code, tests, build config, CI/CD pipelines, GitHub repo configuration,
+    and Copilot AI instructions. Note: the initial commit does not include go.sum
+    because dependencies are resolved locally. CI pipelines will fail until
+    you run 'go mod tidy' and push the resulting go.sum.
+  category: scaffolding
+  tags: [plugin, scaffold, go, provider]
+  links:
+    - name: Plugin SDK
+      url: https://github.com/oakwood-commons/scafctl-plugin-sdk
+    - name: Provider Authoring Guide
+      url: https://github.com/oakwood-commons/scafctl/blob/main/docs/tutorials/plugin-development.md
+
+spec:
+  resolvers:
+    # ── User Inputs ──────────────────────────────────────────────────────────
+    name:
+      description: >-
+        Plugin project name (lowercase with hyphens, 3-60 chars).
+        Convention: scafctl-plugin-<provider-name>
+      type: string
+      example: scafctl-plugin-echo
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: name
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: 'size(__self) >= 3 && size(__self) <= 60'
+              message: "Name must be 3-60 characters"
+          - provider: validation
+            inputs:
+              expression: '__self.matches("^[a-z][a-z0-9-]*[a-z0-9]$")'
+              message: "Name must be lowercase alphanumeric with hyphens"
+
+    module:
+      description: "Go module path (e.g. github.com/myorg/scafctl-plugin-echo)"
+      type: string
+      example: github.com/myorg/scafctl-plugin-echo
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: module
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: 'size(__self) >= 5'
+              message: "Module path is required"
+
+    description:
+      description: "Brief description of what the plugin does"
+      type: string
+      example: Echoes input values
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: description
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: 'size(__self) >= 1'
+              message: "Description is required"
+
+    capabilities:
+      description: "Provider capabilities (comma-separated): from, transform, action, validation. Ignored for auth-handler plugins."
+      type: any
+      example: from,transform
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: capabilities
+          - provider: static
+            inputs:
+              value:
+                expr: '_.plugin_type == "auth-handler" ? ["authentication"] : ["from"]'
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'type(__self) == list ? __self : [__self]'
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: >-
+                _.plugin_type == "auth-handler" ||
+                (size(__self) > 0 && __self.all(c, c in ["from", "transform", "action", "validation"]))
+              message: "Each capability must be one of: from, transform, action, validation"
+
+    create_repo:
+      description: "Whether to create a GitHub repository and configure branch rules"
+      type: string
+      example: "false"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: create_repo
+          - provider: static
+            inputs:
+              value: "false"
+
+    plugin_type:
+      description: "Plugin type: provider or auth-handler"
+      type: string
+      example: provider
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: plugin_type
+          - provider: static
+            inputs:
+              value: provider
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: '__self in ["provider", "auth-handler"]'
+              message: "Must be provider or auth-handler"
+
+    repo_visibility:
+      description: "GitHub repository visibility (public/private)"
+      type: string
+      example: public
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: repo_visibility
+          - provider: static
+            inputs:
+              value: public
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: '__self in ["public", "private"]'
+              message: "Must be public or private"
+
+    # ── Derived Values ───────────────────────────────────────────────────────
+    repo_path:
+      description: "Repository path (module without github.com/ prefix)"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: module
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.replace("github.com/", "")'
+
+    provider_name:
+      description: "Provider name derived from plugin name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: name
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.replace("scafctl-plugin-", "")'
+
+    pkg_name:
+      description: "Go package name (hyphens removed)"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: provider_name
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.replace("-", "")'
+
+    capability_consts:
+      description: "SDK capability constant names mapped from capabilities"
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: capabilities
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: >-
+                __self.map(c,
+                  c == "from" ? "sdkprovider.CapabilityFrom" :
+                  c == "transform" ? "sdkprovider.CapabilityTransform" :
+                  c == "action" ? "sdkprovider.CapabilityAction" :
+                  c == "validation" ? "sdkprovider.CapabilityValidation" :
+                  c == "authentication" ? "authentication" :
+                  "sdkprovider.CapabilityFrom")
+
+    display_name:
+      description: "Human-readable provider display name"
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: provider_name
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.replace("-", " ") + " Provider"'
+
+    # ── Load Templates ───────────────────────────────────────────────────────
+    template_files:
+      description: "Read all .tpl template files from disk"
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    # ── Render Templates ─────────────────────────────────────────────────────
+    rendered:
+      description: "Render all templates with user inputs"
+      type: any
+      dependsOn:
+        - name
+        - module
+        - description
+        - provider_name
+        - pkg_name
+        - capabilities
+        - capability_consts
+        - display_name
+        - plugin_type
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              leftDelim: "<%"
+              rightDelim: "%>"
+              entries:
+                expr: "_.template_files.entries"
+
+    # Rewrite paths: replace PLUGIN_NAME and PKG_NAME placeholders
+    output_files:
+      description: "Final file entries with correct paths"
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: rendered
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: >-
+                __self.map(e, {
+                  "path": e.path.replace("PLUGIN_NAME", _.name).replace("PKG_NAME", _.pkg_name).replace(".tpl", ""),
+                  "content": e.content
+                }).filter(e,
+                  _.plugin_type == "auth-handler"
+                    ? !e.path.endsWith("provider.go") && !e.path.endsWith("provider_test.go")
+                    : !e.path.endsWith("auth_handler.go") && !e.path.endsWith("auth_handler_test.go")
+                )
+
+  # ── Workflow ─────────────────────────────────────────────────────────────
+  workflow:
+    actions:
+      # Write all scaffolded files (skip when pushing to GitHub)
+      write-files:
+        description: "Write rendered plugin project files to output directory"
+        provider: file
+        when:
+          expr: '_.create_repo != "true"'
+        inputs:
+          operation: write-tree
+          basePath:
+            expr: "_.name"
+          entries:
+            rslvr: output_files
+          outputPath: >-
+            {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+          onConflict: skip-unchanged
+
+      # Create GitHub repository (optional)
+      create-github-repo:
+        description: "Create GitHub repository with initial commit (auto_init)"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        inputs:
+          operation: create_repo
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+          description:
+            rslvr: description
+          visibility:
+            rslvr: repo_visibility
+          auto_init: true
+
+      # Configure branch protection via repository rulesets
+      configure-branch-ruleset:
+        description: "Set up branch protection rules for main via rulesets"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [initial-commit]
+        onError: continue
+        inputs:
+          operation: create_ruleset
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+          ruleset_name: main branch protection
+          target: branch
+          enforcement: active
+          include_refs:
+            expr: '["refs/heads/main"]'
+          required_status_checks_contexts:
+            expr: '["test", "lint"]'
+          required_approving_review_count: 1
+          required_linear_history: true
+          requires_commit_signatures: true
+          allow_force_pushes: false
+          allow_deletions: false
+
+      # Configure tag protection via repository rulesets
+      configure-tag-ruleset:
+        description: "Protect version tags from deletion and force pushes"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [initial-commit]
+        onError: continue
+        inputs:
+          operation: create_ruleset
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+          ruleset_name: version tag protection
+          target: tag
+          enforcement: active
+          include_refs:
+            expr: '["refs/tags/v*"]'
+          allow_deletions: false
+          allow_force_pushes: false
+
+      # Enable vulnerability alerts
+      enable-vulnerability-alerts:
+        description: "Enable Dependabot vulnerability alerts"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [create-github-repo]
+        onError: continue
+        inputs:
+          operation: enable_vulnerability_alerts
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+
+      # Enable automated security fixes
+      enable-automated-security-fixes:
+        description: "Enable Dependabot automated security fixes"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [enable-vulnerability-alerts]
+        onError: continue
+        inputs:
+          operation: enable_automated_security_fixes
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+
+      # Get HEAD OID for initial commit (needed after auto_init)
+      get-head-oid:
+        description: "Fetch the HEAD OID of the default branch for create_commit"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [create-github-repo]
+        inputs:
+          operation: get_head_oid
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+          branch: main
+
+      # Push scaffolded files as initial commit via GitHub API (GPG-signed)
+      initial-commit:
+        description: "Push scaffolded files as a GPG-signed initial commit"
+        provider: github
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn:
+          - get-head-oid
+        onError: continue
+        inputs:
+          operation: create_commit
+          owner:
+            expr: '_.module.replace("github.com/", "").split("/")[0]'
+          repo:
+            expr: '_.module.replace("github.com/", "").split("/")[1]'
+          branch: main
+          message: "feat: initial plugin scaffold"
+          expected_head_oid:
+            expr: '__actions["get-head-oid"].results.result.oid'
+          additions:
+            expr: >-
+              _.output_files.map(e, {"path": e.path, "content": e.content})
+
+      # Print next steps
+      next-steps:
+        description: "Print next steps for the user"
+        provider: message
+        inputs:
+          type: success
+          message:
+            tmpl: |
+              {{- if eq .create_repo "true" }}
+              Repository created: https://github.com/{{ .repo_path }}
+
+              Next steps:
+                git clone {{ .module }}.git
+                cd {{ .name }}
+                go mod tidy
+                git add go.sum go.mod
+                git commit -s -S -m "chore: add go.sum"
+                git push
+              {{- else }}
+              Plugin project created in {{ .name }}/
+
+              Next steps:
+                cd {{ .name }}
+                go mod tidy
+              {{- end }}
+              {{- if eq .plugin_type "auth-handler" }}
+                Implement your auth handler logic in internal/{{ .pkg_name }}/auth_handler.go
+              {{- else }}
+                Implement your provider logic in internal/{{ .pkg_name }}/provider.go
+              {{- end }}
+                Run: task test
+                Run: task build
+                Test with scafctl: scafctl run -p {{ .provider_name }}
+
+      # Warn about missing go.sum (only when creating a repo)
+      go-sum-warning:
+        description: "Warn that CI will fail without go.sum"
+        provider: message
+        when:
+          expr: '_.create_repo == "true"'
+        dependsOn: [next-steps]
+        inputs:
+          type: warning
+          message: >-
+            The initial commit does not include go.sum. CI pipelines will fail
+            until you run 'go mod tidy' and push the result.
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      _base:
+        description: Base test case (provider plugin)
+        command: [run, resolver]
+        args: ["-o", "json", "-r", "name=scafctl-plugin-test", "-r", "module=github.com/test/scafctl-plugin-test", "-r", "description=Test plugin", "-r", "capabilities=from", "-r", "create_repo=false", "-r", "repo_visibility=public", "-r", "plugin_type=provider"]
+        files: ["templates/**"]
+        tags: [plugin-template]
+        assertions:
+          - expression: __exitCode == 0
+
+      _base-auth:
+        description: Base test case (auth-handler plugin)
+        command: [run, resolver]
+        args: ["-o", "json", "-r", "name=scafctl-plugin-test", "-r", "module=github.com/test/scafctl-plugin-test", "-r", "description=Test auth handler", "-r", "create_repo=false", "-r", "repo_visibility=public", "-r", "plugin_type=auth-handler"]
+        files: ["templates/**"]
+        tags: [plugin-template]
+        assertions:
+          - expression: __exitCode == 0
+
+      resolves-derived-values:
+        description: Verify derived resolver values
+        extends: [_base]
+        assertions:
+          - expression: __output.provider_name == "test"
+            message: "provider_name should strip scafctl-plugin- prefix"
+          - expression: __output.pkg_name == "test"
+            message: "pkg_name should remove hyphens"
+          - expression: __output.capability_consts == ["sdkprovider.CapabilityFrom"]
+            message: "Should map 'from' to the SDK constant list"
+          - expression: __output.display_name == "test Provider"
+
+      loads-templates:
+        description: Verify template files are loaded
+        extends: [_base]
+        command: [run, resolver, template_files]
+        assertions:
+          - expression: __output.template_files.totalCount > 20
+            message: "Should load at least 20 template files"
+
+      renders-templates:
+        description: Verify templates are rendered with variables
+        extends: [_base]
+        command: [run, resolver, output_files]
+        assertions:
+          - expression: size(__output.output_files) > 20
+            message: "Should render at least 20 template entries"
+          - expression: '__output.output_files.exists(e, e.content.contains("scafctl-plugin-test"))'
+            message: "Rendered content should contain the plugin name"
+          - expression: '__output.output_files.exists(e, e.path.contains("scafctl-plugin-test"))'
+            message: "Paths should have PLUGIN_NAME replaced"
+          - expression: '!__output.output_files.exists(e, e.path.contains("PLUGIN_NAME"))'
+            message: "No paths should have PLUGIN_NAME placeholder remaining"
+          - expression: '!__output.output_files.exists(e, e.path.endsWith(".tpl"))'
+            message: "No paths should have .tpl extension remaining"
+
+      renders-auth-handler-templates:
+        description: Verify auth-handler templates exclude provider files
+        extends: [_base-auth]
+        command: [run, resolver, output_files]
+        assertions:
+          - expression: size(__output.output_files) > 20
+            message: "Should render at least 20 template entries"
+          - expression: '!__output.output_files.exists(e, e.path.endsWith("provider.go"))'
+            message: "Auth-handler should not include provider.go"
+          - expression: '!__output.output_files.exists(e, e.path.endsWith("provider_test.go"))'
+            message: "Auth-handler should not include provider_test.go"
+          - expression: '__output.output_files.exists(e, e.path.endsWith("auth_handler.go"))'
+            message: "Auth-handler should include auth_handler.go"
+          - expression: '__output.output_files.exists(e, e.path.endsWith("auth_handler_test.go"))'
+            message: "Auth-handler should include auth_handler_test.go"
+
+      provider-excludes-auth-handler:
+        description: Verify provider templates exclude auth-handler files
+        extends: [_base]
+        command: [run, resolver, output_files]
+        assertions:
+          - expression: '__output.output_files.exists(e, e.path.endsWith("provider.go"))'
+            message: "Provider should include provider.go"
+          - expression: '!__output.output_files.exists(e, e.path.endsWith("auth_handler.go"))'
+            message: "Provider should not include auth_handler.go"
+          - expression: '!__output.output_files.exists(e, e.path.endsWith("auth_handler_test.go"))'
+            message: "Provider should not include auth_handler_test.go"

--- a/examples/solutions/plugin-template/templates/.github/CODEOWNERS.tpl
+++ b/examples/solutions/plugin-template/templates/.github/CODEOWNERS.tpl
@@ -1,0 +1,2 @@
+# Default owners for everything
+* @OWNER

--- a/examples/solutions/plugin-template/templates/.github/ISSUE_TEMPLATE/bug_report.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/ISSUE_TEMPLATE/bug_report.md.tpl
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug to help us improve <% .name %>
+labels: ["bug"]
+---
+
+## Describe the Bug
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Configure plugin with ...
+2. Run solution with ...
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include full error output.
+
+## Environment
+
+- scafctl version:
+- Plugin version:
+- OS:
+- Go version (if building from source):
+
+## Additional Context
+
+Any other context, screenshots, or log output.

--- a/examples/solutions/plugin-template/templates/.github/ISSUE_TEMPLATE/feature_request.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/ISSUE_TEMPLATE/feature_request.md.tpl
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest an idea for this plugin
+labels: ["enhancement"]
+---
+
+## Problem Statement
+
+What problem does this feature solve?
+
+## Proposed Solution
+
+Describe the solution you'd like.
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Any other context, examples, or mockups.

--- a/examples/solutions/plugin-template/templates/.github/PULL_REQUEST_TEMPLATE.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/PULL_REQUEST_TEMPLATE.md.tpl
@@ -1,0 +1,23 @@
+## Description
+
+Brief description of the changes.
+
+## Related Issues
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
+- [ ] My commits follow conventional commit format
+- [ ] I have added/updated tests for my changes
+- [ ] `go test ./...` passes
+- [ ] `task lint` passes
+- [ ] I have signed off my commits (`git commit -s -S`)

--- a/examples/solutions/plugin-template/templates/.github/SECURITY.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/SECURITY.md.tpl
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security vulnerabilities via
+[GitHub Security Advisories](https://<% .module %>/security/advisories/new).
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+- Any suggested fixes (optional)

--- a/examples/solutions/plugin-template/templates/.github/copilot-instructions.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/copilot-instructions.md.tpl
@@ -1,0 +1,40 @@
+# <% .name %> - AI Agent Instructions
+
+## Overview
+
+<% if eq .plugin_type "auth-handler" -%>
+scafctl auth handler plugin implementing the **<% .provider_name %>** handler.
+<%- else -%>
+scafctl provider plugin implementing the **<% .provider_name %>** provider.
+<%- end %>
+
+## Key Patterns
+
+- **Plugin SDK**: Uses `github.com/oakwood-commons/scafctl-plugin-sdk`
+- **Entry point**: `cmd/<% .name %>/main.go` calls `sdkplugin.<% if eq .plugin_type "auth-handler" %>ServeAuthHandler<% else %>Serve<% end %>()`
+<% if eq .plugin_type "auth-handler" -%>
+- **Handler impl**: `internal/*/auth_handler.go` implements AuthHandlerPlugin interface
+<%- else -%>
+- **Provider impl**: `internal/*/provider.go` implements ProviderPlugin interface
+<%- end %>
+
+## Conventions
+
+- **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- **Signing**: All commits must be GPG/SSH signed (`-S`) and include DCO sign-off (`-s`)
+- **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
+
+## Build & Test Commands
+
+~~~bash
+task build    # Build the plugin binary
+task test     # Run tests
+task lint     # Run linter
+task lint:fix # Run linter with auto-fix
+~~~
+
+## Critical Rules
+
+- **No hardcoded paths**: Use the SDK interfaces for all host interactions
+- **Test coverage**: Every new file must have tests. Target 70%+ patch coverage
+- **Git safety**: Never run git commit/push unless explicitly asked

--- a/examples/solutions/plugin-template/templates/.github/dependabot.yml.tpl
+++ b/examples/solutions/plugin-template/templates/.github/dependabot.yml.tpl
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/examples/solutions/plugin-template/templates/.github/instructions/go-conventions.instructions.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/instructions/go-conventions.instructions.md.tpl
@@ -1,0 +1,22 @@
+---
+description: "Go coding conventions: struct tags, error handling, and formatting."
+applyTo: "**/*.go"
+---
+
+# Go Conventions
+
+## Struct Tags
+
+Always add JSON/YAML tags on exported structs.
+
+## Error Handling
+
+- Return errors with `fmt.Errorf("context: %w", err)`
+- Never panic in library code
+- Check all error returns
+
+## Design Principles
+
+- Prefer composition over inheritance
+- Keep interfaces small (1-3 methods)
+- Accept interfaces, return structs

--- a/examples/solutions/plugin-template/templates/.github/instructions/go-testing.instructions.md.tpl
+++ b/examples/solutions/plugin-template/templates/.github/instructions/go-testing.instructions.md.tpl
@@ -1,0 +1,32 @@
+---
+description: "Go testing conventions: table-driven tests, testify/assert, and benchmarks."
+applyTo: "**/*_test.go"
+---
+
+# Go Testing Conventions
+
+## Framework
+
+- Use standard `go test` with table-driven tests
+- Use `testify/assert` for assertions
+- Always run with `-race` flag
+
+## Coverage Targets
+
+- Domain packages: 80%+
+- Critical logic: 90%+
+- Patch coverage: 70%+
+
+## Benchmarks
+
+Add benchmark tests for performance-sensitive code:
+
+~~~go
+func BenchmarkMyFeature(b *testing.B) {
+    b.ReportAllocs()
+    b.ResetTimer()
+    for b.Loop() {
+        // benchmark code
+    }
+}
+~~~

--- a/examples/solutions/plugin-template/templates/.github/workflows/ci.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/.github/workflows/ci.yaml.tpl
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".gitignore"
+      - "LICENSE"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59.1
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go build ./...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage
+        if: github.event_name == 'push'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: false

--- a/examples/solutions/plugin-template/templates/.github/workflows/codeql.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/.github/workflows/codeql.yaml.tpl
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - run: go build ./...
+      - uses: github/codeql-action/analyze@v3

--- a/examples/solutions/plugin-template/templates/.github/workflows/dco.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/.github/workflows/dco.yaml.tpl
@@ -1,0 +1,27 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dco-check:
+    name: DCO Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by lines
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          missing=0
+          for sha in $(git rev-list --no-merges "${base_sha}..${head_sha}"); do
+            if ! git show -s --format=%B "$sha" | grep -qi "^Signed-off-by:"; then
+              echo "Missing Signed-off-by in commit $sha"
+              missing=1
+            fi
+          done
+          exit $missing

--- a/examples/solutions/plugin-template/templates/.github/workflows/release.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/.github/workflows/release.yaml.tpl
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test -race ./...
+
+  release:
+    name: Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/solutions/plugin-template/templates/.gitignore.tpl
+++ b/examples/solutions/plugin-template/templates/.gitignore.tpl
@@ -1,0 +1,32 @@
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# Coverage
+coverage.*
+*.coverprofile
+
+# Go workspace
+go.work
+go.work.sum
+
+# Build artifacts
+/dist
+/.task
+
+# Editor/IDE
+.vscode/*
+!.vscode/tasks.json
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment
+.env

--- a/examples/solutions/plugin-template/templates/.golangci.yml.tpl
+++ b/examples/solutions/plugin-template/templates/.golangci.yml.tpl
@@ -1,0 +1,12 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - revive
+    - gosec
+    - misspell

--- a/examples/solutions/plugin-template/templates/.goreleaser.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/.goreleaser.yaml.tpl
@@ -1,0 +1,32 @@
+version: 2
+
+project_name: <% .name %>
+
+builds:
+  - id: plugin
+    main: ./cmd/<% .name %>/
+    binary: <% .name %>
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github-native

--- a/examples/solutions/plugin-template/templates/CODE_OF_CONDUCT.md.tpl
+++ b/examples/solutions/plugin-template/templates/CODE_OF_CONDUCT.md.tpl
@@ -1,0 +1,40 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.0.

--- a/examples/solutions/plugin-template/templates/CONTRIBUTING.md.tpl
+++ b/examples/solutions/plugin-template/templates/CONTRIBUTING.md.tpl
@@ -1,0 +1,65 @@
+# Contributing to <% .name %>
+
+Thank you for your interest in contributing! This document provides guidelines.
+
+## Code of Conduct
+
+See our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting Started
+
+### Developer Certificate of Origin (DCO) & Commit Signing
+
+All commits must be:
+1. **GPG/SSH signed** (`-S`) -- verifies commit author identity
+2. **DCO signed-off** (`-s`) -- certifies you have the right to submit
+
+Sign commits with both `-s` and `-S`:
+
+~~~bash
+git commit -s -S -m "feat: add new feature"
+~~~
+
+### Prerequisites
+
+- Go 1.26.0+
+- [Task](https://taskfile.dev/) (go-task)
+- golangci-lint
+
+### Setup
+
+~~~bash
+git clone <% .module %>
+cd <% .name %>
+go mod download
+task build
+task test
+~~~
+
+## Development Workflow
+
+1. Create a branch from `main`
+2. Make your changes
+3. Ensure tests pass: `task test`
+4. Ensure lint passes: `task lint`
+5. Commit with conventional commit messages
+6. Open a Pull Request
+
+## Conventional Commits
+
+Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+~~~text
+feat: add new capability
+fix: correct input validation
+docs: update README
+test: add benchmark tests
+chore: update dependencies
+~~~
+
+## Testing
+
+- Write table-driven tests
+- Use testify/assert for assertions
+- Include benchmarks for new features
+- Target 70%+ coverage on new code

--- a/examples/solutions/plugin-template/templates/LICENSE.tpl
+++ b/examples/solutions/plugin-template/templates/LICENSE.tpl
@@ -1,0 +1,102 @@
+Copyright 2025-2026 Oakwood Commons
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License.
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work.
+
+      "Contribution" shall mean any work of authorship submitted to the
+      Licensor for inclusion in the Work.
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      patent license to make, have made, use, offer to sell, sell, import,
+      and otherwise transfer the Work.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+   8. Limitation of Liability. In no event and under no legal theory shall
+      any Contributor be liable to You for damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work, You may choose to offer acceptance of support, warranty,
+      indemnity, or other liability obligations.
+
+   END OF TERMS AND CONDITIONS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/solutions/plugin-template/templates/README.md.tpl
+++ b/examples/solutions/plugin-template/templates/README.md.tpl
@@ -1,0 +1,74 @@
+# <% .name %>
+
+<% .description %>
+
+## Installation
+
+```bash
+# Build from source
+task build
+
+# Or download from releases
+gh release download --repo <% .module %>
+```
+
+## Usage
+
+<% if eq .plugin_type "auth-handler" -%>
+Register this plugin in your scafctl configuration, then use
+the **<% .provider_name %>** auth handler:
+
+```bash
+scafctl auth login <% .provider_name %>
+```
+
+Once authenticated, reference it in HTTP requests:
+
+```yaml
+resolvers:
+  data:
+    resolve:
+      with:
+        - provider: http
+          inputs:
+            url: https://api.example.com/data
+            auth: <% .provider_name %>
+```
+<%- else -%>
+Register this plugin in your scafctl configuration, then reference
+the **<% .provider_name %>** provider in your solutions:
+
+```yaml
+resolvers:
+  my-value:
+    resolve:
+      with:
+        - provider: <% .provider_name %>
+          inputs:
+            value: "hello"
+```
+<%- end %>
+
+## Development
+
+```bash
+# Run tests
+task test
+
+# Run linter
+task lint
+
+# Build
+task build
+
+# Full CI pipeline
+task ci
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+Apache-2.0 -- see [LICENSE](LICENSE) for details.

--- a/examples/solutions/plugin-template/templates/Taskfile.yaml.tpl
+++ b/examples/solutions/plugin-template/templates/Taskfile.yaml.tpl
@@ -1,0 +1,67 @@
+version: "3"
+
+vars:
+  BINARY: <% .name %>
+  DIST: "{{.ROOT_DIR | toSlash}}/dist"
+  COVER: "{{.ROOT_DIR | toSlash}}/cover"
+
+env:
+  CGO_ENABLED: "0"
+
+tasks:
+  default:
+    cmds:
+      - task: build
+
+  build:
+    desc: Build the plugin binary
+    sources:
+      - "**/*.go"
+      - go.mod
+      - go.sum
+    generates:
+      - "{{.DIST}}/{{.BINARY}}"
+    cmds:
+      - mkdir -p {{.DIST}}
+      - >-
+        go build -ldflags "-s -w"
+        -o {{.DIST}}/{{.BINARY}}
+        ./cmd/{{.BINARY}}/
+
+  test:
+    desc: Run tests
+    cmds:
+      - go test -race -count=1 -shuffle=on -timeout 5m ./...
+
+  test:cover:
+    desc: Run tests with coverage
+    cmds:
+      - mkdir -p {{.COVER}}
+      - go test -race -coverprofile={{.COVER}}/cover.out -covermode=atomic ./...
+
+  lint:
+    desc: Run linter
+    cmds:
+      - golangci-lint run ./...
+
+  lint:fix:
+    desc: Run linter with auto-fix
+    cmds:
+      - golangci-lint run --fix ./...
+
+  bench:
+    desc: Run benchmarks
+    cmds:
+      - go test -run='^$' -bench='.' -benchmem -count=1 ./...
+
+  clean:
+    desc: Remove build artifacts
+    cmds:
+      - rm -rf dist/ cover/ .task/
+
+  ci:
+    desc: Full CI pipeline (lint + test + build)
+    cmds:
+      - task: lint
+      - task: test
+      - task: build

--- a/examples/solutions/plugin-template/templates/cmd/PLUGIN_NAME/main.go.tpl
+++ b/examples/solutions/plugin-template/templates/cmd/PLUGIN_NAME/main.go.tpl
@@ -1,0 +1,16 @@
+// Package main is the entry point for the <% .name %> plugin.
+package main
+
+import (
+	"<% .module %>/internal/<% .pkg_name %>"
+
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
+)
+
+func main() {
+<% if eq .plugin_type "auth-handler" -%>
+	sdkplugin.ServeAuthHandler(&<% .pkg_name %>.Plugin{})
+<%- else -%>
+	sdkplugin.Serve(&<% .pkg_name %>.Plugin{})
+<%- end %>
+}

--- a/examples/solutions/plugin-template/templates/codecov.yml.tpl
+++ b/examples/solutions/plugin-template/templates/codecov.yml.tpl
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true

--- a/examples/solutions/plugin-template/templates/go.mod.tpl
+++ b/examples/solutions/plugin-template/templates/go.mod.tpl
@@ -1,0 +1,10 @@
+module <% .module %>
+
+go 1.26
+
+require (
+	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/google/jsonschema-go/jsonschema v0.2.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.1.0
+	github.com/stretchr/testify v1.10.0
+)

--- a/examples/solutions/plugin-template/templates/internal/PKG_NAME/auth_handler.go.tpl
+++ b/examples/solutions/plugin-template/templates/internal/PKG_NAME/auth_handler.go.tpl
@@ -1,0 +1,126 @@
+// Package <% .pkg_name %> implements the <% .provider_name %> auth handler plugin.
+package <% .pkg_name %>
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl-plugin-sdk/auth"
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
+)
+
+const (
+	// HandlerName is the unique identifier for this auth handler.
+	HandlerName = "<% .provider_name %>"
+
+	// Version is the auth handler version.
+	Version = "0.1.0"
+)
+
+// Plugin implements the scafctl AuthHandlerPlugin interface.
+type Plugin struct {
+	cfg sdkplugin.ProviderConfig
+}
+
+// GetAuthHandlers returns the list of auth handlers exposed by this plugin.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) GetAuthHandlers(_ context.Context) ([]sdkplugin.AuthHandlerInfo, error) {
+	return []sdkplugin.AuthHandlerInfo{
+		{
+			Name:        HandlerName,
+			DisplayName: "<% .display_name %>",
+			Flows:       []auth.Flow{auth.FlowDeviceCode},
+			Capabilities: []auth.Capability{
+				auth.CapScopesOnLogin,
+			},
+		},
+	}, nil
+}
+
+// ConfigureAuthHandler stores host-side configuration.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) ConfigureAuthHandler(_ context.Context, _ string, cfg sdkplugin.ProviderConfig) error {
+	p.cfg = cfg
+	return nil
+}
+
+// Login performs the authentication flow.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) Login(_ context.Context, handlerName string, _ sdkplugin.LoginRequest, _ func(sdkplugin.DeviceCodePrompt)) (*sdkplugin.LoginResponse, error) {
+	if handlerName != HandlerName {
+		return nil, fmt.Errorf("unknown handler: %s", handlerName)
+	}
+
+	// TODO: implement your authentication flow here
+	return &sdkplugin.LoginResponse{
+		Claims: &auth.Claims{
+			Subject: "user@example.com",
+			Email:   "user@example.com",
+			Name:    "Example User",
+		},
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}, nil
+}
+
+// Logout revokes the current session.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) Logout(_ context.Context, handlerName string) error {
+	if handlerName != HandlerName {
+		return fmt.Errorf("unknown handler: %s", handlerName)
+	}
+	return nil
+}
+
+// GetStatus returns the current authentication status.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) GetStatus(_ context.Context, handlerName string) (*auth.Status, error) {
+	if handlerName != HandlerName {
+		return nil, fmt.Errorf("unknown handler: %s", handlerName)
+	}
+	return &auth.Status{Authenticated: false}, nil
+}
+
+// GetToken returns a valid access token, refreshing if necessary.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) GetToken(_ context.Context, handlerName string, _ sdkplugin.TokenRequest) (*sdkplugin.TokenResponse, error) {
+	if handlerName != HandlerName {
+		return nil, fmt.Errorf("unknown handler: %s", handlerName)
+	}
+
+	// TODO: implement token retrieval/refresh logic here
+	return nil, auth.ErrNotAuthenticated
+}
+
+// ListCachedTokens returns information about cached tokens.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) ListCachedTokens(_ context.Context, handlerName string) ([]*auth.CachedTokenInfo, error) {
+	if handlerName != HandlerName {
+		return nil, fmt.Errorf("unknown handler: %s", handlerName)
+	}
+	return nil, nil
+}
+
+// PurgeExpiredTokens removes expired tokens from the cache.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) PurgeExpiredTokens(_ context.Context, handlerName string) (int, error) {
+	if handlerName != HandlerName {
+		return 0, fmt.Errorf("unknown handler: %s", handlerName)
+	}
+	return 0, nil
+}
+
+// StopAuthHandler performs cleanup for the named handler.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) StopAuthHandler(_ context.Context, _ string) error {
+	return nil
+}

--- a/examples/solutions/plugin-template/templates/internal/PKG_NAME/auth_handler_test.go.tpl
+++ b/examples/solutions/plugin-template/templates/internal/PKG_NAME/auth_handler_test.go.tpl
@@ -1,0 +1,119 @@
+package <% .pkg_name %>
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl-plugin-sdk/auth"
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAuthHandlers(t *testing.T) {
+	p := &Plugin{}
+	handlers, err := p.GetAuthHandlers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, handlers, 1)
+	assert.Equal(t, HandlerName, handlers[0].Name)
+	assert.NotEmpty(t, handlers[0].DisplayName)
+	assert.NotEmpty(t, handlers[0].Flows)
+}
+
+func TestConfigureAuthHandler(t *testing.T) {
+	p := &Plugin{}
+	err := p.ConfigureAuthHandler(context.Background(), HandlerName, sdkplugin.ProviderConfig{
+		BinaryName: "scafctl",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "scafctl", p.cfg.BinaryName)
+}
+
+func TestLogin(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("known handler", func(t *testing.T) {
+		resp, err := p.Login(context.Background(), HandlerName, sdkplugin.LoginRequest{}, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, resp.Claims)
+		assert.NotEmpty(t, resp.Claims.Subject)
+		assert.False(t, resp.ExpiresAt.IsZero())
+	})
+
+	t.Run("unknown handler", func(t *testing.T) {
+		_, err := p.Login(context.Background(), "unknown", sdkplugin.LoginRequest{}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown handler")
+	})
+}
+
+func TestLogout(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("known handler", func(t *testing.T) {
+		err := p.Logout(context.Background(), HandlerName)
+		require.NoError(t, err)
+	})
+
+	t.Run("unknown handler", func(t *testing.T) {
+		err := p.Logout(context.Background(), "unknown")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetStatus(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("known handler", func(t *testing.T) {
+		status, err := p.GetStatus(context.Background(), HandlerName)
+		require.NoError(t, err)
+		assert.NotNil(t, status)
+	})
+
+	t.Run("unknown handler", func(t *testing.T) {
+		_, err := p.GetStatus(context.Background(), "unknown")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetToken(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("not authenticated", func(t *testing.T) {
+		_, err := p.GetToken(context.Background(), HandlerName, sdkplugin.TokenRequest{})
+		assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
+	})
+
+	t.Run("unknown handler", func(t *testing.T) {
+		_, err := p.GetToken(context.Background(), "unknown", sdkplugin.TokenRequest{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown handler")
+	})
+}
+
+func TestListCachedTokens(t *testing.T) {
+	p := &Plugin{}
+	tokens, err := p.ListCachedTokens(context.Background(), HandlerName)
+	require.NoError(t, err)
+	assert.Nil(t, tokens)
+}
+
+func TestPurgeExpiredTokens(t *testing.T) {
+	p := &Plugin{}
+	count, err := p.PurgeExpiredTokens(context.Background(), HandlerName)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func BenchmarkGetToken(b *testing.B) {
+	p := &Plugin{}
+	ctx := context.Background()
+	req := sdkplugin.TokenRequest{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = p.GetToken(ctx, HandlerName, req)
+	}
+}

--- a/examples/solutions/plugin-template/templates/internal/PKG_NAME/provider.go.tpl
+++ b/examples/solutions/plugin-template/templates/internal/PKG_NAME/provider.go.tpl
@@ -1,0 +1,124 @@
+// Package <% .pkg_name %> implements the <% .provider_name %> provider plugin.
+package <% .pkg_name %>
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
+	sdkprovider "github.com/oakwood-commons/scafctl-plugin-sdk/provider"
+	sdkhelper "github.com/oakwood-commons/scafctl-plugin-sdk/provider/schemahelper"
+)
+
+const (
+	// ProviderName is the unique identifier for this provider.
+	ProviderName = "<% .provider_name %>"
+
+	// Version is the provider version.
+	Version = "0.1.0"
+)
+
+// Plugin implements the scafctl ProviderPlugin interface.
+type Plugin struct{}
+
+// GetProviders returns the list of providers exposed by this plugin.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) GetProviders(_ context.Context) ([]string, error) {
+	return []string{ProviderName}, nil
+}
+
+// GetProviderDescriptor returns the descriptor for the named provider.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) GetProviderDescriptor(_ context.Context, providerName string) (*sdkprovider.Descriptor, error) {
+	if providerName != ProviderName {
+		return nil, fmt.Errorf("unknown provider: %s", providerName)
+	}
+
+	return &sdkprovider.Descriptor{
+		Name:        ProviderName,
+		DisplayName: "<% .display_name %>",
+		Description: "<% .description %>",
+		APIVersion:  "scafctl.io/v1",
+		Version:     semver.MustParse(Version),
+		Category:    "custom",
+		Capabilities: []sdkprovider.Capability{
+<%- range .capability_consts %>
+			<% . %>,
+<%- end %>
+		},
+		Schema: sdkhelper.ObjectSchema(
+			[]string{"value"},
+			map[string]*jsonschema.Schema{
+				"value": sdkhelper.StringProp(
+					"The input value",
+					sdkhelper.WithExample("hello"),
+				),
+			},
+		),
+	}, nil
+}
+
+// ExecuteProvider executes the named provider with the given input.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) ExecuteProvider(_ context.Context, providerName string, input map[string]any) (*sdkprovider.Output, error) {
+	if providerName != ProviderName {
+		return nil, fmt.Errorf("unknown provider: %s", providerName)
+	}
+
+	value, _ := input["value"].(string)
+
+	// TODO: implement your provider logic here
+	return &sdkprovider.Output{
+		Data: map[string]any{
+			"result": value,
+		},
+	}, nil
+}
+
+// DescribeWhatIf returns a description of what the provider would do.
+//
+//nolint:revive // ctx required by interface
+func (p *Plugin) DescribeWhatIf(_ context.Context, providerName string, input map[string]any) (string, error) {
+	if providerName != ProviderName {
+		return "", fmt.Errorf("unknown provider: %s", providerName)
+	}
+
+	value, _ := input["value"].(string)
+	if value != "" {
+		return fmt.Sprintf("Would process %q", value), nil
+	}
+	return "Would process input value", nil
+}
+
+// ConfigureProvider stores host-side configuration.
+//
+//nolint:revive // ctx and cfg required by interface
+func (p *Plugin) ConfigureProvider(_ context.Context, _ string, _ sdkplugin.ProviderConfig) error {
+	return nil
+}
+
+// ExecuteProviderStream is not supported.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) ExecuteProviderStream(_ context.Context, _ string, _ map[string]any, _ func(sdkplugin.StreamChunk)) error {
+	return sdkplugin.ErrStreamingNotSupported
+}
+
+// ExtractDependencies returns resolver keys this input depends on.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) ExtractDependencies(_ context.Context, _ string, _ map[string]any) ([]string, error) {
+	return nil, nil
+}
+
+// StopProvider performs cleanup for the named provider.
+//
+//nolint:revive // all params required by interface
+func (p *Plugin) StopProvider(_ context.Context, _ string) error {
+	return nil
+}

--- a/examples/solutions/plugin-template/templates/internal/PKG_NAME/provider_test.go.tpl
+++ b/examples/solutions/plugin-template/templates/internal/PKG_NAME/provider_test.go.tpl
@@ -1,0 +1,104 @@
+package <% .pkg_name %>
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProviders(t *testing.T) {
+	p := &Plugin{}
+	providers, err := p.GetProviders(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{ProviderName}, providers)
+}
+
+func TestGetProviderDescriptor(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("known provider", func(t *testing.T) {
+		desc, err := p.GetProviderDescriptor(context.Background(), ProviderName)
+		require.NoError(t, err)
+		assert.Equal(t, ProviderName, desc.Name)
+		assert.NotEmpty(t, desc.Description)
+		assert.NotNil(t, desc.Schema)
+		assert.NotEmpty(t, desc.Capabilities)
+	})
+
+	t.Run("unknown provider", func(t *testing.T) {
+		_, err := p.GetProviderDescriptor(context.Background(), "unknown")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown provider")
+	})
+}
+
+func TestExecuteProvider(t *testing.T) {
+	p := &Plugin{}
+
+	tests := []struct {
+		name    string
+		input   map[string]any
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "basic input",
+			input: map[string]any{"value": "hello"},
+			want:  "hello",
+		},
+		{
+			name:  "empty input",
+			input: map[string]any{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := p.ExecuteProvider(context.Background(), ProviderName, tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, out.Data["result"])
+		})
+	}
+}
+
+func TestExecuteProvider_UnknownProvider(t *testing.T) {
+	p := &Plugin{}
+	_, err := p.ExecuteProvider(context.Background(), "unknown", nil)
+	assert.Error(t, err)
+}
+
+func TestDescribeWhatIf(t *testing.T) {
+	p := &Plugin{}
+
+	t.Run("with value", func(t *testing.T) {
+		desc, err := p.DescribeWhatIf(context.Background(), ProviderName, map[string]any{"value": "test"})
+		require.NoError(t, err)
+		assert.Contains(t, desc, "test")
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		desc, err := p.DescribeWhatIf(context.Background(), ProviderName, map[string]any{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, desc)
+	})
+}
+
+func BenchmarkExecuteProvider(b *testing.B) {
+	p := &Plugin{}
+	input := map[string]any{"value": "bench"}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _ = p.ExecuteProvider(ctx, ProviderName, input)
+	}
+}

--- a/pkg/cmd/scafctl/new/solution_test.go
+++ b/pkg/cmd/scafctl/new/solution_test.go
@@ -26,7 +26,12 @@ func TestCommandNew(t *testing.T) {
 
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 1, "should have 1 subcommand: solution")
-	assert.Equal(t, "solution", subCmds[0].Name())
+
+	names := make([]string, len(subCmds))
+	for i, c := range subCmds {
+		names[i] = c.Name()
+	}
+	assert.Contains(t, names, "solution")
 }
 
 func TestCommandNew_NoRunE(t *testing.T) {

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
@@ -37,6 +38,17 @@ const ProviderName = "github"
 
 // defaultAPIBase is the default GitHub API base URL.
 const defaultAPIBase = "https://api.github.com"
+
+// Default retry configuration values. These are production defaults that can
+// be overridden via WithRetryConfig for testing.
+const (
+	defaultCommitMaxAttempts    = 5
+	defaultCommitRetryBackoff   = 3 * time.Second
+	defaultWaitMaxAttempts      = 15
+	defaultWaitPollInterval     = 2 * time.Second
+	defaultInitRepoMaxRetries   = 3
+	defaultInitRepoRetryBackoff = 1 * time.Second
+)
 
 // allOperations lists every supported operation name for error messages.
 var allOperations = []string{
@@ -55,6 +67,9 @@ var allOperations = []string{
 	"create_branch", "delete_branch", "create_tag", "delete_tag",
 	// Release write operations (REST)
 	"create_release", "update_release", "delete_release",
+	// Repository management operations (GraphQL + REST)
+	"create_repo", "create_ruleset",
+	"enable_vulnerability_alerts", "enable_automated_security_fixes",
 }
 
 // readOperations are operations that return data (CapabilityFrom/Transform).
@@ -72,6 +87,14 @@ type GitHubProvider struct {
 	descriptor *provider.Descriptor
 	// client can be overridden for testing via WithClient option.
 	client *httpc.Client
+
+	// Retry configuration — overridable for testing.
+	commitMaxAttempts    int
+	commitRetryBackoff   time.Duration
+	waitMaxAttempts      int
+	waitPollInterval     time.Duration
+	initRepoMaxRetries   int
+	initRepoRetryBackoff time.Duration
 }
 
 // Option configures a GitHubProvider.
@@ -84,18 +107,38 @@ func WithClient(c *httpc.Client) Option {
 	}
 }
 
+// WithRetryConfig overrides the default retry timing (useful for testing).
+// Attempt counts are clamped to a minimum of 1; durations are clamped to >= 0.
+func WithRetryConfig(commitMaxAttempts int, commitRetryBackoff time.Duration, waitMaxAttempts int, waitPollInterval time.Duration, initRepoMaxRetries int, initRepoRetryBackoff time.Duration) Option {
+	return func(p *GitHubProvider) {
+		p.commitMaxAttempts = max(1, commitMaxAttempts)
+		p.commitRetryBackoff = max(0, commitRetryBackoff)
+		p.waitMaxAttempts = max(1, waitMaxAttempts)
+		p.waitPollInterval = max(0, waitPollInterval)
+		p.initRepoMaxRetries = max(1, initRepoMaxRetries)
+		p.initRepoRetryBackoff = max(0, initRepoRetryBackoff)
+	}
+}
+
 // NewGitHubProvider creates a new GitHub API provider.
 func NewGitHubProvider(opts ...Option) *GitHubProvider {
 	version, _ := semver.NewVersion("2.0.0")
 
 	p := &GitHubProvider{
+		commitMaxAttempts:    defaultCommitMaxAttempts,
+		commitRetryBackoff:   defaultCommitRetryBackoff,
+		waitMaxAttempts:      defaultWaitMaxAttempts,
+		waitPollInterval:     defaultWaitPollInterval,
+		initRepoMaxRetries:   defaultInitRepoMaxRetries,
+		initRepoRetryBackoff: defaultInitRepoRetryBackoff,
 		descriptor: &provider.Descriptor{
 			Name:        ProviderName,
 			DisplayName: "GitHub API",
 			APIVersion:  "v1",
 			Version:     version,
-			Description: "Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, tags) " +
-				"and REST (releases). Uses the configured GitHub auth handler automatically. " +
+			Description: "Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, tags, " +
+				"repos, branch protection) and REST (releases, tag protection, security settings). " +
+				"Uses the configured GitHub auth handler automatically. " +
 				"Commit operations use createCommitOnBranch for GPG-signed multi-file atomic commits.",
 			Category: "data",
 			WhatIf: func(_ context.Context, input any) (string, error) {
@@ -125,7 +168,6 @@ func NewGitHubProvider(opts ...Option) *GitHubProvider {
 				provider.CapabilityAction: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 					"success":   schemahelper.BoolProp("Whether the operation succeeded"),
 					"result":    schemahelper.AnyProp("The API response data — structure varies by operation"),
-					"error":     schemahelper.StringProp("Error message if the operation failed"),
 					"operation": schemahelper.StringProp("The operation that was performed"),
 				}),
 			},
@@ -195,6 +237,46 @@ tag_name: v1.0.0
 name: "Release 1.0.0"
 body: "First stable release"`,
 				},
+				{
+					Name:        "Create a repository",
+					Description: "Create a new GitHub repository with auto-init",
+					YAML: `operation: create_repo
+owner: my-org
+repo: my-new-repo
+description: "A new project"
+visibility: private
+auto_init: true`,
+				},
+				{
+					Name:        "Create branch ruleset",
+					Description: "Configure branch protection via repository rulesets",
+					YAML: `operation: create_ruleset
+owner: my-org
+repo: my-repo
+ruleset_name: main branch protection
+target: branch
+enforcement: active
+include_refs: ["refs/heads/main"]
+required_status_checks_contexts: [test, lint]
+required_approving_review_count: 1
+required_linear_history: true
+requires_commit_signatures: true
+allow_force_pushes: false
+allow_deletions: false`,
+				},
+				{
+					Name:        "Create tag ruleset",
+					Description: "Protect version tags from deletion and force pushes",
+					YAML: `operation: create_ruleset
+owner: my-org
+repo: my-repo
+ruleset_name: version tag protection
+target: tag
+enforcement: active
+include_refs: ["refs/tags/v*"]
+allow_deletions: false
+allow_force_pushes: false`,
+				},
 			},
 			Links: []provider.Link{
 				{Name: "GitHub GraphQL API", URL: "https://docs.github.com/en/graphql"},
@@ -218,7 +300,7 @@ func buildInputSchema() *jsonschema.Schema {
 	}
 
 	return schemahelper.ObjectSchema(
-		[]string{"operation", "owner", "repo"},
+		[]string{"operation"},
 		map[string]*jsonschema.Schema{
 			// --- Common fields ---
 			"operation": schemahelper.StringProp("GitHub API operation to perform",
@@ -353,6 +435,47 @@ func buildInputSchema() *jsonschema.Schema {
 			"release_id": schemahelper.IntProp("Release ID for update_release/delete_release",
 				schemahelper.WithMinimum(1),
 			),
+
+			// --- Repo management fields (GraphQL + REST) ---
+			"description": schemahelper.StringProp("Repository or resource description",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(1000)),
+			),
+			"visibility": schemahelper.StringProp("Repository visibility for create_repo",
+				schemahelper.WithEnum("public", "private"),
+				schemahelper.WithDefault("public"),
+			),
+			"auto_init": schemahelper.BoolProp("Initialize repo with a README (uses REST API; GraphQL lacks auto_init support)"),
+			"ruleset_name": schemahelper.StringProp("Name for the repository ruleset",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"target": schemahelper.StringProp("Ruleset target type",
+				schemahelper.WithEnum("branch", "tag"),
+				schemahelper.WithDefault("branch"),
+			),
+			"enforcement": schemahelper.StringProp("Ruleset enforcement level",
+				schemahelper.WithEnum("active", "disabled", "evaluate"),
+				schemahelper.WithDefault("active"),
+			),
+			"include_refs": schemahelper.ArrayProp("Ref patterns to include (e.g. refs/heads/main, refs/tags/v*)",
+				schemahelper.WithItems(schemahelper.StringProp("Ref pattern")),
+				schemahelper.WithMaxItems(100),
+			),
+			"exclude_refs": schemahelper.ArrayProp("Ref patterns to exclude",
+				schemahelper.WithItems(schemahelper.StringProp("Ref pattern")),
+				schemahelper.WithMaxItems(100),
+			),
+			"required_status_checks_contexts": schemahelper.ArrayProp("Required status check context names",
+				schemahelper.WithItems(schemahelper.StringProp("Context name")),
+				schemahelper.WithMaxItems(50),
+			),
+			"required_approving_review_count": schemahelper.IntProp("Minimum approving reviews required",
+				schemahelper.WithMinimum(0),
+				schemahelper.WithMaximum(10),
+			),
+			"required_linear_history":    schemahelper.BoolProp("Require linear commit history"),
+			"allow_force_pushes":         schemahelper.BoolProp("Allow force pushes to matching refs"),
+			"allow_deletions":            schemahelper.BoolProp("Allow deletion of matching refs"),
+			"requires_commit_signatures": schemahelper.BoolProp("Require signed commits"),
 		},
 	)
 }
@@ -412,6 +535,10 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 	operation, _ := inputs["operation"].(string)
 	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation)
 
+	if operation == "" {
+		return nil, fmt.Errorf("%s: 'operation' is required", ProviderName)
+	}
+
 	// Dry-run support: return mock data for write operations
 	if dryRun := provider.DryRunFromContext(ctx); dryRun {
 		return p.executeDryRun(operation, inputs)
@@ -424,6 +551,12 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 		apiBase = defaultAPIBase
 	}
 	apiBase = strings.TrimRight(apiBase, "/")
+
+	// Most operations require owner and repo. Only create_repo handles
+	// these fields internally (owner is optional, repo validated inside).
+	if operation != "create_repo" && (owner == "" || repo == "") {
+		return nil, fmt.Errorf("%s: 'owner' and 'repo' are required for %s operation", ProviderName, operation)
+	}
 
 	client := p.getClient(ctx)
 
@@ -497,21 +630,21 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 	case "delete_release":
 		result, err = p.executeDeleteRelease(ctx, client, apiBase, owner, repo, inputs)
 
+	// --- Repository management operations (GraphQL + REST) ---
+	case "create_repo":
+		result, err = p.executeCreateRepo(ctx, client, apiBase, inputs)
+	case "create_ruleset":
+		result, err = p.executeCreateRuleset(ctx, client, apiBase, owner, repo, inputs)
+	case "enable_vulnerability_alerts":
+		result, err = p.executeEnableVulnerabilityAlerts(ctx, client, apiBase, owner, repo)
+	case "enable_automated_security_fixes":
+		result, err = p.executeEnableAutomatedSecurityFixes(ctx, client, apiBase, owner, repo)
+
 	default:
 		return nil, fmt.Errorf("%s: unknown operation %q — supported: %s", ProviderName, operation, strings.Join(allOperations, ", "))
 	}
 
 	if err != nil {
-		// For action operations, return success=false rather than a Go error
-		if !readOperations[operation] {
-			return &provider.Output{
-				Data: map[string]any{
-					"success":   false,
-					"operation": operation,
-					"error":     err.Error(),
-				},
-			}, nil
-		}
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)
 	}
 
@@ -615,6 +748,17 @@ func getIntInput(inputs map[string]any, key string) (int, bool) {
 	}
 }
 
+// restError is returned when the GitHub REST API responds with an HTTP error status.
+type restError struct {
+	StatusCode int
+	Message    string
+}
+
+// Error implements the error interface.
+func (e *restError) Error() string {
+	return fmt.Sprintf("GitHub API error (HTTP %d): %s", e.StatusCode, e.Message)
+}
+
 // doRESTRequest performs an authenticated REST API request and returns the parsed JSON.
 // Used for release mutations (no GraphQL mutation available).
 func (p *GitHubProvider) doRESTRequest(ctx context.Context, client *httpc.Client, method, url string, body any) (any, error) {
@@ -650,13 +794,14 @@ func (p *GitHubProvider) doRESTRequest(ctx context.Context, client *httpc.Client
 	}
 
 	if resp.StatusCode >= 400 {
+		msg := string(respBody)
 		var ghErr map[string]any
 		if json.Unmarshal(respBody, &ghErr) == nil {
-			if msg, ok := ghErr["message"].(string); ok {
-				return nil, fmt.Errorf("GitHub API error (HTTP %d): %s", resp.StatusCode, msg)
+			if m, ok := ghErr["message"].(string); ok {
+				msg = m
 			}
 		}
-		return nil, fmt.Errorf("GitHub API error (HTTP %d): %s", resp.StatusCode, string(respBody))
+		return nil, &restError{StatusCode: resp.StatusCode, Message: msg}
 	}
 
 	// DELETE with 204 No Content

--- a/pkg/provider/builtin/githubprovider/github_commits.go
+++ b/pkg/provider/builtin/githubprovider/github_commits.go
@@ -7,17 +7,24 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
-// ─── Create Commit (createCommitOnBranch) ────────────────────────────────────
+// ─── Create Commit ───────────────────────────────────────────────────────────
 
-// executeCreateCommit creates a signed commit on a branch using the GitHub GraphQL
-// createCommitOnBranch mutation. This produces GPG-signed commits automatically
-// (signed by GitHub on behalf of the authenticated user). Supports multi-file
-// atomic commits with additions and deletions.
+// executeCreateCommit creates a signed commit on a branch using the GitHub
+// GraphQL createCommitOnBranch mutation. This produces GPG-signed commits
+// automatically (signed by GitHub on behalf of the authenticated user).
+// Supports multi-file atomic commits with additions and deletions.
+//
+// On freshly created repositories, the user's push permissions may not be
+// fully propagated in the GraphQL layer yet (FORBIDDEN). The function retries
+// up to p.commitMaxAttempts times with backoff to handle this eventual
+// consistency window.
 func (p *GitHubProvider) executeCreateCommit(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branch := getStringInput(inputs, "branch")
 	if branch == "" {
@@ -32,59 +39,127 @@ func (p *GitHubProvider) executeCreateCommit(ctx context.Context, client *httpc.
 		return nil, fmt.Errorf("'expected_head_oid' is required for create_commit operation (use get_head_oid to fetch it)")
 	}
 
-	// Build fileChanges
-	fileChanges := map[string]any{}
-
-	// Process additions
-	if additionsRaw, ok := inputs["additions"].([]any); ok && len(additionsRaw) > 0 {
-		additions := make([]map[string]any, 0, len(additionsRaw))
-		for _, item := range additionsRaw {
-			if m, ok := item.(map[string]any); ok {
-				path, _ := m["path"].(string)
-				content, _ := m["content"].(string)
-				if path == "" || content == "" {
-					return nil, fmt.Errorf("each addition must have 'path' and 'content'")
-				}
-				// The mutation requires base64-encoded content
-				encoded := base64.StdEncoding.EncodeToString([]byte(content))
-				additions = append(additions, map[string]any{
-					"path":     path,
-					"contents": encoded,
-				})
-			}
-		}
-		if len(additions) > 0 {
-			fileChanges["additions"] = additions
-		}
+	additions, deletions, err := parseFileChanges(inputs)
+	if err != nil {
+		return nil, err
 	}
-
-	// Process deletions
-	if deletionsRaw, ok := inputs["deletions"].([]any); ok && len(deletionsRaw) > 0 {
-		deletions := make([]map[string]any, 0, len(deletionsRaw))
-		for _, item := range deletionsRaw {
-			if m, ok := item.(map[string]any); ok {
-				path, _ := m["path"].(string)
-				if path == "" {
-					return nil, fmt.Errorf("each deletion must have 'path'")
-				}
-				deletions = append(deletions, map[string]any{
-					"path": path,
-				})
-			}
-		}
-		if len(deletions) > 0 {
-			fileChanges["deletions"] = deletions
-		}
-	}
-
-	if len(fileChanges) == 0 {
+	if len(additions) == 0 && len(deletions) == 0 {
 		return nil, fmt.Errorf("create_commit requires at least one 'additions' or 'deletions' entry")
 	}
 
-	// Build the mutation input
-	messageInput := map[string]any{
-		"headline": message,
+	// Retry on FORBIDDEN — when a repo was just created, GraphQL write
+	// permissions may take a few seconds to propagate.
+	lgr := logger.FromContext(ctx)
+	var lastErr error
+	for attempt := range p.commitMaxAttempts {
+		if attempt > 0 {
+			delay := time.Duration(attempt) * p.commitRetryBackoff
+			lgr.V(1).Info("retrying createCommitOnBranch after FORBIDDEN",
+				"attempt", attempt+1,
+				"delay", delay,
+				"owner", owner,
+				"repo", repo,
+			)
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+
+		output, err := p.executeCreateCommitGraphQL(ctx, client, apiBase, owner, repo, branch, message, expectedHeadOID, additions, deletions, inputs)
+		if err == nil {
+			return output, nil
+		}
+		lastErr = err
+
+		// Only retry on FORBIDDEN (permission propagation)
+		if !isGraphQLForbidden(err) {
+			return nil, err
+		}
 	}
+	return nil, lastErr
+}
+
+// fileAddition holds a parsed addition entry.
+type fileAddition struct {
+	Path    string
+	Content string // raw (unencoded) content
+}
+
+// fileDeletion holds a parsed deletion entry.
+type fileDeletion struct {
+	Path string
+}
+
+// parseFileChanges extracts additions and deletions from inputs.
+func parseFileChanges(inputs map[string]any) ([]fileAddition, []fileDeletion, error) {
+	var additions []fileAddition
+	if additionsRaw, ok := inputs["additions"].([]any); ok {
+		for _, item := range additionsRaw {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("each addition entry must be an object, got %T", item)
+			}
+			path, _ := m["path"].(string)
+			content, _ := m["content"].(string)
+			if path == "" || content == "" {
+				return nil, nil, fmt.Errorf("each addition must have 'path' and 'content'")
+			}
+			additions = append(additions, fileAddition{Path: path, Content: content})
+		}
+	}
+
+	var deletions []fileDeletion
+	if deletionsRaw, ok := inputs["deletions"].([]any); ok {
+		for _, item := range deletionsRaw {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("each deletion entry must be an object, got %T", item)
+			}
+			path, _ := m["path"].(string)
+			if path == "" {
+				return nil, nil, fmt.Errorf("each deletion must have 'path'")
+			}
+			deletions = append(deletions, fileDeletion{Path: path})
+		}
+	}
+
+	return additions, deletions, nil
+}
+
+// ─── GraphQL path ────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateCommitGraphQL(
+	ctx context.Context, client *httpc.Client, apiBase, owner, repo, branch, message, expectedHeadOID string,
+	additions []fileAddition, deletions []fileDeletion, inputs map[string]any,
+) (*provider.Output, error) {
+	fileChanges := map[string]any{}
+
+	if len(additions) > 0 {
+		gqlAdditions := make([]map[string]any, 0, len(additions))
+		for _, a := range additions {
+			gqlAdditions = append(gqlAdditions, map[string]any{
+				"path":     a.Path,
+				"contents": base64.StdEncoding.EncodeToString([]byte(a.Content)),
+			})
+		}
+		fileChanges["additions"] = gqlAdditions
+	}
+
+	if len(deletions) > 0 {
+		gqlDeletions := make([]map[string]any, 0, len(deletions))
+		for _, d := range deletions {
+			gqlDeletions = append(gqlDeletions, map[string]any{
+				"path": d.Path,
+			})
+		}
+		fileChanges["deletions"] = gqlDeletions
+	}
+
+	messageInput := map[string]any{"headline": message}
 	if messageBody := getStringInput(inputs, "message_body"); messageBody != "" {
 		messageInput["body"] = messageBody
 	}
@@ -106,8 +181,8 @@ func (p *GitHubProvider) executeCreateCommit(ctx context.Context, client *httpc.
       url
       committedDate
       message
-      additions(first: 0) { totalCount }
-      deletions(first: 0) { totalCount }
+      additions
+      deletions
       signature {
         isValid
         signer { login }

--- a/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
+++ b/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
@@ -1,0 +1,493 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// Repository management operations use the GraphQL API where mutations are
+// available (create_repo) and the REST API for repository rulesets and
+// security features (no GraphQL mutations).
+
+// ─── Create Repository (GraphQL) ─────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateRepo(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any) (*provider.Output, error) {
+	name := getStringInput(inputs, "repo")
+	if name == "" {
+		return nil, fmt.Errorf("'repo' is required for create_repo operation")
+	}
+
+	owner := getStringInput(inputs, "owner")
+	autoInit, _ := getBoolInput(inputs, "auto_init")
+
+	// Try GraphQL first (lower permission requirement for most accounts).
+	// Enterprise Managed Users (EMU) cannot use GraphQL mutations, so fall
+	// back to REST if we get a FORBIDDEN error.
+	output, err := p.executeCreateRepoGraphQL(ctx, client, apiBase, inputs, name)
+	if err != nil && isGraphQLForbidden(err) {
+		output, err = p.executeCreateRepoREST(ctx, client, apiBase, inputs, name, autoInit)
+		if err != nil {
+			return nil, err
+		}
+		// Derive the canonical owner from the REST response — /user/repos
+		// creates the repo under the authenticated user, which may differ
+		// from the caller-provided owner.
+		restOwner := extractRESTOwner(output)
+		if restOwner == "" {
+			restOwner = owner
+		}
+		// Wait for GraphQL write access before returning — downstream
+		// operations (create_commit) need it.
+		if waitErr := p.waitForWriteAccess(ctx, client, apiBase, restOwner, name); waitErr != nil {
+			return nil, waitErr
+		}
+		return output, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the resolved nameWithOwner from the GraphQL response — this
+	// is the canonical "owner/repo" regardless of what the caller passed.
+	nwo := extractNameWithOwner(output)
+	if nwo == "" {
+		return nil, fmt.Errorf("GraphQL createRepository response missing nameWithOwner")
+	}
+	resolvedOwner, _, _ := strings.Cut(nwo, "/")
+
+	// GraphQL createRepository doesn't support auto_init, so create an
+	// initial README via the Contents API to establish the default branch.
+	if autoInit {
+		if initErr := p.initRepoWithReadme(ctx, client, apiBase, nwo); initErr != nil {
+			return nil, fmt.Errorf("initializing repository with README: %w", initErr)
+		}
+	}
+
+	// Wait for GraphQL write access before returning — downstream
+	// operations (create_commit) need it.
+	if waitErr := p.waitForWriteAccess(ctx, client, apiBase, resolvedOwner, name); waitErr != nil {
+		return nil, waitErr
+	}
+
+	return output, nil
+}
+
+// extractRESTOwner extracts the repository owner from a REST API create_repo
+// response by parsing the "full_name" field ("owner/repo").
+func extractRESTOwner(output *provider.Output) string {
+	if output == nil {
+		return ""
+	}
+	dataMap, ok := output.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	resultData, ok := dataMap["result"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	fullName, _ := resultData["full_name"].(string)
+	if owner, _, ok := strings.Cut(fullName, "/"); ok {
+		return owner
+	}
+	return ""
+}
+
+// extractNameWithOwner extracts the "owner/repo" string from a create_repo output.
+func extractNameWithOwner(output *provider.Output) string {
+	if output == nil {
+		return ""
+	}
+	dataMap, ok := output.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	resultData, ok := dataMap["result"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := resultData["nameWithOwner"].(string)
+	return v
+}
+
+// isGraphQLForbidden checks whether an error is a GraphQL FORBIDDEN error
+// (e.g., Enterprise Managed User restrictions).
+func isGraphQLForbidden(err error) bool {
+	var gqlErr *GraphQLError
+	if errors.As(err, &gqlErr) {
+		for _, e := range gqlErr.Errors {
+			if e.Type == "FORBIDDEN" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// waitForWriteAccess polls the repository's viewerPermission via GraphQL until
+// the authenticated user has WRITE, MAINTAIN, or ADMIN access. This handles the
+// eventual consistency window after repo creation (especially for EMU/org repos)
+// where GraphQL read access propagates before write access.
+func (p *GitHubProvider) waitForWriteAccess(ctx context.Context, client *httpc.Client, apiBase, owner, repo string) error {
+	lgr := logger.FromContext(ctx)
+
+	query := `query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    viewerPermission
+  }
+}`
+	vars := map[string]any{"owner": owner, "name": repo}
+
+	for attempt := range p.waitMaxAttempts {
+		if attempt > 0 {
+			timer := time.NewTimer(p.waitPollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+
+		data, err := graphqlDo(ctx, client, apiBase, query, vars)
+		if err != nil {
+			lgr.V(1).Info("waitForWriteAccess: GraphQL query failed", "attempt", attempt+1, "error", err)
+			continue
+		}
+
+		permNode, _ := extractNode(data, "repository.viewerPermission")
+		perm, _ := permNode.(string)
+		lgr.V(1).Info("waitForWriteAccess: checked permission", "attempt", attempt+1, "viewerPermission", perm)
+		if perm == "ADMIN" || perm == "WRITE" || perm == "MAINTAIN" {
+			return nil
+		}
+	}
+	return fmt.Errorf("timed out waiting for write access to %s/%s via GraphQL after %d attempts", owner, repo, p.waitMaxAttempts)
+}
+
+// executeCreateRepoGraphQL creates a repository using the GraphQL createRepository mutation.
+func (p *GitHubProvider) executeCreateRepoGraphQL(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any, name string) (*provider.Output, error) {
+	mutInput := map[string]any{
+		"name":       name,
+		"visibility": "PUBLIC",
+	}
+
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		mutInput["description"] = desc
+	}
+
+	if strings.EqualFold(getStringInput(inputs, "visibility"), "private") {
+		mutInput["visibility"] = "PRIVATE"
+	}
+
+	// If owner is specified, resolve its node ID and set ownerId on the mutation input.
+	// The repositoryOwner GraphQL field resolves both users and organizations.
+	owner := getStringInput(inputs, "owner")
+	if owner != "" {
+		orgID, err := p.resolveOwnerID(ctx, client, apiBase, owner)
+		if err != nil {
+			return nil, fmt.Errorf("resolving owner ID for %q: %w", owner, err)
+		}
+		mutInput["ownerId"] = orgID
+	}
+
+	mutation := `mutation($input: CreateRepositoryInput!) {
+  createRepository(input: $input) {
+    repository {
+      id
+      name
+      nameWithOwner
+      url
+      isPrivate
+      defaultBranchRef { name }
+      createdAt
+    }
+  }
+}`
+
+	data, err := graphqlDo(ctx, client, apiBase, mutation, map[string]any{"input": mutInput})
+	if err != nil {
+		return nil, err
+	}
+
+	repoNode, err := extractNodeMap(data, "createRepository.repository")
+	if err != nil {
+		return nil, err
+	}
+
+	return actionOutput("create_repo", repoNode), nil
+}
+
+// initRepoWithReadme creates an initial README.md via the Contents API to
+// establish the default branch on an empty repository. This only requires
+// `repo` scope, unlike POST /orgs/{org}/repos which requires org admin.
+// nameWithOwner is the full "owner/repo" path (e.g. "oakwood-commons/my-repo").
+func (p *GitHubProvider) initRepoWithReadme(ctx context.Context, client *httpc.Client, apiBase, nameWithOwner string) error {
+	repoName := nameWithOwner
+	if idx := strings.LastIndex(nameWithOwner, "/"); idx >= 0 {
+		repoName = nameWithOwner[idx+1:]
+	}
+
+	content := base64.StdEncoding.EncodeToString([]byte("# " + repoName + "\n"))
+	url := fmt.Sprintf("%s/repos/%s/contents/%s", apiBase, nameWithOwner, "README.md")
+	reqBody := map[string]any{
+		"message": "Initial commit",
+		"content": content,
+	}
+
+	// The repository was just created — the REST API may not see it
+	// immediately due to eventual consistency. Retry on 404 only.
+	var lastErr error
+	for attempt := range p.initRepoMaxRetries {
+		if attempt > 0 {
+			timer := time.NewTimer(time.Duration(attempt) * p.initRepoRetryBackoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		_, lastErr = p.doRESTRequest(ctx, client, http.MethodPut, url, reqBody)
+		if lastErr == nil {
+			return nil
+		}
+		// Only retry on 404 (eventual consistency); fail immediately on other errors
+		var restErr *restError
+		if !errors.As(lastErr, &restErr) || restErr.StatusCode != http.StatusNotFound {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+// executeCreateRepoREST creates a repository using the REST API.
+// Used as fallback when GraphQL is forbidden (e.g., Enterprise Managed Users).
+// Tries the org endpoint first; falls back to POST /user/repos on 404 (when
+// the owner is a user account, not an organization).
+func (p *GitHubProvider) executeCreateRepoREST(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any, name string, autoInit bool) (*provider.Output, error) {
+	owner := getStringInput(inputs, "owner")
+	if owner == "" {
+		return nil, fmt.Errorf("'owner' is required for REST repo creation (GraphQL createRepository was forbidden)")
+	}
+
+	reqBody := map[string]any{
+		"name":      name,
+		"auto_init": autoInit,
+	}
+
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		reqBody["description"] = desc
+	}
+
+	reqBody["private"] = strings.EqualFold(getStringInput(inputs, "visibility"), "private")
+
+	// Try org endpoint first.
+	orgURL := fmt.Sprintf("%s/orgs/%s/repos", apiBase, owner)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, orgURL, reqBody)
+	if err != nil {
+		// If 404, the owner is a user account — fall back to /user/repos.
+		var restErr *restError
+		if errors.As(err, &restErr) && restErr.StatusCode == http.StatusNotFound {
+			userURL := fmt.Sprintf("%s/user/repos", apiBase)
+			result, err = p.doRESTRequest(ctx, client, http.MethodPost, userURL, reqBody)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	return actionOutput("create_repo", result), nil
+}
+
+// resolveOwnerID fetches the GraphQL node ID for a user or organization by login.
+func (p *GitHubProvider) resolveOwnerID(ctx context.Context, client *httpc.Client, apiBase, login string) (string, error) {
+	query := `query($login: String!) {
+  repositoryOwner(login: $login) { id }
+}`
+	data, err := graphqlDo(ctx, client, apiBase, query, map[string]any{"login": login})
+	if err != nil {
+		return "", err
+	}
+	ownerNode, err := extractNodeMap(data, "repositoryOwner")
+	if err != nil {
+		return "", fmt.Errorf("owner %q not found: %w", login, err)
+	}
+	id, ok := ownerNode["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("owner ID not found for %q", login)
+	}
+	return id, nil
+}
+
+// ─── Create Ruleset (REST) ───────────────────────────────────────────────────
+//
+// Repository rulesets replace legacy branch protection rules and tag protection.
+// They support branch and tag targets with flexible rule composition.
+// The REST API is used because the GraphQL mutations for rulesets have complex
+// nested union input types that don't map cleanly to a flat input schema.
+
+func (p *GitHubProvider) executeCreateRuleset(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	rulesetName := getStringInput(inputs, "ruleset_name")
+	if rulesetName == "" {
+		return nil, fmt.Errorf("'ruleset_name' is required for create_ruleset operation")
+	}
+
+	target := getStringInput(inputs, "target")
+	if target == "" {
+		target = "branch"
+	}
+
+	enforcement := getStringInput(inputs, "enforcement")
+	if enforcement == "" {
+		enforcement = "active"
+	}
+
+	// Build conditions from include/exclude ref patterns
+	includeRefs := getStringSliceInput(inputs, "include_refs")
+	excludeRefs := getStringSliceInput(inputs, "exclude_refs")
+	if len(includeRefs) == 0 {
+		return nil, fmt.Errorf("'include_refs' is required for create_ruleset operation (e.g. [\"refs/heads/main\"])")
+	}
+
+	// Ensure exclude is never null (API requires an array)
+	if excludeRefs == nil {
+		excludeRefs = []string{}
+	}
+
+	conditions := map[string]any{
+		"ref_name": map[string]any{
+			"include": includeRefs,
+			"exclude": excludeRefs,
+		},
+	}
+
+	// Build rules from individual boolean/parameter fields
+	rules := buildRulesetRules(inputs)
+
+	reqBody := map[string]any{
+		"name":        rulesetName,
+		"target":      target,
+		"enforcement": enforcement,
+		"conditions":  conditions,
+		"rules":       rules,
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/%s/rulesets", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return actionOutput("create_ruleset", result), nil
+}
+
+// buildRulesetRules converts flat input fields into the GitHub Rulesets rules array.
+func buildRulesetRules(inputs map[string]any) []map[string]any {
+	rules := make([]map[string]any, 0)
+
+	// Required status checks
+	if contexts := getStringSliceInput(inputs, "required_status_checks_contexts"); len(contexts) > 0 {
+		checks := make([]map[string]any, 0, len(contexts))
+		for _, name := range contexts {
+			checks = append(checks, map[string]any{"context": name})
+		}
+		rules = append(rules, map[string]any{
+			"type": "required_status_checks",
+			"parameters": map[string]any{
+				"required_status_checks":               checks,
+				"strict_required_status_checks_policy": true,
+			},
+		})
+	}
+
+	// Pull request reviews
+	if approvals, ok := getIntInput(inputs, "required_approving_review_count"); ok && approvals > 0 {
+		rules = append(rules, map[string]any{
+			"type": "pull_request",
+			"parameters": map[string]any{
+				"required_approving_review_count":   approvals,
+				"dismiss_stale_reviews_on_push":     true,
+				"require_code_owner_review":         false,
+				"require_last_push_approval":        false,
+				"required_review_thread_resolution": true,
+			},
+		})
+	}
+
+	// Required signatures
+	if v, ok := getBoolInput(inputs, "requires_commit_signatures"); ok && v {
+		rules = append(rules, map[string]any{
+			"type": "required_signatures",
+		})
+	}
+
+	// Required linear history
+	if v, ok := getBoolInput(inputs, "required_linear_history"); ok && v {
+		rules = append(rules, map[string]any{
+			"type": "required_linear_history",
+		})
+	}
+
+	// Prevent force pushes (non_fast_forward)
+	if v, ok := getBoolInput(inputs, "allow_force_pushes"); ok && !v {
+		rules = append(rules, map[string]any{
+			"type": "non_fast_forward",
+		})
+	}
+
+	// Prevent deletion
+	if v, ok := getBoolInput(inputs, "allow_deletions"); ok && !v {
+		rules = append(rules, map[string]any{
+			"type": "deletion",
+		})
+	}
+
+	return rules
+}
+
+// ─── Enable Vulnerability Alerts (REST) ──────────────────────────────────────
+//
+// Vulnerability alerts have no GraphQL mutation — REST only.
+
+func (p *GitHubProvider) executeEnableVulnerabilityAlerts(ctx context.Context, client *httpc.Client, apiBase, owner, repo string) (*provider.Output, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/vulnerability-alerts", apiBase, owner, repo)
+	_, err := p.doRESTRequest(ctx, client, http.MethodPut, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return actionOutput("enable_vulnerability_alerts", map[string]any{
+		"enabled": true,
+	}), nil
+}
+
+// ─── Enable Automated Security Fixes (REST) ──────────────────────────────────
+//
+// Automated security fixes have no GraphQL mutation — REST only.
+
+func (p *GitHubProvider) executeEnableAutomatedSecurityFixes(ctx context.Context, client *httpc.Client, apiBase, owner, repo string) (*provider.Output, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/automated-security-fixes", apiBase, owner, repo)
+	_, err := p.doRESTRequest(ctx, client, http.MethodPut, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return actionOutput("enable_automated_security_fixes", map[string]any{
+		"enabled": true,
+	}), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_repo_mgmt_test.go
+++ b/pkg/provider/builtin/githubprovider/github_repo_mgmt_test.go
@@ -1,0 +1,1208 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// viewerPermissionResponse returns a mock GraphQL response for the waitForWriteAccess query.
+func viewerPermissionResponse() map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"viewerPermission": "ADMIN",
+			},
+		},
+	}
+}
+
+// ─── Create Repository Tests ─────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateRepo(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle viewerPermission query (waitForWriteAccess)
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+			return
+		}
+
+		if n == 1 {
+			// resolveOwnerID
+			assert.Contains(t, req.Query, "repositoryOwner")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repositoryOwner": map[string]any{"id": "O_test123"},
+				},
+			})
+			return
+		}
+		// createRepository
+		assert.Contains(t, req.Query, "createRepository")
+		input := req.Variables["input"].(map[string]any)
+		assert.Equal(t, "my-new-repo", input["name"])
+		assert.Equal(t, "PRIVATE", input["visibility"])
+		assert.Equal(t, "A test repo", input["description"])
+		assert.Equal(t, "O_test123", input["ownerId"])
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"createRepository": map[string]any{
+					"repository": map[string]any{
+						"id":            "R_123",
+						"name":          "my-new-repo",
+						"nameWithOwner": "test-org/my-new-repo",
+						"url":           "https://github.com/test-org/my-new-repo",
+						"isPrivate":     true,
+						"createdAt":     "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":   "create_repo",
+		"owner":       "test-org",
+		"repo":        "my-new-repo",
+		"description": "A test repo",
+		"visibility":  "private",
+		"api_base":    baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "my-new-repo", result["name"])
+	assert.Equal(t, true, result["isPrivate"])
+}
+
+func TestGitHubProvider_Execute_CreateRepo_DefaultVisibility(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, graphqlHandler(t,
+		func(_ string, vars map[string]any) {
+			input := vars["input"].(map[string]any)
+			assert.Equal(t, "PUBLIC", input["visibility"])
+		},
+		map[string]any{
+			"data": map[string]any{
+				"createRepository": map[string]any{
+					"repository": map[string]any{
+						"id":            "R_456",
+						"name":          "public-repo",
+						"nameWithOwner": "testuser/public-repo",
+					},
+				},
+			},
+		},
+	))
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"repo":      "public-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_CreateRepo_MissingRepo(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "test-org",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'repo' is required")
+}
+
+func TestGitHubProvider_Execute_CreateRepo_MissingNameWithOwner(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle viewerPermission query (waitForWriteAccess)
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+			return
+		}
+
+		if strings.Contains(req.Query, "repositoryOwner") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repositoryOwner": map[string]any{"id": "O_test123"},
+				},
+			})
+			return
+		}
+
+		// createRepository — deliberately omit nameWithOwner
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"createRepository": map[string]any{
+					"repository": map[string]any{
+						"id":   "R_999",
+						"name": "no-nwo-repo",
+					},
+				},
+			},
+		})
+	})
+
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "test-org",
+		"repo":      "no-nwo-repo",
+		"api_base":  baseURL,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing nameWithOwner")
+}
+
+func TestExtractNameWithOwner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		output   *provider.Output
+		expected string
+	}{
+		{
+			name:     "nil output",
+			output:   nil,
+			expected: "",
+		},
+		{
+			name: "valid output",
+			output: &provider.Output{
+				Data: map[string]any{
+					"result": map[string]any{
+						"nameWithOwner": "my-org/my-repo",
+					},
+				},
+			},
+			expected: "my-org/my-repo",
+		},
+		{
+			name: "missing nameWithOwner",
+			output: &provider.Output{
+				Data: map[string]any{
+					"result": map[string]any{
+						"name": "my-repo",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "missing result",
+			output: &provider.Output{
+				Data: map[string]any{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, extractNameWithOwner(tc.output))
+		})
+	}
+}
+
+func TestExtractRESTOwner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		output   *provider.Output
+		expected string
+	}{
+		{
+			name:     "nil output",
+			output:   nil,
+			expected: "",
+		},
+		{
+			name: "valid full_name",
+			output: &provider.Output{
+				Data: map[string]any{
+					"result": map[string]any{
+						"full_name": "actual-user/my-repo",
+					},
+				},
+			},
+			expected: "actual-user",
+		},
+		{
+			name: "missing full_name",
+			output: &provider.Output{
+				Data: map[string]any{
+					"result": map[string]any{
+						"name": "my-repo",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "missing result",
+			output: &provider.Output{
+				Data: map[string]any{},
+			},
+			expected: "",
+		},
+		{
+			name: "full_name without slash",
+			output: &provider.Output{
+				Data: map[string]any{
+					"result": map[string]any{
+						"full_name": "noslash",
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, extractRESTOwner(tc.output))
+		})
+	}
+}
+
+func TestGitHubProvider_Execute_CreateRepo_WithOwner(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle viewerPermission query (waitForWriteAccess)
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+			return
+		}
+
+		if n == 1 {
+			// First call: resolveOwnerID
+			assert.Contains(t, req.Query, "repositoryOwner")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repositoryOwner": map[string]any{
+						"id": "O_org123",
+					},
+				},
+			})
+			return
+		}
+		// Second call: createRepository
+		assert.Contains(t, req.Query, "createRepository")
+		input := req.Variables["input"].(map[string]any)
+		assert.Equal(t, "O_org123", input["ownerId"])
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"createRepository": map[string]any{
+					"repository": map[string]any{
+						"id":            "R_789",
+						"name":          "org-repo",
+						"nameWithOwner": "my-org/org-repo",
+					},
+				},
+			},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "my-org",
+		"repo":      "org-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "org-repo", result["name"])
+}
+
+func TestGitHubProvider_Execute_CreateRepo_GraphQLForbidden_FallsBackToREST(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle GraphQL requests
+		if r.URL.Path == "/graphql" {
+			body, _ := io.ReadAll(r.Body)
+			var req graphqlRequest
+			json.Unmarshal(body, &req) //nolint:errcheck
+
+			// Handle viewerPermission query (waitForWriteAccess)
+			if strings.Contains(req.Query, "viewerPermission") {
+				json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+				return
+			}
+
+			// GraphQL createRepository returns FORBIDDEN (EMU user)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"errors": []any{
+					map[string]any{
+						"message": "As an Enterprise Managed User, you cannot access this content",
+						"type":    "FORBIDDEN",
+					},
+				},
+			})
+			return
+		}
+
+		// REST fallback: POST /orgs/{org}/repos
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/orgs/emu-org/repos", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody) //nolint:errcheck
+		assert.Equal(t, "emu-repo", reqBody["name"])
+		assert.Equal(t, true, reqBody["auto_init"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"id":        float64(200),
+			"name":      "emu-repo",
+			"full_name": "emu-org/emu-repo",
+			"private":   false,
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "emu-org",
+		"repo":      "emu-repo",
+		"auto_init": true,
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "emu-repo", result["name"])
+	assert.Equal(t, int32(3), callCount.Load()) // GraphQL FORBIDDEN + REST create + viewerPermission
+}
+
+func TestGitHubProvider_Execute_CreateRepo_AutoInit_UserRepo(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle GraphQL requests
+		if r.URL.Path == "/graphql" {
+			body, _ := io.ReadAll(r.Body)
+			var req graphqlRequest
+			json.Unmarshal(body, &req) //nolint:errcheck
+
+			// Handle viewerPermission query (waitForWriteAccess)
+			if strings.Contains(req.Query, "viewerPermission") {
+				json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+				return
+			}
+
+			// GraphQL createRepository
+			assert.Contains(t, req.Query, "createRepository")
+			input := req.Variables["input"].(map[string]any)
+			assert.Equal(t, "auto-init-repo", input["name"])
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"createRepository": map[string]any{
+						"repository": map[string]any{
+							"id":            "R_100",
+							"name":          "auto-init-repo",
+							"nameWithOwner": "testuser/auto-init-repo",
+						},
+					},
+				},
+			})
+			return
+		}
+		// REST Contents API to create README.md
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/testuser/auto-init-repo/contents/README.md", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"content": map[string]any{"name": "README.md"}}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":   "create_repo",
+		"repo":        "auto-init-repo",
+		"description": "An auto-init repo",
+		"auto_init":   true,
+		"api_base":    baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "auto-init-repo", result["name"])
+	assert.Equal(t, int32(3), callCount.Load()) // createRepo + viewerPermission + README
+}
+
+func TestGitHubProvider_Execute_CreateRepo_AutoInit_OrgRepo(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle GraphQL requests
+		if r.URL.Path == "/graphql" {
+			body, _ := io.ReadAll(r.Body)
+			var req graphqlRequest
+			json.Unmarshal(body, &req) //nolint:errcheck
+
+			// Handle viewerPermission query (waitForWriteAccess)
+			if strings.Contains(req.Query, "viewerPermission") {
+				json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+				return
+			}
+
+			if strings.Contains(req.Query, "repositoryOwner") {
+				// resolveOwnerID
+				json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+					"data": map[string]any{
+						"repositoryOwner": map[string]any{"id": "O_org456"},
+					},
+				})
+				return
+			}
+
+			// GraphQL createRepository
+			assert.Contains(t, req.Query, "createRepository")
+			input := req.Variables["input"].(map[string]any)
+			assert.Equal(t, "org-auto-repo", input["name"])
+			assert.Equal(t, "O_org456", input["ownerId"])
+			assert.Equal(t, "PRIVATE", input["visibility"])
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"createRepository": map[string]any{
+						"repository": map[string]any{
+							"id":            "R_101",
+							"name":          "org-auto-repo",
+							"nameWithOwner": "my-org/org-auto-repo",
+						},
+					},
+				},
+			})
+			return
+		}
+		// REST Contents API to create README.md
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/my-org/org-auto-repo/contents/README.md", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"content": map[string]any{"name": "README.md"}}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "create_repo",
+		"owner":      "my-org",
+		"repo":       "org-auto-repo",
+		"visibility": "private",
+		"auto_init":  true,
+		"api_base":   baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "org-auto-repo", result["name"])
+	assert.Equal(t, int32(4), callCount.Load()) // resolveOwnerID + createRepo + viewerPermission + README
+}
+
+// ─── Wait for Write Access Tests ─────────────────────────────────────────────
+
+func TestGitHubProvider_WaitForWriteAccess_ImmediateAdmin(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+	})
+
+	client := p.getClient(context.Background())
+	err := p.waitForWriteAccess(context.Background(), client, baseURL, "test-org", "test-repo")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), callCount.Load())
+}
+
+func TestGitHubProvider_WaitForWriteAccess_EventualWrite(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			// First two calls: READ only
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "READ"},
+				},
+			})
+			return
+		}
+		// Third call: WRITE
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"repository": map[string]any{"viewerPermission": "WRITE"},
+			},
+		})
+	})
+
+	client := p.getClient(context.Background())
+	err := p.waitForWriteAccess(context.Background(), client, baseURL, "test-org", "test-repo")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), callCount.Load())
+}
+
+func TestGitHubProvider_WaitForWriteAccess_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"repository": map[string]any{"viewerPermission": "READ"},
+			},
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	client := p.getClient(ctx)
+	err := p.waitForWriteAccess(ctx, client, baseURL, "test-org", "test-repo")
+	require.Error(t, err)
+}
+
+// ─── Create Ruleset Tests ────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateRuleset_BranchProtection(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/rulesets", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody) //nolint:errcheck
+
+		assert.Equal(t, "main branch protection", reqBody["name"])
+		assert.Equal(t, "branch", reqBody["target"])
+		assert.Equal(t, "active", reqBody["enforcement"])
+
+		conditions := reqBody["conditions"].(map[string]any)
+		refName := conditions["ref_name"].(map[string]any)
+		includes := refName["include"].([]any)
+		assert.Contains(t, includes, "refs/heads/main")
+
+		rules := reqBody["rules"].([]any)
+		assert.GreaterOrEqual(t, len(rules), 3)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"id":          float64(1),
+			"name":        "main branch protection",
+			"target":      "branch",
+			"enforcement": "active",
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":                       "create_ruleset",
+		"owner":                           "test-org",
+		"repo":                            "test-repo",
+		"ruleset_name":                    "main branch protection",
+		"target":                          "branch",
+		"enforcement":                     "active",
+		"include_refs":                    []any{"refs/heads/main"},
+		"required_status_checks_contexts": []any{"test", "lint"},
+		"required_approving_review_count": float64(1),
+		"required_linear_history":         true,
+		"requires_commit_signatures":      true,
+		"allow_force_pushes":              false,
+		"allow_deletions":                 false,
+		"api_base":                        baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "main branch protection", result["name"])
+}
+
+func TestGitHubProvider_Execute_CreateRuleset_TagProtection(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/rulesets", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody) //nolint:errcheck
+
+		assert.Equal(t, "tag", reqBody["target"])
+		conditions := reqBody["conditions"].(map[string]any)
+		refName := conditions["ref_name"].(map[string]any)
+		includes := refName["include"].([]any)
+		assert.Contains(t, includes, "refs/tags/v*")
+
+		rules := reqBody["rules"].([]any)
+		ruleTypes := make([]string, 0, len(rules))
+		for _, r := range rules {
+			rm := r.(map[string]any)
+			ruleTypes = append(ruleTypes, rm["type"].(string))
+		}
+		assert.Contains(t, ruleTypes, "deletion")
+		assert.Contains(t, ruleTypes, "non_fast_forward")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"id":          float64(2),
+			"name":        "version tag protection",
+			"target":      "tag",
+			"enforcement": "active",
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":          "create_ruleset",
+		"owner":              "test-org",
+		"repo":               "test-repo",
+		"ruleset_name":       "version tag protection",
+		"target":             "tag",
+		"include_refs":       []any{"refs/tags/v*"},
+		"allow_force_pushes": false,
+		"allow_deletions":    false,
+		"api_base":           baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "tag", result["target"])
+}
+
+func TestGitHubProvider_Execute_CreateRuleset_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation":    "create_ruleset",
+		"owner":        "test-org",
+		"repo":         "test-repo",
+		"include_refs": []any{"refs/heads/main"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'ruleset_name' is required")
+}
+
+func TestGitHubProvider_Execute_CreateRuleset_MissingIncludeRefs(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation":    "create_ruleset",
+		"owner":        "test-org",
+		"repo":         "test-repo",
+		"ruleset_name": "test",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'include_refs' is required")
+}
+
+func TestBuildRulesetRules_AllRules(t *testing.T) {
+	t.Parallel()
+
+	inputs := map[string]any{
+		"required_status_checks_contexts": []any{"test", "lint"},
+		"required_approving_review_count": float64(2),
+		"requires_commit_signatures":      true,
+		"required_linear_history":         true,
+		"allow_force_pushes":              false,
+		"allow_deletions":                 false,
+	}
+
+	rules := buildRulesetRules(inputs)
+	assert.Len(t, rules, 6)
+
+	ruleTypes := make([]string, 0, len(rules))
+	for _, r := range rules {
+		ruleTypes = append(ruleTypes, r["type"].(string))
+	}
+	assert.Contains(t, ruleTypes, "required_status_checks")
+	assert.Contains(t, ruleTypes, "pull_request")
+	assert.Contains(t, ruleTypes, "required_signatures")
+	assert.Contains(t, ruleTypes, "required_linear_history")
+	assert.Contains(t, ruleTypes, "non_fast_forward")
+	assert.Contains(t, ruleTypes, "deletion")
+}
+
+func TestBuildRulesetRules_Empty(t *testing.T) {
+	t.Parallel()
+
+	rules := buildRulesetRules(map[string]any{})
+	assert.Empty(t, rules)
+}
+
+func TestBuildRulesetRules_AllowForcePush_True(t *testing.T) {
+	t.Parallel()
+
+	// When allow_force_pushes is true, non_fast_forward rule should NOT be added
+	rules := buildRulesetRules(map[string]any{
+		"allow_force_pushes": true,
+	})
+	for _, r := range rules {
+		assert.NotEqual(t, "non_fast_forward", r["type"])
+	}
+}
+
+// ─── Enable Vulnerability Alerts Tests ───────────────────────────────────────
+
+func TestGitHubProvider_Execute_EnableVulnerabilityAlerts(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/vulnerability-alerts", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "enable_vulnerability_alerts",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, true, result["enabled"])
+}
+
+// ─── Enable Automated Security Fixes Tests ───────────────────────────────────
+
+func TestGitHubProvider_Execute_EnableAutomatedSecurityFixes(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/automated-security-fixes", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "enable_automated_security_fixes",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, true, result["enabled"])
+}
+
+// ─── REST User Fallback Tests ────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateRepo_RESTFallback_UserRepo(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle GraphQL requests
+		if r.URL.Path == "/graphql" {
+			body, _ := io.ReadAll(r.Body)
+			var req graphqlRequest
+			json.Unmarshal(body, &req) //nolint:errcheck
+
+			// Handle viewerPermission query (waitForWriteAccess)
+			if strings.Contains(req.Query, "viewerPermission") {
+				json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+				return
+			}
+
+			// GraphQL createRepository returns FORBIDDEN (EMU)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"errors": []any{
+					map[string]any{
+						"message": "forbidden",
+						"type":    "FORBIDDEN",
+					},
+				},
+			})
+			return
+		}
+
+		// REST: org endpoint returns 404 (owner is a user, not an org)
+		if r.URL.Path == "/orgs/my-user/repos" {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"}) //nolint:errcheck
+			return
+		}
+
+		// REST: user endpoint succeeds
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/user/repos", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"id":        float64(300),
+			"name":      "user-repo",
+			"full_name": "my-user/user-repo",
+			"private":   false,
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "my-user",
+		"repo":      "user-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	result := data["result"].(map[string]any)
+	assert.Equal(t, "user-repo", result["name"])
+}
+
+func TestGitHubProvider_Execute_CreateRepo_RESTFallback_OwnerDerivedFromResponse(t *testing.T) {
+	t.Parallel()
+
+	// Verifies that waitForWriteAccess uses the canonical owner from the
+	// REST response (full_name), not the caller-provided owner.
+	var mu sync.Mutex
+	var permOwner string
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/graphql" {
+			body, _ := io.ReadAll(r.Body)
+			var req graphqlRequest
+			json.Unmarshal(body, &req) //nolint:errcheck
+
+			if strings.Contains(req.Query, "viewerPermission") {
+				// Capture the owner used in the permission check
+				mu.Lock()
+				permOwner, _ = req.Variables["owner"].(string)
+				mu.Unlock()
+				json.NewEncoder(w).Encode(viewerPermissionResponse()) //nolint:errcheck
+				return
+			}
+
+			// GraphQL createRepository returns FORBIDDEN (EMU)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"errors": []any{
+					map[string]any{"message": "forbidden", "type": "FORBIDDEN"},
+				},
+			})
+			return
+		}
+
+		// REST: org endpoint returns 404
+		if r.URL.Path == "/orgs/wrong-owner/repos" {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"}) //nolint:errcheck
+			return
+		}
+
+		// REST: user endpoint succeeds — actual owner is "actual-user"
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"id":        float64(400),
+			"name":      "my-repo",
+			"full_name": "actual-user/my-repo",
+			"private":   false,
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_repo",
+		"owner":     "wrong-owner",
+		"repo":      "my-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	// waitForWriteAccess should have polled "actual-user", not "wrong-owner"
+	mu.Lock()
+	assert.Equal(t, "actual-user", permOwner)
+	mu.Unlock()
+}
+
+// ─── Dry Run Tests ───────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateRepo_DryRun(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "create_repo",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_CreateRuleset_DryRun(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation":    "create_ruleset",
+		"owner":        "test-org",
+		"repo":         "test-repo",
+		"ruleset_name": "test",
+		"include_refs": []any{"refs/heads/main"},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Init Repo With README Tests ─────────────────────────────────────────────
+
+func TestGitHubProvider_InitRepoWithReadme_Success(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/my-org/my-repo/contents/README.md", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"content": map[string]any{"name": "README.md"}}) //nolint:errcheck
+	})
+
+	client := p.getClient(context.Background())
+	err := p.initRepoWithReadme(context.Background(), client, baseURL, "my-org/my-repo")
+	require.NoError(t, err)
+}
+
+func TestGitHubProvider_InitRepoWithReadme_RetryOn404(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"}) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"content": map[string]any{"name": "README.md"}}) //nolint:errcheck
+	})
+
+	client := p.getClient(context.Background())
+	err := p.initRepoWithReadme(context.Background(), client, baseURL, "my-org/my-repo")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), callCount.Load())
+}
+
+func TestGitHubProvider_InitRepoWithReadme_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"}) //nolint:errcheck
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	client := p.getClient(ctx)
+	err := p.initRepoWithReadme(ctx, client, baseURL, "my-org/my-repo")
+	require.Error(t, err)
+}
+
+func TestGitHubProvider_InitRepoWithReadme_NonRetryableError(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{"message": "Forbidden"}) //nolint:errcheck
+	})
+
+	client := p.getClient(context.Background())
+	err := p.initRepoWithReadme(context.Background(), client, baseURL, "my-org/my-repo")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), callCount.Load(), "should not retry on non-404 errors")
+}
+
+// ─── RESTError Tests ─────────────────────────────────────────────────────────
+
+func TestRESTError(t *testing.T) {
+	t.Parallel()
+
+	err := &restError{StatusCode: 404, Message: "Not Found"}
+	assert.Equal(t, "GitHub API error (HTTP 404): Not Found", err.Error())
+}
+
+// ─── Benchmarks ──────────────────────────────────────────────────────────────
+
+func BenchmarkBuildRulesetRules(b *testing.B) {
+	inputs := map[string]any{
+		"required_status_checks_contexts": []any{"test", "lint", "build"},
+		"required_approving_review_count": float64(2),
+		"requires_commit_signatures":      true,
+		"required_linear_history":         true,
+		"allow_force_pushes":              false,
+		"allow_deletions":                 false,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buildRulesetRules(inputs)
+	}
+}
+
+func BenchmarkIsGraphQLForbidden(b *testing.B) {
+	forbidden := &GraphQLError{Errors: []graphqlError{{Message: "forbidden", Type: "FORBIDDEN"}}}
+	notForbidden := &GraphQLError{Errors: []graphqlError{{Message: "not found", Type: "NOT_FOUND"}}}
+
+	b.Run("forbidden", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			isGraphQLForbidden(forbidden)
+		}
+	})
+
+	b.Run("not_forbidden", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			isGraphQLForbidden(notForbidden)
+		}
+	})
+}
+
+func BenchmarkGitHubProvider_Execute_CreateRepo_DryRun(b *testing.B) {
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation": "create_repo",
+		"owner":     "test-org",
+		"repo":      "bench-repo",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, inputs)
+	}
+}
+
+func BenchmarkGitHubProvider_Execute_CreateRuleset_DryRun(b *testing.B) {
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation":    "create_ruleset",
+		"owner":        "test-org",
+		"repo":         "bench-repo",
+		"ruleset_name": "bench protection",
+		"include_refs": []any{"refs/heads/main"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, inputs)
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_test.go
+++ b/pkg/provider/builtin/githubprovider/github_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -28,7 +30,11 @@ func testProvider(t *testing.T, handler http.HandlerFunc) (*GitHubProvider, stri
 		EnableCache: false,
 		RetryMax:    0,
 	})
-	p := NewGitHubProvider(WithClient(client))
+	p := NewGitHubProvider(
+		WithClient(client),
+		// Use near-zero delays for tests to avoid sleeping.
+		WithRetryConfig(5, time.Millisecond, 15, time.Millisecond, 3, time.Millisecond),
+	)
 	return p, server.URL
 }
 
@@ -46,11 +52,22 @@ func graphqlHandler(t *testing.T, checkQuery func(query string, vars map[string]
 		var req graphqlRequest
 		require.NoError(t, json.Unmarshal(body, &req))
 
+		w.Header().Set("Content-Type", "application/json")
+
+		// Intercept viewerPermission queries (from waitForWriteAccess)
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
 		if checkQuery != nil {
 			checkQuery(req.Query, req.Variables)
 		}
 
-		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(response) //nolint:errcheck
 	}
 }
@@ -70,6 +87,34 @@ func TestNewGitHubProvider(t *testing.T) {
 
 	err := provider.ValidateDescriptor(desc)
 	assert.NoError(t, err)
+}
+
+func TestWithRetryConfig_ClampsValues(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider(
+		WithRetryConfig(0, -time.Second, -1, -time.Millisecond, 0, -time.Second),
+	)
+	assert.Equal(t, 1, p.commitMaxAttempts, "commitMaxAttempts should be clamped to 1")
+	assert.Equal(t, time.Duration(0), p.commitRetryBackoff, "commitRetryBackoff should be clamped to 0")
+	assert.Equal(t, 1, p.waitMaxAttempts, "waitMaxAttempts should be clamped to 1")
+	assert.Equal(t, time.Duration(0), p.waitPollInterval, "waitPollInterval should be clamped to 0")
+	assert.Equal(t, 1, p.initRepoMaxRetries, "initRepoMaxRetries should be clamped to 1")
+	assert.Equal(t, time.Duration(0), p.initRepoRetryBackoff, "initRepoRetryBackoff should be clamped to 0")
+}
+
+func TestWithRetryConfig_PositiveValuesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider(
+		WithRetryConfig(3, 2*time.Second, 10, time.Second, 5, 500*time.Millisecond),
+	)
+	assert.Equal(t, 3, p.commitMaxAttempts)
+	assert.Equal(t, 2*time.Second, p.commitRetryBackoff)
+	assert.Equal(t, 10, p.waitMaxAttempts)
+	assert.Equal(t, time.Second, p.waitPollInterval)
+	assert.Equal(t, 5, p.initRepoMaxRetries)
+	assert.Equal(t, 500*time.Millisecond, p.initRepoRetryBackoff)
 }
 
 // ─── Read Operation Tests ────────────────────────────────────────────────────
@@ -579,16 +624,236 @@ func TestGitHubProvider_Execute_CreateCommit_MissingFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, err := p.Execute(context.Background(), tt.inputs)
-			if err != nil {
-				assert.Contains(t, err.Error(), tt.wantErr)
-			} else {
-				data := output.Data.(map[string]any)
-				assert.Equal(t, false, data["success"])
-				assert.Contains(t, data["error"].(string), tt.wantErr)
-			}
+			_, err := p.Execute(context.Background(), tt.inputs)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestParseFileChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		inputs   map[string]any
+		wantAdds int
+		wantDels int
+		wantErr  string
+	}{
+		{
+			name:     "valid additions and deletions",
+			inputs:   map[string]any{"additions": []any{map[string]any{"path": "a.go", "content": "pkg"}}, "deletions": []any{map[string]any{"path": "b.go"}}},
+			wantAdds: 1,
+			wantDels: 1,
+		},
+		{
+			name:   "empty inputs",
+			inputs: map[string]any{},
+		},
+		{
+			name:    "non-map addition entry",
+			inputs:  map[string]any{"additions": []any{42}},
+			wantErr: "each addition entry must be an object",
+		},
+		{
+			name:    "addition missing path",
+			inputs:  map[string]any{"additions": []any{map[string]any{"content": "c"}}},
+			wantErr: "each addition must have 'path' and 'content'",
+		},
+		{
+			name:    "addition missing content",
+			inputs:  map[string]any{"additions": []any{map[string]any{"path": "f"}}},
+			wantErr: "each addition must have 'path' and 'content'",
+		},
+		{
+			name:    "non-map deletion entry",
+			inputs:  map[string]any{"deletions": []any{"not-a-map"}},
+			wantErr: "each deletion entry must be an object",
+		},
+		{
+			name:    "deletion missing path",
+			inputs:  map[string]any{"deletions": []any{map[string]any{"other": "val"}}},
+			wantErr: "each deletion must have 'path'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			adds, dels, err := parseFileChanges(tt.inputs)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, adds, tt.wantAdds)
+			assert.Len(t, dels, tt.wantDels)
+		})
+	}
+}
+
+// ─── Create Commit Retry Tests ───────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateCommit_RetryOnForbidden(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+
+		// Intercept viewerPermission queries
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
+		n := callCount.Add(1)
+		if n < 3 {
+			// First two attempts: FORBIDDEN
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"errors": []any{
+					map[string]any{
+						"message": "Resource not accessible by personal access token",
+						"type":    "FORBIDDEN",
+					},
+				},
+			})
+			return
+		}
+		// Third attempt: success
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"data": map[string]any{
+				"createCommitOnBranch": map[string]any{
+					"commit": map[string]any{
+						"oid":           "new789",
+						"url":           "https://github.com/o/r/commit/new789",
+						"committedDate": "2026-01-01T00:00:00Z",
+						"message":       "test commit",
+					},
+				},
+			},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":         "create_commit",
+		"owner":             "test-org",
+		"repo":              "test-repo",
+		"branch":            "main",
+		"message":           "test commit",
+		"expected_head_oid": "abc123def456789012345678901234567890abcd",
+		"additions":         []any{map[string]any{"path": "f.go", "content": "pkg"}},
+		"api_base":          baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	assert.Equal(t, int32(3), callCount.Load())
+}
+
+func TestGitHubProvider_Execute_CreateCommit_NonForbiddenError_NoRetry(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
+		callCount.Add(1)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"errors": []any{
+				map[string]any{
+					"message": "Branch not found",
+					"type":    "NOT_FOUND",
+				},
+			},
+		})
+	})
+
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation":         "create_commit",
+		"owner":             "test-org",
+		"repo":              "test-repo",
+		"branch":            "nonexistent",
+		"message":           "test",
+		"expected_head_oid": "abc123def456789012345678901234567890abcd",
+		"additions":         []any{map[string]any{"path": "f.go", "content": "pkg"}},
+		"api_base":          baseURL,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Branch not found")
+	assert.Equal(t, int32(1), callCount.Load(), "should not retry on non-FORBIDDEN errors")
+}
+
+func TestGitHubProvider_Execute_CreateCommit_RetryContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
+		// Always return FORBIDDEN to trigger retry loop
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"errors": []any{
+				map[string]any{
+					"message": "Resource not accessible",
+					"type":    "FORBIDDEN",
+				},
+			},
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":         "create_commit",
+		"owner":             "test-org",
+		"repo":              "test-repo",
+		"branch":            "main",
+		"message":           "test",
+		"expected_head_oid": "abc123def456789012345678901234567890abcd",
+		"additions":         []any{map[string]any{"path": "f.go", "content": "pkg"}},
+		"api_base":          baseURL,
+	})
+
+	require.Error(t, err)
 }
 
 func TestGitHubProvider_Execute_CreateBranch(t *testing.T) {
@@ -688,6 +953,19 @@ func TestGitHubProvider_Execute_DeleteRelease(t *testing.T) {
 
 // ─── Error Handling Tests ────────────────────────────────────────────────────
 
+func TestGitHubProvider_Execute_MissingOperation(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"owner": "test",
+		"repo":  "test",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "'operation' is required")
+}
+
 func TestGitHubProvider_Execute_UnknownOperation(t *testing.T) {
 	p := NewGitHubProvider()
 	_, err := p.Execute(context.Background(), map[string]any{
@@ -749,7 +1027,46 @@ func TestGitHubProvider_Execute_InvalidInput(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected map input")
 }
 
-func TestGitHubProvider_Execute_ActionErrorReturnsSuccessFalse(t *testing.T) {
+func TestGitHubProvider_Execute_MissingOwnerRepo(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+
+	tests := []struct {
+		name   string
+		inputs map[string]any
+	}{
+		{"missing both", map[string]any{"operation": "get_repo"}},
+		{"missing repo", map[string]any{"operation": "create_issue", "owner": "org"}},
+		{"missing owner", map[string]any{"operation": "create_release", "repo": "r"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := p.Execute(context.Background(), tt.inputs)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "'owner' and 'repo' are required")
+		})
+	}
+}
+
+func TestGitHubProvider_Execute_CreateRepo_SkipsOwnerRepoValidation(t *testing.T) {
+	t.Parallel()
+
+	// create_repo should NOT fail the owner/repo validation even without owner
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": "create_repo",
+		"repo":      "test-repo",
+	})
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_ActionErrorReturnsError(t *testing.T) {
 	p, baseURL := testProvider(t, graphqlHandler(t, nil,
 		map[string]any{
 			"errors": []any{
@@ -758,7 +1075,7 @@ func TestGitHubProvider_Execute_ActionErrorReturnsSuccessFalse(t *testing.T) {
 		},
 	))
 
-	output, err := p.Execute(context.Background(), map[string]any{
+	_, err := p.Execute(context.Background(), map[string]any{
 		"operation": "create_issue",
 		"owner":     "nonexistent",
 		"repo":      "repo",
@@ -766,11 +1083,9 @@ func TestGitHubProvider_Execute_ActionErrorReturnsSuccessFalse(t *testing.T) {
 		"api_base":  baseURL,
 	})
 
-	// Action operations return success=false, not a Go error
-	require.NoError(t, err)
-	data := output.Data.(map[string]any)
-	assert.Equal(t, false, data["success"])
-	assert.Contains(t, data["error"].(string), "Repository not found")
+	// Action operations now return Go errors so the executor can stop downstream actions
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Repository not found")
 }
 
 // ─── Dry Run Tests ───────────────────────────────────────────────────────────
@@ -806,6 +1121,21 @@ func TestGitHubProvider_Execute_DryRun_WriteOperation(t *testing.T) {
 	data := output.Data.(map[string]any)
 	assert.Equal(t, true, data["success"])
 	assert.Equal(t, "create_issue", data["operation"])
+}
+
+func TestGitHubProvider_Execute_DryRun_EmptyOperation(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"owner": "test",
+		"repo":  "test",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'operation' is required")
 }
 
 // ─── Helper Tests ────────────────────────────────────────────────────────────


### PR DESCRIPTION
- add create_repo operation via GraphQL with REST fallback for EMU accounts, including auto_init support and write-access polling
- add create_ruleset operation for branch and tag protection via REST repository rulesets API
- add enable_vulnerability_alerts and enable_automated_security_fixes operations via REST
- add retry with backoff on create_commit for FORBIDDEN errors during post-creation permission propagation
- make retry timing configurable via WithRetryConfig option for testing
- add plugin-template example solution for scaffolding new scafctl provider plugins with full CI, docs, and test boilerplate
- update provider development tutorial and reference docs with new operations and examples

BREAKING CHANGE: owner and repo are no longer required top-level schema fields (only operation is required); the error field has been removed from the action output schema
