### PR TITLE
feat(state): add state persistence for resolver values across executions

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -40,7 +40,7 @@ scafctl run solution -f hello.yaml -o yaml
 
 - **[Getting Started](tutorials/getting-started/)** — Install scafctl and run your first solution
 - **[Tutorials](tutorials/)** — Step-by-step guides for resolvers, actions, CEL, catalogs, and more
-- **[State Tutorial](tutorials/state-tutorial/)** — Persist resolver values across executions
+- **[State Tutorial](tutorials/state-tutorial/)** -- Persist resolver values across executions
 - **[Design](design/)** — Architecture, design docs, and contributor guides
 
 ## Examples

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -40,6 +40,7 @@ scafctl run solution -f hello.yaml -o yaml
 
 - **[Getting Started](tutorials/getting-started/)** — Install scafctl and run your first solution
 - **[Tutorials](tutorials/)** — Step-by-step guides for resolvers, actions, CEL, catalogs, and more
+- **[State Tutorial](tutorials/state-tutorial/)** — Persist resolver values across executions
 - **[Design](design/)** — Architecture, design docs, and contributor guides
 
 ## Examples

--- a/docs/design/misc.md
+++ b/docs/design/misc.md
@@ -20,7 +20,7 @@ These concerns apply across resolvers, actions, providers, plugins, and solution
 | Provider Capabilities | ✅ Implemented | `from`, `transform`, `validation`, `authentication`, `action` |
 | Secrets and Sensitive Data | ✅ Implemented | `pkg/secrets` with AES-256-GCM, keychain integration |
 | Secret Redaction | ✅ Implemented | `RedactedError`, `--redact` flag on snapshots |
-| Stateless Core | ✅ Implemented | Providers are stateless, no persistent state |
+| Stateless Core | ✅ Implemented | Providers are stateless; opt-in state persistence via `state` block |
 | Error Model | ✅ Implemented | Rich error types with location, cause, context |
 | Determinism Rules | ✅ Implemented | Resolver purity enforced, `WhatIf` functions declared |
 | Resolver DAG Visualization | ✅ Implemented | ASCII, DOT, Mermaid, JSON formats |
@@ -127,15 +127,25 @@ Render mode supports secret redaction via `--redact` flag on snapshots.
 
 ### Stateless Core
 
-scafctl is stateless by design:
+scafctl is stateless by default:
 
-- No persistent state between runs
+- No persistent state between runs unless explicitly configured
 - No implicit caching
 - No hidden execution memory
 
+### Opt-In State Persistence
+
+Solutions can opt into state persistence via a top-level `state` block. When configured:
+
+- Resolver values marked with `saveToState: true` are persisted to a backend (local file or GitHub)
+- The `state` provider reads previously saved values during resolver execution
+- State is loaded before resolvers run and saved after they complete
+
+See [State Design Doc](state/) for full details.
+
 ### External State
 
-If state is required, it must live outside scafctl, for example:
+For use cases beyond the built-in state system, state can also live outside scafctl:
 
 - Remote APIs
 - Infrastructure systems

--- a/docs/design/state.md
+++ b/docs/design/state.md
@@ -27,15 +27,16 @@ State does not:
 
 | Feature | Status | Location |
 |---------|--------|----------|
-| `CapabilityState` on provider system | ⏳ Planned | `pkg/provider/provider.go` |
-| `StateConfig` on Solution struct | ⏳ Planned | `pkg/solution/solution.go` |
-| `SaveToState` field on Resolver | ⏳ Planned | `pkg/resolver/resolver.go` |
-| `pkg/state/` package (types, manager, context) | ⏳ Planned | `pkg/state/` |
-| `state-file` backend provider | ⏳ Planned | `pkg/provider/builtin/statefileprovider/` |
-| `state` resolver-facing provider | ⏳ Planned | `pkg/provider/builtin/stateprovider/` |
-| State loading lifecycle (pre-execution) | ⏳ Planned | `pkg/cmd/scafctl/run/common.go` |
-| `scafctl state` CLI commands | ⏳ Planned | `pkg/cmd/scafctl/state/` |
-| Validation rules (circular deps, sensitive warnings) | ⏳ Planned | `pkg/solution/` |
+| `CapabilityState` on provider system | Done | `pkg/provider/provider.go` |
+| `state.Config` on Solution struct | Done | `pkg/solution/solution.go` |
+| `SaveToState` field on Resolver | Done | `pkg/resolver/resolver.go` |
+| `pkg/state/` package (types, manager, context, store) | Done | `pkg/state/` |
+| `file` provider state operations | Done | `pkg/provider/builtin/fileprovider/file_state.go` |
+| `github` provider state operations | Done | `pkg/provider/builtin/githubprovider/github_state.go` |
+| `state` resolver-facing provider | Done | `pkg/provider/builtin/stateprovider/` |
+| State loading lifecycle (pre-execution) | Done | `pkg/cmd/scafctl/run/solution.go`, `resolver.go` |
+| `scafctl state` CLI commands | Done | `pkg/cmd/scafctl/state/` |
+| Validation rules (circular deps, sensitive warnings) | Done | `pkg/lint/` |
 | Immutable resolver support | 🔮 Future | See [Immutable Resolvers](#immutable-resolvers-future-enhancement) |
 
 ---
@@ -60,18 +61,18 @@ State is not responsible for:
 
 ## Architecture
 
-State uses a **two-provider model** that keeps backend persistence separate from resolver/action access:
+State uses a **two-layer model** that keeps backend persistence separate from resolver/action access:
 
 | Layer | Provider | Capabilities | Role |
 |-------|----------|-------------|------|
-| Backend | `state-file` | `state` | Reads/writes the state file to disk |
+| Backend | `file` or `github` | `state` (+ others) | Reads/writes the state data to storage |
 | Resolver/Action access | `state` | `from`, `action` | Reads/writes individual state entries |
 
-This separation means:
+State operations are merged into existing providers (`file`, `github`) rather than using dedicated backend providers. This means:
 
-- The backend is swappable — a future `state-s3` or `state-http` provider can replace `state-file` without changing how resolvers access state
-- All persistence goes through the provider system — no special-case I/O outside of providers
-- Community or internal teams can implement custom backends as plugin providers
+- The `file` and `github` providers each gained `CapabilityState` with `state_load`, `state_save`, and `state_delete` operations
+- All persistence goes through the provider system -- no special-case I/O outside of providers
+- Community or internal teams can implement custom backends by adding `CapabilityState` to any provider
 
 ### New Capability: `state`
 
@@ -89,18 +90,18 @@ Required output fields for `state` capability:
 
 State is declared via a top-level `state` field on the `Solution` struct, as a peer to `spec`, `catalog`, `bundle`, and `compose`.
 
-### StateConfig Type
+### Config Type
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | `ValueRef` | Yes | Dynamic activation — literal bool, CEL expression, resolver ref, or Go template |
-| `backend` | `StateBackend` | Yes | Backend provider configuration |
+| `enabled` | `ValueRef` | Yes | Dynamic activation -- literal bool, CEL expression, resolver ref, or Go template |
+| `backend` | `Backend` | Yes | Backend provider configuration |
 
-### StateBackend Type
+### Backend Type
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `provider` | `string` | Yes | Name of a registered provider with `CapabilityState` (e.g., `"state-file"`) |
+| `provider` | `string` | Yes | Name of a registered provider with `CapabilityState` (e.g., `"file"`) |
 | `inputs` | `map[string]*ValueRef` | Yes | Provider-specific inputs — follows the same pattern as resolver provider inputs |
 
 ### Example
@@ -114,7 +115,7 @@ metadata:
 state:
   enabled: true
   backend:
-    provider: state-file
+    provider: file
     inputs:
       path:
         tmpl: "deploy-app/{{ .project_name }}.json"
@@ -160,13 +161,13 @@ When `enabled` references resolvers, those resolvers are included in the [pre-ex
 
 ### Dynamic Backend Inputs
 
-Backend inputs are `ValueRef` types — the same polymorphic type used throughout scafctl. This enables per-project state files:
+Backend inputs are `ValueRef` types -- the same polymorphic type used throughout scafctl. This enables per-project state files:
 
 ~~~yaml
 state:
   enabled: true
   backend:
-    provider: state-file
+    provider: file
     inputs:
       path:
         tmpl: "deploy-app/{{ .project_name }}.json"
@@ -219,9 +220,9 @@ State is persisted as JSON. The schema includes a `schemaVersion` field for forw
 | `metadata.scafctlVersion` | Version of scafctl that last wrote the state |
 | `command.subcommand` | CLI subcommand used (e.g., `run solution`) |
 | `command.parameters` | Key-value pairs from `--parameter` flags |
-| `values` | Map of resolver name to `StateEntry` |
+| `values` | Map of resolver name to `Entry` |
 
-### StateEntry
+### Entry
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -241,7 +242,7 @@ Solution identity (name, version) is already in `metadata` and does not need to 
 
 ### Storage Location
 
-The built-in `state-file` backend stores files under `paths.StateDir()` (`$XDG_STATE_HOME/scafctl/`), which is already defined and documented in `pkg/paths/`. This is the XDG-canonical location for user-specific state data like logs, history, and session state.
+The built-in `file` provider backend stores files under `paths.StateDir()` (`$XDG_STATE_HOME/scafctl/`), which is already defined and documented in `pkg/paths/`. This is the XDG-canonical location for user-specific state data like logs, history, and session state.
 
 On macOS: `~/.local/state/scafctl/`
 
@@ -346,40 +347,55 @@ The `state` provider implements `ExtractDependencies` on its descriptor so the D
 
 ---
 
-## State-File Backend Provider
+## File Provider State Operations
 
-The built-in `state-file` provider handles local JSON file persistence. It is registered with `CapabilityState`.
+The built-in `file` provider supports state persistence via `CapabilityState`. State operations use `state_load`, `state_save`, and `state_delete` as the `operation` input.
 
 ### Input Schema
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `operation` | string (enum: `load`, `save`, `delete`) | Yes | Operation to perform |
+| `operation` | string (enum: `state_load`, `state_save`, `state_delete`) | Yes | Operation to perform |
 | `path` | string | Yes | File path relative to `paths.StateDir()` |
-| `data` | object | For `save` | The full `StateData` object to persist |
+| `data` | object | For `state_save` | The full `Data` object to persist |
 
 ### Operations
 
 | Operation | Behavior |
 |-----------|----------|
-| `load` | Reads JSON from `paths.StateDir()/<path>`. Returns empty state structure if file does not exist (first run). |
-| `save` | Writes `StateData` as JSON to `paths.StateDir()/<path>`. Creates directories as needed. |
-| `delete` | Removes the state file at `paths.StateDir()/<path>`. |
+| `state_load` | Reads JSON from `paths.StateDir()/<path>`. Returns empty state structure if file does not exist (first run). |
+| `state_save` | Writes `Data` as JSON to `paths.StateDir()/<path>`. Creates directories as needed. Uses atomic write (temp + rename). |
+| `state_delete` | Removes the state file at `paths.StateDir()/<path>`. |
 
-### Mock Behavior
+### Dry-Run Behavior
 
-During dry-run: `load` returns empty state, `save` and `delete` are no-ops.
+During dry-run: `state_load` returns empty state, `state_save` and `state_delete` report what-if actions.
+
+## GitHub Provider State Operations
+
+The `github` provider also supports `CapabilityState`, storing state as JSON files in a GitHub repository.
+
+### Input Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `operation` | string (enum: `state_load`, `state_save`, `state_delete`) | Yes | Operation to perform |
+| `owner` | string | Yes | Repository owner |
+| `repo` | string | Yes | Repository name |
+| `path` | string | Yes | File path in the repository |
+| `branch` | string | No | Branch name (defaults to default branch) |
+| `data` | object | For `state_save` | The full `Data` object to persist |
 
 ### Future Backends
 
-The backend is a provider, so new backends are just new providers implementing `CapabilityState`:
+The backend is a provider capability, so new backends are just providers implementing `CapabilityState`:
 
 | Backend | Provider Name | Inputs |
 |---------|---------------|--------|
-| Local file (built-in) | `state-file` | `path` |
-| S3 (future) | `state-s3` | `bucket`, `key`, `region` |
-| HTTP API (future) | `state-http` | `url`, `method`, `headers` |
-| Database (future) | `state-db` | `connectionString`, `table` |
+| Local file (built-in) | `file` | `path` |
+| GitHub repo (built-in) | `github` | `owner`, `repo`, `path`, `branch` |
+| S3 (future) | `s3` (or plugin) | `bucket`, `key`, `region` |
+| HTTP API (future) | `http` (or plugin) | `url`, `method`, `headers` |
 
 No changes to `pkg/state/` or the core execution flow are needed to add a new backend.
 
@@ -393,7 +409,7 @@ The `enabled` and `backend.inputs` fields can reference resolvers, creating orde
 
 1. **Parse** — Extract `state` config from the solution. Identify resolvers referenced by `state.enabled` and `state.backend.inputs` using `ValueRef.ReferencesVariable()`.
 
-2. **Validate** — Ensure referenced resolvers do NOT have `saveToState: true` and do NOT use the `state` or `state-file` provider. This prevents circular dependencies.
+2. **Validate** -- Ensure referenced resolvers do NOT have `saveToState: true` and do NOT use the `state` provider. This prevents circular dependencies.
 
 3. **Pre-execution mini-phase** — Execute ONLY the resolvers referenced by `enabled` and backend inputs in a temporary resolver context. These are executed using a subset call to `resolver.Executor.Execute()` with just the required resolvers.
 
@@ -466,7 +482,7 @@ State loading happens in the command layer (`pkg/cmd/scafctl/run/common.go`) bef
 | Rule | Reason |
 |------|--------|
 | Resolvers referenced in `state.enabled` or `state.backend.inputs` must NOT have `saveToState: true` | Prevents circular dependency: state loading depends on these resolvers, but they would also write to state |
-| Resolvers referenced in `state.enabled` or `state.backend.inputs` must NOT use the `state` or `state-file` provider | Prevents circular dependency: state must be loaded before these providers can function |
+| Resolvers referenced in `state.enabled` or `state.backend.inputs` must NOT use the `state` provider | Prevents circular dependency: state must be loaded before this provider can function |
 | `state.backend.provider` must resolve to a registered provider with `CapabilityState` | Ensures the backend is valid |
 
 ### Lint Warnings
@@ -496,11 +512,11 @@ A `scafctl state` command group provides manual state management, mirroring the 
 
 | Command | Description |
 |---------|-------------|
-| `scafctl state list --path <state-file>` | List all stored keys and metadata |
-| `scafctl state get --path <state-file> --key <key>` | Get a specific value |
-| `scafctl state set --path <state-file> --key <key> --value <value>` | Set a value manually |
-| `scafctl state delete --path <state-file> --key <key>` | Delete a key |
-| `scafctl state clear --path <state-file>` | Clear all values |
+| `scafctl state list --path <file>` | List all stored keys and metadata |
+| `scafctl state get --path <file> --key <key>` | Get a specific value |
+| `scafctl state set --path <file> --key <key> --value <value>` | Set a value manually |
+| `scafctl state delete --path <file> --key <key>` | Delete a key |
+| `scafctl state clear --path <file>` | Clear all values |
 
 - `--path` is relative to `paths.StateDir()`
 - All commands support `-o table/json/yaml/quiet` via `kvx.OutputOptions`
@@ -511,11 +527,13 @@ A `scafctl state` command group provides manual state management, mirroring the 
 
 | Package | Purpose |
 |---------|---------|
-| `pkg/state/types.go` | `StateConfig`, `StateBackend`, `StateData`, `StateEntry`, `CommandInfo` types |
-| `pkg/state/manager.go` | `Manager` — orchestrates pre-execution loading, post-execution saving, context integration |
+| `pkg/state/types.go` | `Config`, `Backend`, `Data`, `Entry`, `CommandInfo` types |
+| `pkg/state/manager.go` | `Manager` -- orchestrates pre-execution loading, post-execution saving, context integration |
 | `pkg/state/context.go` | `WithState(ctx, s)` / `FromContext(ctx)` for passing state through `context.Context` |
+| `pkg/state/store.go` | `LoadFromFile()` / `SaveToFile()` for direct file I/O (used by CLI commands) |
 | `pkg/state/mock.go` | Mock state for testing |
-| `pkg/provider/builtin/statefileprovider/` | `state-file` backend provider (`CapabilityState`) |
+| `pkg/provider/builtin/fileprovider/file_state.go` | State operations for `file` provider (`CapabilityState`) |
+| `pkg/provider/builtin/githubprovider/github_state.go` | State operations for `github` provider (`CapabilityState`) |
 | `pkg/provider/builtin/stateprovider/` | `state` resolver/action provider (`CapabilityFrom`, `CapabilityAction`) |
 | `pkg/cmd/scafctl/state/` | CLI commands (`list`, `get`, `set`, `delete`, `clear`) |
 
@@ -527,8 +545,8 @@ A `scafctl state` command group provides manual state management, mirroring the 
 |------|--------|
 | `pkg/provider/provider.go` | Add `CapabilityState`, update `IsValid()`, add to `capabilityRequiredFields` |
 | `pkg/resolver/resolver.go` | Add `SaveToState bool` field to `Resolver` struct |
-| `pkg/solution/solution.go` | Add `State *StateConfig` field to `Solution` struct |
-| `pkg/provider/builtin/builtin.go` | Register `state-file` and `state` providers |
+| `pkg/solution/solution.go` | Add `State *state.Config` field to `Solution` struct |
+| `pkg/provider/builtin/builtin.go` | Register `state` provider; `file` and `github` providers already have `CapabilityState` |
 | `pkg/cmd/scafctl/run/common.go` | Integrate state loading lifecycle before `executor.Execute()` |
 | `pkg/cmd/scafctl/run/solution.go` | Pass state config to common execution flow |
 | `pkg/cmd/scafctl/render/solution.go` | Support state reads in render mode (writes are no-op) |
@@ -544,7 +562,7 @@ A future `immutable: true` field on the `Resolver` struct enables locking state 
 
 ### Behavior
 
-- When a resolver has both `immutable: true` and `saveToState: true`, the `StateEntry.Immutable` flag is set to `true` on first write
+- When a resolver has both `immutable: true` and `saveToState: true`, the `Entry.Immutable` flag is set to `true` on first write
 - On subsequent runs, any attempt to overwrite an immutable state entry is rejected with an error — both via `saveToState` auto-persistence and via the `state` provider write mode
 - The only way to change an immutable value is via `scafctl state delete` or `scafctl state clear`
 
@@ -571,7 +589,7 @@ On the first run: `state` returns null, `exec` generates a UUID, `saveToState` p
 
 ### Infrastructure
 
-The `StateEntry.Immutable` field is included in the state data schema from day one, defaulting to `false`. Enforcement is deferred to a future release.
+The `Entry.Immutable` field is included in the state data schema from day one, defaulting to `false`. Enforcement is deferred to a future release.
 
 ---
 
@@ -579,8 +597,8 @@ The `StateEntry.Immutable` field is included in the state data schema from day o
 
 | Decision | Rationale |
 |----------|-----------|
-| **Backend as provider** | All I/O stays in the provider system. Backends are extensible — new providers implementing `CapabilityState` require no changes to `pkg/state/`. Plugin providers can implement custom backends. |
-| **Two-provider model** | `state-file` (backend persistence) and `state` (resolver/action access) are separate providers. This keeps the backend swappable without affecting how resolvers interact with state. |
+| **Backend as provider capability** | All I/O stays in the provider system. State operations are merged into existing providers (`file`, `github`) via `CapabilityState`. Plugin providers can add state support to any provider. |
+| **Two-layer model** | Backend providers (`file`, `github`) handle persistence, while the `state` provider handles resolver/action access. The backend is swappable without affecting how resolvers interact with state. |
 | **No implicit state-over-provider** | `saveToState` writes to state, the `state` provider reads from state. Resolvers always execute their configured provider. State never silently replaces provider execution. |
 | **`enabled` as `ValueRef`** | Dynamic state activation via CEL, resolver refs, or templates. Referenced resolvers run in the pre-execution mini-phase. |
 | **Top-level `state` field** | State is a solution-level concern, not a resolver/workflow concern. It sits alongside `spec`, `catalog`, `bundle`, and `compose`. |
@@ -591,4 +609,4 @@ The `StateEntry.Immutable` field is included in the state data schema from day o
 | **Schema version** | `schemaVersion: 1` for forward-compatible format migrations. |
 | **JSON format** | Aligns with the snapshot system serialization format. |
 | **Local solutions allowed** | No restriction on state for non-catalog solutions — useful for the user's own repeated executions even without external validation. |
-| **Immutable deferred** | `StateEntry.Immutable` field included in schema but enforcement is not implemented. |
+| **Immutable deferred** | `Entry.Immutable` field included in schema but enforcement is not implemented. |

--- a/docs/design/state.md
+++ b/docs/design/state.md
@@ -9,10 +9,10 @@ weight: 14
 
 State adds optional, per-solution persistence of resolver values across executions. It enables two primary workflows:
 
-1. **Re-run with same data** — Execute a solution repeatedly and retain resolved values between runs without re-prompting or re-fetching.
-2. **Validation replay** — A validation application can replay the exact command with the same flags and verify it produces the same results.
+1. **Re-run with same data** -- Execute a solution repeatedly and retain resolved values between runs without re-prompting or re-fetching.
+2. **Validation replay** -- A validation application can replay the exact command with the same flags and verify it produces the same results.
 
-State is opt-in. Solutions without a `state` block behave exactly as they do today — stateless, deterministic, and self-contained. State does not change the resolver or provider execution model. It adds a persistence layer accessed exclusively through the provider system.
+State is opt-in. Solutions without a `state` block behave exactly as they do today -- stateless, deterministic, and self-contained. State does not change the resolver or provider execution model. It adds a persistence layer accessed exclusively through the provider system.
 
 State does not:
 
@@ -55,7 +55,7 @@ State is not responsible for:
 - Replacing provider execution (resolvers always run their configured providers)
 - Caching intermediate computations
 - Implicitly altering execution behavior
-- Managing secrets or encryption (sensitive values are stored in plaintext — see [Sensitive Values](#sensitive-values))
+- Managing secrets or encryption (sensitive values are stored in plaintext -- see [Sensitive Values](#sensitive-values))
 
 ---
 
@@ -76,7 +76,7 @@ State operations are merged into existing providers (`file`, `github`) rather th
 
 ### New Capability: `state`
 
-A new `CapabilityState` is added to the provider capability system. This capability signals that a provider can act as a state persistence backend. It is not used by resolvers or actions directly — only by the state manager during the pre-execution and post-execution phases.
+A new `CapabilityState` is added to the provider capability system. This capability signals that a provider can act as a state persistence backend. It is not used by resolvers or actions directly -- only by the state manager during the pre-execution and post-execution phases.
 
 Required output fields for `state` capability:
 
@@ -94,7 +94,7 @@ State is declared via a top-level `state` field on the `Solution` struct, as a p
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | `ValueRef` | Yes | Dynamic activation -- literal bool, CEL expression, resolver ref, or Go template |
+| `enabled` | `ValueRef` | Yes | Dynamic activation -- literal bool, CEL expression, or Go template. Resolver references (`rslvr:`) are not supported because state loads before resolvers run |
 | `backend` | `Backend` | Yes | Backend provider configuration |
 
 ### Backend Type
@@ -102,7 +102,7 @@ State is declared via a top-level `state` field on the `Solution` struct, as a p
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string` | Yes | Name of a registered provider with `CapabilityState` (e.g., `"file"`) |
-| `inputs` | `map[string]*ValueRef` | Yes | Provider-specific inputs — follows the same pattern as resolver provider inputs |
+| `inputs` | `map[string]*ValueRef` | Yes | Provider-specific inputs -- follows the same pattern as resolver provider inputs |
 
 ### Example
 
@@ -118,7 +118,7 @@ state:
     provider: file
     inputs:
       path:
-        tmpl: "deploy-app/{{ .project_name }}.json"
+        tmpl: "deploy-app/{{ .__params.project_name }}.json"
 spec:
   resolvers:
     project_name:
@@ -153,11 +153,10 @@ spec:
 The `enabled` field is a `ValueRef`, which means it supports:
 
 - **Literal**: `enabled: true`
-- **CEL expression**: `enabled: { expr: "env('ENABLE_STATE') == 'true'" }`
-- **Resolver reference**: `enabled: { rslvr: "use_state" }`
-- **Go template**: `enabled: { tmpl: "{{ .enable_state }}" }`
+- **CEL expression**: `enabled: { expr: "__params.enable_state == true" }`
+- **Go template**: `enabled: { tmpl: "{{ .__params.enable_state }}" }`
 
-When `enabled` references resolvers, those resolvers are included in the [pre-execution mini-phase](#state-loading-lifecycle).
+Resolver references (`rslvr:`) are not supported because state is loaded before resolvers run. CEL expressions and templates can access CLI parameters (`-r` flags) via `__params`.
 
 ### Dynamic Backend Inputs
 
@@ -170,10 +169,10 @@ state:
     provider: file
     inputs:
       path:
-        tmpl: "deploy-app/{{ .project_name }}.json"
+        tmpl: "deploy-app/{{ .__params.project_name }}.json"
 ~~~
 
-Here, `project_name` is a resolver that runs during the pre-execution mini-phase. Project A and Project B each get their own state file.
+Here, `project_name` is a CLI parameter passed via `-r project_name=myapp`. Project A and Project B each get their own state file.
 
 ---
 
@@ -229,14 +228,14 @@ State is persisted as JSON. The schema includes a `schemaVersion` field for forw
 | `value` | `any` | The stored resolver value |
 | `type` | `string` | The resolver's declared type (string, int, float, bool, array, any) |
 | `updatedAt` | `timestamp` | When this entry was last written |
-| `immutable` | `bool` | Whether this entry is locked (future enhancement — see [Immutable Resolvers](#immutable-resolvers-future-enhancement)) |
+| `immutable` | `bool` | Whether this entry is locked (future enhancement -- see [Immutable Resolvers](#immutable-resolvers-future-enhancement)) |
 
 ### Command Capture
 
-State stores the most recent invocation's command information — **latest only, no history**. This enables a validation application to replay the exact command:
+State stores the most recent invocation's command information -- **latest only, no history**. This enables a validation application to replay the exact command:
 
-- `command.subcommand` — the CLI subcommand (e.g., `run solution`)
-- `command.parameters` — the `--parameter` key-value pairs passed via `-r` flags
+- `command.subcommand` -- the CLI subcommand (e.g., `run solution`)
+- `command.parameters` -- the `--parameter` key-value pairs passed via `-r` flags
 
 Solution identity (name, version) is already in `metadata` and does not need to be duplicated in `command`.
 
@@ -268,22 +267,22 @@ resolvers:
 
 - `saveToState` defaults to `false`
 - When `true`, the resolver's result is collected for state persistence after execution
-- The resolver always executes its configured provider — `saveToState` does **not** cause the resolver to skip execution or read from state implicitly
+- The resolver always executes its configured provider -- `saveToState` does **not** cause the resolver to skip execution or read from state implicitly
 - To read from state on subsequent runs, use the `state` provider explicitly (see [State Provider](#state-provider))
 
 ### Batch Save
 
 All `saveToState` values are collected after **all** resolvers complete, then flushed to the backend in a single `save` call. This ensures:
 
-- No partial state on failures — if any resolver fails, state is not updated
-- Minimal I/O — one write per execution, not one per resolver
-- Consistent state — all values reflect the same execution
+- No partial state on failures -- if any resolver fails, state is not updated
+- Minimal I/O -- one write per execution, not one per resolver
+- Consistent state -- all values reflect the same execution
 
 ---
 
 ## State Provider
 
-The `state` provider gives resolvers and actions explicit read/write access to individual state entries. It is a separate provider from the backend — it reads/writes the in-memory state data loaded during the pre-execution phase.
+The `state` provider gives resolvers and actions explicit read/write access to individual state entries. It is a separate provider from the backend -- it reads/writes the in-memory state data loaded during the pre-execution phase.
 
 ### Read Mode (`from` capability)
 
@@ -291,13 +290,13 @@ Used by resolvers to read previously stored values:
 
 | Input | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `key` | string | Yes | — | State entry key (typically a resolver name) |
+| `key` | string | Yes | -- | State entry key (typically a resolver name) |
 | `required` | bool | No | `false` | If `true`, error when key is not found |
 | `fallback` | any | No | `null` | Value returned when key is not found and `required` is `false` |
 
 **First run behavior**: When no state file exists (first execution), the state provider returns `null` or `fallback` for all reads. It does not error unless `required: true`.
 
-Example — resolver that uses state on subsequent runs:
+Example -- resolver that uses state on subsequent runs:
 
 ~~~yaml
 resolvers:
@@ -324,11 +323,11 @@ Used by actions to explicitly write values to state:
 
 | Input | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `key` | string | Yes | — | State entry key |
-| `value` | ValueRef | Yes | — | Value to store |
+| `key` | string | Yes | -- | State entry key |
+| `value` | ValueRef | Yes | -- | Value to store |
 | `immutable` | bool | No | `false` | Lock value permanently (future enhancement) |
 
-Example — action that writes to state:
+Example -- action that writes to state:
 
 ~~~yaml
 workflow:
@@ -403,33 +402,31 @@ No changes to `pkg/state/` or the core execution flow are needed to add a new ba
 
 ## State Loading Lifecycle
 
-The `enabled` and `backend.inputs` fields can reference resolvers, creating ordering dependencies. The state loading lifecycle handles this:
+The `enabled` and `backend.inputs` fields are resolved using CLI parameters (`-r` flags) available as `__params` in CEL and template expressions. Resolver outputs (`_`) are only available at save time, not load time.
 
 ### Steps
 
-1. **Parse** — Extract `state` config from the solution. Identify resolvers referenced by `state.enabled` and `state.backend.inputs` using `ValueRef.ReferencesVariable()`.
+1. **Parse** -- Extract `state` config from the solution.
 
-2. **Validate** -- Ensure referenced resolvers do NOT have `saveToState: true` and do NOT use the `state` provider. This prevents circular dependencies.
+2. **Validate** -- Ensure `state.enabled` and `state.backend.inputs` do NOT use direct resolver references (`rslvr:`). State loads before resolvers run, so resolver outputs are not available.
 
-3. **Pre-execution mini-phase** — Execute ONLY the resolvers referenced by `enabled` and backend inputs in a temporary resolver context. These are executed using a subset call to `resolver.Executor.Execute()` with just the required resolvers.
+3. **Evaluate `enabled`** -- Resolve the `ValueRef` using CLI params (`__params`). If falsy, skip state entirely and proceed with normal stateless execution.
 
-4. **Evaluate `enabled`** — Resolve the `ValueRef`. If falsy, skip state entirely and proceed with normal stateless execution.
+4. **Resolve backend inputs** -- Resolve all `ValueRef` inputs for the backend provider (e.g., the `path` template) using CLI params (`__params`).
 
-5. **Resolve backend inputs** — Resolve all `ValueRef` inputs for the backend provider (e.g., the `path` template).
+5. **Load state** -- Call the backend provider with `operation: load` via `provider.Execute()` with `WithExecutionMode(ctx, CapabilityState)`. This is a standalone provider call -- completely independent of the resolver system.
 
-6. **Load state** — Call the backend provider with `operation: load` via `provider.Execute()` with `WithExecutionMode(ctx, CapabilityState)`. This is a standalone provider call — completely independent of the resolver system.
+6. **Capture command** -- Store the current subcommand and parameters in the `command` section of the loaded state data.
 
-7. **Capture command** — Store the current subcommand and parameters in the `command` section of the loaded state data.
+7. **Inject** -- Put the loaded state data into `context.Context` via `state.WithState(ctx, stateData)`.
 
-8. **Inject** — Put the loaded state data into `context.Context` via `state.WithState(ctx, stateData)`.
+8. **Normal execution** -- `resolver.Executor.Execute()` runs. Resolvers with `saveToState: true` persist their results. The `state` provider reads/writes entries via context.
 
-9. **Normal execution** — `resolver.Executor.Execute()` runs. Resolvers with `saveToState: true` persist their results. The `state` provider reads/writes entries via context.
-
-10. **Flush** — After all resolvers complete, collect results from `saveToState` resolvers, update state data, and call the backend provider with `operation: save`.
+9. **Flush** -- After all resolvers complete, collect results from `saveToState` resolvers, update state data, and call the backend provider with `operation: save`.
 
 ### Integration Point
 
-State loading happens in the command layer (`pkg/cmd/scafctl/run/common.go`) before `executor.Execute()` is called. The `provider.Executor` is fully standalone and can be called independently of the resolver system — this is the same pattern used by `run provider`.
+State loading happens in the command layer (`pkg/cmd/scafctl/run/common.go`) before `executor.Execute()` is called. The `provider.Executor` is fully standalone and can be called independently of the resolver system -- this is the same pattern used by `run provider`.
 
 ### Sequence Diagram
 
@@ -442,11 +439,9 @@ State loading happens in the command layer (`pkg/cmd/scafctl/run/common.go`) bef
    │  run sol    │                │                │                │
    ├────────────>│                │                │                │
    │             │                │                │                │
-   │             │ pre-exec mini-phase             │                │
-   │             │ (resolve state.enabled +        │                │
-   │             │  backend inputs)                │                │
-   │             ├───────────────────────────────-->│                │
-   │             │<────────────────────────────────┤                │
+   │             │ evaluate enabled +              │                │
+   │             │ resolve backend inputs          │                │
+   │             │ (using __params from CLI)        │                │
    │             │                │                │                │
    │             │ load state     │                │                │
    │             ├───────────────>│                │                │
@@ -519,7 +514,7 @@ A `scafctl state` command group provides manual state management, mirroring the 
 | `scafctl state clear --path <file>` | Clear all values |
 
 - `--path` is relative to `paths.StateDir()`
-- All commands support `-o table/json/yaml/quiet` via `kvx.OutputOptions`
+- `list` and `get` support `-o table/json/yaml/quiet` via `kvx.OutputOptions`
 
 ---
 
@@ -551,7 +546,7 @@ A `scafctl state` command group provides manual state management, mirroring the 
 | `pkg/cmd/scafctl/run/solution.go` | Pass state config to common execution flow |
 | `pkg/cmd/scafctl/render/solution.go` | Support state reads in render mode (writes are no-op) |
 | `pkg/cmd/scafctl/root.go` | Register `scafctl state` command group |
-| `docs/design/misc.md` | Revise "No persistent state between runs" — note state is now opt-in |
+| `docs/design/misc.md` | Revise "No persistent state between runs" -- note state is now opt-in |
 | `docs/design/future-enhancements.md` | Add immutable resolver entry |
 
 ---
@@ -563,7 +558,7 @@ A future `immutable: true` field on the `Resolver` struct enables locking state 
 ### Behavior
 
 - When a resolver has both `immutable: true` and `saveToState: true`, the `Entry.Immutable` flag is set to `true` on first write
-- On subsequent runs, any attempt to overwrite an immutable state entry is rejected with an error — both via `saveToState` auto-persistence and via the `state` provider write mode
+- On subsequent runs, any attempt to overwrite an immutable state entry is rejected with an error -- both via `saveToState` auto-persistence and via the `state` provider write mode
 - The only way to change an immutable value is via `scafctl state delete` or `scafctl state clear`
 
 ### Example
@@ -600,7 +595,7 @@ The `Entry.Immutable` field is included in the state data schema from day one, d
 | **Backend as provider capability** | All I/O stays in the provider system. State operations are merged into existing providers (`file`, `github`) via `CapabilityState`. Plugin providers can add state support to any provider. |
 | **Two-layer model** | Backend providers (`file`, `github`) handle persistence, while the `state` provider handles resolver/action access. The backend is swappable without affecting how resolvers interact with state. |
 | **No implicit state-over-provider** | `saveToState` writes to state, the `state` provider reads from state. Resolvers always execute their configured provider. State never silently replaces provider execution. |
-| **`enabled` as `ValueRef`** | Dynamic state activation via CEL, resolver refs, or templates. Referenced resolvers run in the pre-execution mini-phase. |
+| **`enabled` as `ValueRef`** | Dynamic state activation via CEL or templates using CLI params (`__params`). Resolver references are not supported because state loads before resolvers run. |
 | **Top-level `state` field** | State is a solution-level concern, not a resolver/workflow concern. It sits alongside `spec`, `catalog`, `bundle`, and `compose`. |
 | **Pre-execution in command layer** | State loading uses standalone `provider.Execute()` before `resolver.Executor.Execute()`. No changes to the resolver executor's core loop. |
 | **Command capture** | Subcommand + parameters only (latest invocation, no history). Sufficient for validation replay. Solution identity comes from metadata. |
@@ -608,5 +603,5 @@ The `Entry.Immutable` field is included in the state data schema from day one, d
 | **Batch save** | State flushed after all resolvers complete via single backend provider `save` call. No partial state on failures. |
 | **Schema version** | `schemaVersion: 1` for forward-compatible format migrations. |
 | **JSON format** | Aligns with the snapshot system serialization format. |
-| **Local solutions allowed** | No restriction on state for non-catalog solutions — useful for the user's own repeated executions even without external validation. |
+| **Local solutions allowed** | No restriction on state for non-catalog solutions -- useful for the user's own repeated executions even without external validation. |
 | **Immutable deferred** | `Entry.Immutable` field included in schema but enforcement is not implemented. |

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -39,7 +39,7 @@ Step-by-step guides for learning scafctl features.
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Telemetry Tutorial](telemetry-tutorial.md) — Ship traces and metrics to Jaeger / Prometheus
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
-- [State Tutorial](state-tutorial.md) — Persist resolver values across executions
+- [State Tutorial](state-tutorial.md) -- Persist resolver values across executions
 
 ## Reference
 

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -39,6 +39,7 @@ Step-by-step guides for learning scafctl features.
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output
 - [Telemetry Tutorial](telemetry-tutorial.md) — Ship traces and metrics to Jaeger / Prometheus
 - [Cache Tutorial](cache-tutorial.md) — Manage cached data and reclaim disk space
+- [State Tutorial](state-tutorial.md) — Persist resolver values across executions
 
 ## Reference
 

--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -1,0 +1,400 @@
+---
+title: "State Tutorial"
+weight: 95
+---
+
+# State Tutorial
+
+This tutorial walks you through using state persistence to retain resolver values across solution executions. You'll learn how to configure state, read from it on subsequent runs, and manage state files via the CLI.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with YAML syntax and solution files
+- Understanding of resolvers and the provider system
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Enabling State](#enabling-state)
+3. [Saving Resolver Values](#saving-resolver-values)
+4. [Reading from State](#reading-from-state)
+5. [First Run vs Subsequent Runs](#first-run-vs-subsequent-runs)
+6. [Dynamic State Paths](#dynamic-state-paths)
+7. [GitHub Backend](#github-backend)
+8. [CLI Commands](#cli-commands)
+9. [Sensitive Values](#sensitive-values)
+10. [Common Patterns](#common-patterns)
+
+---
+
+## Overview
+
+State adds optional, per-solution persistence of resolver values. It enables two workflows:
+
+- **Re-run with same data** -- Retain resolved values between runs without re-prompting.
+- **Validation replay** -- Replay the exact command with the same flags and verify results.
+
+State is opt-in. Solutions without a `state` block behave as they always have -- stateless and self-contained.
+
+### How It Works
+
+1. Before resolvers run, state is loaded from the configured backend (e.g., local file).
+2. The `state` provider can read previously saved values during resolver execution.
+3. After resolvers complete, values marked with `saveToState: true` are persisted.
+
+---
+
+## Enabling State
+
+Add a top-level `state` block to your solution:
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-stateful-app
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: "my-stateful-app.json"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "greeting"
+~~~
+
+Key fields:
+
+- `state.enabled` -- Activates state. Can be a literal `true`, a CEL expression, resolver reference, or template.
+- `state.backend.provider` -- The provider that handles persistence. Use `file` for local files or `github` for GitHub repos.
+- `state.backend.inputs` -- Provider-specific inputs. For `file`, only `path` is required.
+
+The `path` is relative to the XDG state directory (`~/.local/state/scafctl/` on macOS/Linux).
+
+---
+
+## Saving Resolver Values
+
+Mark resolvers with `saveToState: true` to persist their values:
+
+~~~yaml
+spec:
+  resolvers:
+    api_key:
+      type: string
+      sensitive: true
+      saveToState: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "API Key"
+
+    region:
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "AWS Region"
+              default: "us-east-1"
+~~~
+
+All `saveToState` values are collected after all resolvers complete, then flushed to the backend in a single save call. This ensures no partial state on failures.
+
+---
+
+## Reading from State
+
+Use the `state` provider to read previously saved values:
+
+~~~yaml
+spec:
+  resolvers:
+    api_key:
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          # Try reading from state first
+          - provider: state
+            inputs:
+              key: "api_key"
+              required: false
+          # Fall back to prompting the user
+          - provider: parameter
+            inputs:
+              key: "API Key"
+~~~
+
+The resolver fallback chain makes this work naturally:
+
+1. On first run, `state` returns null (no state file exists), so the resolver falls through to `parameter`.
+2. After execution, the result is saved to state via `saveToState: true`.
+3. On subsequent runs, `state` returns the cached value and the chain stops.
+
+### State Provider Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `key` | string | Yes | -- | State entry key (typically a resolver name) |
+| `required` | bool | No | `false` | Error when key is not found |
+| `fallback` | any | No | `null` | Value when key is not found and `required` is `false` |
+
+---
+
+## First Run vs Subsequent Runs
+
+Here's the full flow using a concrete example. Create `state-demo.yaml`:
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: state-demo
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: "state-demo.json"
+spec:
+  resolvers:
+    username:
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "username"
+              required: false
+          - provider: parameter
+            inputs:
+              key: "username"
+
+    run_count:
+      type: int
+      saveToState: true
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "run_count"
+              fallback: 0
+~~~
+
+**First run:**
+
+```
+scafctl run resolver -f state-demo.yaml -r username=alice
+```
+
+Output:
+
+```
+username: alice
+run_count: 0
+```
+
+**Second run** (no parameters needed -- values come from state):
+
+```
+scafctl run resolver -f state-demo.yaml
+```
+
+Output:
+
+```
+username: alice
+run_count: 0
+```
+
+The `username` is now read from state. The `run_count` shows `0` from the fallback because the state provider read phase runs before the new save.
+
+---
+
+## Dynamic State Paths
+
+Use Go templates in backend inputs to create per-project state files:
+
+~~~yaml
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path:
+        tmpl: "deploy/{{ .project_name }}.json"
+spec:
+  resolvers:
+    project_name:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "project"
+~~~
+
+Each project gets its own state file:
+
+```
+~/.local/state/scafctl/deploy/frontend.json
+~/.local/state/scafctl/deploy/backend.json
+```
+
+---
+
+## GitHub Backend
+
+Store state in a GitHub repository instead of the local filesystem:
+
+~~~yaml
+state:
+  enabled: true
+  backend:
+    provider: github
+    inputs:
+      owner: "my-org"
+      repo: "state-store"
+      path: "state/my-app.json"
+      branch: "main"
+~~~
+
+This commits state changes directly to the repository using the GitHub GraphQL API. Authentication is handled by the configured GitHub auth handler.
+
+---
+
+## CLI Commands
+
+The `scafctl state` command group lets you inspect and modify state files directly.
+
+### List keys
+
+```
+scafctl state list --path state-demo.json
+```
+
+### Get a value
+
+```
+scafctl state get --path state-demo.json --key username
+```
+
+### Set a value manually
+
+```
+scafctl state set --path state-demo.json --key username --value bob
+```
+
+### Delete a key
+
+```
+scafctl state delete --path state-demo.json --key username
+```
+
+### Clear all values
+
+```
+scafctl state clear --path state-demo.json
+```
+
+All commands support `-o json`, `-o yaml`, and `-o quiet` output formats.
+
+The `--path` flag is relative to the XDG state directory. Use an absolute path to reference files outside the state directory.
+
+---
+
+## Sensitive Values
+
+When a resolver is marked `sensitive: true` and `saveToState: true`, the value is stored **in plaintext** in the state file. A lint warning is emitted to alert the solution author:
+
+~~~yaml
+resolvers:
+  api_key:
+    type: string
+    sensitive: true
+    saveToState: true
+    resolve:
+      with:
+        - provider: parameter
+          inputs:
+            key: "API Key"
+~~~
+
+```
+scafctl lint -f solution.yaml
+```
+
+```
+WARNING [state-sensitive-value] Sensitive resolver "api_key" with saveToState will be stored in plaintext
+```
+
+This is an explicit, informed decision. Encryption is not used because the validation application running on a separate machine would not have access to decryption keys.
+
+---
+
+## Common Patterns
+
+### Cache expensive API calls
+
+~~~yaml
+resolvers:
+  auth_token:
+    type: string
+    saveToState: true
+    resolve:
+      with:
+        - provider: state
+          inputs:
+            key: "auth_token"
+            required: false
+        - provider: http
+          inputs:
+            url: "https://auth.example.com/token"
+            method: POST
+~~~
+
+On first run, the HTTP call fetches the token. On subsequent runs, it comes from state.
+
+### Dynamic state activation
+
+~~~yaml
+state:
+  enabled:
+    expr: "env('ENABLE_STATE') == 'true'"
+  backend:
+    provider: file
+    inputs:
+      path: "my-app.json"
+~~~
+
+State is only active when the `ENABLE_STATE` environment variable is set to `true`.
+
+### Writing state from actions
+
+~~~yaml
+workflow:
+  actions:
+    - name: save-deployment-id
+      provider: state
+      inputs:
+        key: "deployment_id"
+        value:
+          rslvr: deployment_result
+~~~
+
+Actions can explicitly write values to state using the `state` provider with `action` capability.

--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -75,7 +75,7 @@ spec:
 
 Key fields:
 
-- `state.enabled` -- Activates state. Can be a literal `true`, a CEL expression, resolver reference, or template.
+- `state.enabled` -- Activates state. Can be a literal `true`, a CEL expression, or template. Because state is loaded before resolvers run, direct resolver references (for example, `rslvr:...`) are not currently supported here.
 - `state.backend.provider` -- The provider that handles persistence. Use `file` for local files or `github` for GitHub repos.
 - `state.backend.inputs` -- Provider-specific inputs. For `file`, only `path` is required.
 
@@ -185,28 +185,32 @@ spec:
             inputs:
               key: "username"
 
-    run_count:
-      type: int
+    region:
+      type: string
       saveToState: true
       resolve:
         with:
           - provider: state
             inputs:
-              key: "run_count"
-              fallback: 0
+              key: "region"
+              required: false
+          - provider: parameter
+            inputs:
+              key: "region"
+              default: "us-east-1"
 ~~~
 
 **First run:**
 
 ```
-scafctl run resolver -f state-demo.yaml -r username=alice
+scafctl run resolver -f state-demo.yaml -r username=alice -r region=eu-west-1
 ```
 
 Output:
 
 ```
 username: alice
-run_count: 0
+region: eu-west-1
 ```
 
 **Second run** (no parameters needed -- values come from state):
@@ -219,10 +223,10 @@ Output:
 
 ```
 username: alice
-run_count: 0
+region: eu-west-1
 ```
 
-The `username` is now read from state. The `run_count` shows `0` from the fallback because the state provider read phase runs before the new save.
+Both values are now read from state. No re-prompting needed.
 
 ---
 
@@ -237,7 +241,7 @@ state:
     provider: file
     inputs:
       path:
-        tmpl: "deploy/{{ .project_name }}.json"
+        tmpl: "deploy/{{ .__params.project_name }}.json"
 spec:
   resolvers:
     project_name:
@@ -312,7 +316,7 @@ scafctl state delete --path state-demo.json --key username
 scafctl state clear --path state-demo.json
 ```
 
-All commands support `-o json`, `-o yaml`, and `-o quiet` output formats.
+`scafctl state list` and `scafctl state get` support `-o json`, `-o yaml`, and `-o quiet` output formats.
 
 The `--path` flag is relative to the XDG state directory. Use an absolute path to reference files outside the state directory.
 
@@ -375,14 +379,14 @@ On first run, the HTTP call fetches the token. On subsequent runs, it comes from
 ~~~yaml
 state:
   enabled:
-    expr: "env('ENABLE_STATE') == 'true'"
+    expr: "__params.enable_state == true"
   backend:
     provider: file
     inputs:
       path: "my-app.json"
 ~~~
 
-State is only active when the `ENABLE_STATE` environment variable is set to `true`.
+State is only active when the `enable_state` CLI parameter is set to `true` (e.g., `-r enable_state=true`).
 
 ### Writing state from actions
 

--- a/examples/solutions/state/README.md
+++ b/examples/solutions/state/README.md
@@ -1,0 +1,35 @@
+# State Examples
+
+Demonstrates state persistence across solution executions.
+
+## solution.yaml
+
+A solution that persists resolver values to a local state file.
+On first run, values are collected via parameters. On subsequent runs,
+they are loaded from state automatically.
+
+### First Run
+
+~~~sh
+scafctl run resolver -f solution.yaml -r username=alice -r env=prod
+~~~
+
+### Subsequent Runs
+
+~~~sh
+# No parameters needed -- values come from state
+scafctl run resolver -f solution.yaml
+~~~
+
+### Inspect State
+
+~~~sh
+scafctl state list --path state-example.json
+scafctl state get --path state-example.json --key username
+~~~
+
+### Clear State
+
+~~~sh
+scafctl state clear --path state-example.json
+~~~

--- a/examples/solutions/state/solution.yaml
+++ b/examples/solutions/state/solution.yaml
@@ -1,0 +1,91 @@
+# =============================================================================
+# State Persistence Example
+# =============================================================================
+# Demonstrates state persistence across solution executions.
+# On first run, values are collected via parameters. On subsequent runs,
+# they are loaded from state automatically via the resolver fallback chain.
+#
+# Usage:
+#   First run:  scafctl run resolver -f solution.yaml -r username=alice -r env=prod
+#   Later runs: scafctl run resolver -f solution.yaml
+#   Inspect:    scafctl state list --path state-example.json
+#   Clear:      scafctl state clear --path state-example.json
+# =============================================================================
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: state-example
+  version: 1.0.0
+  description: Demonstrates state persistence across runs
+
+# State configuration -- persists resolver values to a local JSON file
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: "state-example.json"
+
+spec:
+  resolvers:
+    # =========================================================================
+    # Resolver with state fallback -- prompts on first run, cached thereafter
+    # =========================================================================
+    username:
+      description: Username for the deployment
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "username"
+              required: false
+          - provider: parameter
+            inputs:
+              key: "username"
+
+    # =========================================================================
+    # Resolver with default value -- saved to state for consistency
+    # =========================================================================
+    env:
+      description: Target environment
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "env"
+              required: false
+          - provider: parameter
+            inputs:
+              key: "env"
+          - provider: static
+            inputs:
+              value: "dev"
+
+    # =========================================================================
+    # Computed value using state -- shows state in expressions
+    # =========================================================================
+    greeting:
+      description: Greeting message using saved username
+      type: string
+      dependsOn: [username, env]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: "'Hello ' + _.username + ' (env: ' + _.env + ')'"
+
+  # Display the greeting to verify state-backed values
+  workflow:
+    actions:
+      show-greeting:
+        description: Display the greeting built from stateful resolvers
+        provider: message
+        inputs:
+          message:
+            expr: "_.greeting"
+          type: success

--- a/pkg/celexp/context.go
+++ b/pkg/celexp/context.go
@@ -48,6 +48,14 @@ const (
 	// and dependencyCount for any resolver in when conditions and provider inputs.
 	// Example: __plan["myResolver"].phase
 	VarPlan = "__plan"
+
+	// VarParams is the variable name for CLI parameters passed via -r flags.
+	// Available in state backend input expressions so that dynamic backend
+	// configuration (paths, URLs) can reference runtime values explicitly.
+	// Unlike _, which contains resolver outputs, __params always contains the
+	// raw CLI parameters regardless of resolver execution state.
+	// Example: __params.gcp_project
+	VarParams = "__params"
 )
 
 // BuildCELContext creates CEL environment options and variables for evaluation.

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -39,6 +39,7 @@ import (
 	servecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/serve"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/snapshot"
 	solutioncmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/solution"
+	statecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/state"
 	testcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/test"
 	vendorcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/vendor"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/version"
@@ -643,6 +644,7 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.AddCommand(withGroup(groupConfig, secretscmd.CommandSecrets(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, authcmd.CommandAuth(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, cachecmd.CommandCache(cliParams, ioStreams, binaryName)))
+	cCmd.AddCommand(withGroup(groupConfig, statecmd.CommandState(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, credhelpercmd.CommandCredentialHelper(cliParams, ioStreams, binaryName)))
 
 	// Plugin Commands

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -677,7 +677,7 @@ func (o *sharedResolverOptions) resolveVersionConstraintForFile(ctx context.Cont
 // addSharedResolverFlags adds common resolver flags to a cobra command.
 func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().StringVarP(&o.File, "file", "f", "", "Solution file path or catalog name (auto-discovered if not provided, use '-' for stdin)")
-	cCmd.Flags().StringArrayVarP(&o.ResolverParams, "resolver", "r", nil, "Resolver parameters (key=value, key=@- for raw stdin, @file.yaml, or @- for stdin)")
+	cCmd.Flags().StringArrayVarP(&o.ResolverParams, "resolver", "r", nil, "Resolver parameters (key=value, key=@- for raw stdin, @file.yaml, or @- for stdin). Available as __params in state backend expressions")
 	flags.AddKvxOutputFlagsToStruct(cCmd, &o.KvxOutputFlags)
 
 	cCmd.Flags().BoolVar(&o.ResolveAll, "resolve-all", false, "Execute all resolvers regardless of action requirements")

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -30,6 +30,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
@@ -745,6 +746,29 @@ func solutionMetaFromSolution(sol *solution.Solution) *provider.SolutionMeta {
 		Description: sol.Metadata.Description,
 		Category:    sol.Metadata.Category,
 		Tags:        sol.Metadata.Tags,
+	}
+	if sol.Metadata.Version != nil {
+		meta.Version = sol.Metadata.Version.String()
+	}
+	return meta
+}
+
+// buildCommandInfo creates a state.CommandInfo from parsed parameters and subcommand.
+func buildCommandInfo(subcommand string, params map[string]any) state.CommandInfo {
+	paramStrs := make(map[string]string, len(params))
+	for k, v := range params {
+		paramStrs[k] = fmt.Sprintf("%v", v)
+	}
+	return state.CommandInfo{
+		Subcommand: subcommand,
+		Parameters: paramStrs,
+	}
+}
+
+// buildStateSolutionMeta creates a state.SolutionMeta from a solution.
+func buildStateSolutionMeta(sol *solution.Solution) state.SolutionMeta {
+	meta := state.SolutionMeta{
+		Name: sol.Metadata.Name,
 	}
 	if sol.Metadata.Version != nil {
 		meta.Version = sol.Metadata.Version.String()

--- a/pkg/cmd/scafctl/run/common_coverage_test.go
+++ b/pkg/cmd/scafctl/run/common_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -629,4 +630,75 @@ func TestResolveVersionConstraintForFile_RejectsFilePaths(t *testing.T) {
 			assert.Contains(t, err.Error(), "--version can only be used with catalog names")
 		})
 	}
+}
+
+// ── buildCommandInfo tests ────────────────────────────────────────────────────
+
+func TestBuildCommandInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		subcommand string
+		params     map[string]any
+		wantSub    string
+		wantParams map[string]string
+	}{
+		{
+			name:       "empty params",
+			subcommand: "run solution",
+			params:     nil,
+			wantSub:    "run solution",
+			wantParams: map[string]string{},
+		},
+		{
+			name:       "string params",
+			subcommand: "run resolver",
+			params:     map[string]any{"env": "prod", "count": 42},
+			wantSub:    "run resolver",
+			wantParams: map[string]string{"env": "prod", "count": "42"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			info := buildCommandInfo(tc.subcommand, tc.params)
+			assert.Equal(t, tc.wantSub, info.Subcommand)
+			assert.Equal(t, tc.wantParams, info.Parameters)
+		})
+	}
+}
+
+// ── buildStateSolutionMeta tests ──────────────────────────────────────────────
+
+func TestBuildStateSolutionMeta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with version", func(t *testing.T) {
+		t.Parallel()
+		sol := &solution.Solution{
+			Metadata: solution.Metadata{
+				Name: "my-solution",
+			},
+		}
+		sol.Metadata.Version, _ = semver.NewVersion("1.2.3")
+
+		meta := buildStateSolutionMeta(sol)
+		assert.Equal(t, "my-solution", meta.Name)
+		assert.Equal(t, "1.2.3", meta.Version)
+	})
+
+	t.Run("without version", func(t *testing.T) {
+		t.Parallel()
+		sol := &solution.Solution{
+			Metadata: solution.Metadata{
+				Name: "no-version",
+			},
+		}
+
+		meta := buildStateSolutionMeta(sol)
+		assert.Equal(t, "no-version", meta.Name)
+		assert.Empty(t, meta.Version)
+	})
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -457,12 +458,44 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 
 	// Snapshot mode: execute resolvers and save snapshot
 	if o.Snapshot {
+		// Load state before snapshot execution so state provider has context.
+		// State is intentionally NOT saved in snapshot mode because snapshots
+		// are read-only inspections that should not mutate persisted state.
+		if sol.State != nil {
+			snapshotMgr := state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+			loadResult, loadErr := snapshotMgr.Load(ctx, nil, buildCommandInfo("run resolver", params))
+			if loadErr != nil {
+				return o.exitWithCode(ctx, fmt.Errorf("state load: %w", loadErr), exitcode.GeneralError)
+			}
+			if !loadResult.Skipped {
+				ctx = loadResult.Ctx
+			}
+		}
 		return o.showResolverSnapshot(ctx, sol, resolvers, params, reg)
 	}
 
 	// Wire skip-transform flag into shared options for executeResolvers
 	if o.SkipTransform {
 		o.sharedResolverOptions.SkipTransform = true
+	}
+
+	// State lifecycle: load persisted state before resolver execution so that
+	// the state provider can serve previously saved values.
+	// params are passed so that state backend inputs can reference CLI
+	// parameters via CEL/template expressions (e.g. _.appName + '.json').
+	var stateMgr *state.Manager
+	var stateData *state.Data
+	if sol.State != nil {
+		stateMgr = state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+		cmdInfo := buildCommandInfo("run resolver", params)
+		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)
+		if loadErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state load: %w", loadErr), exitcode.GeneralError)
+		}
+		if !loadResult.Skipped {
+			ctx = loadResult.Ctx
+			stateData = loadResult.Data
+		}
 	}
 
 	// Track timing
@@ -475,6 +508,15 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	}
 
 	elapsed := time.Since(start)
+
+	// State lifecycle: save resolver values marked with saveToState.
+	if stateMgr != nil && stateData != nil {
+		allResolvers := sol.Spec.ResolversToSlice()
+		solMeta := buildStateSolutionMeta(sol)
+		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, allResolvers, resolverData, solMeta); saveErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
+		}
+	}
 
 	// Build output and write
 	results := o.buildResolverOutputMap(resolverData, sol)

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -463,7 +463,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		// are read-only inspections that should not mutate persisted state.
 		if sol.State != nil {
 			snapshotMgr := state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
-			loadResult, loadErr := snapshotMgr.Load(ctx, nil, buildCommandInfo("run resolver", params))
+			loadResult, loadErr := snapshotMgr.Load(ctx, params, buildCommandInfo("run resolver", params))
 			if loadErr != nil {
 				return o.exitWithCode(ctx, fmt.Errorf("state load: %w", loadErr), exitcode.GeneralError)
 			}
@@ -482,7 +482,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// State lifecycle: load persisted state before resolver execution so that
 	// the state provider can serve previously saved values.
 	// params are passed so that state backend inputs can reference CLI
-	// parameters via CEL/template expressions (e.g. _.appName + '.json').
+	// parameters via __params in CEL expressions (e.g. __params.appName).
 	var stateMgr *state.Manager
 	var stateData *state.Data
 	if sol.State != nil {
@@ -513,7 +513,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	if stateMgr != nil && stateData != nil {
 		allResolvers := sol.Spec.ResolversToSlice()
 		solMeta := buildStateSolutionMeta(sol)
-		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, allResolvers, resolverData, solMeta); saveErr != nil {
+		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, allResolvers, params, resolverData, solMeta); saveErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
 		}
 	}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -461,6 +462,27 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// --output-dir is explicitly specified (which takes precedence in ResolvePath).
 	actionCtx = provider.WithWorkingDirectory(actionCtx, originalCwd)
 
+	// State lifecycle: load persisted state before resolver execution so that
+	// the state provider can serve previously saved values. State is loaded
+	// even in dry-run mode (resolvers need context) but never saved.
+	// params are passed so that state backend inputs can reference CLI
+	// parameters via CEL/template expressions (e.g. _.appName + '.json').
+	var stateMgr *state.Manager
+	var stateData *state.Data
+	if sol.State != nil {
+		stateMgr = state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+		cmdInfo := buildCommandInfo("run solution", params)
+		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)
+		if loadErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state load: %w", loadErr), exitcode.GeneralError)
+		}
+		if !loadResult.Skipped {
+			ctx = loadResult.Ctx
+			actionCtx = state.WithState(actionCtx, loadResult.Data)
+			stateData = loadResult.Data
+		}
+	}
+
 	// Dry run — execute resolvers with ctx (CWD by default, or base-dir when
 	// --base-dir is explicitly set) so resolver paths resolve accordingly. The
 	// action-phase WhatIf report uses actionCtx which has the working-dir
@@ -522,6 +544,15 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	result, err := actionExecutor.Execute(actionCtx, workflow)
 	if err != nil && result != nil && result.FinalStatus != action.ExecutionPartialSuccess {
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
+	}
+
+	// State lifecycle: save resolver values marked with saveToState after
+	// successful action execution.
+	if stateMgr != nil && stateData != nil {
+		solMeta := buildStateSolutionMeta(sol)
+		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, resolverData, solMeta); saveErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
+		}
 	}
 
 	// Build and write output — only include __execution in output when --show-execution is set

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -466,7 +466,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// the state provider can serve previously saved values. State is loaded
 	// even in dry-run mode (resolvers need context) but never saved.
 	// params are passed so that state backend inputs can reference CLI
-	// parameters via CEL/template expressions (e.g. _.appName + '.json').
+	// parameters via __params in CEL expressions (e.g. __params.appName).
 	var stateMgr *state.Manager
 	var stateData *state.Data
 	if sol.State != nil {
@@ -550,7 +550,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// successful action execution.
 	if stateMgr != nil && stateData != nil {
 		solMeta := buildStateSolutionMeta(sol)
-		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, resolverData, solMeta); saveErr != nil {
+		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta); saveErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
 		}
 	}

--- a/pkg/cmd/scafctl/state/clear.go
+++ b/pkg/cmd/scafctl/state/clear.go
@@ -1,0 +1,57 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandClear creates the 'state clear' command.
+func CommandClear(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	var path string
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear all state values",
+		Long:  "Remove all stored values from a state file, preserving metadata.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			sd, err := state.LoadFromFile(path)
+			if err != nil {
+				err := fmt.Errorf("failed to load state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			count := len(sd.Values)
+			sd.Values = make(map[string]*state.Entry)
+
+			if err := state.SaveToFile(path, sd); err != nil {
+				err := fmt.Errorf("failed to save state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			w.Successf("Cleared %d entries\n", count)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/delete.go
+++ b/pkg/cmd/scafctl/state/delete.go
@@ -1,0 +1,67 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandDelete creates the 'state delete' command.
+func CommandDelete(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		path string
+		key  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a state key",
+		Long:  "Remove a specific key from a state file.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			sd, err := state.LoadFromFile(path)
+			if err != nil {
+				err := fmt.Errorf("failed to load state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			if _, ok := sd.Values[key]; !ok {
+				err := fmt.Errorf("key %q not found in state", key)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.FileNotFound)
+			}
+
+			delete(sd.Values, key)
+
+			if err := state.SaveToFile(path, sd); err != nil {
+				err := fmt.Errorf("failed to save state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			w.Successf("Deleted key %q\n", key)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
+	cmd.Flags().StringVar(&key, "key", "", "Key to delete")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("key")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/get.go
+++ b/pkg/cmd/scafctl/state/get.go
@@ -4,25 +4,30 @@
 package state
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
+// getOptions holds the options for the get command.
+type getOptions struct {
+	flags.KvxOutputFlags
+	Path string
+	Key  string
+}
+
 // CommandGet creates the 'state get' command.
-func CommandGet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
-	var (
-		path         string
-		key          string
-		outputFormat string
-	)
+func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	opts := &getOptions{
+		KvxOutputFlags: flags.KvxOutputFlags{AppName: cliParams.BinaryName},
+	}
 
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -35,44 +40,42 @@ func CommandGet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command
 				return fmt.Errorf("writer not initialized in context")
 			}
 
-			sd, err := state.LoadFromFile(path)
+			sd, err := state.LoadFromFile(opts.Path)
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
-			entry, ok := sd.Values[key]
+			entry, ok := sd.Values[opts.Key]
 			if !ok {
-				err := fmt.Errorf("key %q not found in state", key)
+				err := fmt.Errorf("key %q not found in state", opts.Key)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.FileNotFound)
 			}
 
-			switch outputFormat {
-			case "json":
-				data, marshalErr := json.MarshalIndent(entry, "", "  ")
-				if marshalErr != nil {
-					return fmt.Errorf("failed to marshal entry: %w", marshalErr)
-				}
-				w.Plainln(string(data))
-			case "yaml":
-				data, marshalErr := yaml.Marshal(entry)
-				if marshalErr != nil {
-					return fmt.Errorf("failed to marshal entry: %w", marshalErr)
-				}
-				w.Plain(string(data))
-			default:
-				w.Plainf("%v\n", entry.Value)
+			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
+
+			updatedAt := ""
+			if !entry.UpdatedAt.IsZero() {
+				updatedAt = entry.UpdatedAt.Format("2006-01-02T15:04:05Z")
 			}
 
-			return nil
+			data := []map[string]any{{
+				"key":       opts.Key,
+				"value":     entry.Value,
+				"type":      entry.Type,
+				"updatedAt": updatedAt,
+				"immutable": entry.Immutable,
+			}}
+
+			return kvxOpts.Write(data)
 		},
 	}
 
-	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
-	cmd.Flags().StringVar(&key, "key", "", "Key to retrieve")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json, yaml)")
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+	cmd.Flags().StringVar(&opts.Path, "path", "", "State file path (relative to state directory)")
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Key to retrieve")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagRequired("key")
 

--- a/pkg/cmd/scafctl/state/get.go
+++ b/pkg/cmd/scafctl/state/get.go
@@ -1,0 +1,80 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// CommandGet creates the 'state get' command.
+func CommandGet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		path         string
+		key          string
+		outputFormat string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a state value",
+		Long:  "Retrieve and display the value of a specific state key.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			sd, err := state.LoadFromFile(path)
+			if err != nil {
+				err := fmt.Errorf("failed to load state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			entry, ok := sd.Values[key]
+			if !ok {
+				err := fmt.Errorf("key %q not found in state", key)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.FileNotFound)
+			}
+
+			switch outputFormat {
+			case "json":
+				data, marshalErr := json.MarshalIndent(entry, "", "  ")
+				if marshalErr != nil {
+					return fmt.Errorf("failed to marshal entry: %w", marshalErr)
+				}
+				w.Plainln(string(data))
+			case "yaml":
+				data, marshalErr := yaml.Marshal(entry)
+				if marshalErr != nil {
+					return fmt.Errorf("failed to marshal entry: %w", marshalErr)
+				}
+				w.Plain(string(data))
+			default:
+				w.Plainf("%v\n", entry.Value)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
+	cmd.Flags().StringVar(&key, "key", "", "Key to retrieve")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json, yaml)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("key")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/list.go
+++ b/pkg/cmd/scafctl/state/list.go
@@ -1,0 +1,91 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// listOptions holds the options for the list command.
+type listOptions struct {
+	flags.KvxOutputFlags
+	Path string
+}
+
+// CommandList creates the 'state list' command.
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	opts := &listOptions{
+		KvxOutputFlags: flags.KvxOutputFlags{AppName: cliParams.BinaryName},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List stored state keys",
+		Long:  "List all keys and metadata in a state file.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			if opts.Path == "" {
+				err := fmt.Errorf("--path is required")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			sd, err := state.LoadFromFile(opts.Path)
+			if err != nil {
+				err := fmt.Errorf("failed to load state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			if len(sd.Values) == 0 {
+				if !cliParams.IsQuiet {
+					w.Warning("No state entries found")
+				}
+				return nil
+			}
+
+			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
+
+			keys := make([]string, 0, len(sd.Values))
+			for k := range sd.Values {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			data := make([]map[string]any, 0, len(sd.Values))
+			for _, name := range keys {
+				entry := sd.Values[name]
+				data = append(data, map[string]any{
+					"key":       name,
+					"type":      entry.Type,
+					"updatedAt": entry.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+					"immutable": entry.Immutable,
+				})
+			}
+
+			return kvxOpts.Write(data)
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+	cmd.Flags().StringVar(&opts.Path, "path", "", "State file path (relative to state directory)")
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/list.go
+++ b/pkg/cmd/scafctl/state/list.go
@@ -71,10 +71,14 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			data := make([]map[string]any, 0, len(sd.Values))
 			for _, name := range keys {
 				entry := sd.Values[name]
+				updatedAt := ""
+				if !entry.UpdatedAt.IsZero() {
+					updatedAt = entry.UpdatedAt.Format("2006-01-02T15:04:05Z")
+				}
 				data = append(data, map[string]any{
 					"key":       name,
 					"type":      entry.Type,
-					"updatedAt": entry.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+					"updatedAt": updatedAt,
 					"immutable": entry.Immutable,
 				})
 			}

--- a/pkg/cmd/scafctl/state/set.go
+++ b/pkg/cmd/scafctl/state/set.go
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandSet creates the 'state set' command.
+func CommandSet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		path      string
+		key       string
+		value     string
+		valueType string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set a state value",
+		Long:  "Set or update a value in a state file.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			sd, err := state.LoadFromFile(path)
+			if err != nil {
+				err := fmt.Errorf("failed to load state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			// Check if entry is immutable
+			if existing, ok := sd.Values[key]; ok && existing.Immutable {
+				err := fmt.Errorf("key %q is immutable and cannot be modified", key)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			sd.Values[key] = &state.Entry{
+				Value:     value,
+				Type:      valueType,
+				UpdatedAt: time.Now().UTC(),
+			}
+
+			if err := state.SaveToFile(path, sd); err != nil {
+				err := fmt.Errorf("failed to save state: %w", err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			w.Successf("Set key %q\n", key)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
+	cmd.Flags().StringVar(&key, "key", "", "Key to set")
+	cmd.Flags().StringVar(&value, "value", "", "Value to store")
+	cmd.Flags().StringVar(&valueType, "type", "string", "Value type (string, int, bool, etc.)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("key")
+	_ = cmd.MarkFlagRequired("value")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/set.go
+++ b/pkg/cmd/scafctl/state/set.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -50,7 +51,7 @@ func CommandSet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command
 			}
 
 			sd.Values[key] = &state.Entry{
-				Value:     value,
+				Value:     coerceValue(value, valueType),
 				Type:      valueType,
 				UpdatedAt: time.Now().UTC(),
 			}
@@ -75,4 +76,24 @@ func CommandSet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command
 	_ = cmd.MarkFlagRequired("value")
 
 	return cmd
+}
+
+// coerceValue converts a string CLI value to the appropriate Go type based on
+// the --type flag, so that state entries are stored with the correct type.
+func coerceValue(raw, typ string) any {
+	switch typ {
+	case "int":
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return v
+		}
+	case "float":
+		if v, err := strconv.ParseFloat(raw, 64); err == nil {
+			return v
+		}
+	case "bool":
+		if v, err := strconv.ParseBool(raw); err == nil {
+			return v
+		}
+	}
+	return raw
 }

--- a/pkg/cmd/scafctl/state/state.go
+++ b/pkg/cmd/scafctl/state/state.go
@@ -1,0 +1,46 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package state provides commands for managing scafctl state files.
+package state
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandState creates the 'state' command group.
+func CommandState(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Manage solution state files",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			View and manage persisted state files.
+
+			State files store resolver values across solution executions. They are
+			created automatically when a solution has a state block with a file backend.
+
+			State files are stored under the XDG state directory:
+			  - Linux/macOS: ~/.local/state/scafctl/
+			  - Windows:     %LOCALAPPDATA%\scafctl\state\
+
+			The --path flag specifies the state file relative to the state directory.
+			Use an absolute path to reference files outside the state directory.
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandGet(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandSet(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandDelete(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandClear(cliParams, ioStreams, cmdPath))
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/state/state_test.go
+++ b/pkg/cmd/scafctl/state/state_test.go
@@ -176,6 +176,87 @@ func TestCommandSet_Immutable(t *testing.T) {
 	assert.Contains(t, buf.String(), "immutable")
 }
 
+func TestCommandSet_TypedInt(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "port", "--value", "8080", "--type", "int"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	// JSON round-trips int64 as float64
+	assert.Equal(t, float64(8080), sd.Values["port"].Value)
+}
+
+func TestCommandSet_TypedBool(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "enabled", "--value", "true", "--type", "bool"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	assert.Equal(t, true, sd.Values["enabled"].Value)
+}
+
+func TestCommandSet_TypedFloat(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "ratio", "--value", "3.14", "--type", "float"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	assert.Equal(t, 3.14, sd.Values["ratio"].Value)
+}
+
+// ── coerceValue unit tests ────────────────────────────────────────────────────
+
+func TestCoerceValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		raw      string
+		typ      string
+		expected any
+	}{
+		{name: "string default", raw: "hello", typ: "string", expected: "hello"},
+		{name: "int valid", raw: "42", typ: "int", expected: int64(42)},
+		{name: "int invalid fallback", raw: "abc", typ: "int", expected: "abc"},
+		{name: "bool true", raw: "true", typ: "bool", expected: true},
+		{name: "bool false", raw: "false", typ: "bool", expected: false},
+		{name: "bool invalid fallback", raw: "nope", typ: "bool", expected: "nope"},
+		{name: "float valid", raw: "2.71", typ: "float", expected: 2.71},
+		{name: "float invalid fallback", raw: "abc", typ: "float", expected: "abc"},
+		{name: "unknown type", raw: "x", typ: "custom", expected: "x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, coerceValue(tt.raw, tt.typ))
+		})
+	}
+}
+
 // ── Delete tests ──────────────────────────────────────────────────────────────
 
 func TestCommandDelete_Found(t *testing.T) {

--- a/pkg/cmd/scafctl/state/state_test.go
+++ b/pkg/cmd/scafctl/state/state_test.go
@@ -1,0 +1,249 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestContext(t *testing.T) (context.Context, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	ios := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	w := writer.New(ios, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	return ctx, &buf
+}
+
+func seedState(t *testing.T, path string) {
+	t.Helper()
+	sd := state.NewData()
+	sd.Values["env"] = &state.Entry{Value: "prod", Type: "string", UpdatedAt: time.Now().UTC()}
+	sd.Values["count"] = &state.Entry{Value: float64(42), Type: "int", UpdatedAt: time.Now().UTC()}
+	require.NoError(t, state.SaveToFile(path, sd))
+}
+
+// ── CommandState tests ────────────────────────────────────────────────────────
+
+func TestCommandState_HasSubcommands(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{}
+	cmd := CommandState(cliParams, ios, "testcli")
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "get")
+	assert.Contains(t, names, "set")
+	assert.Contains(t, names, "delete")
+	assert.Contains(t, names, "clear")
+}
+
+// ── List tests ────────────────────────────────────────────────────────────────
+
+func TestCommandList_EmptyState(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "empty.json")
+	ctx, buf := newTestContext(t)
+
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandList(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No state entries found")
+}
+
+func TestCommandList_WithEntries(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandList(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "env")
+	assert.Contains(t, buf.String(), "count")
+}
+
+// ── Get tests ─────────────────────────────────────────────────────────────────
+
+func TestCommandGet_Found(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandGet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "env"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "prod")
+}
+
+func TestCommandGet_NotFound(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandGet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "missing"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "not found")
+}
+
+func TestCommandGet_JSON(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandGet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "env", "-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"value"`)
+	assert.Contains(t, buf.String(), `"type"`)
+}
+
+// ── Set tests ─────────────────────────────────────────────────────────────────
+
+func TestCommandSet_NewKey(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "region", "--value", "us-east-1"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	require.Contains(t, sd.Values, "region")
+	assert.Equal(t, "us-east-1", sd.Values["region"].Value)
+}
+
+func TestCommandSet_Immutable(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	sd := state.NewData()
+	sd.Values["locked"] = &state.Entry{Value: "v1", Type: "string", Immutable: true, UpdatedAt: time.Now().UTC()}
+	require.NoError(t, state.SaveToFile(path, sd))
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "locked", "--value", "v2"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "immutable")
+}
+
+// ── Delete tests ──────────────────────────────────────────────────────────────
+
+func TestCommandDelete_Found(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandDelete(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "env"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Deleted")
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	assert.NotContains(t, sd.Values, "env")
+	assert.Contains(t, sd.Values, "count")
+}
+
+func TestCommandDelete_NotFound(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandDelete(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--key", "missing"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "not found")
+}
+
+// ── Clear tests ───────────────────────────────────────────────────────────────
+
+func TestCommandClear(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+	seedState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Cleared 2 entries")
+
+	sd, loadErr := state.LoadFromFile(path)
+	require.NoError(t, loadErr)
+	assert.Empty(t, sd.Values)
+}
+
+func TestCommandClear_EmptyState(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "empty.json")
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Cleared 0 entries")
+}

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -278,4 +278,29 @@ Key operations:
 The catalog supports versioning, visibility controls (public/private), and beta flags.`,
 		SeeAlso: []string{"bundle", "compose"},
 	},
+	// --- State ---
+	{
+		Name:     "state",
+		Title:    "State Persistence",
+		Category: "state",
+		Summary:  "Opt-in persistence that saves and restores resolver values across solution runs.",
+		Explanation: `State persistence allows a solution to remember resolver values between executions. When enabled, resolved values marked with 'saveToState: true' are saved after execution and restored on the next run.
+
+**Configuration** — add a top-level 'state' block to the solution:
+- **enabled** — literal bool, CEL expression, or template controlling activation.
+- **backend** — which provider stores the state (e.g., file, github, http).
+
+**Lifecycle**:
+1. Before resolvers run, the state manager calls the backend provider with 'state_load' to load any existing state.
+2. Loaded state is available to the 'state' provider via the fallback chain pattern.
+3. After execution, resolvers with 'saveToState: true' are persisted via 'state_save'.
+
+**State provider** — used inside resolver fallback chains to read individual keys from loaded state. Returns null when the key is not found (if required: false), so the next provider in the chain takes over.
+
+**Backend providers** — file (local JSON via XDG state dir), github (GitHub GraphQL API), http (remote REST API). Each implements CapabilityState with state_load, state_save, and state_delete operations.`,
+		Examples: []string{
+			"# Enable state with file backend\nstate:\n  enabled: true\n  backend:\n    provider: file\n    inputs:\n      path: \"my-app-state.json\"\n\nspec:\n  resolvers:\n    username:\n      type: string\n      saveToState: true\n      resolve:\n        with:\n          - provider: state\n            inputs:\n              key: \"username\"\n              required: false\n          - provider: parameter\n            inputs:\n              name: \"username\"",
+		},
+		SeeAlso: []string{"resolver", "provider", "cel-expression"},
+	},
 }

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -91,6 +91,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintWorkflow(sol, result, registry)
+	lintState(sol, result, registry)
 	lintTests(sol, filePath, result)
 	lintProviderInputs(sol, result, registry)
 
@@ -947,4 +948,171 @@ func FilterBySeverity(result *Result, minSeverity string) *Result {
 	}
 
 	return filtered
+}
+
+// stateReadProviders are providers that read from loaded state and cannot
+// be used by resolvers referenced in state config (circular dependency).
+var stateReadProviders = map[string]bool{
+	"state": true,
+}
+
+// lintState validates the solution's state configuration.
+func lintState(sol *solution.Solution, result *Result, registry *provider.Registry) {
+	if sol.State == nil {
+		return
+	}
+
+	if !lintStateBackend(sol, result, registry) {
+		return
+	}
+	lintStateResolverRefs(sol, result)
+	lintStateSensitive(sol, result)
+	lintStateCircularDeps(sol, result)
+}
+
+// lintStateBackend validates the backend provider configuration.
+// Returns false if further state linting should be skipped (e.g., backend is missing).
+func lintStateBackend(sol *solution.Solution, result *Result, registry *provider.Registry) bool {
+	location := "state"
+
+	backendName := sol.State.Backend.Provider
+	if backendName == "" {
+		result.addFinding(SeverityError, "state", location+".backend.provider",
+			"state backend provider is not specified",
+			"Set backend.provider to a registered provider with CapabilityState (e.g., 'file')",
+			"missing-state-backend")
+		return false
+	}
+
+	prov, found := registry.Get(backendName)
+	if !found {
+		result.addFinding(SeverityError, "state", location+".backend.provider",
+			fmt.Sprintf("state backend provider '%s' not found in registry", backendName),
+			"Use a registered state backend provider such as 'state-file' or 'state-github'",
+			"invalid-state-backend")
+	} else {
+		desc := prov.Descriptor()
+		hasState := false
+		for _, cap := range desc.Capabilities {
+			if cap == provider.CapabilityState {
+				hasState = true
+				break
+			}
+		}
+		if !hasState {
+			result.addFinding(SeverityError, "state", location+".backend.provider",
+				fmt.Sprintf("provider '%s' does not have CapabilityState", backendName),
+				"Use a provider that implements CapabilityState",
+				"invalid-state-backend")
+		}
+	}
+
+	lintNilInputs(sol.State.Backend.Inputs, location+".backend", result)
+	return true
+}
+
+// lintStateResolverRefs checks for direct rslvr: references in state config.
+// These won't work because state loads before resolvers run.
+func lintStateResolverRefs(sol *solution.Solution, result *Result) {
+	location := "state"
+
+	if sol.State.Enabled != nil && sol.State.Enabled.Resolver != nil {
+		result.addFinding(SeverityError, "state", location+".enabled",
+			fmt.Sprintf("state.enabled uses rslvr: %q — resolver results are not available at state load time", *sol.State.Enabled.Resolver),
+			"Use a literal value, env var, or CEL expression instead (e.g. expr: \"env('ENABLE_STATE') == 'true'\")",
+			"state-resolver-ref")
+	}
+	for inputKey, input := range sol.State.Backend.Inputs {
+		if input != nil && input.Resolver != nil {
+			result.addFinding(SeverityError, "state", fmt.Sprintf("%s.backend.inputs.%s", location, inputKey),
+				fmt.Sprintf("state backend input %q uses rslvr: %q — resolver results are not available at state load time", inputKey, *input.Resolver),
+				"Use a CEL expression referencing a CLI parameter instead (e.g. expr: \"_.appName + '-state.json'\")",
+				"state-resolver-ref")
+		}
+	}
+}
+
+// lintStateSensitive warns about resolvers that are both sensitive and saveToState.
+func lintStateSensitive(sol *solution.Solution, result *Result) {
+	for name, res := range sol.Spec.Resolvers {
+		if res != nil && res.Sensitive && res.SaveToState {
+			result.addFinding(SeverityWarning, "security",
+				fmt.Sprintf("resolvers.%s", name),
+				fmt.Sprintf("resolver '%s' is sensitive and has saveToState: true — value will be stored in plaintext", name),
+				"Acknowledge the risk or remove saveToState for sensitive resolvers",
+				"sensitive-state")
+		}
+	}
+}
+
+// lintStateCircularDeps checks for circular dependencies between state config
+// and resolvers that use saveToState or the state-reading provider.
+func lintStateCircularDeps(sol *solution.Solution, result *Result) {
+	stateResolverRefs := collectStateResolverRefs(sol)
+
+	if sol.Spec.Resolvers == nil || len(stateResolverRefs) == 0 {
+		return
+	}
+
+	for refName := range stateResolverRefs {
+		res, exists := sol.Spec.Resolvers[refName]
+		if !exists {
+			continue
+		}
+
+		refLocation := fmt.Sprintf("resolvers.%s", refName)
+
+		if res.SaveToState {
+			result.addFinding(SeverityError, "state", refLocation,
+				fmt.Sprintf("resolver '%s' is referenced by state config and has saveToState: true (circular dependency)", refName),
+				"Remove saveToState from resolvers referenced by state.enabled or state.backend.inputs",
+				"state-circular-dependency")
+		}
+
+		if res.Resolve != nil {
+			for _, step := range res.Resolve.With {
+				if stateReadProviders[step.Provider] {
+					result.addFinding(SeverityError, "state", refLocation,
+						fmt.Sprintf("resolver '%s' is referenced by state config and uses '%s' provider (circular dependency)", refName, step.Provider),
+						"State-referenced resolvers cannot use state-reading providers",
+						"state-circular-dependency")
+				}
+			}
+		}
+	}
+}
+
+// collectStateResolverRefs returns the resolver names referenced by state.enabled
+// and state.backend.inputs.
+func collectStateResolverRefs(sol *solution.Solution) map[string]bool {
+	refs := make(map[string]bool)
+	if sol.State == nil {
+		return refs
+	}
+
+	collectFromValueRef := func(vr interface{ ReferencedVariables() map[string]struct{} }) {
+		if vr == nil {
+			return
+		}
+		for name := range vr.ReferencedVariables() {
+			refs[name] = true
+		}
+	}
+
+	if sol.State.Enabled != nil {
+		collectFromValueRef(sol.State.Enabled)
+		if sol.State.Enabled.Resolver != nil {
+			refs[*sol.State.Enabled.Resolver] = true
+		}
+	}
+	for _, input := range sol.State.Backend.Inputs {
+		if input != nil {
+			collectFromValueRef(input)
+			if input.Resolver != nil {
+				refs[*input.Resolver] = true
+			}
+		}
+	}
+
+	return refs
 }

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -988,7 +988,7 @@ func lintStateBackend(sol *solution.Solution, result *Result, registry *provider
 	if !found {
 		result.addFinding(SeverityError, "state", location+".backend.provider",
 			fmt.Sprintf("state backend provider '%s' not found in registry", backendName),
-			"Use a registered state backend provider such as 'state-file' or 'state-github'",
+			"Use a registered provider with CapabilityState such as 'file', 'github', or 'http'",
 			"invalid-state-backend")
 	} else {
 		desc := prov.Descriptor()
@@ -1019,14 +1019,14 @@ func lintStateResolverRefs(sol *solution.Solution, result *Result) {
 	if sol.State.Enabled != nil && sol.State.Enabled.Resolver != nil {
 		result.addFinding(SeverityError, "state", location+".enabled",
 			fmt.Sprintf("state.enabled uses rslvr: %q — resolver results are not available at state load time", *sol.State.Enabled.Resolver),
-			"Use a literal value, env var, or CEL expression instead (e.g. expr: \"env('ENABLE_STATE') == 'true'\")",
+			"Use a literal value or CEL expression referencing CLI params instead (e.g. expr: \"__params.enable_state == true\")",
 			"state-resolver-ref")
 	}
 	for inputKey, input := range sol.State.Backend.Inputs {
 		if input != nil && input.Resolver != nil {
 			result.addFinding(SeverityError, "state", fmt.Sprintf("%s.backend.inputs.%s", location, inputKey),
 				fmt.Sprintf("state backend input %q uses rslvr: %q — resolver results are not available at state load time", inputKey, *input.Resolver),
-				"Use a CEL expression referencing a CLI parameter instead (e.g. expr: \"_.appName + '-state.json'\")",
+				"Use a CEL expression referencing a CLI parameter instead (e.g. expr: \"__params.appName + '-state.json'\")",
 				"state-resolver-ref")
 		}
 	}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1148,4 +1149,288 @@ func TestLintTemplateUnderscorePrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newStateProvider(name string, capability provider.Capability) *fakeProvider {
+	outputSchema := &jsonschema.Schema{Type: "object"}
+	if capability == provider.CapabilityState {
+		outputSchema = &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"success": {Type: "boolean"},
+			},
+		}
+	}
+	return &fakeProvider{
+		desc: &provider.Descriptor{
+			Name:        name,
+			APIVersion:  "v1",
+			Version:     semver.MustParse("1.0.0"),
+			Description: "State provider",
+			Capabilities: []provider.Capability{
+				capability,
+			},
+			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				capability: outputSchema,
+			},
+		},
+	}
+}
+
+func TestLintState_MissingBackendProvider(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{Provider: ""},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "missing-state-backend")
+	assert.Len(t, findings, 1)
+}
+
+func TestLintState_InvalidBackendProvider(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{Provider: "nonexistent"},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "invalid-state-backend")
+	assert.Len(t, findings, 1)
+}
+
+func TestLintState_ProviderWithoutCapabilityState(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{Provider: "static"},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "invalid-state-backend")
+	assert.Len(t, findings, 1)
+}
+
+func TestLintState_CircularDependency_SaveToState(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"use_state": {
+					Type:        "string",
+					SaveToState: true,
+					Resolve:     &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Resolver: strPtr("use_state")},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-circular-dependency")
+	assert.GreaterOrEqual(t, len(findings), 1)
+}
+
+func TestLintState_CircularDependency_UsesStateProvider(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"env_check": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "state"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Resolver: strPtr("env_check")},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newStateProvider("state", provider.CapabilityFrom))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-circular-dependency")
+	assert.GreaterOrEqual(t, len(findings), 1)
+}
+
+func TestLintState_SensitiveWithSaveToState(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"api_key": {
+					Type:        "string",
+					Sensitive:   true,
+					SaveToState: true,
+					Resolve:     &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "sensitive-state")
+	assert.Len(t, findings, 1)
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+}
+
+func TestLintState_ValidConfig(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"greeting": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "test.json"}},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	stateFindings := []*Finding{}
+	for _, f := range result.Findings {
+		if f.Category == "state" || f.RuleName == "sensitive-state" {
+			stateFindings = append(stateFindings, f)
+		}
+	}
+	assert.Empty(t, stateFindings)
+}
+
+func TestLintState_ResolverRefInEnabled(t *testing.T) {
+	rslvrName := "my_flag"
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"my_flag": {
+					Type:    "bool",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Resolver: &rslvrName},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "test.json"}},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-resolver-ref")
+	assert.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "state.enabled")
+	assert.Contains(t, findings[0].Message, "my_flag")
+}
+
+func TestLintState_ResolverRefInBackendInputs(t *testing.T) {
+	rslvrName := "app_name"
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"app_name": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs: map[string]*spec.ValueRef{
+					"path": {Resolver: &rslvrName},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-resolver-ref")
+	assert.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "path")
+	assert.Contains(t, findings[0].Message, "app_name")
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -305,6 +305,46 @@ var KnownRules = map[string]RuleMeta{
 			"# Wrong:\ntmpl: \"Deploying {{ ._.config.appName }}\"\n\n# Correct:\ntmpl: \"Deploying {{ .config.appName }}\"",
 		},
 	},
+	"missing-state-backend": {
+		Rule:        "missing-state-backend",
+		Severity:    string(SeverityError),
+		Category:    "state",
+		Description: "The state block is configured but the backend provider is not specified.",
+		Why:         "State persistence requires a backend provider (e.g., 'file' or 'github') with CapabilityState to load and save state data.",
+		Fix:         "Add a backend.provider field to the state block, e.g.:\n  state:\n    enabled: true\n    backend:\n      provider: file",
+	},
+	"invalid-state-backend": {
+		Rule:        "invalid-state-backend",
+		Severity:    string(SeverityError),
+		Category:    "state",
+		Description: "The state backend references a provider that is not registered or lacks CapabilityState.",
+		Why:         "State backends must implement CapabilityState. Using an unregistered or incompatible provider will fail at runtime.",
+		Fix:         "Use a registered provider with CapabilityState such as 'file' or 'github'.",
+	},
+	"state-circular-dependency": {
+		Rule:        "state-circular-dependency",
+		Severity:    string(SeverityError),
+		Category:    "state",
+		Description: "A resolver referenced by state.enabled or state.backend.inputs has saveToState or uses the state-reading provider.",
+		Why:         "State loading depends on these resolvers, but they would also read/write state, creating a circular dependency.",
+		Fix:         "Ensure resolvers referenced by state config do not have saveToState: true and do not use state backend providers.",
+	},
+	"sensitive-state": {
+		Rule:        "sensitive-state",
+		Severity:    string(SeverityWarning),
+		Category:    "security",
+		Description: "A resolver marked sensitive: true also has saveToState: true. The sensitive value will be stored in plaintext in the state file.",
+		Why:         "Sensitive values (API keys, tokens) saved to state are persisted unencrypted. This is intentional for validation replay but should be an explicit, informed decision.",
+		Fix:         "Acknowledge the risk or remove saveToState from sensitive resolvers. Consider using the secret provider for sensitive values that do not need state persistence.",
+	},
+	"state-resolver-ref": {
+		Rule:        "state-resolver-ref",
+		Severity:    string(SeverityError),
+		Category:    "state",
+		Description: "A state.enabled or state.backend.inputs field uses a direct rslvr: reference. State is loaded before resolvers run, so resolver results are not available.",
+		Why:         "State configuration is resolved before resolver execution using only CLI parameters (-r flags) and environment data. Direct rslvr: references will fail at runtime because resolver results do not exist yet.",
+		Fix:         "Use a CEL expression referencing CLI parameters instead, e.g.:\n  path:\n    expr: \"_.appName + '-state.json'\"\nwhere appName is passed via -r appName=myapp.",
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -343,7 +343,7 @@ var KnownRules = map[string]RuleMeta{
 		Category:    "state",
 		Description: "A state.enabled or state.backend.inputs field uses a direct rslvr: reference. State is loaded before resolvers run, so resolver results are not available.",
 		Why:         "State configuration is resolved before resolver execution using only CLI parameters (-r flags) and environment data. Direct rslvr: references will fail at runtime because resolver results do not exist yet.",
-		Fix:         "Use a CEL expression referencing CLI parameters instead, e.g.:\n  path:\n    expr: \"_.appName + '-state.json'\"\nwhere appName is passed via -r appName=myapp.",
+		Fix:         "Use a CEL expression referencing CLI parameters instead, e.g.:\n  path:\n    expr: \"__params.appName + '-state.json'\"\nwhere appName is passed via -r appName=myapp.",
 	},
 }
 

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 31 rules — update this when new rules are added
-	assert.Equal(t, 31, len(KnownRules), "expected 31 known lint rules")
+	// We expect exactly 36 rules — update this when new rules are added
+	assert.Equal(t, 36, len(KnownRules), "expected 36 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -726,6 +726,9 @@ func (s *Server) registerTools() {
 
 	// REST API tools
 	s.registerAPITools()
+
+	// State inspection tools
+	s.registerStateTools()
 }
 
 // registerResources registers all MCP resources on the server.

--- a/pkg/mcp/tools_state.go
+++ b/pkg/mcp/tools_state.go
@@ -1,0 +1,209 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+// registerStateTools registers state inspection MCP tools.
+func (s *Server) registerStateTools() {
+	listTool := mcp.NewTool("state_list",
+		mcp.WithDescription(fmt.Sprintf("List all entries in a %s state file. Shows key names, types, values, and timestamps. Use this to inspect persisted resolver values between solution runs.", s.name)),
+		mcp.WithTitleAnnotation("List State Entries"),
+		mcp.WithToolIcons(toolIcons["config"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("State file path relative to the XDG state directory (e.g., 'my-app-state.json')"),
+		),
+	)
+	s.mcpServer.AddTool(listTool, s.handleStateList)
+
+	getTool := mcp.NewTool("state_get",
+		mcp.WithDescription(fmt.Sprintf("Get a single entry from a %s state file by key. Returns the value, type, and metadata for the specified key.", s.name)),
+		mcp.WithTitleAnnotation("Get State Entry"),
+		mcp.WithToolIcons(toolIcons["config"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("State file path relative to the XDG state directory"),
+		),
+		mcp.WithString("key",
+			mcp.Required(),
+			mcp.Description("State entry key to retrieve (typically a resolver name)"),
+		),
+	)
+	s.mcpServer.AddTool(getTool, s.handleStateGet)
+
+	deleteTool := mcp.NewTool("state_delete",
+		mcp.WithDescription(fmt.Sprintf("Delete a single entry from a %s state file by key, or clear all entries. This modifies the state file on disk.", s.name)),
+		mcp.WithTitleAnnotation("Delete State Entry"),
+		mcp.WithToolIcons(toolIcons["config"]),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("State file path relative to the XDG state directory"),
+		),
+		mcp.WithString("key",
+			mcp.Description("State entry key to delete. Omit to clear all entries."),
+		),
+	)
+	s.mcpServer.AddTool(deleteTool, s.handleStateDelete)
+}
+
+// handleStateList lists all entries in a state file.
+func (s *Server) handleStateList(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path := request.GetString("path", "")
+	if path == "" {
+		return newStructuredError(ErrCodeInvalidInput, "path is required",
+			WithField("path"),
+			WithSuggestion("Provide the state file path (e.g., 'my-app-state.json')"),
+		), nil
+	}
+
+	sd, err := state.LoadFromFile(path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err),
+			WithSuggestion("Check that the path is correct and the file is valid JSON"),
+		), nil
+	}
+
+	type entryInfo struct {
+		Key       string `json:"key"`
+		Value     any    `json:"value"`
+		Type      string `json:"type,omitempty"`
+		UpdatedAt string `json:"updatedAt,omitempty"`
+		Immutable bool   `json:"immutable,omitempty"`
+	}
+
+	keys := make([]string, 0, len(sd.Values))
+	for k := range sd.Values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	entries := make([]entryInfo, 0, len(sd.Values))
+	for _, key := range keys {
+		entry := sd.Values[key]
+		info := entryInfo{
+			Key:       key,
+			Value:     entry.Value,
+			Type:      entry.Type,
+			Immutable: entry.Immutable,
+		}
+		if !entry.UpdatedAt.IsZero() {
+			info.UpdatedAt = entry.UpdatedAt.Format("2006-01-02T15:04:05Z")
+		}
+		entries = append(entries, info)
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"path":     path,
+		"count":    len(entries),
+		"entries":  entries,
+		"metadata": sd.Metadata,
+	})
+}
+
+// handleStateGet retrieves a single state entry by key.
+func (s *Server) handleStateGet(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path := request.GetString("path", "")
+	if path == "" {
+		return newStructuredError(ErrCodeInvalidInput, "path is required",
+			WithField("path"),
+		), nil
+	}
+
+	key := request.GetString("key", "")
+	if key == "" {
+		return newStructuredError(ErrCodeInvalidInput, "key is required",
+			WithField("key"),
+			WithSuggestion("Use state_list to see available keys"),
+			WithRelatedTools("state_list"),
+		), nil
+	}
+
+	sd, err := state.LoadFromFile(path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err)), nil
+	}
+
+	entry, ok := sd.Values[key]
+	if !ok {
+		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("key %q not found in state", key),
+			WithField("key"),
+			WithSuggestion("Use state_list to see available keys"),
+			WithRelatedTools("state_list"),
+		), nil
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"key":   key,
+		"entry": entry,
+	})
+}
+
+// handleStateDelete deletes a single key or clears all entries from a state file.
+func (s *Server) handleStateDelete(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path := request.GetString("path", "")
+	if path == "" {
+		return newStructuredError(ErrCodeInvalidInput, "path is required",
+			WithField("path"),
+		), nil
+	}
+
+	sd, err := state.LoadFromFile(path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err)), nil
+	}
+
+	key := request.GetString("key", "")
+
+	if key != "" {
+		// Delete a single key
+		if _, ok := sd.Values[key]; !ok {
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("key %q not found in state", key),
+				WithField("key"),
+				WithRelatedTools("state_list"),
+			), nil
+		}
+
+		delete(sd.Values, key)
+		if err := state.SaveToFile(path, sd); err != nil {
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
+		}
+
+		return mcp.NewToolResultJSON(map[string]any{
+			"success": true,
+			"message": fmt.Sprintf("deleted key %q", key),
+		})
+	}
+
+	// Clear all entries
+	count := len(sd.Values)
+	sd.Values = make(map[string]*state.Entry)
+	if err := state.SaveToFile(path, sd); err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("cleared %d entries", count),
+	})
+}

--- a/pkg/mcp/tools_state_test.go
+++ b/pkg/mcp/tools_state_test.go
@@ -1,0 +1,193 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedTestState(t *testing.T, path string) {
+	t.Helper()
+	sd := state.NewData()
+	sd.Values["env"] = &state.Entry{Value: "prod", Type: "string", UpdatedAt: time.Now().UTC()}
+	sd.Values["count"] = &state.Entry{Value: float64(42), Type: "int", UpdatedAt: time.Now().UTC()}
+	require.NoError(t, state.SaveToFile(path, sd))
+}
+
+func newStateRequest(name string, args map[string]any) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{}
+	req.Params.Name = name
+	req.Params.Arguments = args
+	return req
+}
+
+func TestHandleStateList(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("with entries", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateList(context.Background(), newStateRequest("state_list", map[string]any{
+			"path": path,
+		}))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var output map[string]any
+		text := result.Content[0].(mcp.TextContent).Text
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		assert.Equal(t, float64(2), output["count"])
+		entries := output["entries"].([]any)
+		assert.Len(t, entries, 2)
+	})
+
+	t.Run("empty state", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.json")
+
+		result, err := srv.handleStateList(context.Background(), newStateRequest("state_list", map[string]any{
+			"path": path,
+		}))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var output map[string]any
+		text := result.Content[0].(mcp.TextContent).Text
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		assert.Equal(t, float64(0), output["count"])
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		result, err := srv.handleStateList(context.Background(), newStateRequest("state_list", map[string]any{}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleStateGet(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("existing key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateGet(context.Background(), newStateRequest("state_get", map[string]any{
+			"path": path,
+			"key":  "env",
+		}))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var output map[string]any
+		text := result.Content[0].(mcp.TextContent).Text
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		assert.Equal(t, "env", output["key"])
+		entry := output["entry"].(map[string]any)
+		assert.Equal(t, "prod", entry["value"])
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateGet(context.Background(), newStateRequest("state_get", map[string]any{
+			"path": path,
+			"key":  "nonexistent",
+		}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		result, err := srv.handleStateGet(context.Background(), newStateRequest("state_get", map[string]any{
+			"key": "env",
+		}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing key param", func(t *testing.T) {
+		result, err := srv.handleStateGet(context.Background(), newStateRequest("state_get", map[string]any{
+			"path": "/tmp/foo.json",
+		}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestHandleStateDelete(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("delete single key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateDelete(context.Background(), newStateRequest("state_delete", map[string]any{
+			"path": path,
+			"key":  "env",
+		}))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		// Verify key was deleted
+		sd, loadErr := state.LoadFromFile(path)
+		require.NoError(t, loadErr)
+		assert.NotContains(t, sd.Values, "env")
+		assert.Contains(t, sd.Values, "count")
+	})
+
+	t.Run("delete nonexistent key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateDelete(context.Background(), newStateRequest("state_delete", map[string]any{
+			"path": path,
+			"key":  "nope",
+		}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("clear all", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		seedTestState(t, path)
+
+		result, err := srv.handleStateDelete(context.Background(), newStateRequest("state_delete", map[string]any{
+			"path": path,
+		}))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var output map[string]any
+		text := result.Content[0].(mcp.TextContent).Text
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Contains(t, output["message"], "cleared 2 entries")
+
+		// Verify all entries gone
+		sd, loadErr := state.LoadFromFile(path)
+		require.NoError(t, loadErr)
+		assert.Empty(t, sd.Values)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		result, err := srv.handleStateDelete(context.Background(), newStateRequest("state_delete", map[string]any{}))
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/parameterprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/secretprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/sleepprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/stateprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/validationprovider"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -78,6 +79,7 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		hclprovider.NewHCLProvider(),
 		metadataprovider.New(),
 		messageprovider.NewMessageProvider(),
+		stateprovider.New(),
 	}
 
 	// Initialize secrets store for the secret provider.
@@ -148,6 +150,7 @@ func ProviderNames() []string {
 		"github",
 		"metadata",
 		"message",
+		"state",
 	}
 }
 

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -74,7 +74,7 @@ func TestProviderNames(t *testing.T) {
 	names := ProviderNames()
 
 	// Should have all built-in providers
-	expectedCount := 19 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl, github, metadata, message
+	expectedCount := 20 // http, env, cel, file, directory, validation, exec, git, debug, sleep, parameter, static, go-template, secret, identity, hcl, github, metadata, message, state
 	assert.Len(t, names, expectedCount, "should have %d built-in providers", expectedCount)
 
 	// Verify expected names are present
@@ -98,6 +98,7 @@ func TestProviderNames(t *testing.T) {
 		"github",
 		"metadata",
 		"message",
+		"state",
 	}
 
 	for _, expected := range expectedNames {
@@ -177,6 +178,7 @@ func TestAllProvidersRegistered(t *testing.T) {
 		{"metadata", "metadata"},
 		{"github", "GitHub"},
 		{"message", "message"},
+		{"state", "state"},
 	}
 
 	for _, expected := range expectedProviders {

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -59,6 +59,12 @@ func NewFileProvider() *FileProvider {
 				case "write-tree":
 					basePath, _ := inputs["basePath"].(string)
 					return fmt.Sprintf("Would write file tree to %s", basePath), nil
+				case "state_load":
+					return fmt.Sprintf("Would load state from %s", path), nil
+				case "state_save":
+					return fmt.Sprintf("Would save state to %s", path), nil
+				case "state_delete":
+					return fmt.Sprintf("Would delete state at %s", path), nil
 				default:
 					return fmt.Sprintf("Would perform file %s on %s", operation, path), nil
 				}
@@ -67,11 +73,13 @@ func NewFileProvider() *FileProvider {
 				provider.CapabilityFrom,      // read, exists operations
 				provider.CapabilityAction,    // write, delete operations
 				provider.CapabilityTransform, // transform operations on file content
+				provider.CapabilityState,     // state_load, state_save, state_delete operations
 			},
 			Schema: schemahelper.ObjectSchema([]string{"operation"}, map[string]*jsonschema.Schema{
 				"operation": schemahelper.StringProp("Operation to perform",
 					schemahelper.WithExample("read"),
-					schemahelper.WithEnum("read", "write", "exists", "delete", "write-tree")),
+					schemahelper.WithEnum("read", "write", "exists", "delete", "write-tree", "state_load", "state_save", "state_delete")),
+				"data": schemahelper.AnyProp("The full StateData object to persist (required for state_save operation)"),
 				"path": schemahelper.StringProp("File path (absolute or relative). Required for read, write, exists, delete operations.",
 					schemahelper.WithExample("./config.yaml"),
 					schemahelper.WithMaxLength(4096)),
@@ -144,6 +152,10 @@ func NewFileProvider() *FileProvider {
 					"content": schemahelper.StringProp("File content (for read operation)"),
 					"path":    schemahelper.StringProp("Absolute path to the file"),
 					"size":    schemahelper.IntProp("File size in bytes"),
+				}),
+				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
+					"data":    schemahelper.AnyProp("The loaded state data (for state_load operation)"),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success":      schemahelper.BoolProp("Whether the operation succeeded (for write/delete operations)"),
@@ -257,6 +269,11 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 	}
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation)
+
+	// State operations use the XDG state directory, not CWD-relative paths
+	if strings.HasPrefix(operation, "state_") {
+		return p.dispatchStateOperation(ctx, operation, inputs)
+	}
 
 	// write-tree uses basePath instead of path
 	if operation == "write-tree" {

--- a/pkg/provider/builtin/fileprovider/file_state.go
+++ b/pkg/provider/builtin/fileprovider/file_state.go
@@ -1,0 +1,150 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package fileprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+// executeStateLoad loads state from a JSON file in the XDG state directory.
+func (p *FileProvider) executeStateLoad(absPath string) (*provider.Output, error) {
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		// First run -- return empty state
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	}
+
+	data, err := os.ReadFile(absPath) //nolint:gosec // path is validated by caller
+	if err != nil {
+		return nil, fmt.Errorf("state load: %w", err)
+	}
+
+	var stateData state.Data
+	if err := json.Unmarshal(data, &stateData); err != nil {
+		return nil, fmt.Errorf("state load: unmarshal: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"data":    &stateData,
+		},
+	}, nil
+}
+
+// executeStateSave persists state as a JSON file, using atomic write (temp + rename).
+func (p *FileProvider) executeStateSave(absPath string, inputs map[string]any) (*provider.Output, error) {
+	rawData, ok := inputs["data"]
+	if !ok {
+		return nil, fmt.Errorf("state save: data is required")
+	}
+
+	jsonBytes, err := json.MarshalIndent(rawData, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("state save: marshal: %w", err)
+	}
+
+	dir := filepath.Dir(absPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("state save: create directory: %w", err)
+	}
+
+	// Atomic write: temp file + rename
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return nil, fmt.Errorf("state save: create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(jsonBytes); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("state save: write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("state save: close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, absPath); err != nil { //nolint:gosec // absPath validated by resolveStatePath
+		return nil, fmt.Errorf("state save: rename: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDelete removes a state file.
+func (p *FileProvider) executeStateDelete(absPath string) (*provider.Output, error) {
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	}
+
+	if err := os.Remove(absPath); err != nil {
+		return nil, fmt.Errorf("state delete: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDryRun handles dry-run mode for state operations.
+func (p *FileProvider) executeStateDryRun(operation string) (*provider.Output, error) {
+	switch operation {
+	case "state_load":
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	case "state_save", "state_delete":
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown state operation: %s", operation)
+	}
+}
+
+// dispatchStateOperation handles the state capability branch in Execute.
+func (p *FileProvider) dispatchStateOperation(ctx context.Context, operation string, inputs map[string]any) (*provider.Output, error) {
+	statePath, _ := inputs["path"].(string)
+	if statePath == "" {
+		return nil, fmt.Errorf("%s: path is required for state operations", ProviderName)
+	}
+
+	absPath, err := state.ResolveStatePath(statePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	if provider.DryRunFromContext(ctx) {
+		return p.executeStateDryRun(operation)
+	}
+
+	switch operation {
+	case "state_load":
+		return p.executeStateLoad(absPath)
+	case "state_save":
+		return p.executeStateSave(absPath, inputs)
+	case "state_delete":
+		return p.executeStateDelete(absPath)
+	default:
+		return nil, fmt.Errorf("%s: unsupported state operation: %s", ProviderName, operation)
+	}
+}

--- a/pkg/provider/builtin/fileprovider/file_state_test.go
+++ b/pkg/provider/builtin/fileprovider/file_state_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package fileprovider
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileProvider_StateCapability(t *testing.T) {
+	p := NewFileProvider()
+	desc := p.Descriptor()
+	assert.Contains(t, desc.Capabilities, provider.CapabilityState)
+	assert.Contains(t, desc.OutputSchemas, provider.CapabilityState)
+}
+
+func TestFileProvider_StateLoad_NotFound(t *testing.T) {
+	p := NewFileProvider()
+
+	result, err := p.executeStateLoad(filepath.Join(t.TempDir(), "nonexistent.json"))
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.NotNil(t, data["data"])
+}
+
+func TestFileProvider_StateRoundTrip(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+	absPath := filepath.Join(tmpDir, "state.json")
+
+	stateData := state.NewData()
+	stateData.Values = map[string]*state.Entry{
+		"greeting": {Value: "hello"},
+	}
+
+	// Save
+	saveResult, err := p.executeStateSave(absPath, map[string]any{"data": stateData})
+	require.NoError(t, err)
+	assert.True(t, saveResult.Data.(map[string]any)["success"].(bool))
+
+	// Verify file exists on disk
+	_, err = os.Stat(absPath)
+	require.NoError(t, err)
+
+	// Load
+	loadResult, err := p.executeStateLoad(absPath)
+	require.NoError(t, err)
+	loadMap := loadResult.Data.(map[string]any)
+	assert.True(t, loadMap["success"].(bool))
+
+	loaded, ok := loadMap["data"].(*state.Data)
+	require.True(t, ok)
+	assert.Equal(t, "hello", loaded.Values["greeting"].Value)
+
+	// Delete
+	delResult, err := p.executeStateDelete(absPath)
+	require.NoError(t, err)
+	assert.True(t, delResult.Data.(map[string]any)["success"].(bool))
+
+	// Verify file is gone
+	_, err = os.Stat(absPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFileProvider_StateDeleteNotFound(t *testing.T) {
+	p := NewFileProvider()
+
+	result, err := p.executeStateDelete(filepath.Join(t.TempDir(), "nonexistent.json"))
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+}
+
+func TestFileProvider_StateDispatch(t *testing.T) {
+	p := NewFileProvider()
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityState)
+
+	// Dispatch routes state_load through the Execute path
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"path":      "some/path.json",
+	})
+	require.NoError(t, err)
+	// state_load with non-existent file returns empty state
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+}
+
+func TestFileProvider_StateDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		hasData   bool
+	}{
+		{"load", "state_load", true},
+		{"save", "state_save", false},
+		{"delete", "state_delete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewFileProvider()
+			ctx := provider.WithDryRun(context.Background(), true)
+
+			result, err := p.dispatchStateOperation(ctx, tt.operation, map[string]any{
+				"path": "test.json",
+				"data": state.NewData(),
+			})
+			require.NoError(t, err)
+			data := result.Data.(map[string]any)
+			assert.True(t, data["success"].(bool))
+			if tt.hasData {
+				assert.NotNil(t, data["data"])
+			}
+		})
+	}
+}
+
+func TestFileProvider_StateMissingPath(t *testing.T) {
+	p := NewFileProvider()
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityState)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path is required")
+}
+
+func TestFileProvider_StateLoadInvalidJSON(t *testing.T) {
+	p := NewFileProvider()
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "bad.json")
+	require.NoError(t, os.WriteFile(statePath, []byte("{invalid"), 0o600))
+
+	_, err := p.executeStateLoad(statePath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestFileProvider_StateSaveMarshal(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+	absPath := filepath.Join(tmpDir, "map-test.json")
+
+	result, err := p.executeStateSave(absPath, map[string]any{
+		"data": map[string]any{"key": "value"},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+
+	raw, err := os.ReadFile(absPath)
+	require.NoError(t, err)
+	var loaded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &loaded))
+	assert.Equal(t, "value", loaded["key"])
+}
+
+func TestFileProvider_StateSaveMissingData(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+	absPath := filepath.Join(tmpDir, "no-data.json")
+
+	_, err := p.executeStateSave(absPath, map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "data is required")
+}
+
+func BenchmarkFileProvider_StateLoad(b *testing.B) {
+	p := NewFileProvider()
+	tmpDir := b.TempDir()
+
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"x": {Value: "y"},
+	}
+	data, _ := json.MarshalIndent(sd, "", "  ")
+	statePath := filepath.Join(tmpDir, "bench.json")
+	require.NoError(b, os.WriteFile(statePath, data, 0o600))
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeStateLoad(statePath)
+	}
+}
+
+func BenchmarkFileProvider_StateSave(b *testing.B) {
+	p := NewFileProvider()
+	tmpDir := b.TempDir()
+
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"x": {Value: "y"},
+	}
+	absPath := filepath.Join(tmpDir, "bench.json")
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeStateSave(absPath, map[string]any{"data": sd})
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -158,15 +158,29 @@ func NewGitHubProvider(opts ...Option) *GitHubProvider {
 				owner, _ := inputs["owner"].(string)
 				repo, _ := inputs["repo"].(string)
 				target := owner + "/" + repo
-				return fmt.Sprintf("Would perform GitHub %s on %s", operation, target), nil
+				switch operation {
+				case "state_load":
+					return fmt.Sprintf("Would load state from %s", target), nil
+				case "state_save":
+					return fmt.Sprintf("Would save state to %s (creating a commit)", target), nil
+				case "state_delete":
+					return fmt.Sprintf("Would delete state at %s (creating a commit)", target), nil
+				default:
+					return fmt.Sprintf("Would perform GitHub %s on %s", operation, target), nil
+				}
 			},
 			Capabilities: []provider.Capability{
 				provider.CapabilityFrom,
 				provider.CapabilityTransform,
 				provider.CapabilityAction,
+				provider.CapabilityState,
 			},
 			Schema: buildInputSchema(),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
+					"data":    schemahelper.AnyProp("The loaded state data (for state_load operation)"),
+				}),
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"result": schemahelper.AnyProp("The API response data — structure varies by operation"),
 				}),
@@ -593,6 +607,9 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 
 	// Dry-run support: return mock data for write operations
 	if dryRun := provider.DryRunFromContext(ctx); dryRun {
+		if strings.HasPrefix(operation, "state_") {
+			return p.executeStateDryRun(operation)
+		}
 		return p.executeDryRun(operation, inputs)
 	}
 
@@ -611,6 +628,11 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 	}
 
 	client := p.getClient(ctx)
+
+	// State operations use dedicated dispatch
+	if strings.HasPrefix(operation, "state_") {
+		return p.dispatchStateOperation(ctx, client, apiBase, owner, repo, inputs)
+	}
 
 	var result *provider.Output
 	var err error

--- a/pkg/provider/builtin/githubprovider/github_state.go
+++ b/pkg/provider/builtin/githubprovider/github_state.go
@@ -1,0 +1,260 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+// dispatchStateOperation handles the state capability branch in Execute.
+func (p *GitHubProvider) dispatchStateOperation(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	operation := getStringInput(inputs, "operation")
+
+	path := getStringInput(inputs, "path")
+	if path == "" {
+		return nil, fmt.Errorf("'path' is required for state operations")
+	}
+	branch := getStringInput(inputs, "branch")
+	if branch == "" {
+		return nil, fmt.Errorf("'branch' is required for state operations")
+	}
+
+	switch operation {
+	case "state_load":
+		return p.executeStateLoad(ctx, client, apiBase, owner, repo, path, branch)
+	case "state_save":
+		return p.executeStateSave(ctx, client, apiBase, owner, repo, path, branch, inputs)
+	case "state_delete":
+		return p.executeStateDelete(ctx, client, apiBase, owner, repo, path, branch, inputs)
+	default:
+		return nil, fmt.Errorf("unsupported state operation: %s", operation)
+	}
+}
+
+// executeStateLoad fetches a state JSON file from the repo and parses it.
+func (p *GitHubProvider) executeStateLoad(ctx context.Context, client *httpc.Client, apiBase, owner, repo, path, branch string) (*provider.Output, error) {
+	expression := branch + ":" + path
+
+	query := `query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Blob {
+        text
+      }
+    }
+  }
+}`
+	vars := map[string]any{"owner": owner, "name": repo, "expression": expression}
+	data, err := graphqlDo(ctx, client, apiBase, query, vars)
+	if err != nil {
+		return nil, fmt.Errorf("state load: %w", err)
+	}
+
+	obj, err := extractNode(data, "repository.object")
+	if err != nil {
+		return nil, fmt.Errorf("state load: %w", err)
+	}
+	if obj == nil {
+		// File not found -- first run, return empty state
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	}
+
+	blob, ok := obj.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("state load: unexpected object format")
+	}
+
+	text, _ := blob["text"].(string)
+	var stateData state.Data
+	if err := json.Unmarshal([]byte(text), &stateData); err != nil {
+		return nil, fmt.Errorf("state load: unmarshal: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"data":    &stateData,
+		},
+	}, nil
+}
+
+// executeStateSave serializes state data and commits it to the repo.
+func (p *GitHubProvider) executeStateSave(ctx context.Context, client *httpc.Client, apiBase, owner, repo, path, branch string, inputs map[string]any) (*provider.Output, error) {
+	rawData, ok := inputs["data"]
+	if !ok {
+		return nil, fmt.Errorf("state save: 'data' is required")
+	}
+
+	jsonBytes, err := json.MarshalIndent(rawData, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("state save: marshal: %w", err)
+	}
+
+	headOID, err := p.getHeadOID(ctx, client, apiBase, owner, repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("state save: %w", err)
+	}
+
+	message := stateCommitMessage(inputs, "chore(state): update state")
+	encoded := base64.StdEncoding.EncodeToString(jsonBytes)
+
+	if err := p.createStateCommit(ctx, client, apiBase, owner, repo, branch, message, headOID,
+		[]map[string]any{{"path": path, "contents": encoded}}, nil); err != nil {
+		return nil, fmt.Errorf("state save: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDelete removes a state file from the repo via commit.
+func (p *GitHubProvider) executeStateDelete(ctx context.Context, client *httpc.Client, apiBase, owner, repo, path, branch string, inputs map[string]any) (*provider.Output, error) {
+	// Check if file exists first
+	expression := branch + ":" + path
+	query := `query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Blob { oid }
+    }
+  }
+}`
+	vars := map[string]any{"owner": owner, "name": repo, "expression": expression}
+	data, err := graphqlDo(ctx, client, apiBase, query, vars)
+	if err != nil {
+		return nil, fmt.Errorf("state delete: check: %w", err)
+	}
+
+	obj, err := extractNode(data, "repository.object")
+	if err != nil {
+		return nil, fmt.Errorf("state delete: check: %w", err)
+	}
+	if obj == nil {
+		// File doesn't exist -- nothing to delete
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	}
+
+	headOID, err := p.getHeadOID(ctx, client, apiBase, owner, repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("state delete: %w", err)
+	}
+
+	message := stateCommitMessage(inputs, "chore(state): delete state")
+	if err := p.createStateCommit(ctx, client, apiBase, owner, repo, branch, message, headOID,
+		nil, []map[string]any{{"path": path}}); err != nil {
+		return nil, fmt.Errorf("state delete: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDryRun returns mock output for state operations during dry-run.
+func (p *GitHubProvider) executeStateDryRun(operation string) (*provider.Output, error) {
+	switch operation {
+	case "state_load":
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	case "state_save", "state_delete":
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown state operation: %s", operation)
+	}
+}
+
+// getHeadOID retrieves the HEAD commit OID for a branch.
+func (p *GitHubProvider) getHeadOID(ctx context.Context, client *httpc.Client, apiBase, owner, repo, branch string) (string, error) {
+	qualifiedName := "refs/heads/" + branch
+	query := `query($owner: String!, $name: String!, $qualifiedName: String!) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: $qualifiedName) {
+      target { oid }
+    }
+  }
+}`
+	vars := map[string]any{"owner": owner, "name": repo, "qualifiedName": qualifiedName}
+	data, err := graphqlDo(ctx, client, apiBase, query, vars)
+	if err != nil {
+		return "", fmt.Errorf("get head OID: %w", err)
+	}
+
+	ref, err := extractNode(data, "repository.ref")
+	if err != nil {
+		return "", fmt.Errorf("get head OID: %w", err)
+	}
+	if ref == nil {
+		return "", fmt.Errorf("branch %q not found", branch)
+	}
+
+	refMap, ok := ref.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("unexpected ref format")
+	}
+	target, ok := refMap["target"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("unexpected ref target format")
+	}
+	oid, _ := target["oid"].(string)
+	return oid, nil
+}
+
+// createStateCommit creates a commit with file additions and/or deletions.
+func (p *GitHubProvider) createStateCommit(ctx context.Context, client *httpc.Client, apiBase, owner, repo, branch, message, headOID string, additions, deletions []map[string]any) error {
+	nwo := owner + "/" + repo
+	mutation := `mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid }
+  }
+}`
+	fileChanges := map[string]any{}
+	if len(additions) > 0 {
+		fileChanges["additions"] = additions
+	}
+	if len(deletions) > 0 {
+		fileChanges["deletions"] = deletions
+	}
+
+	input := map[string]any{
+		"branch": map[string]any{
+			"repositoryNameWithOwner": nwo,
+			"branchName":              branch,
+		},
+		"message":         map[string]any{"headline": message},
+		"fileChanges":     fileChanges,
+		"expectedHeadOid": headOID,
+	}
+	vars := map[string]any{"input": input}
+
+	_, err := graphqlDo(ctx, client, apiBase, mutation, vars)
+	return err
+}
+
+// stateCommitMessage extracts a custom commit message from inputs or returns the fallback.
+func stateCommitMessage(inputs map[string]any, fallback string) string {
+	if msg, ok := inputs["message"].(string); ok && msg != "" {
+		return msg
+	}
+	return fallback
+}

--- a/pkg/provider/builtin/githubprovider/github_state_test.go
+++ b/pkg/provider/builtin/githubprovider/github_state_test.go
@@ -1,0 +1,318 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubProvider_StateCapability(t *testing.T) {
+	p := NewGitHubProvider()
+	desc := p.Descriptor()
+	assert.Contains(t, desc.Capabilities, provider.CapabilityState)
+	assert.Contains(t, desc.OutputSchemas, provider.CapabilityState)
+}
+
+func TestGitHubProvider_StateLoad_Found(t *testing.T) {
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"key1": {Value: "val1", Type: "string"},
+	}
+	stateJSON, _ := json.Marshal(sd)
+
+	p, baseURL := testProvider(t, graphqlHandler(t, nil, map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"object": map[string]any{
+					"text": string(stateJSON),
+				},
+			},
+		},
+	}))
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "state_load",
+		"owner":     "org",
+		"repo":      "repo",
+		"path":      ".scafctl/state.json",
+		"branch":    "main",
+		"api_base":  baseURL,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	loaded, ok := data["data"].(*state.Data)
+	require.True(t, ok)
+	assert.Equal(t, "val1", loaded.Values["key1"].Value)
+}
+
+func TestGitHubProvider_StateLoad_NotFound(t *testing.T) {
+	p, baseURL := testProvider(t, graphqlHandler(t, nil, map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"object": nil,
+			},
+		},
+	}))
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "state_load",
+		"owner":     "org",
+		"repo":      "repo",
+		"path":      ".scafctl/state.json",
+		"branch":    "main",
+		"api_base":  baseURL,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.NotNil(t, data["data"])
+}
+
+func TestGitHubProvider_StateSave(t *testing.T) {
+	callCount := 0
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+
+		// Intercept viewerPermission queries
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
+		callCount++
+		switch {
+		case strings.Contains(req.Query, "qualifiedName"):
+			// get_head_oid response
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{
+						"ref": map[string]any{
+							"target": map[string]any{"oid": "abc123"},
+						},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "createCommitOnBranch"):
+			// create_commit response
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"createCommitOnBranch": map[string]any{
+						"commit": map[string]any{"oid": "def456"},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+		}
+	})
+
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"env": {Value: "prod", Type: "string"},
+	}
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "state_save",
+		"owner":     "org",
+		"repo":      "repo",
+		"path":      ".scafctl/state.json",
+		"branch":    "main",
+		"api_base":  baseURL,
+		"data":      sd,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+	assert.Equal(t, 2, callCount) // get_head_oid + create_commit
+}
+
+func TestGitHubProvider_StateDelete_Found(t *testing.T) {
+	callCount := 0
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req graphqlRequest
+		json.Unmarshal(body, &req) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(req.Query, "viewerPermission") {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{"viewerPermission": "ADMIN"},
+				},
+			})
+			return
+		}
+
+		callCount++
+		switch {
+		case strings.Contains(req.Query, "expression") && !strings.Contains(req.Query, "createCommit"):
+			// File exists check
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{
+						"object": map[string]any{"oid": "exists"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "qualifiedName"):
+			// get_head_oid
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"repository": map[string]any{
+						"ref": map[string]any{
+							"target": map[string]any{"oid": "abc123"},
+						},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "createCommitOnBranch"):
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": map[string]any{
+					"createCommitOnBranch": map[string]any{
+						"commit": map[string]any{"oid": "del789"},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+		}
+	})
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "state_delete",
+		"owner":     "org",
+		"repo":      "repo",
+		"path":      ".scafctl/state.json",
+		"branch":    "main",
+		"api_base":  baseURL,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+	assert.Equal(t, 3, callCount) // check + get_head_oid + create_commit
+}
+
+func TestGitHubProvider_StateDelete_NotFound(t *testing.T) {
+	p, baseURL := testProvider(t, graphqlHandler(t, nil, map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"object": nil,
+			},
+		},
+	}))
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "state_delete",
+		"owner":     "org",
+		"repo":      "repo",
+		"path":      ".scafctl/state.json",
+		"branch":    "main",
+		"api_base":  baseURL,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+}
+
+func TestGitHubProvider_StateDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		hasData   bool
+	}{
+		{"load", "state_load", true},
+		{"save", "state_save", false},
+		{"delete", "state_delete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewGitHubProvider()
+			ctx := provider.WithDryRun(context.Background(), true)
+
+			result, err := p.Execute(ctx, map[string]any{
+				"operation": tt.operation,
+				"owner":     "org",
+				"repo":      "repo",
+				"path":      "state.json",
+				"branch":    "main",
+			})
+			require.NoError(t, err)
+			data := result.Data.(map[string]any)
+			assert.True(t, data["success"].(bool))
+			if tt.hasData {
+				assert.NotNil(t, data["data"])
+			}
+		})
+	}
+}
+
+func TestGitHubProvider_StateMissingInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		inputs  map[string]any
+		errText string
+	}{
+		{
+			name:    "missing path",
+			inputs:  map[string]any{"operation": "state_load", "owner": "o", "repo": "r", "branch": "main"},
+			errText: "path",
+		},
+		{
+			name:    "missing branch",
+			inputs:  map[string]any{"operation": "state_load", "owner": "o", "repo": "r", "path": "s.json"},
+			errText: "branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, baseURL := testProvider(t, graphqlHandler(t, nil, map[string]any{}))
+			tt.inputs["api_base"] = baseURL
+
+			_, err := p.Execute(context.Background(), tt.inputs)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errText)
+		})
+	}
+}
+
+func TestStateCommitMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   map[string]any
+		fallback string
+		expected string
+	}{
+		{"custom", map[string]any{"message": "custom msg"}, "default", "custom msg"},
+		{"fallback", map[string]any{}, "default msg", "default msg"},
+		{"empty", map[string]any{"message": ""}, "fallback", "fallback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stateCommitMessage(tt.inputs, tt.fallback))
+		})
+	}
+}

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -139,6 +139,15 @@ func NewHTTPProvider() *HTTPProvider {
 				if !ok {
 					return "", nil
 				}
+				operation, _ := inputs["operation"].(string)
+				switch operation {
+				case "state_load":
+					return fmt.Sprintf("Would load state from %s", inputs[fieldURL]), nil
+				case "state_save":
+					return fmt.Sprintf("Would save state to %s", inputs[fieldURL]), nil
+				case "state_delete":
+					return fmt.Sprintf("Would delete state at %s", inputs[fieldURL]), nil
+				}
 				method, _ := inputs[fieldMethod].(string)
 				if method == "" {
 					method = "GET"
@@ -150,8 +159,12 @@ func NewHTTPProvider() *HTTPProvider {
 				provider.CapabilityFrom,
 				provider.CapabilityAction,
 				provider.CapabilityTransform,
+				provider.CapabilityState,
 			},
 			Schema: schemahelper.ObjectSchema([]string{fieldURL}, map[string]*jsonschema.Schema{
+				"operation": schemahelper.StringProp("Operation to perform. Only used for state operations.",
+					schemahelper.WithEnum("state_load", "state_save", "state_delete")),
+				"data": schemahelper.AnyProp("The full StateData object to persist (required for state_save operation)"),
 				fieldURL: schemahelper.StringProp("The URL to request",
 					schemahelper.WithExample("https://api.example.com/users"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(2048)),
@@ -260,6 +273,10 @@ func NewHTTPProvider() *HTTPProvider {
 					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
+				}),
+				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
+					"data":    schemahelper.AnyProp("The loaded state data (for state_load operation)"),
 				}),
 			},
 			Examples: []provider.Example{
@@ -457,6 +474,11 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 	}
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName, fieldURL, inputs[fieldURL])
+
+	// State operations use a dedicated dispatch path
+	if operation, _ := inputs["operation"].(string); strings.HasPrefix(operation, "state_") {
+		return p.dispatchStateOperation(ctx, operation, inputs)
+	}
 
 	// Check for dry-run mode
 	if provider.DryRunFromContext(ctx) {

--- a/pkg/provider/builtin/httpprovider/http_state.go
+++ b/pkg/provider/builtin/httpprovider/http_state.go
@@ -1,0 +1,298 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+// executeStateLoad loads state from a remote HTTP endpoint via GET.
+func (p *HTTPProvider) executeStateLoad(ctx context.Context, client *httpc.Client, urlStr string, headers map[string]any) (*provider.Output, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("state load: create request: %w", err)
+	}
+	setHeaders(req, headers)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("state load: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	limit := maxResponseBodySize(ctx)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("state load: read response: %w", err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("state load: response body exceeds maximum size of %d bytes", limit)
+	}
+
+	// 404 means no state yet -- return empty state
+	if resp.StatusCode == http.StatusNotFound {
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("state load: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stateData state.Data
+	if err := json.Unmarshal(body, &stateData); err != nil {
+		return nil, fmt.Errorf("state load: unmarshal: %w", err)
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"data":    &stateData,
+		},
+	}, nil
+}
+
+// executeStateSave persists state to a remote HTTP endpoint via PUT.
+func (p *HTTPProvider) executeStateSave(
+	ctx context.Context, client *httpc.Client, urlStr string,
+	headers, inputs map[string]any,
+) (*provider.Output, error) {
+	rawData, ok := inputs["data"]
+	if !ok {
+		return nil, fmt.Errorf("state save: data is required")
+	}
+
+	jsonBytes, err := json.Marshal(rawData)
+	if err != nil {
+		return nil, fmt.Errorf("state save: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, urlStr, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return nil, fmt.Errorf("state save: create request: %w", err)
+	}
+	setHeaders(req, headers)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Provide GetBody for auth retry replays.
+	capturedBody := jsonBytes
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(capturedBody)), nil
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("state save: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Drain and discard response body
+	limit := maxResponseBodySize(ctx)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("state save: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDelete removes state from a remote HTTP endpoint via DELETE.
+func (p *HTTPProvider) executeStateDelete(ctx context.Context, client *httpc.Client, urlStr string, headers map[string]any) (*provider.Output, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("state delete: create request: %w", err)
+	}
+	setHeaders(req, headers)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("state delete: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Drain and discard response body
+	limit := maxResponseBodySize(ctx)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+
+	// 404 is acceptable -- state was already absent
+	if resp.StatusCode == http.StatusNotFound {
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("state delete: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &provider.Output{
+		Data: map[string]any{"success": true},
+	}, nil
+}
+
+// executeStateDryRun handles dry-run mode for state operations.
+func (p *HTTPProvider) executeStateDryRun(operation string) (*provider.Output, error) {
+	switch operation {
+	case "state_load":
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    state.NewData(),
+			},
+		}, nil
+	case "state_save", "state_delete":
+		return &provider.Output{
+			Data: map[string]any{"success": true},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown state operation: %s", operation)
+	}
+}
+
+// dispatchStateOperation handles the state capability branch in Execute.
+func (p *HTTPProvider) dispatchStateOperation(ctx context.Context, operation string, inputs map[string]any) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("executing state operation", "provider", ProviderName, "operation", operation)
+
+	urlStr, _ := inputs[fieldURL].(string)
+	if urlStr == "" {
+		return nil, fmt.Errorf("%s: url is required for state operations", ProviderName)
+	}
+
+	if provider.DryRunFromContext(ctx) {
+		return p.executeStateDryRun(operation)
+	}
+
+	// SSRF protection
+	if !privateIPsAllowed(ctx) {
+		if err := validateURLNotPrivate(urlStr); err != nil {
+			return nil, fmt.Errorf("%s: %w", ProviderName, err)
+		}
+	}
+
+	// Build timeout
+	timeout := 30
+	if t, ok := inputs["timeout"].(int); ok && t > 0 {
+		timeout = t
+	}
+	if t, ok := inputs["timeout"].(float64); ok && t > 0 {
+		timeout = int(t)
+	}
+	timeoutDuration := time.Duration(timeout) * time.Second
+
+	// Build headers
+	headers := make(map[string]any)
+	if h, ok := inputs[fieldHeaders].(map[string]any); ok {
+		for k, v := range h {
+			headers[k] = v
+		}
+	}
+
+	// Handle authentication
+	authProvider, _ := inputs["authProvider"].(string)
+	scope, _ := inputs["scope"].(string)
+	if authProvider != "" {
+		if err := p.injectAuthHeader(ctx, authProvider, scope, timeoutDuration, headers); err != nil {
+			return nil, err
+		}
+	}
+
+	// Build httpc client
+	retryCfg := parseRetryConfig(inputs)
+	httpcCfg := buildHTTPClientConfig(timeoutDuration, retryCfg)
+
+	// Wire 401 token-refresh when an auth provider is configured.
+	if authProvider != "" {
+		httpcCfg.OnUnauthorized = p.buildOnUnauthorized(ctx, authProvider, scope, timeoutDuration)
+	}
+
+	client := httpc.NewClient(httpcCfg)
+
+	switch operation {
+	case "state_load":
+		return p.executeStateLoad(ctx, client, urlStr, headers)
+	case "state_save":
+		return p.executeStateSave(ctx, client, urlStr, headers, inputs)
+	case "state_delete":
+		return p.executeStateDelete(ctx, client, urlStr, headers)
+	default:
+		return nil, fmt.Errorf("%s: unsupported state operation: %s", ProviderName, operation)
+	}
+}
+
+// setHeaders sets headers on an HTTP request from a map.
+func setHeaders(req *http.Request, headers map[string]any) {
+	for key, value := range headers {
+		if strValue, ok := value.(string); ok {
+			req.Header.Set(key, strValue)
+		}
+	}
+}
+
+// injectAuthHeader obtains an auth token and injects it into the headers map.
+func (p *HTTPProvider) injectAuthHeader(ctx context.Context, authProviderName, scope string, timeoutDuration time.Duration, headers map[string]any) error {
+	handler, err := auth.GetHandler(ctx, authProviderName)
+	if err != nil {
+		return fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	requiresScope := auth.HasCapability(handler.Capabilities(), auth.CapScopesOnTokenRequest)
+	if scope == "" && requiresScope {
+		return fmt.Errorf("%s: scope is required when authProvider %q is set (handler supports per-request scopes)", ProviderName, authProviderName)
+	}
+	if scope != "" && !requiresScope {
+		scope = ""
+	}
+
+	minValidFor := timeoutDuration + 60*time.Second
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope:       scope,
+		MinValidFor: minValidFor,
+	})
+	if err != nil {
+		return fmt.Errorf("%s: failed to get auth token: %w", ProviderName, err)
+	}
+
+	headers["Authorization"] = fmt.Sprintf("%s %s", token.TokenType, token.AccessToken)
+	return nil
+}
+
+// buildOnUnauthorized returns an httpc.OnUnauthorized callback for 401 retry.
+func (p *HTTPProvider) buildOnUnauthorized(_ context.Context, authProviderName, scope string, timeoutDuration time.Duration) func(context.Context) (string, error) {
+	return func(unauthCtx context.Context) (string, error) {
+		handler, handlerErr := auth.GetHandler(unauthCtx, authProviderName)
+		if handlerErr != nil {
+			return "", handlerErr
+		}
+		token, tokenErr := handler.GetToken(unauthCtx, auth.TokenOptions{
+			Scope:        scope,
+			MinValidFor:  timeoutDuration + 60*time.Second,
+			ForceRefresh: true,
+		})
+		if tokenErr != nil {
+			return "", tokenErr
+		}
+		return fmt.Sprintf("%s %s", token.TokenType, token.AccessToken), nil
+	}
+}

--- a/pkg/provider/builtin/httpprovider/http_state_test.go
+++ b/pkg/provider/builtin/httpprovider/http_state_test.go
@@ -1,0 +1,471 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPProvider_StateCapability(t *testing.T) {
+	p := NewHTTPProvider()
+	desc := p.Descriptor()
+	assert.Contains(t, desc.Capabilities, provider.CapabilityState)
+	assert.Contains(t, desc.OutputSchemas, provider.CapabilityState)
+}
+
+func TestHTTPProvider_StateLoad_Success(t *testing.T) {
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"greeting": {Value: "hello"},
+	}
+	body, err := json.Marshal(sd)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	loaded, ok := data["data"].(*state.Data)
+	require.True(t, ok)
+	assert.Equal(t, "hello", loaded.Values["greeting"].Value)
+}
+
+func TestHTTPProvider_StateLoad_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.NotNil(t, data["data"])
+}
+
+func TestHTTPProvider_StateLoad_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 500")
+}
+
+func TestHTTPProvider_StateLoad_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{invalid"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestHTTPProvider_StateSave_Success(t *testing.T) {
+	var receivedBody []byte
+	var receivedMethod string
+	var receivedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"key": {Value: "value"},
+	}
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_save",
+		"url":       server.URL,
+		"data":      sd,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	assert.Equal(t, http.MethodPut, receivedMethod)
+	assert.Equal(t, "application/json", receivedContentType)
+
+	var saved state.Data
+	require.NoError(t, json.Unmarshal(receivedBody, &saved))
+	assert.Equal(t, "value", saved.Values["key"].Value)
+}
+
+func TestHTTPProvider_StateSave_MissingData(t *testing.T) {
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_save",
+		"url":       "https://example.com/state",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "data is required")
+}
+
+func TestHTTPProvider_StateSave_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_save",
+		"url":       server.URL,
+		"data":      state.NewData(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 403")
+}
+
+func TestHTTPProvider_StateDelete_Success(t *testing.T) {
+	var receivedMethod string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_delete",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, http.MethodDelete, receivedMethod)
+}
+
+func TestHTTPProvider_StateDelete_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_delete",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+}
+
+func TestHTTPProvider_StateDelete_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_delete",
+		"url":       server.URL,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 500")
+}
+
+func TestHTTPProvider_StateMissingURL(t *testing.T) {
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "url is required")
+}
+
+func TestHTTPProvider_StateDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		hasData   bool
+	}{
+		{"load", "state_load", true},
+		{"save", "state_save", false},
+		{"delete", "state_delete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHTTPProvider()
+			ctx := provider.WithDryRun(testContext(t), true)
+
+			result, err := p.Execute(ctx, map[string]any{
+				"operation": tt.operation,
+				"url":       "https://example.com/state",
+				"data":      state.NewData(),
+			})
+			require.NoError(t, err)
+			data := result.Data.(map[string]any)
+			assert.True(t, data["success"].(bool))
+			if tt.hasData {
+				assert.NotNil(t, data["data"])
+			}
+		})
+	}
+}
+
+func TestHTTPProvider_StateWithHeaders(t *testing.T) {
+	var receivedAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("X-Custom-Token")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+		"headers": map[string]any{
+			"X-Custom-Token": "my-secret",
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Data.(map[string]any)["success"].(bool))
+	assert.Equal(t, "my-secret", receivedAuth)
+}
+
+func TestHTTPProvider_StateUnsupportedOperation(t *testing.T) {
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.dispatchStateOperation(ctx, "state_unknown", map[string]any{
+		"url": "https://example.com/state",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported state operation")
+}
+
+func TestHTTPProvider_StateRoundTrip(t *testing.T) {
+	// In-memory state store
+	var stored []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if stored == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(stored)
+		case http.MethodPut:
+			var err error
+			stored, err = io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			stored = nil
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	// Load -- empty
+	loadResult, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+	assert.True(t, loadResult.Data.(map[string]any)["success"].(bool))
+
+	// Save
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{
+		"env": {Value: "production"},
+	}
+	saveResult, err := p.Execute(ctx, map[string]any{
+		"operation": "state_save",
+		"url":       server.URL,
+		"data":      sd,
+	})
+	require.NoError(t, err)
+	assert.True(t, saveResult.Data.(map[string]any)["success"].(bool))
+
+	// Load again -- should have data
+	loadResult2, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+	loaded := loadResult2.Data.(map[string]any)["data"].(*state.Data)
+	assert.Equal(t, "production", loaded.Values["env"].Value)
+
+	// Delete
+	delResult, err := p.Execute(ctx, map[string]any{
+		"operation": "state_delete",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+	assert.True(t, delResult.Data.(map[string]any)["success"].(bool))
+
+	// Load after delete -- empty again
+	loadResult3, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, loadResult3.Data.(map[string]any)["data"])
+}
+
+func TestHTTPProvider_StateWhatIf(t *testing.T) {
+	p := NewHTTPProvider()
+	desc := p.Descriptor()
+
+	tests := []struct {
+		operation string
+		contains  string
+	}{
+		{"state_load", "Would load state from"},
+		{"state_save", "Would save state to"},
+		{"state_delete", "Would delete state at"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			msg, err := desc.WhatIf(context.Background(), map[string]any{
+				"operation": tt.operation,
+				"url":       "https://api.example.com/state",
+			})
+			require.NoError(t, err)
+			assert.Contains(t, msg, tt.contains)
+		})
+	}
+}
+
+func BenchmarkHTTPProvider_StateLoad(b *testing.B) {
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{"x": {Value: "y"}}
+	body, _ := json.Marshal(sd)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(b)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, map[string]any{
+			"operation": "state_load",
+			"url":       server.URL,
+		})
+	}
+}
+
+func BenchmarkHTTPProvider_StateSave(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(b)
+	sd := state.NewData()
+	sd.Values = map[string]*state.Entry{"x": {Value: "y"}}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, map[string]any{
+			"operation": "state_save",
+			"url":       server.URL,
+			"data":      sd,
+		})
+	}
+}

--- a/pkg/provider/builtin/stateprovider/mock.go
+++ b/pkg/provider/builtin/stateprovider/mock.go
@@ -5,4 +5,4 @@ package stateprovider
 
 // This file is intentionally minimal -- the state provider has no external
 // dependencies to mock. It operates entirely on in-memory StateData from context.
-// Tests use state.NewMockStateData() and state.WithState() directly.
+// Tests use state.NewMockData() and state.WithState() directly.

--- a/pkg/provider/builtin/stateprovider/mock.go
+++ b/pkg/provider/builtin/stateprovider/mock.go
@@ -1,0 +1,8 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package stateprovider
+
+// This file is intentionally minimal -- the state provider has no external
+// dependencies to mock. It operates entirely on in-memory StateData from context.
+// Tests use state.NewMockStateData() and state.WithState() directly.

--- a/pkg/provider/builtin/stateprovider/state.go
+++ b/pkg/provider/builtin/stateprovider/state.go
@@ -1,0 +1,169 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package stateprovider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+const (
+	// ProviderName is the name of this provider.
+	ProviderName = "state"
+
+	// Version is the provider version.
+	Version = "1.0.0"
+)
+
+// StateProvider gives resolvers and actions explicit read/write access to
+// individual state entries. It reads/writes the in-memory StateData loaded
+// during the pre-execution phase (via state.FromContext).
+type StateProvider struct{}
+
+// New creates a new state provider.
+func New() *StateProvider {
+	return &StateProvider{}
+}
+
+// Descriptor returns the provider's metadata and schema.
+func (p *StateProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:        ProviderName,
+		DisplayName: "State Provider",
+		Description: "Provides read/write access to individual state entries for resolvers and actions. Reads from and writes to the in-memory state loaded during pre-execution.",
+		APIVersion:  "v1",
+		Version:     semver.MustParse(Version),
+		Category:    "state",
+		Tags:        []string{"state", "persistence", "resolver"},
+		Capabilities: []provider.Capability{
+			provider.CapabilityFrom,
+			provider.CapabilityAction,
+		},
+		Schema: schemahelper.ObjectSchema([]string{"key"}, map[string]*jsonschema.Schema{
+			"key": schemahelper.StringProp("State entry key (typically a resolver name)",
+				schemahelper.WithMaxLength(253),
+				schemahelper.WithExample("auth_token"),
+				schemahelper.WithPattern(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)),
+			"required": schemahelper.BoolProp("If true, error when key is not found",
+				schemahelper.WithDefault(false)),
+			"fallback": schemahelper.AnyProp("Value returned when key is not found and required is false"),
+			"value":    schemahelper.AnyProp("Value to store (for write/action mode)"),
+			"type": schemahelper.StringProp("Resolver type for the entry (for write/action mode)",
+				schemahelper.WithExample("string"),
+				schemahelper.WithMaxLength(30)),
+			"immutable": schemahelper.BoolProp("Lock value permanently (future enhancement)",
+				schemahelper.WithDefault(false)),
+		}),
+		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+			provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"value": schemahelper.AnyProp("The state entry value"),
+			}),
+			provider.CapabilityAction: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+				"success": schemahelper.BoolProp("Whether the write succeeded"),
+			}),
+		},
+		// ExtractDependencies is nil -- the state provider's key input is a literal string,
+		// not a resolver reference. The DAG builder should not extract dependencies from it.
+		WhatIf: func(_ context.Context, input any) (string, error) {
+			inputs, ok := input.(map[string]any)
+			if !ok {
+				return "", nil
+			}
+			key, _ := inputs["key"].(string)
+			if _, hasValue := inputs["value"]; hasValue {
+				return fmt.Sprintf("Would write state key %q", key), nil
+			}
+			return fmt.Sprintf("Would read state key %q", key), nil
+		},
+	}
+}
+
+// Execute runs the state provider.
+// In CapabilityFrom mode (resolve phase): reads a key from state.
+// In CapabilityAction mode (action phase): writes a key to state.
+func (p *StateProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	inputs, ok := input.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid input type: %T", input)
+	}
+
+	key, _ := inputs["key"].(string)
+	if key == "" {
+		return nil, fmt.Errorf("key is required")
+	}
+
+	// Check if this is a write operation (action mode)
+	if _, hasValue := inputs["value"]; hasValue {
+		return p.write(ctx, key, inputs)
+	}
+
+	// Read operation (from mode)
+	return p.read(ctx, key, inputs)
+}
+
+func (p *StateProvider) read(ctx context.Context, key string, inputs map[string]any) (*provider.Output, error) {
+	stateData, ok := state.FromContext(ctx)
+	if !ok || stateData == nil {
+		// No state in context -- behave as if empty state (first run)
+		return p.handleMissing(key, inputs)
+	}
+
+	entry, exists := stateData.Values[key]
+	if !exists || entry == nil {
+		return p.handleMissing(key, inputs)
+	}
+
+	return &provider.Output{
+		Data: entry.Value,
+	}, nil
+}
+
+func (p *StateProvider) handleMissing(key string, inputs map[string]any) (*provider.Output, error) {
+	required, _ := inputs["required"].(bool)
+	if required {
+		return nil, fmt.Errorf("state key %q not found: %w", key, state.ErrKeyNotFound)
+	}
+
+	// Return fallback value (nil/null if not specified)
+	fallback := inputs["fallback"]
+	return &provider.Output{
+		Data: fallback,
+	}, nil
+}
+
+func (p *StateProvider) write(ctx context.Context, key string, inputs map[string]any) (*provider.Output, error) {
+	stateData, ok := state.FromContext(ctx)
+	if !ok || stateData == nil {
+		return nil, fmt.Errorf("state not available in context: cannot write key %q", key)
+	}
+
+	// Check immutability of existing entry (future enforcement)
+	if existing, exists := stateData.Values[key]; exists && existing.Immutable {
+		return nil, fmt.Errorf("state key %q: %w", key, state.ErrImmutableEntry)
+	}
+
+	value := inputs["value"]
+	entryType, _ := inputs["type"].(string)
+	immutable, _ := inputs["immutable"].(bool)
+
+	stateData.Values[key] = &state.Entry{
+		Value:     value,
+		Type:      entryType,
+		UpdatedAt: time.Now().UTC(),
+		Immutable: immutable,
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+		},
+	}, nil
+}

--- a/pkg/provider/builtin/stateprovider/state.go
+++ b/pkg/provider/builtin/stateprovider/state.go
@@ -63,9 +63,7 @@ func (p *StateProvider) Descriptor() *provider.Descriptor {
 				schemahelper.WithDefault(false)),
 		}),
 		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
-			provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-				"value": schemahelper.AnyProp("The state entry value"),
-			}),
+			provider.CapabilityFrom: schemahelper.AnyProp("The state entry value (scalar or object)"),
 			provider.CapabilityAction: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 				"success": schemahelper.BoolProp("Whether the write succeeded"),
 			}),

--- a/pkg/provider/builtin/stateprovider/state_benchmark_test.go
+++ b/pkg/provider/builtin/stateprovider/state_benchmark_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package stateprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/state"
+)
+
+func BenchmarkExecute_Read(b *testing.B) {
+	stateData := state.NewMockData("bench", "1.0.0", map[string]*state.Entry{
+		"key1": {Value: "val1", Type: "string"},
+	})
+	ctx := state.WithState(context.Background(), stateData)
+	p := New()
+	input := map[string]any{
+		"key": "key1",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecute_Read_Miss(b *testing.B) {
+	stateData := state.NewMockData("bench", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+	p := New()
+	input := map[string]any{
+		"key":      "missing",
+		"fallback": "default",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecute_Write(b *testing.B) {
+	stateData := state.NewMockData("bench", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+	p := New()
+	input := map[string]any{
+		"key":   "key1",
+		"value": "val1",
+		"type":  "string",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(ctx, input)
+	}
+}

--- a/pkg/provider/builtin/stateprovider/state_test.go
+++ b/pkg/provider/builtin/stateprovider/state_test.go
@@ -1,0 +1,220 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package stateprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptor(t *testing.T) {
+	p := New()
+	desc := p.Descriptor()
+
+	assert.Equal(t, ProviderName, desc.Name)
+	assert.Equal(t, "v1", desc.APIVersion)
+	assert.NotNil(t, desc.Version)
+	assert.Contains(t, desc.Capabilities, provider.CapabilityFrom)
+	assert.Contains(t, desc.Capabilities, provider.CapabilityAction)
+	assert.NotNil(t, desc.Schema)
+}
+
+func TestValidateDescriptor(t *testing.T) {
+	p := New()
+	err := provider.ValidateDescriptor(p.Descriptor())
+	assert.NoError(t, err)
+}
+
+func TestExecute_Read_Hit(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", map[string]*state.Entry{
+		"auth_token": {Value: "tok-123", Type: "string"},
+	})
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	output, err := p.Execute(ctx, map[string]any{
+		"key": "auth_token",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "tok-123", output.Data)
+}
+
+func TestExecute_Read_Miss_WithFallback(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	output, err := p.Execute(ctx, map[string]any{
+		"key":      "missing_key",
+		"required": false,
+		"fallback": "default-value",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "default-value", output.Data)
+}
+
+func TestExecute_Read_Miss_NoFallback(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	output, err := p.Execute(ctx, map[string]any{
+		"key": "missing_key",
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, output.Data)
+}
+
+func TestExecute_Read_Miss_Required(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	_, err := p.Execute(ctx, map[string]any{
+		"key":      "missing_key",
+		"required": true,
+	})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrKeyNotFound)
+}
+
+func TestExecute_Read_NoStateInContext(t *testing.T) {
+	p := New()
+	output, err := p.Execute(context.Background(), map[string]any{
+		"key":      "some_key",
+		"fallback": "fallback-val",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-val", output.Data)
+}
+
+func TestExecute_Read_NoStateInContext_Required(t *testing.T) {
+	p := New()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"key":      "some_key",
+		"required": true,
+	})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrKeyNotFound)
+}
+
+func TestExecute_Write(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", nil)
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	output, err := p.Execute(ctx, map[string]any{
+		"key":   "deploy_id",
+		"value": "dep-456",
+		"type":  "string",
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)
+	assert.True(t, result["success"].(bool))
+
+	// Verify state was updated
+	entry, exists := stateData.Values["deploy_id"]
+	require.True(t, exists)
+	assert.Equal(t, "dep-456", entry.Value)
+	assert.Equal(t, "string", entry.Type)
+	assert.False(t, entry.Immutable)
+	assert.False(t, entry.UpdatedAt.IsZero())
+}
+
+func TestExecute_Write_Overwrite(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", map[string]*state.Entry{
+		"key1": {Value: "old", Type: "string"},
+	})
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	_, err := p.Execute(ctx, map[string]any{
+		"key":   "key1",
+		"value": "new",
+		"type":  "string",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "new", stateData.Values["key1"].Value)
+}
+
+func TestExecute_Write_ImmutableEntry(t *testing.T) {
+	stateData := state.NewMockData("test-sol", "1.0.0", map[string]*state.Entry{
+		"locked_key": {Value: "locked", Type: "string", Immutable: true},
+	})
+	ctx := state.WithState(context.Background(), stateData)
+
+	p := New()
+	_, err := p.Execute(ctx, map[string]any{
+		"key":   "locked_key",
+		"value": "new-value",
+	})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrImmutableEntry)
+	// Value should not have changed
+	assert.Equal(t, "locked", stateData.Values["locked_key"].Value)
+}
+
+func TestExecute_Write_NoStateInContext(t *testing.T) {
+	p := New()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"key":   "some_key",
+		"value": "some_value",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "state not available")
+}
+
+func TestExecute_MissingKey(t *testing.T) {
+	p := New()
+	_, err := p.Execute(context.Background(), map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "key is required")
+}
+
+func TestExecute_InvalidInputType(t *testing.T) {
+	p := New()
+	_, err := p.Execute(context.Background(), "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid input type")
+}
+
+func TestWhatIf(t *testing.T) {
+	p := New()
+	desc := p.Descriptor()
+	require.NotNil(t, desc.WhatIf)
+
+	t.Run("read", func(t *testing.T) {
+		msg, err := desc.WhatIf(context.Background(), map[string]any{
+			"key": "token",
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, msg, "read")
+		assert.Contains(t, msg, "token")
+	})
+
+	t.Run("write", func(t *testing.T) {
+		msg, err := desc.WhatIf(context.Background(), map[string]any{
+			"key":   "token",
+			"value": "abc",
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, msg, "write")
+		assert.Contains(t, msg, "token")
+	})
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -3,7 +3,11 @@
 
 package provider
 
-import sdkprovider "github.com/oakwood-commons/scafctl-plugin-sdk/provider"
+import (
+	"fmt"
+
+	sdkprovider "github.com/oakwood-commons/scafctl-plugin-sdk/provider"
+)
 
 // --- SDK type aliases ---
 
@@ -25,6 +29,12 @@ const (
 	CapabilityValidation     = sdkprovider.CapabilityValidation
 	CapabilityAuthentication = sdkprovider.CapabilityAuthentication
 	CapabilityAction         = sdkprovider.CapabilityAction
+
+	// CapabilityState signals that a provider can act as a state persistence backend.
+	// Providers with this capability handle load/save/delete operations for solution state.
+	// This capability is defined in scafctl (not the SDK) because state is an application-level
+	// concern that external plugin providers can also implement.
+	CapabilityState Capability = "state"
 )
 
 // Contact represents maintainer contact information.
@@ -37,4 +47,66 @@ type Link = sdkprovider.Link
 type Example = sdkprovider.Example
 
 // ValidateDescriptor validates that a Descriptor meets all requirements.
-func ValidateDescriptor(desc *Descriptor) error { return sdkprovider.ValidateDescriptor(desc) }
+// It extends the SDK validation with scafctl-specific capabilities (e.g., CapabilityState).
+func ValidateDescriptor(desc *Descriptor) error {
+	// Temporarily strip scafctl-specific capabilities before calling the SDK validator,
+	// then validate them locally. This avoids "unknown capability" errors from the SDK.
+	var localCaps []Capability
+	var sdkCaps []Capability
+	for _, cap := range desc.Capabilities {
+		if cap == CapabilityState {
+			localCaps = append(localCaps, cap)
+		} else {
+			sdkCaps = append(sdkCaps, cap)
+		}
+	}
+
+	// Validate SDK-known capabilities via the SDK validator using a shallow
+	// copy so we never mutate the caller's descriptor (avoids data races if
+	// registration ever runs concurrently).
+	if len(sdkCaps) > 0 {
+		sdkDesc := *desc
+		sdkDesc.Capabilities = sdkCaps
+		if err := sdkprovider.ValidateDescriptor(&sdkDesc); err != nil {
+			return err
+		}
+	}
+
+	// Validate scafctl-specific capabilities locally
+	for _, cap := range localCaps {
+		schema, exists := desc.OutputSchemas[cap]
+		if !exists {
+			return fmt.Errorf("missing output schema for capability %q", cap)
+		}
+		requiredFields := stateCapabilityRequiredFields()
+		for fieldName, expectedType := range requiredFields {
+			if schema == nil || schema.Properties == nil {
+				return fmt.Errorf("capability %q requires output field %q", cap, fieldName)
+			}
+			prop, found := schema.Properties[fieldName]
+			if !found || prop == nil {
+				return fmt.Errorf("capability %q requires output field %q", cap, fieldName)
+			}
+			if prop.Type != expectedType {
+				return fmt.Errorf("capability %q field %q must be type %q, got %q", cap, fieldName, expectedType, prop.Type)
+			}
+		}
+	}
+
+	return nil
+}
+
+// stateCapabilityRequiredFields returns the required output fields for CapabilityState.
+func stateCapabilityRequiredFields() map[string]string {
+	return map[string]string{
+		"success": "boolean",
+	}
+}
+
+// IsCapabilityValid checks if the capability is valid, including scafctl-specific capabilities.
+func IsCapabilityValid(c Capability) bool {
+	if c == CapabilityState {
+		return true
+	}
+	return c.IsValid()
+}

--- a/pkg/provider/registry.go
+++ b/pkg/provider/registry.go
@@ -277,7 +277,7 @@ func (r *Registry) validateDescriptor(desc *Descriptor) error {
 
 	// Validate all capabilities
 	for i, cap := range desc.Capabilities {
-		if !cap.IsValid() {
+		if !IsCapabilityValid(cap) {
 			return fmt.Errorf("capability at index %d (%q) is not valid", i, cap)
 		}
 	}

--- a/pkg/provider/registry_test.go
+++ b/pkg/provider/registry_test.go
@@ -696,3 +696,179 @@ func TestValidateDescriptor(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDescriptor_CapabilityState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		desc    *Descriptor
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid state capability",
+			desc: &Descriptor{
+				Name:         "test-state",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "State provider",
+				Capabilities: []Capability{CapabilityFrom, CapabilityState},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"key": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityFrom: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"value": {Type: "string"},
+						},
+					},
+					CapabilityState: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"success": {Type: "boolean"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing output schema for state",
+			desc: &Descriptor{
+				Name:         "test-state",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "State provider",
+				Capabilities: []Capability{CapabilityFrom, CapabilityState},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"key": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityFrom: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"value": {Type: "string"},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "missing output schema",
+		},
+		{
+			name: "state output schema missing success field",
+			desc: &Descriptor{
+				Name:         "test-state",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "State provider",
+				Capabilities: []Capability{CapabilityFrom, CapabilityState},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"key": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityFrom: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"value": {Type: "string"},
+						},
+					},
+					CapabilityState: {
+						Type:       "object",
+						Properties: map[string]*jsonschema.Schema{},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "requires output field",
+		},
+		{
+			name: "state only - no SDK caps",
+			desc: &Descriptor{
+				Name:         "pure-state",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "Pure state provider",
+				Capabilities: []Capability{CapabilityState},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"op": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityState: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"success": {Type: "boolean"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDescriptor(tt.desc)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateDescriptor_DoesNotMutateCapabilities(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		Name:         "test-state",
+		APIVersion:   "v1",
+		Version:      semver.MustParse("1.0.0"),
+		Description:  "State provider",
+		Capabilities: []Capability{CapabilityFrom, CapabilityState},
+		Schema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"key": {Type: "string"},
+			},
+		},
+		OutputSchemas: map[Capability]*jsonschema.Schema{
+			CapabilityFrom: {
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"value": {Type: "string"},
+				},
+			},
+			CapabilityState: {
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"success": {Type: "boolean"},
+				},
+			},
+		},
+	}
+
+	origCaps := make([]Capability, len(desc.Capabilities))
+	copy(origCaps, desc.Capabilities)
+
+	err := ValidateDescriptor(desc)
+	require.NoError(t, err)
+	assert.Equal(t, origCaps, desc.Capabilities, "capabilities should not be mutated")
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -168,6 +168,12 @@ type Resolver struct {
 	// Timeout
 	Timeout *time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Maximum execution time (default: 30s)" example:"30s"`
 
+	// SaveToState marks this resolver's result for state persistence after execution.
+	// When true, the resolver's result is collected after all resolvers complete and
+	// flushed to the backend in a single save call. The resolver always executes its
+	// configured provider -- saveToState does not cause implicit reads from state.
+	SaveToState bool `json:"saveToState,omitempty" yaml:"saveToState,omitempty" doc:"Persist resolver result to state after execution" example:"true"`
+
 	// Phases
 	Resolve   *ResolvePhase   `json:"resolve" yaml:"resolve" doc:"Value resolution phase"`
 	Transform *TransformPhase `json:"transform,omitempty" yaml:"transform,omitempty" doc:"Value transformation phase"`

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"gopkg.in/yaml.v3"
 )
 
@@ -83,6 +84,12 @@ type Solution struct {
 	// Spec defines the execution specification containing resolvers, templates, and actions.
 	// This is where the actual work of the solution is defined.
 	Spec Spec `json:"spec,omitempty" yaml:"spec,omitempty" doc:"Execution specification"`
+
+	// State configures optional per-solution persistence of resolver values across executions.
+	// When configured, resolvers with saveToState: true have their results persisted to a
+	// backend (e.g., local file, GitHub repo) and can be read back on subsequent runs via
+	// the state provider. State is opt-in -- solutions without this field are stateless.
+	State *state.Config `json:"state,omitempty" yaml:"state,omitempty" doc:"Optional state persistence configuration" required:"false"`
 
 	// path is an internal field for the file path where the solution was loaded from
 	path string `json:"-" yaml:"-"`
@@ -388,6 +395,10 @@ func (s *Solution) Validate() error {
 		default:
 			problems = append(problems, "catalog.visibility must be public, private, or internal when set")
 		}
+	}
+
+	if s.State != nil && s.State.Backend.Provider == "" {
+		problems = append(problems, "state.backend.provider is required when state is configured")
 	}
 
 	if len(problems) > 0 {

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -1,0 +1,23 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+)
+
+// stateContextKey is the context key for storing StateData.
+type stateContextKey struct{}
+
+// WithState returns a new context with the StateData stored in it.
+func WithState(ctx context.Context, data *Data) context.Context {
+	return context.WithValue(ctx, stateContextKey{}, data)
+}
+
+// FromContext retrieves the StateData from the context.
+// Returns the StateData and true if found, or nil and false if not present.
+func FromContext(ctx context.Context) (*Data, bool) {
+	data, ok := ctx.Value(stateContextKey{}).(*Data)
+	return data, ok
+}

--- a/pkg/state/context_test.go
+++ b/pkg/state/context_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithState_FromContext(t *testing.T) {
+	data := NewMockData("test-sol", "1.0.0", map[string]*Entry{
+		"key1": {Value: "val1", Type: "string"},
+	})
+
+	ctx := WithState(context.Background(), data)
+	got, ok := FromContext(ctx)
+
+	assert.True(t, ok)
+	assert.Same(t, data, got)
+	assert.Equal(t, "test-sol", got.Metadata.Solution)
+	assert.Len(t, got.Values, 1)
+}
+
+func TestFromContext_Missing(t *testing.T) {
+	got, ok := FromContext(context.Background())
+
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestWithState_OverwritesPrevious(t *testing.T) {
+	data1 := NewMockData("sol-1", "1.0.0", nil)
+	data2 := NewMockData("sol-2", "2.0.0", nil)
+
+	ctx := WithState(context.Background(), data1)
+	ctx = WithState(ctx, data2)
+
+	got, ok := FromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "sol-2", got.Metadata.Solution)
+}

--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -1,0 +1,17 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import "errors"
+
+var (
+	// ErrInvalidBackend indicates the configured backend provider lacks CapabilityState.
+	ErrInvalidBackend = errors.New("state backend provider does not have CapabilityState")
+
+	// ErrKeyNotFound indicates a requested state key does not exist.
+	ErrKeyNotFound = errors.New("state key not found")
+
+	// ErrImmutableEntry indicates an attempt to overwrite an immutable state entry.
+	ErrImmutableEntry = errors.New("cannot overwrite immutable state entry")
+)

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -1,0 +1,354 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// Manager orchestrates the state lifecycle: pre-execution loading, context
+// injection, and post-execution saving. It is called by the CLI command
+// layer before and after resolver execution.
+type Manager struct {
+	registry *provider.Registry
+	config   *Config
+	version  string // scafctl build version for metadata
+}
+
+// NewManager creates a state manager for the given state configuration.
+func NewManager(config *Config, registry *provider.Registry, version string) *Manager {
+	return &Manager{
+		config:   config,
+		registry: registry,
+		version:  version,
+	}
+}
+
+// LoadResult is returned by Load with the loaded state and enriched context.
+type LoadResult struct {
+	// Ctx is the context enriched with state.WithState.
+	Ctx context.Context
+
+	// Data is the loaded (or empty) state data.
+	Data *Data
+
+	// Skipped is true when state is disabled or the enabled ValueRef is falsy.
+	Skipped bool
+}
+
+// Load executes the pre-execution state lifecycle:
+//  1. Resolves the enabled ValueRef (if it references resolvers, those must
+//     already be resolved and available in resolverData).
+//  2. If disabled, returns LoadResult{Skipped: true}.
+//  3. Resolves backend inputs.
+//  4. Calls the backend provider with operation=state_load.
+//  5. Captures command info.
+//  6. Injects state into context via WithState.
+func (m *Manager) Load(ctx context.Context, resolverData map[string]any, command CommandInfo) (*LoadResult, error) {
+	if m.config == nil {
+		return &LoadResult{Ctx: ctx, Skipped: true}, nil
+	}
+
+	// Evaluate enabled
+	enabled, err := m.evaluateEnabled(ctx, resolverData)
+	if err != nil {
+		return nil, fmt.Errorf("state: evaluate enabled: %w", err)
+	}
+	if !enabled {
+		return &LoadResult{Ctx: ctx, Skipped: true}, nil
+	}
+
+	// Resolve backend inputs
+	backendInputs, err := m.resolveBackendInputs(ctx, resolverData)
+	if err != nil {
+		return nil, fmt.Errorf("state: resolve backend inputs: %w", err)
+	}
+
+	// Look up backend provider
+	backendProvider, err := m.getBackendProvider()
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute load
+	backendInputs["operation"] = "state_load"
+	execCtx := provider.WithExecutionMode(ctx, provider.CapabilityState)
+	result, err := provider.Execute(execCtx, backendProvider, backendInputs)
+	if err != nil {
+		return nil, fmt.Errorf("state: backend load: %w", err)
+	}
+
+	// Extract state data from result
+	stateData, err := extractStateData(result)
+	if err != nil {
+		return nil, fmt.Errorf("state: extract loaded data: %w", err)
+	}
+
+	// Capture command info
+	stateData.Command = command
+
+	// Inject into context
+	enrichedCtx := WithState(ctx, stateData)
+
+	return &LoadResult{
+		Ctx:  enrichedCtx,
+		Data: stateData,
+	}, nil
+}
+
+// Save executes the post-execution state lifecycle:
+//  1. Collects saveToState resolver results from resolverCtx.
+//  2. Updates state data with collected values.
+//  3. Updates metadata timestamps.
+//  4. Calls the backend provider with operation=state_save.
+func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver, resolverData map[string]any, solMeta SolutionMeta) error {
+	if m.config == nil || stateData == nil {
+		return nil
+	}
+
+	// Collect saveToState values
+	now := time.Now().UTC()
+	for _, r := range resolvers {
+		if !r.SaveToState {
+			continue
+		}
+		result, ok := resolverCtx.GetResult(r.Name)
+		if !ok || result.Status != resolver.ExecutionStatusSuccess {
+			continue
+		}
+
+		stateData.Values[r.Name] = &Entry{
+			Value:     result.Value,
+			Type:      string(r.Type),
+			UpdatedAt: now,
+		}
+	}
+
+	// Update metadata
+	if stateData.Metadata.CreatedAt.IsZero() {
+		stateData.Metadata.CreatedAt = now
+	}
+	stateData.Metadata.LastUpdatedAt = now
+	stateData.Metadata.Solution = solMeta.Name
+	stateData.Metadata.Version = solMeta.Version
+	stateData.Metadata.ScafctlVersion = m.version
+
+	// Resolve backend inputs for save
+	backendInputs, err := m.resolveBackendInputs(ctx, resolverData)
+	if err != nil {
+		return fmt.Errorf("state: resolve backend inputs for save: %w", err)
+	}
+
+	// Look up backend provider
+	backendProvider, err := m.getBackendProvider()
+	if err != nil {
+		return err
+	}
+
+	// Execute save — convert stateData to map[string]any so that the provider
+	// executor's JSON-schema validator can inspect the value (it cannot
+	// validate Go structs directly).
+	backendInputs["operation"] = "state_save"
+	dataMap, err := structToMap(stateData)
+	if err != nil {
+		return fmt.Errorf("state: marshal state data: %w", err)
+	}
+	backendInputs["data"] = dataMap
+	execCtx := provider.WithExecutionMode(ctx, provider.CapabilityState)
+	if _, err := provider.Execute(execCtx, backendProvider, backendInputs); err != nil {
+		return fmt.Errorf("state: backend save: %w", err)
+	}
+
+	return nil
+}
+
+// SolutionMeta contains solution identity for state metadata.
+type SolutionMeta struct {
+	Name    string
+	Version string
+}
+
+// RequiredResolvers returns the resolver names that must be resolved before
+// state loading (referenced by enabled and backend inputs ValueRefs).
+func (m *Manager) RequiredResolvers() []string {
+	if m.config == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+
+	collect := func(vr *spec.ValueRef) {
+		if vr == nil {
+			return
+		}
+		// Direct resolver reference
+		if vr.Resolver != nil {
+			name := *vr.Resolver
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				names = append(names, name)
+			}
+		}
+		// CEL or template references
+		for name := range vr.ReferencedVariables() {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+
+	collect(m.config.Enabled)
+	for _, input := range m.config.Backend.Inputs {
+		collect(input)
+	}
+
+	return names
+}
+
+// evaluateEnabled resolves the enabled ValueRef and coerces to bool.
+func (m *Manager) evaluateEnabled(ctx context.Context, resolverData map[string]any) (bool, error) {
+	if m.config.Enabled == nil {
+		// No enabled field means enabled by default when state block is present
+		return true, nil
+	}
+
+	val, err := m.config.Enabled.Resolve(ctx, resolverData, nil)
+	if err != nil {
+		return false, fmt.Errorf("resolve enabled: %w", err)
+	}
+
+	return isTruthy(val), nil
+}
+
+// resolveBackendInputs resolves all backend input ValueRefs.
+func (m *Manager) resolveBackendInputs(ctx context.Context, resolverData map[string]any) (map[string]any, error) {
+	resolved := make(map[string]any, len(m.config.Backend.Inputs))
+
+	for key, vr := range m.config.Backend.Inputs {
+		if vr == nil {
+			continue
+		}
+		val, err := vr.Resolve(ctx, resolverData, nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolve input %q: %w", key, err)
+		}
+		resolved[key] = val
+	}
+
+	return resolved, nil
+}
+
+// getBackendProvider looks up the backend provider from the registry.
+func (m *Manager) getBackendProvider() (provider.Provider, error) {
+	name := m.config.Backend.Provider
+	if name == "" {
+		return nil, fmt.Errorf("state: backend provider name is empty")
+	}
+
+	prov, exists := m.registry.Get(name)
+	if !exists {
+		return nil, fmt.Errorf("state: backend provider %q not found in registry: %w", name, ErrInvalidBackend)
+	}
+
+	// Verify it has CapabilityState
+	desc := prov.Descriptor()
+	hasState := false
+	for _, cap := range desc.Capabilities {
+		if cap == provider.CapabilityState {
+			hasState = true
+			break
+		}
+	}
+	if !hasState {
+		return nil, fmt.Errorf("state: provider %q does not have CapabilityState: %w", name, ErrInvalidBackend)
+	}
+
+	return prov, nil
+}
+
+// extractStateData extracts *Data from a provider execution result.
+// It handles both direct *Data pointers (returned by in-process providers)
+// and map[string]any representations (returned after JSON round-trips).
+func extractStateData(result *provider.ExecutionResult) (*Data, error) {
+	if result == nil {
+		return nil, fmt.Errorf("nil execution result")
+	}
+
+	dataMap, ok := result.Output.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected map output, got %T", result.Output.Data)
+	}
+
+	sd, ok := dataMap["data"]
+	if !ok {
+		return nil, fmt.Errorf("missing 'data' field in backend output")
+	}
+
+	// Direct pointer — returned by in-process providers.
+	if stateData, ok := sd.(*Data); ok {
+		return stateData, nil
+	}
+
+	// Map representation — may occur after JSON serialization round-trips
+	// (e.g., plugin providers or test mocks).
+	if m, ok := sd.(map[string]any); ok {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return nil, fmt.Errorf("marshal state map: %w", err)
+		}
+		var stateData Data
+		if err := json.Unmarshal(b, &stateData); err != nil {
+			return nil, fmt.Errorf("unmarshal state map: %w", err)
+		}
+		return &stateData, nil
+	}
+
+	return nil, fmt.Errorf("expected *Data or map[string]any, got %T", sd)
+}
+
+// isTruthy coerces a value to bool.
+func isTruthy(v any) bool {
+	if v == nil {
+		return false
+	}
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		return val != "" && val != "false" && val != "0"
+	case int:
+		return val != 0
+	case int64:
+		return val != 0
+	case float64:
+		return val != 0
+	default:
+		return true
+	}
+}
+
+// structToMap converts a Go struct to a map[string]any via JSON round-trip.
+// This is necessary because the provider executor's schema validator cannot
+// validate Go structs directly.
+func structToMap(v any) (map[string]any, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
@@ -45,20 +47,20 @@ type LoadResult struct {
 }
 
 // Load executes the pre-execution state lifecycle:
-//  1. Resolves the enabled ValueRef (if it references resolvers, those must
-//     already be resolved and available in resolverData).
+//  1. Evaluates the enabled ValueRef using CLI params (available as __params
+//     in CEL expressions). No resolver data is available at load time.
 //  2. If disabled, returns LoadResult{Skipped: true}.
-//  3. Resolves backend inputs.
+//  3. Resolves backend inputs with params as __params.
 //  4. Calls the backend provider with operation=state_load.
 //  5. Captures command info.
 //  6. Injects state into context via WithState.
-func (m *Manager) Load(ctx context.Context, resolverData map[string]any, command CommandInfo) (*LoadResult, error) {
+func (m *Manager) Load(ctx context.Context, params map[string]any, command CommandInfo) (*LoadResult, error) {
 	if m.config == nil {
 		return &LoadResult{Ctx: ctx, Skipped: true}, nil
 	}
 
-	// Evaluate enabled
-	enabled, err := m.evaluateEnabled(ctx, resolverData)
+	// Evaluate enabled — no resolver data at load time, only CLI params
+	enabled, err := m.evaluateEnabled(ctx, nil, params)
 	if err != nil {
 		return nil, fmt.Errorf("state: evaluate enabled: %w", err)
 	}
@@ -66,8 +68,8 @@ func (m *Manager) Load(ctx context.Context, resolverData map[string]any, command
 		return &LoadResult{Ctx: ctx, Skipped: true}, nil
 	}
 
-	// Resolve backend inputs
-	backendInputs, err := m.resolveBackendInputs(ctx, resolverData)
+	// Resolve backend inputs — no resolver data at load time, only CLI params
+	backendInputs, err := m.resolveBackendInputs(ctx, nil, params)
 	if err != nil {
 		return nil, fmt.Errorf("state: resolve backend inputs: %w", err)
 	}
@@ -109,9 +111,18 @@ func (m *Manager) Load(ctx context.Context, resolverData map[string]any, command
 //  2. Updates state data with collected values.
 //  3. Updates metadata timestamps.
 //  4. Calls the backend provider with operation=state_save.
-func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver, resolverData map[string]any, solMeta SolutionMeta) error {
+//
+// params are the original CLI parameters, available as __params in backend
+// input CEL expressions. resolverData contains resolver outputs, available
+// as _ in CEL expressions.
+func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver, params, resolverData map[string]any, solMeta SolutionMeta) error {
 	if m.config == nil || stateData == nil {
 		return nil
+	}
+
+	// Ensure maps are initialized before assigning entries
+	if stateData.Values == nil {
+		stateData.Values = make(map[string]*Entry)
 	}
 
 	// Collect saveToState values
@@ -141,8 +152,9 @@ func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolv
 	stateData.Metadata.Version = solMeta.Version
 	stateData.Metadata.ScafctlVersion = m.version
 
-	// Resolve backend inputs for save
-	backendInputs, err := m.resolveBackendInputs(ctx, resolverData)
+	// Resolve backend inputs for save — resolver outputs are available as _
+	// and CLI params as __params in backend input expressions.
+	backendInputs, err := m.resolveBackendInputs(ctx, resolverData, params)
 	if err != nil {
 		return fmt.Errorf("state: resolve backend inputs for save: %w", err)
 	}
@@ -217,13 +229,14 @@ func (m *Manager) RequiredResolvers() []string {
 }
 
 // evaluateEnabled resolves the enabled ValueRef and coerces to bool.
-func (m *Manager) evaluateEnabled(ctx context.Context, resolverData map[string]any) (bool, error) {
+// CLI params are available as __params in CEL expressions.
+func (m *Manager) evaluateEnabled(ctx context.Context, resolverData, params map[string]any) (bool, error) {
 	if m.config.Enabled == nil {
 		// No enabled field means enabled by default when state block is present
 		return true, nil
 	}
 
-	val, err := m.config.Enabled.Resolve(ctx, resolverData, nil)
+	val, err := resolveWithParams(ctx, m.config.Enabled, resolverData, params)
 	if err != nil {
 		return false, fmt.Errorf("resolve enabled: %w", err)
 	}
@@ -232,14 +245,15 @@ func (m *Manager) evaluateEnabled(ctx context.Context, resolverData map[string]a
 }
 
 // resolveBackendInputs resolves all backend input ValueRefs.
-func (m *Manager) resolveBackendInputs(ctx context.Context, resolverData map[string]any) (map[string]any, error) {
+// resolverData becomes _ in CEL; params becomes __params.
+func (m *Manager) resolveBackendInputs(ctx context.Context, resolverData, params map[string]any) (map[string]any, error) {
 	resolved := make(map[string]any, len(m.config.Backend.Inputs))
 
 	for key, vr := range m.config.Backend.Inputs {
 		if vr == nil {
 			continue
 		}
-		val, err := vr.Resolve(ctx, resolverData, nil)
+		val, err := resolveWithParams(ctx, vr, resolverData, params)
 		if err != nil {
 			return nil, fmt.Errorf("resolve input %q: %w", key, err)
 		}
@@ -247,6 +261,50 @@ func (m *Manager) resolveBackendInputs(ctx context.Context, resolverData map[str
 	}
 
 	return resolved, nil
+}
+
+// resolveWithParams resolves a ValueRef with CLI params available as __params.
+// resolverData is passed as the standard _ variable. For literal and resolver-ref
+// ValueRefs, params are not used (they are only relevant for CEL and templates).
+func resolveWithParams(ctx context.Context, vr *spec.ValueRef, resolverData, params map[string]any) (any, error) {
+	if vr == nil {
+		return nil, nil
+	}
+
+	// Literal and resolver references don't need params
+	if vr.Literal != nil || vr.Resolver != nil {
+		return vr.Resolve(ctx, resolverData, nil)
+	}
+
+	// CEL expression — inject __params as an additional variable
+	if vr.Expr != nil {
+		additionalVars := map[string]any{celexp.VarParams: params}
+		result, err := celexp.EvaluateExpression(ctx, string(*vr.Expr), resolverData, additionalVars)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate expression: %w", err)
+		}
+		return result, nil
+	}
+
+	// Go template — add __params to template data
+	if vr.Tmpl != nil {
+		templateData := make(map[string]any, len(resolverData)+2)
+		for k, val := range resolverData {
+			templateData[k] = val
+		}
+		templateData[celexp.VarParams] = params
+		result, err := gotmpl.Execute(ctx, gotmpl.TemplateOptions{
+			Content:    string(*vr.Tmpl),
+			Data:       templateData,
+			MissingKey: gotmpl.MissingKeyError,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute template: %w", err)
+		}
+		return result.Output, nil
+	}
+
+	return nil, fmt.Errorf("empty value reference")
 }
 
 // getBackendProvider looks up the backend provider from the registry.

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -1,0 +1,597 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockBackendProvider implements provider.Provider for testing the manager.
+type mockBackendProvider struct {
+	loadData  *Data
+	loadErr   error
+	saveErr   error
+	saveCalls []map[string]any
+}
+
+func (m *mockBackendProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:        "mock-state",
+		DisplayName: "Mock State",
+		Description: "Mock state backend for testing",
+		APIVersion:  "v1",
+		Version:     semver.MustParse("1.0.0"),
+		Capabilities: []provider.Capability{
+			provider.CapabilityState,
+		},
+		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+			provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+				"success": schemahelper.BoolProp("Whether the operation succeeded"),
+			}),
+		},
+	}
+}
+
+func (m *mockBackendProvider) Execute(_ context.Context, input any) (*provider.Output, error) {
+	inputs, _ := input.(map[string]any)
+	op, _ := inputs["operation"].(string)
+
+	switch op {
+	case "state_load":
+		if m.loadErr != nil {
+			return nil, m.loadErr
+		}
+		data := m.loadData
+		if data == nil {
+			data = NewData()
+		}
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"data":    data,
+			},
+		}, nil
+	case "state_save":
+		if m.saveErr != nil {
+			return nil, m.saveErr
+		}
+		m.saveCalls = append(m.saveCalls, inputs)
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+			},
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func newTestRegistry(t *testing.T, p provider.Provider) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	err := reg.Register(p)
+	assert.NoError(t, err, "failed to register mock provider")
+	return reg
+}
+
+func literalValueRef(val any) *spec.ValueRef {
+	return &spec.ValueRef{Literal: val}
+}
+
+func TestManagerLoad(t *testing.T) {
+	existingState := NewData()
+	existingState.Metadata.Solution = "test-app"
+	existingState.Values["existing_key"] = &Entry{Value: "existing_val", Type: "string"}
+
+	tests := []struct {
+		name     string
+		config   *Config
+		backend  *mockBackendProvider
+		wantSkip bool
+		wantErr  bool
+		check    func(t *testing.T, result *LoadResult)
+	}{
+		{
+			name:     "nil config skips",
+			config:   nil,
+			wantSkip: true,
+		},
+		{
+			name: "enabled true loads state",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("test.json")},
+				},
+			},
+			backend: &mockBackendProvider{loadData: existingState},
+			check: func(t *testing.T, result *LoadResult) {
+				assert.False(t, result.Skipped)
+				assert.NotNil(t, result.Data)
+				assert.Equal(t, "test-app", result.Data.Metadata.Solution)
+			},
+		},
+		{
+			name: "enabled false skips",
+			config: &Config{
+				Enabled: literalValueRef(false),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			wantSkip: true,
+		},
+		{
+			name: "nil enabled means enabled",
+			config: &Config{
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			check: func(t *testing.T, result *LoadResult) {
+				assert.False(t, result.Skipped)
+				assert.NotNil(t, result.Data)
+			},
+		},
+		{
+			name: "backend load error",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{loadErr: assert.AnError},
+			wantErr: true,
+		},
+		{
+			name: "provider not found",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "nonexistent",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "command is captured",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			check: func(t *testing.T, result *LoadResult) {
+				assert.Equal(t, "run solution", result.Data.Command.Subcommand)
+				assert.Equal(t, "bar", result.Data.Command.Parameters["foo"])
+			},
+		},
+		{
+			name: "state injected into context",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			check: func(t *testing.T, result *LoadResult) {
+				sd, ok := FromContext(result.Ctx)
+				assert.True(t, ok)
+				assert.NotNil(t, sd)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reg *provider.Registry
+			if tt.backend != nil {
+				reg = newTestRegistry(t, tt.backend)
+			} else {
+				reg = provider.NewRegistry()
+			}
+
+			mgr := NewManager(tt.config, reg, "test-version")
+			cmd := CommandInfo{
+				Subcommand: "run solution",
+				Parameters: map[string]string{"foo": "bar"},
+			}
+			result, err := mgr.Load(context.Background(), nil, cmd)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.wantSkip {
+				assert.True(t, result.Skipped)
+				return
+			}
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestManagerSave(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		backend *mockBackendProvider
+		state   *Data
+		setup   func() (*resolver.Context, []*resolver.Resolver)
+		wantErr bool
+		check   func(t *testing.T, sd *Data, backend *mockBackendProvider)
+	}{
+		{
+			name:   "nil config is noop",
+			config: nil,
+			state:  NewData(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				return resolver.NewContext(), nil
+			},
+		},
+		{
+			name: "collects saveToState values",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			state:   NewData(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				rctx := resolver.NewContext()
+				rctx.SetResult("api_key", &resolver.ExecutionResult{
+					Value:  "secret123",
+					Status: resolver.ExecutionStatusSuccess,
+				})
+				rctx.SetResult("name", &resolver.ExecutionResult{
+					Value:  "app",
+					Status: resolver.ExecutionStatusSuccess,
+				})
+				rctx.SetResult("failed_one", &resolver.ExecutionResult{
+					Value:  "x",
+					Status: resolver.ExecutionStatusFailed,
+				})
+				resolvers := []*resolver.Resolver{
+					{Name: "api_key", Type: "string", SaveToState: true},
+					{Name: "name", Type: "string", SaveToState: false},
+					{Name: "failed_one", Type: "string", SaveToState: true},
+				}
+				return rctx, resolvers
+			},
+			check: func(t *testing.T, sd *Data, backend *mockBackendProvider) {
+				// api_key should be saved (saveToState + success)
+				assert.Contains(t, sd.Values, "api_key")
+				assert.Equal(t, "secret123", sd.Values["api_key"].Value)
+				assert.Equal(t, "string", sd.Values["api_key"].Type)
+
+				// name should NOT be saved (saveToState is false)
+				_, hasName := sd.Values["name"]
+				assert.False(t, hasName)
+
+				// failed_one should NOT be saved (status is failed)
+				_, hasFailed := sd.Values["failed_one"]
+				assert.False(t, hasFailed)
+
+				// backend save should have been called
+				assert.Len(t, backend.saveCalls, 1)
+			},
+		},
+		{
+			name: "updates metadata",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			state:   NewData(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				return resolver.NewContext(), nil
+			},
+			check: func(t *testing.T, sd *Data, _ *mockBackendProvider) {
+				assert.Equal(t, "my-app", sd.Metadata.Solution)
+				assert.Equal(t, "2.0.0", sd.Metadata.Version)
+				assert.Equal(t, "test-version", sd.Metadata.ScafctlVersion)
+				assert.False(t, sd.Metadata.CreatedAt.IsZero())
+				assert.False(t, sd.Metadata.LastUpdatedAt.IsZero())
+			},
+		},
+		{
+			name: "preserves existing createdAt",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			state: func() *Data {
+				sd := NewData()
+				sd.Metadata.CreatedAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+				return sd
+			}(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				return resolver.NewContext(), nil
+			},
+			check: func(t *testing.T, sd *Data, _ *mockBackendProvider) {
+				assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), sd.Metadata.CreatedAt)
+			},
+		},
+		{
+			name: "save backend error",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{saveErr: assert.AnError},
+			state:   NewData(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				return resolver.NewContext(), nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reg *provider.Registry
+			if tt.backend != nil {
+				reg = newTestRegistry(t, tt.backend)
+			} else {
+				reg = provider.NewRegistry()
+			}
+
+			mgr := NewManager(tt.config, reg, "test-version")
+			rctx, resolvers := tt.setup()
+			solMeta := SolutionMeta{Name: "my-app", Version: "2.0.0"}
+
+			err := mgr.Save(context.Background(), tt.state, rctx, resolvers, nil, solMeta)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, tt.state, tt.backend)
+			}
+		})
+	}
+}
+
+func TestManagerRequiredResolvers(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		want   []string
+	}{
+		{
+			name:   "nil config",
+			config: nil,
+			want:   nil,
+		},
+		{
+			name: "literal values no resolvers",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Inputs: map[string]*spec.ValueRef{"path": literalValueRef("test.json")},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "resolver reference in enabled",
+			config: &Config{
+				Enabled: &spec.ValueRef{Resolver: strPtr("use_state")},
+				Backend: Backend{
+					Inputs: map[string]*spec.ValueRef{},
+				},
+			},
+			want: []string{"use_state"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewManager(tt.config, nil, "v")
+			got := mgr.RequiredResolvers()
+			if tt.want == nil {
+				assert.Empty(t, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsTruthy(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want bool
+	}{
+		{"nil", nil, false},
+		{"true", true, true},
+		{"false", false, false},
+		{"non-empty string", "yes", true},
+		{"empty string", "", false},
+		{"false string", "false", false},
+		{"zero string", "0", false},
+		{"int 1", 1, true},
+		{"int 0", 0, false},
+		{"int64 1", int64(1), true},
+		{"int64 0", int64(0), false},
+		{"float64 1", float64(1), true},
+		{"float64 0", float64(0), false},
+		{"struct", struct{}{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isTruthy(tt.val))
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestStructToMap(t *testing.T) {
+	t.Run("converts struct to map", func(t *testing.T) {
+		sd := NewData()
+		sd.SchemaVersion = 1
+		sd.Metadata.Solution = "test-app"
+		sd.Values["key1"] = &Entry{Value: "val1", Type: "string"}
+
+		m, err := structToMap(sd)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1), m["schemaVersion"])
+
+		meta, ok := m["metadata"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "test-app", meta["solution"])
+
+		vals, ok := m["values"].(map[string]any)
+		assert.True(t, ok)
+		entry, ok := vals["key1"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "val1", entry["value"])
+		assert.Equal(t, "string", entry["type"])
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		sd := NewData()
+		m, err := structToMap(sd)
+		assert.NoError(t, err)
+		assert.NotNil(t, m)
+		assert.Equal(t, float64(SchemaVersionCurrent), m["schemaVersion"])
+	})
+}
+
+func TestExtractStateData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil result", func(t *testing.T) {
+		t.Parallel()
+		_, err := extractStateData(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil execution result")
+	})
+
+	t.Run("non-map output", func(t *testing.T) {
+		t.Parallel()
+		_, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: "not a map"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected map output")
+	})
+
+	t.Run("missing data field", func(t *testing.T) {
+		t.Parallel()
+		_, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{"success": true}},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing 'data'")
+	})
+
+	t.Run("direct pointer", func(t *testing.T) {
+		t.Parallel()
+		expected := NewMockData("test", "1.0.0", map[string]*Entry{
+			"env": {Value: "prod", Type: "string"},
+		})
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    expected,
+			}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("map fallback", func(t *testing.T) {
+		t.Parallel()
+		// Simulate what happens when a provider returns data as map[string]any
+		// (e.g., after JSON round-trip through a plugin boundary).
+		dataMap := map[string]any{
+			"schemaVersion": float64(1),
+			"metadata": map[string]any{
+				"solution":       "test-app",
+				"version":        "1.0.0",
+				"scafctlVersion": "dev",
+				"createdAt":      "2025-01-01T00:00:00Z",
+				"lastUpdatedAt":  "2025-01-01T00:00:00Z",
+			},
+			"command": map[string]any{
+				"subcommand": "run solution",
+				"parameters": map[string]any{},
+			},
+			"values": map[string]any{
+				"region": map[string]any{
+					"value":     "us-east-1",
+					"type":      "string",
+					"updatedAt": "2025-01-01T00:00:00Z",
+					"immutable": false,
+				},
+			},
+		}
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    dataMap,
+			}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, result.SchemaVersion)
+		assert.Equal(t, "test-app", result.Metadata.Solution)
+		assert.Contains(t, result.Values, "region")
+		assert.Equal(t, "us-east-1", result.Values["region"].Value)
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		t.Parallel()
+		_, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    42,
+			}},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected *Data or map[string]any")
+	})
+}

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -378,7 +380,7 @@ func TestManagerSave(t *testing.T) {
 			rctx, resolvers := tt.setup()
 			solMeta := SolutionMeta{Name: "my-app", Version: "2.0.0"}
 
-			err := mgr.Save(context.Background(), tt.state, rctx, resolvers, nil, solMeta)
+			err := mgr.Save(context.Background(), tt.state, rctx, resolvers, nil, nil, solMeta)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -593,5 +595,135 @@ func TestExtractStateData(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "expected *Data or map[string]any")
+	})
+}
+
+func TestManagerLoad_ParamsAsParams(t *testing.T) {
+	t.Run("CEL __params in backend inputs", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+
+		expr := celexp.Expression("'gcp/' + __params.project + '/state.json'")
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": {Expr: &expr}},
+			},
+		}
+		mgr := NewManager(cfg, reg, "v")
+		params := map[string]any{"project": "my-proj"}
+		result, err := mgr.Load(context.Background(), params, CommandInfo{Subcommand: "run solution"})
+		assert.NoError(t, err)
+		assert.False(t, result.Skipped)
+	})
+
+	t.Run("CEL __params in enabled", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+
+		expr := celexp.Expression("__params.state_enabled == true")
+		cfg := &Config{
+			Enabled: &spec.ValueRef{Expr: &expr},
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{},
+			},
+		}
+		mgr := NewManager(cfg, reg, "v")
+
+		// enabled=true
+		result, err := mgr.Load(context.Background(), map[string]any{"state_enabled": true}, CommandInfo{})
+		assert.NoError(t, err)
+		assert.False(t, result.Skipped)
+
+		// enabled=false
+		result, err = mgr.Load(context.Background(), map[string]any{"state_enabled": false}, CommandInfo{})
+		assert.NoError(t, err)
+		assert.True(t, result.Skipped)
+	})
+
+	t.Run("Go template __params in backend inputs", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+
+		tmpl := gotmpl.GoTemplatingContent("gcp/{{ .__params.project }}/state.json")
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": {Tmpl: &tmpl}},
+			},
+		}
+		mgr := NewManager(cfg, reg, "v")
+		params := map[string]any{"project": "my-proj"}
+		result, err := mgr.Load(context.Background(), params, CommandInfo{})
+		assert.NoError(t, err)
+		assert.False(t, result.Skipped)
+	})
+
+	t.Run("nil params does not panic", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("default.json")},
+			},
+		}
+		mgr := NewManager(cfg, reg, "v")
+		result, err := mgr.Load(context.Background(), nil, CommandInfo{})
+		assert.NoError(t, err)
+		assert.False(t, result.Skipped)
+	})
+}
+
+func TestResolveWithParams(t *testing.T) {
+	t.Run("nil valueref returns nil", func(t *testing.T) {
+		val, err := resolveWithParams(context.Background(), nil, nil, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("literal ignores params", func(t *testing.T) {
+		vr := literalValueRef("static")
+		val, err := resolveWithParams(context.Background(), vr, nil, map[string]any{"key": "val"})
+		assert.NoError(t, err)
+		assert.Equal(t, "static", val)
+	})
+
+	t.Run("CEL uses __params", func(t *testing.T) {
+		expr := celexp.Expression("__params.name + '-state.json'")
+		vr := &spec.ValueRef{Expr: &expr}
+		val, err := resolveWithParams(context.Background(), vr, nil, map[string]any{"name": "myapp"})
+		assert.NoError(t, err)
+		assert.Equal(t, "myapp-state.json", val)
+	})
+
+	t.Run("CEL uses both _ and __params", func(t *testing.T) {
+		expr := celexp.Expression("_.resolver_out + '/' + __params.project")
+		vr := &spec.ValueRef{Expr: &expr}
+		resolverData := map[string]any{"resolver_out": "computed"}
+		params := map[string]any{"project": "my-proj"}
+		val, err := resolveWithParams(context.Background(), vr, resolverData, params)
+		assert.NoError(t, err)
+		assert.Equal(t, "computed/my-proj", val)
+	})
+
+	t.Run("template uses __params", func(t *testing.T) {
+		tmpl := gotmpl.GoTemplatingContent("{{ .__params.project }}/state.json")
+		vr := &spec.ValueRef{Tmpl: &tmpl}
+		val, err := resolveWithParams(context.Background(), vr, nil, map[string]any{"project": "my-proj"})
+		assert.NoError(t, err)
+		assert.Equal(t, "my-proj/state.json", val)
+	})
+
+	t.Run("empty valueref returns error", func(t *testing.T) {
+		vr := &spec.ValueRef{}
+		_, err := resolveWithParams(context.Background(), vr, nil, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "empty value reference")
 	})
 }

--- a/pkg/state/mock.go
+++ b/pkg/state/mock.go
@@ -1,0 +1,24 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import "time"
+
+// NewMockData creates a StateData populated with test data.
+// Use this in tests that need a pre-populated state.
+func NewMockData(solution, version string, values map[string]*Entry) *Data {
+	now := time.Now().UTC()
+	data := NewData()
+	data.Metadata = Metadata{
+		Solution:       solution,
+		Version:        version,
+		CreatedAt:      now,
+		LastUpdatedAt:  now,
+		ScafctlVersion: "test",
+	}
+	if values != nil {
+		data.Values = values
+	}
+	return data
+}

--- a/pkg/state/store.go
+++ b/pkg/state/store.go
@@ -87,14 +87,16 @@ func ResolveStatePath(path string) (string, error) {
 		return "", fmt.Errorf("state path is required")
 	}
 
-	// Reject path traversal
+	// Reject path traversal by checking individual segments
 	cleaned := filepath.Clean(path)
-	if strings.Contains(cleaned, "..") {
-		return "", fmt.Errorf("path traversal not allowed: %s", path)
+	for _, seg := range strings.Split(cleaned, string(filepath.Separator)) {
+		if seg == ".." {
+			return "", fmt.Errorf("path traversal not allowed: %s", path)
+		}
 	}
 
 	if filepath.IsAbs(path) {
-		return path, nil
+		return filepath.Clean(path), nil
 	}
 
 	return filepath.Join(paths.StateDir(), cleaned), nil

--- a/pkg/state/store.go
+++ b/pkg/state/store.go
@@ -1,0 +1,101 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+// LoadFromFile reads and unmarshals a StateData JSON file.
+// If the file does not exist, it returns an empty StateData.
+// The path is resolved relative to paths.StateDir() unless absolute.
+func LoadFromFile(path string) (*Data, error) {
+	absPath, err := ResolveStatePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return NewData(), nil
+	}
+
+	data, err := os.ReadFile(absPath) //nolint:gosec // path validated by ResolveStatePath
+	if err != nil {
+		return nil, fmt.Errorf("read state file: %w", err)
+	}
+
+	var sd Data
+	if err := json.Unmarshal(data, &sd); err != nil {
+		return nil, fmt.Errorf("unmarshal state file: %w", err)
+	}
+
+	return &sd, nil
+}
+
+// SaveToFile marshals and writes StateData to a JSON file using atomic write.
+// The path is resolved relative to paths.StateDir() unless absolute.
+func SaveToFile(path string, sd *Data) error {
+	absPath, err := ResolveStatePath(path)
+	if err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.MarshalIndent(sd, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+
+	dir := filepath.Dir(absPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create state directory: %w", err)
+	}
+
+	// Atomic write: temp file + rename
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(jsonBytes); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, absPath); err != nil { //nolint:gosec // absPath validated by ResolveStatePath
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// ResolveStatePath resolves a state file path. Absolute paths are used as-is.
+// Relative paths are resolved against paths.StateDir().
+// Path traversal (../) is rejected.
+func ResolveStatePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("state path is required")
+	}
+
+	// Reject path traversal
+	cleaned := filepath.Clean(path)
+	if strings.Contains(cleaned, "..") {
+		return "", fmt.Errorf("path traversal not allowed: %s", path)
+	}
+
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	return filepath.Join(paths.StateDir(), cleaned), nil
+}

--- a/pkg/state/store_test.go
+++ b/pkg/state/store_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromFile_NotFound(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "missing.json")
+
+	sd, err := LoadFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, SchemaVersionCurrent, sd.SchemaVersion)
+	assert.Empty(t, sd.Values)
+}
+
+func TestLoadFromFile_RoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.json")
+
+	sd := NewData()
+	sd.Values["mykey"] = &Entry{
+		Value:     "hello",
+		Type:      "string",
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	sd.Metadata.Solution = "test-sol"
+
+	err := SaveToFile(path, sd)
+	require.NoError(t, err)
+
+	loaded, err := LoadFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "test-sol", loaded.Metadata.Solution)
+	require.Contains(t, loaded.Values, "mykey")
+	assert.Equal(t, "hello", loaded.Values["mykey"].Value)
+	assert.Equal(t, "string", loaded.Values["mykey"].Type)
+}
+
+func TestLoadFromFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("{invalid"), 0o600))
+
+	_, err := LoadFromFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestSaveToFile_CreatesDirectory(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "subdir", "nested", "state.json")
+
+	err := SaveToFile(path, NewData())
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+}
+
+func TestResolveStatePath_EmptyPath(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveStatePath("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestResolveStatePath_Traversal(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveStatePath("../../../etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "traversal")
+}
+
+func TestResolveStatePath_Absolute(t *testing.T) {
+	t.Parallel()
+	abs := "/tmp/test-state.json"
+	result, err := ResolveStatePath(abs)
+	require.NoError(t, err)
+	assert.Equal(t, abs, result)
+}
+
+func TestLoadFromFile_EmptyPath(t *testing.T) {
+	t.Parallel()
+	_, err := LoadFromFile("")
+	require.Error(t, err)
+}
+
+func TestSaveToFile_EmptyPath(t *testing.T) {
+	t.Parallel()
+	err := SaveToFile("", NewData())
+	require.Error(t, err)
+}
+
+func BenchmarkLoadFromFile(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "bench.json")
+	sd := NewData()
+	for i := range 100 {
+		sd.Values[filepath.Join("key", string(rune('a'+i%26)))] = &Entry{
+			Value: "value",
+			Type:  "string",
+		}
+	}
+	require.NoError(b, SaveToFile(path, sd))
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = LoadFromFile(path)
+	}
+}
+
+func BenchmarkSaveToFile(b *testing.B) {
+	dir := b.TempDir()
+	sd := NewData()
+	sd.Values["key"] = &Entry{Value: "val", Type: "string"}
+
+	b.ResetTimer()
+	for i := range b.N {
+		path := filepath.Join(dir, filepath.Base(filepath.Join("bench", string(rune('a'+i%26))+".json")))
+		_ = SaveToFile(path, sd)
+	}
+}

--- a/pkg/state/store_test.go
+++ b/pkg/state/store_test.go
@@ -112,8 +112,9 @@ func BenchmarkLoadFromFile(b *testing.B) {
 	}
 	require.NoError(b, SaveToFile(path, sd))
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, _ = LoadFromFile(path)
 	}
 }
@@ -123,9 +124,10 @@ func BenchmarkSaveToFile(b *testing.B) {
 	sd := NewData()
 	sd.Values["key"] = &Entry{Value: "val", Type: "string"}
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := range b.N {
-		path := filepath.Join(dir, filepath.Base(filepath.Join("bench", string(rune('a'+i%26))+".json")))
+	for b.Loop() {
+		path := filepath.Join(dir, "bench.json")
 		_ = SaveToFile(path, sd)
 	}
 }

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -16,8 +16,25 @@ const (
 
 // Config is the solution-level state configuration.
 // It is a top-level peer to Spec, Catalog, Bundle, and Compose on the Solution struct.
+//
+// CLI parameters passed via -r flags are available as __params in CEL expressions
+// and Go templates used in Enabled and Backend.Inputs. This allows dynamic backend
+// configuration without requiring resolver execution (which happens after state load).
+//
+// Example:
+//
+//	state:
+//	  enabled:
+//	    expr: "__params.state_enabled == true"
+//	  backend:
+//	    provider: file
+//	    inputs:
+//	      path:
+//	        expr: "'gcp/' + __params.project + '/state.json'"
 type Config struct {
-	// Enabled controls whether state persistence is active. Supports literal bool, CEL, resolver ref, or template.
+	// Enabled controls whether state persistence is active. Supports literal bool, CEL expression, or template.
+	// Resolver references (rslvr:) are not supported because state is loaded before resolver execution.
+	// Use __params to reference CLI parameters (e.g. expr: "__params.enable_state == true").
 	Enabled *spec.ValueRef `json:"enabled" yaml:"enabled" doc:"Dynamic activation of state persistence"`
 
 	// Backend configures which provider handles state persistence.
@@ -30,6 +47,12 @@ type Backend struct {
 	Provider string `json:"provider" yaml:"provider" doc:"Provider name with CapabilityState" maxLength:"253" example:"file"`
 
 	// Inputs are provider-specific inputs. Each value is a ValueRef for dynamic resolution.
+	//
+	// CEL expressions use __params for CLI parameters (e.g. __params.project) and _ for
+	// resolver outputs (available at save time only, not load time).
+	//
+	// Go templates spread resolver data at top level (e.g. {{ .name }}) and expose CLI
+	// parameters under __params (e.g. {{ .__params.project }}).
 	Inputs map[string]*spec.ValueRef `json:"inputs" yaml:"inputs" doc:"Provider-specific inputs (ValueRef for dynamic resolution)"`
 }
 

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -1,0 +1,104 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+const (
+	// SchemaVersionCurrent is the current state file schema version.
+	SchemaVersionCurrent = 1
+)
+
+// Config is the solution-level state configuration.
+// It is a top-level peer to Spec, Catalog, Bundle, and Compose on the Solution struct.
+type Config struct {
+	// Enabled controls whether state persistence is active. Supports literal bool, CEL, resolver ref, or template.
+	Enabled *spec.ValueRef `json:"enabled" yaml:"enabled" doc:"Dynamic activation of state persistence"`
+
+	// Backend configures which provider handles state persistence.
+	Backend Backend `json:"backend" yaml:"backend" doc:"Backend provider configuration"`
+}
+
+// Backend configures the state persistence backend.
+type Backend struct {
+	// Provider is the name of a registered provider with CapabilityState (e.g., "file").
+	Provider string `json:"provider" yaml:"provider" doc:"Provider name with CapabilityState" maxLength:"253" example:"file"`
+
+	// Inputs are provider-specific inputs. Each value is a ValueRef for dynamic resolution.
+	Inputs map[string]*spec.ValueRef `json:"inputs" yaml:"inputs" doc:"Provider-specific inputs (ValueRef for dynamic resolution)"`
+}
+
+// Data is the complete persisted state structure.
+// It is serialized as JSON to the backend storage.
+type Data struct {
+	// SchemaVersion enables forward-compatible format migrations.
+	SchemaVersion int `json:"schemaVersion" doc:"Format version for migrations"`
+
+	// Metadata identifies the solution and tracks timestamps.
+	Metadata Metadata `json:"metadata" doc:"Solution identity and timestamps"`
+
+	// Command captures the most recent invocation for validation replay.
+	Command CommandInfo `json:"command" doc:"Most recent invocation"`
+
+	// Values maps resolver names to persisted entries.
+	Values map[string]*Entry `json:"values" doc:"Resolver name to persisted entry"`
+}
+
+// Metadata identifies the solution and tracks state lifecycle timestamps.
+type Metadata struct {
+	// Solution is the solution name from metadata.name.
+	Solution string `json:"solution" doc:"Solution name from metadata.name" maxLength:"253"`
+
+	// Version is the solution semver string.
+	Version string `json:"version" doc:"Solution semver" maxLength:"30"`
+
+	// CreatedAt is when the state file was first created.
+	CreatedAt time.Time `json:"createdAt" doc:"First state file creation"`
+
+	// LastUpdatedAt is when the state file was most recently saved.
+	LastUpdatedAt time.Time `json:"lastUpdatedAt" doc:"Most recent save"`
+
+	// ScafctlVersion is the version of scafctl that last wrote the state.
+	ScafctlVersion string `json:"scafctlVersion" doc:"Version of scafctl that last wrote" maxLength:"30"`
+}
+
+// CommandInfo captures the most recent invocation for validation replay.
+// Only the latest invocation is stored -- no history.
+type CommandInfo struct {
+	// Subcommand is the CLI subcommand used (e.g., "run solution").
+	Subcommand string `json:"subcommand" doc:"CLI subcommand used" maxLength:"100" example:"run solution"`
+
+	// Parameters are the key-value pairs from --parameter flags.
+	Parameters map[string]string `json:"parameters" doc:"Key-value pairs from --parameter flags"`
+}
+
+// Entry is a single persisted resolver value.
+type Entry struct {
+	// Value is the stored resolver value.
+	Value any `json:"value" doc:"Stored resolver value"`
+
+	// Type is the resolver's declared type (string, int, float, bool, array, object, any).
+	Type string `json:"type" doc:"Resolver declared type" maxLength:"30" example:"string"`
+
+	// UpdatedAt is when this entry was last written.
+	UpdatedAt time.Time `json:"updatedAt" doc:"When this entry was last written"`
+
+	// Immutable indicates whether this entry is locked permanently (future enhancement).
+	Immutable bool `json:"immutable" doc:"Locked permanently (future enhancement)"`
+}
+
+// NewData returns an initialized empty StateData with the current schema version.
+func NewData() *Data {
+	return &Data{
+		SchemaVersion: SchemaVersionCurrent,
+		Values:        make(map[string]*Entry),
+		Command: CommandInfo{
+			Parameters: make(map[string]string),
+		},
+	}
+}

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -1,0 +1,156 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStateData(t *testing.T) {
+	data := NewData()
+	assert.Equal(t, SchemaVersionCurrent, data.SchemaVersion)
+	assert.NotNil(t, data.Values)
+	assert.Empty(t, data.Values)
+	assert.NotNil(t, data.Command.Parameters)
+	assert.Empty(t, data.Command.Parameters)
+}
+
+func TestStateData_JSONRoundTrip(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+
+	original := &Data{
+		SchemaVersion: 1,
+		Metadata: Metadata{
+			Solution:       "deploy-app",
+			Version:        "1.0.0",
+			CreatedAt:      now,
+			LastUpdatedAt:  now,
+			ScafctlVersion: "0.9.0",
+		},
+		Command: CommandInfo{
+			Subcommand: "run solution",
+			Parameters: map[string]string{
+				"project": "foo",
+			},
+		},
+		Values: map[string]*Entry{
+			"api_key": {
+				Value:     "sk-abc123",
+				Type:      "string",
+				UpdatedAt: now,
+				Immutable: false,
+			},
+			"count": {
+				Value:     float64(42),
+				Type:      "int",
+				UpdatedAt: now,
+				Immutable: true,
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Data
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.SchemaVersion, restored.SchemaVersion)
+	assert.Equal(t, original.Metadata.Solution, restored.Metadata.Solution)
+	assert.Equal(t, original.Metadata.Version, restored.Metadata.Version)
+	assert.Equal(t, original.Metadata.ScafctlVersion, restored.Metadata.ScafctlVersion)
+	assert.Equal(t, original.Command.Subcommand, restored.Command.Subcommand)
+	assert.Equal(t, original.Command.Parameters, restored.Command.Parameters)
+	assert.Len(t, restored.Values, 2)
+	assert.Equal(t, "sk-abc123", restored.Values["api_key"].Value)
+	assert.Equal(t, "string", restored.Values["api_key"].Type)
+	assert.False(t, restored.Values["api_key"].Immutable)
+	assert.Equal(t, float64(42), restored.Values["count"].Value)
+	assert.True(t, restored.Values["count"].Immutable)
+}
+
+func TestStateData_EmptyJSONRoundTrip(t *testing.T) {
+	original := NewData()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Data
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, SchemaVersionCurrent, restored.SchemaVersion)
+	assert.Empty(t, restored.Values)
+}
+
+func TestNewMockStateData(t *testing.T) {
+	values := map[string]*Entry{
+		"key1": {Value: "val1", Type: "string"},
+	}
+
+	data := NewMockData("test-sol", "2.0.0", values)
+
+	assert.Equal(t, SchemaVersionCurrent, data.SchemaVersion)
+	assert.Equal(t, "test-sol", data.Metadata.Solution)
+	assert.Equal(t, "2.0.0", data.Metadata.Version)
+	assert.Equal(t, "test", data.Metadata.ScafctlVersion)
+	assert.False(t, data.Metadata.CreatedAt.IsZero())
+	assert.Len(t, data.Values, 1)
+	assert.Equal(t, "val1", data.Values["key1"].Value)
+}
+
+func TestNewMockStateData_NilValues(t *testing.T) {
+	data := NewMockData("test-sol", "1.0.0", nil)
+
+	assert.NotNil(t, data.Values)
+	assert.Empty(t, data.Values)
+}
+
+func TestStateEntry_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry Entry
+	}{
+		{
+			name:  "string value",
+			entry: Entry{Value: "hello", Type: "string", UpdatedAt: time.Now().UTC()},
+		},
+		{
+			name:  "number value",
+			entry: Entry{Value: float64(42), Type: "int", UpdatedAt: time.Now().UTC()},
+		},
+		{
+			name:  "bool value",
+			entry: Entry{Value: true, Type: "bool", UpdatedAt: time.Now().UTC()},
+		},
+		{
+			name:  "array value",
+			entry: Entry{Value: []any{"a", "b"}, Type: "array", UpdatedAt: time.Now().UTC()},
+		},
+		{
+			name:  "immutable",
+			entry: Entry{Value: "locked", Type: "string", Immutable: true, UpdatedAt: time.Now().UTC()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.entry)
+			require.NoError(t, err)
+
+			var restored Entry
+			err = json.Unmarshal(data, &restored)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.entry.Type, restored.Type)
+			assert.Equal(t, tt.entry.Immutable, restored.Immutable)
+		})
+	}
+}

--- a/tests/integration/solutions/state/solution.yaml
+++ b/tests/integration/solutions/state/solution.yaml
@@ -1,0 +1,117 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-state-persistence
+  version: 1.0.0
+  description: |
+    Functional tests for state persistence.
+    Verifies state loading, saving, fallback chains with the state provider,
+    and round-trip persistence via pre-seeded state files.
+
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+
+spec:
+  resolvers:
+    greeting:
+      description: A greeting resolved from static, saved to state
+      type: string
+      saveToState: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello-world
+
+    counter:
+      description: A numeric value resolved from static, saved to state
+      type: int
+      saveToState: true
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 42
+
+    fromState:
+      description: Read a value from state with fallback to static
+      type: string
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "greeting"
+              required: true
+          - provider: static
+            inputs:
+              value: fallback-value
+
+    fromStateOptional:
+      description: Read a value from state with required false (returns fallback)
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "nonexistent"
+              required: false
+              fallback: optional-fallback
+
+  testing:
+    config:
+      # resolve-defaults: resolvers depend on state context
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+
+    cases:
+      _base:
+        description: Base template for state tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [state]
+        assertions:
+          - expression: __exitCode == 0
+
+      first-run-static:
+        description: Verify resolvers work on first run (empty state) with correct fallback behavior
+        extends: [_base]
+        tags: [smoke]
+        env:
+          XDG_STATE_HOME: /tmp/scafctl-it-state-first-run
+        init:
+          - command: "rm -rf /tmp/scafctl-it-state-first-run && mkdir -p /tmp/scafctl-it-state-first-run/scafctl"
+        cleanup:
+          - command: "rm -rf /tmp/scafctl-it-state-first-run"
+        assertions:
+          - expression: __output.greeting == "hello-world"
+            message: "Static resolver should produce hello-world"
+          - expression: __output.counter == 42
+            message: "Static resolver should produce 42"
+          - expression: __output.fromState == "fallback-value"
+            message: "State miss with required=true should fall through to static"
+          - expression: __output.fromStateOptional == "optional-fallback"
+            message: "State miss with required=false should return fallback"
+
+      state-preseeded:
+        description: Verify state provider reads from a pre-seeded state file
+        extends: [_base]
+        env:
+          XDG_STATE_HOME: /tmp/scafctl-it-state-preseeded
+        init:
+          - command: "rm -rf /tmp/scafctl-it-state-preseeded && mkdir -p /tmp/scafctl-it-state-preseeded/scafctl"
+          - command: >-
+              printf '{"schemaVersion":1,"metadata":{"solution":"test-state-persistence","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"values":{"greeting":{"value":"hello-from-state","type":"string","updatedAt":"2025-01-01T00:00:00Z"}}}'
+              > /tmp/scafctl-it-state-preseeded/scafctl/state.json
+        cleanup:
+          - command: "rm -rf /tmp/scafctl-it-state-preseeded"
+        assertions:
+          - expression: __output.fromState == "hello-from-state"
+            message: "State provider should read pre-seeded value"
+          - expression: __output.greeting == "hello-world"
+            message: "Static resolver ignores state and produces hello-world"
+          - expression: __output.fromStateOptional == "optional-fallback"
+            message: "Non-existent key should return fallback"


### PR DESCRIPTION
- add pkg/state with Manager, types, store, context, and error
  sentinels for the state lifecycle (load → execute → save)
- add CapabilityState to the provider system so file, github, and
  http providers can act as state backends
- add stateprovider for resolver fallback chains to read/write
  individual state entries from in-memory state
- add SaveToState field on Resolver and State config on Solution
- wire state load/save lifecycle into run resolver and run solution
  commands, with load-only semantics for snapshot mode
- add 5 lint rules: missing-state-backend, invalid-state-backend,
  state-circular-dependency, sensitive-state, state-resolver-ref
- add CLI commands: state list, get, set, delete, clear
- add MCP tools: state_list, state_get, state_delete
- add state concept to built-in concepts
- extend ValidateDescriptor to handle scafctl-specific capabilities
  without mutating the caller's descriptor
- consolidate path traversal validation into exported
  state.ResolveStatePath, reused by file provider
- add deterministic key ordering in state list output
- add docs, tutorial, and example solution for state

Closes #241