### PR TITLE
feat!: provider enhancements, auth TUI, build ergonomics, and dry-run improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,3 @@ __debug*
 issues/
 # Bubble Tea debug logs
 tea_debug.log
-
-# Bubble Tea debug logs
-tea_debug.log

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/mark3labs/mcp-go v0.47.1
-	github.com/oakwood-commons/kvx v0.8.2
+	github.com/oakwood-commons/kvx v0.10.0
 	github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -148,7 +149,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.2.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oakwood-commons/kvx v0.8.2 h1:0P0cJMwvLDAbmY1hYdySaxPoTc8KLnvO7tFT+07qt5g=
-github.com/oakwood-commons/kvx v0.8.2/go.mod h1:zbIX4bI9K3XytdDIcR1GPOluv80QlpE3jmfGLLOHQsU=
+github.com/oakwood-commons/kvx v0.10.0 h1:f6OLSzESrprIUXBGY9De8FIGA6jzZu/gOzhKDqbMxOA=
+github.com/oakwood-commons/kvx v0.10.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1 h1:oroVda37T0o38ldr+by+ZgB+bmHYb8yRp0ep3xXmn24=
 github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1/go.mod h1:rTVtlxWjYBdgcUWEOrdQJF1jBEFtYLtSjZThx8nZEr0=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=

--- a/pkg/auth/entra/authcode_flow.go
+++ b/pkg/auth/entra/authcode_flow.go
@@ -98,12 +98,14 @@ func (h *Handler) authCodeLogin(ctx context.Context, opts auth.LoginOptions) (*a
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
-	if err := BrowserOpener(ctx, authURL); err != nil {
+	browserOpenErr := BrowserOpener(ctx, authURL)
+	if browserOpenErr != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
-		// Notify via callback if available so the CLI can display the URL
-		if opts.DeviceCodeCallback != nil {
-			opts.DeviceCodeCallback("", authURL, fmt.Sprintf("Open this URL in your browser to authenticate:\n%s", authURL))
-		}
+	}
+	// Always notify the CLI callback with the auth URL so the TUI can show
+	// a "Re-open in browser" action. Empty userCode signals a browser flow.
+	if opts.DeviceCodeCallback != nil {
+		opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
 	}
 
 	// Wait for authorization code or timeout

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -76,6 +76,8 @@ func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.R
 	if err := oauth.OpenBrowser(ctx, authURL); err != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
 		// Notify callback so the CLI can display the URL to the user.
+		// Note: This reuses DeviceCodeCallback with an empty userCode for browser-based ADC auth.
+		// The CLI callback handles empty codes by showing only the URL.
 		if opts.DeviceCodeCallback != nil {
 			opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
 		}

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -73,14 +73,14 @@ func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.R
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
-	if err := oauth.OpenBrowser(ctx, authURL); err != nil {
+	browserOpenErr := oauth.OpenBrowser(ctx, authURL)
+	if browserOpenErr != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
-		// Notify callback so the CLI can display the URL to the user.
-		// Note: This reuses DeviceCodeCallback with an empty userCode for browser-based ADC auth.
-		// The CLI callback handles empty codes by showing only the URL.
-		if opts.DeviceCodeCallback != nil {
-			opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
-		}
+	}
+	// Always notify the CLI callback with the auth URL so the TUI can show
+	// a "Re-open in browser" action. Empty userCode signals a browser flow.
+	if opts.DeviceCodeCallback != nil {
+		opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
 	}
 
 	// Wait for authorization code or timeout

--- a/pkg/auth/gcp/adc_flow.go
+++ b/pkg/auth/gcp/adc_flow.go
@@ -75,6 +75,10 @@ func (h *Handler) adcLogin(ctx context.Context, opts auth.LoginOptions) (*auth.R
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
 	if err := oauth.OpenBrowser(ctx, authURL); err != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
+		// Notify callback so the CLI can display the URL to the user.
+		if opts.DeviceCodeCallback != nil {
+			opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
+		}
 	}
 
 	// Wait for authorization code or timeout

--- a/pkg/auth/gcp/device_code_flow.go
+++ b/pkg/auth/gcp/device_code_flow.go
@@ -1,0 +1,235 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	// deviceCodeEndpoint is the Google OAuth 2.0 device authorization endpoint.
+	deviceCodeEndpoint = "https://oauth2.googleapis.com/device/code"
+
+	// defaultDeviceCodePollInterval is the minimum polling interval for device code flow.
+	defaultDeviceCodePollInterval = 5 * time.Second
+
+	// slowDownIncrement is the interval increase when the server returns "slow_down".
+	slowDownIncrement = 5 * time.Second
+)
+
+// DeviceCodeResponse represents the response from Google's device authorization endpoint.
+type DeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// deviceCodeLogin performs the OAuth 2.0 device code authentication flow.
+// This is useful in headless/SSH environments where a browser cannot be opened locally.
+func (h *Handler) deviceCodeLogin(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("starting GCP device code authentication flow", "handler", HandlerName)
+
+	// Use configured client ID, or fall back to Google's well-known ADC client credentials
+	clientID := h.config.ClientID
+	clientSecret := h.config.ClientSecret
+	if clientID == "" {
+		lgr.V(1).Info("no client ID configured, using Google's default ADC client credentials")
+		clientID = DefaultADCClientID
+		clientSecret = DefaultADCClientSecret
+	}
+
+	// Determine scopes
+	scopes := opts.Scopes
+	if len(scopes) == 0 {
+		scopes = h.config.DefaultScopes
+	}
+	scopeStr := strings.Join(scopes, " ")
+
+	// Determine timeout
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Step 1: Request device code from Google
+	deviceCode, err := h.requestGCPDeviceCode(ctx, clientID, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("device code request failed: %w", err)
+	}
+
+	lgr.V(1).Info("device code obtained",
+		"userCode", deviceCode.UserCode,
+		"verificationURL", deviceCode.VerificationURL,
+	)
+
+	// Step 2: Notify callback with device code info for CLI display
+	if opts.DeviceCodeCallback != nil {
+		opts.DeviceCodeCallback(deviceCode.UserCode, deviceCode.VerificationURL,
+			"Enter this code to authenticate with Google Cloud")
+	}
+
+	// Step 3: Poll for token
+	tokenResp, err := h.pollGCPDeviceToken(ctx, deviceCode, clientID, clientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("device code polling failed: %w", err)
+	}
+
+	// Step 4: Store credentials
+	if err := h.storeCredentials(ctx, tokenResp, auth.FlowDeviceCode, scopes, ""); err != nil {
+		return nil, fmt.Errorf("failed to store credentials: %w", err)
+	}
+
+	// Cache the access token
+	if tokenResp.AccessToken != "" {
+		expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		if cacheErr := h.tokenCache.Set(ctx, auth.FlowDeviceCode, auth.FingerprintHash(clientID), scopeStr, &auth.Token{
+			AccessToken: tokenResp.AccessToken,
+			TokenType:   tokenResp.TokenType,
+			ExpiresAt:   expiresAt,
+			Scope:       scopeStr,
+		}); cacheErr != nil {
+			lgr.V(1).Info("failed to cache access token", "error", cacheErr)
+		}
+	}
+
+	// Extract claims
+	claims, err := extractClaims(tokenResp)
+	if err != nil {
+		if tokenResp.AccessToken != "" {
+			claims, err = h.fetchUserinfoClaims(ctx, tokenResp.AccessToken)
+			if err != nil {
+				claims = &auth.Claims{Issuer: "https://accounts.google.com"}
+			}
+		} else {
+			claims = &auth.Claims{Issuer: "https://accounts.google.com"}
+		}
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	lgr.V(1).Info("GCP device code flow completed successfully",
+		"email", claims.Email,
+		"expiresIn", tokenResp.ExpiresIn,
+	)
+
+	return &auth.Result{
+		Claims:    claims,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// requestGCPDeviceCode requests a device code from Google's device authorization endpoint.
+func (h *Handler) requestGCPDeviceCode(ctx context.Context, clientID string, scopes []string) (*DeviceCodeResponse, error) {
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", strings.Join(scopes, " "))
+
+	resp, err := h.httpClient.PostForm(ctx, deviceCodeEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		var errResp TokenErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("device code request failed (%d): %s - %s",
+			resp.StatusCode, errResp.Error, errResp.ErrorDescription)
+	}
+
+	var deviceCode DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceCode); err != nil {
+		return nil, fmt.Errorf("failed to parse device code response: %w", err)
+	}
+
+	return &deviceCode, nil
+}
+
+// pollGCPDeviceToken polls Google's token endpoint until the user completes
+// authentication or the device code expires.
+func (h *Handler) pollGCPDeviceToken(ctx context.Context, deviceCode *DeviceCodeResponse, clientID, clientSecret string) (*TokenResponse, error) {
+	lgr := logger.FromContext(ctx)
+
+	interval := time.Duration(deviceCode.Interval) * time.Second
+	if interval < defaultDeviceCodePollInterval {
+		interval = defaultDeviceCodePollInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("authentication timed out or cancelled: %w", auth.ErrTimeout)
+		case <-ticker.C:
+			data := url.Values{}
+			data.Set("client_id", clientID)
+			if clientSecret != "" {
+				data.Set("client_secret", clientSecret)
+			}
+			data.Set("device_code", deviceCode.DeviceCode)
+			data.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+
+			resp, err := h.httpClient.PostForm(ctx, tokenEndpoint, data)
+			if err != nil {
+				lgr.V(1).Info("transient network error during device code poll, continuing", "error", err)
+				continue
+			}
+
+			var body struct {
+				TokenResponse
+				TokenErrorResponse
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				resp.Body.Close()
+				return nil, fmt.Errorf("failed to parse token response: %w", err)
+			}
+			resp.Body.Close()
+
+			// Success: access_token present
+			if body.AccessToken != "" {
+				return &TokenResponse{
+					AccessToken:  body.AccessToken,
+					RefreshToken: body.RefreshToken,
+					TokenType:    body.TokenType,
+					ExpiresIn:    body.ExpiresIn,
+					Scope:        body.Scope,
+					IDToken:      body.IDToken,
+				}, nil
+			}
+
+			// Handle polling errors per RFC 8628
+			switch body.Error {
+			case "authorization_pending":
+				continue
+			case "slow_down":
+				interval += slowDownIncrement
+				ticker.Reset(interval)
+				lgr.V(1).Info("slow_down received, increasing poll interval", "newInterval", interval)
+				continue
+			case "expired_token":
+				return nil, fmt.Errorf("device code expired, please try again: %w", auth.ErrTimeout)
+			case "access_denied":
+				return nil, fmt.Errorf("user denied access: %w", auth.ErrUserCancelled)
+			default:
+				return nil, fmt.Errorf("token request failed: %s - %s", body.Error, body.ErrorDescription)
+			}
+		}
+	}
+}

--- a/pkg/auth/gcp/device_code_flow_test.go
+++ b/pkg/auth/gcp/device_code_flow_test.go
@@ -1,0 +1,365 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeIDToken(t testing.TB, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return fmt.Sprintf("%s.%s.fakesig", header, body)
+}
+
+func TestDeviceCodeLogin_Success(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "12345",
+		"email": "user@example.com",
+		"name":  "Test User",
+		"iss":   "https://accounts.google.com",
+	})
+
+	// Response 1: device code request
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode:      "test-device-code",
+		UserCode:        "ABCD-1234",
+		VerificationURL: "https://www.google.com/device",
+		ExpiresIn:       1800,
+		Interval:        1,
+	})
+
+	// Response 2: token response (immediate success)
+	mockHTTP.AddResponse(200, TokenResponse{
+		AccessToken:  "test-access-token",
+		RefreshToken: "test-refresh-token",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		Scope:        "openid email",
+		IDToken:      idToken,
+	})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	var callbackCalled bool
+	var callbackCode, callbackURL string
+
+	result, err := handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Timeout: 10 * time.Second,
+		DeviceCodeCallback: func(code, url, message string) {
+			callbackCalled = true
+			callbackCode = code
+			callbackURL = url
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, callbackCalled)
+	assert.Equal(t, "ABCD-1234", callbackCode)
+	assert.Equal(t, "https://www.google.com/device", callbackURL)
+	assert.Equal(t, "user@example.com", result.Claims.Email)
+	assert.Equal(t, "Test User", result.Claims.Name)
+
+	// Verify device code request was made correctly
+	require.Len(t, mockHTTP.Requests, 2)
+	assert.Equal(t, deviceCodeEndpoint, mockHTTP.Requests[0].Endpoint)
+	assert.Equal(t, DefaultADCClientID, mockHTTP.Requests[0].Data.Get("client_id"))
+
+	// Verify token request
+	assert.Equal(t, tokenEndpoint, mockHTTP.Requests[1].Endpoint)
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:device_code", mockHTTP.Requests[1].Data.Get("grant_type"))
+	assert.Equal(t, "test-device-code", mockHTTP.Requests[1].Data.Get("device_code"))
+}
+
+func TestDeviceCodeLogin_CustomClientID(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "12345",
+		"email": "user@example.com",
+		"iss":   "https://accounts.google.com",
+	})
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "CODE",
+		VerificationURL: "https://www.google.com/device",
+		ExpiresIn:       1800,
+		Interval:        1,
+	})
+	mockHTTP.AddResponse(200, TokenResponse{
+		AccessToken: "token",
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+		IDToken:     idToken,
+	})
+
+	handler, err := New(
+		WithSecretStore(store),
+		WithHTTPClient(mockHTTP),
+		WithConfig(&Config{ClientID: "custom-id", ClientSecret: "custom-secret"}),
+	)
+	require.NoError(t, err)
+
+	result, err := handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify custom client ID was used
+	assert.Equal(t, "custom-id", mockHTTP.Requests[0].Data.Get("client_id"))
+	assert.Equal(t, "custom-id", mockHTTP.Requests[1].Data.Get("client_id"))
+	assert.Equal(t, "custom-secret", mockHTTP.Requests[1].Data.Get("client_secret"))
+}
+
+func TestDeviceCodeLogin_PollPending(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub": "12345", "email": "user@example.com", "iss": "https://accounts.google.com",
+	})
+
+	// Device code response
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "CODE",
+		VerificationURL: "https://www.google.com/device",
+		ExpiresIn:       1800,
+		Interval:        0, // Will be floored to defaultDeviceCodePollInterval
+	})
+
+	// First poll: authorization_pending
+	mockHTTP.AddResponse(200, struct {
+		TokenResponse
+		TokenErrorResponse
+	}{TokenErrorResponse: TokenErrorResponse{Error: "authorization_pending"}})
+
+	// Second poll: success
+	mockHTTP.AddResponse(200, TokenResponse{
+		AccessToken: "token", TokenType: "Bearer", ExpiresIn: 3600, IDToken: idToken,
+	})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	result, err := handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Should have made 3 requests: device code + 2 polls
+	assert.Len(t, mockHTTP.Requests, 3)
+}
+
+func TestDeviceCodeLogin_AccessDenied(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "CODE",
+		VerificationURL: "https://www.google.com/device",
+		ExpiresIn:       1800,
+		Interval:        0,
+	})
+
+	mockHTTP.AddResponse(200, struct {
+		TokenResponse
+		TokenErrorResponse
+	}{TokenErrorResponse: TokenErrorResponse{Error: "access_denied"}})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	_, err = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 10 * time.Second,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrUserCancelled)
+}
+
+func TestDeviceCodeLogin_ExpiredToken(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "CODE",
+		VerificationURL: "https://www.google.com/device",
+		ExpiresIn:       1800,
+		Interval:        0,
+	})
+
+	mockHTTP.AddResponse(200, struct {
+		TokenResponse
+		TokenErrorResponse
+	}{TokenErrorResponse: TokenErrorResponse{Error: "expired_token"}})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	_, err = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 10 * time.Second,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrTimeout)
+}
+
+func TestDeviceCodeLogin_DeviceCodeRequestFails(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	mockHTTP.AddResponse(400, TokenErrorResponse{
+		Error:            "invalid_client",
+		ErrorDescription: "bad client ID",
+	})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	_, err = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 10 * time.Second,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "device code request failed")
+}
+
+func TestDeviceCodeLogin_DefaultScopes(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub": "12345", "email": "user@example.com", "iss": "https://accounts.google.com",
+	})
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode: "dc", UserCode: "CODE", VerificationURL: "https://www.google.com/device",
+		ExpiresIn: 1800, Interval: 1,
+	})
+	mockHTTP.AddResponse(200, TokenResponse{
+		AccessToken: "token", TokenType: "Bearer", ExpiresIn: 3600, IDToken: idToken,
+	})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	_, err = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Should use default scopes
+	scopeParam := mockHTTP.Requests[0].Data.Get("scope")
+	assert.Contains(t, scopeParam, "openid")
+	assert.Contains(t, scopeParam, "email")
+	assert.Contains(t, scopeParam, "cloud-platform")
+}
+
+func TestDeviceCodeLogin_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode: "dc", UserCode: "CODE", VerificationURL: "https://www.google.com/device",
+		ExpiresIn: 1800, Interval: 1,
+	})
+
+	// No token response — context will cancel first
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err = handler.deviceCodeLogin(ctx, auth.LoginOptions{
+		Timeout: 1 * time.Millisecond,
+	})
+	require.Error(t, err)
+}
+
+func TestLogin_RoutesToDeviceCode(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub": "12345", "email": "user@example.com", "iss": "https://accounts.google.com",
+	})
+
+	mockHTTP.AddResponse(200, DeviceCodeResponse{
+		DeviceCode: "dc", UserCode: "CODE", VerificationURL: "https://www.google.com/device",
+		ExpiresIn: 1800, Interval: 1,
+	})
+	mockHTTP.AddResponse(200, TokenResponse{
+		AccessToken: "token", TokenType: "Bearer", ExpiresIn: 3600, IDToken: idToken,
+	})
+
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	result, err := handler.Login(context.Background(), auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "user@example.com", result.Claims.Email)
+}
+
+func BenchmarkDeviceCodeLogin(b *testing.B) {
+	store := secrets.NewMockStore()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		mockHTTP := NewMockHTTPClient()
+		idToken := makeIDToken(b, map[string]any{
+			"sub": "12345", "email": "user@example.com", "iss": "https://accounts.google.com",
+		})
+		mockHTTP.AddResponse(200, DeviceCodeResponse{
+			DeviceCode: "dc", UserCode: "CODE", VerificationURL: "https://www.google.com/device",
+			ExpiresIn: 1800, Interval: 1,
+		})
+		mockHTTP.AddResponse(200, TokenResponse{
+			AccessToken: "token", TokenType: "Bearer", ExpiresIn: 3600, IDToken: idToken,
+		})
+		handler, _ := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+		_, _ = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+			Timeout: 10 * time.Second,
+		})
+	}
+}

--- a/pkg/auth/gcp/handler.go
+++ b/pkg/auth/gcp/handler.go
@@ -183,6 +183,7 @@ func (h *Handler) DisplayName() string {
 func (h *Handler) SupportedFlows() []auth.Flow {
 	return []auth.Flow{
 		auth.FlowInteractive,
+		auth.FlowDeviceCode,
 		auth.FlowServicePrincipal,
 		auth.FlowWorkloadIdentity,
 		auth.FlowMetadata,
@@ -219,6 +220,11 @@ func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Resu
 	// Check if service account flow is requested or detected
 	if opts.Flow == auth.FlowServicePrincipal || (opts.Flow == "" && HasServiceAccountCredentials()) {
 		return h.serviceAccountLogin(ctx, opts)
+	}
+
+	// Check if device code flow is explicitly requested
+	if opts.Flow == auth.FlowDeviceCode {
+		return h.deviceCodeLogin(ctx, opts)
 	}
 
 	// Check if gcloud ADC flow is explicitly requested

--- a/pkg/auth/gcp/handler_test.go
+++ b/pkg/auth/gcp/handler_test.go
@@ -105,11 +105,12 @@ func TestHandler_SupportedFlows(t *testing.T) {
 
 	flows := handler.SupportedFlows()
 	assert.Contains(t, flows, auth.FlowInteractive)
+	assert.Contains(t, flows, auth.FlowDeviceCode)
 	assert.Contains(t, flows, auth.FlowServicePrincipal)
 	assert.Contains(t, flows, auth.FlowWorkloadIdentity)
 	assert.Contains(t, flows, auth.FlowMetadata)
 	assert.Contains(t, flows, auth.FlowGcloudADC)
-	assert.Len(t, flows, 5)
+	assert.Len(t, flows, 6)
 }
 
 func TestHandler_Capabilities(t *testing.T) {

--- a/pkg/auth/github/authcode_flow.go
+++ b/pkg/auth/github/authcode_flow.go
@@ -76,12 +76,14 @@ func (h *Handler) authCodeLogin(ctx context.Context, opts auth.LoginOptions) (*a
 
 	// Open browser
 	lgr.V(1).Info("opening browser for authentication", "url", authURL)
-	if err := BrowserOpener(ctx, authURL); err != nil {
+	browserOpenErr := BrowserOpener(ctx, authURL)
+	if browserOpenErr != nil {
 		lgr.V(0).Info("failed to open browser, please open this URL manually", "url", authURL)
-		// Notify via callback if available so the CLI can display the URL
-		if opts.DeviceCodeCallback != nil {
-			opts.DeviceCodeCallback("", authURL, fmt.Sprintf("Open this URL in your browser to authenticate:\n%s", authURL))
-		}
+	}
+	// Always notify the CLI callback with the auth URL so the TUI can show
+	// a "Re-open in browser" action. Empty userCode signals a browser flow.
+	if opts.DeviceCodeCallback != nil {
+		opts.DeviceCodeCallback("", authURL, "Open this URL in your browser to authenticate")
 	}
 
 	// Wait for authorization code or timeout

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -160,6 +160,12 @@ func (f ExtFunction) GetDescription() string {
 	return f.Description
 }
 
+// GetSubNames returns individual function names within this group
+// (e.g., "base64.encode", "base64.decode" for the "encoders" group).
+func (f ExtFunction) GetSubNames() []string {
+	return f.FunctionNames
+}
+
 // Example represents a usage example for a CEL extension function,
 // including the expression to evaluate and the expected result.
 type Example struct {

--- a/pkg/celexp/celexp_test.go
+++ b/pkg/celexp/celexp_test.go
@@ -344,6 +344,14 @@ func TestExtFunction_GetName(t *testing.T) {
 	assert.Equal(t, "myFunc", f.GetName())
 }
 
+func TestExtFunction_GetSubNames(t *testing.T) {
+	f := ExtFunction{FunctionNames: []string{"base64.encode", "base64.decode"}}
+	assert.Equal(t, []string{"base64.encode", "base64.decode"}, f.GetSubNames())
+
+	empty := ExtFunction{}
+	assert.Nil(t, empty.GetSubNames())
+}
+
 func TestInitFromAppConfig(t *testing.T) {
 	ResetForTesting()
 	defer ResetForTesting()

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -389,7 +389,7 @@ func loginGCP(ctx context.Context, w *writer.Writer, binaryName string, flow aut
 			Flow:           auth.FlowServicePrincipal,
 			Description:    "Detected service account key in environment",
 		},
-	}, auth.FlowDeviceCode)
+	}, auth.FlowInteractive)
 	flow = detection.Flow
 	if detection.Description != "" {
 		w.Info(detection.Description)
@@ -738,8 +738,9 @@ func executeLoginWithStatusTUI(
 }
 
 // executeLoginWithBrowserTUI runs the auth code (browser) login flow using the
-// kvx status screen TUI. Unlike device-code, there is no user code to display.
-// The TUI shows a spinner with the auth URL while the browser tab completes.
+// kvx status screen TUI. It also sets a DeviceCodeCallback so that handlers
+// which internally use device code within a FlowInteractive (e.g., GitHub
+// without client_secret) get the rich device-code TUI instead.
 func executeLoginWithBrowserTUI(
 	ctx context.Context,
 	w *writer.Writer,
@@ -752,11 +753,16 @@ func executeLoginWithBrowserTUI(
 	scopes []string,
 	ioStreams *terminal.IOStreams,
 ) error {
+	type deviceCodeData struct {
+		userCode        string
+		verificationURI string
+	}
 	type loginOutcome struct {
 		result *auth.Result
 		err    error
 	}
 
+	deviceCodeChan := make(chan deviceCodeData, 1)
 	outcomeChan := make(chan loginOutcome, 1)
 	done := make(chan tui.StatusResult, 1)
 
@@ -766,12 +772,47 @@ func executeLoginWithBrowserTUI(
 		Flow:         flow,
 		Timeout:      timeout,
 		CallbackPort: callbackPort,
+		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
+			select {
+			case deviceCodeChan <- deviceCodeData{userCode: userCode, verificationURI: verificationURI}:
+			default:
+			}
+		},
 	}
 
 	go func() {
 		result, err := handler.Login(ctx, loginOpts)
 		outcomeChan <- loginOutcome{result: result, err: err}
 	}()
+
+	// Wait briefly for a device code callback. If the handler internally
+	// uses device code (e.g., GitHub FlowInteractive without client_secret),
+	// we want to show the device-code TUI instead of the browser TUI.
+	w.Infof("Initiating authentication with %s...", handler.DisplayName())
+
+	var useDeviceCodeTUI bool
+	var dci deviceCodeData
+	select {
+	case dci = <-deviceCodeChan:
+		useDeviceCodeTUI = true
+	case outcome := <-outcomeChan:
+		// Login completed before any TUI was shown.
+		if outcome.err != nil {
+			if ctx.Err() != nil {
+				return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+			}
+			err := fmt.Errorf("authentication failed: %w", outcome.err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+		w.Info("")
+		return displayLoginResult(w, outcome.result, flow)
+	case <-time.After(500 * time.Millisecond):
+		// No device code within 500ms — assume browser flow.
+		useDeviceCodeTUI = false
+	case <-ctx.Done():
+		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
 
 	// Forward the login outcome to the TUI done channel.
 	var capturedOutcome loginOutcome
@@ -791,19 +832,57 @@ func executeLoginWithBrowserTUI(
 		close(outcomeReady)
 	}()
 
-	data := map[string]any{
-		"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-	}
+	var data map[string]any
+	var schema *tui.DisplaySchema
 
-	schema := &tui.DisplaySchema{
-		Version: "v1",
-		Status: &tui.StatusDisplayConfig{
-			TitleField:     "title",
-			WaitMessage:    "Waiting for browser authentication...",
-			SuccessMessage: "Authenticated successfully!",
-			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-			DoneDelay:      "2s",
-		},
+	if useDeviceCodeTUI {
+		data = map[string]any{
+			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
+			"url":   dci.verificationURI,
+			"code":  dci.userCode,
+		}
+		schema = &tui.DisplaySchema{
+			Version: "v1",
+			Status: &tui.StatusDisplayConfig{
+				TitleField:     "title",
+				WaitMessage:    "Waiting for authentication...",
+				SuccessMessage: "Authenticated successfully!",
+				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+				DoneDelay:      "2s",
+				DisplayFields: []tui.StatusFieldDisplay{
+					{Label: "URL", Field: "url"},
+					{Label: "Code", Field: "code"},
+				},
+				Actions: []tui.StatusActionConfig{
+					{
+						Label: "Copy code",
+						Type:  "copy-value",
+						Field: "code",
+						Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
+					},
+					{
+						Label: "Open URL",
+						Type:  "open-url",
+						Field: "url",
+						Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+					},
+				},
+			},
+		}
+	} else {
+		data = map[string]any{
+			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
+		}
+		schema = &tui.DisplaySchema{
+			Version: "v1",
+			Status: &tui.StatusDisplayConfig{
+				TitleField:     "title",
+				WaitMessage:    "Waiting for browser authentication...",
+				SuccessMessage: "Authenticated successfully!",
+				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+				DoneDelay:      "2s",
+			},
+		}
 	}
 
 	cfg := tui.DefaultConfig()

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -76,6 +76,7 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 
 			For the 'gcp' handler, this supports:
 			- interactive: Browser-based OAuth (default for workstations)
+			- device-code: Device code flow for headless/SSH environments
 			- service-principal: Service account key (GOOGLE_APPLICATION_CREDENTIALS)
 			- workload-identity: Workload Identity Federation (GOOGLE_EXTERNAL_ACCOUNT)
 			- metadata: GCE metadata server (auto-detected on GCE/GKE/Cloud Run)
@@ -147,6 +148,9 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 
 			  # Login with GCP using browser OAuth (default)
 			  scafctl auth login gcp
+
+			  # Login with GCP device code flow (headless/SSH)
+			  scafctl auth login gcp --flow device-code
 
 			  # Login with GCP service account key
 			  scafctl auth login gcp --flow service-principal
@@ -835,7 +839,9 @@ func executeLoginWithBrowserTUI(
 	var data map[string]any
 	var schema *tui.DisplaySchema
 
-	if useDeviceCodeTUI {
+	switch {
+	case useDeviceCodeTUI && dci.userCode != "":
+		// Real device code flow (e.g., GitHub without client_secret)
 		data = map[string]any{
 			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
 			"url":   dci.verificationURI,
@@ -869,7 +875,35 @@ func executeLoginWithBrowserTUI(
 				},
 			},
 		}
-	} else {
+	case useDeviceCodeTUI && dci.userCode == "" && dci.verificationURI != "":
+		// Browser auth code flow — handler reported the auth URL via callback
+		data = map[string]any{
+			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
+			"url":   dci.verificationURI,
+		}
+		schema = &tui.DisplaySchema{
+			Version: "v1",
+			Status: &tui.StatusDisplayConfig{
+				TitleField:     "title",
+				WaitMessage:    "Waiting for browser authentication...",
+				SuccessMessage: "Authenticated successfully!",
+				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+				DoneDelay:      "2s",
+				DisplayFields: []tui.StatusFieldDisplay{
+					{Label: "URL", Field: "url"},
+				},
+				Actions: []tui.StatusActionConfig{
+					{
+						Label: "Re-open in browser",
+						Type:  "open-url",
+						Field: "url",
+						Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+					},
+				},
+			},
+		}
+	default:
+		// No callback fired — show minimal browser waiting TUI
 		data = map[string]any{
 			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
 		}
@@ -947,6 +981,9 @@ func displayLoginResult(w *writer.Writer, result *auth.Result, flow auth.Flow) e
 	}
 	if flow == auth.FlowInteractive {
 		w.Info("  Flow:     Interactive (Browser OAuth)")
+	}
+	if flow == auth.FlowDeviceCode {
+		w.Info("  Flow:     Device Code")
 	}
 	return nil
 }

--- a/pkg/cmd/scafctl/auth/login_coverage_test.go
+++ b/pkg/cmd/scafctl/auth/login_coverage_test.go
@@ -787,3 +787,81 @@ func TestCommandLogin_EmbedderBinaryName(t *testing.T) {
 	assert.Equal(t, "login <handler>", cmd.Use)
 	assert.NotNil(t, cmd.RunE)
 }
+
+// TestCommandLogin_InteractiveFlow_SetsDeviceCodeCallback verifies that the
+// non-terminal FlowInteractive path sets a DeviceCodeCallback on LoginOptions,
+// so handlers that internally use device code (e.g., GitHub without client_secret)
+// can still display the code to the user.
+func TestCommandLogin_InteractiveFlow_SetsDeviceCodeCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("github")
+	mock.DisplayNameValue = "GitHub"
+	mock.FlowsValue = []auth.Flow{auth.FlowInteractive, auth.FlowDeviceCode}
+	mock.CapabilitiesValue = []auth.Capability{auth.CapHostname}
+	mock.SetNotAuthenticated()
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{
+			Username: "testuser",
+		},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github", "--flow", "interactive"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	require.Len(t, mock.LoginCalls, 1)
+	assert.Equal(t, auth.FlowInteractive, mock.LoginCalls[0].Flow)
+	assert.NotNil(t, mock.LoginCalls[0].DeviceCodeCallback,
+		"DeviceCodeCallback should be set for interactive flow so handlers "+
+			"that internally use device code can display the code")
+}
+
+// TestCommandLogin_DeviceCodeFlow_SetsDeviceCodeCallback verifies that the
+// non-terminal FlowDeviceCode path also sets a DeviceCodeCallback.
+func TestCommandLogin_DeviceCodeFlow_SetsDeviceCodeCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.FlowsValue = []auth.Flow{auth.FlowDeviceCode, auth.FlowInteractive}
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+	}
+	mock.SetNotAuthenticated()
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{
+			Email: "test@example.com",
+		},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--flow", "device-code"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	require.Len(t, mock.LoginCalls, 1)
+	assert.Equal(t, auth.FlowDeviceCode, mock.LoginCalls[0].Flow)
+	assert.NotNil(t, mock.LoginCalls[0].DeviceCodeCallback,
+		"DeviceCodeCallback should be set for device-code flow")
+}

--- a/pkg/cmd/scafctl/auth/login_coverage_test.go
+++ b/pkg/cmd/scafctl/auth/login_coverage_test.go
@@ -96,12 +96,12 @@ func TestDisplayLoginResult(t *testing.T) {
 			expected: []string{"Authentication successful", "sameuser"},
 		},
 		{
-			name: "minimal claims",
+			name: "minimal claims with device code flow",
 			result: &auth.Result{
 				Claims: &auth.Claims{},
 			},
 			flow:     auth.FlowDeviceCode,
-			expected: []string{"Authentication successful"},
+			expected: []string{"Authentication successful", "Device Code"},
 		},
 	}
 

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -282,11 +282,28 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	// Determine version (priority: --version flag > metadata.version)
-	version, _, err := solution.ResolveArtifactVersion(opts.Version, sol.Metadata.Version)
+	// Determine version (priority: --version flag > metadata.version > auto-increment)
+	version, versionOverride, err := solution.ResolveArtifactVersion(opts.Version, sol.Metadata.Version)
 	if err != nil {
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+		// No explicit version and no metadata version — try auto-increment
+		if opts.Version == "" && sol.Metadata.Version == nil {
+			localCat, catErr := catalog.NewLocalCatalog(*lgr)
+			if catErr == nil {
+				nextVer, nextErr := solution.NextPatchVersion(ctx, localCat, catalog.ArtifactKindSolution, name)
+				if nextErr == nil {
+					version = nextVer
+					w.Infof("Auto-incremented version to %s", version.String())
+					err = nil
+				}
+			}
+		}
+		if err != nil {
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	}
+	if versionOverride {
+		w.Warningf("--version %s overrides metadata.version %s", version.String(), sol.Metadata.Version.String())
 	}
 	w.Verbosef("Resolved artifact: %s@%s", name, version.String())
 
@@ -305,6 +322,12 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 	// artifact always carries the authoritative values.
 	needsReserialization := false
 	if sol.Metadata.Name != name {
+		// Name mismatch: error unless --force
+		if sol.Metadata.Name != "" && !opts.Force {
+			w.Errorf("name mismatch: --name %q does not match metadata.name %q", name, sol.Metadata.Name)
+			w.Infof("Use --force to override the metadata name")
+			return exitcode.Errorf("name mismatch")
+		}
 		lgr.V(1).Info("stamping artifact name into solution", "from", sol.Metadata.Name, "to", name)
 		sol.Metadata.Name = name
 		needsReserialization = true

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -30,6 +30,7 @@ var celFunctionSchemaJSON []byte
 type FunctionSummary struct {
 	Name        string `json:"name" yaml:"name" required:"true"`
 	Description string `json:"description" yaml:"description"`
+	Functions   string `json:"functions" yaml:"functions"`
 	Custom      bool   `json:"custom" yaml:"custom"`
 }
 
@@ -43,8 +44,9 @@ type Options struct {
 	flags.KvxOutputFlags
 
 	// Filter options
-	Custom  bool // Show only custom (scafctl-specific) functions
-	BuiltIn bool // Show only built-in (cel-go) functions
+	Custom  bool   // Show only custom (scafctl-specific) functions
+	BuiltIn bool   // Show only built-in (cel-go) functions
+	Search  string // Search functions by name or description
 
 	// For dependency injection in tests
 	allFn     func() celexp.ExtFunctionList
@@ -112,6 +114,7 @@ Examples:
 	// Filter flags
 	cCmd.Flags().BoolVar(&options.Custom, "custom", false, fmt.Sprintf("Show only custom %s functions", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&options.BuiltIn, "builtin", false, "Show only built-in cel-go functions")
+	cCmd.Flags().StringVarP(&options.Search, "search", "s", "", "Search functions by name or description")
 
 	return cCmd
 }
@@ -169,6 +172,18 @@ func (o *Options) RunListFunctions(ctx context.Context) error {
 		}
 	}
 
+	// Apply search filter
+	if o.Search != "" {
+		funcs = filterBySearch(funcs, o.Search)
+		if len(funcs) == 0 {
+			err := fmt.Errorf("no CEL functions matching %q found", o.Search)
+			if w := writer.FromContext(ctx); w != nil {
+				w.Errorf("%v", err)
+			}
+			return exitcode.WithCode(err, exitcode.FileNotFound)
+		}
+	}
+
 	// Full data for json/yaml and interactive TUI
 	if o.Output == "json" || o.Output == "yaml" || o.Interactive {
 		output := celdetail.BuildFunctionList(funcs)
@@ -181,6 +196,7 @@ func (o *Options) RunListFunctions(ctx context.Context) error {
 		summaries = append(summaries, FunctionSummary{
 			Name:        fn.Name,
 			Description: fn.Description,
+			Functions:   strings.Join(fn.FunctionNames, ", "),
 			Custom:      fn.Custom,
 		})
 	}
@@ -310,9 +326,10 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		kvx.WithOutputAppName(o.BinaryName+" get cel-functions"),
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputDisplaySchemaJSON(celFunctionSchemaJSON),
-		kvx.WithOutputColumnOrder([]string{"name", "description"}),
+		kvx.WithOutputColumnOrder([]string{"name", "functions", "description"}),
 		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
 			"name":          {MaxWidth: 25, Priority: 10},
+			"functions":     {MaxWidth: 40, Priority: 8},
 			"custom":        {Hidden: true},
 			"functionNames": {Hidden: true},
 			"links":         {Hidden: true},
@@ -321,4 +338,26 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 	)
 
 	return kvxOpts.Write(data)
+}
+
+// filterBySearch filters functions by substring match on name, description,
+// or function names. This enables CLI discoverability of individual functions
+// within groups (e.g., searching "base64" finds the "encoders" group).
+func filterBySearch(funcs celexp.ExtFunctionList, query string) celexp.ExtFunctionList {
+	q := strings.ToLower(query)
+	filtered := make(celexp.ExtFunctionList, 0, len(funcs))
+	for _, fn := range funcs {
+		if strings.Contains(strings.ToLower(fn.Name), q) ||
+			strings.Contains(strings.ToLower(fn.Description), q) {
+			filtered = append(filtered, fn)
+			continue
+		}
+		for _, name := range fn.FunctionNames {
+			if strings.Contains(strings.ToLower(name), q) {
+				filtered = append(filtered, fn)
+				break
+			}
+		}
+	}
+	return filtered
 }

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
@@ -252,3 +252,106 @@ func TestCommandCelFunction_Creation(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("custom"))
 	assert.NotNil(t, cmd.Flags().Lookup("builtin"))
 }
+
+func TestRunListFunctions_SearchByFunctionName(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Search = "test_custom"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.custom")
+	assert.NotContains(t, output, "test.builtin")
+}
+
+func TestRunListFunctions_SearchByDescription(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Search = "built-in"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test.builtin")
+	assert.NotContains(t, output, "test.custom")
+}
+
+func TestRunListFunctions_SearchNoMatch(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	opts.Search = "nonexistent_xyz"
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	err := opts.RunListFunctions(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no CEL functions matching")
+}
+
+func TestRunListFunctions_FunctionsColumnInTable(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	err := opts.RunListFunctions(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test_custom")
+	assert.Contains(t, output, "test_builtin")
+}
+
+func TestFilterBySearch(t *testing.T) {
+	t.Parallel()
+	funcs := celexp.ExtFunctionList{
+		{Name: "encoders", Description: "Encoding functions", FunctionNames: []string{"base64.decode", "base64.encode"}},
+		{Name: "strings", Description: "String functions", FunctionNames: []string{"charAt", "join"}},
+		{Name: "math", Description: "Math functions", FunctionNames: []string{"math.abs"}},
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		wantLen int
+		wantHas string
+	}{
+		{"match by function name", "base64", 1, "encoders"},
+		{"match by group name", "strings", 1, "strings"},
+		{"match by description", "Math", 1, "math"},
+		{"case insensitive", "BASE64", 1, "encoders"},
+		{"no match", "nonexistent", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := filterBySearch(funcs, tt.query)
+			assert.Len(t, result, tt.wantLen)
+			if tt.wantLen > 0 {
+				assert.Equal(t, tt.wantHas, result[0].Name)
+			}
+		})
+	}
+}
+
+func TestCommandCelFunction_SearchFlag(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{}
+	ioStreams := &terminal.IOStreams{}
+	cmd := CommandCelFunction(cliParams, ioStreams, "test/path")
+
+	f := cmd.Flags().Lookup("search")
+	assert.NotNil(t, f)
+	assert.Equal(t, "s", f.Shorthand)
+}

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -43,8 +43,9 @@ type Options struct {
 	flags.KvxOutputFlags
 
 	// Filter options
-	Custom bool // Show only custom (scafctl-specific) functions
-	Sprig  bool // Show only sprig library functions
+	Custom bool   // Show only custom (scafctl-specific) functions
+	Sprig  bool   // Show only sprig library functions
+	Search string // Search functions by name or description
 
 	// For dependency injection in tests
 	allFn    func() gotmpl.ExtFunctionList
@@ -111,6 +112,7 @@ Examples:
 	// Filter flags
 	cCmd.Flags().BoolVar(&options.Custom, "custom", false, fmt.Sprintf("Show only custom %s functions", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&options.Sprig, "sprig", false, "Show only sprig library functions")
+	cCmd.Flags().StringVarP(&options.Search, "search", "s", "", "Search functions by name or description")
 
 	return cCmd
 }
@@ -149,6 +151,18 @@ func (o *Options) RunListFunctions(ctx context.Context) error {
 	}
 
 	funcs := o.getFunctions()
+
+	// Apply search filter
+	if o.Search != "" {
+		funcs = filterBySearch(funcs, o.Search)
+		if len(funcs) == 0 {
+			err := fmt.Errorf("no Go template functions matching %q found", o.Search)
+			if w := writer.FromContext(ctx); w != nil {
+				w.Errorf("%v", err)
+			}
+			return exitcode.WithCode(err, exitcode.FileNotFound)
+		}
+	}
 
 	// Interactive mode
 	if o.Interactive {
@@ -297,4 +311,17 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 	)
 
 	return kvxOpts.Write(data)
+}
+
+// filterBySearch filters functions by substring match on name or description.
+func filterBySearch(funcs gotmpl.ExtFunctionList, query string) gotmpl.ExtFunctionList {
+	q := strings.ToLower(query)
+	filtered := make(gotmpl.ExtFunctionList, 0, len(funcs))
+	for _, fn := range funcs {
+		if strings.Contains(strings.ToLower(fn.Name), q) ||
+			strings.Contains(strings.ToLower(fn.Description), q) {
+			filtered = append(filtered, fn)
+		}
+	}
+	return filtered
 }

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
@@ -6,6 +6,7 @@ package gotmplfunction
 import (
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -67,5 +68,43 @@ func BenchmarkCommandGotmplFunction(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+	}
+}
+
+func TestCommandGotmplFunction_SearchFlag(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+
+	f := cmd.Flags().Lookup("search")
+	assert.NotNil(t, f, "search flag should exist")
+	assert.Equal(t, "s", f.Shorthand)
+}
+
+func TestFilterBySearch(t *testing.T) {
+	t.Parallel()
+	funcs := gotmpl.ExtFunctionList{
+		{Name: "toHcl", Description: "Converts a value to HCL format"},
+		{Name: "toYaml", Description: "Converts a value to YAML format"},
+		{Name: "upper", Description: "Converts string to uppercase"},
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		wantLen int
+	}{
+		{"match by name", "toHcl", 1},
+		{"match by description", "YAML", 1},
+		{"match multiple", "Converts", 3},
+		{"case insensitive", "TOHCL", 1},
+		{"no match", "nonexistent", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := filterBySearch(funcs, tt.query)
+			assert.Len(t, result, tt.wantLen)
+		})
 	}
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -158,6 +158,11 @@ type RootOptions struct {
 	// binaries. Discovered plugins are registered in the auth.Registry
 	// alongside built-in handlers during PersistentPreRunE.
 	AuthPluginDirs []string
+
+	// ActionDiscoveryFileNames overrides the file names used by "run action"
+	// auto-discovery. When empty, the defaults from
+	// settings.ActionFileNamesFor are used.
+	ActionDiscoveryFileNames []string
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -207,6 +212,12 @@ func Root(opts *RootOptions) *cobra.Command {
 	settings.RootSolutionFolders = settings.SolutionFoldersFor(binaryName)
 	settings.SolutionFileNames = settings.SolutionFileNamesFor(binaryName)
 
+	// Wire embedder-supplied action discovery file names into cliParams
+	// so they are available via settings.FromContext during command execution.
+	if len(opts.ActionDiscoveryFileNames) > 0 {
+		cliParams.ActionDiscoveryFileNames = opts.ActionDiscoveryFileNames
+	}
+
 	// Resolve IOStreams: use caller-provided or default to OS streams.
 	ioStreams := opts.IOStreams
 	if ioStreams == nil {
@@ -252,6 +263,11 @@ func Root(opts *RootOptions) *cobra.Command {
 			}
 			if !cCmd.Flags().Changed("quiet") {
 				cliParams.IsQuiet = cfg.Settings.Quiet
+			}
+
+			// Apply discovery config: config file fills in when embedder didn't set it.
+			if len(cliParams.ActionDiscoveryFileNames) == 0 && len(cfg.Discovery.ActionFiles) > 0 {
+				cliParams.ActionDiscoveryFileNames = cfg.Discovery.ActionFiles
 			}
 
 			// Resolve log level with precedence: flag > --debug > env > config > default ("none")

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -245,6 +245,9 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		"names", o.Names,
 		"dryRun", o.DryRun)
 
+	// Prefer action files during auto-discovery.
+	o.discoveryMode = settings.DiscoveryModeAction
+
 	absOutputDir, err := o.resolveOutputDir(ctx, o.DryRun)
 	if err != nil {
 		return o.exitWithCode(ctx, err, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -597,11 +597,36 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 		return nil, nil, "", func() {}, err
 	}
 
-	if w != nil && w.VerboseEnabled() {
-		w.Verbosef("Solution loaded: %s (version=%s, dir=%s)",
-			result.Solution.Metadata.Name,
-			result.Solution.Metadata.Version,
-			result.SolutionDir)
+	if w != nil {
+		sol := result.Solution
+		name := sol.Metadata.Name
+		var ver string
+		if sol.Metadata.Version != nil {
+			ver = sol.Metadata.Version.String()
+		}
+		source := sol.GetPath()
+
+		if w.VerboseEnabled() {
+			w.Verbosef("Solution loaded: %s (version=%s, dir=%s)",
+				name, ver, result.SolutionDir)
+		}
+
+		// Show a concise summary so the user knows what was resolved.
+		// Skip when structured output is requested to avoid polluting JSON/YAML.
+		if o.Output != "json" && o.Output != "yaml" {
+			switch {
+			case name != "" && ver != "" && source != "":
+				w.Infof("Solution: %s@%s (%s)", name, ver, source)
+			case name != "" && ver != "":
+				w.Infof("Solution: %s@%s", name, ver)
+			case name != "" && source != "":
+				w.Infof("Solution: %s (%s)", name, source)
+			case name != "":
+				w.Infof("Solution: %s", name)
+			case source != "":
+				w.Infof("Solution: %s", source)
+			}
+		}
 	}
 
 	return result.Solution, result.Registry, result.SolutionDir, result.Cleanup, nil

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -204,6 +204,9 @@ type sharedResolverOptions struct {
 	// For dependency injection in tests
 	getter   get.Interface
 	registry *provider.Registry
+
+	// discoveryMode controls which file names auto-discovery searches for.
+	discoveryMode settings.DiscoveryMode
 }
 
 // getEffectiveResolverConfig returns resolver config values, using app config
@@ -572,17 +575,27 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 		}))
 	}
 
+	if o.discoveryMode != settings.DiscoveryModeDefault {
+		opts = append(opts, prepare.WithDiscoveryMode(o.discoveryMode))
+	}
+
+	// Resolve binary name once for verbose output and user-facing messages.
+	binaryName := settings.CliBinaryName
+	if o.CliParams != nil && o.CliParams.BinaryName != "" {
+		binaryName = o.CliParams.BinaryName
+	}
+
 	// Emit verbose discovery information before loading
 	if w != nil && w.VerboseEnabled() {
 		switch o.File {
 		case "":
-			binaryName := settings.CliBinaryName
-			if o.CliParams != nil && o.CliParams.BinaryName != "" {
-				binaryName = o.CliParams.BinaryName
+			var customActionFiles []string
+			if o.CliParams != nil {
+				customActionFiles = o.CliParams.ActionDiscoveryFileNames
 			}
 			folders := settings.SolutionFoldersFor(binaryName)
-			fileNames := settings.SolutionFileNamesFor(binaryName)
-			w.Verbosef("Auto-discovering solution (binary=%s)", binaryName)
+			fileNames := settings.FileNamesForMode(o.discoveryMode, binaryName, customActionFiles)
+			w.Verbosef("Auto-discovering solution (binary=%s, mode=%s)", binaryName, o.discoveryMode)
 			w.Verbosef("  Search folders: %v", folders)
 			w.Verbosef("  Search filenames: %v", fileNames)
 		case "-":
@@ -626,6 +639,16 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 				w.Infof("Solution: %s", name)
 			case source != "":
 				w.Infof("Solution: %s", source)
+			}
+
+			// Emit discovery-specific informational messages.
+			disc := result.DiscoveredFrom
+			if disc.AlternatePath != "" {
+				if disc.IsActionFile {
+					w.Infof("  (solution.yaml also found at %s)", disc.AlternatePath)
+				} else {
+					w.Infof("  (actions.yaml also found at %s; use '%s run action' to execute actions)", disc.AlternatePath, binaryName)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -612,8 +612,9 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 		}
 
 		// Show a concise summary so the user knows what was resolved.
-		// Skip when structured output is requested to avoid polluting JSON/YAML.
-		if o.Output != "json" && o.Output != "yaml" {
+		// Skip when structured or quiet output is requested to avoid polluting machine-readable output.
+		format, _ := kvx.ParseOutputFormat(o.Output)
+		if !kvx.IsStructuredFormat(format) && format != kvx.OutputFormatQuiet {
 			switch {
 			case name != "" && ver != "" && source != "":
 				w.Infof("Solution: %s@%s (%s)", name, ver, source)

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -343,6 +343,9 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		"onConflict", o.OnConflict,
 		"backup", o.Backup)
 
+	// Skip action files during auto-discovery.
+	o.discoveryMode = settings.DiscoveryModeSolution
+
 	// Validate and prepare output directory before execution (fail-fast).
 	// In dry-run mode, resolve the path without creating the directory.
 	absOutputDir, err := o.resolveOutputDir(ctx, o.DryRun)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,6 +29,7 @@ type Config struct {
 	Auth       GlobalAuthConfig `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth" doc:"Authentication handler configuration"`
 	Build      BuildConfig      `json:"build,omitempty" yaml:"build,omitempty" mapstructure:"build" doc:"Build command configuration"`
 	APIServer  APIServerConfig  `json:"apiServer,omitempty" yaml:"apiServer,omitempty" mapstructure:"apiServer" doc:"REST API server configuration"`
+	Discovery  DiscoveryConfig  `json:"discovery,omitempty" yaml:"discovery,omitempty" mapstructure:"discovery" doc:"Auto-discovery configuration"`
 }
 
 // CatalogConfig represents a single catalog configuration.
@@ -452,6 +453,13 @@ func (b *BuildConfig) IsAutoCacheRemoteArtifacts() bool {
 		return true
 	}
 	return *b.AutoCacheRemoteArtifacts
+}
+
+// DiscoveryConfig holds auto-discovery preferences.
+type DiscoveryConfig struct {
+	// ActionFiles overrides the file names searched during "run action"
+	// auto-discovery. When empty, the built-in defaults are used.
+	ActionFiles []string `json:"actionFiles,omitempty" yaml:"actionFiles,omitempty" mapstructure:"actionFiles" doc:"File names for action auto-discovery" maxItems:"20"`
 }
 
 // APIServerConfig holds REST API server configuration.

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -116,12 +116,27 @@ func Generate(ctx context.Context, sol *solution.Solution, opts Options) (*Repor
 				}
 			}
 
-			// Collect sorted action entries
+			// Build section map (actions=0, finally=1 for sorting)
+			sectionOrder := map[string]int{"actions": 0, "finally": 1}
+
+			// Collect action entries sorted by (section, phase, name) for accurate
+			// DAG phase-order previews instead of alphabetical order.
 			names := make([]string, 0, len(graph.Actions))
 			for name := range graph.Actions {
 				names = append(names, name)
 			}
-			sort.Strings(names)
+			sort.Slice(names, func(i, j int) bool {
+				ai, aj := graph.Actions[names[i]], graph.Actions[names[j]]
+				si, sj := sectionOrder[ai.Section], sectionOrder[aj.Section]
+				if si != sj {
+					return si < sj
+				}
+				pi, pj := phaseMap[names[i]], phaseMap[names[j]]
+				if pi != pj {
+					return pi < pj
+				}
+				return names[i] < names[j]
+			})
 
 			for _, name := range names {
 				ea := graph.Actions[name]

--- a/pkg/dryrun/dryrun_test.go
+++ b/pkg/dryrun/dryrun_test.go
@@ -132,9 +132,40 @@ func TestGenerate_ActionPlanSorted(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, report.ActionPlan, 3)
 
+	// All actions are independent (no deps), so they're in the same phase.
+	// Within a phase, actions are sorted alphabetically.
 	assert.Equal(t, "a-action", report.ActionPlan[0].Name)
 	assert.Equal(t, "m-action", report.ActionPlan[1].Name)
 	assert.Equal(t, "z-action", report.ActionPlan[2].Name)
+}
+
+func TestGenerate_ActionPlanSortedByPhase(t *testing.T) {
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"z-deploy": {Provider: "shell", DependsOn: []string{"a-build"}},
+			"a-build":  {Provider: "shell"},
+		},
+		Finally: map[string]*action.Action{
+			"cleanup": {Provider: "shell"},
+		},
+	}
+
+	report, err := Generate(context.Background(), sol, Options{})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 3)
+
+	// Phase order: a-build (actions, phase 1) -> z-deploy (actions, phase 2) -> cleanup (finally)
+	assert.Equal(t, "a-build", report.ActionPlan[0].Name)
+	assert.Equal(t, "actions", report.ActionPlan[0].Section)
+	assert.Equal(t, 1, report.ActionPlan[0].Phase)
+
+	assert.Equal(t, "z-deploy", report.ActionPlan[1].Name)
+	assert.Equal(t, "actions", report.ActionPlan[1].Section)
+	assert.Equal(t, 2, report.ActionPlan[1].Phase)
+
+	assert.Equal(t, "cleanup", report.ActionPlan[2].Name)
+	assert.Equal(t, "finally", report.ActionPlan[2].Section)
 }
 
 func TestGenerate_NoWorkflow(t *testing.T) {

--- a/pkg/mcp/function_filter.go
+++ b/pkg/mcp/function_filter.go
@@ -18,6 +18,13 @@ type namedFunction interface {
 	GetDescription() string
 }
 
+// subNamed is an optional interface for functions that contain
+// individually named sub-functions (e.g., CEL groups like "encoders"
+// containing "base64.encode", "base64.decode").
+type subNamed interface {
+	GetSubNames() []string
+}
+
 // filterAndReturnNamedFunctions filters a slice of named items by substring match on Name,
 // then returns the result as JSON. This deduplicates the shared filter-by-name logic
 // between handleListCELFunctions and handleListGoTemplateFunctions.
@@ -39,6 +46,16 @@ func filterAndReturnNamedFunctions[T namedFunction](
 		for _, f := range functions {
 			if strings.Contains(strings.ToLower(f.GetName()), nameLower) {
 				filtered = append(filtered, f)
+				continue
+			}
+			// Check individual function names within the group.
+			if sn, ok := any(f).(subNamed); ok {
+				for _, sub := range sn.GetSubNames() {
+					if strings.Contains(strings.ToLower(sub), nameLower) {
+						filtered = append(filtered, f)
+						break
+					}
+				}
 			}
 		}
 		if len(filtered) == 0 {
@@ -71,6 +88,16 @@ func searchFunctions[T namedFunction](
 		if strings.Contains(strings.ToLower(f.GetName()), queryLower) ||
 			strings.Contains(strings.ToLower(f.GetDescription()), queryLower) {
 			filtered = append(filtered, f)
+			continue
+		}
+		// Check individual function names within the group.
+		if sn, ok := any(f).(subNamed); ok {
+			for _, sub := range sn.GetSubNames() {
+				if strings.Contains(strings.ToLower(sub), queryLower) {
+					filtered = append(filtered, f)
+					break
+				}
+			}
 		}
 	}
 	if len(filtered) == 0 {

--- a/pkg/mcp/function_filter_test.go
+++ b/pkg/mcp/function_filter_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFuncWithSubs implements namedFunction + subNamed for testing.
+type testFuncWithSubs struct {
+	testFunc
+	subNames []string
+}
+
+func (t testFuncWithSubs) GetSubNames() []string { return t.subNames }
+
+func TestFilterAndReturnNamedFunctions_MatchesSubNames(t *testing.T) {
+	funcs := []testFuncWithSubs{
+		{testFunc: testFunc{name: "encoders", description: "Encoding functions"}, subNames: []string{"base64.encode", "base64.decode"}},
+		{testFunc: testFunc{name: "strings", description: "String functions"}, subNames: []string{"strings.upper", "strings.lower"}},
+	}
+
+	// Match by sub-function name
+	result, err := filterAndReturnNamedFunctions(funcs, "base64", "test function", "test_tool")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	// Match by group name
+	result, err = filterAndReturnNamedFunctions(funcs, "encoders", "test function", "test_tool")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	// No match
+	result, err = filterAndReturnNamedFunctions(funcs, "nonexistent", "test function", "test_tool")
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestSearchFunctions_MatchesSubNames(t *testing.T) {
+	funcs := []testFuncWithSubs{
+		{testFunc: testFunc{name: "encoders", description: "Encoding functions"}, subNames: []string{"base64.encode", "base64.decode"}},
+		{testFunc: testFunc{name: "strings", description: "String functions"}, subNames: []string{"strings.upper", "strings.lower"}},
+	}
+
+	// Match by sub-function name
+	filtered, errResult := searchFunctions(funcs, "base64.decode", "test function", "test_tool")
+	assert.Nil(t, errResult)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "encoders", filtered[0].GetName())
+
+	// Match by description
+	filtered, errResult = searchFunctions(funcs, "Encoding", "test function", "test_tool")
+	assert.Nil(t, errResult)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "encoders", filtered[0].GetName())
+
+	// No match
+	filtered, errResult = searchFunctions(funcs, "nonexistent", "test function", "test_tool")
+	assert.NotNil(t, errResult)
+	assert.Nil(t, filtered)
+}
+
+func TestFilterAndReturnNamedFunctions_WithoutSubNames(t *testing.T) {
+	funcs := []testFunc{
+		{name: "strlen", description: "String length"},
+		{name: "concat", description: "Concatenate strings"},
+	}
+
+	// Types without GetSubNames still work (name match only)
+	result, err := filterAndReturnNamedFunctions(funcs, "str", "test function", "test_tool")
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// No match
+	result, err = filterAndReturnNamedFunctions(funcs, "nonexistent", "test function", "test_tool")
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}

--- a/pkg/provider/builtin/directoryprovider/directory.go
+++ b/pkg/provider/builtin/directoryprovider/directory.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -802,7 +804,10 @@ func (p *DirectoryProvider) executeMove(ctx context.Context, absPath string, inp
 
 	// Try atomic rename first (works on same device).
 	if renameErr := os.Rename(absPath, absDest); renameErr != nil {
-		// Fall back to copy + remove for cross-device moves.
+		// Only fall back to copy + remove for cross-device errors (EXDEV).
+		if !errors.Is(renameErr, syscall.EXDEV) {
+			return nil, fmt.Errorf("failed to rename directory: %w", renameErr)
+		}
 		if err := copyDir(absPath, absDest); err != nil {
 			return nil, fmt.Errorf("failed to move directory (copy phase): %w", err)
 		}

--- a/pkg/provider/builtin/directoryprovider/directory.go
+++ b/pkg/provider/builtin/directoryprovider/directory.go
@@ -74,6 +74,9 @@ func NewDirectoryProvider() *DirectoryProvider {
 				case "copy":
 					dest, _ := inputs["destination"].(string)
 					return fmt.Sprintf("Would copy directory %s to %s", path, dest), nil
+				case "move":
+					dest, _ := inputs["destination"].(string)
+					return fmt.Sprintf("Would move directory %s to %s", path, dest), nil
 				case "list":
 					return fmt.Sprintf("Would list directory %s", path), nil
 				default:
@@ -87,7 +90,7 @@ func NewDirectoryProvider() *DirectoryProvider {
 			Schema: schemahelper.ObjectSchema([]string{"operation", "path"}, map[string]*jsonschema.Schema{
 				"operation": schemahelper.StringProp("Operation to perform",
 					schemahelper.WithExample("list"),
-					schemahelper.WithEnum("list", "mkdir", "rmdir", "copy")),
+					schemahelper.WithEnum("list", "mkdir", "rmdir", "copy", "move")),
 				"path": schemahelper.StringProp("Target directory path (absolute or relative)",
 					schemahelper.WithExample("./src"),
 					schemahelper.WithMaxLength(4096)),
@@ -116,6 +119,8 @@ func NewDirectoryProvider() *DirectoryProvider {
 					schemahelper.WithDefault(false)),
 				"destination": schemahelper.StringProp("Destination path for copy operation",
 					schemahelper.WithMaxLength(4096)),
+				"filesOnly": schemahelper.BoolProp("Exclude directory entries from list output; only file entries are returned",
+					schemahelper.WithDefault(false)),
 				"force": schemahelper.BoolProp("Force removal of non-empty directories for rmdir",
 					schemahelper.WithDefault(false)),
 			}),
@@ -217,6 +222,16 @@ inputs:
   path: ./config
   destination: ./config-backup`,
 				},
+				{
+					Name:        "Move directory",
+					Description: "Move (rename) a directory to a new path",
+					YAML: `name: rename-output
+provider: directory
+inputs:
+  operation: move
+  path: ./output
+  destination: ./dist`,
+				},
 			},
 		},
 	}
@@ -272,6 +287,8 @@ func (p *DirectoryProvider) Execute(ctx context.Context, input any) (*provider.O
 		result, err = p.executeRmdir(absPath, inputs)
 	case "copy":
 		result, err = p.executeCopy(ctx, absPath, inputs)
+	case "move":
+		result, err = p.executeMove(ctx, absPath, inputs)
 	default:
 		return nil, fmt.Errorf("%s: unsupported operation: %s", ProviderName, operation)
 	}
@@ -294,6 +311,7 @@ type listOptions struct {
 	filterRegex    *regexp.Regexp
 	excludeHidden  bool
 	checksum       string
+	filesOnly      bool
 }
 
 // entryInfo holds information about a single directory entry.
@@ -368,6 +386,10 @@ func parseListOptions(inputs map[string]any) (*listOptions, error) {
 
 	if v, ok := inputs["excludeHidden"].(bool); ok {
 		opts.excludeHidden = v
+	}
+
+	if v, ok := inputs["filesOnly"].(bool); ok {
+		opts.filesOnly = v
 	}
 
 	if v, ok := inputs["checksum"].(string); ok && v != "" {
@@ -540,7 +562,10 @@ func (p *DirectoryProvider) walkDirectory(
 			}
 		}
 
-		emit(entry)
+		// Skip directory entries when filesOnly is set
+		if !isDir || !opts.filesOnly {
+			emit(entry)
+		}
 
 		// Recurse into subdirectories
 		if isDir && opts.recursive && depth < opts.maxDepth {
@@ -750,6 +775,52 @@ func (p *DirectoryProvider) executeCopy(ctx context.Context, absPath string, inp
 	}, nil
 }
 
+// executeMove moves (renames) a directory to a new location.
+// It uses os.Rename for same-device moves (atomic) and falls back to
+// copy-then-remove for cross-device moves.
+func (p *DirectoryProvider) executeMove(ctx context.Context, absPath string, inputs map[string]any) (*provider.Output, error) {
+	destination, ok := inputs["destination"].(string)
+	if !ok || destination == "" {
+		return nil, fmt.Errorf("destination is required for move operation")
+	}
+
+	absDest, err := provider.ResolvePath(ctx, destination)
+	if err != nil {
+		return nil, fmt.Errorf("invalid destination path: %w", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("source directory does not exist: %s", absPath)
+		}
+		return nil, fmt.Errorf("failed to stat source: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("source is not a directory: %s", absPath)
+	}
+
+	// Try atomic rename first (works on same device).
+	if renameErr := os.Rename(absPath, absDest); renameErr != nil {
+		// Fall back to copy + remove for cross-device moves.
+		if err := copyDir(absPath, absDest); err != nil {
+			return nil, fmt.Errorf("failed to move directory (copy phase): %w", err)
+		}
+		if err := os.RemoveAll(absPath); err != nil {
+			return nil, fmt.Errorf("failed to move directory (remove source phase): %w", err)
+		}
+	}
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success":     true,
+			"operation":   "move",
+			"path":        absPath,
+			"destination": absDest,
+		},
+	}, nil
+}
+
 // copyDir recursively copies a directory tree from src to dst.
 func copyDir(src, dst string) error {
 	srcInfo, err := os.Stat(src)
@@ -888,6 +959,26 @@ func (p *DirectoryProvider) executeDryRun(ctx context.Context, operation, absPat
 				"destination": absDest,
 				"_dryRun":     true,
 				"_message":    fmt.Sprintf("Would copy %s to %s", absPath, absDest),
+			},
+		}, nil
+
+	case "move":
+		destination, ok := inputs["destination"].(string)
+		if !ok || destination == "" {
+			return nil, fmt.Errorf("destination is required for move operation")
+		}
+		absDest, err := provider.ResolvePath(ctx, destination)
+		if err != nil {
+			return nil, fmt.Errorf("resolving move destination: %w", err)
+		}
+		return &provider.Output{
+			Data: map[string]any{
+				"success":     true,
+				"operation":   "move",
+				"path":        absPath,
+				"destination": absDest,
+				"_dryRun":     true,
+				"_message":    fmt.Sprintf("Would move %s to %s", absPath, absDest),
 			},
 		}, nil
 

--- a/pkg/provider/builtin/directoryprovider/directory_test.go
+++ b/pkg/provider/builtin/directoryprovider/directory_test.go
@@ -45,6 +45,7 @@ func TestDirectoryProvider_Descriptor(t *testing.T) {
 	assert.Contains(t, desc.Schema.Properties, "filterGlob")
 	assert.Contains(t, desc.Schema.Properties, "filterRegex")
 	assert.Contains(t, desc.Schema.Properties, "excludeHidden")
+	assert.Contains(t, desc.Schema.Properties, "filesOnly")
 	assert.Contains(t, desc.Schema.Properties, "checksum")
 	assert.NotNil(t, desc.OutputSchemas[provider.CapabilityFrom])
 	assert.NotNil(t, desc.OutputSchemas[provider.CapabilityAction])
@@ -307,6 +308,111 @@ func TestDirectoryProvider_List_ExcludeHidden(t *testing.T) {
 	assert.Equal(t, 1, data["totalCount"])
 	entries := data["entries"].([]map[string]any)
 	assert.Equal(t, "visible.txt", entries[0]["name"])
+}
+
+func TestDirectoryProvider_List_FilesOnly(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+		"filesOnly": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 2, data["totalCount"])
+	assert.Equal(t, 0, data["dirCount"])
+	assert.Equal(t, 2, data["fileCount"])
+
+	entries := data["entries"].([]map[string]any)
+	assert.Len(t, entries, 2)
+	for _, e := range entries {
+		assert.Equal(t, "file", e["type"])
+	}
+}
+
+func TestDirectoryProvider_List_FilesOnly_Recursive(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "mid.txt"), []byte("mid"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "deep.txt"), []byte("deep"), 0o644))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+		"recursive": true,
+		"filesOnly": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	assert.Equal(t, 3, data["totalCount"])
+	assert.Equal(t, 0, data["dirCount"])
+	assert.Equal(t, 3, data["fileCount"])
+
+	entries := data["entries"].([]map[string]any)
+	assert.Len(t, entries, 3)
+	for _, e := range entries {
+		assert.Equal(t, "file", e["type"])
+	}
+}
+
+func TestDirectoryProvider_List_FilesOnly_WithIncludeContent(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":      "list",
+		"path":           dir,
+		"filesOnly":      true,
+		"includeContent": true,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	entries := data["entries"].([]map[string]any)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "file.txt", entries[0]["name"])
+	assert.Equal(t, "content", entries[0]["content"])
+}
+
+func TestDirectoryProvider_List_FilesOnly_DefaultFalse(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "list",
+		"path":      dir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+
+	// Default behavior includes directories
+	assert.Equal(t, 2, data["totalCount"])
+	assert.Equal(t, 1, data["dirCount"])
 }
 
 func TestDirectoryProvider_List_IncludesHiddenByDefault(t *testing.T) {
@@ -1079,6 +1185,121 @@ func TestDirectoryProvider_DryRun_Copy_MissingDestination(t *testing.T) {
 }
 
 // =============================================================================
+// Move operation tests
+// =============================================================================
+
+func TestDirectoryProvider_Move_Success(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "source")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("root content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "sub", "nested.txt"), []byte("nested"), 0o644))
+
+	dstDir := filepath.Join(dir, "destination")
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":   "move",
+		"path":        srcDir,
+		"destination": dstDir,
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "move", data["operation"])
+
+	// Destination should have the files
+	content, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "root content", string(content))
+
+	content, err = os.ReadFile(filepath.Join(dstDir, "sub", "nested.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(content))
+
+	// Source should no longer exist
+	_, err = os.Stat(srcDir)
+	assert.True(t, os.IsNotExist(err), "source directory should be removed after move")
+}
+
+func TestDirectoryProvider_Move_MissingDestination(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "move",
+		"path":      dir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination is required")
+}
+
+func TestDirectoryProvider_Move_SourceNotExists(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "move",
+		"path":        "/nonexistent/dir",
+		"destination": "/tmp/dest",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source directory does not exist")
+}
+
+func TestDirectoryProvider_Move_SourceNotDirectory(t *testing.T) {
+	p := NewDirectoryProvider()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation":   "move",
+		"path":        filePath,
+		"destination": filepath.Join(dir, "dest"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source is not a directory")
+}
+
+func TestDirectoryProvider_DryRun_Move(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":   "move",
+		"path":        dir,
+		"destination": filepath.Join(dir, "dest"),
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["_dryRun"].(bool))
+	assert.Contains(t, data["_message"].(string), "Would move")
+}
+
+func TestDirectoryProvider_DryRun_Move_MissingDestination(t *testing.T) {
+	p := NewDirectoryProvider()
+	dir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "move",
+		"path":      dir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination is required")
+}
+
+// =============================================================================
 // Helper function tests
 // =============================================================================
 
@@ -1210,6 +1431,11 @@ func TestDirectoryProvider_WhatIf_Operations(t *testing.T) {
 		{
 			name:     "copy",
 			input:    map[string]any{"operation": "copy", "path": "/tmp/src", "destination": "/tmp/dst"},
+			contains: "/tmp/src",
+		},
+		{
+			name:     "move",
+			input:    map[string]any{"operation": "move", "path": "/tmp/src", "destination": "/tmp/dst"},
 			contains: "/tmp/src",
 		},
 		{

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -97,7 +97,7 @@ func NewExecProvider() *ExecProvider {
 					schemahelper.WithExample("auto"),
 					schemahelper.WithMaxLength(10)),
 				"raw":         schemahelper.BoolProp("Return trimmed stdout string instead of the full result map. Only applies in resolver/transform mode; action mode always returns the full map"),
-				"passthrough": schemahelper.BoolProp("Stream stdout/stderr directly to the user's terminal in real-time instead of capturing. Colors, formatting, and TTY features are preserved. Result stdout/stderr fields will be empty. Default: false"),
+				"passthrough": schemahelper.BoolProp("Stream stdout/stderr directly to the user's terminal in real-time when terminal IO streams are available instead of capturing. Colors, formatting, and TTY features are preserved. When passthrough uses terminal IO streams, result stdout/stderr fields are empty; otherwise output may be captured and returned in those fields. Default: false"),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom:      schemahelper.AnyProp("Full result map (stdout, stderr, exitCode, success, command, shell) by default; trimmed stdout string when raw: true"),

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -96,7 +96,8 @@ func NewExecProvider() *ExecProvider {
 					schemahelper.WithDefault("auto"),
 					schemahelper.WithExample("auto"),
 					schemahelper.WithMaxLength(10)),
-				"raw": schemahelper.BoolProp("Return trimmed stdout string instead of the full result map. Only applies in resolver/transform mode; action mode always returns the full map"),
+				"raw":         schemahelper.BoolProp("Return trimmed stdout string instead of the full result map. Only applies in resolver/transform mode; action mode always returns the full map"),
+				"passthrough": schemahelper.BoolProp("Stream stdout/stderr directly to the user's terminal in real-time instead of capturing. Colors, formatting, and TTY features are preserved. Result stdout/stderr fields will be empty. Default: false"),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom:      schemahelper.AnyProp("Full result map (stdout, stderr, exitCode, success, command, shell) by default; trimmed stdout string when raw: true"),
@@ -315,16 +316,30 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 	var stdout, stderr bytes.Buffer
 	var stdoutWriter, stderrWriter io.Writer = &stdout, &stderr
 	streamed := false
+	passthrough, _ := inputs["passthrough"].(bool)
 
-	mode, _ := provider.ExecutionModeFromContext(ctx)
-	if mode == provider.CapabilityAction {
+	if passthrough {
+		// Passthrough mode: stream directly to terminal, don't capture
 		if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
 			if ioStreams.Out != nil {
-				stdoutWriter = io.MultiWriter(&stdout, ioStreams.Out)
-				streamed = true
+				stdoutWriter = ioStreams.Out
 			}
 			if ioStreams.ErrOut != nil {
-				stderrWriter = io.MultiWriter(&stderr, ioStreams.ErrOut)
+				stderrWriter = ioStreams.ErrOut
+			}
+			streamed = true
+		}
+	} else {
+		mode, _ := provider.ExecutionModeFromContext(ctx)
+		if mode == provider.CapabilityAction {
+			if ioStreams, ok := provider.IOStreamsFromContext(ctx); ok && ioStreams != nil {
+				if ioStreams.Out != nil {
+					stdoutWriter = io.MultiWriter(&stdout, ioStreams.Out)
+					streamed = true
+				}
+				if ioStreams.ErrOut != nil {
+					stderrWriter = io.MultiWriter(&stderr, ioStreams.ErrOut)
+				}
 			}
 		}
 	}

--- a/pkg/provider/builtin/execprovider/exec_test.go
+++ b/pkg/provider/builtin/execprovider/exec_test.go
@@ -4,6 +4,7 @@
 package execprovider
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -731,4 +732,87 @@ func TestExecProvider_Execute_NoExecutionMode_ReturnsFullMap(t *testing.T) {
 	data, ok := output.Data.(map[string]any)
 	require.True(t, ok, "expected map, got %T", output.Data)
 	assert.Equal(t, "hello\n", data["stdout"])
+}
+
+func TestExecProvider_Execute_Passthrough(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	var termErr bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termErr,
+	})
+
+	inputs := map[string]any{
+		"command":     "echo",
+		"args":        []any{"passthrough-test"},
+		"passthrough": true,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	// Passthrough: output streamed to terminal, not captured in result
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	assert.Empty(t, data["stdout"], "passthrough should not capture stdout")
+	assert.Equal(t, 0, data["exitCode"])
+	assert.Equal(t, true, data["success"])
+
+	// Terminal should have received the output
+	assert.Contains(t, termOut.String(), "passthrough-test")
+}
+
+func TestExecProvider_Execute_Passthrough_ExitCode(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termOut,
+	})
+
+	inputs := map[string]any{
+		"command":     "exit 42",
+		"passthrough": true,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	assert.Equal(t, 42, data["exitCode"])
+	assert.Equal(t, false, data["success"])
+}
+
+func TestExecProvider_Execute_PassthroughFalse_StillCaptures(t *testing.T) {
+	p := NewExecProvider()
+
+	var termOut bytes.Buffer
+	ctx := provider.WithIOStreams(context.Background(), &provider.IOStreams{
+		Out:    &termOut,
+		ErrOut: &termOut,
+	})
+
+	inputs := map[string]any{
+		"command":     "echo",
+		"args":        []any{"captured"},
+		"passthrough": false,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok, "expected map, got %T", output.Data)
+	// Default behavior: stdout is captured
+	assert.Contains(t, data["stdout"], "captured")
 }

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -88,10 +88,12 @@ func NewFileProvider() *FileProvider {
 				"basePath": schemahelper.StringProp("Destination root directory (required for write-tree operation). Entries are written relative to this path.",
 					schemahelper.WithExample("./output"),
 					schemahelper.WithMaxLength(4096)),
-				"entries": schemahelper.ArrayProp("Array of {path, content} objects to write (required for write-tree operation). Typically produced by the go-template provider's render-tree operation.",
+				"entries": schemahelper.ArrayProp("Array of {path, content} objects to write (required for write-tree operation). "+
+					"Entries without a content field (e.g. directory entries) are silently skipped. "+
+					"Typically produced by the go-template provider's render-tree operation.",
 					schemahelper.WithItems(schemahelper.ObjectProp(
-						"A file entry with relative path and content to write",
-						[]string{"path", "content"},
+						"A file entry with relative path and optional content to write",
+						[]string{"path"},
 						map[string]*jsonschema.Schema{
 							"path":    schemahelper.StringProp("Relative file path within basePath"),
 							"content": schemahelper.StringProp("File content to write"),
@@ -840,7 +842,8 @@ func (p *FileProvider) parseWriteTreeEntries(inputs map[string]any) ([]writeTree
 
 		content, ok := entry["content"].(string)
 		if !ok {
-			return nil, fmt.Errorf("entries[%d].content is required and must be a string", i)
+			// Skip directory entries (no content field) silently.
+			continue
 		}
 
 		entryOnConflict, _ := entry["onConflict"].(string)

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -840,10 +840,14 @@ func (p *FileProvider) parseWriteTreeEntries(inputs map[string]any) ([]writeTree
 			return nil, fmt.Errorf("entries[%d].path is required and must be a string", i)
 		}
 
-		content, ok := entry["content"].(string)
-		if !ok {
-			// Skip directory entries (no content field) silently.
+		contentRaw, hasContent := entry["content"]
+		if !hasContent || contentRaw == nil {
+			// Skip directory entries (no content key) silently.
 			continue
+		}
+		content, ok := contentRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("entries[%d].content must be a string, got %T", i, contentRaw)
 		}
 
 		entryOnConflict, _ := entry["onConflict"].(string)

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -1058,6 +1058,26 @@ func TestFileProvider_WriteTree_MixedFilesAndDirectories(t *testing.T) {
 	assert.Equal(t, "LOGO", string(content2))
 }
 
+func TestFileProvider_WriteTree_NonStringContentErrors(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "file.txt", "content": 123},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "entries[0].content must be a string")
+}
+
 func TestFileProvider_WriteTree_DryRun(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -999,7 +999,7 @@ func TestFileProvider_WriteTree_MissingEntryPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "entries[0].path is required")
 }
 
-func TestFileProvider_WriteTree_MissingEntryContent(t *testing.T) {
+func TestFileProvider_WriteTree_MissingEntryContent_Skipped(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
 
@@ -1008,15 +1008,54 @@ func TestFileProvider_WriteTree_MissingEntryContent(t *testing.T) {
 		"operation": "write-tree",
 		"basePath":  tmpDir,
 		"entries": []any{
-			map[string]any{"path": "file.txt"},
+			map[string]any{"path": "dir-only/"},
 		},
 	}
 
 	result, err := p.Execute(ctx, inputs)
 
-	assert.Error(t, err)
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "entries[0].content is required")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 0, data["filesWritten"])
+}
+
+func TestFileProvider_WriteTree_MixedFilesAndDirectories(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "src/"},
+			map[string]any{"path": "src/main.go", "content": "package main"},
+			map[string]any{"path": "assets/"},
+			map[string]any{"path": "assets/logo.txt", "content": "LOGO"},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 2, data["filesWritten"])
+
+	paths := data["paths"].([]string)
+	assert.Len(t, paths, 2)
+	assert.Contains(t, paths, "src/main.go")
+	assert.Contains(t, paths, "assets/logo.txt")
+
+	// Verify files were actually written
+	content1, err := os.ReadFile(filepath.Join(tmpDir, "src", "main.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "package main", string(content1))
+
+	content2, err := os.ReadFile(filepath.Join(tmpDir, "assets", "logo.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "LOGO", string(content2))
 }
 
 func TestFileProvider_WriteTree_DryRun(t *testing.T) {

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -373,7 +375,7 @@ func buildInputSchema() *jsonschema.Schema {
 				schemahelper.WithExample("main"),
 				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
 			),
-			"commit_sha": schemahelper.StringProp("Commit SHA for list_commit_pulls operation",
+			"commit_sha": schemahelper.StringProp("Commit SHA for list_commit_pulls operation (alias: sha)",
 				schemahelper.WithExample("abc123def456"),
 				schemahelper.WithMaxLength(*ptrs.IntPtr(40)),
 			),
@@ -786,6 +788,45 @@ func getPerPage(inputs map[string]any) int {
 func getStringInput(inputs map[string]any, key string) string {
 	v, _ := inputs[key].(string)
 	return v
+}
+
+// getStringInputWithAliases extracts a string from the input map, trying the
+// primary key first then falling back to aliases in order.
+func getStringInputWithAliases(inputs map[string]any, key string, aliases ...string) string {
+	if v := getStringInput(inputs, key); v != "" {
+		return v
+	}
+	for _, alias := range aliases {
+		if v := getStringInput(inputs, alias); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// commonInputKeys are top-level inputs handled by Execute before dispatch.
+// They are excluded from the "received inputs" list in error messages.
+var commonInputKeys = []string{"operation", "owner", "repo", "api_base", "token"}
+
+// requiredInputError builds an error for a missing required input, listing the
+// operation-specific keys the caller provided so the user can spot typos.
+func requiredInputError(operation, field string, inputs map[string]any, hint string) error {
+	var userKeys []string
+	for k := range inputs {
+		if !slices.Contains(commonInputKeys, k) {
+			userKeys = append(userKeys, k)
+		}
+	}
+	sort.Strings(userKeys)
+
+	msg := fmt.Sprintf("'%s' is required for %s operation", field, operation)
+	if len(userKeys) > 0 {
+		msg += fmt.Sprintf(" (received inputs: %s)", strings.Join(userKeys, ", "))
+	}
+	if hint != "" {
+		msg += "; " + hint
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 // getStringSliceInput extracts a string slice from the input map.

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -63,6 +63,8 @@ var allOperations = []string{
 	"list_review_threads", "reply_to_review_thread", "resolve_review_thread",
 	// CI/CD check operations (REST)
 	"list_check_runs", "get_workflow_run",
+	// Commit lookup operations (REST)
+	"list_commit_pulls",
 	// Issue write operations
 	"create_issue", "update_issue", "create_issue_comment",
 	// PR write operations
@@ -88,6 +90,7 @@ var readOperations = map[string]bool{
 	"list_pr_comments":    true,
 	"list_review_threads": true,
 	"list_check_runs":     true, "get_workflow_run": true,
+	"list_commit_pulls": true,
 }
 
 // GitHubProvider implements GitHub API operations as a provider.
@@ -369,6 +372,10 @@ func buildInputSchema() *jsonschema.Schema {
 			"ref": schemahelper.StringProp("Git reference (branch, tag, or commit SHA). Defaults to the repo's default branch.",
 				schemahelper.WithExample("main"),
 				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"commit_sha": schemahelper.StringProp("Commit SHA for list_commit_pulls operation",
+				schemahelper.WithExample("abc123def456"),
+				schemahelper.WithMaxLength(*ptrs.IntPtr(40)),
 			),
 			"number": schemahelper.IntProp("Issue or pull request number",
 				schemahelper.WithMinimum(1),
@@ -659,6 +666,10 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 		result, err = p.executeListCheckRuns(ctx, client, apiBase, owner, repo, inputs)
 	case "get_workflow_run":
 		result, err = p.executeGetWorkflowRun(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Commit lookup operations (REST) ---
+	case "list_commit_pulls":
+		result, err = p.executeListCommitPulls(ctx, client, apiBase, owner, repo, inputs)
 
 	// --- Issue write operations (GraphQL mutations) ---
 	case "create_issue":

--- a/pkg/provider/builtin/githubprovider/github_checks.go
+++ b/pkg/provider/builtin/githubprovider/github_checks.go
@@ -19,7 +19,7 @@ import (
 func (p *GitHubProvider) executeListCheckRuns(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	ref := getStringInput(inputs, "ref")
 	if ref == "" {
-		return nil, fmt.Errorf("'ref' is required for list_check_runs operation")
+		return nil, requiredInputError("list_check_runs", "ref", inputs, "")
 	}
 
 	restURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs", apiBase, owner, repo, url.PathEscape(ref))
@@ -72,7 +72,7 @@ func (p *GitHubProvider) executeListCheckRuns(ctx context.Context, client *httpc
 func (p *GitHubProvider) executeGetWorkflowRun(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	runID, ok := getIntInput(inputs, "run_id")
 	if !ok || runID == 0 {
-		return nil, fmt.Errorf("'run_id' is required for get_workflow_run operation")
+		return nil, requiredInputError("get_workflow_run", "run_id", inputs, "")
 	}
 
 	// Fetch the workflow run
@@ -145,9 +145,9 @@ func (p *GitHubProvider) executeGetWorkflowRun(ctx context.Context, client *http
 // executeListCommitPulls lists pull requests associated with a commit via the REST API.
 // Uses: GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls
 func (p *GitHubProvider) executeListCommitPulls(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
-	commitSHA := getStringInput(inputs, "commit_sha")
+	commitSHA := getStringInputWithAliases(inputs, "commit_sha", "sha")
 	if commitSHA == "" {
-		return nil, fmt.Errorf("'commit_sha' is required for list_commit_pulls operation")
+		return nil, requiredInputError("list_commit_pulls", "commit_sha", inputs, "")
 	}
 
 	restURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/pulls", apiBase, owner, repo, url.PathEscape(commitSHA))

--- a/pkg/provider/builtin/githubprovider/github_checks.go
+++ b/pkg/provider/builtin/githubprovider/github_checks.go
@@ -139,3 +139,61 @@ func (p *GitHubProvider) executeGetWorkflowRun(ctx context.Context, client *http
 		"jobs":          jobs,
 	}), nil
 }
+
+// ─── List Commit Pulls ───────────────────────────────────────────────────────
+
+// executeListCommitPulls lists pull requests associated with a commit via the REST API.
+// Uses: GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls
+func (p *GitHubProvider) executeListCommitPulls(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	commitSHA := getStringInput(inputs, "commit_sha")
+	if commitSHA == "" {
+		return nil, fmt.Errorf("'commit_sha' is required for list_commit_pulls operation")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/pulls", apiBase, owner, repo, url.PathEscape(commitSHA))
+	result, err := p.doRESTRequest(ctx, client, "GET", restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing commit pulls: %w", err)
+	}
+
+	pulls, ok := result.([]any)
+	if !ok {
+		return readOutput(map[string]any{
+			"total_count":   0,
+			"pull_requests": []any{},
+		}), nil
+	}
+
+	// Slim down each PR to essential fields.
+	prs := make([]any, 0, len(pulls))
+	for _, pr := range pulls {
+		prMap, ok := pr.(map[string]any)
+		if !ok {
+			continue
+		}
+		slim := map[string]any{
+			"number":     prMap["number"],
+			"title":      prMap["title"],
+			"state":      prMap["state"],
+			"html_url":   prMap["html_url"],
+			"created_at": prMap["created_at"],
+			"merged_at":  prMap["merged_at"],
+			"draft":      prMap["draft"],
+		}
+		if user, ok := prMap["user"].(map[string]any); ok {
+			slim["user"] = user["login"]
+		}
+		if head, ok := prMap["head"].(map[string]any); ok {
+			slim["head_ref"] = head["ref"]
+		}
+		if base, ok := prMap["base"].(map[string]any); ok {
+			slim["base_ref"] = base["ref"]
+		}
+		prs = append(prs, slim)
+	}
+
+	return readOutput(map[string]any{
+		"total_count":   len(prs),
+		"pull_requests": prs,
+	}), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_checks_test.go
+++ b/pkg/provider/builtin/githubprovider/github_checks_test.go
@@ -250,3 +250,130 @@ func BenchmarkExecuteListCheckRuns(b *testing.B) {
 		_, _ = p.Execute(context.Background(), inputs)
 	}
 }
+
+// ─── List Commit Pulls Tests ─────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListCommitPulls(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/commits/abc123def456/pulls", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{
+				"number":     float64(42),
+				"title":      "Add feature X",
+				"state":      "closed",
+				"html_url":   "https://github.com/test-org/test-repo/pull/42",
+				"created_at": "2025-01-01T00:00:00Z",
+				"merged_at":  "2025-01-02T00:00:00Z",
+				"draft":      false,
+				"user":       map[string]any{"login": "octocat", "id": float64(1)},
+				"head":       map[string]any{"ref": "feature-x", "sha": "abc123def456"},
+				"base":       map[string]any{"ref": "main", "sha": "def789"},
+			},
+			map[string]any{
+				"number":     float64(99),
+				"title":      "Backport feature X",
+				"state":      "open",
+				"html_url":   "https://github.com/test-org/test-repo/pull/99",
+				"created_at": "2025-01-03T00:00:00Z",
+				"merged_at":  nil,
+				"draft":      true,
+				"user":       map[string]any{"login": "bot", "id": float64(2)},
+				"head":       map[string]any{"ref": "backport-x", "sha": "abc123def456"},
+				"base":       map[string]any{"ref": "release-1.0", "sha": "ghi012"},
+			},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "list_commit_pulls",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"commit_sha": "abc123def456",
+		"api_base":   baseURL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, 2, result["total_count"])
+	prs := result["pull_requests"].([]any)
+	assert.Len(t, prs, 2)
+
+	pr1 := prs[0].(map[string]any)
+	assert.Equal(t, float64(42), pr1["number"])
+	assert.Equal(t, "Add feature X", pr1["title"])
+	assert.Equal(t, "closed", pr1["state"])
+	assert.Equal(t, "octocat", pr1["user"])
+	assert.Equal(t, "feature-x", pr1["head_ref"])
+	assert.Equal(t, "main", pr1["base_ref"])
+
+	pr2 := prs[1].(map[string]any)
+	assert.Equal(t, float64(99), pr2["number"])
+	assert.Equal(t, true, pr2["draft"])
+	assert.Equal(t, "backport-x", pr2["head_ref"])
+	assert.Equal(t, "release-1.0", pr2["base_ref"])
+}
+
+func TestGitHubProvider_Execute_ListCommitPulls_Empty(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "list_commit_pulls",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"commit_sha": "abc123",
+		"api_base":   baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, 0, result["total_count"])
+	prs := result["pull_requests"].([]any)
+	assert.Empty(t, prs)
+}
+
+func TestExecuteListCommitPulls_MissingCommitSHA(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeListCommitPulls(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "commit_sha")
+}
+
+func BenchmarkExecuteListCommitPulls(b *testing.B) {
+	p, baseURL := testProvider(b, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{
+				"number": float64(1), "title": "PR 1", "state": "closed",
+				"html_url": "https://github.com/o/r/pull/1",
+				"user":     map[string]any{"login": "u"}, "head": map[string]any{"ref": "f"}, "base": map[string]any{"ref": "m"},
+			},
+		})
+	})
+
+	inputs := map[string]any{
+		"operation":  "list_commit_pulls",
+		"owner":      "org",
+		"repo":       "repo",
+		"commit_sha": "abc123",
+		"api_base":   baseURL,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Execute(context.Background(), inputs)
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_checks_test.go
+++ b/pkg/provider/builtin/githubprovider/github_checks_test.go
@@ -377,3 +377,40 @@ func BenchmarkExecuteListCommitPulls(b *testing.B) {
 		_, _ = p.Execute(context.Background(), inputs)
 	}
 }
+
+func TestGitHubProvider_Execute_ListCommitPulls_SHAAlias(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/test-org/test-repo/commits/abc123/pulls", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{}) //nolint:errcheck
+	})
+
+	// Use "sha" instead of "commit_sha" — alias should work
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_commit_pulls",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"sha":       "abc123",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, 0, result["total_count"])
+}
+
+func TestExecuteListCommitPulls_MissingCommitSHA_ShowsReceivedInputs(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeListCommitPulls(
+		t.Context(), nil, "https://api.github.com", "owner", "repo",
+		map[string]any{"wrong_field": "abc123"},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "commit_sha")
+	assert.Contains(t, err.Error(), "received inputs:")
+	assert.Contains(t, err.Error(), "wrong_field")
+}

--- a/pkg/provider/builtin/githubprovider/github_commits.go
+++ b/pkg/provider/builtin/githubprovider/github_commits.go
@@ -28,15 +28,15 @@ import (
 func (p *GitHubProvider) executeCreateCommit(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branch := getStringInput(inputs, "branch")
 	if branch == "" {
-		return nil, fmt.Errorf("'branch' is required for create_commit operation")
+		return nil, requiredInputError("create_commit", "branch", inputs, "")
 	}
 	message := getStringInput(inputs, "message")
 	if message == "" {
-		return nil, fmt.Errorf("'message' is required for create_commit operation")
+		return nil, requiredInputError("create_commit", "message", inputs, "")
 	}
 	expectedHeadOID := getStringInput(inputs, "expected_head_oid")
 	if expectedHeadOID == "" {
-		return nil, fmt.Errorf("'expected_head_oid' is required for create_commit operation (use get_head_oid to fetch it)")
+		return nil, requiredInputError("create_commit", "expected_head_oid", inputs, "use get_head_oid to fetch it")
 	}
 
 	additions, deletions, err := parseFileChanges(inputs)
@@ -247,11 +247,11 @@ func (p *GitHubProvider) executeCreateRef(ctx context.Context, client *httpc.Cli
 func (p *GitHubProvider) executeCreateBranch(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branch := getStringInput(inputs, "branch")
 	if branch == "" {
-		return nil, fmt.Errorf("'branch' is required for create_branch operation")
+		return nil, requiredInputError("create_branch", "branch", inputs, "")
 	}
 	oid := getStringInput(inputs, "oid")
 	if oid == "" {
-		return nil, fmt.Errorf("'oid' is required for create_branch operation (commit SHA to point the branch at)")
+		return nil, requiredInputError("create_branch", "oid", inputs, "commit SHA to point the branch at")
 	}
 	return p.executeCreateRef(ctx, client, apiBase, owner, repo, "create_branch", "refs/heads/"+branch, oid)
 }
@@ -261,7 +261,7 @@ func (p *GitHubProvider) executeCreateBranch(ctx context.Context, client *httpc.
 func (p *GitHubProvider) executeDeleteBranch(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branch := getStringInput(inputs, "branch")
 	if branch == "" {
-		return nil, fmt.Errorf("'branch' is required for delete_branch operation")
+		return nil, requiredInputError("delete_branch", "branch", inputs, "")
 	}
 
 	refID, err := p.resolveRefID(ctx, client, apiBase, owner, repo, "refs/heads/"+branch)
@@ -291,11 +291,11 @@ func (p *GitHubProvider) executeDeleteBranch(ctx context.Context, client *httpc.
 func (p *GitHubProvider) executeCreateTag(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	tag := getStringInput(inputs, "tag")
 	if tag == "" {
-		return nil, fmt.Errorf("'tag' is required for create_tag operation")
+		return nil, requiredInputError("create_tag", "tag", inputs, "")
 	}
 	oid := getStringInput(inputs, "oid")
 	if oid == "" {
-		return nil, fmt.Errorf("'oid' is required for create_tag operation (commit SHA to point the tag at)")
+		return nil, requiredInputError("create_tag", "oid", inputs, "commit SHA to point the tag at")
 	}
 	return p.executeCreateRef(ctx, client, apiBase, owner, repo, "create_tag", "refs/tags/"+tag, oid)
 }
@@ -305,7 +305,7 @@ func (p *GitHubProvider) executeCreateTag(ctx context.Context, client *httpc.Cli
 func (p *GitHubProvider) executeDeleteTag(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	tag := getStringInput(inputs, "tag")
 	if tag == "" {
-		return nil, fmt.Errorf("'tag' is required for delete_tag operation")
+		return nil, requiredInputError("delete_tag", "tag", inputs, "")
 	}
 
 	refID, err := p.resolveRefID(ctx, client, apiBase, owner, repo, "refs/tags/"+tag)

--- a/pkg/provider/builtin/githubprovider/github_issues.go
+++ b/pkg/provider/builtin/githubprovider/github_issues.go
@@ -17,7 +17,7 @@ import (
 func (p *GitHubProvider) executeCreateIssue(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	title := getStringInput(inputs, "title")
 	if title == "" {
-		return nil, fmt.Errorf("'title' is required for create_issue operation")
+		return nil, requiredInputError("create_issue", "title", inputs, "")
 	}
 
 	// First, resolve the repository node ID
@@ -91,7 +91,7 @@ func (p *GitHubProvider) executeCreateIssue(ctx context.Context, client *httpc.C
 func (p *GitHubProvider) executeUpdateIssue(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for update_issue operation")
+		return nil, requiredInputError("update_issue", "number", inputs, "")
 	}
 
 	// Resolve issue node ID
@@ -175,11 +175,11 @@ func (p *GitHubProvider) executeUpdateIssue(ctx context.Context, client *httpc.C
 func (p *GitHubProvider) executeCreateIssueComment(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for create_issue_comment operation")
+		return nil, requiredInputError("create_issue_comment", "number", inputs, "")
 	}
 	body := getStringInput(inputs, "body")
 	if body == "" {
-		return nil, fmt.Errorf("'body' is required for create_issue_comment operation")
+		return nil, requiredInputError("create_issue_comment", "body", inputs, "")
 	}
 
 	// Resolve issue node ID

--- a/pkg/provider/builtin/githubprovider/github_pulls.go
+++ b/pkg/provider/builtin/githubprovider/github_pulls.go
@@ -16,15 +16,15 @@ import (
 func (p *GitHubProvider) executeCreatePullRequest(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	title := getStringInput(inputs, "title")
 	if title == "" {
-		return nil, fmt.Errorf("'title' is required for create_pull_request operation")
+		return nil, requiredInputError("create_pull_request", "title", inputs, "")
 	}
 	head := getStringInput(inputs, "head")
 	if head == "" {
-		return nil, fmt.Errorf("'head' is required for create_pull_request operation")
+		return nil, requiredInputError("create_pull_request", "head", inputs, "")
 	}
 	base := getStringInput(inputs, "base")
 	if base == "" {
-		return nil, fmt.Errorf("'base' is required for create_pull_request operation")
+		return nil, requiredInputError("create_pull_request", "base", inputs, "")
 	}
 
 	repoID, err := p.resolveRepoID(ctx, client, apiBase, owner, repo)
@@ -80,7 +80,7 @@ func (p *GitHubProvider) executeCreatePullRequest(ctx context.Context, client *h
 func (p *GitHubProvider) executeUpdatePullRequest(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for update_pull_request operation")
+		return nil, requiredInputError("update_pull_request", "number", inputs, "")
 	}
 
 	prID, err := p.resolvePullRequestID(ctx, client, apiBase, owner, repo, num)
@@ -132,7 +132,7 @@ func (p *GitHubProvider) executeUpdatePullRequest(ctx context.Context, client *h
 func (p *GitHubProvider) executeMergePullRequest(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for merge_pull_request operation")
+		return nil, requiredInputError("merge_pull_request", "number", inputs, "")
 	}
 
 	prID, err := p.resolvePullRequestID(ctx, client, apiBase, owner, repo, num)
@@ -190,7 +190,7 @@ func (p *GitHubProvider) executeMergePullRequest(ctx context.Context, client *ht
 func (p *GitHubProvider) executeClosePullRequest(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for close_pull_request operation")
+		return nil, requiredInputError("close_pull_request", "number", inputs, "")
 	}
 
 	prID, err := p.resolvePullRequestID(ctx, client, apiBase, owner, repo, num)

--- a/pkg/provider/builtin/githubprovider/github_reads.go
+++ b/pkg/provider/builtin/githubprovider/github_reads.go
@@ -66,7 +66,7 @@ func (p *GitHubProvider) executeGetRepo(ctx context.Context, client *httpc.Clien
 func (p *GitHubProvider) executeGetFile(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	path := getStringInput(inputs, "path")
 	if path == "" {
-		return nil, fmt.Errorf("'path' is required for get_file operation")
+		return nil, requiredInputError("get_file", "path", inputs, "")
 	}
 	ref := getStringInput(inputs, "ref")
 
@@ -247,7 +247,7 @@ func (p *GitHubProvider) executeListPullRequests(ctx context.Context, client *ht
 func (p *GitHubProvider) executeGetPullRequest(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for get_pull_request operation")
+		return nil, requiredInputError("get_pull_request", "number", inputs, "")
 	}
 
 	query := `query($owner: String!, $name: String!, $number: Int!) {
@@ -368,7 +368,7 @@ func (p *GitHubProvider) executeListIssues(ctx context.Context, client *httpc.Cl
 func (p *GitHubProvider) executeGetIssue(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for get_issue operation")
+		return nil, requiredInputError("get_issue", "number", inputs, "")
 	}
 
 	query := `query($owner: String!, $name: String!, $number: Int!) {
@@ -407,7 +407,7 @@ func (p *GitHubProvider) executeGetIssue(ctx context.Context, client *httpc.Clie
 func (p *GitHubProvider) executeListIssueComments(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for list_issue_comments operation")
+		return nil, requiredInputError("list_issue_comments", "number", inputs, "")
 	}
 	perPage := getPerPage(inputs)
 
@@ -477,7 +477,7 @@ func (p *GitHubProvider) executeListBranches(ctx context.Context, client *httpc.
 func (p *GitHubProvider) executeGetBranch(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branchName := getStringInput(inputs, "branch")
 	if branchName == "" {
-		return nil, fmt.Errorf("'branch' is required for get_branch operation")
+		return nil, requiredInputError("get_branch", "branch", inputs, "")
 	}
 
 	qualifiedName := "refs/heads/" + branchName
@@ -550,7 +550,7 @@ func (p *GitHubProvider) executeListTags(ctx context.Context, client *httpc.Clie
 func (p *GitHubProvider) executeGetHeadOID(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	branchName := getStringInput(inputs, "branch")
 	if branchName == "" {
-		return nil, fmt.Errorf("'branch' is required for get_head_oid operation")
+		return nil, requiredInputError("get_head_oid", "branch", inputs, "")
 	}
 
 	qualifiedName := "refs/heads/" + branchName
@@ -596,7 +596,7 @@ func (p *GitHubProvider) executeGetHeadOID(ctx context.Context, client *httpc.Cl
 func (p *GitHubProvider) executeListPRComments(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for list_pr_comments operation")
+		return nil, requiredInputError("list_pr_comments", "number", inputs, "")
 	}
 	perPage := getPerPage(inputs)
 

--- a/pkg/provider/builtin/githubprovider/github_releases.go
+++ b/pkg/provider/builtin/githubprovider/github_releases.go
@@ -20,7 +20,7 @@ import (
 func (p *GitHubProvider) executeCreateRelease(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	tagName := getStringInput(inputs, "tag_name")
 	if tagName == "" {
-		return nil, fmt.Errorf("'tag_name' is required for create_release operation")
+		return nil, requiredInputError("create_release", "tag_name", inputs, "")
 	}
 
 	reqBody := map[string]any{
@@ -56,7 +56,7 @@ func (p *GitHubProvider) executeCreateRelease(ctx context.Context, client *httpc
 func (p *GitHubProvider) executeUpdateRelease(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	releaseID, ok := getIntInput(inputs, "release_id")
 	if !ok || releaseID == 0 {
-		return nil, fmt.Errorf("'release_id' is required for update_release operation")
+		return nil, requiredInputError("update_release", "release_id", inputs, "")
 	}
 
 	reqBody := map[string]any{}
@@ -93,7 +93,7 @@ func (p *GitHubProvider) executeUpdateRelease(ctx context.Context, client *httpc
 func (p *GitHubProvider) executeDeleteRelease(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	releaseID, ok := getIntInput(inputs, "release_id")
 	if !ok || releaseID == 0 {
-		return nil, fmt.Errorf("'release_id' is required for delete_release operation")
+		return nil, requiredInputError("delete_release", "release_id", inputs, "")
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/releases/%d", apiBase, owner, repo, releaseID)

--- a/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
+++ b/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
@@ -26,7 +26,7 @@ import (
 func (p *GitHubProvider) executeCreateRepo(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any) (*provider.Output, error) {
 	name := getStringInput(inputs, "repo")
 	if name == "" {
-		return nil, fmt.Errorf("'repo' is required for create_repo operation")
+		return nil, requiredInputError("create_repo", "repo", inputs, "")
 	}
 
 	owner := getStringInput(inputs, "owner")
@@ -280,7 +280,7 @@ func (p *GitHubProvider) initRepoWithReadme(ctx context.Context, client *httpc.C
 func (p *GitHubProvider) executeCreateRepoREST(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any, name string, autoInit bool) (*provider.Output, error) {
 	owner := getStringInput(inputs, "owner")
 	if owner == "" {
-		return nil, fmt.Errorf("'owner' is required for REST repo creation (GraphQL createRepository was forbidden)")
+		return nil, requiredInputError("create_repo", "owner", inputs, "GraphQL createRepository was forbidden, falling back to REST")
 	}
 
 	reqBody := map[string]any{
@@ -344,7 +344,7 @@ func (p *GitHubProvider) resolveOwnerID(ctx context.Context, client *httpc.Clien
 func (p *GitHubProvider) executeCreateRuleset(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	rulesetName := getStringInput(inputs, "ruleset_name")
 	if rulesetName == "" {
-		return nil, fmt.Errorf("'ruleset_name' is required for create_ruleset operation")
+		return nil, requiredInputError("create_ruleset", "ruleset_name", inputs, "")
 	}
 
 	target := getStringInput(inputs, "target")
@@ -361,7 +361,7 @@ func (p *GitHubProvider) executeCreateRuleset(ctx context.Context, client *httpc
 	includeRefs := getStringSliceInput(inputs, "include_refs")
 	excludeRefs := getStringSliceInput(inputs, "exclude_refs")
 	if len(includeRefs) == 0 {
-		return nil, fmt.Errorf("'include_refs' is required for create_ruleset operation (e.g. [\"refs/heads/main\"])")
+		return nil, requiredInputError("create_ruleset", "include_refs", inputs, `e.g. ["refs/heads/main"]`)
 	}
 
 	// Ensure exclude is never null (API requires an array)

--- a/pkg/provider/builtin/githubprovider/github_reviews.go
+++ b/pkg/provider/builtin/githubprovider/github_reviews.go
@@ -5,7 +5,6 @@ package githubprovider
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -16,7 +15,7 @@ import (
 func (p *GitHubProvider) executeListReviewThreads(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
 	num, ok := getIntInput(inputs, "number")
 	if !ok || num == 0 {
-		return nil, fmt.Errorf("'number' is required for list_review_threads operation")
+		return nil, requiredInputError("list_review_threads", "number", inputs, "")
 	}
 	perPage := getPerPage(inputs)
 
@@ -61,11 +60,11 @@ func (p *GitHubProvider) executeListReviewThreads(ctx context.Context, client *h
 func (p *GitHubProvider) executeReplyToReviewThread(ctx context.Context, client *httpc.Client, apiBase, _, _ string, inputs map[string]any) (*provider.Output, error) {
 	threadID := getStringInput(inputs, "thread_id")
 	if threadID == "" {
-		return nil, fmt.Errorf("'thread_id' is required for reply_to_review_thread operation")
+		return nil, requiredInputError("reply_to_review_thread", "thread_id", inputs, "")
 	}
 	body := getStringInput(inputs, "body")
 	if body == "" {
-		return nil, fmt.Errorf("'body' is required for reply_to_review_thread operation")
+		return nil, requiredInputError("reply_to_review_thread", "body", inputs, "")
 	}
 
 	mutation := `mutation($id: ID!, $body: String!) {
@@ -97,7 +96,7 @@ func (p *GitHubProvider) executeReplyToReviewThread(ctx context.Context, client 
 func (p *GitHubProvider) executeResolveReviewThread(ctx context.Context, client *httpc.Client, apiBase, _, _ string, inputs map[string]any) (*provider.Output, error) {
 	threadID := getStringInput(inputs, "thread_id")
 	if threadID == "" {
-		return nil, fmt.Errorf("'thread_id' is required for resolve_review_thread operation")
+		return nil, requiredInputError("resolve_review_thread", "thread_id", inputs, "")
 	}
 
 	mutation := `mutation($threadId: ID!) {

--- a/pkg/provider/builtin/githubprovider/github_test.go
+++ b/pkg/provider/builtin/githubprovider/github_test.go
@@ -1345,3 +1345,151 @@ func TestMapIssueStateForMutation(t *testing.T) {
 	assert.Equal(t, "CLOSED", mapIssueStateForMutation("CLOSED"))
 	assert.Equal(t, "OTHER", mapIssueStateForMutation("OTHER"))
 }
+
+func TestGetStringInputWithAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		inputs   map[string]any
+		key      string
+		aliases  []string
+		expected string
+	}{
+		{
+			name:     "primary key found",
+			inputs:   map[string]any{"commit_sha": "abc123"},
+			key:      "commit_sha",
+			aliases:  []string{"sha"},
+			expected: "abc123",
+		},
+		{
+			name:     "alias found",
+			inputs:   map[string]any{"sha": "def456"},
+			key:      "commit_sha",
+			aliases:  []string{"sha"},
+			expected: "def456",
+		},
+		{
+			name:     "primary takes precedence over alias",
+			inputs:   map[string]any{"commit_sha": "primary", "sha": "alias"},
+			key:      "commit_sha",
+			aliases:  []string{"sha"},
+			expected: "primary",
+		},
+		{
+			name:     "no match returns empty",
+			inputs:   map[string]any{"other": "value"},
+			key:      "commit_sha",
+			aliases:  []string{"sha"},
+			expected: "",
+		},
+		{
+			name:     "no aliases",
+			inputs:   map[string]any{"ref": "main"},
+			key:      "ref",
+			expected: "main",
+		},
+		{
+			name:     "second alias matches",
+			inputs:   map[string]any{"s": "short"},
+			key:      "commit_sha",
+			aliases:  []string{"sha", "s"},
+			expected: "short",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := getStringInputWithAliases(tt.inputs, tt.key, tt.aliases...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRequiredInputError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		operation  string
+		field      string
+		inputs     map[string]any
+		hint       string
+		wantField  string
+		wantOp     string
+		wantInputs bool
+		wantHint   string
+	}{
+		{
+			name:      "basic error with no extra inputs",
+			operation: "list_commit_pulls",
+			field:     "commit_sha",
+			inputs:    map[string]any{"operation": "list_commit_pulls", "owner": "o", "repo": "r"},
+			wantField: "commit_sha",
+			wantOp:    "list_commit_pulls",
+		},
+		{
+			name:       "error shows user inputs excluding common keys",
+			operation:  "list_commit_pulls",
+			field:      "commit_sha",
+			inputs:     map[string]any{"operation": "list_commit_pulls", "owner": "o", "repo": "r", "sha": "abc"},
+			wantField:  "commit_sha",
+			wantOp:     "list_commit_pulls",
+			wantInputs: true,
+		},
+		{
+			name:      "error with hint",
+			operation: "create_commit",
+			field:     "expected_head_oid",
+			inputs:    map[string]any{"operation": "create_commit", "owner": "o", "repo": "r"},
+			hint:      "use get_head_oid to fetch it",
+			wantField: "expected_head_oid",
+			wantOp:    "create_commit",
+			wantHint:  "use get_head_oid to fetch it",
+		},
+		{
+			name:       "error with extra inputs and hint",
+			operation:  "create_branch",
+			field:      "oid",
+			inputs:     map[string]any{"operation": "create_branch", "owner": "o", "repo": "r", "branch": "main"},
+			hint:       "commit SHA to point the branch at",
+			wantField:  "oid",
+			wantOp:     "create_branch",
+			wantInputs: true,
+			wantHint:   "commit SHA to point the branch at",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := requiredInputError(tt.operation, tt.field, tt.inputs, tt.hint)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantField)
+			assert.Contains(t, err.Error(), tt.wantOp)
+			if tt.wantInputs {
+				assert.Contains(t, err.Error(), "received inputs:")
+			}
+			if tt.wantHint != "" {
+				assert.Contains(t, err.Error(), tt.wantHint)
+			}
+		})
+	}
+}
+
+func BenchmarkRequiredInputError(b *testing.B) {
+	inputs := map[string]any{
+		"operation": "list_commit_pulls",
+		"owner":     "org",
+		"repo":      "repo",
+		"sha":       "abc123",
+		"per_page":  30,
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = requiredInputError("list_commit_pulls", "commit_sha", inputs, "")
+	}
+}

--- a/pkg/provider/builtin/hclprovider/hcl.go
+++ b/pkg/provider/builtin/hclprovider/hcl.go
@@ -111,7 +111,7 @@ func NewHCLProvider(opts ...Option) *HCLProvider {
 		descriptor: &provider.Descriptor{
 			Name:        ProviderName,
 			DisplayName: "HCL",
-			Description: "Processes HCL (HashiCorp Configuration Language) content. Supports parsing into structured data, formatting to canonical style, validating syntax, and generating HCL from structured input. Accepts single files, multiple paths, or a directory of .tf files.",
+			Description: "Parse, format, validate, and generate Terraform/OpenTofu HCL configuration. Operations: 'parse' extracts structured blocks (variables, resources, data sources, modules, outputs, locals, providers, terraform, moved, import, check) into typed maps; 'format' rewrites content to canonical HCL style; 'validate' checks syntax and returns diagnostics with source positions; 'generate' produces HCL (.tf) or Terraform JSON (.tf.json) from structured block data. Accepts inline content, a single file path, multiple file paths, or a directory of .tf/.tf.json files.",
 			APIVersion:  "v1",
 			Version:     version,
 			Category:    "data",

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -286,6 +286,8 @@ func SolutionFileNamesFor(binaryName string) []string {
 		fmt.Sprintf("%s.yml", binaryName),
 		"solution.json",
 		fmt.Sprintf("%s.json", binaryName),
+		"actions.yaml",
+		"actions.yml",
 	}
 }
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -268,6 +269,32 @@ func DefaultPluginCacheDir() string {
 	return PluginCacheDirFor(CliBinaryName)
 }
 
+// DiscoveryMode controls which file names auto-discovery searches for.
+type DiscoveryMode int
+
+const (
+	// DiscoveryModeDefault searches all known file names (current behavior).
+	DiscoveryModeDefault DiscoveryMode = iota
+	// DiscoveryModeAction searches action files first, then falls back to solution files.
+	DiscoveryModeAction
+	// DiscoveryModeSolution searches only solution files (excludes actions.yaml/yml).
+	DiscoveryModeSolution
+)
+
+// String returns a human-readable label for the discovery mode.
+func (m DiscoveryMode) String() string {
+	switch m {
+	case DiscoveryModeDefault:
+		return "default"
+	case DiscoveryModeAction:
+		return "action"
+	case DiscoveryModeSolution:
+		return "solution"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}
+
 // SolutionFoldersFor returns the solution folder search paths for the given binary name.
 func SolutionFoldersFor(binaryName string) []string {
 	return []string{
@@ -289,6 +316,59 @@ func SolutionFileNamesFor(binaryName string) []string {
 		"actions.yaml",
 		"actions.yml",
 	}
+}
+
+// ActionFileNamesFor returns the action-preferred file names for the given binary name.
+// Action files come first, then solution files as fallback.
+func ActionFileNamesFor(binaryName string) []string {
+	return []string{
+		"actions.yaml",
+		"actions.yml",
+		"solution.yaml",
+		"solution.yml",
+		fmt.Sprintf("%s.yaml", binaryName),
+		fmt.Sprintf("%s.yml", binaryName),
+		"solution.json",
+		fmt.Sprintf("%s.json", binaryName),
+	}
+}
+
+// SolutionOnlyFileNamesFor returns file names excluding actions.yaml/yml.
+func SolutionOnlyFileNamesFor(binaryName string) []string {
+	return []string{
+		"solution.yaml",
+		"solution.yml",
+		fmt.Sprintf("%s.yaml", binaryName),
+		fmt.Sprintf("%s.yml", binaryName),
+		"solution.json",
+		fmt.Sprintf("%s.json", binaryName),
+	}
+}
+
+// FileNamesForMode returns the appropriate file name list based on mode and binary name.
+// When customActionFiles is non-empty and mode is DiscoveryModeAction, those file names
+// are used instead of the defaults (with solution files appended as fallback).
+func FileNamesForMode(mode DiscoveryMode, binaryName string, customActionFiles []string) []string {
+	switch mode {
+	case DiscoveryModeDefault:
+		return SolutionFileNamesFor(binaryName)
+	case DiscoveryModeAction:
+		if len(customActionFiles) > 0 {
+			// Concat avoids mutating the caller's backing array.
+			return slices.Concat(customActionFiles, SolutionOnlyFileNamesFor(binaryName))
+		}
+		return ActionFileNamesFor(binaryName)
+	case DiscoveryModeSolution:
+		return SolutionOnlyFileNamesFor(binaryName)
+	default:
+		return SolutionFileNamesFor(binaryName)
+	}
+}
+
+// IsActionFile returns true when the given filename is an action file
+// (actions.yaml or actions.yml).
+func IsActionFile(name string) bool {
+	return name == "actions.yaml" || name == "actions.yml"
 }
 
 // HTTPCacheKeyPrefixFor returns the HTTP cache key prefix for the given binary name.
@@ -334,6 +414,10 @@ type Run struct {
 	Verbose            bool               `json:"verbose" yaml:"verbose" doc:"Whether to enable verbose output"`
 	ExitOnError        bool               `json:"exitOnError" yaml:"exitOnError" doc:"Whether to exit on error"`
 	BinaryName         string             `json:"binaryName" yaml:"binaryName" doc:"Runtime binary name for the CLI" maxLength:"64" example:"scafctl"`
+
+	// ActionDiscoveryFileNames overrides the file names used by "run action"
+	// auto-discovery. When empty, defaults from ActionFileNamesFor are used.
+	ActionDiscoveryFileNames []string `json:"-" yaml:"-"`
 }
 
 // NewCliParams initializes and returns a pointer to a Run struct with default CLI parameters.

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -35,9 +35,7 @@ func TestNewCliParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewCliParams()
-			if *got != *tt.want {
-				t.Errorf("NewCliParams() = %+v, want %+v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -210,4 +208,133 @@ func TestSafeEnvPrefix(t *testing.T) {
 			assert.Equal(t, tt.want, SafeEnvPrefix(tt.binaryName))
 		})
 	}
+}
+
+func TestActionFileNamesFor(t *testing.T) {
+	t.Parallel()
+	names := ActionFileNamesFor("mycli")
+	// Action files must come first.
+	assert.Equal(t, "actions.yaml", names[0])
+	assert.Equal(t, "actions.yml", names[1])
+	// Solution files follow as fallback.
+	assert.Contains(t, names, "solution.yaml")
+	assert.Contains(t, names, "mycli.yaml")
+}
+
+func TestSolutionOnlyFileNamesFor(t *testing.T) {
+	t.Parallel()
+	names := SolutionOnlyFileNamesFor("mycli")
+	for _, n := range names {
+		assert.False(t, IsActionFile(n), "should not contain action files: %s", n)
+	}
+	assert.Contains(t, names, "solution.yaml")
+	assert.Contains(t, names, "mycli.yaml")
+}
+
+func TestIsActionFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"actions.yaml", true},
+		{"actions.yml", true},
+		{"solution.yaml", false},
+		{"actions.json", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsActionFile(tt.name))
+		})
+	}
+}
+
+func TestFileNamesForMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		mode              DiscoveryMode
+		binaryName        string
+		customActionFiles []string
+		wantFirst         string
+		wantContains      string
+		wantNotContains   string
+	}{
+		{
+			name:         "default mode returns all",
+			mode:         DiscoveryModeDefault,
+			binaryName:   "scafctl",
+			wantFirst:    "solution.yaml",
+			wantContains: "actions.yaml",
+		},
+		{
+			name:         "action mode prefers actions",
+			mode:         DiscoveryModeAction,
+			binaryName:   "scafctl",
+			wantFirst:    "actions.yaml",
+			wantContains: "solution.yaml",
+		},
+		{
+			name:            "solution mode excludes actions",
+			mode:            DiscoveryModeSolution,
+			binaryName:      "scafctl",
+			wantFirst:       "solution.yaml",
+			wantNotContains: "actions.yaml",
+		},
+		{
+			name:              "action mode with custom files",
+			mode:              DiscoveryModeAction,
+			binaryName:        "mycli",
+			customActionFiles: []string{"custom.yaml"},
+			wantFirst:         "custom.yaml",
+			wantContains:      "solution.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := FileNamesForMode(tt.mode, tt.binaryName, tt.customActionFiles)
+			assert.NotEmpty(t, result)
+			assert.Equal(t, tt.wantFirst, result[0])
+			if tt.wantContains != "" {
+				assert.Contains(t, result, tt.wantContains)
+			}
+			if tt.wantNotContains != "" {
+				assert.NotContains(t, result, tt.wantNotContains)
+			}
+		})
+	}
+}
+
+func TestDiscoveryMode_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mode DiscoveryMode
+		want string
+	}{
+		{DiscoveryModeDefault, "default"},
+		{DiscoveryModeAction, "action"},
+		{DiscoveryModeSolution, "solution"},
+		{DiscoveryMode(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.mode.String())
+		})
+	}
+}
+
+func TestFileNamesForMode_CustomActionFiles_NoMutation(t *testing.T) {
+	t.Parallel()
+	custom := make([]string, 1, 10) // extra capacity to detect append mutation
+	custom[0] = "custom.yaml"
+	original := make([]string, len(custom))
+	copy(original, custom)
+
+	_ = FileNamesForMode(DiscoveryModeAction, "scafctl", custom)
+
+	assert.Equal(t, original, custom, "FileNamesForMode must not mutate the input slice")
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -98,14 +98,14 @@ func TestSolutionFileNamesFor(t *testing.T) {
 		{
 			name:        "default binary name",
 			binaryName:  "scafctl",
-			wantLen:     6,
-			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json"},
+			wantLen:     8,
+			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json", "actions.yaml", "actions.yml"},
 		},
 		{
 			name:        "custom binary name",
 			binaryName:  "mycli",
-			wantLen:     6,
-			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json"},
+			wantLen:     8,
+			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json", "actions.yaml", "actions.yml"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/solution/build.go
+++ b/pkg/solution/build.go
@@ -4,8 +4,10 @@
 package solution
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -63,4 +65,32 @@ func ResolveArtifactVersion(explicitVersion string, metadataVersion *semver.Vers
 	}
 
 	return nil, false, fmt.Errorf("no version: solution has no version in metadata; provide --version or set metadata.version")
+}
+
+// NextPatchVersion queries the catalog for existing versions of the named artifact
+// and returns the next patch version. If no versions exist, it returns 0.1.0.
+func NextPatchVersion(ctx context.Context, cat catalog.Catalog, kind catalog.ArtifactKind, name string) (*semver.Version, error) {
+	artifacts, err := cat.List(ctx, kind, name)
+	if err != nil {
+		return nil, fmt.Errorf("listing catalog versions for %q: %w", name, err)
+	}
+
+	var versions []*semver.Version
+	for _, a := range artifacts {
+		if a.Reference.Version != nil {
+			versions = append(versions, a.Reference.Version)
+		}
+	}
+
+	if len(versions) == 0 {
+		return semver.MustParse("0.1.0"), nil
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].LessThan(versions[j])
+	})
+
+	highest := versions[len(versions)-1]
+	next := semver.New(highest.Major(), highest.Minor(), highest.Patch()+1, "", "")
+	return next, nil
 }

--- a/pkg/solution/build_test.go
+++ b/pkg/solution/build_test.go
@@ -4,12 +4,47 @@
 package solution
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockCatalog implements catalog.Catalog for testing NextPatchVersion.
+type mockCatalog struct {
+	artifacts []catalog.ArtifactInfo
+	listErr   error
+}
+
+func (m *mockCatalog) Name() string { return "mock" }
+func (m *mockCatalog) Store(_ context.Context, _ catalog.Reference, _, _ []byte, _ map[string]string, _ bool) (catalog.ArtifactInfo, error) {
+	return catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalog) Fetch(_ context.Context, _ catalog.Reference) ([]byte, catalog.ArtifactInfo, error) {
+	return nil, catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalog) FetchWithBundle(_ context.Context, _ catalog.Reference) ([]byte, []byte, catalog.ArtifactInfo, error) {
+	return nil, nil, catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalog) Resolve(_ context.Context, _ catalog.Reference) (catalog.ArtifactInfo, error) {
+	return catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalog) List(_ context.Context, _ catalog.ArtifactKind, _ string) ([]catalog.ArtifactInfo, error) {
+	return m.artifacts, m.listErr
+}
+
+func (m *mockCatalog) Exists(_ context.Context, _ catalog.Reference) (bool, error) {
+	return false, nil
+}
+func (m *mockCatalog) Delete(_ context.Context, _ catalog.Reference) error { return nil }
 
 func TestResolveArtifactName(t *testing.T) {
 	t.Run("explicit name takes priority", func(t *testing.T) {
@@ -105,5 +140,75 @@ func BenchmarkResolveArtifactVersion(b *testing.B) {
 	metadata := semver.MustParse("1.0.0")
 	for b.Loop() {
 		_, _, _ = ResolveArtifactVersion("2.0.0", metadata)
+	}
+}
+
+func TestNextPatchVersion(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no existing versions returns 0.1.0", func(t *testing.T) {
+		cat := &mockCatalog{}
+		v, err := NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
+		require.NoError(t, err)
+		assert.Equal(t, "0.1.0", v.String())
+	})
+
+	t.Run("increments patch from highest version", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("1.0.0")}, CreatedAt: time.Now()},
+				{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}, CreatedAt: time.Now()},
+				{Reference: catalog.Reference{Version: semver.MustParse("1.1.0")}, CreatedAt: time.Now()},
+			},
+		}
+		v, err := NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.4", v.String())
+	})
+
+	t.Run("single version increments patch", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("0.1.0")}, CreatedAt: time.Now()},
+			},
+		}
+		v, err := NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
+		require.NoError(t, err)
+		assert.Equal(t, "0.1.1", v.String())
+	})
+
+	t.Run("skips artifacts without version", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Name: "my-app"}, CreatedAt: time.Now()},                                     // no version (alias tag)
+				{Reference: catalog.Reference{Name: "my-app", Version: semver.MustParse("2.0.0")}, CreatedAt: time.Now()}, // has version
+			},
+		}
+		v, err := NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.1", v.String())
+	})
+
+	t.Run("catalog list error", func(t *testing.T) {
+		cat := &mockCatalog{listErr: assert.AnError}
+		_, err := NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "listing catalog versions")
+	})
+}
+
+func BenchmarkNextPatchVersion(b *testing.B) {
+	ctx := context.Background()
+	cat := &mockCatalog{
+		artifacts: []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Version: semver.MustParse("1.0.0")}},
+			{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}},
+			{Reference: catalog.Reference{Version: semver.MustParse("1.1.0")}},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
 	}
 }

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -54,6 +54,19 @@ type RemoteResolver interface {
 	FetchRemoteSolution(ctx context.Context, ref string) (content, bundleData []byte, err error)
 }
 
+// DiscoveryResult holds metadata from the last FindSolution call.
+type DiscoveryResult struct {
+	// Path is the discovered file path. Empty if nothing found.
+	Path string
+	// IsActionFile is true when the discovered file is an actions.yaml/yml.
+	IsActionFile bool
+	// Mode is the discovery mode that was used.
+	Mode settings.DiscoveryMode
+	// AlternatePath is populated when action mode finds an actions file and a
+	// solution.yaml also exists in the same directory.
+	AlternatePath string
+}
+
 type Getter struct {
 	readFile          fs.ReadFileFunc
 	statFunc          fs.StatFunc
@@ -63,6 +76,9 @@ type Getter struct {
 	remoteResolver    RemoteResolver
 	solutionFolders   []string
 	solutionFileNames []string
+	discoveryMode     settings.DiscoveryMode
+	customActionFiles []string
+	lastDiscovery     DiscoveryResult
 }
 
 // Option defines a function type that modifies a Getter instance.
@@ -123,6 +139,22 @@ func WithRemoteResolver(resolver RemoteResolver) Option {
 	}
 }
 
+// WithDiscoveryMode returns an Option that sets the discovery mode on the Getter.
+// This controls which file names FindSolution searches for.
+func WithDiscoveryMode(mode settings.DiscoveryMode) Option {
+	return func(g *Getter) {
+		g.discoveryMode = mode
+	}
+}
+
+// WithCustomActionFiles returns an Option that overrides the action file names
+// used when discovery mode is DiscoveryModeAction.
+func WithCustomActionFiles(files []string) Option {
+	return func(g *Getter) {
+		g.customActionFiles = files
+	}
+}
+
 // WithSolutionDiscovery overrides the default solution folder and file name
 // lists used by FindSolution. Pass the result of settings.SolutionFoldersFor
 // and settings.SolutionFileNamesFor to search for <binaryName>.yaml etc.
@@ -172,11 +204,16 @@ func NewGetter(opts ...Option) *Getter {
 func NewGetterFromContext(ctx context.Context, opts ...Option) *Getter {
 	var ctxOpts []Option
 	if ctx != nil {
-		if s, ok := settings.FromContext(ctx); ok && s.BinaryName != "" && s.BinaryName != settings.CliBinaryName {
-			ctxOpts = append(ctxOpts, WithSolutionDiscovery(
-				settings.SolutionFoldersFor(s.BinaryName),
-				settings.SolutionFileNamesFor(s.BinaryName),
-			))
+		if s, ok := settings.FromContext(ctx); ok {
+			if s.BinaryName != "" && s.BinaryName != settings.CliBinaryName {
+				ctxOpts = append(ctxOpts, WithSolutionDiscovery(
+					settings.SolutionFoldersFor(s.BinaryName),
+					settings.SolutionFileNamesFor(s.BinaryName),
+				))
+			}
+			if len(s.ActionDiscoveryFileNames) > 0 {
+				ctxOpts = append(ctxOpts, WithCustomActionFiles(s.ActionDiscoveryFileNames))
+			}
 		}
 	}
 	return NewGetter(append(ctxOpts, opts...)...)
@@ -722,22 +759,120 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 // FindSolution searches for a solution file by iterating over the configured root solution folders
 // and solution file names. It returns the full path to the first solution file found using the
 // provided stat function. If no solution file is found, it returns an empty string.
+//
+// When discoveryMode is set, the file name list is overridden via
+// settings.FileNamesForMode before searching. The result metadata is stored
+// and can be retrieved via LastDiscoveryResult().
 func (o *Getter) FindSolution() string {
+	// Override file names based on discovery mode.
+	fileNames := o.solutionFileNames
+	if o.discoveryMode != settings.DiscoveryModeDefault {
+		binaryName := settings.CliBinaryName
+		// Infer binary name from the existing file name list (first non-action entry).
+		for _, fn := range o.solutionFileNames {
+			if fn != "solution.yaml" && fn != "solution.yml" &&
+				fn != "solution.json" && fn != "actions.yaml" && fn != "actions.yml" {
+				binaryName = strings.TrimSuffix(strings.TrimSuffix(fn, ".yaml"), ".yml")
+				binaryName = strings.TrimSuffix(binaryName, ".json")
+				break
+			}
+		}
+		fileNames = settings.FileNamesForMode(o.discoveryMode, binaryName, o.customActionFiles)
+	}
+
 	o.logger.V(1).Info("searching for solution file",
 		"folders", o.solutionFolders,
-		"fileNames", o.solutionFileNames)
+		"fileNames", fileNames,
+		"mode", o.discoveryMode)
+
+	o.lastDiscovery = DiscoveryResult{Mode: o.discoveryMode}
+
+	// In action mode, if the first match is a non-action file (e.g.,
+	// cldctl/solution.yaml), remember it as a fallback and keep searching
+	// remaining folders for an actual action file (e.g., ./actions.yaml).
+	var fallbackPath string
+	var fallbackFilename string
+
 	for _, folder := range o.solutionFolders {
-		for _, filename := range o.solutionFileNames {
+		for _, filename := range fileNames {
 			fullPath := filepath.NormalizeFilePath(pathlib.Join(folder, filename))
 			if filepath.PathExists(fullPath, o.statFunc) {
 				o.logger.V(1).Info("found solution file", "path", fullPath)
+				isAction := settings.IsActionFile(filename)
+
+				// In action mode, prefer action files over non-action files.
+				// If we find a non-action file first, stash it and keep looking.
+				if o.discoveryMode == settings.DiscoveryModeAction && !isAction && fallbackPath == "" {
+					fallbackPath = fullPath
+					fallbackFilename = filename
+					o.logger.V(1).Info("non-action file found in action mode, continuing search for action files",
+						"fallback", fullPath)
+					// Skip to the next folder (no point checking more file names in
+					// this folder — we already found the best match here).
+					break
+				}
+
+				o.lastDiscovery.Path = fullPath
+				o.lastDiscovery.IsActionFile = isAction
+				o.lastDiscovery.AlternatePath = o.discoverAlternatePath(fullPath, isAction)
+
+				// If we had a fallback, record it as the alternate path so the
+				// user knows another solution file exists.
+				if fallbackPath != "" {
+					o.lastDiscovery.AlternatePath = fallbackPath
+				}
+
 				return fullPath
 			}
 			o.logger.V(2).Info("solution file not found", "path", fullPath)
 		}
 	}
+
+	// If no action file was found but we have a fallback, use it.
+	if fallbackPath != "" {
+		o.logger.V(1).Info("no action file found, using fallback", "path", fallbackPath)
+		o.lastDiscovery.Path = fallbackPath
+		o.lastDiscovery.IsActionFile = settings.IsActionFile(fallbackFilename)
+		return fallbackPath
+	}
+
 	o.logger.V(1).Info("no solution file found in any default location")
 	return ""
+}
+
+// LastDiscoveryResult returns metadata from the most recent FindSolution call.
+func (o *Getter) LastDiscoveryResult() DiscoveryResult {
+	return o.lastDiscovery
+}
+
+// discoverAlternatePath checks whether a complementary file exists in the same
+// directory as the discovered solution file. In action mode it looks for
+// solution.yaml; in solution mode it looks for actions.yaml.
+func (o *Getter) discoverAlternatePath(fullPath string, isAction bool) string {
+	var alternates []string
+	switch {
+	case o.discoveryMode == settings.DiscoveryModeAction && isAction:
+		alternates = []string{"solution.yaml", "solution.yml"}
+	case o.discoveryMode == settings.DiscoveryModeSolution && !isAction:
+		alternates = []string{"actions.yaml", "actions.yml"}
+	default:
+		return ""
+	}
+
+	dir := pathlib.Dir(fullPath)
+	for _, alt := range alternates {
+		altPath := filepath.NormalizeFilePath(pathlib.Join(dir, alt))
+		if filepath.PathExists(altPath, o.statFunc) {
+			return altPath
+		}
+	}
+	return ""
+}
+
+// SetDiscoveryMode sets the discovery mode on the Getter. This is useful when
+// the mode needs to be changed after construction (e.g., from prepare).
+func (o *Getter) SetDiscoveryMode(mode settings.DiscoveryMode) {
+	o.discoveryMode = mode
 }
 
 // PossibleSolutionPaths returns a slice of possible solution file paths by combining

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -588,8 +588,8 @@ func TestGetPossibleSolutionPaths(t *testing.T) {
 	t.Run("returns all possible paths", func(t *testing.T) {
 		paths := PossibleSolutionPaths()
 
-		// Should have 3 folders * 6 filenames = 18 paths
-		assert.Len(t, paths, 18)
+		// Should have 3 folders * 8 filenames = 24 paths
+		assert.Len(t, paths, 24)
 	})
 
 	t.Run("contains expected paths", func(t *testing.T) {

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -1734,5 +1735,210 @@ spec:
 		require.NoError(t, err)
 		assert.Equal(t, "hello-world", sol.Metadata.Name)
 		assert.Equal(t, []byte("remote-bundle"), bundleData)
+	})
+}
+
+func TestFindSolution_DiscoveryMode(t *testing.T) {
+	t.Run("action mode prefers actions.yaml", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "actions.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "actions.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.True(t, result.IsActionFile)
+		assert.Equal(t, settings.DiscoveryModeAction, result.Mode)
+	})
+
+	t.Run("solution mode skips actions.yaml as candidate", func(t *testing.T) {
+		searchPaths := []string{}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			searchPaths = append(searchPaths, path)
+			if path == "actions.yaml" || path == "solution.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeSolution),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "solution.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.False(t, result.IsActionFile)
+		// solution.yaml must be found before any action file is probed;
+		// action files are only checked for the AlternatePath hint, not as candidates.
+		solIdx := slices.Index(searchPaths, "solution.yaml")
+		for i, p := range searchPaths {
+			if settings.IsActionFile(p) {
+				assert.Greater(t, i, solIdx,
+					"action file %q was checked before solution.yaml was found", p)
+			}
+		}
+		// AlternatePath should be populated since actions.yaml exists.
+		assert.Equal(t, "actions.yaml", result.AlternatePath)
+	})
+
+	t.Run("action mode falls back to solution.yaml", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "solution.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "solution.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.False(t, result.IsActionFile)
+	})
+
+	t.Run("action mode populates AlternatePath when solution.yaml also exists", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "actions.yaml" || path == "solution.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "actions.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.True(t, result.IsActionFile)
+		assert.Equal(t, "solution.yaml", result.AlternatePath)
+	})
+
+	t.Run("custom action files override defaults", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "custom.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+			WithCustomActionFiles([]string{"custom.yaml"}),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "custom.yaml", path)
+	})
+
+	t.Run("solution mode populates AlternatePath when actions.yaml also exists", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "solution.yaml" || path == "actions.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeSolution),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "solution.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.False(t, result.IsActionFile)
+		assert.Equal(t, "actions.yaml", result.AlternatePath)
+	})
+
+	t.Run("SetDiscoveryMode changes mode after construction", func(t *testing.T) {
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if path == "solution.yaml" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+		getter.SetDiscoveryMode(settings.DiscoveryModeSolution)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "solution.yaml", path)
+		assert.Equal(t, settings.DiscoveryModeSolution, getter.LastDiscoveryResult().Mode)
+	})
+
+	t.Run("action mode prefers root actions.yaml over subfolder solution.yaml", func(t *testing.T) {
+		// Simulates: cldctl/solution.yaml exists, root actions.yaml exists.
+		// In action mode, root actions.yaml should be preferred even though
+		// subfolder solution.yaml is found first in folder-priority order.
+		existingFiles := map[string]bool{
+			"cldctl/solution.yaml": true,
+			"actions.yaml":         true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+			WithSolutionDiscovery(
+				[]string{"cldctl", ".cldctl", ""},
+				settings.ActionFileNamesFor("cldctl"),
+			),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "actions.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.True(t, result.IsActionFile)
+		// The subfolder solution.yaml should be recorded as the alternate path.
+		assert.Equal(t, "cldctl/solution.yaml", result.AlternatePath)
+	})
+
+	t.Run("action mode uses subfolder solution.yaml when no action file exists anywhere", func(t *testing.T) {
+		existingFiles := map[string]bool{
+			"cldctl/solution.yaml": true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+			WithSolutionDiscovery(
+				[]string{"cldctl", ".cldctl", ""},
+				settings.ActionFileNamesFor("cldctl"),
+			),
+		)
+		path := getter.FindSolution()
+
+		assert.Equal(t, "cldctl/solution.yaml", path)
+		result := getter.LastDiscoveryResult()
+		assert.False(t, result.IsActionFile)
 	})
 }

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -47,6 +47,7 @@ type prepareConfig struct {
 	noCache       bool
 	pluginCfg     *plugin.ProviderConfig
 	clientOpts    []plugin.ClientOption
+	discoveryMode settings.DiscoveryMode
 }
 
 // WithGetter provides a custom solution getter. If not set, one is created
@@ -130,6 +131,14 @@ func WithClientOptions(opts ...plugin.ClientOption) Option {
 	}
 }
 
+// WithDiscoveryMode sets the discovery mode used when auto-discovering
+// solution files. See settings.DiscoveryMode for available modes.
+func WithDiscoveryMode(mode settings.DiscoveryMode) Option {
+	return func(c *prepareConfig) {
+		c.discoveryMode = mode
+	}
+}
+
 // Result holds the output of PrepareSolution.
 type Result struct {
 	// Solution is the loaded and prepared solution.
@@ -145,6 +154,9 @@ type Result struct {
 	// Cleanup must be deferred by the caller. It handles temp directory
 	// removal, working directory restoration, and metrics output.
 	Cleanup func() `json:"-" yaml:"-"`
+	// DiscoveredFrom holds metadata about how the solution file was discovered.
+	// Only populated when auto-discovery is used (path was empty).
+	DiscoveredFrom get.DiscoveryResult `json:"-" yaml:"-"`
 }
 
 // Solution loads a solution from the given path, extracts any bundle,
@@ -171,6 +183,17 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	getter := cfg.getter
 	if getter == nil {
 		getter = NewDefaultGetter(ctx, cfg.noCache)
+	}
+
+	// When discovery mode is set and no explicit path is provided,
+	// perform discovery up front so we can capture the result metadata.
+	var discoveredFrom get.DiscoveryResult
+	if path == "" && cfg.discoveryMode != settings.DiscoveryModeDefault {
+		if g, ok := getter.(*get.Getter); ok {
+			g.SetDiscoveryMode(cfg.discoveryMode)
+			path = g.FindSolution()
+			discoveredFrom = g.LastDiscoveryResult()
+		}
 	}
 
 	// Load the solution (with bundle if available)
@@ -320,10 +343,11 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	}
 
 	return &Result{
-		Solution:    sol,
-		Registry:    reg,
-		SolutionDir: solutionDir,
-		Cleanup:     cleanup,
+		Solution:       sol,
+		Registry:       reg,
+		SolutionDir:    solutionDir,
+		Cleanup:        cleanup,
+		DiscoveredFrom: discoveredFrom,
 	}, nil
 }
 

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -270,6 +270,12 @@ func TestOptions(t *testing.T) {
 		WithPluginFetcher(f)(cfg)
 		assert.Equal(t, f, cfg.pluginFetcher)
 	})
+
+	t.Run("WithDiscoveryMode sets discoveryMode", func(t *testing.T) {
+		cfg := &prepareConfig{}
+		WithDiscoveryMode(settings.DiscoveryModeAction)(cfg)
+		assert.Equal(t, settings.DiscoveryModeAction, cfg.discoveryMode)
+	})
 }
 
 func TestLoadSolutionWithBundle_Stdin_NilReader(t *testing.T) {

--- a/pkg/spec/condition.go
+++ b/pkg/spec/condition.go
@@ -4,6 +4,7 @@
 package spec
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -115,7 +116,7 @@ func (c *Condition) UnmarshalJSON(data []byte) error {
 	*c = Condition{}
 
 	// Null -> zero-value Condition (nil Expr).
-	if string(data) == "null" {
+	if string(bytes.TrimSpace(data)) == "null" {
 		return nil
 	}
 

--- a/pkg/spec/condition.go
+++ b/pkg/spec/condition.go
@@ -5,15 +5,167 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"gopkg.in/yaml.v3"
 )
 
 // Condition represents a conditional execution clause.
 // It wraps a CEL expression that must evaluate to a boolean value.
+//
+// Supported YAML forms:
+//   - Boolean literal:  when: true / when: false
+//   - String shorthand: when: "_.environment == 'prod'"
+//   - Explicit object:  when: { expr: "_.environment == 'prod'" }
+//   - Expression alias: when: { expression: "_.environment == 'prod'" }
 type Condition struct {
 	Expr *celexp.Expression `json:"expr" yaml:"expr" doc:"CEL expression that must evaluate to boolean" example:"_.environment == 'prod'"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshalling for Condition.
+// It supports boolean literals, string shorthand, and the explicit {expr: ...} form.
+func (c *Condition) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return c.unmarshalScalarYAML(node)
+	case yaml.MappingNode:
+		return c.unmarshalMappingYAML(node)
+	case yaml.AliasNode:
+		return c.UnmarshalYAML(node.Alias)
+	case yaml.DocumentNode, yaml.SequenceNode:
+		return fmt.Errorf("invalid condition at line %d, column %d: expected boolean, string, or object {expr: \"...\"}, got unsupported node kind", node.Line, node.Column)
+	default:
+		return fmt.Errorf("invalid condition at line %d, column %d: expected boolean, string, or object {expr: \"...\"}, got unsupported node kind", node.Line, node.Column)
+	}
+}
+
+func (c *Condition) unmarshalScalarYAML(node *yaml.Node) error {
+	switch node.Tag {
+	case "!!bool":
+		// Boolean literal: when: true / false -> stored as CEL expression "true"/"false"
+		expr := celexp.Expression(node.Value)
+		c.Expr = &expr
+		return nil
+	case "!!str":
+		if node.Value == "" {
+			return fmt.Errorf("invalid condition at line %d, column %d: empty string is not a valid CEL expression", node.Line, node.Column)
+		}
+		expr := celexp.Expression(node.Value)
+		c.Expr = &expr
+		return nil
+	case "!!null":
+		// Null -> zero-value Condition (nil Expr), consistent with JSON null handling.
+		c.Expr = nil
+		return nil
+	default:
+		return fmt.Errorf("invalid condition at line %d, column %d: unsupported type %s; use true, false, a CEL expression string, or {expr: \"...\"}", node.Line, node.Column, node.Tag)
+	}
+}
+
+func (c *Condition) unmarshalMappingYAML(node *yaml.Node) error {
+	// Support both "expr" and "expression" keys.
+	type conditionAlias struct {
+		Expr       *celexp.Expression `yaml:"expr"`
+		Expression *celexp.Expression `yaml:"expression"`
+	}
+	var raw conditionAlias
+	if err := node.Decode(&raw); err != nil {
+		return fmt.Errorf("invalid condition at line %d, column %d: %w", node.Line, node.Column, err)
+	}
+	if raw.Expr != nil && raw.Expression != nil {
+		return fmt.Errorf("invalid condition at line %d, column %d: specify either 'expr' or 'expression', not both", node.Line, node.Column)
+	}
+	if raw.Expression != nil {
+		c.Expr = raw.Expression
+	} else {
+		c.Expr = raw.Expr
+	}
+	return nil
+}
+
+// MarshalYAML implements custom YAML marshalling for Condition.
+// If the expression is a literal "true" or "false", it marshals as a boolean.
+// Otherwise it uses the string shorthand form for compact output.
+func (c Condition) MarshalYAML() (any, error) {
+	if c.Expr == nil {
+		return nil, nil
+	}
+	s := string(*c.Expr)
+	switch s {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return s, nil
+	}
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for Condition.
+// It supports boolean literals, string shorthand, and the explicit {"expr": "..."} form.
+func (c *Condition) UnmarshalJSON(data []byte) error {
+	*c = Condition{}
+
+	// Null -> zero-value Condition (nil Expr).
+	if string(data) == "null" {
+		return nil
+	}
+
+	// Try boolean
+	var b bool
+	if json.Unmarshal(data, &b) == nil {
+		s := fmt.Sprintf("%t", b)
+		expr := celexp.Expression(s)
+		c.Expr = &expr
+		return nil
+	}
+
+	// Try string
+	var s string
+	if json.Unmarshal(data, &s) == nil {
+		if s == "" {
+			return fmt.Errorf("invalid condition: empty string is not a valid CEL expression")
+		}
+		expr := celexp.Expression(s)
+		c.Expr = &expr
+		return nil
+	}
+
+	// Try object with expr or expression
+	var obj struct {
+		Expr       *celexp.Expression `json:"expr"`
+		Expression *celexp.Expression `json:"expression"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("invalid condition: expected boolean, string, or object {\"expr\": \"...\"}: %w", err)
+	}
+	if obj.Expr != nil && obj.Expression != nil {
+		return fmt.Errorf("invalid condition: specify either 'expr' or 'expression', not both")
+	}
+	if obj.Expression != nil {
+		c.Expr = obj.Expression
+	} else {
+		c.Expr = obj.Expr
+	}
+	return nil
+}
+
+// MarshalJSON implements custom JSON marshalling for Condition.
+func (c Condition) MarshalJSON() ([]byte, error) {
+	if c.Expr == nil {
+		return []byte("null"), nil
+	}
+	s := string(*c.Expr)
+	switch s {
+	case "true":
+		return []byte("true"), nil
+	case "false":
+		return []byte("false"), nil
+	default:
+		return json.Marshal(s)
+	}
 }
 
 // Evaluate evaluates the condition with the given resolver data.

--- a/pkg/spec/condition.go
+++ b/pkg/spec/condition.go
@@ -77,11 +77,17 @@ func (c *Condition) unmarshalMappingYAML(node *yaml.Node) error {
 	if raw.Expr != nil && raw.Expression != nil {
 		return fmt.Errorf("invalid condition at line %d, column %d: specify either 'expr' or 'expression', not both", node.Line, node.Column)
 	}
-	if raw.Expression != nil {
-		c.Expr = raw.Expression
-	} else {
-		c.Expr = raw.Expr
+	if raw.Expr == nil && raw.Expression == nil {
+		return fmt.Errorf("invalid condition at line %d, column %d: expected object with 'expr' or 'expression'", node.Line, node.Column)
 	}
+	expr := raw.Expr
+	if raw.Expression != nil {
+		expr = raw.Expression
+	}
+	if string(*expr) == "" {
+		return fmt.Errorf("invalid condition at line %d, column %d: empty string is not a valid CEL expression", node.Line, node.Column)
+	}
+	c.Expr = expr
 	return nil
 }
 
@@ -144,11 +150,16 @@ func (c *Condition) UnmarshalJSON(data []byte) error {
 	if obj.Expr != nil && obj.Expression != nil {
 		return fmt.Errorf("invalid condition: specify either 'expr' or 'expression', not both")
 	}
+	var expr *celexp.Expression
 	if obj.Expression != nil {
-		c.Expr = obj.Expression
+		expr = obj.Expression
 	} else {
-		c.Expr = obj.Expr
+		expr = obj.Expr
 	}
+	if expr != nil && string(*expr) == "" {
+		return fmt.Errorf("invalid condition: empty string is not a valid CEL expression")
+	}
+	c.Expr = expr
 	return nil
 }
 

--- a/pkg/spec/condition_test.go
+++ b/pkg/spec/condition_test.go
@@ -5,11 +5,13 @@ package spec
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCondition_Evaluate_NilCondition(t *testing.T) {
@@ -168,4 +170,281 @@ func TestCondition_EvaluateWithAdditionalVars(t *testing.T) {
 	result, err := cond.EvaluateWithAdditionalVars(ctx, nil, additionalVars)
 	require.NoError(t, err)
 	assert.True(t, result)
+}
+
+func TestCondition_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantExpr    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			wantExpr: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			wantExpr: "false",
+		},
+		{
+			name:     "string shorthand",
+			input:    `"_.environment == 'prod'"`,
+			wantExpr: "_.environment == 'prod'",
+		},
+		{
+			name:     "explicit object form",
+			input:    `expr: "_.count > 5"`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:     "expression alias",
+			input:    `expression: "_.count > 5"`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:        "both expr and expression",
+			input:       "expr: \"a\"\nexpression: \"b\"",
+			wantErr:     true,
+			errContains: "not both",
+		},
+		{
+			name:        "empty string",
+			input:       `""`,
+			wantErr:     true,
+			errContains: "empty string",
+		},
+		{
+			name:     "null value unmarshals to zero condition",
+			input:    "null",
+			wantExpr: "",
+		},
+		{
+			name:        "integer value",
+			input:       "42",
+			wantErr:     true,
+			errContains: "unsupported type",
+		},
+		{
+			name:        "sequence value",
+			input:       "- foo\n- bar",
+			wantErr:     true,
+			errContains: "unsupported node kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := yaml.Unmarshal([]byte(tt.input), &c)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantExpr == "" {
+				assert.Nil(t, c.Expr)
+			} else {
+				require.NotNil(t, c.Expr)
+				assert.Equal(t, tt.wantExpr, string(*c.Expr))
+			}
+		})
+	}
+}
+
+func TestCondition_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantExpr    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			wantExpr: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			wantExpr: "false",
+		},
+		{
+			name:     "string shorthand",
+			input:    `"_.environment == 'prod'"`,
+			wantExpr: "_.environment == 'prod'",
+		},
+		{
+			name:     "explicit object form",
+			input:    `{"expr": "_.count > 5"}`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:     "expression alias",
+			input:    `{"expression": "_.count > 5"}`,
+			wantExpr: "_.count > 5",
+		},
+		{
+			name:        "both expr and expression",
+			input:       `{"expr": "a", "expression": "b"}`,
+			wantErr:     true,
+			errContains: "not both",
+		},
+		{
+			name:        "empty string",
+			input:       `""`,
+			wantErr:     true,
+			errContains: "empty string",
+		},
+		{
+			name:  "null value",
+			input: "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := json.Unmarshal([]byte(tt.input), &c)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantExpr == "" {
+				assert.Nil(t, c.Expr)
+			} else {
+				require.NotNil(t, c.Expr)
+				assert.Equal(t, tt.wantExpr, string(*c.Expr))
+			}
+		})
+	}
+}
+
+func TestCondition_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{name: "true", expr: "true", expected: "true\n"},
+		{name: "false", expr: "false", expected: "false\n"},
+		{name: "expression", expr: "_.env == 'prod'", expected: "_.env == 'prod'\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := celexp.Expression(tt.expr)
+			c := Condition{Expr: &expr}
+			data, err := yaml.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestCondition_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{name: "true", expr: "true", expected: "true"},
+		{name: "false", expr: "false", expected: "false"},
+		{name: "expression", expr: "_.env == 'prod'", expected: `"_.env == 'prod'"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := celexp.Expression(tt.expr)
+			c := Condition{Expr: &expr}
+			data, err := json.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestCondition_MarshalJSON_Nil(t *testing.T) {
+	c := Condition{Expr: nil}
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestCondition_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "bool true", input: "true\n"},
+		{name: "bool false", input: "false\n"},
+		{name: "string expr", input: "_.env == 'prod'\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Condition
+			err := yaml.Unmarshal([]byte(tt.input), &c)
+			require.NoError(t, err)
+
+			data, err := yaml.Marshal(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, string(data))
+		})
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_Bool(b *testing.B) {
+	data := []byte("true")
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_String(b *testing.B) {
+	data := []byte(`"_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalYAML_Object(b *testing.B) {
+	data := []byte(`expr: "_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = yaml.Unmarshal(data, &c)
+	}
+}
+
+func BenchmarkCondition_UnmarshalJSON(b *testing.B) {
+	data := []byte(`"_.environment == 'prod'"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var c Condition
+		_ = json.Unmarshal(data, &c)
+	}
 }

--- a/pkg/spec/condition_test.go
+++ b/pkg/spec/condition_test.go
@@ -218,6 +218,24 @@ func TestCondition_UnmarshalYAML(t *testing.T) {
 			errContains: "empty string",
 		},
 		{
+			name:        "empty expr in object form",
+			input:       `expr: ""`,
+			wantErr:     true,
+			errContains: "empty string is not a valid CEL expression",
+		},
+		{
+			name:        "empty expression in object form",
+			input:       `expression: ""`,
+			wantErr:     true,
+			errContains: "empty string is not a valid CEL expression",
+		},
+		{
+			name:        "object with no expr or expression",
+			input:       `foo: bar`,
+			wantErr:     true,
+			errContains: "expected object with 'expr' or 'expression'",
+		},
+		{
 			name:     "null value unmarshals to zero condition",
 			input:    "null",
 			wantExpr: "",
@@ -302,6 +320,18 @@ func TestCondition_UnmarshalJSON(t *testing.T) {
 			input:       `""`,
 			wantErr:     true,
 			errContains: "empty string",
+		},
+		{
+			name:        "empty expr in JSON object form",
+			input:       `{"expr": ""}`,
+			wantErr:     true,
+			errContains: "empty string is not a valid CEL expression",
+		},
+		{
+			name:        "empty expression in JSON object form",
+			input:       `{"expression": ""}`,
+			wantErr:     true,
+			errContains: "empty string is not a valid CEL expression",
 		},
 		{
 			name:  "null value",

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -16,6 +18,7 @@ import (
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	toml "github.com/pelletier/go-toml/v2"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,6 +66,16 @@ const (
 
 	// OutputFormatTOML outputs as TOML (for config files/scripting)
 	OutputFormatTOML OutputFormat = "toml"
+)
+
+const (
+	// minColumnWidth is the minimum average characters per column before
+	// writeText switches from table to list rendering. Tables with very
+	// narrow columns become unreadable.
+	minColumnWidth = 10
+
+	// defaultTermWidth is assumed when the terminal width cannot be detected.
+	defaultTermWidth = 80
 )
 
 // String returns the string representation of the output format.
@@ -659,12 +672,38 @@ func (o *OutputOptions) writeText(data any) error {
 	}
 
 	hints := resolveColumnHints(o.SchemaJSON, o.ColumnHints)
+
+	piped := !IsTerminal(o.IOStreams.Out)
+
+	// When there are many columns relative to the available width, a table
+	// becomes unreadable because each column gets only a few characters.
+	// Detect this and fall back to a vertical list layout.
+	// Also fall back when output is piped and data contains nested
+	// objects/arrays, because the columnar renderer serializes them as
+	// truncated one-line JSON which is unusable in scripts.
+	if cols := countDataColumns(outputData); cols > 0 {
+		width := o.terminalWidth()
+		if width/(cols+1) < minColumnWidth || (piped && hasNestedValues(outputData)) {
+			output := tui.RenderList(outputData, true)
+			fmt.Fprint(o.IOStreams.Out, output)
+			return nil
+		}
+	}
+
 	output := tui.RenderTable(outputData, tui.TableOptions{
 		Bordered:    false,
 		NoColor:     true,
 		ColumnOrder: o.ColumnOrder,
 		ColumnHints: hints,
 	})
+
+	// When piped on Windows the console defaults to OEM/CP437 encoding,
+	// which garbles UTF-8 box-drawing characters (e.g., ─ → ΓöÇ).
+	// Replace them with ASCII dashes so piped output is always readable.
+	if piped {
+		output = strings.ReplaceAll(output, "─", "-")
+	}
+
 	fmt.Fprint(o.IOStreams.Out, output)
 	return nil
 }
@@ -708,8 +747,16 @@ func writeSummaryLine(w io.Writer, summary map[string]any) {
 }
 
 // writeYAML writes data as YAML.
+// Before marshaling, literal escape sequences like \n in string values are
+// expanded to real newlines so that yaml.Marshal renders them as readable
+// block scalars instead of single-line strings with escaped characters.
+//
+// NOTE: expandEscapedNewlines mutates maps and slices in place. This is safe
+// here because writeYAML is a terminal step that does not return data to the
+// caller. Do not reuse data after calling writeYAML.
 func (o *OutputOptions) writeYAML(data any) error {
-	yamlData, err := yaml.Marshal(data)
+	expanded := expandEscapedNewlines(data)
+	yamlData, err := yaml.Marshal(expanded)
 	if err != nil {
 		return fmt.Errorf("failed to marshal YAML: %w", err)
 	}
@@ -892,4 +939,96 @@ func csvApplyColumnOrder(headers, order []string) []string {
 		}
 	}
 	return result
+}
+
+// terminalWidth returns the current terminal width, falling back to
+// defaultTermWidth when detection fails (e.g., piped output).
+func (o *OutputOptions) terminalWidth() int {
+	if f, ok := o.IOStreams.Out.(*os.File); ok {
+		fd := f.Fd()
+		if fd <= uintptr(math.MaxInt) {
+			if w, _, err := term.GetSize(int(fd)); err == nil && w > 0 {
+				return w
+			}
+		}
+	}
+	return defaultTermWidth
+}
+
+// countDataColumns returns the number of columns that a table rendering
+// would produce for the given data. It inspects the first map element in
+// a slice or a single map's keys.
+func countDataColumns(data any) int {
+	switch v := data.(type) {
+	case []any:
+		if len(v) == 0 {
+			return 0
+		}
+		if m, ok := v[0].(map[string]any); ok {
+			return len(m)
+		}
+	case map[string]any:
+		return len(v)
+	}
+	return 0
+}
+
+// hasNestedValues reports whether any value in the first row of data is
+// itself a map or slice. Such values are serialized as truncated JSON in
+// columnar tables, making piped output unusable.
+func hasNestedValues(data any) bool {
+	var row map[string]any
+	switch v := data.(type) {
+	case []any:
+		if len(v) == 0 {
+			return false
+		}
+		m, ok := v[0].(map[string]any)
+		if !ok {
+			return false
+		}
+		row = m
+	case map[string]any:
+		row = v
+	default:
+		return false
+	}
+	for _, val := range row {
+		switch val.(type) {
+		case map[string]any, []any:
+			return true
+		}
+	}
+	return false
+}
+
+// expandEscapedNewlines recursively walks data and replaces literal "\n"
+// (two characters: backslash + n) in string values with real newline
+// characters. This ensures yaml.Marshal renders multiline strings as
+// readable block scalars instead of opaque single-line strings.
+//
+// Maps and slices are modified in place to avoid allocation when the
+// caller does not need the original data (e.g., writeYAML). String
+// values are replaced by their expanded copies only when escapes exist.
+func expandEscapedNewlines(data any) any {
+	switch v := data.(type) {
+	case string:
+		if strings.Contains(v, `\n`) {
+			v = strings.ReplaceAll(v, `\r\n`, "\n")
+			v = strings.ReplaceAll(v, `\n`, "\n")
+		}
+		return v
+	case map[string]any:
+		for k, val := range v {
+			v[k] = expandEscapedNewlines(val)
+		}
+		return v
+	case []any:
+		for i, val := range v {
+			v[i] = expandEscapedNewlines(val)
+		}
+		return v
+	default:
+		return data
+	}
 }

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -568,8 +568,10 @@ func (o *OutputOptions) writeStructured(data any) error {
 		}
 	}
 
-	// Print scalar values as plain text instead of JSON wrapping.
-	if isScalar(outputData) {
+	// Print scalar values as plain text for non-structured formats.
+	// Structured formats (JSON, YAML, CSV, TOML) must go through their
+	// serializers so values are encoded correctly (e.g. quoted strings in JSON).
+	if isScalar(outputData) && !IsStructuredFormat(o.Format) {
 		fmt.Fprintln(o.IOStreams.Out, outputData)
 		return nil
 	}
@@ -760,23 +762,33 @@ func (o *OutputOptions) writeTOML(data any) error {
 // Scalar values are written as a single cell.
 func (o *OutputOptions) writeCSV(data any) error {
 	w := csv.NewWriter(o.IOStreams.Out)
-	defer w.Flush()
 
+	var err error
 	switch v := data.(type) {
 	case []any:
-		return o.writeCSVSlice(w, v)
+		err = o.writeCSVSlice(w, v)
 	case []map[string]any:
 		items := make([]any, len(v))
 		for i, m := range v {
 			items[i] = m
 		}
-		return o.writeCSVSlice(w, items)
+		err = o.writeCSVSlice(w, items)
 	case map[string]any:
-		return o.writeCSVSlice(w, []any{v})
+		err = o.writeCSVSlice(w, []any{v})
 	default:
 		// Scalar or unsupported type -- write as single value
-		return w.Write([]string{fmt.Sprintf("%v", data)})
+		err = w.Write([]string{fmt.Sprintf("%v", data)})
 	}
+
+	w.Flush()
+
+	if err != nil {
+		return fmt.Errorf("failed to write CSV data: %w", err)
+	}
+	if fErr := w.Error(); fErr != nil {
+		return fmt.Errorf("failed to flush CSV data: %w", fErr)
+	}
+	return nil
 }
 
 // writeCSVSlice writes a slice of items as CSV rows with a header row.

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -5,6 +5,7 @@ package kvx
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	toml "github.com/pelletier/go-toml/v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -55,6 +57,12 @@ const (
 	// Works in any context (TTY and non-TTY) and is the fallback for
 	// table/auto formats when output is piped.
 	OutputFormatText OutputFormat = "text"
+
+	// OutputFormatCSV outputs as comma-separated values (for spreadsheets/scripting)
+	OutputFormatCSV OutputFormat = "csv"
+
+	// OutputFormatTOML outputs as TOML (for config files/scripting)
+	OutputFormatTOML OutputFormat = "toml"
 )
 
 // String returns the string representation of the output format.
@@ -74,6 +82,8 @@ func BaseOutputFormats() []string {
 		string(OutputFormatText),
 		string(OutputFormatJSON),
 		string(OutputFormatYAML),
+		string(OutputFormatCSV),
+		string(OutputFormatTOML),
 		string(OutputFormatQuiet),
 		string(OutputFormatTest),
 	}
@@ -84,7 +94,7 @@ func BaseOutputFormats() []string {
 // bordered table output. Mermaid is included because it is a piping-friendly
 // plain-text format even though Write() routes it through the kvx renderer.
 func IsStructuredFormat(format OutputFormat) bool {
-	return format == OutputFormatJSON || format == OutputFormatYAML || format == OutputFormatMermaid
+	return format == OutputFormatJSON || format == OutputFormatYAML || format == OutputFormatMermaid || format == OutputFormatCSV || format == OutputFormatTOML
 }
 
 // isScalar returns true if data is a scalar value (string, number, bool)
@@ -209,6 +219,10 @@ func ParseOutputFormat(s string) (OutputFormat, bool) {
 		return OutputFormatMermaid, true
 	case "text":
 		return OutputFormatText, true
+	case "csv":
+		return OutputFormatCSV, true
+	case "toml":
+		return OutputFormatTOML, true
 	default:
 		return "", false
 	}
@@ -477,10 +491,10 @@ func (o *OutputOptions) writeKvx(data any) error {
 		kvxOpts = append(kvxOpts, WithLayout("tree"))
 	case OutputFormatMermaid:
 		kvxOpts = append(kvxOpts, WithLayout("mermaid"))
-	case OutputFormatAuto, OutputFormatJSON, OutputFormatYAML, OutputFormatQuiet, OutputFormatTest, OutputFormatText:
+	case OutputFormatAuto, OutputFormatJSON, OutputFormatYAML, OutputFormatCSV, OutputFormatTOML, OutputFormatQuiet, OutputFormatTest, OutputFormatText:
 		// Auto and empty use default layout (auto).
-		// JSON/YAML/Quiet/Test are handled upstream and should not reach here,
-		// but are listed for exhaustiveness.
+		// Structured formats (JSON/YAML/CSV/TOML), Quiet, and Test are handled
+		// upstream and should not reach here, but are listed for exhaustiveness.
 	}
 
 	return View(data, kvxOpts...)
@@ -554,11 +568,21 @@ func (o *OutputOptions) writeStructured(data any) error {
 		}
 	}
 
+	// Print scalar values as plain text instead of JSON wrapping.
+	if isScalar(outputData) {
+		fmt.Fprintln(o.IOStreams.Out, outputData)
+		return nil
+	}
+
 	switch o.Format {
 	case OutputFormatJSON:
 		return o.writeJSON(outputData)
 	case OutputFormatYAML:
 		return o.writeYAML(outputData)
+	case OutputFormatCSV:
+		return o.writeCSV(outputData)
+	case OutputFormatTOML:
+		return o.writeTOML(outputData)
 	case OutputFormatTable, OutputFormatAuto, OutputFormatList, OutputFormatTree, OutputFormatMermaid, OutputFormatText, OutputFormatQuiet, OutputFormatTest:
 		// These formats are handled upstream (writeKvx or command-level test generation),
 		// and should not reach writeStructured.
@@ -718,4 +742,142 @@ func StructToMap(v any) (any, error) {
 		return nil, fmt.Errorf("failed to unmarshal from JSON: %w", err)
 	}
 	return result, nil
+}
+
+// writeTOML writes data as TOML.
+func (o *OutputOptions) writeTOML(data any) error {
+	tomlData, err := toml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal TOML: %w", err)
+	}
+	fmt.Fprint(o.IOStreams.Out, string(tomlData))
+	return nil
+}
+
+// writeCSV writes data as comma-separated values.
+// For a slice of maps, column headers are derived from the union of all keys.
+// For a single map, it writes a two-row CSV (header + values).
+// Scalar values are written as a single cell.
+func (o *OutputOptions) writeCSV(data any) error {
+	w := csv.NewWriter(o.IOStreams.Out)
+	defer w.Flush()
+
+	switch v := data.(type) {
+	case []any:
+		return o.writeCSVSlice(w, v)
+	case []map[string]any:
+		items := make([]any, len(v))
+		for i, m := range v {
+			items[i] = m
+		}
+		return o.writeCSVSlice(w, items)
+	case map[string]any:
+		return o.writeCSVSlice(w, []any{v})
+	default:
+		// Scalar or unsupported type -- write as single value
+		return w.Write([]string{fmt.Sprintf("%v", data)})
+	}
+}
+
+// writeCSVSlice writes a slice of items as CSV rows with a header row.
+func (o *OutputOptions) writeCSVSlice(w *csv.Writer, items []any) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Check if all items are scalars (no header row needed).
+	allScalar := true
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			allScalar = false
+			break
+		}
+	}
+
+	if allScalar {
+		for _, item := range items {
+			if err := w.Write([]string{fmt.Sprintf("%v", item)}); err != nil {
+				return fmt.Errorf("failed to write CSV row: %w", err)
+			}
+		}
+		return nil
+	}
+
+	// Collect all keys across all items for consistent columns
+	keySet := make(map[string]struct{})
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			for k := range m {
+				keySet[k] = struct{}{}
+			}
+		}
+	}
+
+	headers := make([]string, 0, len(keySet))
+	for k := range keySet {
+		headers = append(headers, k)
+	}
+	sort.Strings(headers)
+
+	// Apply column order if configured
+	if len(o.ColumnOrder) > 0 {
+		headers = csvApplyColumnOrder(headers, o.ColumnOrder)
+	}
+
+	// Write header row
+	if err := w.Write(headers); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	// Write data rows
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			// Non-map item in a mixed slice -- write as single column padded to header width
+			row := make([]string, len(headers))
+			row[0] = fmt.Sprintf("%v", item)
+			if err := w.Write(row); err != nil {
+				return fmt.Errorf("failed to write CSV row: %w", err)
+			}
+			continue
+		}
+		row := make([]string, len(headers))
+		for i, h := range headers {
+			if v, exists := m[h]; exists {
+				row[i] = fmt.Sprintf("%v", v)
+			}
+		}
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("failed to write CSV row: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// csvApplyColumnOrder reorders headers based on the preferred column order.
+// Fields in the order list come first; remaining fields are appended in their original order.
+func csvApplyColumnOrder(headers, order []string) []string {
+	orderSet := make(map[string]struct{}, len(order))
+	for _, o := range order {
+		orderSet[o] = struct{}{}
+	}
+
+	result := make([]string, 0, len(headers))
+	// Add ordered columns first (preserving order list sequence)
+	for _, o := range order {
+		for _, h := range headers {
+			if h == o {
+				result = append(result, h)
+				break
+			}
+		}
+	}
+	// Append remaining columns not in order list
+	for _, h := range headers {
+		if _, ok := orderSet[h]; !ok {
+			result = append(result, h)
+		}
+	}
+	return result
 }

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -48,7 +48,9 @@ func TestBaseOutputFormats(t *testing.T) {
 	assert.Contains(t, formats, "test")
 	assert.Contains(t, formats, "tree")
 	assert.Contains(t, formats, "mermaid")
-	assert.Len(t, formats, 10)
+	assert.Contains(t, formats, "csv")
+	assert.Contains(t, formats, "toml")
+	assert.Len(t, formats, 12)
 }
 
 func TestIsStructuredFormat(t *testing.T) {
@@ -1202,4 +1204,198 @@ func TestWriteSummaryLine(t *testing.T) {
 	assert.Contains(t, output, "errorCount=3")
 	assert.Contains(t, output, "file=test.yaml")
 	assert.NotContains(t, output, "nested", "non-scalar fields should be skipped")
+}
+
+func TestOutputOptions_Write_CSV(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := []map[string]any{
+		{"name": "alice", "age": 30},
+		{"name": "bob", "age": 25},
+	}
+
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	assert.Contains(t, lines, "age")
+	assert.Contains(t, lines, "name")
+	assert.Contains(t, lines, "alice")
+	assert.Contains(t, lines, "bob")
+}
+
+func TestOutputOptions_Write_CSV_SingleMap(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := map[string]any{"name": "alice", "role": "admin"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	assert.Contains(t, lines, "name")
+	assert.Contains(t, lines, "alice")
+}
+
+func TestOutputOptions_Write_CSV_Empty(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := []any{}
+	err := opts.Write(data)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func TestOutputOptions_Write_CSV_ColumnOrder(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+	opts.ColumnOrder = []string{"name", "age"}
+
+	data := []map[string]any{{"age": 30, "name": "alice"}}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	headerEnd := lines[:len("name,age")]
+	assert.Equal(t, "name,age", headerEnd)
+}
+
+func TestOutputOptions_Write_CSV_ScalarSlice(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	data := []any{"foo", "bar", "baz"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	lines := out.String()
+	assert.Contains(t, lines, "foo")
+	assert.Contains(t, lines, "bar")
+	assert.Contains(t, lines, "baz")
+}
+
+func TestOutputOptions_Write_CSV_ScalarValue(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatCSV
+
+	err := opts.Write("hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", out.String())
+}
+
+func TestOutputOptions_Write_TOML(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatTOML
+
+	data := map[string]any{"name": "alice", "role": "admin"}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "name = 'alice'")
+	assert.Contains(t, output, "role = 'admin'")
+}
+
+func TestOutputOptions_Write_TOML_Nested(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+
+	opts := NewOutputOptions(ioStreams)
+	opts.Format = OutputFormatTOML
+
+	data := map[string]any{
+		"name": "test",
+		"settings": map[string]any{
+			"verbose": true,
+			"timeout": 30,
+		},
+	}
+	err := opts.Write(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "name = 'test'")
+	assert.Contains(t, output, "[settings]")
+	assert.Contains(t, output, "verbose = true")
+	assert.Contains(t, output, "timeout = 30")
+}
+
+func TestParseOutputFormat_CSV(t *testing.T) {
+	format, ok := ParseOutputFormat("csv")
+	assert.True(t, ok)
+	assert.Equal(t, OutputFormatCSV, format)
+}
+
+func TestParseOutputFormat_TOML(t *testing.T) {
+	format, ok := ParseOutputFormat("toml")
+	assert.True(t, ok)
+	assert.Equal(t, OutputFormatTOML, format)
+}
+
+func TestIsStructuredFormat_CSV(t *testing.T) {
+	assert.True(t, IsStructuredFormat(OutputFormatCSV))
+}
+
+func TestIsStructuredFormat_TOML(t *testing.T) {
+	assert.True(t, IsStructuredFormat(OutputFormatTOML))
+}
+
+func BenchmarkOutputOptions_Write_CSV(b *testing.B) {
+	data := []map[string]any{
+		{"name": "alice", "age": 30, "role": "admin"},
+		{"name": "bob", "age": 25, "role": "user"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		out := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{Out: out}
+		opts := NewOutputOptions(ioStreams)
+		opts.Format = OutputFormatCSV
+		_ = opts.Write(data)
+	}
+}
+
+func BenchmarkOutputOptions_Write_TOML(b *testing.B) {
+	data := map[string]any{
+		"name": "alice",
+		"age":  30,
+		"settings": map[string]any{
+			"verbose": true,
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		out := &bytes.Buffer{}
+		ioStreams := &terminal.IOStreams{Out: out}
+		opts := NewOutputOptions(ioStreams)
+		opts.Format = OutputFormatTOML
+		_ = opts.Write(data)
+	}
 }

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -6,6 +6,7 @@ package kvx
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1398,4 +1399,208 @@ func BenchmarkOutputOptions_Write_TOML(b *testing.B) {
 		opts.Format = OutputFormatTOML
 		_ = opts.Write(data)
 	}
+}
+
+func TestCountDataColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     any
+		expected int
+	}{
+		{"nil", nil, 0},
+		{"scalar", "hello", 0},
+		{"empty slice", []any{}, 0},
+		{"map", map[string]any{"a": 1, "b": 2, "c": 3}, 3},
+		{"slice of maps", []any{
+			map[string]any{"a": 1, "b": 2},
+			map[string]any{"a": 3, "b": 4},
+		}, 2},
+		{"slice of non-maps", []any{1, 2, 3}, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, countDataColumns(tc.data))
+		})
+	}
+}
+
+func TestWriteText_FallsBackToListWhenTooManyColumns(t *testing.T) {
+	// Create data with many columns -- enough that 80 / (cols+1) < minColumnWidth
+	row := make(map[string]any)
+	for i := range 20 {
+		row[fmt.Sprintf("column_%02d", i)] = fmt.Sprintf("value_%d", i)
+	}
+	data := []any{row}
+
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+	opts := NewOutputOptions(ioStreams)
+
+	err := opts.writeText(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	// With 20 columns and 80 char width, avg is 80/21 ≈ 3 < minColumnWidth(10),
+	// so it should render as a list (vertical key: value), not a table (horizontal headers).
+	// List format uses "key: value" lines, not padded header rows.
+	assert.Contains(t, output, "column_00")
+	// A table would have all column headers on a single line; list format would not.
+	lines := strings.Split(output, "\n")
+	// First non-empty line should not contain all 20 column names (that's a table header)
+	firstLine := ""
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			firstLine = l
+			break
+		}
+	}
+	// In list format, the first line should not have more than a few column names
+	colCount := 0
+	for i := range 20 {
+		if strings.Contains(firstLine, fmt.Sprintf("column_%02d", i)) {
+			colCount++
+		}
+	}
+	assert.Less(t, colCount, 5, "expected list format (few columns per line), got table-like output")
+}
+
+func TestExpandEscapedNewlines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected any
+	}{
+		{
+			name:     "string with literal backslash-n",
+			input:    `line1\nline2\nline3`,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "string without escapes",
+			input:    "no escapes here",
+			expected: "no escapes here",
+		},
+		{
+			name:     "string with backslash-r-n",
+			input:    `line1\r\nline2`,
+			expected: "line1\nline2",
+		},
+		{
+			name:     "map with mixed values",
+			input:    map[string]any{"desc": `hello\nworld`, "name": "plain"},
+			expected: map[string]any{"desc": "hello\nworld", "name": "plain"},
+		},
+		{
+			name:     "slice of strings",
+			input:    []any{`a\nb`, "c"},
+			expected: []any{"a\nb", "c"},
+		},
+		{
+			name:     "non-string passthrough",
+			input:    42,
+			expected: 42,
+		},
+		{
+			name:     "nil",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, expandEscapedNewlines(tc.input))
+		})
+	}
+}
+
+func TestWriteYAML_ExpandsEscapedNewlines(t *testing.T) {
+	data := map[string]any{
+		"description": `line1\nline2\nline3`,
+		"name":        "simple",
+	}
+
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+	opts := NewOutputOptions(ioStreams)
+
+	err := opts.writeYAML(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	// The YAML output should use block scalar style for the multiline value,
+	// not a single-line string with literal \n.
+	assert.Contains(t, output, "line1\n")
+	assert.Contains(t, output, "line2\n")
+	assert.NotContains(t, output, `\n`)
+}
+
+func TestHasNestedValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     any
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"scalar", "hello", false},
+		{"flat map", map[string]any{"a": 1, "b": "two"}, false},
+		{"map with nested map", map[string]any{"a": 1, "nested": map[string]any{"x": 1}}, true},
+		{"map with nested slice", map[string]any{"a": 1, "items": []any{1, 2}}, true},
+		{"slice of flat maps", []any{map[string]any{"a": 1, "b": 2}}, false},
+		{"slice of nested maps", []any{map[string]any{"a": 1, "nested": map[string]any{"x": 1}}}, true},
+		{"empty slice", []any{}, false},
+		{"slice of non-maps", []any{1, 2}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, hasNestedValues(tc.data))
+		})
+	}
+}
+
+func TestWriteText_ReplacesUnicodeBoxDrawingWhenPiped(t *testing.T) {
+	// Use a bytes.Buffer (not *os.File), which IsTerminal treats as non-TTY.
+	data := []any{
+		map[string]any{"name": "alice", "age": 30},
+		map[string]any{"name": "bob", "age": 25},
+	}
+
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+	opts := NewOutputOptions(ioStreams)
+
+	err := opts.writeText(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	// Non-TTY output should not contain Unicode box-drawing characters
+	assert.NotContains(t, output, "─", "piped output should use ASCII dashes, not Unicode box-drawing")
+	// Should still contain the separator line (as ASCII dashes)
+	assert.Contains(t, output, "---")
+}
+
+func TestWriteText_FallsBackToListForNestedValuesWhenPiped(t *testing.T) {
+	// Data with nested objects — piped output should use list format
+	data := []any{
+		map[string]any{
+			"name":    "myapp",
+			"version": map[string]any{"major": 1, "minor": 2},
+		},
+	}
+
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+	opts := NewOutputOptions(ioStreams)
+
+	err := opts.writeText(data)
+	require.NoError(t, err)
+
+	output := out.String()
+	// List format renders key: value vertically, not as a columnar table.
+	// The output should contain the nested fields expanded, not truncated JSON.
+	assert.NotContains(t, output, "...", "nested values should not be truncated")
+	assert.Contains(t, output, "name")
+	assert.Contains(t, output, "myapp")
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2420,7 +2420,7 @@ func TestIntegration_BuildSolution_WithName(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("XDG_CACHE_HOME", tmpDir)
 
-	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name")
+	stdout, stderr, exitCode := runScafctl(t, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--name", "my-custom-name", "--force")
 
 	if exitCode != 0 {
 		t.Logf("stdout: %s", stdout)


### PR DESCRIPTION
- add move/rename operation to directory provider with cross-device fallback (copy + remove)
- add list_commit_pulls operation to GitHub provider via REST API
- add passthrough mode to exec provider for streaming terminal output
- write-tree now silently skips directory entries without content, removing the need for CEL .filter(e, has(e.content)) workarounds
- add actions.yaml and actions.yml to solution auto-discovery filenames
- display solution name, version, and source path after loading
- sort dry-run action plan by section (actions before finally) and phase
- add consistent device code and browser auth TUI experience across all auth handlers including GCP ADC flow
- add condition shorthand syntax with expr/expression field support and improved error messages
- add auto-increment patch version and name mismatch validation for build solution command
- add kvx status screen TUI for browser auth waiting state
- clean up duplicate .gitignore entry and fix go.mod dependency

BREAKING CHANGE: write-tree no longer errors on entries missing content -- they are silently skipped as directory entries

Closes #168
Closes #258
Closes #165
Closes #169
Closes #171