### PR TITLE
feat(provider)!: add GitHub provider v2.1 operations with write-op guard

### DIFF
--- a/examples/providers/github-write-operations.yaml
+++ b/examples/providers/github-write-operations.yaml
@@ -2,7 +2,6 @@
 # Warning: Write operations modify real repositories. Use with care.
 #
 # Run: scafctl run solution -f examples/providers/github-write-operations.yaml
-# Run: scafctl run resolver -f examples/providers/github-write-operations.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -14,6 +13,7 @@ metadata:
     GitHub provider write operations: issues, PRs, commits, branches, tags,
     releases, repo management, rulesets, and security settings.
     Commits are automatically GPG-signed via createCommitOnBranch.
+    Write operations must be used in workflow actions, not resolvers.
 
 spec:
   resolvers:
@@ -29,147 +29,210 @@ spec:
               owner: cli
               repo: cli
 
-    # Write operation examples (commented - uncomment to use)
-    #
-    # Create an issue:
-    #   new-issue:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_issue
-    #             owner: my-org
-    #             repo: my-repo
-    #             title: "Bug: something is broken"
-    #             body: "Steps to reproduce..."
-    #             labels:
-    #               - bug
-    #               - priority/high
-    #
-    # Create a pull request:
-    #   new-pr:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_pull_request
-    #             owner: my-org
-    #             repo: my-repo
-    #             title: "feat: add new scaffolding templates"
-    #             body: "This PR adds new templates."
-    #             head: feature-branch
-    #             base: main
-    #             draft: true
-    #
-    # Create a signed commit:
-    #   signed-commit:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_commit
-    #             owner: my-org
-    #             repo: my-repo
-    #             branch: feature-branch
-    #             message: "feat: add scaffolded project files"
-    #             expected_head_oid: abc123def456789012345678901234567890abcd
-    #             additions:
-    #               - path: src/main.go
-    #                 content: "package main"
-    #
-    # Create a release:
-    #   new-release:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_release
-    #             owner: my-org
-    #             repo: my-repo
-    #             tag_name: v1.0.0
-    #             name: "Release 1.0.0"
-    #             body: "First stable release"
-    #             prerelease: false
-    #             target_commitish: main
-    #
-    # Create a repository (GraphQL, REST fallback for EMU):
-    #   new-repo:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_repo
-    #             owner: my-org
-    #             repo: my-new-repo
-    #             description: "A new project"
-    #             visibility: private
-    #             auto_init: true
-    #
-    # Create a branch protection ruleset (REST):
-    #   branch-ruleset:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_ruleset
-    #             owner: my-org
-    #             repo: my-repo
-    #             ruleset_name: main branch protection
-    #             target: branch
-    #             enforcement: active
-    #             include_refs:
-    #               - refs/heads/main
-    #             required_status_checks_contexts:
-    #               - test
-    #               - lint
-    #             required_approving_review_count: 1
-    #             required_linear_history: true
-    #             requires_commit_signatures: true
-    #             allow_force_pushes: false
-    #             allow_deletions: false
-    #
-    # Create a tag protection ruleset (REST):
-    #   tag-ruleset:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: create_ruleset
-    #             owner: my-org
-    #             repo: my-repo
-    #             ruleset_name: version tag protection
-    #             target: tag
-    #             enforcement: active
-    #             include_refs:
-    #               - "refs/tags/v*"
-    #             allow_deletions: false
-    #             allow_force_pushes: false
-    #
-    # Enable vulnerability alerts (REST):
-    #   vuln-alerts:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: enable_vulnerability_alerts
-    #             owner: my-org
-    #             repo: my-repo
-    #
-    # Enable automated security fixes (REST):
-    #   auto-security-fixes:
-    #     type: any
-    #     resolve:
-    #       with:
-    #         - provider: github
-    #           inputs:
-    #             operation: enable_automated_security_fixes
-    #             owner: my-org
-    #             repo: my-repo
+  # Write operations go in workflow actions -- the write-op guard rejects
+  # these in resolver context.
+  workflow:
+    actions:
+      # Write operation examples (commented - uncomment to use)
+      #
+      # Create an issue:
+      # new-issue:
+      #   provider: github
+      #   inputs:
+      #     operation: create_issue
+      #     owner: my-org
+      #     repo: my-repo
+      #     title: "Bug: something is broken"
+      #     body: "Steps to reproduce..."
+      #     labels:
+      #       - bug
+      #       - priority/high
+      #
+      # Create a pull request:
+      # new-pr:
+      #   provider: github
+      #   inputs:
+      #     operation: create_pull_request
+      #     owner: my-org
+      #     repo: my-repo
+      #     title: "feat: add new scaffolding templates"
+      #     body: "This PR adds new templates."
+      #     head: feature-branch
+      #     base: main
+      #     draft: true
+      #
+      # Create a signed commit:
+      # signed-commit:
+      #   provider: github
+      #   inputs:
+      #     operation: create_commit
+      #     owner: my-org
+      #     repo: my-repo
+      #     branch: feature-branch
+      #     message: "feat: add scaffolded project files"
+      #     expected_head_oid: abc123def456789012345678901234567890abcd
+      #     additions:
+      #       - path: src/main.go
+      #         content: "package main"
+      #
+      # Create a release:
+      # new-release:
+      #   provider: github
+      #   inputs:
+      #     operation: create_release
+      #     owner: my-org
+      #     repo: my-repo
+      #     tag_name: v1.0.0
+      #     name: "Release 1.0.0"
+      #     body: "First stable release"
+      #     prerelease: false
+      #     target_commitish: main
+      #
+      # Create a repository (GraphQL, REST fallback for EMU):
+      # new-repo:
+      #   provider: github
+      #   inputs:
+      #     operation: create_repo
+      #     owner: my-org
+      #     repo: my-new-repo
+      #     description: "A new project"
+      #     visibility: private
+      #     auto_init: true
+      #
+      # Create a branch protection ruleset (REST):
+      # branch-ruleset:
+      #   provider: github
+      #   inputs:
+      #     operation: create_ruleset
+      #     owner: my-org
+      #     repo: my-repo
+      #     ruleset_name: main branch protection
+      #     target: branch
+      #     enforcement: active
+      #     include_refs:
+      #       - refs/heads/main
+      #     required_status_checks_contexts:
+      #       - test
+      #       - lint
+      #     required_approving_review_count: 1
+      #     required_linear_history: true
+      #     requires_commit_signatures: true
+      #     allow_force_pushes: false
+      #     allow_deletions: false
+      #
+      # Create a tag protection ruleset (REST):
+      # tag-ruleset:
+      #   provider: github
+      #   inputs:
+      #     operation: create_ruleset
+      #     owner: my-org
+      #     repo: my-repo
+      #     ruleset_name: version tag protection
+      #     target: tag
+      #     enforcement: active
+      #     include_refs:
+      #       - "refs/tags/v*"
+      #     allow_deletions: false
+      #     allow_force_pushes: false
+      #
+      # Enable vulnerability alerts (REST):
+      # vuln-alerts:
+      #   provider: github
+      #   inputs:
+      #     operation: enable_vulnerability_alerts
+      #     owner: my-org
+      #     repo: my-repo
+      #
+      # Enable automated security fixes (REST):
+      # auto-security-fixes:
+      #   provider: github
+      #   inputs:
+      #     operation: enable_automated_security_fixes
+      #     owner: my-org
+      #     repo: my-repo
+      #
+      # ─── v2.1 operations ──────────────────────────────────────────────
+      #
+      # Generic API call (escape hatch for any endpoint):
+      # custom-api-call:
+      #   provider: github
+      #   inputs:
+      #     operation: api_call
+      #     endpoint: /repos/my-org/my-repo/labels
+      #     method: GET
+      #
+      # Create a label:
+      # new-label:
+      #   provider: github
+      #   inputs:
+      #     operation: create_label
+      #     owner: my-org
+      #     repo: my-repo
+      #     label_name: help-wanted
+      #     color: "00ff00"
+      #     label_description: "Extra attention is needed"
+      #
+      # Add reaction to an issue:
+      # react-to-issue:
+      #   provider: github
+      #   inputs:
+      #     operation: add_reaction
+      #     owner: my-org
+      #     repo: my-repo
+      #     number: 42
+      #     reaction_content: "+1"
+      #
+      # Dispatch a workflow:
+      # trigger-ci:
+      #   provider: github
+      #   inputs:
+      #     operation: dispatch_workflow
+      #     owner: my-org
+      #     repo: my-repo
+      #     workflow_id: ci.yml
+      #     ref: main
+      #     workflow_inputs:
+      #       environment: staging
+      #
+      # Create a webhook:
+      # new-webhook:
+      #   provider: github
+      #   inputs:
+      #     operation: create_webhook
+      #     owner: my-org
+      #     repo: my-repo
+      #     webhook_url: https://example.com/webhook
+      #     webhook_events:
+      #       - push
+      #       - pull_request
+      #
+      # Update repository settings:
+      # configure-repo:
+      #   provider: github
+      #   inputs:
+      #     operation: update_repo
+      #     owner: my-org
+      #     repo: my-repo
+      #     description: "Updated description"
+      #     has_wiki: false
+      #     delete_branch_on_merge: true
+      #
+      # Fork a repository:
+      # fork:
+      #   provider: github
+      #   inputs:
+      #     operation: fork_repo
+      #     owner: upstream-org
+      #     repo: upstream-repo
+      #     organization: my-org
+      #     default_branch_only: true
+      #
+      # Add collaborator:
+      # add-user:
+      #   provider: github
+      #   inputs:
+      #     operation: add_collaborator
+      #     owner: my-org
+      #     repo: my-repo
+      #     username: new-contributor
+      #     permission: push

--- a/examples/solutions/github-provider-validation/solution.yaml
+++ b/examples/solutions/github-provider-validation/solution.yaml
@@ -1,0 +1,508 @@
+# GitHub Provider Validation Solution
+#
+# Demonstrates the proper scafctl pattern: resolvers READ data, actions WRITE.
+# All operations target oakwood-commons/scafctl-test-sandbox (a dedicated sandbox).
+#
+# Prerequisites: scafctl auth login github
+#
+# Run:  scafctl run solution -f examples/solutions/github-provider-validation/solution.yaml
+# Run:  scafctl run solution -f examples/solutions/github-provider-validation/solution.yaml -r org=my-org -r repo=my-repo
+# Test: scafctl run action -f examples/solutions/github-provider-validation/solution.yaml test-pr
+# Clean: scafctl run action -f examples/solutions/github-provider-validation/solution.yaml clean-pr
+# Lint: scafctl lint -f examples/solutions/github-provider-validation/solution.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: github-provider-validation
+  version: 1.0.0
+  description: |
+    End-to-end validation of GitHub provider v2.1 operations.
+    Resolvers gather data from oakwood-commons/scafctl-test-sandbox,
+    then workflow actions create, update, and clean up test resources.
+
+spec:
+  # =====================================================================
+  # RESOLVERS -- Read-only data gathering
+  # =====================================================================
+  resolvers:
+    # ─── Parameters (overridable from CLI with -r) ────────────────────────
+
+    org:
+      description: GitHub organization or user
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: org
+          - provider: static
+            inputs:
+              value: oakwood-commons
+
+    repo:
+      description: GitHub repository name
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: repo
+          - provider: static
+            inputs:
+              value: scafctl-test-sandbox
+
+    # ─── GitHub data resolvers ────────────────────────────────────────────
+
+    labels:
+      description: List all repository labels
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_labels
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    milestones:
+      description: List all milestones
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_milestones
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    topics:
+      description: List repository topics
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_topics
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    collaborators:
+      description: List repository collaborators
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_collaborators
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    webhooks:
+      description: List repository webhooks
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_webhooks
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    workflow-runs:
+      description: List recent workflow runs
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_workflow_runs
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+              per_page: 5
+
+    environments:
+      description: List deployment environments
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_environments
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    repo-variables:
+      description: List repository action variables
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_repo_variables
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    repo-info:
+      description: Fetch repo metadata
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_repo
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    custom-properties:
+      description: List custom properties set on the repository
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_custom_properties
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+
+    readme:
+      description: Fetch the repository README
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: get_file
+              owner: {rslvr: org}
+              repo: {rslvr: repo}
+              path: README.md
+
+    # ─── Derived data ─────────────────────────────────────────────────────
+
+    label-count:
+      description: Count of labels before changes
+      type: int
+      dependsOn: [labels]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "size(_['labels'].result)"
+
+    topic-names:
+      description: Current topic names
+      type: any
+      dependsOn: [topics]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_['topics'].result.names"
+
+  # =====================================================================
+  # WORKFLOW -- Write operations (create, update, clean up)
+  # =====================================================================
+  workflow:
+    actions:
+      # ─── Step 1: Create test resources ──────────────────────────────────
+
+      create-label:
+        description: Create a test label
+        displayName: Create Label
+        provider: github
+        onError: continue
+        inputs:
+          operation: create_label
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          label_name: scafctl-validation-test
+          color: "1d76db"
+          label_description: "Created by github-provider-validation solution"
+
+      create-milestone:
+        description: Create a test milestone
+        displayName: Create Milestone
+        provider: github
+        onError: continue
+        inputs:
+          operation: create_milestone
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          title: validation-milestone
+          description: "Created by github-provider-validation solution"
+
+      set-topics:
+        description: Set repository topics
+        displayName: Set Topics
+        provider: github
+        inputs:
+          operation: replace_topics
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          topics:
+            - golang
+            - cli
+            - scaffolding
+            - cel
+            - validation-test
+
+      set-custom-properties:
+        description: Set custom properties on the repository
+        displayName: Set Custom Properties
+        provider: github
+        onError: continue
+        inputs:
+          operation: set_custom_properties
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          properties:
+            environment: validation
+            team: platform-engineering
+
+      # ─── Step 2: Update resources ──────────────────────────────────────
+
+      update-label:
+        description: Update the test label
+        displayName: Update Label
+        provider: github
+        dependsOn: [create-label]
+        inputs:
+          operation: update_label
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          label_name: scafctl-validation-test
+          color: "e4e669"
+          new_label_name: scafctl-validation-updated
+
+      update-repo:
+        description: Update repository description
+        displayName: Update Repo Settings
+        provider: github
+        inputs:
+          operation: update_repo
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          description: "Sandbox repo for scafctl GitHub provider validation (updated)"
+          has_wiki: false
+          delete_branch_on_merge: true
+
+      # ─── Step 3: Clean up ──────────────────────────────────────────────
+
+      delete-label:
+        description: Delete the test label
+        displayName: Cleanup Label
+        provider: github
+        dependsOn: [update-label]
+        onError: continue
+        inputs:
+          operation: delete_label
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          label_name: scafctl-validation-updated
+
+      restore-topics:
+        description: Restore topics to clean state
+        displayName: Restore Topics
+        provider: github
+        dependsOn: [set-topics]
+        inputs:
+          operation: replace_topics
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          topics:
+            - golang
+            - cli
+            - scaffolding
+            - cel
+            - devops
+
+      restore-custom-properties:
+        description: Restore custom properties to defaults
+        displayName: Restore Custom Properties
+        provider: github
+        dependsOn: [set-custom-properties]
+        onError: continue
+        inputs:
+          operation: set_custom_properties
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          properties:
+            environment: sandbox
+            team: scafctl
+
+      restore-repo:
+        description: Restore repository description
+        displayName: Restore Repo Settings
+        provider: github
+        dependsOn: [update-repo]
+        inputs:
+          operation: update_repo
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          description: "Sandbox repo for scafctl GitHub provider validation"
+
+      # ─── test-pr: Create branch, commit file, open PR ──────────────────
+      #
+      # Usage: scafctl run action -f solution.yaml test-pr
+      #   (runs the full chain via dependencies)
+
+      msg-pr-start:
+        description: Announce PR workflow
+        displayName: Start
+        provider: message
+        inputs:
+          message: "🚀 Starting PR workflow: get HEAD → create branch → commit → open PR"
+          type: info
+
+      get-main-head:
+        description: Get the HEAD OID of main branch
+        displayName: Get Main HEAD
+        provider: github
+        dependsOn: [msg-pr-start]
+        inputs:
+          operation: get_head_oid
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          branch: main
+
+      msg-head-oid:
+        description: Show the HEAD OID
+        displayName: Show HEAD
+        provider: message
+        dependsOn: [get-main-head]
+        inputs:
+          message: {expr: "'📌 Got main HEAD: ' + __actions['get-main-head'].results.result.oid"}
+          type: success
+
+      create-feature-branch:
+        description: Create a feature branch from main
+        displayName: Create Branch
+        provider: github
+        dependsOn: [msg-head-oid]
+        inputs:
+          operation: create_branch
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          branch: scafctl-validation-branch
+          oid: {expr: "__actions['get-main-head'].results.result.oid"}
+
+      msg-branch-created:
+        description: Confirm branch creation
+        displayName: Branch Created
+        provider: message
+        dependsOn: [create-feature-branch]
+        inputs:
+          message: "🌿 Created branch: scafctl-validation-branch"
+          type: success
+
+      commit-file:
+        description: Commit a new file to the feature branch
+        displayName: Commit File
+        provider: github
+        dependsOn: [msg-branch-created]
+        inputs:
+          operation: create_commit
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          branch: scafctl-validation-branch
+          message: "chore: add validation test file"
+          message_body: "Created by github-provider-validation solution"
+          expected_head_oid: {expr: "__actions['get-main-head'].results.result.oid"}
+          additions:
+            - path: validation/test.txt
+              content: |
+                This file was created by scafctl github-provider-validation.
+
+      msg-file-committed:
+        description: Confirm file commit
+        displayName: File Committed
+        provider: message
+        dependsOn: [commit-file]
+        inputs:
+          message: "📄 Committed validation/test.txt to scafctl-validation-branch"
+          type: success
+
+      open-pr:
+        description: Open a pull request for the feature branch
+        displayName: Open PR
+        provider: github
+        dependsOn: [msg-file-committed]
+        inputs:
+          operation: create_pull_request
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          title: "chore: scafctl validation test"
+          head: scafctl-validation-branch
+          base: main
+          body: |
+            Automated PR created by `github-provider-validation` solution.
+            Run `scafctl run action -f solution.yaml clean-pr` to clean up.
+
+      test-pr:
+        description: Show PR result
+        displayName: Test PR
+        provider: message
+        dependsOn: [open-pr]
+        inputs:
+          message: {expr: "'🔗 Opened PR #' + string(__actions['open-pr'].results.result.number) + ': ' + __actions['open-pr'].results.result.url"}
+          type: success
+
+      # ─── clean-pr: Close any open validation PR and delete branch ──────
+      #
+      # Usage: scafctl run action -f solution.yaml clean-pr
+      #   (runs independently -- no dependency on test-pr)
+
+      msg-clean-start:
+        description: Announce cleanup
+        displayName: Cleanup Start
+        provider: message
+        inputs:
+          message: "🧹 Cleaning up: finding PR, closing, and deleting branch..."
+          type: info
+
+      find-validation-pr:
+        description: Find open PR from validation branch
+        displayName: Find PR
+        provider: github
+        dependsOn: [msg-clean-start]
+        inputs:
+          operation: list_pull_requests
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          state: open
+          head: scafctl-validation-branch
+
+      close-validation-pr:
+        description: Close the validation PR (if found)
+        displayName: Close PR
+        provider: github
+        dependsOn: [find-validation-pr]
+        onError: continue
+        when: {expr: "size(__actions['find-validation-pr'].results.result) > 0"}
+        inputs:
+          operation: close_pull_request
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          number: {expr: "int(__actions['find-validation-pr'].results.result[0].number)"}
+
+      delete-validation-branch:
+        description: Delete the validation branch
+        displayName: Delete Branch
+        provider: github
+        dependsOn: [close-validation-pr]
+        onError: continue
+        inputs:
+          operation: delete_branch
+          owner: {rslvr: org}
+          repo: {rslvr: repo}
+          branch: scafctl-validation-branch
+
+      clean-pr:
+        description: Cleanup complete
+        displayName: Clean PR
+        provider: message
+        dependsOn: [delete-validation-branch]
+        inputs:
+          message: "✅ Cleaned up: validation PR closed and branch deleted"
+          type: success

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/mark3labs/mcp-go v0.47.1
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.10.1
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.2.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/oakwood-commons/httpc v0.1.0 h1:syQbjqerxGEVngGWOtyGhkwFFUnJekm+amnuK
 github.com/oakwood-commons/httpc v0.1.0/go.mod h1:vQ7KZ7NK7tF9Inqzikuo1HKozTw2Y0tHMp316PqwkEA=
 github.com/oakwood-commons/kvx v0.10.1 h1:Mgf3FxiaY0jgZAJIpFvIn1ia5xzzgpl3tQn/vKzveDQ=
 github.com/oakwood-commons/kvx v0.10.1/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1 h1:oroVda37T0o38ldr+by+ZgB+bmHYb8yRp0ep3xXmn24=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.1.1/go.mod h1:rTVtlxWjYBdgcUWEOrdQJF1jBEFtYLtSjZThx8nZEr0=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.2.0 h1:2heU9E2pJJ+WEuCB8QYZdJp8mN2plzwgu4zGZZiE1YQ=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.2.0/go.mod h1:rTVtlxWjYBdgcUWEOrdQJF1jBEFtYLtSjZThx8nZEr0=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/provider/builtin/githubprovider/github.go
+++ b/pkg/provider/builtin/githubprovider/github.go
@@ -77,8 +77,30 @@ var allOperations = []string{
 	// Release write operations (REST)
 	"create_release", "update_release", "delete_release",
 	// Repository management operations (GraphQL + REST)
-	"create_repo", "create_ruleset",
+	"create_repo", "update_repo", "create_ruleset",
 	"enable_vulnerability_alerts", "enable_automated_security_fixes",
+	// Label operations (REST)
+	"list_labels", "create_label", "update_label", "delete_label",
+	"add_labels_to_issue", "remove_label_from_issue",
+	// Milestone operations (REST)
+	"list_milestones", "create_milestone", "update_milestone", "delete_milestone",
+	// Reaction operations (REST)
+	"add_reaction", "list_reactions", "delete_reaction",
+	// Collaborator operations (REST)
+	"list_collaborators", "add_collaborator", "remove_collaborator",
+	// Webhook operations (REST)
+	"list_webhooks", "create_webhook", "update_webhook", "delete_webhook",
+	// GitHub Actions operations (REST)
+	"dispatch_workflow", "list_workflow_runs", "cancel_workflow_run", "rerun_workflow",
+	"list_repo_variables", "create_or_update_variable", "delete_variable",
+	"list_environments", "create_or_update_environment", "delete_environment",
+	// Repository settings (REST)
+	"list_topics", "replace_topics",
+	"fork_repo", "create_from_template",
+	// Custom properties (REST)
+	"list_custom_properties", "set_custom_properties",
+	// Generic API call (REST)
+	"api_call",
 }
 
 // readOperations are operations that return data (CapabilityFrom/Transform).
@@ -92,7 +114,17 @@ var readOperations = map[string]bool{
 	"list_pr_comments":    true,
 	"list_review_threads": true,
 	"list_check_runs":     true, "get_workflow_run": true,
-	"list_commit_pulls": true,
+	"list_commit_pulls":      true,
+	"list_labels":            true,
+	"list_milestones":        true,
+	"list_reactions":         true,
+	"list_collaborators":     true,
+	"list_webhooks":          true,
+	"list_workflow_runs":     true,
+	"list_repo_variables":    true,
+	"list_environments":      true,
+	"list_topics":            true,
+	"list_custom_properties": true,
 }
 
 // GitHubProvider implements GitHub API operations as a provider.
@@ -135,7 +167,7 @@ func WithRetryConfig(commitMaxAttempts int, commitRetryBackoff time.Duration, wa
 
 // NewGitHubProvider creates a new GitHub API provider.
 func NewGitHubProvider(opts ...Option) *GitHubProvider {
-	version, _ := semver.NewVersion("2.0.0")
+	version, _ := semver.NewVersion("2.1.0")
 
 	p := &GitHubProvider{
 		commitMaxAttempts:    defaultCommitMaxAttempts,
@@ -150,7 +182,9 @@ func NewGitHubProvider(opts ...Option) *GitHubProvider {
 			APIVersion:  "v1",
 			Version:     version,
 			Description: "Interact with GitHub via GraphQL (reads, issues, PRs, review threads, signed commits, branches, tags, " +
-				"repos, branch protection) and REST (releases, CI check runs, workflow runs, tag protection, security settings). " +
+				"repos, branch protection) and REST (releases, CI check runs, workflow runs, labels, milestones, reactions, " +
+				"collaborators, webhooks, Actions workflows, variables, environments, repo settings, tag protection, security settings). " +
+				"Includes a generic api_call operation for arbitrary GitHub REST endpoints. " +
 				"Uses the configured GitHub auth handler automatically. " +
 				"Commit operations use createCommitOnBranch for GPG-signed multi-file atomic commits.",
 			Category: "data",
@@ -170,7 +204,48 @@ func NewGitHubProvider(opts ...Option) *GitHubProvider {
 				provider.CapabilityTransform,
 				provider.CapabilityAction,
 			},
-			Schema: buildInputSchema(),
+			// WriteOperations lists operations that mutate state.
+			// These are rejected in resolver (CapabilityFrom) context.
+			// api_call is intentionally excluded: the user controls the HTTP method,
+			// so it cannot be classified as read or write at the provider level.
+			WriteOperations: []string{
+				// Review thread mutations
+				"reply_to_review_thread", "resolve_review_thread",
+				// Issue mutations
+				"create_issue", "update_issue", "create_issue_comment",
+				// PR mutations
+				"create_pull_request", "update_pull_request", "merge_pull_request", "close_pull_request",
+				// Commit & ref mutations
+				"create_commit",
+				"create_branch", "delete_branch", "create_tag", "delete_tag",
+				// Release mutations
+				"create_release", "update_release", "delete_release",
+				// Repository management
+				"create_repo", "update_repo", "create_ruleset",
+				"enable_vulnerability_alerts", "enable_automated_security_fixes",
+				// Label mutations
+				"create_label", "update_label", "delete_label",
+				"add_labels_to_issue", "remove_label_from_issue",
+				// Milestone mutations
+				"create_milestone", "update_milestone", "delete_milestone",
+				// Reaction mutations
+				"add_reaction", "delete_reaction",
+				// Collaborator mutations
+				"add_collaborator", "remove_collaborator",
+				// Webhook mutations
+				"create_webhook", "update_webhook", "delete_webhook",
+				// GitHub Actions mutations
+				"dispatch_workflow", "cancel_workflow_run", "rerun_workflow",
+				"create_or_update_variable", "delete_variable",
+				"create_or_update_environment", "delete_environment",
+				// Repository settings mutations
+				"replace_topics",
+				"fork_repo", "create_from_template",
+				// Custom properties mutations
+				"set_custom_properties",
+			},
+			SensitiveFields: []string{"webhook_secret"},
+			Schema:          buildInputSchema(),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"result": schemahelper.AnyProp("The API response data — structure varies by operation"),
@@ -322,6 +397,80 @@ ref: main`,
 owner: my-org
 repo: my-repo
 run_id: 12345678`,
+				},
+				{
+					Name:        "Generic API call",
+					Description: "Call any GitHub REST endpoint using the authenticated client",
+					YAML: `operation: api_call
+api_base: https://api.github.com
+endpoint: /repos/my-org/my-repo/labels
+method: POST
+request_body:
+  name: help-wanted
+  color: "00ff00"
+  description: "Extra attention is needed"`,
+				},
+				{
+					Name:        "Create a label",
+					Description: "Create a repository label with color",
+					YAML: `operation: create_label
+owner: my-org
+repo: my-repo
+label_name: bug
+color: d73a4a
+label_description: "Something isn't working"`,
+				},
+				{
+					Name:        "Add reaction to issue",
+					Description: "React to an issue with a thumbs up",
+					YAML: `operation: add_reaction
+owner: my-org
+repo: my-repo
+number: 42
+reaction_content: "+1"`,
+				},
+				{
+					Name:        "Dispatch a workflow",
+					Description: "Trigger a GitHub Actions workflow",
+					YAML: `operation: dispatch_workflow
+owner: my-org
+repo: my-repo
+workflow_id: ci.yml
+ref: main
+workflow_inputs:
+  environment: production`,
+				},
+				{
+					Name:        "Create a webhook",
+					Description: "Set up a repository webhook",
+					YAML: `operation: create_webhook
+owner: my-org
+repo: my-repo
+webhook_url: https://example.com/webhook
+webhook_events:
+  - push
+  - pull_request
+webhook_secret: my-secret`,
+				},
+				{
+					Name:        "Update repository settings",
+					Description: "Configure repository features and merge settings",
+					YAML: `operation: update_repo
+owner: my-org
+repo: my-repo
+description: "Updated project description"
+has_wiki: false
+delete_branch_on_merge: true
+allow_squash_merge: true`,
+				},
+				{
+					Name:        "Fork a repository",
+					Description: "Fork a repository into an organization",
+					YAML: `operation: fork_repo
+owner: upstream-org
+repo: upstream-repo
+organization: my-org
+default_branch_only: true`,
 				},
 			},
 			Links: []provider.Link{
@@ -537,6 +686,155 @@ func buildInputSchema() *jsonschema.Schema {
 			"allow_force_pushes":         schemahelper.BoolProp("Allow force pushes to matching refs"),
 			"allow_deletions":            schemahelper.BoolProp("Allow deletion of matching refs"),
 			"requires_commit_signatures": schemahelper.BoolProp("Require signed commits"),
+
+			// --- Label fields ---
+			"label_name": schemahelper.StringProp("Label name for create/update/delete label operations",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"new_label_name": schemahelper.StringProp("New name when renaming a label (update_label)",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"color": schemahelper.StringProp("Hex color code for labels (without #)",
+				schemahelper.WithPattern("^[0-9a-fA-F]{6}$"),
+				schemahelper.WithExample("00ff00"),
+			),
+			"label_description": schemahelper.StringProp("Description for a label",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(1000)),
+			),
+
+			// --- Milestone fields ---
+			"milestone_number": schemahelper.IntProp("Milestone number for update/delete operations",
+				schemahelper.WithMinimum(1),
+			),
+			"due_on": schemahelper.StringProp("Due date for milestone (ISO 8601: YYYY-MM-DDTHH:MM:SSZ)",
+				schemahelper.WithFormat("date-time"),
+			),
+
+			// --- Reaction fields ---
+			"reaction_content": schemahelper.StringProp("Reaction emoji to add",
+				schemahelper.WithEnum("+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"),
+			),
+			"reaction_subject": schemahelper.StringProp("Subject type for the reaction",
+				schemahelper.WithEnum("issue", "pull_request", "issue_comment"),
+				schemahelper.WithDefault("issue"),
+			),
+			"reaction_id": schemahelper.IntProp("Reaction ID for delete_reaction",
+				schemahelper.WithMinimum(1),
+			),
+			"comment_id": schemahelper.IntProp("Comment ID for reaction/comment operations",
+				schemahelper.WithMinimum(1),
+			),
+
+			// --- Collaborator fields ---
+			"username": schemahelper.StringProp("GitHub username for collaborator operations",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"permission": schemahelper.StringProp("Permission level for collaborators",
+				schemahelper.WithEnum("pull", "triage", "push", "maintain", "admin"),
+			),
+
+			// --- Webhook fields ---
+			"webhook_url": schemahelper.StringProp("Payload URL for the webhook",
+				schemahelper.WithFormat("uri"),
+			),
+			"webhook_events": schemahelper.ArrayProp("Events that trigger the webhook",
+				schemahelper.WithItems(schemahelper.StringProp("Event name")),
+				schemahelper.WithMaxItems(50),
+			),
+			"webhook_content_type": schemahelper.StringProp("Content type for webhook payloads",
+				schemahelper.WithEnum("json", "form"),
+				schemahelper.WithDefault("json"),
+			),
+			"webhook_secret": schemahelper.StringProp("Secret for webhook signature verification"),
+			"webhook_active": schemahelper.BoolProp("Whether the webhook is active"),
+			"hook_id": schemahelper.IntProp("Webhook ID for update/delete operations",
+				schemahelper.WithMinimum(1),
+			),
+
+			// --- GitHub Actions fields ---
+			"workflow_id": schemahelper.StringProp("Workflow file name or ID (e.g. ci.yml or numeric ID)",
+				schemahelper.WithExample("ci.yml"),
+			),
+			"workflow_inputs": schemahelper.ObjectProp("Input parameters for workflow dispatch",
+				nil, nil,
+			),
+			"workflow_status": schemahelper.StringProp("Filter workflow runs by status",
+				schemahelper.WithEnum("completed", "action_required", "cancelled", "failure", "neutral",
+					"skipped", "stale", "success", "timed_out", "in_progress", "queued", "requested", "waiting"),
+			),
+
+			// --- Variable fields ---
+			"variable_name": schemahelper.StringProp("Repository variable name",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"variable_value": schemahelper.StringProp("Repository variable value",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(65536)),
+			),
+
+			// --- Environment fields ---
+			"environment_name": schemahelper.StringProp("Deployment environment name",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"wait_timer": schemahelper.IntProp("Wait timer in minutes before deployments proceed",
+				schemahelper.WithMinimum(0),
+				schemahelper.WithMaximum(43200),
+			),
+			"reviewers": schemahelper.ArrayProp("Required reviewers for environment (objects with 'type' and 'id', e.g. [{\"type\": \"User\", \"id\": 123}])",
+				schemahelper.WithItems(schemahelper.ObjectProp("Reviewer object", nil, nil)),
+				schemahelper.WithMaxItems(6),
+			),
+
+			// --- Repo settings fields ---
+			"homepage": schemahelper.StringProp("Repository homepage URL",
+				schemahelper.WithFormat("uri"),
+			),
+			"default_branch": schemahelper.StringProp("Default branch name",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"has_issues":             schemahelper.BoolProp("Enable issues feature"),
+			"has_projects":           schemahelper.BoolProp("Enable projects feature"),
+			"has_wiki":               schemahelper.BoolProp("Enable wiki feature"),
+			"allow_squash_merge":     schemahelper.BoolProp("Allow squash merging"),
+			"allow_merge_commit":     schemahelper.BoolProp("Allow merge commits"),
+			"allow_rebase_merge":     schemahelper.BoolProp("Allow rebase merging"),
+			"delete_branch_on_merge": schemahelper.BoolProp("Automatically delete head branches after merge"),
+			"archived":               schemahelper.BoolProp("Archive the repository"),
+			"topics": schemahelper.ArrayProp("Repository topics/tags",
+				schemahelper.WithItems(schemahelper.StringProp("Topic name")),
+				schemahelper.WithMaxItems(20),
+			),
+			"organization": schemahelper.StringProp("Organization to fork into (fork_repo)",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"default_branch_only": schemahelper.BoolProp("Fork only the default branch"),
+			"new_repo_name": schemahelper.StringProp("Name for new repository (create_from_template)",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"new_owner": schemahelper.StringProp("Owner for new repository (create_from_template)",
+				schemahelper.WithMaxLength(*ptrs.IntPtr(200)),
+			),
+			"include_all_branches": schemahelper.BoolProp("Include all branches when creating from template"),
+
+			// --- Custom properties fields ---
+			"properties": schemahelper.ObjectProp("Custom properties to set (key-value map, e.g. {\"env\": \"prod\", \"team\": \"platform\"})",
+				nil, nil,
+			),
+
+			// --- Generic API call fields ---
+			"endpoint": schemahelper.StringProp("Relative API path for api_call (e.g. /repos/{owner}/{repo}/labels). Must start with /.",
+				schemahelper.WithExample("/repos/octocat/hello-world/labels"),
+				schemahelper.WithMaxLength(*ptrs.IntPtr(2000)),
+			),
+			"method": schemahelper.StringProp("HTTP method for api_call",
+				schemahelper.WithEnum("GET", "POST", "PUT", "PATCH", "DELETE"),
+				schemahelper.WithDefault("GET"),
+			),
+			"query_params": schemahelper.ObjectProp("Query parameters for api_call",
+				nil, nil,
+			),
+			"request_body": schemahelper.ObjectProp("Request body (JSON object) for api_call POST/PUT/PATCH",
+				nil, nil,
+			),
 		},
 	)
 }
@@ -613,9 +911,9 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 	}
 	apiBase = strings.TrimRight(apiBase, "/")
 
-	// Most operations require owner and repo. Only create_repo handles
+	// Most operations require owner and repo. Only create_repo and api_call handle
 	// these fields internally (owner is optional, repo validated inside).
-	if operation != "create_repo" && (owner == "" || repo == "") {
+	if operation != "create_repo" && operation != "api_call" && (owner == "" || repo == "") {
 		return nil, fmt.Errorf("%s: 'owner' and 'repo' are required for %s operation", ProviderName, operation)
 	}
 
@@ -714,12 +1012,106 @@ func (p *GitHubProvider) Execute(ctx context.Context, input any) (*provider.Outp
 	// --- Repository management operations (GraphQL + REST) ---
 	case "create_repo":
 		result, err = p.executeCreateRepo(ctx, client, apiBase, inputs)
+	case "update_repo":
+		result, err = p.executeUpdateRepo(ctx, client, apiBase, owner, repo, inputs)
 	case "create_ruleset":
 		result, err = p.executeCreateRuleset(ctx, client, apiBase, owner, repo, inputs)
 	case "enable_vulnerability_alerts":
 		result, err = p.executeEnableVulnerabilityAlerts(ctx, client, apiBase, owner, repo)
 	case "enable_automated_security_fixes":
 		result, err = p.executeEnableAutomatedSecurityFixes(ctx, client, apiBase, owner, repo)
+
+	// --- Label operations (REST) ---
+	case "list_labels":
+		result, err = p.executeListLabels(ctx, client, apiBase, owner, repo, inputs)
+	case "create_label":
+		result, err = p.executeCreateLabel(ctx, client, apiBase, owner, repo, inputs)
+	case "update_label":
+		result, err = p.executeUpdateLabel(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_label":
+		result, err = p.executeDeleteLabel(ctx, client, apiBase, owner, repo, inputs)
+	case "add_labels_to_issue":
+		result, err = p.executeAddLabelsToIssue(ctx, client, apiBase, owner, repo, inputs)
+	case "remove_label_from_issue":
+		result, err = p.executeRemoveLabelFromIssue(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Milestone operations (REST) ---
+	case "list_milestones":
+		result, err = p.executeListMilestones(ctx, client, apiBase, owner, repo, inputs)
+	case "create_milestone":
+		result, err = p.executeCreateMilestone(ctx, client, apiBase, owner, repo, inputs)
+	case "update_milestone":
+		result, err = p.executeUpdateMilestone(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_milestone":
+		result, err = p.executeDeleteMilestone(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Reaction operations (REST) ---
+	case "add_reaction":
+		result, err = p.executeAddReaction(ctx, client, apiBase, owner, repo, inputs)
+	case "list_reactions":
+		result, err = p.executeListReactions(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_reaction":
+		result, err = p.executeDeleteReaction(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Collaborator operations (REST) ---
+	case "list_collaborators":
+		result, err = p.executeListCollaborators(ctx, client, apiBase, owner, repo, inputs)
+	case "add_collaborator":
+		result, err = p.executeAddCollaborator(ctx, client, apiBase, owner, repo, inputs)
+	case "remove_collaborator":
+		result, err = p.executeRemoveCollaborator(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Webhook operations (REST) ---
+	case "list_webhooks":
+		result, err = p.executeListWebhooks(ctx, client, apiBase, owner, repo, inputs)
+	case "create_webhook":
+		result, err = p.executeCreateWebhook(ctx, client, apiBase, owner, repo, inputs)
+	case "update_webhook":
+		result, err = p.executeUpdateWebhook(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_webhook":
+		result, err = p.executeDeleteWebhook(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- GitHub Actions operations (REST) ---
+	case "dispatch_workflow":
+		result, err = p.executeDispatchWorkflow(ctx, client, apiBase, owner, repo, inputs)
+	case "list_workflow_runs":
+		result, err = p.executeListWorkflowRuns(ctx, client, apiBase, owner, repo, inputs)
+	case "cancel_workflow_run":
+		result, err = p.executeCancelWorkflowRun(ctx, client, apiBase, owner, repo, inputs)
+	case "rerun_workflow":
+		result, err = p.executeRerunWorkflow(ctx, client, apiBase, owner, repo, inputs)
+	case "list_repo_variables":
+		result, err = p.executeListRepoVariables(ctx, client, apiBase, owner, repo, inputs)
+	case "create_or_update_variable":
+		result, err = p.executeCreateOrUpdateVariable(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_variable":
+		result, err = p.executeDeleteVariable(ctx, client, apiBase, owner, repo, inputs)
+	case "list_environments":
+		result, err = p.executeListEnvironments(ctx, client, apiBase, owner, repo, inputs)
+	case "create_or_update_environment":
+		result, err = p.executeCreateOrUpdateEnvironment(ctx, client, apiBase, owner, repo, inputs)
+	case "delete_environment":
+		result, err = p.executeDeleteEnvironment(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Repo settings (REST) ---
+	case "list_topics":
+		result, err = p.executeListTopics(ctx, client, apiBase, owner, repo)
+	case "replace_topics":
+		result, err = p.executeReplaceTopics(ctx, client, apiBase, owner, repo, inputs)
+	case "fork_repo":
+		result, err = p.executeForkRepo(ctx, client, apiBase, owner, repo, inputs)
+	case "create_from_template":
+		result, err = p.executeCreateFromTemplate(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Custom properties (REST) ---
+	case "list_custom_properties":
+		result, err = p.executeListCustomProperties(ctx, client, apiBase, owner, repo)
+	case "set_custom_properties":
+		result, err = p.executeSetCustomProperties(ctx, client, apiBase, owner, repo, inputs)
+
+	// --- Generic API call (REST) ---
+	case "api_call":
+		result, err = p.executeAPICall(ctx, client, apiBase, inputs)
 
 	default:
 		return nil, fmt.Errorf("%s: unknown operation %q — supported: %s", ProviderName, operation, strings.Join(allOperations, ", "))
@@ -827,6 +1219,15 @@ func requiredInputError(operation, field string, inputs map[string]any, hint str
 		msg += "; " + hint
 	}
 	return fmt.Errorf("%s", msg)
+}
+
+// getMapInput extracts a map[string]any from the input map.
+func getMapInput(inputs map[string]any, key string) map[string]any {
+	v, ok := inputs[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return v
 }
 
 // getStringSliceInput extracts a string slice from the input map.

--- a/pkg/provider/builtin/githubprovider/github_actions.go
+++ b/pkg/provider/builtin/githubprovider/github_actions.go
@@ -1,0 +1,212 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ─── Dispatch Workflow ───────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDispatchWorkflow(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	workflowID := getStringInput(inputs, "workflow_id")
+	if workflowID == "" {
+		return nil, requiredInputError("dispatch_workflow", "workflow_id", inputs, "workflow filename (e.g. ci.yml) or numeric ID")
+	}
+
+	ref := getStringInput(inputs, "ref")
+	if ref == "" {
+		return nil, requiredInputError("dispatch_workflow", "ref", inputs, "branch or tag to run the workflow on")
+	}
+
+	reqBody := map[string]any{
+		"ref": ref,
+	}
+	if workflowInputs := getMapInput(inputs, "workflow_inputs"); len(workflowInputs) > 0 {
+		reqBody["inputs"] = workflowInputs
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/workflows/%s/dispatches", apiBase, owner, repo, url.PathEscape(workflowID))
+	_, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("dispatching workflow: %w", err)
+	}
+	// dispatch_workflow returns 204 No Content on success.
+	return actionOutput("dispatch_workflow", map[string]any{"dispatched": true}), nil
+}
+
+// ─── List Workflow Runs ──────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListWorkflowRuns(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs?per_page=%d", apiBase, owner, repo, perPage)
+
+	if status := getStringInput(inputs, "workflow_status"); status != "" {
+		restURL += "&status=" + url.QueryEscape(status)
+	}
+	if branch := getStringInput(inputs, "branch"); branch != "" {
+		restURL += "&branch=" + url.QueryEscape(branch)
+	}
+
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing workflow runs: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Cancel Workflow Run ─────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCancelWorkflowRun(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	runID, ok := getIntInput(inputs, "run_id")
+	if !ok || runID == 0 {
+		return nil, requiredInputError("cancel_workflow_run", "run_id", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/cancel", apiBase, owner, repo, runID)
+	_, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cancelling workflow run: %w", err)
+	}
+	return actionOutput("cancel_workflow_run", map[string]any{"cancelled": true}), nil
+}
+
+// ─── Rerun Workflow ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeRerunWorkflow(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	runID, ok := getIntInput(inputs, "run_id")
+	if !ok || runID == 0 {
+		return nil, requiredInputError("rerun_workflow", "run_id", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/rerun", apiBase, owner, repo, runID)
+	_, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("rerunning workflow: %w", err)
+	}
+	return actionOutput("rerun_workflow", map[string]any{"rerun": true}), nil
+}
+
+// ─── List Repository Variables ───────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListRepoVariables(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/variables?per_page=%d", apiBase, owner, repo, perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing repo variables: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Create or Update Repository Variable ────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateOrUpdateVariable(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	varName := getStringInput(inputs, "variable_name")
+	if varName == "" {
+		return nil, requiredInputError("create_or_update_variable", "variable_name", inputs, "")
+	}
+	varValue := getStringInput(inputs, "variable_value")
+	if varValue == "" {
+		return nil, requiredInputError("create_or_update_variable", "variable_value", inputs, "")
+	}
+
+	reqBody := map[string]any{
+		"name":  varName,
+		"value": varValue,
+	}
+
+	// Try to update first (PATCH). If the variable doesn't exist (404), create it (POST).
+	updateURL := fmt.Sprintf("%s/repos/%s/%s/actions/variables/%s", apiBase, owner, repo, url.PathEscape(varName))
+	_, err := p.doRESTRequest(ctx, client, http.MethodPatch, updateURL, reqBody)
+	if err != nil {
+		var re *restError
+		if !errors.As(err, &re) || re.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("updating variable: %w", err)
+		}
+		// Variable not found -- create it.
+		createURL := fmt.Sprintf("%s/repos/%s/%s/actions/variables", apiBase, owner, repo)
+		result, createErr := p.doRESTRequest(ctx, client, http.MethodPost, createURL, reqBody)
+		if createErr != nil {
+			return nil, fmt.Errorf("creating variable: %w", createErr)
+		}
+		return actionOutput("create_or_update_variable", result), nil
+	}
+	return actionOutput("create_or_update_variable", map[string]any{"updated": true}), nil
+}
+
+// ─── Delete Repository Variable ──────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteVariable(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	varName := getStringInput(inputs, "variable_name")
+	if varName == "" {
+		return nil, requiredInputError("delete_variable", "variable_name", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/actions/variables/%s", apiBase, owner, repo, url.PathEscape(varName))
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting variable: %w", err)
+	}
+	return actionOutput("delete_variable", result), nil
+}
+
+// ─── List Environments ───────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListEnvironments(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/environments?per_page=%d", apiBase, owner, repo, perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing environments: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Create or Update Environment ────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateOrUpdateEnvironment(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	envName := getStringInput(inputs, "environment_name")
+	if envName == "" {
+		return nil, requiredInputError("create_or_update_environment", "environment_name", inputs, "")
+	}
+
+	reqBody := map[string]any{}
+	if reviewers, ok := inputs["reviewers"].([]any); ok && len(reviewers) > 0 {
+		reqBody["reviewers"] = reviewers
+	}
+	if waitTimer, ok := getIntInput(inputs, "wait_timer"); ok {
+		reqBody["wait_timer"] = waitTimer
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/environments/%s", apiBase, owner, repo, url.PathEscape(envName))
+	result, err := p.doRESTRequest(ctx, client, http.MethodPut, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating/updating environment: %w", err)
+	}
+	return actionOutput("create_or_update_environment", result), nil
+}
+
+// ─── Delete Environment ──────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteEnvironment(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	envName := getStringInput(inputs, "environment_name")
+	if envName == "" {
+		return nil, requiredInputError("delete_environment", "environment_name", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/environments/%s", apiBase, owner, repo, url.PathEscape(envName))
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting environment: %w", err)
+	}
+	return actionOutput("delete_environment", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_actions_test.go
+++ b/pkg/provider/builtin/githubprovider/github_actions_test.go
@@ -1,0 +1,748 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Dispatch Workflow Tests ─────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_DispatchWorkflow(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/actions/workflows/ci.yml/dispatches", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "main", body["ref"])
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":   "dispatch_workflow",
+		"owner":       "test-org",
+		"repo":        "test-repo",
+		"api_base":    baseURL,
+		"workflow_id": "ci.yml",
+		"ref":         "main",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteDispatchWorkflow_MissingWorkflowID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDispatchWorkflow(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"ref": "main",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "workflow_id")
+}
+
+func TestExecuteDispatchWorkflow_MissingRef(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDispatchWorkflow(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"workflow_id": "ci.yml",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ref")
+}
+
+// ─── List Workflow Runs Tests ────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListWorkflowRuns(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/actions/runs")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"total_count":   float64(1),
+			"workflow_runs": []any{map[string]any{"id": float64(1), "status": "completed"}},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_workflow_runs",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, float64(1), result["total_count"])
+}
+
+// ─── Cancel/Rerun Workflow Tests ─────────────────────────────────────────────
+
+func TestExecuteCancelWorkflowRun_MissingRunID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCancelWorkflowRun(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "run_id")
+}
+
+func TestExecuteRerunWorkflow_MissingRunID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeRerunWorkflow(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "run_id")
+}
+
+// ─── Variable Tests ──────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListRepoVariables(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/actions/variables")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"total_count": float64(1),
+			"variables":   []any{map[string]any{"name": "MY_VAR", "value": "hello"}},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_repo_variables",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, float64(1), result["total_count"])
+}
+
+func TestExecuteCreateOrUpdateVariable_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateOrUpdateVariable(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"variable_value": "val",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "variable_name")
+}
+
+func TestExecuteDeleteVariable_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteVariable(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "variable_name")
+}
+
+// ─── Environment Tests ───────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListEnvironments(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/environments", r.URL.Path)
+		assert.Equal(t, "30", r.URL.Query().Get("per_page"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"total_count":  float64(1),
+			"environments": []any{map[string]any{"name": "production"}},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_environments",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	assert.Equal(t, float64(1), result["total_count"])
+}
+
+func TestExecuteCreateOrUpdateEnvironment_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateOrUpdateEnvironment(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "environment_name")
+}
+
+func TestExecuteDeleteEnvironment_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteEnvironment(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "environment_name")
+}
+
+// ─── Repo Settings Tests ─────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_UpdateRepo(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "new description", body["description"])
+		assert.Equal(t, true, body["has_wiki"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"name": "test-repo"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":   "update_repo",
+		"owner":       "test-org",
+		"repo":        "test-repo",
+		"api_base":    baseURL,
+		"description": "new description",
+		"has_wiki":    true,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_ListTopics(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/topics", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"names": []any{"go", "cli"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_topics",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"].(map[string]any)
+	names := result["names"].([]any)
+	assert.Len(t, names, 2)
+}
+
+func TestGitHubProvider_Execute_ForkRepo(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/upstream-org/upstream-repo/forks", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]any{"full_name": "my-org/upstream-repo"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":    "fork_repo",
+		"owner":        "upstream-org",
+		"repo":         "upstream-repo",
+		"api_base":     baseURL,
+		"organization": "my-org",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteCreateFromTemplate_MissingNewName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateFromTemplate(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "new_repo_name")
+}
+
+// ─── Cancel Workflow Run ─────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CancelWorkflowRun(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/actions/runs/123/cancel", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "cancel_workflow_run",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"run_id":    float64(123),
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Rerun Workflow ──────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_RerunWorkflow(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/actions/runs/456/rerun", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "rerun_workflow",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"run_id":    float64(456),
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Create or Update Variable ───────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateOrUpdateVariable(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		// First call is PATCH (update attempt), respond with success
+		if r.Method == http.MethodPatch {
+			assert.Equal(t, "/repos/test-org/test-repo/actions/variables/MY_VAR", r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Errorf("unexpected method: %s", r.Method)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "create_or_update_variable",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"variable_name":  "MY_VAR",
+		"variable_value": "my-value",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_CreateOrUpdateVariable_CreateFallback(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodPatch {
+			// Variable doesn't exist - return 404
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message":"Not Found"}`)) //nolint:errcheck
+			return
+		}
+		if r.Method == http.MethodPost {
+			assert.Equal(t, "/repos/test-org/test-repo/actions/variables", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"name":"MY_VAR","value":"my-value"}`)) //nolint:errcheck
+			return
+		}
+		t.Errorf("unexpected method: %s", r.Method)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "create_or_update_variable",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"variable_name":  "MY_VAR",
+		"variable_value": "my-value",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	assert.Equal(t, 2, callCount, "should have made PATCH then POST")
+}
+
+func TestGitHubProvider_Execute_CreateOrUpdateVariable_NoFallbackOnNon404(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// Return 403 Forbidden -- should NOT trigger create fallback
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"Resource not accessible by integration"}`)) //nolint:errcheck
+	})
+
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "create_or_update_variable",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"variable_name":  "MY_VAR",
+		"variable_value": "my-value",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updating variable")
+	assert.Equal(t, 1, callCount, "should have made only the PATCH call, no POST fallback")
+}
+
+// ─── Delete Variable ─────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_DeleteVariable(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/actions/variables/MY_VAR", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":     "delete_variable",
+		"owner":         "test-org",
+		"repo":          "test-repo",
+		"api_base":      baseURL,
+		"variable_name": "MY_VAR",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Create or Update Environment ────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateOrUpdateEnvironment(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/environments/staging", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"name": "staging"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "create_or_update_environment",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"environment_name": "staging",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Delete Environment ──────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_DeleteEnvironment(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/environments/staging", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "delete_environment",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"environment_name": "staging",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Replace Topics ──────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ReplaceTopics(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/topics", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		names := body["names"].([]any)
+		assert.Len(t, names, 2)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"names": []string{"go", "cli"}}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "replace_topics",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"topics":    []any{"go", "cli"},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_ReplaceTopics_Empty(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"names": []string{}}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "replace_topics",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Create from Template ────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_CreateFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/template-org/template-repo/generate", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "new-project", body["name"])
+		assert.Equal(t, "my-org", body["owner"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"full_name": "my-org/new-project"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":     "create_from_template",
+		"owner":         "template-org",
+		"repo":          "template-repo",
+		"api_base":      baseURL,
+		"new_repo_name": "new-project",
+		"new_owner":     "my-org",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Update Repo ─────────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_UpdateRepo_BoolSettings(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, false, body["has_wiki"])
+		assert.Equal(t, true, body["allow_squash_merge"])
+		assert.Equal(t, true, body["has_issues"])
+		assert.Equal(t, false, body["has_projects"])
+		assert.Equal(t, true, body["allow_merge_commit"])
+		assert.Equal(t, false, body["allow_rebase_merge"])
+		assert.Equal(t, true, body["delete_branch_on_merge"])
+		assert.Equal(t, false, body["archived"])
+		assert.Equal(t, "Updated desc", body["description"])
+		assert.Equal(t, "https://example.com", body["homepage"])
+		assert.Equal(t, "private", body["visibility"])
+		assert.Equal(t, "develop", body["default_branch"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"full_name": "test-org/test-repo"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":              "update_repo",
+		"owner":                  "test-org",
+		"repo":                   "test-repo",
+		"api_base":               baseURL,
+		"has_wiki":               false,
+		"allow_squash_merge":     true,
+		"has_issues":             true,
+		"has_projects":           false,
+		"allow_merge_commit":     true,
+		"allow_rebase_merge":     false,
+		"delete_branch_on_merge": true,
+		"archived":               false,
+		"description":            "Updated desc",
+		"homepage":               "https://example.com",
+		"visibility":             "private",
+		"default_branch":         "develop",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Custom Properties Tests ─────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListCustomProperties(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/properties/values", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{ //nolint:errcheck
+			{"property_name": "environment", "value": "production"},
+			{"property_name": "team", "value": "platform"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_custom_properties",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"]
+	props := result.([]any)
+	assert.Len(t, props, 2)
+}
+
+func TestGitHubProvider_Execute_SetCustomProperties(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/properties/values", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req) //nolint:errcheck
+		props := req["properties"].([]any)
+		assert.NotEmpty(t, props)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "set_custom_properties",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"properties": map[string]any{
+			"environment": "staging",
+			"team":        "platform",
+		},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_SetCustomProperties_MissingProperties(t *testing.T) {
+	t.Parallel()
+
+	p, _ := testProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := p.Execute(context.Background(), map[string]any{
+		"operation": "set_custom_properties",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "properties")
+}
+
+func BenchmarkActionsValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeDispatchWorkflow(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeDeleteVariable(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeDeleteEnvironment(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_api_call.go
+++ b/pkg/provider/builtin/githubprovider/github_api_call.go
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// allowedAPIMethods are the HTTP methods allowed for the api_call operation.
+var allowedAPIMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodPatch:  true,
+	http.MethodDelete: true,
+}
+
+// executeAPICall performs an arbitrary authenticated GitHub REST API request.
+// The endpoint must be a relative path (e.g. "/repos/{owner}/{repo}/labels").
+// The full URL is constructed as api_base + endpoint, reusing the provider's
+// auth pipeline.
+func (p *GitHubProvider) executeAPICall(ctx context.Context, client *httpc.Client, apiBase string, inputs map[string]any) (*provider.Output, error) {
+	endpoint := getStringInput(inputs, "endpoint")
+	if endpoint == "" {
+		return nil, requiredInputError("api_call", "endpoint", inputs, "must be a relative path starting with /")
+	}
+
+	// Security: endpoint must be a relative path -- reject absolute URLs.
+	if !strings.HasPrefix(endpoint, "/") {
+		return nil, fmt.Errorf("api_call: endpoint must be a relative path starting with /, got %q", endpoint)
+	}
+	if strings.Contains(endpoint, "://") {
+		return nil, fmt.Errorf("api_call: endpoint must be a relative path, not an absolute URL: %q", endpoint)
+	}
+	// Reject endpoints with query strings -- use query_params input instead.
+	if strings.Contains(endpoint, "?") {
+		return nil, fmt.Errorf("api_call: endpoint must not contain query string (?); use query_params input instead: %q", endpoint)
+	}
+	// Reject path traversal: decode percent-encoding, then check for '..' segments.
+	decodedPath, err := url.PathUnescape(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("api_call: invalid endpoint encoding: %w", err)
+	}
+	// Check each segment for ".." to catch traversal in any form.
+	for _, seg := range strings.Split(decodedPath, "/") {
+		if seg == ".." {
+			return nil, fmt.Errorf("api_call: endpoint must not contain path traversal (..): %q", endpoint)
+		}
+	}
+
+	method := getStringInput(inputs, "method")
+	if method == "" {
+		method = http.MethodGet
+	}
+	if !allowedAPIMethods[method] {
+		return nil, fmt.Errorf("api_call: unsupported HTTP method %q — allowed: GET, POST, PUT, PATCH, DELETE", method)
+	}
+
+	// Build query string from query_params if provided.
+	queryParams := getMapInput(inputs, "query_params")
+	requestURL := apiBase + endpoint
+	if len(queryParams) > 0 {
+		keys := make([]string, 0, len(queryParams))
+		for k := range queryParams {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		vals := url.Values{}
+		for _, k := range keys {
+			vals.Set(k, fmt.Sprint(queryParams[k]))
+		}
+		requestURL += "?" + vals.Encode()
+	}
+
+	// Extract body for mutating methods.
+	var body any
+	if method != http.MethodGet && method != http.MethodDelete {
+		if b, ok := inputs["request_body"]; ok {
+			body = b
+		}
+	}
+
+	result, err := p.doRESTRequest(ctx, client, method, requestURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("api_call %s %s: %w", method, endpoint, err)
+	}
+
+	// For read methods return readOutput; for mutations return actionOutput.
+	if method == http.MethodGet {
+		return readOutput(result), nil
+	}
+	return actionOutput("api_call", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_api_call_test.go
+++ b/pkg/provider/builtin/githubprovider/github_api_call_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── api_call Tests ──────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_APICall_GET(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/labels", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"name": "bug", "color": "d73a4a"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "api_call",
+		"api_base":  baseURL,
+		"endpoint":  "/repos/test-org/test-repo/labels",
+		"method":    "GET",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result := output.Data.(map[string]any)["result"]
+	labels, ok := result.([]any)
+	require.True(t, ok)
+	assert.Len(t, labels, 1)
+}
+
+func TestGitHubProvider_Execute_APICall_POST(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/labels", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "enhancement", body["name"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"name": "enhancement", "id": float64(1)}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":    "api_call",
+		"api_base":     baseURL,
+		"endpoint":     "/repos/test-org/test-repo/labels",
+		"method":       "POST",
+		"request_body": map[string]any{"name": "enhancement", "color": "a2eeef"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+	assert.Equal(t, "api_call", data["operation"])
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsAbsoluteURL(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "https://evil.example.com/steal",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "relative path starting with /")
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsSchemeInPath(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "/foo://bar",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "relative path")
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "/repos/../../../etc/passwd",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsInvalidMethod(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "/repos/owner/repo",
+		"method":   "TRACE",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported HTTP method")
+}
+
+func TestGitHubProvider_Execute_APICall_MissingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "endpoint")
+}
+
+func TestGitHubProvider_Execute_APICall_DefaultsToGET(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"ok": true}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "api_call",
+		"api_base":  baseURL,
+		"endpoint":  "/repos/test-org/test-repo",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+}
+
+func TestGitHubProvider_Execute_APICall_QueryParams(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":    "api_call",
+		"api_base":     baseURL,
+		"endpoint":     "/repos/test-org/test-repo/labels",
+		"query_params": map[string]any{"per_page": "100"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+}
+
+func TestGitHubProvider_Execute_APICall_AllowsTripleDotEndpoint(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/owner/repo/compare/main...feature", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"status": "ahead"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "api_call",
+		"api_base":  baseURL,
+		"endpoint":  "/repos/owner/repo/compare/main...feature",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsPercentEncodedTraversal(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "/repos/%2e%2e/%2e%2e/etc/passwd",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestGitHubProvider_Execute_APICall_RejectsQueryStringInEndpoint(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAPICall(t.Context(), nil, "https://api.github.com", map[string]any{
+		"endpoint": "/repos/owner/repo/labels?per_page=100",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query_params")
+}
+
+// ─── Benchmarks ──────────────────────────────────────────────────────────────
+
+func BenchmarkAPICallValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	inputs := map[string]any{
+		"endpoint": "/repos/owner/repo/labels",
+		"method":   "GET",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		// Only tests validation path — will error on nil client but validates inputs first.
+		_, _ = p.executeAPICall(context.Background(), nil, "https://api.github.com", inputs)
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_collaborators.go
+++ b/pkg/provider/builtin/githubprovider/github_collaborators.go
@@ -1,0 +1,63 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ─── List Collaborators ──────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListCollaborators(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/collaborators?per_page=%d", apiBase, owner, repo, perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing collaborators: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Add Collaborator ────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeAddCollaborator(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	username := getStringInput(inputs, "username")
+	if username == "" {
+		return nil, requiredInputError("add_collaborator", "username", inputs, "")
+	}
+
+	reqBody := map[string]any{}
+	if permission := getStringInput(inputs, "permission"); permission != "" {
+		reqBody["permission"] = permission
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/collaborators/%s", apiBase, owner, repo, url.PathEscape(username))
+	result, err := p.doRESTRequest(ctx, client, http.MethodPut, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("adding collaborator: %w", err)
+	}
+	return actionOutput("add_collaborator", result), nil
+}
+
+// ─── Remove Collaborator ─────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeRemoveCollaborator(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	username := getStringInput(inputs, "username")
+	if username == "" {
+		return nil, requiredInputError("remove_collaborator", "username", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/collaborators/%s", apiBase, owner, repo, url.PathEscape(username))
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("removing collaborator: %w", err)
+	}
+	return actionOutput("remove_collaborator", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_collaborators_test.go
+++ b/pkg/provider/builtin/githubprovider/github_collaborators_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Collaborator Tests ──────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListCollaborators(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/collaborators")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"login": "user1"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_collaborators",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"]
+	collabs := result.([]any)
+	assert.Len(t, collabs, 1)
+}
+
+func TestGitHubProvider_Execute_AddCollaborator(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/collaborators/new-user", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": float64(1)}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "add_collaborator",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"api_base":   baseURL,
+		"username":   "new-user",
+		"permission": "push",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteAddCollaborator_MissingUsername(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAddCollaborator(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
+}
+
+func TestExecuteRemoveCollaborator_MissingUsername(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeRemoveCollaborator(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
+}
+
+func TestGitHubProvider_Execute_RemoveCollaborator(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/collaborators/old-user", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "remove_collaborator",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"username":  "old-user",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func BenchmarkCollaboratorValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeAddCollaborator(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeRemoveCollaborator(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_labels.go
+++ b/pkg/provider/builtin/githubprovider/github_labels.go
@@ -1,0 +1,138 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ─── List Labels ─────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListLabels(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/labels?per_page=%d", apiBase, owner, repo, perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing labels: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Create Label ────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateLabel(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	name := getStringInput(inputs, "label_name")
+	if name == "" {
+		return nil, requiredInputError("create_label", "label_name", inputs, "")
+	}
+
+	reqBody := map[string]any{
+		"name": name,
+	}
+	if color := getStringInput(inputs, "color"); color != "" {
+		reqBody["color"] = color
+	}
+	if desc := getStringInput(inputs, "label_description"); desc != "" {
+		reqBody["description"] = desc
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/labels", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating label: %w", err)
+	}
+	return actionOutput("create_label", result), nil
+}
+
+// ─── Update Label ────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeUpdateLabel(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	name := getStringInput(inputs, "label_name")
+	if name == "" {
+		return nil, requiredInputError("update_label", "label_name", inputs, "")
+	}
+
+	reqBody := map[string]any{}
+	if newName := getStringInput(inputs, "new_label_name"); newName != "" {
+		reqBody["new_name"] = newName
+	}
+	if color := getStringInput(inputs, "color"); color != "" {
+		reqBody["color"] = color
+	}
+	if desc := getStringInput(inputs, "label_description"); desc != "" {
+		reqBody["description"] = desc
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", apiBase, owner, repo, url.PathEscape(name))
+	result, err := p.doRESTRequest(ctx, client, http.MethodPatch, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("updating label: %w", err)
+	}
+	return actionOutput("update_label", result), nil
+}
+
+// ─── Delete Label ────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteLabel(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	name := getStringInput(inputs, "label_name")
+	if name == "" {
+		return nil, requiredInputError("delete_label", "label_name", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", apiBase, owner, repo, url.PathEscape(name))
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting label: %w", err)
+	}
+	return actionOutput("delete_label", result), nil
+}
+
+// ─── Add Labels to Issue ─────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeAddLabelsToIssue(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	number, ok := getIntInput(inputs, "number")
+	if !ok || number == 0 {
+		return nil, requiredInputError("add_labels_to_issue", "number", inputs, "")
+	}
+	labels := getStringSliceInput(inputs, "labels")
+	if len(labels) == 0 {
+		return nil, requiredInputError("add_labels_to_issue", "labels", inputs, "")
+	}
+
+	reqBody := map[string]any{
+		"labels": labels,
+	}
+	restURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels", apiBase, owner, repo, number)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("adding labels to issue: %w", err)
+	}
+	return actionOutput("add_labels_to_issue", result), nil
+}
+
+// ─── Remove Label from Issue ─────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeRemoveLabelFromIssue(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	number, ok := getIntInput(inputs, "number")
+	if !ok || number == 0 {
+		return nil, requiredInputError("remove_label_from_issue", "number", inputs, "")
+	}
+	labelName := getStringInput(inputs, "label_name")
+	if labelName == "" {
+		return nil, requiredInputError("remove_label_from_issue", "label_name", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels/%s", apiBase, owner, repo, number, url.PathEscape(labelName))
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("removing label from issue: %w", err)
+	}
+	return actionOutput("remove_label_from_issue", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_labels_milestones_test.go
+++ b/pkg/provider/builtin/githubprovider/github_labels_milestones_test.go
@@ -1,0 +1,385 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Label Tests ─────────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListLabels(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/labels")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"name": "bug", "color": "d73a4a"},
+			map[string]any{"name": "enhancement", "color": "a2eeef"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_labels",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result := output.Data.(map[string]any)["result"]
+	labels := result.([]any)
+	assert.Len(t, labels, 2)
+}
+
+func TestGitHubProvider_Execute_CreateLabel(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/labels", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "bug", body["name"])
+		assert.Equal(t, "d73a4a", body["color"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"name": "bug", "color": "d73a4a", "id": float64(1)}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "create_label",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"api_base":   baseURL,
+		"label_name": "bug",
+		"color":      "d73a4a",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_DeleteLabel(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/labels/bug", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "delete_label",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"api_base":   baseURL,
+		"label_name": "bug",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteCreateLabel_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateLabel(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "label_name")
+}
+
+func TestExecuteDeleteLabel_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteLabel(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "label_name")
+}
+
+func TestGitHubProvider_Execute_AddLabelsToIssue(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/5/labels", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"name": "bug"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "add_labels_to_issue",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"number":    float64(5),
+		"labels":    []any{"bug"},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteAddLabelsToIssue_MissingNumber(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAddLabelsToIssue(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"labels": []any{"bug"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "number")
+}
+
+func TestExecuteRemoveLabelFromIssue_MissingLabel(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeRemoveLabelFromIssue(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"number": float64(5),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "label_name")
+}
+
+// ─── Milestone Tests ─────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListMilestones(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/milestones")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"title": "v1.0", "number": float64(1)},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_milestones",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result := output.Data.(map[string]any)["result"]
+	milestones := result.([]any)
+	assert.Len(t, milestones, 1)
+}
+
+func TestGitHubProvider_Execute_CreateMilestone(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/milestones", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "v1.0", body["title"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"title": "v1.0", "number": float64(1)}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "create_milestone",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"title":     "v1.0",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteCreateMilestone_MissingTitle(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateMilestone(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "title")
+}
+
+func TestExecuteUpdateMilestone_MissingNumber(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeUpdateMilestone(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"title": "v2.0",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "milestone_number")
+}
+
+func TestExecuteDeleteMilestone_MissingNumber(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteMilestone(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "milestone_number")
+}
+
+// ─── Update Label Tests ──────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_UpdateLabel(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/labels/old-name", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "new-name", body["new_name"])
+		assert.Equal(t, "ff0000", body["color"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"name": "new-name", "color": "ff0000"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "update_label",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"label_name":     "old-name",
+		"new_label_name": "new-name",
+		"color":          "ff0000",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteUpdateLabel_MissingName(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeUpdateLabel(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "label_name")
+}
+
+// ─── Remove Label from Issue Tests ───────────────────────────────────────────
+
+func TestGitHubProvider_Execute_RemoveLabelFromIssue(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/5/labels/bug", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":  "remove_label_from_issue",
+		"owner":      "test-org",
+		"repo":       "test-repo",
+		"api_base":   baseURL,
+		"number":     float64(5),
+		"label_name": "bug",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Update Milestone Tests ──────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_UpdateMilestone(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/milestones/1", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "v2.0", body["title"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"number": float64(1), "title": "v2.0"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "update_milestone",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"milestone_number": float64(1),
+		"title":            "v2.0",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Delete Milestone Tests ──────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_DeleteMilestone(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/milestones/1", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "delete_milestone",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"milestone_number": float64(1),
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+// ─── Benchmarks ──────────────────────────────────────────────────────────────
+
+func BenchmarkLabelMilestoneValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeCreateLabel(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeCreateMilestone(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_milestones.go
+++ b/pkg/provider/builtin/githubprovider/github_milestones.go
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ─── List Milestones ─────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListMilestones(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	state := getStringInput(inputs, "state")
+	if state == "" {
+		state = "open"
+	}
+	restURL := fmt.Sprintf("%s/repos/%s/%s/milestones?state=%s&per_page=%d", apiBase, owner, repo, url.QueryEscape(state), perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing milestones: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Create Milestone ────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateMilestone(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	title := getStringInput(inputs, "title")
+	if title == "" {
+		return nil, requiredInputError("create_milestone", "title", inputs, "")
+	}
+
+	reqBody := map[string]any{
+		"title": title,
+	}
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		reqBody["description"] = desc
+	}
+	if state := getStringInput(inputs, "state"); state != "" {
+		reqBody["state"] = state
+	}
+	if dueOn := getStringInput(inputs, "due_on"); dueOn != "" {
+		reqBody["due_on"] = dueOn
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/milestones", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating milestone: %w", err)
+	}
+	return actionOutput("create_milestone", result), nil
+}
+
+// ─── Update Milestone ────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeUpdateMilestone(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	milestoneNumber, ok := getIntInput(inputs, "milestone_number")
+	if !ok || milestoneNumber == 0 {
+		return nil, requiredInputError("update_milestone", "milestone_number", inputs, "")
+	}
+
+	reqBody := map[string]any{}
+	if title := getStringInput(inputs, "title"); title != "" {
+		reqBody["title"] = title
+	}
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		reqBody["description"] = desc
+	}
+	if state := getStringInput(inputs, "state"); state != "" {
+		reqBody["state"] = state
+	}
+	if dueOn := getStringInput(inputs, "due_on"); dueOn != "" {
+		reqBody["due_on"] = dueOn
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/milestones/%d", apiBase, owner, repo, milestoneNumber)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPatch, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("updating milestone: %w", err)
+	}
+	return actionOutput("update_milestone", result), nil
+}
+
+// ─── Delete Milestone ────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteMilestone(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	milestoneNumber, ok := getIntInput(inputs, "milestone_number")
+	if !ok || milestoneNumber == 0 {
+		return nil, requiredInputError("delete_milestone", "milestone_number", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/milestones/%d", apiBase, owner, repo, milestoneNumber)
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting milestone: %w", err)
+	}
+	return actionOutput("delete_milestone", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_reactions.go
+++ b/pkg/provider/builtin/githubprovider/github_reactions.go
@@ -1,0 +1,148 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// Reaction content values supported by the GitHub API.
+// See: https://docs.github.com/en/rest/reactions/reactions
+var validReactionContents = map[string]bool{
+	"+1":       true,
+	"-1":       true,
+	"laugh":    true,
+	"confused": true,
+	"heart":    true,
+	"hooray":   true,
+	"rocket":   true,
+	"eyes":     true,
+}
+
+// ─── Add Reaction ────────────────────────────────────────────────────────────
+
+// executeAddReaction adds a reaction to an issue, PR, or comment.
+// The reaction_subject determines the API path:
+//   - "issue" or "pull_request" → /repos/{owner}/{repo}/issues/{number}/reactions
+//   - "issue_comment" → /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
+func (p *GitHubProvider) executeAddReaction(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	content := getStringInput(inputs, "reaction_content")
+	if content == "" {
+		return nil, requiredInputError("add_reaction", "reaction_content", inputs, "must be one of: +1, -1, laugh, confused, heart, hooray, rocket, eyes")
+	}
+	if !validReactionContents[content] {
+		return nil, fmt.Errorf("add_reaction: invalid reaction_content %q — must be one of: +1, -1, laugh, confused, heart, hooray, rocket, eyes", content)
+	}
+
+	subject := getStringInput(inputs, "reaction_subject")
+	if subject == "" {
+		subject = "issue"
+	}
+
+	reqBody := map[string]any{
+		"content": content,
+	}
+
+	var restURL string
+	switch subject {
+	case "issue", "pull_request":
+		number, ok := getIntInput(inputs, "number")
+		if !ok || number == 0 {
+			return nil, requiredInputError("add_reaction", "number", inputs, "required when reaction_subject is issue or pull_request")
+		}
+		// GitHub's REST API uses the issues endpoint for both issues and PRs.
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/%d/reactions", apiBase, owner, repo, number)
+	case "issue_comment":
+		commentID, ok := getIntInput(inputs, "comment_id")
+		if !ok || commentID == 0 {
+			return nil, requiredInputError("add_reaction", "comment_id", inputs, "required when reaction_subject is issue_comment")
+		}
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d/reactions", apiBase, owner, repo, commentID)
+	default:
+		return nil, fmt.Errorf("add_reaction: unsupported reaction_subject %q — must be one of: issue, pull_request, issue_comment", subject)
+	}
+
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("adding reaction: %w", err)
+	}
+	return actionOutput("add_reaction", result), nil
+}
+
+// ─── List Reactions ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListReactions(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	subject := getStringInput(inputs, "reaction_subject")
+	if subject == "" {
+		subject = "issue"
+	}
+	perPage := getPerPage(inputs)
+
+	var restURL string
+	switch subject {
+	case "issue", "pull_request":
+		number, ok := getIntInput(inputs, "number")
+		if !ok || number == 0 {
+			return nil, requiredInputError("list_reactions", "number", inputs, "required when reaction_subject is issue or pull_request")
+		}
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/%d/reactions?per_page=%d", apiBase, owner, repo, number, perPage)
+	case "issue_comment":
+		commentID, ok := getIntInput(inputs, "comment_id")
+		if !ok || commentID == 0 {
+			return nil, requiredInputError("list_reactions", "comment_id", inputs, "required when reaction_subject is issue_comment")
+		}
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d/reactions?per_page=%d", apiBase, owner, repo, commentID, perPage)
+	default:
+		return nil, fmt.Errorf("list_reactions: unsupported reaction_subject %q — must be one of: issue, pull_request, issue_comment", subject)
+	}
+
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing reactions: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Delete Reaction ─────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteReaction(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	reactionID, ok := getIntInput(inputs, "reaction_id")
+	if !ok || reactionID == 0 {
+		return nil, requiredInputError("delete_reaction", "reaction_id", inputs, "")
+	}
+
+	subject := getStringInput(inputs, "reaction_subject")
+	if subject == "" {
+		subject = "issue"
+	}
+
+	var restURL string
+	switch subject {
+	case "issue", "pull_request":
+		number, ok := getIntInput(inputs, "number")
+		if !ok || number == 0 {
+			return nil, requiredInputError("delete_reaction", "number", inputs, "required when reaction_subject is issue or pull_request")
+		}
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/%d/reactions/%d", apiBase, owner, repo, number, reactionID)
+	case "issue_comment":
+		commentID, ok := getIntInput(inputs, "comment_id")
+		if !ok || commentID == 0 {
+			return nil, requiredInputError("delete_reaction", "comment_id", inputs, "required when reaction_subject is issue_comment")
+		}
+		restURL = fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d/reactions/%d", apiBase, owner, repo, commentID, reactionID)
+	default:
+		return nil, fmt.Errorf("delete_reaction: unsupported reaction_subject %q — must be one of: issue, pull_request, issue_comment", subject)
+	}
+
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting reaction: %w", err)
+	}
+	return actionOutput("delete_reaction", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_reactions_test.go
+++ b/pkg/provider/builtin/githubprovider/github_reactions_test.go
@@ -1,0 +1,263 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Reaction Tests ──────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_AddReaction(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/42/reactions", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "+1", body["content"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": float64(1), "content": "+1"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "add_reaction",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"number":           float64(42),
+		"reaction_content": "+1",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_AddReaction_Comment(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/comments/123/reactions", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": float64(1), "content": "heart"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "add_reaction",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"comment_id":       float64(123),
+		"reaction_content": "heart",
+		"reaction_subject": "issue_comment",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteAddReaction_MissingContent(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAddReaction(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"number": float64(1),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reaction_content")
+}
+
+func TestExecuteAddReaction_InvalidContent(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAddReaction(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"number":           float64(1),
+		"reaction_content": "invalid",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid reaction_content")
+}
+
+func TestExecuteAddReaction_InvalidSubject(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeAddReaction(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"reaction_content": "+1",
+		"reaction_subject": "commit",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported reaction_subject")
+}
+
+func TestGitHubProvider_Execute_ListReactions(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/issues/42/reactions")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"id": float64(1), "content": "+1"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_reactions",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"number":    float64(42),
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"]
+	reactions := result.([]any)
+	assert.Len(t, reactions, 1)
+}
+
+func TestExecuteDeleteReaction_MissingID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteReaction(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"number": float64(1),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reaction_id")
+}
+
+func TestGitHubProvider_Execute_DeleteReaction(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/42/reactions/100", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":   "delete_reaction",
+		"owner":       "test-org",
+		"repo":        "test-repo",
+		"api_base":    baseURL,
+		"number":      float64(42),
+		"reaction_id": float64(100),
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_ListReactions_Comment(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/issues/comments/99/reactions")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"id": float64(200), "content": "rocket"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "list_reactions",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"comment_id":       float64(99),
+		"reaction_subject": "issue_comment",
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"]
+	reactions := result.([]any)
+	assert.Len(t, reactions, 1)
+}
+
+func TestExecuteDeleteReaction_Comment(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/issues/comments/99/reactions/200", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":        "delete_reaction",
+		"owner":            "test-org",
+		"repo":             "test-repo",
+		"api_base":         baseURL,
+		"comment_id":       float64(99),
+		"reaction_id":      float64(200),
+		"reaction_subject": "issue_comment",
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteListReactions_MissingNumber(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeListReactions(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "number")
+}
+
+func TestExecuteListReactions_InvalidSubject(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeListReactions(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"reaction_subject": "commit",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported reaction_subject")
+}
+
+func TestExecuteDeleteReaction_InvalidSubject(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteReaction(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{
+		"reaction_id":      float64(1),
+		"reaction_subject": "commit",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported reaction_subject")
+}
+
+func BenchmarkReactionValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeAddReaction(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeDeleteReaction(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
+++ b/pkg/provider/builtin/githubprovider/github_repo_mgmt.go
@@ -491,3 +491,176 @@ func (p *GitHubProvider) executeEnableAutomatedSecurityFixes(ctx context.Context
 		"enabled": true,
 	}), nil
 }
+
+// ─── Update Repository ───────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeUpdateRepo(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	reqBody := map[string]any{}
+
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		reqBody["description"] = desc
+	}
+	if homepage := getStringInput(inputs, "homepage"); homepage != "" {
+		reqBody["homepage"] = homepage
+	}
+	if visibility := getStringInput(inputs, "visibility"); visibility != "" {
+		reqBody["visibility"] = visibility
+	}
+	if defaultBranch := getStringInput(inputs, "default_branch"); defaultBranch != "" {
+		reqBody["default_branch"] = defaultBranch
+	}
+	if v, ok := getBoolInput(inputs, "has_issues"); ok {
+		reqBody["has_issues"] = v
+	}
+	if v, ok := getBoolInput(inputs, "has_projects"); ok {
+		reqBody["has_projects"] = v
+	}
+	if v, ok := getBoolInput(inputs, "has_wiki"); ok {
+		reqBody["has_wiki"] = v
+	}
+	if v, ok := getBoolInput(inputs, "allow_squash_merge"); ok {
+		reqBody["allow_squash_merge"] = v
+	}
+	if v, ok := getBoolInput(inputs, "allow_merge_commit"); ok {
+		reqBody["allow_merge_commit"] = v
+	}
+	if v, ok := getBoolInput(inputs, "allow_rebase_merge"); ok {
+		reqBody["allow_rebase_merge"] = v
+	}
+	if v, ok := getBoolInput(inputs, "delete_branch_on_merge"); ok {
+		reqBody["delete_branch_on_merge"] = v
+	}
+	if v, ok := getBoolInput(inputs, "archived"); ok {
+		reqBody["archived"] = v
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPatch, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("updating repository: %w", err)
+	}
+	return actionOutput("update_repo", result), nil
+}
+
+// ─── List Topics ─────────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListTopics(ctx context.Context, client *httpc.Client, apiBase, owner, repo string) (*provider.Output, error) {
+	restURL := fmt.Sprintf("%s/repos/%s/%s/topics", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing topics: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Replace Topics ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeReplaceTopics(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	topics := getStringSliceInput(inputs, "topics")
+	if topics == nil {
+		topics = []string{}
+	}
+
+	reqBody := map[string]any{
+		"names": topics,
+	}
+	restURL := fmt.Sprintf("%s/repos/%s/%s/topics", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPut, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("replacing topics: %w", err)
+	}
+	return actionOutput("replace_topics", result), nil
+}
+
+// ─── Fork Repository ─────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeForkRepo(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	reqBody := map[string]any{}
+	if org := getStringInput(inputs, "organization"); org != "" {
+		reqBody["organization"] = org
+	}
+	if name := getStringInput(inputs, "name"); name != "" {
+		reqBody["name"] = name
+	}
+	if v, ok := getBoolInput(inputs, "default_branch_only"); ok {
+		reqBody["default_branch_only"] = v
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/forks", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("forking repository: %w", err)
+	}
+	return actionOutput("fork_repo", result), nil
+}
+
+// ─── Create from Template ────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateFromTemplate(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	newOwner := getStringInput(inputs, "new_owner")
+	if newOwner == "" {
+		newOwner = owner
+	}
+	newName := getStringInput(inputs, "new_repo_name")
+	if newName == "" {
+		return nil, requiredInputError("create_from_template", "new_repo_name", inputs, "")
+	}
+
+	reqBody := map[string]any{
+		"owner": newOwner,
+		"name":  newName,
+	}
+	if desc := getStringInput(inputs, "description"); desc != "" {
+		reqBody["description"] = desc
+	}
+	if v, ok := getBoolInput(inputs, "include_all_branches"); ok {
+		reqBody["include_all_branches"] = v
+	}
+	if visibility := getStringInput(inputs, "visibility"); visibility != "" {
+		reqBody["private"] = visibility == "private"
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/generate", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating from template: %w", err)
+	}
+	return actionOutput("create_from_template", result), nil
+}
+
+// ─── List Custom Properties ──────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListCustomProperties(ctx context.Context, client *httpc.Client, apiBase, owner, repo string) (*provider.Output, error) {
+	restURL := fmt.Sprintf("%s/repos/%s/%s/properties/values", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing custom properties: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Set Custom Properties ───────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeSetCustomProperties(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	props := getMapInput(inputs, "properties")
+	if len(props) == 0 {
+		return nil, requiredInputError("set_custom_properties", "properties", inputs, "map of property_name -> value")
+	}
+
+	// Convert flat map to GitHub API format: [{"property_name": "k", "value": "v"}, ...]
+	propList := make([]map[string]any, 0, len(props))
+	for k, v := range props {
+		propList = append(propList, map[string]any{
+			"property_name": k,
+			"value":         v,
+		})
+	}
+	reqBody := map[string]any{"properties": propList}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/properties/values", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPatch, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("setting custom properties: %w", err)
+	}
+	return actionOutput("set_custom_properties", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_test.go
+++ b/pkg/provider/builtin/githubprovider/github_test.go
@@ -1493,3 +1493,45 @@ func BenchmarkRequiredInputError(b *testing.B) {
 		_ = requiredInputError("list_commit_pulls", "commit_sha", inputs, "")
 	}
 }
+
+// ─── WriteOperations Tests ──────────────────────────────────────────
+
+func TestGitHubProvider_WriteOperations(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	ops := p.Descriptor().WriteOperations
+
+	assert.NotEmpty(t, ops, "should have write operations")
+	assert.Contains(t, ops, "create_label")
+	assert.Contains(t, ops, "fork_repo")
+	assert.Contains(t, ops, "merge_pull_request")
+	assert.Contains(t, ops, "set_custom_properties")
+	assert.NotContains(t, ops, "list_labels")
+	assert.NotContains(t, ops, "get_repo")
+	assert.NotContains(t, ops, "api_call")
+}
+
+func TestGitHubProvider_WriteOperations_CoverAllOperations(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	ops := p.Descriptor().WriteOperations
+	writeSet := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		writeSet[op] = true
+	}
+
+	// Every operation must be either in readOperations or writeOps (except api_call)
+	for _, op := range allOperations {
+		if op == "api_call" {
+			continue // intentionally unclassified
+		}
+		isRead := readOperations[op]
+		isWrite := writeSet[op]
+		assert.True(t, isRead || isWrite,
+			"operation %q is not classified as read or write — add it to readOperations or Descriptor.WriteOperations", op)
+		assert.False(t, isRead && isWrite,
+			"operation %q is classified as both read and write", op)
+	}
+}

--- a/pkg/provider/builtin/githubprovider/github_webhooks.go
+++ b/pkg/provider/builtin/githubprovider/github_webhooks.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ─── List Webhooks ───────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeListWebhooks(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	perPage := getPerPage(inputs)
+	restURL := fmt.Sprintf("%s/repos/%s/%s/hooks?per_page=%d", apiBase, owner, repo, perPage)
+	result, err := p.doRESTRequest(ctx, client, http.MethodGet, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing webhooks: %w", err)
+	}
+	return readOutput(result), nil
+}
+
+// ─── Create Webhook ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeCreateWebhook(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	webhookURL := getStringInput(inputs, "webhook_url")
+	if webhookURL == "" {
+		return nil, requiredInputError("create_webhook", "webhook_url", inputs, "")
+	}
+
+	events := getStringSliceInput(inputs, "webhook_events")
+	if len(events) == 0 {
+		events = []string{"push"}
+	}
+
+	contentType := getStringInput(inputs, "webhook_content_type")
+	if contentType == "" {
+		contentType = "json"
+	}
+
+	config := map[string]any{
+		"url":          webhookURL,
+		"content_type": contentType,
+	}
+	if secret := getStringInput(inputs, "webhook_secret"); secret != "" {
+		config["secret"] = secret
+	}
+
+	active := true
+	if v, ok := getBoolInput(inputs, "webhook_active"); ok {
+		active = v
+	}
+
+	reqBody := map[string]any{
+		"name":   "web",
+		"active": active,
+		"events": events,
+		"config": config,
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/hooks", apiBase, owner, repo)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPost, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating webhook: %w", err)
+	}
+	return actionOutput("create_webhook", result), nil
+}
+
+// ─── Update Webhook ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeUpdateWebhook(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	hookID, ok := getIntInput(inputs, "hook_id")
+	if !ok || hookID == 0 {
+		return nil, requiredInputError("update_webhook", "hook_id", inputs, "")
+	}
+
+	reqBody := map[string]any{}
+
+	config := map[string]any{}
+	if webhookURL := getStringInput(inputs, "webhook_url"); webhookURL != "" {
+		config["url"] = webhookURL
+	}
+	if contentType := getStringInput(inputs, "webhook_content_type"); contentType != "" {
+		config["content_type"] = contentType
+	}
+	if secret := getStringInput(inputs, "webhook_secret"); secret != "" {
+		config["secret"] = secret
+	}
+	if len(config) > 0 {
+		reqBody["config"] = config
+	}
+
+	if events := getStringSliceInput(inputs, "webhook_events"); len(events) > 0 {
+		reqBody["events"] = events
+	}
+	if active, ok := getBoolInput(inputs, "webhook_active"); ok {
+		reqBody["active"] = active
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/hooks/%d", apiBase, owner, repo, hookID)
+	result, err := p.doRESTRequest(ctx, client, http.MethodPatch, restURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("updating webhook: %w", err)
+	}
+	return actionOutput("update_webhook", result), nil
+}
+
+// ─── Delete Webhook ──────────────────────────────────────────────────────────
+
+func (p *GitHubProvider) executeDeleteWebhook(ctx context.Context, client *httpc.Client, apiBase, owner, repo string, inputs map[string]any) (*provider.Output, error) {
+	hookID, ok := getIntInput(inputs, "hook_id")
+	if !ok || hookID == 0 {
+		return nil, requiredInputError("delete_webhook", "hook_id", inputs, "")
+	}
+
+	restURL := fmt.Sprintf("%s/repos/%s/%s/hooks/%d", apiBase, owner, repo, hookID)
+	result, err := p.doRESTRequest(ctx, client, http.MethodDelete, restURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("deleting webhook: %w", err)
+	}
+	return actionOutput("delete_webhook", result), nil
+}

--- a/pkg/provider/builtin/githubprovider/github_webhooks_test.go
+++ b/pkg/provider/builtin/githubprovider/github_webhooks_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package githubprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Webhook Tests ───────────────────────────────────────────────────────────
+
+func TestGitHubProvider_Execute_ListWebhooks(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/test-org/test-repo/hooks")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{ //nolint:errcheck
+			map[string]any{"id": float64(1), "name": "web"},
+		})
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "list_webhooks",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+	})
+
+	require.NoError(t, err)
+	result := output.Data.(map[string]any)["result"]
+	hooks := result.([]any)
+	assert.Len(t, hooks, 1)
+}
+
+func TestGitHubProvider_Execute_CreateWebhook(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/hooks", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "web", body["name"])
+		config := body["config"].(map[string]any)
+		assert.Equal(t, "https://example.com/webhook", config["url"])
+		assert.Equal(t, "json", config["content_type"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": float64(1), "name": "web"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "create_webhook",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"webhook_url":    "https://example.com/webhook",
+		"webhook_events": []any{"push", "pull_request"},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestExecuteCreateWebhook_MissingURL(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeCreateWebhook(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "webhook_url")
+}
+
+func TestExecuteUpdateWebhook_MissingHookID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeUpdateWebhook(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook_id")
+}
+
+func TestExecuteDeleteWebhook_MissingHookID(t *testing.T) {
+	t.Parallel()
+
+	p := NewGitHubProvider()
+	_, err := p.executeDeleteWebhook(t.Context(), nil, "https://api.github.com", "owner", "repo", map[string]any{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook_id")
+}
+
+func TestGitHubProvider_Execute_UpdateWebhook(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/hooks/10", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		config := body["config"].(map[string]any)
+		assert.Equal(t, "https://new.example.com/hook", config["url"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"id": float64(10), "name": "web"}) //nolint:errcheck
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation":      "update_webhook",
+		"owner":          "test-org",
+		"repo":           "test-repo",
+		"api_base":       baseURL,
+		"hook_id":        float64(10),
+		"webhook_url":    "https://new.example.com/hook",
+		"webhook_events": []any{"push"},
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func TestGitHubProvider_Execute_DeleteWebhook(t *testing.T) {
+	t.Parallel()
+
+	p, baseURL := testProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/repos/test-org/test-repo/hooks/10", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	output, err := p.Execute(context.Background(), map[string]any{
+		"operation": "delete_webhook",
+		"owner":     "test-org",
+		"repo":      "test-repo",
+		"api_base":  baseURL,
+		"hook_id":   float64(10),
+	})
+
+	require.NoError(t, err)
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data["success"])
+}
+
+func BenchmarkWebhookValidation(b *testing.B) {
+	p := NewGitHubProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.executeCreateWebhook(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+		_, _ = p.executeDeleteWebhook(context.Background(), nil, "https://api.github.com", "o", "r", map[string]any{})
+	}
+}

--- a/pkg/provider/executor.go
+++ b/pkg/provider/executor.go
@@ -77,6 +77,38 @@ func validateExecutionMode(ctx context.Context, desc *Descriptor) error {
 	return fmt.Errorf("provider %q does not support capability %q; supported: %v", desc.Name, execMode, desc.Capabilities)
 }
 
+// ValidateWriteOperation checks whether a write operation is being used in a read-only
+// context. Providers with Descriptor.WriteOperations populated declare which operations
+// mutate state; these are only allowed in action (CapabilityAction) context and rejected
+// in resolver resolve (CapabilityFrom) and transform (CapabilityTransform) contexts.
+//
+// Semantics follow the SDK convention:
+//   - nil WriteOperations: provider cannot classify (no enforcement)
+//   - empty []string{}: all operations are reads (everything allowed)
+//   - populated: listed operations are blocked outside action context
+func ValidateWriteOperation(ctx context.Context, p Provider, resolvedInputs map[string]any) error {
+	desc := p.Descriptor()
+	if desc == nil || desc.WriteOperations == nil {
+		return nil // provider cannot classify operations — no enforcement
+	}
+
+	execMode, ok := ExecutionModeFromContext(ctx)
+	if !ok || execMode == CapabilityAction {
+		return nil // writes are allowed in action context
+	}
+
+	operation, _ := resolvedInputs["operation"].(string)
+	if operation == "" {
+		return nil
+	}
+
+	if desc.IsWriteOperation(operation) {
+		return fmt.Errorf("operation %q is a write operation and cannot be used in read-only execution mode %q; use a workflow action instead", operation, execMode)
+	}
+
+	return nil
+}
+
 // Execute executes a provider with the given inputs and context.
 // It performs:
 // 1. Execution mode validation against provider capabilities
@@ -128,6 +160,11 @@ func (e *Executor) Execute(ctx context.Context, provider Provider, inputs map[st
 	resolvedInputs, err := inputResolver.ResolveInputs(inputs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve inputs: %w", err)
+	}
+
+	// Check for write operations in resolver context
+	if err := ValidateWriteOperation(ctx, provider, resolvedInputs); err != nil {
+		return nil, err
 	}
 
 	// Validate resolved inputs

--- a/pkg/provider/executor_test.go
+++ b/pkg/provider/executor_test.go
@@ -696,3 +696,117 @@ func TestExecutor_Execute_ContextCancellation(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context canceled")
 }
+
+// ─── Write Operation Classification Tests ────────────────────────────────────
+
+// newMockWriteClassifierProvider creates a mock with WriteOperations on the Descriptor.
+func newMockWriteClassifierProvider(writeOps []string) *mockExecutableProvider {
+	version, _ := semver.NewVersion("1.0.0")
+	return &mockExecutableProvider{
+		descriptor: &Descriptor{
+			Name:            "test-provider",
+			APIVersion:      "v1",
+			Version:         version,
+			Description:     "Mock provider for testing",
+			Capabilities:    []Capability{CapabilityFrom, CapabilityAction, CapabilityTransform},
+			WriteOperations: writeOps,
+			Schema: schemahelper.ObjectSchema([]string{"operation"}, map[string]*jsonschema.Schema{
+				"operation": schemahelper.StringProp("Operation to perform"),
+			}),
+			OutputSchemas: map[Capability]*jsonschema.Schema{
+				CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"result": schemahelper.StringProp(""),
+				}),
+				CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+					"success": schemahelper.BoolProp(""),
+				}),
+			},
+		},
+	}
+}
+
+func TestValidateWriteOperation_BlocksWriteInResolver(t *testing.T) {
+	t.Parallel()
+
+	p := newMockWriteClassifierProvider([]string{"create_label", "delete_label"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityFrom)
+
+	_, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "create_label",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+	assert.Contains(t, err.Error(), "create_label")
+	assert.Contains(t, err.Error(), "workflow action")
+}
+
+func TestValidateWriteOperation_AllowsReadInResolver(t *testing.T) {
+	t.Parallel()
+
+	p := newMockWriteClassifierProvider([]string{"create_label", "delete_label"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityFrom)
+
+	result, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "list_labels",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestValidateWriteOperation_AllowsWriteInAction(t *testing.T) {
+	t.Parallel()
+
+	p := newMockWriteClassifierProvider([]string{"create_label"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityAction)
+
+	result, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "create_label",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestValidateWriteOperation_BlocksWriteInTransform(t *testing.T) {
+	t.Parallel()
+
+	p := newMockWriteClassifierProvider([]string{"create_label", "delete_label"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityTransform)
+
+	_, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "create_label",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+	assert.Contains(t, err.Error(), "create_label")
+	assert.Contains(t, err.Error(), "workflow action")
+}
+
+func TestValidateWriteOperation_SkipsNonClassifier(t *testing.T) {
+	t.Parallel()
+
+	// Provider without WriteOperations (nil) — no enforcement
+	p := newMockExecutableProvider("test-provider", nil)
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityFrom)
+
+	result, err := executor.Execute(ctx, p, map[string]any{
+		"input1":    "value",
+		"operation": "create_label",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -1226,6 +1226,11 @@ func (e *Executor) executeProviderWithIterationContext(ctx context.Context, prov
 
 	ctxWithResolvers := provider.WithResolverContext(ctx, resolverData)
 
+	// Check for write operations in resolver context
+	if err := provider.ValidateWriteOperation(ctxWithResolvers, prov, inputs); err != nil {
+		return nil, err
+	}
+
 	// Also pass the iteration context separately so providers can access aliases
 	provIterCtx := &provider.IterationContext{
 		Item:       iterCtx.Item,
@@ -1398,6 +1403,11 @@ func (e *Executor) executeProviderWithSelf(ctx context.Context, providerName str
 		resolverData["__self"] = self
 	}
 	ctxWithResolvers := provider.WithResolverContext(ctx, resolverData)
+
+	// Check for write operations in resolver context
+	if err := provider.ValidateWriteOperation(ctxWithResolvers, prov, inputs); err != nil {
+		return nil, err
+	}
 
 	// Execute provider
 	output, err := prov.Execute(ctxWithResolvers, inputs)

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -1771,3 +1771,108 @@ func TestExecutor_ValidatePhase_WhenWithSelf(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// ─── Write Operation Guard Tests ─────────────────────────────────────────────
+
+// mockWriteClassifierProvider returns a Descriptor with WriteOperations populated.
+type mockWriteClassifierProvider struct {
+	name        string
+	writeOps    []string
+	executeFunc func(ctx context.Context, inputs map[string]any) (*provider.Output, error)
+}
+
+func (m *mockWriteClassifierProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:            m.name,
+		APIVersion:      "v1",
+		Description:     "Mock provider with write operations",
+		Capabilities:    []provider.Capability{provider.CapabilityFrom, provider.CapabilityAction},
+		WriteOperations: m.writeOps,
+	}
+}
+
+func (m *mockWriteClassifierProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	inputs, _ := input.(map[string]any)
+	if m.executeFunc != nil {
+		return m.executeFunc(ctx, inputs)
+	}
+	return &provider.Output{Data: "mock-value"}, nil
+}
+
+func TestExecutor_WriteOperationGuard_BlocksInResolver(t *testing.T) {
+	t.Parallel()
+
+	registry := newMockRegistry()
+	err := registry.Register(&mockWriteClassifierProvider{
+		name:     "github",
+		writeOps: []string{"create_label", "delete_label"},
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: map[string]any{"result": "ok"}}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+	resolvers := []*Resolver{
+		{
+			Name: "labels",
+			Type: TypeAny,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "github",
+						Inputs: map[string]*ValueRef{
+							"operation": {Literal: "create_label"},
+							"owner":     {Literal: "test"},
+							"repo":      {Literal: "test"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityFrom)
+	_, err = executor.Execute(ctx, resolvers, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+}
+
+func TestExecutor_WriteOperationGuard_AllowsReadInResolver(t *testing.T) {
+	t.Parallel()
+
+	registry := newMockRegistry()
+	err := registry.Register(&mockWriteClassifierProvider{
+		name:     "github",
+		writeOps: []string{"create_label"},
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: map[string]any{"result": []any{}}}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+	resolvers := []*Resolver{
+		{
+			Name: "labels",
+			Type: TypeAny,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "github",
+						Inputs: map[string]*ValueRef{
+							"operation": {Literal: "list_labels"},
+							"owner":     {Literal: "test"},
+							"repo":      {Literal: "test"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityFrom)
+	results, err := executor.Execute(ctx, resolvers, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, results)
+}

--- a/tests/integration/solutions/providers/github-v3-operations/solution.yaml
+++ b/tests/integration/solutions/providers/github-v3-operations/solution.yaml
@@ -1,0 +1,871 @@
+# GitHub Provider v3 Operations -- Functional Tests
+#
+# Tests GitHub provider operations against a mock HTTP server.
+# Read operations are resolvers, write operations are workflow actions.
+# Exception: api_call is intentionally unclassified (user controls the HTTP
+# method), so it can be used in resolvers even with mutating methods.
+#
+# Run: scafctl test -f tests/integration/solutions/providers/github-v3-operations/solution.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: github-v3-operations-test
+  version: 1.0.0
+  description: |
+    Functional tests for GitHub provider operations.
+    Uses a mock HTTP server to validate labels, milestones, reactions,
+    collaborators, webhooks, GitHub Actions, repo settings, custom
+    properties, and the generic api_call endpoint.
+
+spec:
+  # =====================================================================
+  # RESOLVERS -- Read operations + unclassified api_call
+  # =====================================================================
+  resolvers:
+    mock-base-url:
+      description: Base URL of mock GitHub API server
+      type: string
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+    # ─── Generic API Call ─────────────────────────────────────────────
+    api-call-get:
+      description: Generic GET api_call to list labels
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: api_call
+              api_base:
+                rslvr: mock-base-url
+              endpoint: /repos/test-org/test-repo/labels
+              method: GET
+
+    api-call-post:
+      description: Generic POST api_call to create a resource
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: api_call
+              api_base:
+                rslvr: mock-base-url
+              endpoint: /repos/test-org/test-repo/labels
+              method: POST
+              request_body:
+                name: new-label
+                color: "ff0000"
+
+    # ─── Label reads ──────────────────────────────────────────────────
+    list-labels:
+      description: List repository labels
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_labels
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── Milestone reads ─────────────────────────────────────────────
+    list-milestones:
+      description: List milestones
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_milestones
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── Reaction reads ──────────────────────────────────────────────
+    list-reactions:
+      description: List reactions on an issue
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_reactions
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+              number: 42
+
+    # ─── Collaborator reads ───────────────────────────────────────────
+    list-collaborators:
+      description: List repository collaborators
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_collaborators
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── Webhook reads ────────────────────────────────────────────────
+    list-webhooks:
+      description: List repository webhooks
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_webhooks
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── GitHub Actions reads ─────────────────────────────────────────
+    list-workflow-runs:
+      description: List workflow runs
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_workflow_runs
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    list-repo-variables:
+      description: List repository variables
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_repo_variables
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    list-environments:
+      description: List deployment environments
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_environments
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── Repository settings reads ────────────────────────────────────
+    list-topics:
+      description: List repository topics
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_topics
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+    # ─── Custom properties reads ──────────────────────────────────────
+    list-custom-properties:
+      description: List custom properties
+      type: any
+      resolve:
+        with:
+          - provider: github
+            inputs:
+              operation: list_custom_properties
+              owner: test-org
+              repo: test-repo
+              api_base:
+                rslvr: mock-base-url
+
+  # =====================================================================
+  # WORKFLOW -- Write operations
+  # =====================================================================
+  workflow:
+    actions:
+      create-label:
+        description: Create a new label
+        provider: github
+        inputs:
+          operation: create_label
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          label_name: help-wanted
+          color: "00ff00"
+          label_description: "Extra attention is needed"
+
+      delete-label:
+        description: Delete a label
+        provider: github
+        inputs:
+          operation: delete_label
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          label_name: old-label
+
+      add-labels-to-issue:
+        description: Add labels to an issue
+        provider: github
+        inputs:
+          operation: add_labels_to_issue
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          number: 42
+          labels:
+            - bug
+            - priority/high
+
+      create-milestone:
+        description: Create a milestone
+        provider: github
+        inputs:
+          operation: create_milestone
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          title: "v1.0"
+          description: "First release"
+
+      add-reaction:
+        description: Add a thumbs-up reaction to an issue
+        provider: github
+        inputs:
+          operation: add_reaction
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          number: 42
+          reaction_content: "+1"
+
+      add-collaborator:
+        description: Add a collaborator
+        provider: github
+        inputs:
+          operation: add_collaborator
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          username: new-contributor
+          permission: push
+
+      create-webhook:
+        description: Create a webhook
+        provider: github
+        inputs:
+          operation: create_webhook
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          webhook_url: https://example.com/webhook
+          webhook_events:
+            - push
+            - pull_request
+
+      dispatch-workflow:
+        description: Trigger a workflow dispatch
+        provider: github
+        inputs:
+          operation: dispatch_workflow
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          workflow_id: ci.yml
+          ref: main
+          workflow_inputs:
+            environment: staging
+
+      update-repo:
+        description: Update repository settings
+        provider: github
+        inputs:
+          operation: update_repo
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          description: "Updated project description"
+          has_wiki: false
+          delete_branch_on_merge: true
+
+      replace-topics:
+        description: Replace repository topics
+        provider: github
+        inputs:
+          operation: replace_topics
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          topics:
+            - golang
+            - cli
+            - scaffolding
+
+      fork-repo:
+        description: Fork a repository
+        provider: github
+        inputs:
+          operation: fork_repo
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          organization: my-org
+          default_branch_only: true
+
+      set-custom-properties:
+        description: Set custom properties
+        provider: github
+        inputs:
+          operation: set_custom_properties
+          owner: test-org
+          repo: test-repo
+          api_base:
+            rslvr: mock-base-url
+          properties:
+            environment: staging
+            team: platform
+
+  # =====================================================================
+  # TEST CONFIGURATION
+  # =====================================================================
+  testing:
+    config:
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: mock-github-api
+          type: http
+          portEnv: MOCK_HTTP_PORT
+          baseUrlEnv: MOCK_BASE_URL
+          routes:
+            # ── Labels ─────────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/labels
+              method: GET
+              status: 200
+              body: |
+                [
+                  {"id": 1, "name": "bug", "color": "d73a4a", "description": "Something is broken"},
+                  {"id": 2, "name": "enhancement", "color": "a2eeef", "description": "New feature"}
+                ]
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/labels
+              method: POST
+              status: 201
+              body: |
+                {"id": 3, "name": "help-wanted", "color": "00ff00", "description": "Extra attention is needed"}
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/labels/old-label
+              method: DELETE
+              status: 204
+              body: "{}"
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/issues/42/labels
+              method: POST
+              status: 200
+              body: |
+                [{"id": 1, "name": "bug"}, {"id": 4, "name": "priority/high"}]
+              headers:
+                Content-Type: application/json
+
+            # ── Milestones ─────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/milestones
+              method: GET
+              status: 200
+              body: |
+                [{"number": 1, "title": "v1.0", "description": "First release"}]
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/milestones
+              method: POST
+              status: 201
+              body: |
+                {"number": 2, "title": "v1.0", "description": "First release"}
+              headers:
+                Content-Type: application/json
+
+            # ── Reactions ──────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/issues/42/reactions
+              method: POST
+              status: 201
+              body: |
+                {"id": 100, "content": "+1", "user": {"login": "test-user"}}
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/issues/42/reactions
+              method: GET
+              status: 200
+              body: |
+                [
+                  {"id": 100, "content": "+1", "user": {"login": "user-a"}},
+                  {"id": 101, "content": "heart", "user": {"login": "user-b"}}
+                ]
+              headers:
+                Content-Type: application/json
+
+            # ── Collaborators ──────────────────────────────────────────
+            - path: /repos/test-org/test-repo/collaborators
+              method: GET
+              status: 200
+              body: |
+                [
+                  {"login": "owner", "permissions": {"admin": true}},
+                  {"login": "contributor", "permissions": {"push": true}}
+                ]
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/collaborators/new-contributor
+              method: PUT
+              status: 201
+              body: |
+                {"id": 1, "invitee": {"login": "new-contributor"}, "permissions": "push"}
+              headers:
+                Content-Type: application/json
+
+            # ── Webhooks ───────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/hooks
+              method: GET
+              status: 200
+              body: |
+                [{"id": 1, "url": "https://api.github.com/repos/test-org/test-repo/hooks/1", "config": {"url": "https://example.com/hook"}, "events": ["push"]}]
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/hooks
+              method: POST
+              status: 201
+              body: |
+                {"id": 2, "url": "https://api.github.com/repos/test-org/test-repo/hooks/2", "config": {"url": "https://example.com/webhook"}, "events": ["push", "pull_request"]}
+              headers:
+                Content-Type: application/json
+
+            # ── GitHub Actions ─────────────────────────────────────────
+            - path: /repos/test-org/test-repo/actions/workflows/ci.yml/dispatches
+              method: POST
+              status: 204
+              body: "{}"
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/actions/runs
+              method: GET
+              status: 200
+              body: |
+                {"total_count": 2, "workflow_runs": [{"id": 1, "status": "completed"}, {"id": 2, "status": "in_progress"}]}
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/actions/variables
+              method: GET
+              status: 200
+              body: |
+                {"total_count": 1, "variables": [{"name": "ENV", "value": "prod"}]}
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/environments
+              method: GET
+              status: 200
+              body: |
+                {"total_count": 2, "environments": [{"name": "staging"}, {"name": "production"}]}
+              headers:
+                Content-Type: application/json
+
+            # ── Repository Settings ────────────────────────────────────
+            - path: /repos/test-org/test-repo
+              method: PATCH
+              status: 200
+              body: |
+                {"full_name": "test-org/test-repo", "description": "Updated project description", "has_wiki": false, "delete_branch_on_merge": true}
+              headers:
+                Content-Type: application/json
+
+            # ── Topics ─────────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/topics
+              method: GET
+              status: 200
+              body: |
+                {"names": ["golang", "cli"]}
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/topics
+              method: PUT
+              status: 200
+              body: |
+                {"names": ["golang", "cli", "scaffolding"]}
+              headers:
+                Content-Type: application/json
+
+            # ── Fork ───────────────────────────────────────────────────
+            - path: /repos/test-org/test-repo/forks
+              method: POST
+              status: 202
+              body: |
+                {"full_name": "my-org/test-repo", "fork": true, "owner": {"login": "my-org"}}
+              headers:
+                Content-Type: application/json
+
+            # ── Custom Properties ──────────────────────────────────────
+            - path: /repos/test-org/test-repo/properties/values
+              method: GET
+              status: 200
+              body: |
+                [{"property_name": "environment", "value": "production"}, {"property_name": "team", "value": "platform"}]
+              headers:
+                Content-Type: application/json
+
+            - path: /repos/test-org/test-repo/properties/values
+              method: PATCH
+              status: 204
+              body: "{}"
+              headers:
+                Content-Type: application/json
+
+    cases:
+      _resolver-base:
+        description: Base template for resolver tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [provider, github, v3]
+
+      _action-base:
+        description: Base template for action tests
+        command: [run, action]
+        args: ["-o", "json"]
+        tags: [provider, github, v3]
+
+      # ── API Call Tests ──────────────────────────────────────────────
+      api-call-get:
+        description: Generic api_call GET returns label list
+        extends: [_resolver-base]
+        tags: [api-call]
+        args: ["api-call-get", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "api_call GET should succeed"
+          - expression: size(__output['api-call-get'].result) == 2
+            message: "Should return 2 labels"
+          - expression: __output['api-call-get'].result[0].name == 'bug'
+            message: "First label should be bug"
+
+      api-call-post:
+        description: Generic api_call POST creates a resource
+        extends: [_resolver-base]
+        tags: [api-call]
+        args: ["api-call-post", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "api_call POST should succeed"
+          - expression: __output['api-call-post'].success == true
+            message: "api_call POST should report success"
+
+      # ── Label Read Tests ────────────────────────────────────────────
+      list-labels:
+        description: List labels returns expected labels
+        extends: [_resolver-base]
+        tags: [labels]
+        args: ["list-labels", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_labels should succeed"
+          - expression: size(__output['list-labels'].result) == 2
+            message: "Should return 2 labels"
+
+      # ── Label Write Tests ───────────────────────────────────────────
+      create-label:
+        description: Create a new label
+        extends: [_action-base]
+        tags: [labels]
+        args: ["create-label", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "create_label should succeed"
+          - expression: __output.actions['create-label'].status == 'succeeded'
+            message: "Should report success"
+
+      delete-label:
+        description: Delete a label
+        extends: [_action-base]
+        tags: [labels]
+        args: ["delete-label", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "delete_label should succeed"
+          - expression: __output.actions['delete-label'].status == 'succeeded'
+            message: "Should report success"
+
+      add-labels-to-issue:
+        description: Add labels to an issue
+        extends: [_action-base]
+        tags: [labels]
+        args: ["add-labels-to-issue", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "add_labels_to_issue should succeed"
+          - expression: __output.actions['add-labels-to-issue'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Milestone Read Tests ────────────────────────────────────────
+      list-milestones:
+        description: List milestones
+        extends: [_resolver-base]
+        tags: [milestones]
+        args: ["list-milestones", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_milestones should succeed"
+          - expression: size(__output['list-milestones'].result) == 1
+            message: "Should return 1 milestone"
+          - expression: __output['list-milestones'].result[0].title == 'v1.0'
+            message: "Milestone should be v1.0"
+
+      # ── Milestone Write Tests ───────────────────────────────────────
+      create-milestone:
+        description: Create a milestone
+        extends: [_action-base]
+        tags: [milestones]
+        args: ["create-milestone", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "create_milestone should succeed"
+          - expression: __output.actions['create-milestone'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Reaction Read Tests ─────────────────────────────────────────
+      list-reactions:
+        description: List reactions on issue
+        extends: [_resolver-base]
+        tags: [reactions]
+        args: ["list-reactions", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_reactions should succeed"
+          - expression: size(__output['list-reactions'].result) == 2
+            message: "Should return 2 reactions"
+
+      # ── Reaction Write Tests ────────────────────────────────────────
+      add-reaction:
+        description: Add thumbs-up reaction
+        extends: [_action-base]
+        tags: [reactions]
+        args: ["add-reaction", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "add_reaction should succeed"
+          - expression: __output.actions['add-reaction'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Collaborator Read Tests ─────────────────────────────────────
+      list-collaborators:
+        description: List collaborators
+        extends: [_resolver-base]
+        tags: [collaborators]
+        args: ["list-collaborators", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_collaborators should succeed"
+          - expression: size(__output['list-collaborators'].result) == 2
+            message: "Should return 2 collaborators"
+
+      # ── Collaborator Write Tests ────────────────────────────────────
+      add-collaborator:
+        description: Add a collaborator
+        extends: [_action-base]
+        tags: [collaborators]
+        args: ["add-collaborator", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "add_collaborator should succeed"
+          - expression: __output.actions['add-collaborator'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Webhook Read Tests ──────────────────────────────────────────
+      list-webhooks:
+        description: List webhooks
+        extends: [_resolver-base]
+        tags: [webhooks]
+        args: ["list-webhooks", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_webhooks should succeed"
+          - expression: size(__output['list-webhooks'].result) == 1
+            message: "Should return 1 webhook"
+
+      # ── Webhook Write Tests ─────────────────────────────────────────
+      create-webhook:
+        description: Create a webhook
+        extends: [_action-base]
+        tags: [webhooks]
+        args: ["create-webhook", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "create_webhook should succeed"
+          - expression: __output.actions['create-webhook'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── GitHub Actions Read Tests ───────────────────────────────────
+      list-workflow-runs:
+        description: List workflow runs
+        extends: [_resolver-base]
+        tags: [actions]
+        args: ["list-workflow-runs", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_workflow_runs should succeed"
+          - expression: __output['list-workflow-runs'].result.total_count == 2.0
+            message: "Should return 2 workflow runs"
+
+      list-repo-variables:
+        description: List repository variables
+        extends: [_resolver-base]
+        tags: [actions]
+        args: ["list-repo-variables", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_repo_variables should succeed"
+          - expression: __output['list-repo-variables'].result.total_count == 1.0
+            message: "Should return 1 variable"
+
+      list-environments:
+        description: List deployment environments
+        extends: [_resolver-base]
+        tags: [actions]
+        args: ["list-environments", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_environments should succeed"
+          - expression: __output['list-environments'].result.total_count == 2.0
+            message: "Should return 2 environments"
+
+      # ── GitHub Actions Write Tests ──────────────────────────────────
+      dispatch-workflow:
+        description: Dispatch a workflow
+        extends: [_action-base]
+        tags: [actions]
+        args: ["dispatch-workflow", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "dispatch_workflow should succeed"
+          - expression: __output.actions['dispatch-workflow'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Repository Settings Write Tests ─────────────────────────────
+      update-repo:
+        description: Update repository settings
+        extends: [_action-base]
+        tags: [repo-settings]
+        args: ["update-repo", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "update_repo should succeed"
+          - expression: __output.actions['update-repo'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Topics Read Tests ───────────────────────────────────────────
+      list-topics:
+        description: List repository topics
+        extends: [_resolver-base]
+        tags: [repo-settings]
+        args: ["list-topics", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_topics should succeed"
+          - expression: size(__output['list-topics'].result.names) == 2
+            message: "Should return 2 topics"
+
+      # ── Topics Write Tests ──────────────────────────────────────────
+      replace-topics:
+        description: Replace repository topics
+        extends: [_action-base]
+        tags: [repo-settings]
+        args: ["replace-topics", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "replace_topics should succeed"
+          - expression: __output.actions['replace-topics'].status == 'succeeded'
+            message: "Should report success"
+
+      fork-repo:
+        description: Fork a repository
+        extends: [_action-base]
+        tags: [repo-settings]
+        args: ["fork-repo", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "fork_repo should succeed"
+          - expression: __output.actions['fork-repo'].status == 'succeeded'
+            message: "Should report success"
+
+      # ── Custom Properties Read Tests ────────────────────────────────
+      list-custom-properties:
+        description: List custom properties
+        extends: [_resolver-base]
+        tags: [custom-properties]
+        args: ["list-custom-properties", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "list_custom_properties should succeed"
+          - expression: size(__output['list-custom-properties'].result) == 2
+            message: "Should return 2 custom properties"
+
+      # ── Custom Properties Write Tests ───────────────────────────────
+      set-custom-properties:
+        description: Set custom properties
+        extends: [_action-base]
+        tags: [custom-properties]
+        args: ["set-custom-properties", "-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "set_custom_properties should succeed"
+          - expression: __output.actions['set-custom-properties'].status == 'succeeded'
+            message: "Should report success"


### PR DESCRIPTION
- add 40+ new GitHub operations: labels, milestones, reactions, collaborators, webhooks, GitHub Actions, repo settings, custom properties, topics, fork, template, and generic api_call
- add ValidateWriteOperation to block write ops in resolver context across all execution paths (executor, iteration, and self)
- declare WriteOperations on GitHub provider Descriptor for read/write classification with exhaustive coverage test
- add api_call operation for arbitrary authenticated REST requests with endpoint validation (path traversal, absolute URL rejection)
- use url.PathEscape for user inputs in URL path segments and url.QueryEscape/url.Values for query parameters
- mark webhook_secret as SensitiveField to prevent debug logging
- fix api_call to only accept "request_body" (remove undocumented "body" fallback that collided with the PR/issue body field)
- add validation example and solution for end-to-end testing

BREAKING CHANGE: resolvers now reject write operations declared in a provider's WriteOperations list; use workflow actions instead

Relates to #284