### PR TITLE
fix(gotmpl)!: register built-in functions for template reference extra action

### DIFF
--- a/.github/skills/solution-spec/SKILL.md
+++ b/.github/skills/solution-spec/SKILL.md
@@ -86,8 +86,43 @@ spec:
 ### Phase Execution Order
 
 1. **Resolve**: Providers execute in order. First non-null result wins (`until:` controls early stop).
-2. **Transform**: Applied sequentially. `__self` is the current value.
+2. **Transform**: Applied sequentially. `__self` is the current value. Supports `forEach` for array iteration.
 3. **Validate**: All rules checked. Resolver fails if any validation fails.
+
+### forEach (Resolve and Transform Steps)
+
+`forEach` is supported on both `resolve.with` and `transform.with` steps. It is NOT supported on `validate.with`.
+
+**Key difference**: On resolve steps, `forEach.in` is **required** (no `__self` available). On transform steps, `forEach.in` defaults to `__self`.
+
+```yaml
+# Resolve: fan-out HTTP requests directly
+resolve:
+  with:
+    - provider: http
+      forEach:
+        in:             # required on resolve (no __self)
+          rslvr: moduleList
+        item: mod
+        concurrency: 10
+      inputs:
+        url:
+          expr: 'mod.url'
+
+# Transform: double each number
+transform:
+  with:
+    - provider: cel
+      forEach:
+        item: num       # alias for __item (current element)
+        index: i        # alias for __index (current 0-based index)
+      inputs:
+        expression: "num * 2"
+```
+
+**Fields**: `item`, `index`, `in` (ValueRef; required on resolve, defaults to `__self` on transform), `concurrency` (int), `keepSkipped` (bool), `onError` (actions only: `fail`|`continue`).
+
+**Context variables**: `__item` and `__index` are always injected. Custom aliases (`item`, `index` fields) are added alongside them.
 
 ### Dependency Resolution (DAG)
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -43,6 +43,7 @@ Providers are execution primitives used by resolvers and actions. Each provider 
 | [parameter](#parameter) | ✅ | ❌ | ❌ | ❌ |
 | [secret](#secret) | ✅ | ❌ | ❌ | ❌ |
 | [sleep](#sleep) | ✅ | ✅ | ✅ | ✅ |
+| [solution](#solution) | ✅ | ❌ | ❌ | ✅ |
 | [static](#static) | ✅ | ✅ | ❌ | ❌ |
 | [validation](#validation) | ❌ | ✅ | ✅ | ❌ |
 
@@ -322,7 +323,7 @@ Execute shell commands using an embedded cross-platform POSIX shell interpreter.
 | `args` | array | ❌ | — | Additional arguments appended to the command. Arguments are automatically shell-quoted for safety |
 | `stdin` | string | ❌ | — | Standard input to provide to the command |
 | `workingDir` | string | ❌ | — | Working directory for command execution |
-| `env` | object | ❌ | — | Environment variables to set (key-value pairs). Merged with the parent process environment |
+| `env` | object | ❌ | — | Environment variables to set (key-value pairs). Merged with the parent process environment. `NO_COLOR=1` and `TERM=dumb` are injected automatically to prevent child processes from emitting ANSI escape codes in captured output (override by setting them explicitly) |
 | `timeout` | int | ❌ | — | Timeout in seconds (0 or omit for no timeout, max 3600) |
 | `shell` | string | ❌ | `auto` | Shell interpreter to use: `auto` (embedded POSIX shell — works on all platforms), `sh` (alias for auto), `bash` (external bash), `pwsh` (external PowerShell Core), `cmd` (external cmd.exe — Windows only) |
 
@@ -559,9 +560,9 @@ The git provider enforces several security measures:
 
 ## github
 
-Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, tags, repos) and REST (releases, rulesets, security settings). Uses the configured GitHub auth handler automatically. Commit operations use `createCommitOnBranch` for GPG-signed multi-file atomic commits.
+Interact with GitHub via GraphQL (reads, issues, PRs, review threads, signed commits, branches, tags, repos, branch protection) and REST (releases, CI check runs, workflow runs, labels, milestones, reactions, collaborators, webhooks, Actions workflows, variables, environments, repo settings, topics, custom properties, security settings). Uses the configured GitHub auth handler automatically. Commit operations use `createCommitOnBranch` for GPG-signed multi-file atomic commits. Includes a generic `api_call` operation for arbitrary GitHub REST endpoints.
 
-> For arbitrary HTTP requests to GitHub, use the `http` provider with `auth: github`.
+> For arbitrary GitHub REST endpoints not covered by a named operation, use the built-in `api_call` operation instead of falling back to the `http` provider.
 
 ### Capabilities
 
@@ -613,6 +614,61 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 | `allow_force_pushes` | bool | ❌ | Allow force pushes to matching refs |
 | `allow_deletions` | bool | ❌ | Allow deletion of matching refs |
 | `requires_commit_signatures` | bool | ❌ | Require signed commits |
+| `commit_sha` | string | ❌ | Commit SHA for `list_commit_pulls` (alias: `sha`) |
+| `endpoint` | string | ❌ | Relative API path for `api_call` (e.g. `/repos/{owner}/{repo}/labels`). Must start with `/` |
+| `method` | string | ❌ | HTTP method for `api_call`: `GET`, `POST`, `PUT`, `PATCH`, `DELETE` (default: `GET`) |
+| `request_body` | object | ❌ | Request body for `api_call` (used with POST/PUT/PATCH) |
+| `query_params` | object | ❌ | Query string parameters for `api_call` (e.g. `{per_page: 100}`) |
+| `state_reason` | string | ❌ | Reason for closing an issue: `completed`, `not_planned`, `reopened` |
+| `thread_id` | string | ❌ | Review thread node ID for `reply_to_review_thread` and `resolve_review_thread` |
+| `run_id` | int | ❌ | Workflow run ID for `get_workflow_run`, `cancel_workflow_run`, `rerun_workflow` |
+| `commit_title` | string | ❌ | Commit title for `merge_pull_request` |
+| `commit_message` | string | ❌ | Commit message body for `merge_pull_request` |
+| `message_body` | string | ❌ | Extended commit message body for `create_commit` |
+| `description` | string | ❌ | Description for repo, label, milestone, or environment |
+| `label_name` | string | ❌ | Label name for label CRUD operations |
+| `new_label_name` | string | ❌ | New label name when renaming (`update_label`) |
+| `color` | string | ❌ | Hex color code for labels, without `#` (e.g. `00ff00`) |
+| `label_description` | string | ❌ | Description for a label |
+| `milestone_number` | int | ❌ | Milestone number for update/delete operations |
+| `due_on` | string | ❌ | Due date for milestone (ISO 8601: `YYYY-MM-DDTHH:MM:SSZ`) |
+| `reaction_content` | string | ❌ | Reaction emoji: `+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes` |
+| `reaction_subject` | string | ❌ | Subject type for reaction: `issue`, `pull_request`, `issue_comment` (default: `issue`) |
+| `reaction_id` | int | ❌ | Reaction ID for `delete_reaction` |
+| `comment_id` | int | ❌ | Comment ID for reaction/comment operations |
+| `username` | string | ❌ | GitHub username for collaborator operations |
+| `permission` | string | ❌ | Permission level: `pull`, `triage`, `push`, `maintain`, `admin` |
+| `webhook_url` | string | ❌ | Payload URL for the webhook |
+| `webhook_events` | array | ❌ | Events that trigger the webhook (e.g. `["push", "pull_request"]`) |
+| `webhook_content_type` | string | ❌ | Content type for webhook payloads: `json` or `form` (default: `json`) |
+| `webhook_secret` | string | ❌ | Secret for webhook signature verification (sensitive) |
+| `webhook_active` | bool | ❌ | Whether the webhook is active |
+| `hook_id` | int | ❌ | Webhook ID for update/delete operations |
+| `workflow_id` | string | ❌ | Workflow file name or numeric ID (e.g. `ci.yml`) |
+| `workflow_inputs` | object | ❌ | Input parameters for `dispatch_workflow` |
+| `workflow_status` | string | ❌ | Filter workflow runs by status (e.g. `completed`, `in_progress`, `queued`) |
+| `variable_name` | string | ❌ | Repository variable name |
+| `variable_value` | string | ❌ | Repository variable value |
+| `environment_name` | string | ❌ | Deployment environment name |
+| `wait_timer` | int | ❌ | Wait timer in minutes before deployments proceed (0--43200) |
+| `reviewers` | array | ❌ | Required reviewers for environment (objects with `type` and `id`) |
+| `homepage` | string | ❌ | Repository homepage URL (`update_repo`) |
+| `default_branch` | string | ❌ | Default branch name (`update_repo`) |
+| `has_issues` | bool | ❌ | Enable issues feature (`update_repo`) |
+| `has_projects` | bool | ❌ | Enable projects feature (`update_repo`) |
+| `has_wiki` | bool | ❌ | Enable wiki feature (`update_repo`) |
+| `allow_squash_merge` | bool | ❌ | Allow squash merging (`update_repo`) |
+| `allow_merge_commit` | bool | ❌ | Allow merge commits (`update_repo`) |
+| `allow_rebase_merge` | bool | ❌ | Allow rebase merging (`update_repo`) |
+| `delete_branch_on_merge` | bool | ❌ | Auto-delete head branches after merge (`update_repo`) |
+| `archived` | bool | ❌ | Archive the repository (`update_repo`) |
+| `topics` | array | ❌ | Repository topics/tags for `replace_topics` |
+| `organization` | string | ❌ | Organization to fork into (`fork_repo`) |
+| `default_branch_only` | bool | ❌ | Fork only the default branch (`fork_repo`) |
+| `new_repo_name` | string | ❌ | Name for new repository (`create_from_template`) |
+| `new_owner` | string | ❌ | Owner for new repository (`create_from_template`) |
+| `include_all_branches` | bool | ❌ | Include all branches when creating from template |
+| `properties` | object | ❌ | Custom properties to set (key-value map for `set_custom_properties`) |
 
 ### Operations
 
@@ -633,6 +689,22 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 | `get_branch` | Get a single branch |
 | `list_tags` | List tags |
 | `get_head_oid` | Get HEAD commit SHA for a branch |
+| `list_pr_comments` | List comments on a pull request |
+| `list_review_threads` | List review threads on a pull request |
+| `list_check_runs` | List check runs for a ref (REST) |
+| `get_workflow_run` | Get a workflow run by ID (REST) |
+| `list_workflow_runs` | List workflow runs (REST, filterable by status) |
+| `list_commit_pulls` | List pull requests associated with a commit SHA (REST) |
+| `list_labels` | List repository labels (REST) |
+| `list_milestones` | List milestones (REST) |
+| `list_reactions` | List reactions on an issue, PR, or comment (REST) |
+| `list_collaborators` | List repository collaborators (REST) |
+| `list_webhooks` | List repository webhooks (REST) |
+| `list_repo_variables` | List repository variables (REST) |
+| `list_environments` | List deployment environments (REST) |
+| `list_topics` | List repository topics (REST) |
+| `list_custom_properties` | List custom properties (REST) |
+| `api_call` | Generic REST API call to any GitHub endpoint (see below) |
 
 **Write operations** (capability: `action` — returns `success` boolean):
 
@@ -657,6 +729,47 @@ Interact with GitHub via GraphQL (reads, issues, PRs, signed commits, branches, 
 | `create_ruleset` | REST | Create a repository ruleset (branch or tag protection) |
 | `enable_vulnerability_alerts` | REST | Enable Dependabot vulnerability alerts |
 | `enable_automated_security_fixes` | REST | Enable Dependabot automated security fixes |
+| `update_repo` | REST | Update repository settings |
+| `reply_to_review_thread` | GraphQL | Reply to a review thread |
+| `resolve_review_thread` | GraphQL | Resolve a review thread |
+| `create_label` | REST | Create a repository label |
+| `update_label` | REST | Update a label (name, color, description) |
+| `delete_label` | REST | Delete a label |
+| `add_labels_to_issue` | REST | Add labels to an issue |
+| `remove_label_from_issue` | REST | Remove a label from an issue |
+| `create_milestone` | REST | Create a milestone |
+| `update_milestone` | REST | Update a milestone |
+| `delete_milestone` | REST | Delete a milestone |
+| `add_reaction` | REST | Add a reaction to an issue, PR, or comment |
+| `delete_reaction` | REST | Remove a reaction |
+| `add_collaborator` | REST | Add a repository collaborator |
+| `remove_collaborator` | REST | Remove a repository collaborator |
+| `create_webhook` | REST | Create a repository webhook |
+| `update_webhook` | REST | Update a webhook |
+| `delete_webhook` | REST | Delete a webhook |
+| `dispatch_workflow` | REST | Trigger a workflow dispatch event |
+| `cancel_workflow_run` | REST | Cancel a workflow run |
+| `rerun_workflow` | REST | Re-run a workflow |
+| `create_or_update_variable` | REST | Create or update a repository variable |
+| `delete_variable` | REST | Delete a repository variable |
+| `create_or_update_environment` | REST | Create or update a deployment environment |
+| `delete_environment` | REST | Delete a deployment environment |
+| `replace_topics` | REST | Replace all repository topics |
+| `fork_repo` | REST | Fork a repository |
+| `create_from_template` | REST | Create a repository from a template |
+| `set_custom_properties` | REST | Set custom properties on a repository |
+
+#### `api_call` operation
+
+A generic escape hatch for any GitHub REST API endpoint not covered by a named operation.
+Keeps auth handling, GHE hostname resolution, and API versioning consistent without
+needing the `http` provider.
+
+- `endpoint` is required and must be a relative path starting with `/`
+- Path traversal (`..`) and query strings (`?`) in `endpoint` are rejected -- use `query_params` instead
+- For `GET` requests, the output uses `readOutput` (same shape as other read operations)
+- For mutating methods (`POST`/`PUT`/`PATCH`/`DELETE`), the output uses `actionOutput`
+- `api_call` is intentionally excluded from the write-operation guard -- the user controls the HTTP method, so it cannot be classified at the provider level
 
 ### Output
 
@@ -787,6 +900,231 @@ action:
         operation: enable_vulnerability_alerts
         owner: my-org
         repo: my-repo
+
+# Update repository settings
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: update_repo
+        owner: my-org
+        repo: my-repo
+        description: "Updated description"
+        has_wiki: false
+        delete_branch_on_merge: true
+
+# Reply to a review thread
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: reply_to_review_thread
+        owner: my-org
+        repo: my-repo
+        thread_id: "PRRT_abc123"
+        body: "Fixed in the latest commit, thanks!"
+
+# Create and manage labels
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_label
+        owner: my-org
+        repo: my-repo
+        label_name: "priority/critical"
+        color: "e11d48"
+        label_description: "Critical priority issues"
+
+# Add labels to an issue
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: add_labels_to_issue
+        owner: my-org
+        repo: my-repo
+        number: 42
+        labels:
+          - bug
+          - priority/critical
+
+# Create a milestone
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_milestone
+        owner: my-org
+        repo: my-repo
+        title: "v2.0.0"
+        description: "Second major release"
+        due_on: "2026-06-01T00:00:00Z"
+
+# Add a reaction to an issue
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: add_reaction
+        owner: my-org
+        repo: my-repo
+        number: 42
+        reaction_content: "+1"
+
+# Add a collaborator
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: add_collaborator
+        owner: my-org
+        repo: my-repo
+        username: octocat
+        permission: push
+
+# Create a webhook
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_webhook
+        owner: my-org
+        repo: my-repo
+        webhook_url: "https://example.com/webhook"
+        webhook_events:
+          - push
+          - pull_request
+        webhook_content_type: json
+
+# Dispatch a workflow
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: dispatch_workflow
+        owner: my-org
+        repo: my-repo
+        workflow_id: deploy.yml
+        ref: main
+        workflow_inputs:
+          environment: production
+
+# List workflow runs (read)
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: list_workflow_runs
+        owner: my-org
+        repo: my-repo
+        workflow_id: ci.yml
+        workflow_status: completed
+
+# Create or update a repository variable
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_or_update_variable
+        owner: my-org
+        repo: my-repo
+        variable_name: DEPLOY_ENV
+        variable_value: production
+
+# Create a deployment environment with reviewers
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_or_update_environment
+        owner: my-org
+        repo: my-repo
+        environment_name: production
+        wait_timer: 30
+        reviewers:
+          - type: User
+            id: 12345
+
+# Replace repository topics
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: replace_topics
+        owner: my-org
+        repo: my-repo
+        topics:
+          - go
+          - cli
+          - scaffolding
+
+# Fork a repository
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: fork_repo
+        owner: upstream-org
+        repo: cool-project
+        organization: my-org
+        default_branch_only: true
+
+# Create from template
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: create_from_template
+        owner: template-org
+        repo: go-template
+        new_owner: my-org
+        new_repo_name: my-new-service
+        description: "Service from template"
+        include_all_branches: false
+
+# List check runs for a ref (read)
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: list_check_runs
+        owner: my-org
+        repo: my-repo
+        ref: main
+
+# List pull requests associated with a commit
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: list_commit_pulls
+        owner: my-org
+        repo: my-repo
+        commit_sha: abc123def456
+
+# Generic REST API call (read)
+resolve:
+  with:
+    - provider: github
+      inputs:
+        operation: api_call
+        endpoint: /repos/my-org/my-repo/labels
+        query_params:
+          per_page: 100
+
+# Generic REST API call (write)
+action:
+  with:
+    - provider: github
+      inputs:
+        operation: api_call
+        endpoint: /repos/my-org/my-repo/labels
+        method: POST
+        request_body:
+          name: bug
+          color: d73a4a
+          description: "Something isn't working"
 ```
 
 > [!TIP]
@@ -1473,7 +1811,7 @@ resolve:
 
 ## metadata
 
-Returns runtime metadata about the scafctl process and the currently-executing solution. Requires no inputs — all data is gathered from the execution context and process environment. Useful for conditional logic, auditing, and passing runtime info to templates and downstream resolvers.
+Returns runtime metadata about the scafctl process and the currently-executing solution, including platform information. Requires no inputs -- all data is gathered from the execution context and process environment. Useful for conditional logic, auditing, cross-platform solutions, and passing runtime info to templates and downstream resolvers.
 
 ### Capabilities
 
@@ -1502,6 +1840,9 @@ None. The metadata provider accepts no inputs.
 | `solution.description` | string | Solution description |
 | `solution.category` | string | Solution category |
 | `solution.tags` | string[] | Solution tags |
+| `os` | string | Operating system (`runtime.GOOS`): `darwin`, `linux`, `windows`, etc. |
+| `arch` | string | CPU architecture (`runtime.GOARCH`): `amd64`, `arm64`, etc. |
+| `shell` | string | Detected shell name (e.g. `bash`, `zsh`, `fish`, `pwsh`, `powershell`, `cmd.exe`). On Unix, reads `$SHELL`. On Windows, detects PowerShell via `PSModulePath` and parent process inspection, then falls back to Git Bash (`$SHELL`) and finally `%ComSpec%`. Empty if not detected. |
 
 ### Examples
 
@@ -1539,7 +1880,7 @@ resolvers:
 
 ## message
 
-Outputs styled terminal messages with built-in types, custom formatting via lipgloss, destination control, and respects `--quiet` and `--no-color` flags. For dynamic interpolation, use the framework's `tmpl:` or `expr:` ValueRef on the `message` input — the provider does not handle templating internally.
+Outputs styled terminal messages with built-in types, custom formatting via lipgloss, destination control, and respects `--quiet` and `--no-color` flags. For dynamic interpolation, use the framework's `tmpl:` or `expr:` ValueRef on the `message` input --- the provider does not handle templating internally. Use `type: raw` for machine-readable output that bypasses the 8192-character limit and writes content directly without formatting.
 
 ### Capabilities
 
@@ -1549,10 +1890,10 @@ Outputs styled terminal messages with built-in types, custom formatting via lipg
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `message` | string | ✅ | Message text to output. Use `tmpl:` or `expr:` ValueRef for dynamic interpolation. |
-| `type` | string | ❌ | Message type: `success`, `warning`, `error`, `info` (default), `debug`, `plain` |
-| `label` | string | ❌ | Contextual prefix rendered as dimmed `[label]` between icon and message (e.g., `step 2/5`) |
-| `style` | object | ❌ | Custom formatting that merges on top of type defaults: `color` (hex or named), `bold`, `italic`, `icon` |
+| `message` | string | ✅ | Message text to output. Use `tmpl:` or `expr:` ValueRef for dynamic interpolation. Limited to 8192 characters unless `type: raw`. |
+| `type` | string | ❌ | Message type: `success`, `warning`, `error`, `info` (default), `debug`, `plain`, `raw` |
+| `label` | string | ❌ | Contextual prefix rendered as dimmed `[label]` between icon and message (e.g., `step 2/5`). Not supported with `type: raw`. |
+| `style` | object | ❌ | Custom formatting that merges on top of type defaults: `color` (hex or named), `bold`, `italic`, `icon`. Not supported with `type: raw`. |
 | `destination` | string | ❌ | Output target: `stdout` (default) or `stderr` |
 | `newline` | bool | ❌ | Append trailing newline (default: `true`) |
 
@@ -1634,6 +1975,20 @@ resolvers:
             message:
               expr: "'Processed ' + string(size(_.items)) + ' items'"
             type: success
+```
+
+**Raw output (machine-readable, no length limit):**
+
+```yaml
+actions:
+  emit-index:
+    steps:
+      - provider: message
+        inputs:
+          message:
+            rslvr: registry_index_json
+          type: raw
+          newline: false
 ```
 
 ---
@@ -1775,6 +2130,89 @@ inputs:
 
 ---
 
+## solution
+
+Execute a sub-solution and return its results as a structured envelope. Supports recursive composition with circular reference detection and configurable depth limits. In `from` mode, only the resolver phase runs. In `action` mode, resolvers run first, then the workflow (if present).
+
+### Capabilities
+
+`from`, `action`
+
+### Inputs
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `source` | string | Yes | Sub-solution location: file path, catalog reference (e.g. `deploy-to-k8s@2.0.0`), or URL |
+| `inputs` | object | ❌ | Parameters passed to the sub-solution's `parameter` provider |
+| `resolvers` | array | ❌ | Resolver names to execute from the child solution; when empty all resolvers run |
+| `propagateErrors` | bool | ❌ | Whether sub-solution failures cause a Go error (default: `true`) |
+| `maxDepth` | int | ❌ | Maximum nesting depth for recursive composition, 1--100 (default: `10`) |
+| `timeout` | string | ❌ | Maximum duration for sub-solution execution (Go duration, e.g. `30s`, `5m`) |
+
+### Output
+
+**From capability (resolver-only):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `resolvers` | object | Resolver values from the sub-solution (keyed by resolver name) |
+| `status` | string | Overall status: `success` or `failed` |
+| `errors` | array | Resolver errors encountered during execution |
+
+**Action capability (resolvers + workflow):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `resolvers` | object | Resolver values from the sub-solution |
+| `workflow` | object | Aggregate workflow status (`finalStatus`, `failedActions`, `skippedActions`) |
+| `status` | string | Overall status: `success` or `failed` |
+| `errors` | array | Resolver errors encountered during execution |
+| `success` | bool | Whether the solution succeeded |
+
+### Examples
+
+```yaml
+# Load child solution (from capability)
+resolve:
+  with:
+    - provider: solution
+      inputs:
+        source: "./child-solution.yaml"
+        inputs:
+          environment: "production"
+
+# Execute child solution with workflow (action capability)
+action:
+  with:
+    - provider: solution
+      inputs:
+        source: "deploy-to-k8s@2.0.0"
+        inputs:
+          cluster: prod-east
+          replicas: 3
+        timeout: "5m"
+
+# Select specific resolvers from child solution
+resolve:
+  with:
+    - provider: solution
+      inputs:
+        source: "./shared/config.yaml"
+        resolvers:
+          - database_config
+          - cache_config
+
+# Soft failures (don't propagate errors)
+resolve:
+  with:
+    - provider: solution
+      inputs:
+        source: "./optional-enrichment.yaml"
+        propagateErrors: false
+```
+
+---
+
 ## static
 
 Return a constant value. Useful for defaults and fallbacks.
@@ -1873,6 +2311,95 @@ validate:
         message: "Version must be semver format and >= v1.0.0"
 
 ```
+
+## forEach with Providers
+
+The `forEach` clause iterates over an array, executing a provider once per element and collecting results into an output array.
+
+### Supported Phases
+
+| Phase | Supported | `forEach.in` | Notes |
+|-------|:---------:|:------------:|-------|
+| `transform.with` | Yes | Optional (defaults to `__self`) | Most common -- transform an existing value |
+| `resolve.with` | Yes | **Required** | No `__self` in resolve phase |
+| `validate.with` | No | -- | Not supported |
+
+### forEach Clause Fields
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `item` | string | No | Variable name alias for current array element. `__item` is always available. |
+| `index` | string | No | Variable name alias for current 0-based index. `__index` is always available. |
+| `in` | ValueRef | Resolve: Yes, Transform: No | Array to iterate over. Defaults to `__self` (transform only). |
+| `concurrency` | int | No | Maximum parallel iterations. `0` (default) means unlimited. |
+| `keepSkipped` | bool | No | Retain `nil` entries for items skipped by `when` condition (default: `false`). |
+| `onError` | string | No | Error handling: `fail` (default) or `continue`. Actions only; resolvers ignore this. |
+
+### How It Works
+
+1. The `in` source (or `__self` for transform) is evaluated to get an input array.
+2. The provider executes once per element, with `__item`/`__index` (and any custom aliases) injected into the expression context.
+3. Results are collected into an output array preserving order.
+4. If a `when` condition is present, items where `when` is `false` are removed from the output (unless `keepSkipped: true`).
+
+### Examples
+
+```yaml
+# Resolve: fan-out HTTP requests directly (no static placeholder needed)
+resolve:
+  with:
+    - provider: http
+      forEach:
+        in:
+          rslvr: moduleList
+        item: mod
+        concurrency: 10
+      inputs:
+        url:
+          expr: '"https://registry.example.com/v1/modules/" + mod.name + "/versions"'
+        method: GET
+        autoParseJson: true
+
+# Transform: double each number in an array
+transform:
+  with:
+    - provider: cel
+      forEach:
+        item: num
+        index: i
+      inputs:
+        expression: "num * 2"
+
+# Transform: filter and keep only active users
+transform:
+  with:
+    - provider: cel
+      forEach:
+        item: user
+      when:
+        expr: "user.active == true"
+      inputs:
+        expression: "user"
+
+# Preserve index alignment with keepSkipped
+transform:
+  with:
+    - provider: cel
+      forEach:
+        item: x
+        keepSkipped: true
+      when:
+        expr: "x > 5"
+      inputs:
+        expression: "x"
+```
+
+> [!NOTE]
+> On resolve steps, `forEach.in` is **required** because there is no `__self` in the resolve phase. On transform steps, `forEach.in` defaults to `__self` (the current value being transformed).
+
+For a full walkthrough with runnable examples, see the [Resolver Tutorial -- Array Iteration with forEach](resolver-tutorial.md#array-iteration-with-foreach).
+
+---
 
 ## Next Steps
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -91,6 +91,7 @@ Action workflows demonstrate executing tasks with dependencies, parallelism, and
 | [template-render.yaml](actions/template-render.yaml) | Render files from templates | `scafctl run solution -f examples/actions/template-render.yaml` |
 | [go-template-inline.yaml](actions/go-template-inline.yaml) | Inline Go templates with loops/conditionals | `scafctl run solution -f examples/actions/go-template-inline.yaml` |
 | [complex-workflow.yaml](actions/complex-workflow.yaml) | Full CI/CD-style workflow | `scafctl run solution -f examples/actions/complex-workflow.yaml` |
+| [tmpl-with-actions.yaml](actions/tmpl-with-actions.yaml) | Using tmpl: to format __actions results | `scafctl run solution -f examples/actions/tmpl-with-actions.yaml` |
 
 ---
 
@@ -139,6 +140,13 @@ Resolvers demonstrate dynamic value computation, validation, and transformation.
 | [cel-transforms.yaml](resolvers/cel-transforms.yaml) | Data transformation patterns with CEL | `scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o yaml` |
 | [go-template-sprig.yaml](resolvers/go-template-sprig.yaml) | Sprig v3 functions in Go templates | `scafctl run resolver -f examples/resolvers/go-template-sprig.yaml -o json` |
 | [go-template-extensions.yaml](resolvers/go-template-extensions.yaml) | Custom Go template extensions (toHcl, toYaml, fromYaml) | `scafctl run resolver -f examples/resolvers/go-template-extensions.yaml -o json` |
+| [go-template-ignored-blocks.yaml](resolvers/go-template-ignored-blocks.yaml) | Using scafctl:ignore blocks to skip rendering | `scafctl run resolver -f examples/resolvers/go-template-ignored-blocks.yaml` |
+| [cel-basics.yaml](resolvers/cel-basics.yaml) | CEL expression basics: literals, operators, lists | `scafctl run resolver -f examples/resolvers/cel-basics.yaml -o json` |
+| [cel-builtins.yaml](resolvers/cel-builtins.yaml) | CEL built-in functions: math, encoding, sets | `scafctl run resolver -f examples/resolvers/cel-builtins.yaml -o json` |
+| [cel-common-patterns.yaml](resolvers/cel-common-patterns.yaml) | Conditionals, map building, filtering, merging | `scafctl run resolver -f examples/resolvers/cel-common-patterns.yaml -o json` |
+| [foreach-filter.yaml](resolvers/foreach-filter.yaml) | ForEach in resolve phase with filter | `scafctl run resolver -f examples/resolvers/foreach-filter.yaml -o json` |
+| [plan-aware.yaml](resolvers/plan-aware.yaml) | Resolvers that adapt to execution phase | `scafctl run resolver -f examples/resolvers/plan-aware.yaml` |
+| [messages.yaml](resolvers/messages.yaml) | Custom error messages on resolver failure | `scafctl run resolver -f examples/resolvers/messages.yaml` |
 
 ---
 
@@ -155,9 +163,9 @@ Complete solutions demonstrating real-world use cases.
 | [k8s-clusters/](solutions/k8s-clusters/) | Read a Go template file, iterate 10 K8s clusters, render and write unique manifests |
 | [bad-solution-yaml/](solutions/bad-solution-yaml/) | Invalid solution demonstrating error handling for conflicting ValueRef keys |
 | [tested-solution/](solutions/tested-solution/) | Functional testing features: assertions, inheritance, tags, watch mode |
-| [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` — generates starter test suites |
-| [github-auth/](solutions/github-auth/) | GitHub authentication — identity, API calls, and status checks |
-| [message-demo/](solutions/message-demo/) | Message provider — styled terminal output with templates |
+| [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` -- generates starter test suites |
+| [github-auth/](solutions/github-auth/) | GitHub authentication -- identity, API calls, and status checks |
+| [message-demo/](solutions/message-demo/) | Message provider -- styled terminal output with templates |
 
 ---
 

--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -7,7 +7,7 @@ This directory contains example action configurations demonstrating the Actions 
 | Example | Description |
 |---------|-------------|
 | [hello-world.yaml](hello-world.yaml) | Simplest possible action workflow |
-| [sequential-chain.yaml](sequential-chain.yaml) | Linear action dependency chain (A → B → C) |
+| [sequential-chain.yaml](sequential-chain.yaml) | Linear action dependency chain (A -> B -> C) |
 | [parallel-with-deps.yaml](parallel-with-deps.yaml) | Diamond pattern with parallel execution |
 | [action-alias.yaml](action-alias.yaml) | Action aliases for shorter expression references |
 | [foreach-deploy.yaml](foreach-deploy.yaml) | ForEach expansion for deploying to multiple targets |
@@ -19,6 +19,9 @@ This directory contains example action configurations demonstrating the Actions 
 | [finally-cleanup.yaml](finally-cleanup.yaml) | Finally section for cleanup actions |
 | [complex-workflow.yaml](complex-workflow.yaml) | Full CI/CD-style workflow with all features |
 | [template-render.yaml](template-render.yaml) | Real-world: read template, render with go-template, write output |
+| [go-template-inline.yaml](go-template-inline.yaml) | Inline Go templates with loops and conditionals |
+| [result-schema-validation.yaml](result-schema-validation.yaml) | JSON Schema validation of action results |
+| [tmpl-with-actions.yaml](tmpl-with-actions.yaml) | Using tmpl: ValueRef to format __actions results |
 
 ## Running Examples
 

--- a/examples/actions/tmpl-with-actions.yaml
+++ b/examples/actions/tmpl-with-actions.yaml
@@ -1,0 +1,56 @@
+# Run: scafctl run solution -f examples/actions/tmpl-with-actions.yaml
+#
+# Demonstrates using tmpl: ValueRef to access __actions results.
+# The tmpl: input references __actions via Go template functions like
+# index, len, and printf. These are properly deferred until the
+# referenced actions complete.
+#
+# Action results are structured as:
+#   __actions.<name>.results.<field>
+#   __actions.<name>.status  (succeeded/failed/skipped)
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: tmpl-actions-demo
+  version: 1.0.0
+  description: Using Go templates to format action results
+
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello from resolvers"
+
+  workflow:
+    actions:
+      fetch-data:
+        description: Simulate fetching data
+        provider: exec
+        inputs:
+          command: "echo 'fetched 42 records'"
+          raw: true
+
+      deploy:
+        description: Simulate deployment
+        provider: exec
+        inputs:
+          command: "echo 'deployed to staging'"
+          raw: true
+
+      format-summary:
+        description: Format action results using tmpl with __actions
+        provider: message
+        dependsOn: [fetch-data, deploy]
+        inputs:
+          message:
+            tmpl: |
+              Summary:
+              - Fetch: {{ index .__actions "fetch-data" "status" }} -> {{ index .__actions "fetch-data" "results" "stdout" | trim }}
+              - Deploy: {{ index .__actions "deploy" "status" }} -> {{ index .__actions "deploy" "results" "stdout" | trim }}
+              - Action count: {{ len .__actions }}
+          type: info

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -11,6 +11,8 @@ This directory contains practical examples demonstrating various resolver patter
 | [hello-world.yaml](hello-world.yaml) | Simplest possible resolver |
 | [parameters.yaml](parameters.yaml) | Using CLI parameters with defaults |
 | [dependencies.yaml](dependencies.yaml) | Resolver dependencies and execution phases |
+| [plan-aware.yaml](plan-aware.yaml) | Resolvers that adapt behavior based on execution phase |
+| [messages.yaml](messages.yaml) | Custom error messages on resolver failure |
 
 ### Configuration Patterns
 
@@ -18,14 +20,13 @@ This directory contains practical examples demonstrating various resolver patter
 |---------|-------------|
 | [env-config.yaml](env-config.yaml) | Environment-based configuration |
 | [feature-flags.yaml](feature-flags.yaml) | Feature toggle pattern with fallbacks |
-| [multi-env.yaml](multi-env.yaml) | Multi-environment configuration |
 
 ### Data Processing
 
 | Example | Description |
 |---------|-------------|
 | [transform-pipeline.yaml](transform-pipeline.yaml) | Multi-step data transformation |
-| [foreach-filter.yaml](foreach-filter.yaml) | ForEach in resolve phase with `filter: true` to strip nil results |
+| [foreach-filter.yaml](foreach-filter.yaml) | ForEach in resolve phase with filter to strip nil results |
 | [validation.yaml](validation.yaml) | Input validation patterns |
 
 ### CEL Expressions
@@ -38,17 +39,24 @@ This directory contains practical examples demonstrating various resolver patter
 | [cel-extensions.yaml](cel-extensions.yaml) | All custom CEL extension functions (arrays, map, strings, etc.) |
 | [cel-transforms.yaml](cel-transforms.yaml) | Data transformation patterns (filter, aggregate, enrich) |
 
+### Go Templates
+
+| Example | Description |
+|---------|-------------|
+| [go-template-extensions.yaml](go-template-extensions.yaml) | Custom extension functions: toHcl, toYaml, fromYaml |
+| [go-template-sprig.yaml](go-template-sprig.yaml) | Sprig template functions (strings, type conversion, etc.) |
+| [go-template-ignored-blocks.yaml](go-template-ignored-blocks.yaml) | Using scafctl:ignore blocks to skip template rendering |
+
 ### Integration
 
 | Example | Description |
 |---------|-------------|
-| [http-api.yaml](http-api.yaml) | Fetching data from HTTP APIs |
 | [secrets.yaml](secrets.yaml) | Secure handling of sensitive values |
 | [identity.yaml](identity.yaml) | Accessing authentication identity info |
 
 ## Running Examples
 
-```bash
+~~~bash
 # Run resolvers only (for debugging and inspection)
 scafctl run resolver -f examples/resolvers/hello-world.yaml
 
@@ -63,17 +71,14 @@ scafctl run resolver -f examples/resolvers/dependencies.yaml --progress
 
 # Output as YAML
 scafctl run resolver -f examples/resolvers/env-config.yaml -o yaml
-
-# Run resolver-only solution
-scafctl run resolver -f examples/resolvers/hello-world.yaml
-```
+~~~
 
 ## Creating Your Own
 
 Use these examples as templates for your own solutions. Key things to remember:
 
-1. **Start simple** - Begin with static values and add complexity
-2. **Use types** - Explicitly declare types for better error messages
-3. **Validate inputs** - Add validation rules for critical values
-4. **Handle errors** - Use `error_behavior: continue` for fallbacks
-5. **Mark sensitive data** - Use `sensitive: true` to redact secrets in table output (JSON/YAML reveal values for machine consumption; use `--show-sensitive` to reveal in all formats)
+1. **Start simple** -- begin with static values and add complexity
+2. **Use types** -- explicitly declare types for better error messages
+3. **Validate inputs** -- add validation rules for critical values
+4. **Handle errors** -- use `onError: continue` for fallbacks
+5. **Mark sensitive data** -- use `sensitive: true` to redact secrets in table output (JSON/YAML reveal values for machine consumption; use `--show-sensitive` to reveal in all formats)

--- a/examples/solutions/compose-demo/resolvers.yaml
+++ b/examples/solutions/compose-demo/resolvers.yaml
@@ -1,0 +1,19 @@
+spec:
+  resolvers:
+    environment:
+      type: string
+      description: Target environment
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: staging
+
+    app_name:
+      type: string
+      description: Application name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-service

--- a/examples/solutions/compose-demo/solution.yaml
+++ b/examples/solutions/compose-demo/solution.yaml
@@ -1,0 +1,16 @@
+# Run: scafctl run resolver -f examples/solutions/compose-demo/solution.yaml
+#
+# Demonstrates the compose feature: splitting a solution across multiple
+# YAML files for better organization. The resolvers and workflow are
+# defined in separate files and merged at load time.
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: compose-demo
+  version: 1.0.0
+  description: Solution composition using the compose field
+
+compose:
+  - resolvers.yaml
+  - workflow.yaml

--- a/examples/solutions/compose-demo/workflow.yaml
+++ b/examples/solutions/compose-demo/workflow.yaml
@@ -1,0 +1,9 @@
+spec:
+  workflow:
+    actions:
+      greet:
+        provider: message
+        inputs:
+          message:
+            expr: "'Deploying ' + _.app_name + ' to ' + _.environment"
+          type: success

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
@@ -194,7 +195,6 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	ivan.dev/httpcache v0.1.1 // indirect

--- a/pkg/action/graph_test.go
+++ b/pkg/action/graph_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -254,6 +255,52 @@ func TestBuildGraph_DeferredInputs(t *testing.T) {
 
 	// Implicit dependency on build should be added
 	assert.Contains(t, deployAction.Dependencies, "build")
+}
+
+func TestBuildGraph_DeferredInputs_TmplWithIndex(t *testing.T) {
+	// Regression test: templates using Go built-in functions (index, len, printf)
+	// must be recognised as referencing __actions and deferred, not evaluated
+	// immediately which would fail with "map has no entry for key __actions".
+	ctx := context.Background()
+	tmpl := gotmpl.GoTemplatingContent(`Files written:
+{{ range (index .__actions "write-files" "results" "filesStatus") }}  - {{ .path }} ({{ .status }})
+{{ end }}`)
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"write-files": {
+				Provider: "file",
+				Inputs: map[string]*spec.ValueRef{
+					"operation": literalRef("write-tree"),
+				},
+			},
+			"show-results": {
+				Provider:  "message",
+				DependsOn: []string{"write-files"},
+				Inputs: map[string]*spec.ValueRef{
+					"message": {Tmpl: &tmpl},
+				},
+			},
+		},
+	}
+
+	graph, err := BuildGraph(ctx, w, nil, nil)
+	require.NoError(t, err)
+
+	// write-files should have only materialized inputs
+	writeAction := graph.Actions["write-files"]
+	assert.NotEmpty(t, writeAction.MaterializedInputs)
+	assert.Empty(t, writeAction.DeferredInputs)
+
+	// show-results should have message deferred (references __actions via index)
+	showAction := graph.Actions["show-results"]
+	require.Contains(t, showAction.DeferredInputs, "message")
+	deferredMsg := showAction.DeferredInputs["message"]
+	assert.True(t, deferredMsg.IsDeferred())
+	assert.Equal(t, string(tmpl), deferredMsg.OriginalTmpl)
+	assert.Empty(t, deferredMsg.OriginalExpr, "should be tmpl-based, not expr")
+
+	// Implicit dependency on write-files
+	assert.Contains(t, showAction.Dependencies, "write-files")
 }
 
 func TestBuildGraph_ImplicitDependencies(t *testing.T) {

--- a/pkg/auth/oauth/callback.go
+++ b/pkg/auth/oauth/callback.go
@@ -120,6 +120,23 @@ func (cs *CallbackServer) sendResult(r CallbackResult) {
 	})
 }
 
+// authErrorHTML returns an HTML error page with the error message and
+// troubleshooting advice. The errMsg must already be HTML-escaped.
+func authErrorHTML(escapedErrMsg string) string {
+	return fmt.Sprintf(`<html><body>
+<h1>Authentication Failed</h1>
+<p>%s</p>
+<h2>Troubleshooting</h2>
+<ul>
+<li>Open a browser and log in to your identity provider (e.g. Azure, GitHub, Google) before retrying the CLI login.</li>
+<li>Ensure your account has the required permissions for the requested scopes.</li>
+<li>If you need additional scopes (e.g. for GitHub), re-run login with the --scope flag: <code>auth login &lt;handler&gt; --scope &lt;scope&gt;</code></li>
+<li>Check that cookies and JavaScript are enabled in the browser that opened this page.</li>
+</ul>
+<p>You can close this window.</p>
+</body></html>`, escapedErrMsg)
+}
+
 func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -133,7 +150,7 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		}
 		cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p><p>You can close this window.</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+		fmt.Fprint(w, authErrorHTML(html.EscapeString(errMsg)))
 		return
 	}
 
@@ -145,7 +162,7 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 			errMsg := "state parameter mismatch (possible CSRF attack)"
 			cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
 			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p><p>You can close this window.</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+			fmt.Fprint(w, authErrorHTML(html.EscapeString(errMsg)))
 			return
 		}
 	}
@@ -259,7 +276,7 @@ func (cs *CallbackServer) handleImplicitTokenPost(w http.ResponseWriter, r *http
 			errMsg := "state parameter mismatch (possible CSRF attack)"
 			cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
 			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+			fmt.Fprint(w, authErrorHTML(html.EscapeString(errMsg)))
 			return
 		}
 	}
@@ -273,7 +290,7 @@ func (cs *CallbackServer) handleImplicitTokenPost(w http.ResponseWriter, r *http
 		}
 		cs.sendResult(CallbackResult{Err: fmt.Errorf("OAuth error: %s", errMsg)})
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>%s</p></body></html>", html.EscapeString(errMsg)) //nolint:gosec // input is escaped
+		fmt.Fprint(w, authErrorHTML(html.EscapeString(errMsg)))
 		return
 	}
 

--- a/pkg/auth/oauth/callback_test.go
+++ b/pkg/auth/oauth/callback_test.go
@@ -464,3 +464,34 @@ func TestImplicitCallbackServer_AllowsSameOrigin(t *testing.T) {
 		t.Fatal("timed out waiting for callback result")
 	}
 }
+
+func TestAuthErrorHTML_ContainsTroubleshooting(t *testing.T) {
+	page := authErrorHTML("something went wrong")
+	assert.Contains(t, page, "Authentication Failed")
+	assert.Contains(t, page, "something went wrong")
+	assert.Contains(t, page, "Troubleshooting")
+	assert.Contains(t, page, "log in to your identity provider")
+}
+
+func TestCallbackServer_ErrorPageIncludesTroubleshooting(t *testing.T) {
+	ctx := context.Background()
+	cs, err := StartCallbackServer(ctx, 0, "")
+	require.NoError(t, err)
+	defer cs.Close()
+
+	resp, err := http.Get(fmt.Sprintf("%s/?error=access_denied&error_description=user+not+found", cs.RedirectURI)) //nolint:noctx // test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Troubleshooting")
+	assert.Contains(t, string(body), "log in to your identity provider")
+
+	select {
+	case result := <-cs.ResultChan():
+		assert.Error(t, result.Err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback result")
+	}
+}

--- a/pkg/cmd/scafctl/catalog/index.go
+++ b/pkg/cmd/scafctl/catalog/index.go
@@ -114,7 +114,6 @@ func commandIndexPush(cliParams *settings.Run, ioStreams *terminal.IOStreams) *c
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			opts.AppName = cliParams.BinaryName
 			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
 				kvx.WithIOStreams(ioStreams),
 				kvx.WithOutputColumnOrder([]string{"kind", "name", "latestVersion"}),
@@ -161,7 +160,6 @@ func commandIndexShow(cliParams *settings.Run, ioStreams *terminal.IOStreams) *c
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			opts.AppName = cliParams.BinaryName
 			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
 				kvx.WithIOStreams(ioStreams),
 				kvx.WithOutputColumnOrder([]string{"kind", "name", "latestVersion"}),
@@ -188,6 +186,9 @@ func runIndexPush(ctx context.Context, opts *IndexPushOptions, outputOpts *kvx.O
 		return exitcode.WithCode(err, exitcode.CatalogError)
 	}
 
+	// Use catalog name as table header instead of binary name.
+	outputOpts.AppName = remoteCatalog.Name()
+
 	artifacts, err := remoteCatalog.ListRepositories(ctx)
 	if err != nil {
 		w.Errorf("failed to discover artifacts: %v", err)
@@ -200,7 +201,7 @@ func runIndexPush(ctx context.Context, opts *IndexPushOptions, outputOpts *kvx.O
 	}
 
 	// Enrich artifacts with their latest semver version.
-	w.PlainStderrf("Resolving latest versions for %d artifact(s)...", len(artifacts))
+	w.Verbosef("Resolving latest versions for %d artifact(s)...", len(artifacts))
 	remoteCatalog.ResolveLatestVersions(ctx, artifacts)
 
 	if opts.DryRun {
@@ -208,21 +209,21 @@ func runIndexPush(ctx context.Context, opts *IndexPushOptions, outputOpts *kvx.O
 		currentArtifacts, fetchErr := remoteCatalog.FetchIndex(ctx)
 		if fetchErr != nil {
 			w.Verbosef("No existing index found, showing full list: %v", fetchErr)
-			w.PlainStderrf("Dry run: %d artifact(s) would be indexed to catalog %q (%s):\n",
+			w.Verbosef("Dry run: %d artifact(s) would be indexed to catalog %q (%s)",
 				len(artifacts), remoteCatalog.Name(), remoteCatalog.Registry())
 			return writeIndexList(artifacts, outputOpts)
 		}
 
 		diff := catalog.DiffIndex(currentArtifacts, artifacts)
-		w.PlainStderrf("Dry run: %d artifact(s) would be indexed to catalog %q (%s)\n",
+		w.Verbosef("Dry run: %d artifact(s) would be indexed to catalog %q (%s)",
 			diff.Total, remoteCatalog.Name(), remoteCatalog.Registry())
-		w.PlainStderrf("Changes: %d added, %d removed, %d version-changed, %d unchanged\n",
+		w.Verbosef("Changes: %d added, %d removed, %d version-changed, %d unchanged",
 			diff.Added, diff.Removed, diff.Changed,
 			diff.Total-diff.Added-diff.Changed)
 		return writeIndexDiff(diff, outputOpts)
 	}
 
-	w.PlainStderrf("Pushing catalog index with %d artifact(s)...", len(artifacts))
+	w.Verbosef("Pushing catalog index with %d artifact(s)...", len(artifacts))
 
 	if err := remoteCatalog.PushIndex(ctx, artifacts); err != nil {
 		err = fmt.Errorf("failed to push catalog index: %w", err)
@@ -231,7 +232,7 @@ func runIndexPush(ctx context.Context, opts *IndexPushOptions, outputOpts *kvx.O
 		return exitcode.WithCode(err, exitcode.CatalogError)
 	}
 
-	w.PlainStderrf("Pushed catalog index with %d artifact(s)", len(artifacts))
+	w.Verbosef("Pushed catalog index with %d artifact(s)", len(artifacts))
 	return writeIndexList(artifacts, outputOpts)
 }
 
@@ -245,6 +246,9 @@ func runIndexShow(ctx context.Context, opts *IndexShowOptions, outputOpts *kvx.O
 		return exitcode.WithCode(err, exitcode.CatalogError)
 	}
 
+	// Use catalog name as table header instead of binary name.
+	outputOpts.AppName = remoteCatalog.Name()
+
 	artifacts, err := remoteCatalog.FetchIndex(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to fetch catalog index: %w", err)
@@ -253,11 +257,11 @@ func runIndexShow(ctx context.Context, opts *IndexShowOptions, outputOpts *kvx.O
 	}
 
 	if len(artifacts) == 0 {
-		w.PlainStderrf("Catalog index is empty.")
+		w.Verbosef("Catalog index is empty.")
 		return writeIndexList(nil, outputOpts)
 	}
 
-	w.PlainStderrf("Catalog index contains %d artifact(s):\n", len(artifacts))
+	w.Verbosef("Catalog index contains %d artifact(s)", len(artifacts))
 	return writeIndexList(artifacts, outputOpts)
 }
 

--- a/pkg/cmd/scafctl/catalog/index_test.go
+++ b/pkg/cmd/scafctl/catalog/index_test.go
@@ -247,3 +247,44 @@ func BenchmarkWriteIndexDiff(b *testing.B) {
 		_ = writeIndexDiff(diff, outputOpts)
 	}
 }
+
+func TestWriteIndexList_AppNameInOutputOpts(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+	outputOpts.AppName = "my-catalog"
+
+	artifacts := []catalogpkg.DiscoveredArtifact{
+		{Kind: catalogpkg.ArtifactKindSolution, Name: "hello-world", LatestVersion: "1.0.0"},
+	}
+
+	err := writeIndexList(artifacts, outputOpts)
+	require.NoError(t, err)
+
+	var items []IndexListItem
+	err = json.Unmarshal(out.Bytes(), &items)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "hello-world", items[0].Name)
+
+	// AppName should be preserved on the outputOpts (used as table header).
+	assert.Equal(t, "my-catalog", outputOpts.AppName)
+}
+
+func TestCommandIndexPush_NoAppNameInRunE(t *testing.T) {
+	t.Parallel()
+
+	// Verify that the RunE closure does NOT set AppName on opts.
+	// AppName should be set later in runIndexPush from the catalog name.
+	cliParams := &settings.Run{BinaryName: "mycli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandIndex(cliParams, ioStreams, "mycli/catalog")
+
+	push, _, err := cmd.Find([]string{"push"})
+	require.NoError(t, err)
+
+	// The push command should exist and have RunE wired.
+	assert.NotNil(t, push.RunE)
+}

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -293,7 +293,7 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 		artifacts = filterArtifactsByCatalog(artifacts, opts.Catalog)
 	}
 
-	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "" || opts.Name != "", outputOpts)
+	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
 }
 
 // runListFromRemoteRef lists artifacts from a full OCI reference
@@ -381,7 +381,7 @@ func runListFromRemoteRef(ctx context.Context, opts *ListOptions, outputOpts *kv
 		w.Verbosef("After version filter %q: %d artifact(s)", opts.VersionConstraint, len(artifacts))
 	}
 
-	return writeArtifactList(w, artifacts, true, outputOpts)
+	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
 }
 
 func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.ArtifactKind, outputOpts *kvx.OutputOptions) error {
@@ -435,7 +435,7 @@ func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.Artifact
 		}
 	}
 
-	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "" || opts.Name != "", outputOpts)
+	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
 }
 
 // listRemoteArtifacts fetches artifacts from a configured remote catalog.

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -591,6 +591,92 @@ func TestCommandList_EmbedderBinaryName(t *testing.T) {
 	assert.NotNil(t, cmd.RunE)
 }
 
+func TestWriteArtifactList_NameWithoutAllVersions_ShowsLatestOnly(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	now := time.Now()
+	artifacts := []catalogpkg.ArtifactInfo{
+		{
+			Reference: catalogpkg.Reference{
+				Name:    "email-notifier",
+				Kind:    catalogpkg.ArtifactKindSolution,
+				Version: semver.MustParse("2.0.0"),
+			},
+			Digest:    "sha256:aaa",
+			CreatedAt: now,
+			Catalog:   "local",
+		},
+		{
+			Reference: catalogpkg.Reference{
+				Name:    "email-notifier",
+				Kind:    catalogpkg.ArtifactKindSolution,
+				Version: semver.MustParse("1.0.0"),
+			},
+			Digest:    "sha256:bbb",
+			CreatedAt: now,
+			Catalog:   "local",
+		},
+	}
+
+	// showAll=false simulates --name without --all-versions.
+	// Previously --name implied --all-versions; now it does not.
+	w := writer.New(ioStreams, &settings.Run{})
+	err := writeArtifactList(w, artifacts, false, outputOpts)
+	require.NoError(t, err)
+
+	var items []ArtifactListItem
+	err = json.Unmarshal(out.Bytes(), &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 1, "--name without --all-versions should show only the latest version")
+	assert.Equal(t, "2.0.0", items[0].Version)
+}
+
+func TestWriteArtifactList_LatestOnly_AssertsSingleResult(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	now := time.Now()
+	artifacts := []catalogpkg.ArtifactInfo{
+		{
+			Reference: catalogpkg.Reference{
+				Name:    "my-solution",
+				Kind:    catalogpkg.ArtifactKindSolution,
+				Version: semver.MustParse("2.0.0"),
+			},
+			Digest:    "sha256:aaa",
+			CreatedAt: now,
+			Catalog:   "local",
+		},
+		{
+			Reference: catalogpkg.Reference{
+				Name:    "my-solution",
+				Kind:    catalogpkg.ArtifactKindSolution,
+				Version: semver.MustParse("1.0.0"),
+			},
+			Digest:    "sha256:bbb",
+			CreatedAt: now,
+			Catalog:   "local",
+		},
+	}
+
+	w := writer.New(ioStreams, &settings.Run{})
+	err := writeArtifactList(w, artifacts, false, outputOpts)
+	require.NoError(t, err)
+
+	var items []ArtifactListItem
+	err = json.Unmarshal(out.Bytes(), &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 1, "showAll=false should keep only the latest version per name+kind")
+	assert.Equal(t, "2.0.0", items[0].Version)
+}
+
 func BenchmarkWriteArtifactList(b *testing.B) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	outputOpts := kvx.NewOutputOptions(ioStreams)

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -66,10 +66,6 @@ type ResolverOptions struct {
 	// DynamicArgs are resolver parameters from positional key=value syntax
 	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
 	DynamicArgs []string
-
-	// positionalPathErr is set in PreRun when the user passes a local file
-	// path as a positional argument instead of using -f/--file.
-	positionalPathErr error
 }
 
 // CommandResolver creates the 'run resolver' subcommand
@@ -92,7 +88,7 @@ func CommandResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	}
 
 	cCmd := &cobra.Command{
-		Use:     "resolver [name[@version]] [resolver-name...] [key=value...]",
+		Use:     "resolver [resolver-name...] [key=value...]",
 		Aliases: []string{"res", "resolvers"},
 		Short:   "Execute resolvers for debugging and inspection",
 		Long: strings.ReplaceAll(`Execute resolvers from a solution without running actions.
@@ -108,26 +104,19 @@ usage summary, and an aggregate summary.
 
 SOLUTION SOURCE:
   Solutions can be loaded from:
-  - Local catalog: Use the solution name (e.g., "my-app" or "my-app@1.2.3")
-  - Local file: Use -f flag or provide a path with separators (e.g., "./solution.yaml")
-  - URL: Provide an HTTP(S) URL, either via -f/--file or as the first positional argument
+  - Local file or catalog: Use -f flag (e.g., -f ./solution.yaml or -f my-app@1.2.3)
+  - URL: Provide an HTTP(S) URL via -f/--file (also detected as a positional arg)
   - Auto-discovery: If no source is specified, searches for solution.yaml in current directory
 
-  When -f/--file is not provided, the first positional argument is used as
-  the solution reference (catalog name, file path, or URL). This matches
-  the behavior of 'scafctl run solution'.
-
 RESOLVER SELECTION:
-  Pass resolver names as positional arguments (after the solution reference)
-  to execute only specific resolvers and their transitive dependencies.
-  When no names are provided, all resolvers in the solution are executed.
+  Pass resolver names as positional arguments to execute only specific
+  resolvers and their transitive dependencies. When no names are provided,
+  all resolvers in the solution are executed.
 
   Examples:
     scafctl run resolver                           Execute all resolvers (auto-discovery)
-    scafctl run resolver my-app                    Execute all resolvers from catalog
-    scafctl run resolver my-app@1.2.3              Execute all resolvers from catalog version
-    scafctl run resolver my-app db config          Execute 'db', 'config', and their deps
-    scafctl run resolver db config -f sol.yaml     Execute 'db', 'config', and their deps
+    scafctl run resolver db config                 Execute 'db', 'config', and their deps
+    scafctl run resolver db config -f my-app       Execute from catalog, filter to db + config
 
 SKIPPING PHASES:
   Use --skip-validation to skip the validation phase of all resolvers.
@@ -167,20 +156,20 @@ EXIT CODES:
   4  File not found
 
 Examples:
-  # Run all resolvers from catalog by name (latest version)
-  scafctl run resolver my-app
+  # Run all resolvers (auto-discovery)
+  scafctl run resolver
 
-  # Run all resolvers from specific catalog version
-  scafctl run resolver my-app@1.2.3
-
-  # Run specific resolvers from catalog
-  scafctl run resolver my-app db config
+  # Run specific resolvers (with their dependencies)
+  scafctl run resolver db config
 
   # Run all resolvers from a solution file
   scafctl run resolver -f ./my-solution.yaml
 
-  # Run specific resolvers (with their dependencies)
-  scafctl run resolver db config -f ./my-solution.yaml
+  # Run specific resolvers from catalog
+  scafctl run resolver db config -f my-app
+
+  # Run all resolvers from specific catalog version
+  scafctl run resolver -f my-app@1.2.3
 
   # Run with parameters (positional key=value — recommended)
   scafctl run resolver -f ./my-solution.yaml env=prod region=us-east1
@@ -242,33 +231,8 @@ Examples:
 			cCmd.Flags().Visit(func(f *pflag.Flag) {
 				options.flagsChanged[f.Name] = true
 			})
-			// Split positional args: bare words are resolver names,
-			// args containing '=' or starting with '@' are dynamic parameters.
-			// When -f/--file is not explicitly set, the first bare word is
-			// treated as the solution reference (catalog name or registry ref).
-			// Local file paths must use -f/--file.
 			fileExplicit := options.flagsChanged["file"]
-			for _, arg := range args {
-				switch {
-				case !fileExplicit && options.File == "" && filepath.IsURL(arg):
-					// URL solution references (may contain '=' in query params)
-					options.File = arg
-					fileExplicit = true
-				case strings.Contains(arg, "=") || strings.HasPrefix(arg, "@"):
-					options.DynamicArgs = append(options.DynamicArgs, arg)
-				case !fileExplicit && options.File == "":
-					// First bare word becomes the solution reference — must be
-					// a catalog name or registry ref, not a local file path.
-					if err := get.ValidatePositionalRef(arg, "", cliParams.BinaryName+" run resolver"); err != nil {
-						options.positionalPathErr = err
-					} else {
-						options.File = arg
-					}
-					fileExplicit = true // only the first one
-				default:
-					options.Names = append(options.Names, arg)
-				}
-			}
+			parseResolverArgs(args, options, fileExplicit)
 		},
 		RunE:         makeRunEFunc(cfg, "resolver"),
 		SilenceUsage: true,
@@ -291,15 +255,28 @@ Examples:
 	return cCmd
 }
 
+// parseResolverArgs splits positional args into resolver names and dynamic parameters.
+// Bare words are resolver names, args containing '=' or starting with '@' are parameters.
+// Only URLs (http(s)://, oci://) are auto-detected as solution refs when no -f flag is set.
+// This matches the parseActionArgs pattern: solution source is always via -f or auto-discovery.
+func parseResolverArgs(args []string, options *ResolverOptions, fileExplicit bool) {
+	for _, arg := range args {
+		switch {
+		case !fileExplicit && options.File == "" && filepath.IsURL(arg):
+			options.File = arg
+			fileExplicit = true
+		case strings.Contains(arg, "=") || strings.HasPrefix(arg, "@"):
+			options.DynamicArgs = append(options.DynamicArgs, arg)
+		default:
+			options.Names = append(options.Names, arg)
+		}
+	}
+}
+
 // Run executes the resolver-only flow
 func (o *ResolverOptions) Run(ctx context.Context) error {
 	if o.BinaryName == "" {
 		o.BinaryName = settings.CliBinaryName
-	}
-
-	// Fail early if PreRun detected a local file path as positional arg
-	if o.positionalPathErr != nil {
-		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)
 	}
 
 	// Include pre-release versions in catalog resolution when --pre-release is set.

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -33,7 +33,7 @@ func TestCommandResolver(t *testing.T) {
 
 	cmd := CommandResolver(cliParams, streams, "")
 
-	assert.Equal(t, "resolver [name[@version]] [resolver-name...] [key=value...]", cmd.Use)
+	assert.Equal(t, "resolver [resolver-name...] [key=value...]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.Contains(t, cmd.Aliases, "res")
 	assert.Contains(t, cmd.Aliases, "resolvers")
@@ -1809,22 +1809,18 @@ func TestResolverOptions_PositionalKeyValue_OnlyParams(t *testing.T) {
 func TestResolverOptions_PositionalKeyValue_OnlyNames(t *testing.T) {
 	t.Parallel()
 
-	// Without -f, first bare word is solution ref, rest are resolver names
+	// All bare words are resolver names (no positional solution ref)
 	args := []string{"db", "config", "auth"}
-	var solutionRef string
 	var names, dynamicArgs []string
 	for _, arg := range args {
 		if containsEqualsOrAtPrefix(arg) {
 			dynamicArgs = append(dynamicArgs, arg)
-		} else if solutionRef == "" {
-			solutionRef = arg
 		} else {
 			names = append(names, arg)
 		}
 	}
 
-	assert.Equal(t, "db", solutionRef)
-	assert.Equal(t, []string{"config", "auth"}, names)
+	assert.Equal(t, []string{"db", "config", "auth"}, names)
 	assert.Empty(t, dynamicArgs)
 }
 
@@ -1976,82 +1972,74 @@ func TestExtractSolutionPath_EmptyFlag(t *testing.T) {
 	assert.Empty(t, path)
 }
 
-func TestResolverArgs_CatalogNameAsFirstArg(t *testing.T) {
+func TestResolverArgs_AllBareWordsAreNames(t *testing.T) {
 	t.Parallel()
 
-	// Without -f, first bare word is the solution reference
-	ref, names, dynamicArgs := splitResolverArgs(
+	// All bare words are resolver names, not solution refs
+	names, dynamicArgs := splitResolverArgs(
 		[]string{"my-app", "db", "config", "env=prod"},
 		false, // -f not set
 	)
-	assert.Equal(t, "my-app", ref)
-	assert.Equal(t, []string{"db", "config"}, names)
+	assert.Equal(t, []string{"my-app", "db", "config"}, names)
 	assert.Equal(t, []string{"env=prod"}, dynamicArgs)
 }
 
-func TestResolverArgs_CatalogNameWithVersion(t *testing.T) {
+func TestResolverArgs_AtPrefixIsDynamicArg(t *testing.T) {
 	t.Parallel()
 
-	// Catalog name with @version should become the solution reference
-	ref, names, dynamicArgs := splitResolverArgs(
-		[]string{"my-app@1.2.3", "db"},
+	// Args starting with @ are dynamic args
+	names, dynamicArgs := splitResolverArgs(
+		[]string{"@override", "db"},
 		false,
 	)
-	// my-app@1.2.3 doesn't start with @ and doesn't contain =,
-	// so it's a bare word and becomes the solution ref
-	assert.Equal(t, "my-app@1.2.3", ref)
 	assert.Equal(t, []string{"db"}, names)
-	assert.Empty(t, dynamicArgs)
+	assert.Equal(t, []string{"@override"}, dynamicArgs)
 }
 
 func TestResolverArgs_WithFileFlagAllBareWordsAreNames(t *testing.T) {
 	t.Parallel()
 
 	// With -f set, all bare words are resolver names
-	ref, names, dynamicArgs := splitResolverArgs(
+	names, dynamicArgs := splitResolverArgs(
 		[]string{"db", "config", "auth"},
 		true, // -f was set
 	)
-	assert.Empty(t, ref)
 	assert.Equal(t, []string{"db", "config", "auth"}, names)
 	assert.Empty(t, dynamicArgs)
 }
 
-func TestResolverArgs_OnlyCatalogName(t *testing.T) {
+func TestResolverArgs_SingleBareWordIsName(t *testing.T) {
 	t.Parallel()
 
-	// Just a catalog name, no resolver filters
-	ref, names, dynamicArgs := splitResolverArgs(
+	// Single bare word is a resolver name, not a solution ref
+	names, dynamicArgs := splitResolverArgs(
 		[]string{"sln-starter-kit"},
 		false,
 	)
-	assert.Equal(t, "sln-starter-kit", ref)
-	assert.Empty(t, names)
+	assert.Equal(t, []string{"sln-starter-kit"}, names)
 	assert.Empty(t, dynamicArgs)
 }
 
-func TestResolverArgs_CatalogNameWithParams(t *testing.T) {
+func TestResolverArgs_BareWordWithParams(t *testing.T) {
 	t.Parallel()
 
-	// Catalog name + key=value params, no resolver name filters
-	ref, names, dynamicArgs := splitResolverArgs(
+	// Bare word is a resolver name, key=value args are dynamic
+	names, dynamicArgs := splitResolverArgs(
 		[]string{"sln-starter-kit", "env=prod", "region=us-east-1"},
 		false,
 	)
-	assert.Equal(t, "sln-starter-kit", ref)
-	assert.Empty(t, names)
+	assert.Equal(t, []string{"sln-starter-kit"}, names)
 	assert.Equal(t, []string{"env=prod", "region=us-east-1"}, dynamicArgs)
 }
 
 func TestResolverArgs_OnlyParamsNoFile(t *testing.T) {
 	t.Parallel()
 
-	// Only key=value params — no solution ref, no names (auto-discovery)
-	ref, names, dynamicArgs := splitResolverArgs(
+	// Only key=value params — no names (auto-discovery)
+	names, dynamicArgs := splitResolverArgs(
 		[]string{"env=prod"},
 		false,
 	)
-	assert.Empty(t, ref)
 	assert.Empty(t, names)
 	assert.Equal(t, []string{"env=prod"}, dynamicArgs)
 }
@@ -2060,16 +2048,15 @@ func TestResolverArgs_NoArgs(t *testing.T) {
 	t.Parallel()
 
 	// No args at all (auto-discovery)
-	ref, names, dynamicArgs := splitResolverArgs(
+	names, dynamicArgs := splitResolverArgs(
 		[]string{},
 		false,
 	)
-	assert.Empty(t, ref)
 	assert.Empty(t, names)
 	assert.Empty(t, dynamicArgs)
 }
 
-func TestResolverArgs_PreRun_CatalogName(t *testing.T) {
+func TestResolverArgs_PreRun_AllBareWordsAreNames(t *testing.T) {
 	t.Parallel()
 
 	streams, _, _ := terminal.NewTestIOStreams()
@@ -2078,15 +2065,16 @@ func TestResolverArgs_PreRun_CatalogName(t *testing.T) {
 	cmd := CommandResolver(cliParams, streams, "")
 
 	// Simulate: scafctl run resolver sln-starter-kit db config
+	// All bare words should become resolver names, not solution refs
 	args := []string{"sln-starter-kit", "db", "config"}
 	cmd.PreRun(cmd, args)
 
-	// After PreRun, the file flag should be set to the catalog name
+	// No file should be set — use auto-discovery
 	path := extractSolutionPath(cmd)
-	assert.Equal(t, "sln-starter-kit", path)
+	assert.Empty(t, path)
 }
 
-func TestResolverArgs_PreRun_CatalogNameWithVersion(t *testing.T) {
+func TestResolverArgs_PreRun_AtVersionIsDynamicArg(t *testing.T) {
 	t.Parallel()
 
 	streams, _, _ := terminal.NewTestIOStreams()
@@ -2094,12 +2082,13 @@ func TestResolverArgs_PreRun_CatalogNameWithVersion(t *testing.T) {
 
 	cmd := CommandResolver(cliParams, streams, "")
 
-	// Simulate: scafctl run resolver sln-starter-kit@1.2.0
-	args := []string{"sln-starter-kit@1.2.0"}
+	// Simulate: scafctl run resolver db @override
+	// @override starts with @ so becomes a dynamic arg
+	args := []string{"db", "@override"}
 	cmd.PreRun(cmd, args)
 
 	path := extractSolutionPath(cmd)
-	assert.Equal(t, "sln-starter-kit@1.2.0", path)
+	assert.Empty(t, path)
 }
 
 func TestResolverArgs_PreRun_FileFlagTakesPrecedence(t *testing.T) {
@@ -2155,20 +2144,17 @@ func TestResolverArgs_PreRun_URLWithMultipleQueryParams(t *testing.T) {
 	assert.Equal(t, "https://storage.example.com/sol.yaml?sig=abc&exp=123", path)
 }
 
-// splitResolverArgs mirrors the new PreRun logic: when fileExplicit is false,
-// the first bare word becomes the solution reference.
-func splitResolverArgs(args []string, fileExplicit bool) (solutionRef string, names, dynamicArgs []string) {
+// splitResolverArgs mirrors the new PreRun logic: all bare words are resolver
+// names, args with '=' or '@' prefix are dynamic params.
+func splitResolverArgs(args []string, _ bool) (names, dynamicArgs []string) {
 	for _, arg := range args {
 		if containsEqualsOrAtPrefix(arg) {
 			dynamicArgs = append(dynamicArgs, arg)
-		} else if !fileExplicit && solutionRef == "" {
-			solutionRef = arg
-			fileExplicit = true
 		} else {
 			names = append(names, arg)
 		}
 	}
-	return solutionRef, names, dynamicArgs
+	return names, dynamicArgs
 }
 
 // containsEqualsOrAtPrefix mirrors the logic used in PreRun to split args.

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -138,6 +138,37 @@ Use list_cel_functions to see all available CEL functions and evaluate_cel to te
 		},
 		SeeAlso: []string{"resolver", "action", "template-functions"},
 	},
+	// --- forEach ---
+	{
+		Name:     "foreach",
+		Title:    "forEach (Array Iteration)",
+		Category: "resolvers",
+		Summary:  "Iterate over an array in resolve or transform steps, executing a provider once per element.",
+		Explanation: `forEach is supported on both resolve.with and transform.with steps. It is NOT supported on validate.with.
+
+When forEach is present, the provider executes once per element and results are collected into an output array preserving order.
+
+Key difference between phases:
+- On resolve steps, forEach.in is REQUIRED (no __self available in resolve phase).
+- On transform steps, forEach.in defaults to __self (the current value).
+
+Fields:
+- item: Variable alias for current element (default: __item always available)
+- index: Variable alias for current 0-based index (default: __index always available)
+- in: ValueRef for source array (required on resolve, defaults to __self on transform)
+- concurrency: Max parallel iterations (0 = unlimited)
+- keepSkipped: Retain nil entries for items skipped by when condition (default: false)
+- onError: Error handling (fail or continue). Actions only; resolvers ignore this.
+
+Context variables __item and __index are always injected. Custom aliases (item, index fields) are added alongside them.
+
+Filtering: Combine forEach with a step-level 'when' condition to filter arrays. Items where when is false are removed from the output unless keepSkipped is true.`,
+		Examples: []string{
+			"# Resolve: fan-out HTTP requests\nresolve:\n  with:\n    - provider: http\n      forEach:\n        in:\n          rslvr: urls\n        item: url\n      inputs:\n        url:\n          expr: \"url\"",
+			"# Transform: double each number\ntransform:\n  with:\n    - provider: cel\n      forEach:\n        item: num\n      inputs:\n        expression: \"num * 2\"",
+		},
+		SeeAlso: []string{"resolver", "action", "cel-expression"},
+	},
 	// --- Testing ---
 	{
 		Name:     "functional-testing",
@@ -153,9 +184,24 @@ Key features:
 - **CEL assertions** — validate output structure and values.
 - **Tags** — organize and filter tests (e.g., --tag smoke).
 - **Templates** — share common config via extends and test templates (names starting with _).
-- **File dependencies** — declare which files the test needs via the files list (supports paths, globs, directories).`,
+- **File dependencies** — declare which files the test needs via the files list (supports paths, globs, directories).
+- **Shared config (config)** — suite-level env, setup, cleanup, and files via spec.testing.config.
+
+## Test templates and inheritance
+
+Template cases reduce duplication across tests that share files, env vars, or other config. A template is a regular test case whose name starts with '_'. Templates are NOT executed as tests.
+
+Rules:
+- Template names must start with '_' (e.g., '_files-base', '_common-env').
+- Templates are defined alongside regular cases in spec.testing.cases.
+- A test inherits from templates via the 'extends' field, which must be an array: extends: [_files-base].
+- Multiple templates can be listed: extends: [_files-base, _common-env] — applied left-to-right.
+- Inherited fields are merged; the child test's own fields take precedence.
+- Templates can extend other templates (up to 10 levels deep).
+- Template cases do not need a command field — they exist only for inheritance.`,
 		Examples: []string{
 			"spec:\n  testing:\n    cases:\n      smoke-test:\n        description: Verify basic rendering\n        command: [render, solution]\n        exitCode: 0\n        files: [templates/]\n        assertions:\n          - expression: \"size(__output) > 0\"\n            message: Output should not be empty",
+			"# Template case (not executed, used for inheritance)\nspec:\n  testing:\n    cases:\n      _files-base:\n        files:\n          - templates/.github/copilot-instructions.md.tpl\n          - templates/.github/instructions/terraform-hcl.instructions.md.tpl\n\n      resolve-defaults:\n        extends: [_files-base]\n        command: [run, resolver]\n        args: [-o, json]\n        exitCode: 0\n\n      render-defaults:\n        extends: [_files-base]\n        command: [render, solution]\n        exitCode: 0",
 		},
 		SeeAlso: []string{"test-sandbox", "test-assertions", "test-scaffold"},
 	},

--- a/pkg/errexplain/errexplain.go
+++ b/pkg/errexplain/errexplain.go
@@ -268,5 +268,28 @@ func knownPatterns() []pattern {
 				}
 			},
 		},
+		{
+			name:  "directory-not-found",
+			regex: regexp.MustCompile(`directory "?([^"]+)"? does not exist`),
+			build: func(m []string, fullError string) Explanation {
+				dir := m[1]
+				exp := Explanation{
+					Category:  "path_resolution",
+					Summary:   fmt.Sprintf("Directory %q was not found on disk", dir),
+					RootCause: "The referenced directory does not exist. If this solution was auto-pulled from a catalog, relative paths cannot be resolved because catalog content is stored as OCI blobs, not as files on disk.",
+					Suggestions: []string{
+						"If the solution was loaded from a catalog, run 'catalog pull <name>' first to extract files locally",
+						"Check that the path is correct relative to the solution file location",
+						"Ensure the solution is bundled with its static content when publishing to a catalog",
+						"Use an absolute path or set the working directory with --cwd",
+					},
+				}
+				if strings.Contains(fullError, "catalog:") {
+					exp.RootCause = "The solution was loaded from a catalog without a bundle. " +
+						"Relative directory paths cannot be resolved because catalog content is stored as OCI blobs, not as files on disk."
+				}
+				return exp
+			},
+		},
 	}
 }

--- a/pkg/errexplain/errexplain_test.go
+++ b/pkg/errexplain/errexplain_test.go
@@ -113,6 +113,19 @@ func TestExplain_CELProvider(t *testing.T) {
 	assert.True(t, found, "should include CEL-specific suggestion")
 }
 
+func TestExplain_DirectoryNotFound(t *testing.T) {
+	exp := Explain(`directory "/tmp/static" does not exist: stat /tmp/static: no such file or directory`)
+	assert.Equal(t, "path_resolution", exp.Category)
+	assert.Contains(t, exp.Summary, "/tmp/static")
+	assert.Contains(t, exp.Suggestions[0], "catalog pull")
+}
+
+func TestExplain_DirectoryNotFound_CatalogContext(t *testing.T) {
+	exp := Explain(`catalog: directory "static" does not exist: stat static: no such file or directory`)
+	assert.Equal(t, "path_resolution", exp.Category)
+	assert.Contains(t, exp.RootCause, "loaded from a catalog without a bundle")
+}
+
 func BenchmarkExplain(b *testing.B) {
 	errors := []string{
 		`resolver "api" failed in resolve phase (step 0, provider http): connection refused`,

--- a/pkg/gotmpl/refs.go
+++ b/pkg/gotmpl/refs.go
@@ -21,6 +21,15 @@ type TemplateReference struct {
 	Position string
 }
 
+// goTemplateBuiltins lists the function names that text/template provides
+// out of the box. parse.Parse needs these declared explicitly so it can
+// recognise them during parsing.
+var goTemplateBuiltins = []string{
+	"and", "call", "html", "index", "slice", "js", "len", "not", "or",
+	"print", "printf", "println", "urlquery",
+	"eq", "ne", "lt", "le", "gt", "ge",
+}
+
 // GetReferences extracts all references to Data from a Go template
 // This method parses the template and extracts variable references (e.g., .User, .Items)
 // It excludes function calls and Go template control variables (like $var)
@@ -50,9 +59,19 @@ func (s *Service) GetReferences(ctx context.Context, opts TemplateOptions) ([]Te
 		rightDelim = DefaultRightDelim
 	}
 
-	// Parse the template using text/template/parse
-	// We need to use the internal parse package which handles delimiters through the lexer
-	trees, err := parse.Parse(opts.Name, opts.Content, leftDelim, rightDelim)
+	// Parse the template using text/template/parse.
+	// Pass the service's function map so the parser recognises built-in and
+	// extension functions (e.g. index, printf, sprig helpers). Without this,
+	// templates that call these functions fail to parse and their variable
+	// references are silently lost.
+	funcNames := make(map[string]any, len(s.defaultFuncs)+len(goTemplateBuiltins))
+	for _, name := range goTemplateBuiltins {
+		funcNames[name] = true
+	}
+	for k := range s.defaultFuncs {
+		funcNames[k] = true // parse.Parse only checks existence, not the value
+	}
+	trees, err := parse.Parse(opts.Name, opts.Content, leftDelim, rightDelim, funcNames)
 	if err != nil {
 		lgr.Error(err, "failed to parse template for reference extraction",
 			"name", opts.Name)

--- a/pkg/gotmpl/refs_test.go
+++ b/pkg/gotmpl/refs_test.go
@@ -277,6 +277,31 @@ func TestService_GetReferences(t *testing.T) {
 			},
 			want: []string{".Items", ".Name", ".Price"},
 		},
+		{
+			name: "builtin index function with __actions",
+			opts: TemplateOptions{
+				Name: "actions.tmpl",
+				Content: `{{ range (index .__actions "write-files" "results" "filesStatus") }}  - {{ .path }}
+{{ end }}`,
+			},
+			want: []string{".__actions", ".path"},
+		},
+		{
+			name: "builtin len function",
+			opts: TemplateOptions{
+				Name:    "len.tmpl",
+				Content: `{{ len .Items }} items: {{ .Title }}`,
+			},
+			want: []string{".Items", ".Title"},
+		},
+		{
+			name: "builtin printf function",
+			opts: TemplateOptions{
+				Name:    "printf.tmpl",
+				Content: `{{ printf "%s-%s" .Env .Region }}`,
+			},
+			want: []string{".Env", ".Region"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -612,6 +612,11 @@ func collectReferencedResolvers(sol *solution.Solution) map[string]bool {
 // "rslvr", "expr", or "tmpl" key are treated as resolver references.
 func scanLiteralForResolverRefs(v any, pattern *regexp.Regexp, refs map[string]bool) {
 	switch val := v.(type) {
+	case string:
+		// Scan plain string literals for _.resolverName patterns.
+		// This catches CEL expression inputs (e.g., `expression: "has(_.foo)"`),
+		// Go template inputs, and any other string that may reference resolvers.
+		scanExpressionForResolverRefs(val, pattern, refs)
 	case map[string]any:
 		// Check if this map itself is a resolver reference
 		if rslvr, ok := val["rslvr"]; ok {

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -502,4 +503,53 @@ func TestLintResolvers_NoValidateBlockFlaggedUnused(t *testing.T) {
 		rules = append(rules, f.RuleName)
 	}
 	assert.Contains(t, rules, "unused-resolver")
+}
+
+func TestLintResolvers_CELExpressionInputNotFlaggedUnused(t *testing.T) {
+	// Resolvers referenced only via _.name in a CEL provider's expression
+	// input (a string literal) should NOT be flagged as unused.
+	reg := provider.NewRegistry()
+	celProv := newFakeProvider("cel", nil)
+	execProv := newFakeProvider("exec", nil)
+	require.NoError(t, reg.Register(celProv))
+	require.NoError(t, reg.Register(execProv))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"winResult": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "exec"}},
+			},
+		},
+		"unixResult": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "exec"}},
+			},
+		},
+		"result": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "cel",
+					Inputs: map[string]*spec.ValueRef{
+						"expression": {
+							Literal: `has(_.winResult) ? _.winResult : _.unixResult`,
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		if f.RuleName == "unused-resolver" {
+			assert.NotContains(t, f.Message, "winResult",
+				"winResult referenced in CEL expression should not be flagged unused")
+			assert.NotContains(t, f.Message, "unixResult",
+				"unixResult referenced in CEL expression should not be flagged unused")
+		}
+	}
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -414,6 +414,43 @@ func TestCollectReferencedResolvers_NestedInArray(t *testing.T) {
 	assert.True(t, refs["env"], "should detect rslvr inside array elements")
 }
 
+func TestCollectReferencedResolvers_StringLiteralWithResolverRef(t *testing.T) {
+	// CEL provider's `expression` input is a plain string literal containing
+	// _.resolverName and has(_.resolverName) patterns. These must be detected.
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"localIpWindows": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "exec"}},
+					},
+				},
+				"localIpUnix": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "exec"}},
+					},
+				},
+				"localIp": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs: map[string]*spec.ValueRef{
+								"expression": {
+									Literal: `has(_.localIpWindows) ? _.localIpWindows : has(_.localIpUnix) ? _.localIpUnix : ""`,
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	refs := collectReferencedResolvers(sol)
+	assert.True(t, refs["localIpWindows"], "should detect resolver ref in string literal (has pattern)")
+	assert.True(t, refs["localIpUnix"], "should detect resolver ref in string literal (has pattern)")
+}
+
 func TestLintResolverSelfReferences(t *testing.T) {
 	validationProv := newFakeProvider("validation", map[string]*jsonschema.Schema{
 		"expression": {Type: "string"},

--- a/pkg/mcp/tools_testing.go
+++ b/pkg/mcp/tools_testing.go
@@ -161,10 +161,16 @@ func (s *Server) handleGenerateTestScaffold(_ context.Context, request mcp.CallT
 			},
 			"fileDependencies": func() string {
 				if len(input.FileDependencies) > 0 {
-					return fmt.Sprintf("Detected %d file dependencies from provider inputs. These have been auto-populated in each test case's 'files' field.", len(input.FileDependencies))
+					return fmt.Sprintf("Detected %d file dependencies from provider inputs. A _files-base template case has been generated and all test cases extend it via 'extends: [_files-base]'.", len(input.FileDependencies))
 				}
-				return "No file dependencies were detected. If your solution references external files (templates, configs, etc.), add them to each test case's 'files' field."
+				return "No file dependencies were detected. If your solution references external files (templates, configs, etc.), add them to each test case's 'files' field or create a _files-base template case and extend it."
 			}(),
+			"templates": []string{
+				"Template cases start with '_' (e.g., _files-base) and are not executed as tests",
+				"Tests inherit from templates via extends: [_template-name] (must be an array)",
+				"Templates are defined alongside regular cases in spec.testing.cases",
+				"Use templates to share files, env vars, or other common config across tests",
+			},
 			"commonPatterns": []string{
 				"Use 'expr' in assertions to write CEL expressions that check resolved values",
 				"Use 'contains' for partial string matching in resolver outputs",

--- a/pkg/provider/builtin/execprovider/exec.go
+++ b/pkg/provider/builtin/execprovider/exec.go
@@ -280,7 +280,23 @@ func (p *ExecProvider) executeCommand(ctx context.Context, command string, input
 		if !ok {
 			return nil, fmt.Errorf("env must be an object with string keys")
 		}
+		// Inject NO_COLOR=1 and TERM=dumb unless the user explicitly set them.
+		// This prevents child processes (especially PowerShell) from emitting ANSI
+		// escape codes in captured output, which corrupts downstream processing
+		// and breaks YAML block-scalar formatting.
+		if _, exists := envMap["NO_COLOR"]; !exists {
+			envMap["NO_COLOR"] = "1"
+		}
+		if _, exists := envMap["TERM"]; !exists {
+			envMap["TERM"] = "dumb"
+		}
 		env = shellexec.MergeEnv(envMap)
+	} else {
+		// No user env — still inject NO_COLOR and TERM.
+		env = shellexec.MergeEnv(map[string]any{
+			"NO_COLOR": "1",
+			"TERM":     "dumb",
+		})
 	}
 
 	// Set up stdin

--- a/pkg/provider/builtin/execprovider/exec_test.go
+++ b/pkg/provider/builtin/execprovider/exec_test.go
@@ -816,3 +816,71 @@ func TestExecProvider_Execute_PassthroughFalse_StillCaptures(t *testing.T) {
 	// Default behavior: stdout is captured
 	assert.Contains(t, data["stdout"], "captured")
 }
+
+func TestExecProvider_Execute_InjectsNoColor(t *testing.T) {
+	p := NewExecProvider()
+	ctx := context.Background()
+
+	// Without user-provided env, NO_COLOR and TERM should still be injected.
+	inputs := map[string]any{
+		"command": "echo NO_COLOR=$NO_COLOR TERM=$TERM",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, data["stdout"], "NO_COLOR=1")
+	assert.Contains(t, data["stdout"], "TERM=dumb")
+}
+
+func TestExecProvider_Execute_InjectsNoColor_WithUserEnv(t *testing.T) {
+	p := NewExecProvider()
+	ctx := context.Background()
+
+	// User provides env but not NO_COLOR — it should be injected.
+	inputs := map[string]any{
+		"command": "echo NO_COLOR=$NO_COLOR TERM=$TERM MY_VAR=$MY_VAR",
+		"env": map[string]any{
+			"MY_VAR": "hello",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, data["stdout"], "NO_COLOR=1")
+	assert.Contains(t, data["stdout"], "TERM=dumb")
+	assert.Contains(t, data["stdout"], "MY_VAR=hello")
+}
+
+func TestExecProvider_Execute_UserCanOverrideNoColor(t *testing.T) {
+	p := NewExecProvider()
+	ctx := context.Background()
+
+	// User explicitly sets NO_COLOR — it should not be overridden.
+	inputs := map[string]any{
+		"command": "echo NO_COLOR=$NO_COLOR",
+		"env": map[string]any{
+			"NO_COLOR": "",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, data["stdout"], "NO_COLOR=")
+	// Ensure it's the user's empty value, not "1"
+	assert.NotContains(t, data["stdout"], "NO_COLOR=1")
+}

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -792,6 +792,17 @@ func extractDependencies(inputs map[string]any) []string {
 		return deps
 	}
 
+	// Build set of keys provided by the data input so we can exclude them
+	// from resolver dependencies. The data map's keys become top-level
+	// template context variables (e.g., data: {config: ...} provides .config)
+	// and should not be treated as resolver references.
+	dataKeys := make(map[string]bool)
+	if dataMap, ok := inputs["data"].(map[string]any); ok {
+		for k := range dataMap {
+			dataKeys[k] = true
+		}
+	}
+
 	// Extract the first segment of each reference path as the dependency name
 	// e.g., ".config.host" -> "config", "._.name" -> "name"
 	for _, ref := range refs {
@@ -805,6 +816,11 @@ func extractDependencies(inputs map[string]any) []string {
 		// Get first segment (before any dots)
 		if idx := strings.Index(path, "."); idx > 0 {
 			path = path[:idx]
+		}
+
+		// Skip references satisfied by the data input
+		if dataKeys[path] {
+			continue
 		}
 
 		addDep(path)

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -1194,3 +1194,52 @@ func TestExtractCELDeps(t *testing.T) {
 		assert.Empty(t, found)
 	})
 }
+
+func TestExtractDependencies_DataKeyExclusion(t *testing.T) {
+	t.Run("data keys excluded from template refs", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ toYaml .config }}",
+			"data": map[string]any{
+				"config": map[string]any{"port": 8080},
+			},
+		})
+		for _, d := range deps {
+			assert.NotEqual(t, "config", d, "config should be excluded (provided by data)")
+		}
+	})
+
+	t.Run("resolver ref in template not excluded", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ ._.environment }} {{ .config }}",
+			"data": map[string]any{
+				"config": map[string]any{"port": 8080},
+			},
+		})
+		assert.Contains(t, deps, "environment", "resolver ref should be extracted")
+		for _, d := range deps {
+			assert.NotEqual(t, "config", d, "config should be excluded")
+		}
+	})
+
+	t.Run("no data input does not exclude", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .config }}",
+		})
+		assert.Contains(t, deps, "config")
+	})
+
+	t.Run("multiple data keys all excluded", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .config }} {{ .labels }} {{ ._.resolver1 }}",
+			"data": map[string]any{
+				"config": map[string]any{"port": 8080},
+				"labels": map[string]any{"app": "test"},
+			},
+		})
+		assert.Contains(t, deps, "resolver1")
+		for _, d := range deps {
+			assert.NotEqual(t, "config", d)
+			assert.NotEqual(t, "labels", d)
+		}
+	})
+}

--- a/pkg/provider/builtin/messageprovider/message.go
+++ b/pkg/provider/builtin/messageprovider/message.go
@@ -41,6 +41,7 @@ var typeDefaults = map[string]messageStyle{
 	typeInfo:    {icon: "💡", color: "#00FFFF"},
 	typeDebug:   {icon: "🐛", color: "#FF00FF", bold: true},
 	typePlain:   {},
+	typeRaw:     {},
 }
 
 // ProviderName is the name of this provider used for error wrapping and identification.
@@ -80,6 +81,7 @@ const (
 	typeInfo    = "info"
 	typeDebug   = "debug"
 	typePlain   = "plain"
+	typeRaw     = "raw"
 )
 
 // Destination constants.
@@ -141,9 +143,8 @@ func NewMessageProvider() *MessageProvider {
 			},
 			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 				fieldMessage: schemahelper.StringProp(
-					"The message text to output (text mode). Mutually exclusive with 'data'. For dynamic interpolation, use tmpl: or expr: ValueRef on this input instead of passing templates directly.",
+					"The message text to output (text mode). Mutually exclusive with 'data'. For dynamic interpolation, use tmpl: or expr: ValueRef on this input instead of passing templates directly. Limited to 8192 characters unless type is 'raw'.",
 					schemahelper.WithExample("Deployment completed successfully"),
-					schemahelper.WithMaxLength(maxMessageLength),
 				),
 				fieldData: schemahelper.AnyProp(
 					"Structured data to render (data mode). Mutually exclusive with 'message'. Arrays render as tables or card lists; objects render as key-value views or sectioned detail views. Supports rslvr:/expr:/tmpl: ValueRef.",
@@ -177,8 +178,8 @@ func NewMessageProvider() *MessageProvider {
 					schemahelper.WithMaxLength(maxLabelLength),
 				),
 				fieldType: schemahelper.StringProp(
-					"The message type that determines icon and color styling. Maps to built-in terminal output styles: success (✅ green), warning (⚠️ yellow), error (❌ red), info (💡 cyan), debug (🐛 magenta), plain (no styling).",
-					schemahelper.WithEnum(typeSuccess, typeWarning, typeError, typeInfo, typeDebug, typePlain),
+					"The message type that determines icon and color styling. Maps to built-in terminal output styles: success (✅ green), warning (⚠️ yellow), error (❌ red), info (💡 cyan), debug (🐛 magenta), plain (no styling), raw (no formatting, bypasses maxLength).",
+					schemahelper.WithEnum(typeSuccess, typeWarning, typeError, typeInfo, typeDebug, typePlain, typeRaw),
 					schemahelper.WithDefault(typeInfo),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(10)),
 				),
@@ -325,6 +326,16 @@ inputs:
   format: tree
   label: Dependencies`,
 				},
+				{
+					Name:        "Raw output",
+					Description: "Write raw content to stdout without formatting or length limits",
+					YAML: `name: emit-json
+provider: message
+inputs:
+  message:
+    rslvr: registry_index_json
+  type: raw`,
+				},
 			},
 		},
 	}
@@ -387,6 +398,17 @@ func (p *MessageProvider) executeTextMode(ctx context.Context, inputs map[string
 	dest := stringField(inputs, fieldDestination, destStdout)
 	newline := boolField(inputs, fieldNewline, true)
 
+	// Raw mode: write content directly without formatting or length limits.
+	if msgType == typeRaw {
+		return p.executeRawMode(ctx, inputs, msgStr, dest, newline)
+	}
+
+	// Enforce maxLength at runtime for non-raw types (schema no longer carries it
+	// because JSON Schema cannot conditionally apply maxLength based on type).
+	if len(msgStr) > maxMessageLength {
+		return nil, fmt.Errorf("%s: message exceeds maximum length of %d characters (use type: raw for large output)", ProviderName, maxMessageLength)
+	}
+
 	// Get settings from context for quiet/noColor.
 	noColor := false
 	isQuiet := false
@@ -424,6 +446,54 @@ func (p *MessageProvider) executeTextMode(ctx context.Context, inputs map[string
 		Data: map[string]any{
 			"success": true,
 			"message": plain,
+		},
+		Streamed: streamed,
+	}, nil
+}
+
+// rawOnlyRejectedFields are input fields that are not supported in raw mode.
+var rawOnlyRejectedFields = []string{fieldStyle, fieldLabel}
+
+// executeRawMode writes content directly to stdout without formatting, color,
+// icons, or length limits. This is intended for machine-readable output such as
+// JSON or YAML blobs produced by solutions.
+func (p *MessageProvider) executeRawMode(ctx context.Context, inputs map[string]any, content, dest string, newline bool) (*provider.Output, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Reject fields that are meaningless in raw mode.
+	for _, field := range rawOnlyRejectedFields {
+		if _, ok := inputs[field]; ok {
+			return nil, fmt.Errorf("%s: '%s' is not supported with type: raw", ProviderName, field)
+		}
+	}
+
+	// Build the raw output (no ANSI, no icon, no wrapping).
+	output := content
+	if newline {
+		output += "\n"
+	}
+
+	// Write to the terminal. Raw mode ignores --quiet because it is intended
+	// for machine-readable output that callers may pipe or redirect.
+	streamed := false
+	ioStreams, ok := provider.IOStreamsFromContext(ctx)
+	if ok && ioStreams != nil {
+		if err := p.writeToTerminal(ioStreams, output, dest); err != nil {
+			return nil, fmt.Errorf("%s: failed to write raw output: %w", ProviderName, err)
+		}
+		streamed = true
+	}
+
+	lgr.V(1).Info("Raw output",
+		fieldDestination, dest,
+		"length", len(content),
+		"written", streamed,
+	)
+
+	return &provider.Output{
+		Data: map[string]any{
+			"success": true,
+			"message": content,
 		},
 		Streamed: streamed,
 	}, nil
@@ -560,6 +630,15 @@ func whatIf(_ context.Context, input any) (string, error) {
 	dest := stringField(inputs, fieldDestination, destStdout)
 	label := stringField(inputs, fieldLabel, "")
 	msg := stringField(inputs, fieldMessage, "")
+
+	// Raw mode: describe the raw output with content length.
+	if msgType == typeRaw {
+		if msg == "" {
+			return fmt.Sprintf("Would write raw output to %s", dest), nil
+		}
+		return fmt.Sprintf("Would write raw output (%d bytes) to %s", len(msg), dest), nil
+	}
+
 	if msg == "" {
 		if label != "" {
 			return fmt.Sprintf("Would output %s message [%s] to %s", msgType, label, dest), nil
@@ -782,6 +861,20 @@ func (p *MessageProvider) executeDryRun(inputs map[string]any) (*provider.Output
 	dest := stringField(inputs, fieldDestination, destStdout)
 	label := stringField(inputs, fieldLabel, "")
 	msg := stringField(inputs, fieldMessage, "<dynamic>")
+
+	// Raw mode dry-run.
+	if msgType == typeRaw {
+		desc := fmt.Sprintf("[dry-run] Would write raw output (%d bytes) to %s", len(msg), dest)
+		return &provider.Output{
+			Data: map[string]any{
+				"success": true,
+				"message": msg,
+			},
+			Metadata: map[string]any{
+				"description": desc,
+			},
+		}, nil
+	}
 
 	desc := fmt.Sprintf("[dry-run] Would output %s message to %s: %s", msgType, dest, msg)
 	if label != "" {

--- a/pkg/provider/builtin/messageprovider/message_test.go
+++ b/pkg/provider/builtin/messageprovider/message_test.go
@@ -703,6 +703,229 @@ func TestDescriptorValidation(t *testing.T) {
 	require.NoError(t, err, "message provider descriptor should be valid")
 }
 
+// --- Raw mode tests ---
+
+func TestMessageProvider_Execute_RawMode_BasicOutput(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": `{"key": "value"}`,
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	assert.True(t, out.Streamed)
+	assert.Equal(t, "{\"key\": \"value\"}\n", stdout.String())
+
+	data := out.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, `{"key": "value"}`, data["message"])
+}
+
+func TestMessageProvider_Execute_RawMode_ExceedsMaxLength(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	// Create content that exceeds maxMessageLength (8192).
+	longContent := strings.Repeat("x", 10000)
+	out, err := p.Execute(ctx, map[string]any{
+		"message": longContent,
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	assert.True(t, out.Streamed)
+	assert.Equal(t, longContent+"\n", stdout.String())
+
+	data := out.Data.(map[string]any)
+	assert.Equal(t, longContent, data["message"])
+}
+
+func TestMessageProvider_Execute_RawMode_NoANSICodes(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: false})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "raw content",
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+
+	// Raw mode must never contain ANSI escape codes.
+	assert.NotContains(t, stdout.String(), "\x1b[")
+	data := out.Data.(map[string]any)
+	assert.NotContains(t, data["message"].(string), "\x1b[")
+}
+
+func TestMessageProvider_Execute_RawMode_NewlineFalse(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "no trailing",
+		"type":    "raw",
+		"newline": false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "no trailing", stdout.String())
+}
+
+func TestMessageProvider_Execute_RawMode_NewlineDefault(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "with newline",
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "with newline\n", stdout.String())
+}
+
+func TestMessageProvider_Execute_RawMode_RejectsStyle(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "test",
+		"type":    "raw",
+		"style":   map[string]any{"bold": true},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'style' is not supported with type: raw")
+}
+
+func TestMessageProvider_Execute_RawMode_RejectsLabel(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message": "test",
+		"type":    "raw",
+		"label":   "step 1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'label' is not supported with type: raw")
+}
+
+func TestMessageProvider_Execute_RawMode_Stderr(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, stderr := testCtx(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"message":     "stderr raw",
+		"type":        "raw",
+		"destination": "stderr",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "stderr raw\n", stderr.String())
+}
+
+func TestMessageProvider_Execute_RawMode_IgnoresQuiet(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{IsQuiet: true})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "not suppressed",
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+	// Raw mode ignores --quiet because it's meant for machine output.
+	assert.Equal(t, "not suppressed\n", stdout.String())
+	assert.True(t, out.Streamed)
+}
+
+func TestMessageProvider_Execute_RawMode_DryRun(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, nil)
+	ctx = provider.WithDryRun(ctx, true)
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "raw content",
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String()) // Dry-run doesn't write.
+
+	data := out.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+	assert.Equal(t, "raw content", data["message"])
+
+	assert.Contains(t, out.Metadata["description"], "[dry-run]")
+	assert.Contains(t, out.Metadata["description"], "raw output")
+}
+
+func TestMessageProvider_Execute_NonRaw_ExceedsMaxLength(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, _, _ := testCtx(t, nil)
+
+	longMsg := strings.Repeat("x", maxMessageLength+1)
+	_, err := p.Execute(ctx, map[string]any{
+		"message": longMsg,
+		"type":    "info",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum length")
+	assert.Contains(t, err.Error(), "use type: raw")
+}
+
+func TestMessageProvider_Execute_NonRaw_AtMaxLength(t *testing.T) {
+	p := NewMessageProvider()
+	ctx, stdout, _ := testCtx(t, &settings.Run{NoColor: true})
+
+	exactMsg := strings.Repeat("x", maxMessageLength)
+	out, err := p.Execute(ctx, map[string]any{
+		"message": exactMsg,
+		"type":    "plain",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Streamed)
+	assert.Equal(t, exactMsg+"\n", stdout.String())
+}
+
+func TestMessageProvider_WhatIf_RawMode(t *testing.T) {
+	p := NewMessageProvider()
+	desc := p.Descriptor()
+
+	t.Run("with message", func(t *testing.T) {
+		msg, err := desc.WhatIf(context.Background(), map[string]any{
+			"message": "some content",
+			"type":    "raw",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, msg, "raw output")
+		assert.Contains(t, msg, "12 bytes")
+	})
+
+	t.Run("no message", func(t *testing.T) {
+		msg, err := desc.WhatIf(context.Background(), map[string]any{
+			"type": "raw",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, msg, "raw output")
+	})
+}
+
+func TestMessageProvider_Execute_RawMode_NoIOStreams(t *testing.T) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{})
+
+	out, err := p.Execute(ctx, map[string]any{
+		"message": "no streams",
+		"type":    "raw",
+	})
+	require.NoError(t, err)
+
+	data := out.Data.(map[string]any)
+	assert.Equal(t, "no streams", data["message"])
+	assert.False(t, out.Streamed)
+}
+
 // --- Benchmarks ---
 
 func BenchmarkExecutePlainMessage(b *testing.B) {
@@ -802,6 +1025,26 @@ func BenchmarkExecuteWithLabel(b *testing.B) {
 		"label":   "step 3/5",
 	}
 
+	b.ResetTimer()
+	for b.Loop() {
+		stdout.Reset()
+		_, _ = p.Execute(ctx, input)
+	}
+}
+
+func BenchmarkExecuteRawMode(b *testing.B) {
+	p := NewMessageProvider()
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = settings.IntoContext(ctx, &settings.Run{NoColor: false})
+	stdout := &bytes.Buffer{}
+	ctx = provider.WithIOStreams(ctx, &provider.IOStreams{Out: stdout, ErrOut: &bytes.Buffer{}})
+
+	input := map[string]any{
+		"message": strings.Repeat("x", 10000),
+		"type":    "raw",
+	}
+
+	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
 		stdout.Reset()

--- a/pkg/provider/builtin/metadataprovider/metadata.go
+++ b/pkg/provider/builtin/metadataprovider/metadata.go
@@ -6,6 +6,9 @@ package metadataprovider
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
@@ -17,6 +20,14 @@ import (
 
 // ProviderName is the name of this provider.
 const ProviderName = "metadata"
+
+// parentProcessNameFunc returns the parent process executable name.
+// Points to the platform-specific parentProcessName by default.
+// Overridable for testing.
+var parentProcessNameFunc = parentProcessName
+
+// goosFunc returns the current OS. Overridable for testing.
+var goosFunc = func() string { return runtime.GOOS }
 
 // MetadataProvider returns runtime metadata about the scafctl process and
 // the currently-executing solution. It requires no inputs — all data is
@@ -34,12 +45,12 @@ func (p *MetadataProvider) Descriptor() *provider.Descriptor {
 		Name:        ProviderName,
 		DisplayName: "Metadata Provider",
 		APIVersion:  "v1",
-		Version:     semver.MustParse("2.0.0"),
-		Description: "Returns runtime metadata about the scafctl process and the currently-executing solution. Provides the scafctl version, CLI arguments, working directory, entrypoint type (cli/api), command path, and solution metadata. Requires no inputs.",
+		Version:     semver.MustParse("3.1.0"),
+		Description: "Returns runtime metadata about the scafctl process and the currently-executing solution. Provides the scafctl version, CLI arguments, working directory, entrypoint type (cli/api), command path, solution metadata, and platform information (os, arch), and the user's default shell. Requires no inputs.",
 		Schema:      schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{}),
 		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 			provider.CapabilityFrom: schemahelper.ObjectSchema(
-				[]string{"version", "args", "cwd", "entrypoint", "command", "solution"},
+				[]string{"version", "args", "cwd", "entrypoint", "command", "solution", "os", "arch", "shell"},
 				map[string]*jsonschema.Schema{
 					"version": schemahelper.ObjectProp("Build version information", nil, map[string]*jsonschema.Schema{
 						"buildVersion": schemahelper.StringProp("Semantic version of the scafctl build"),
@@ -58,6 +69,9 @@ func (p *MetadataProvider) Descriptor() *provider.Descriptor {
 						"category":    schemahelper.StringProp("Solution category"),
 						"tags":        schemahelper.ArrayProp("Solution tags", schemahelper.WithItems(schemahelper.StringProp("A tag"))),
 					}),
+					"os":    schemahelper.StringProp("Operating system (runtime.GOOS)", schemahelper.WithEnum("aix", "android", "darwin", "dragonfly", "freebsd", "illumos", "ios", "js", "linux", "netbsd", "openbsd", "plan9", "solaris", "wasip1", "windows")),
+					"arch":  schemahelper.StringProp("CPU architecture (runtime.GOARCH)", schemahelper.WithEnum("386", "amd64", "arm", "arm64", "loong64", "mips", "mips64", "mips64le", "mipsle", "ppc64", "ppc64le", "riscv64", "s390x", "wasm")),
+					"shell": schemahelper.StringProp("User's shell (from $SHELL on Unix; PSModulePath/parent-process heuristic on Windows; %ComSpec% fallback)"),
 				},
 			),
 		},
@@ -65,7 +79,7 @@ func (p *MetadataProvider) Descriptor() *provider.Descriptor {
 			provider.CapabilityFrom,
 		},
 		Category: "Core",
-		Tags:     []string{"metadata", "solution", "introspection", "runtime"},
+		Tags:     []string{"metadata", "solution", "introspection", "runtime", "platform"},
 		Examples: []provider.Example{
 			{
 				Name:        "Runtime metadata",
@@ -134,8 +148,66 @@ func (p *MetadataProvider) Execute(ctx context.Context, _ any) (*provider.Output
 		"entrypoint": entrypoint,
 		"command":    command,
 		"solution":   solData,
+		"os":         runtime.GOOS,
+		"arch":       runtime.GOARCH,
+		"shell":      detectShell(),
 	}
 
 	lgr.V(1).Info("provider completed", "provider", ProviderName)
 	return &provider.Output{Data: result}, nil
+}
+
+// detectShell returns the base name of the user's shell.
+//
+// On Unix, $SHELL is the canonical source (user's configured login shell).
+//
+// On Windows, %ComSpec% always points to cmd.exe regardless of the running
+// shell, so we use a multi-step heuristic:
+//  1. $SHELL set → authoritative on Unix; also covers Git Bash / MSYS2 / Cygwin on Windows.
+//  2. PSModulePath set (Windows only) → PowerShell session. Inspect the parent
+//     process name to distinguish "pwsh" (PowerShell 7+) from "powershell"
+//     (Windows PowerShell 5.x). Falls back to "pwsh" if introspection fails.
+//  3. %ComSpec% → last resort on Windows (almost always cmd.exe).
+//
+// Returns an empty string if nothing is detected.
+func detectShell() string {
+	// Unix fast path: $SHELL is authoritative.
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return filepath.Base(shell)
+	}
+
+	// Windows heuristic: PSModulePath is set in every PowerShell session.
+	if goosFunc() == "windows" {
+		if os.Getenv("PSModulePath") != "" {
+			return detectPowerShellVariant()
+		}
+	}
+
+	// Fallback: %ComSpec% on Windows (cmd.exe), empty on Unix.
+	if comspec := os.Getenv("ComSpec"); comspec != "" {
+		return filepath.Base(comspec)
+	}
+	return ""
+}
+
+// detectPowerShellVariant inspects the parent process to distinguish
+// "pwsh" (PowerShell 7+) from "powershell" (Windows PowerShell 5.x).
+// Returns "pwsh" if the parent cannot be determined.
+func detectPowerShellVariant() string {
+	name := parentProcessNameFunc()
+	if name == "" {
+		return "pwsh"
+	}
+
+	base := filepath.Base(name)
+	base = strings.TrimSuffix(base, ".exe")
+	switch base {
+	case "powershell":
+		return "powershell"
+	case "pwsh":
+		return "pwsh"
+	}
+
+	// Default to modern PowerShell if parent is something unexpected.
+	return "pwsh"
 }

--- a/pkg/provider/builtin/metadataprovider/metadata_test.go
+++ b/pkg/provider/builtin/metadataprovider/metadata_test.go
@@ -6,6 +6,7 @@ package metadataprovider
 import (
 	"context"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -75,6 +76,10 @@ func TestExecute_FullContext(t *testing.T) {
 	// Verify command.
 	assert.Equal(t, "scafctl/run/solution", result["command"])
 
+	// Verify platform info.
+	assert.Equal(t, runtime.GOOS, result["os"])
+	assert.Equal(t, runtime.GOARCH, result["arch"])
+
 	// Verify solution metadata.
 	solMap, ok := result["solution"].(map[string]any)
 	require.True(t, ok, "solution should be a map")
@@ -128,6 +133,10 @@ func TestExecute_NoContext(t *testing.T) {
 	assert.NotNil(t, result["version"])
 	assert.NotNil(t, result["args"])
 	assert.NotEmpty(t, result["cwd"])
+
+	// os and arch should always be populated.
+	assert.Equal(t, runtime.GOOS, result["os"])
+	assert.Equal(t, runtime.GOARCH, result["arch"])
 }
 
 func TestExecute_NoSolutionMetadata(t *testing.T) {
@@ -151,4 +160,133 @@ func TestExecute_NoSolutionMetadata(t *testing.T) {
 	solMap, ok := result["solution"].(map[string]any)
 	require.True(t, ok)
 	assert.Empty(t, solMap)
+}
+
+func TestDetectShell_FromSHELL(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	assert.Equal(t, "zsh", detectShell())
+}
+
+func TestDetectShell_FromComSpec(t *testing.T) {
+	t.Setenv("SHELL", "")
+	t.Setenv("PSModulePath", "")
+	t.Setenv("ComSpec", "/c/Windows/system32/cmd.exe")
+	assert.Equal(t, "cmd.exe", detectShell())
+}
+
+func TestDetectShell_Empty(t *testing.T) {
+	t.Setenv("SHELL", "")
+	t.Setenv("PSModulePath", "")
+	t.Setenv("ComSpec", "")
+	assert.Equal(t, "", detectShell())
+}
+
+func TestDetectShell_SHELLTakesPrecedence(t *testing.T) {
+	// $SHELL should win even if PSModulePath and ComSpec are set.
+	t.Setenv("SHELL", "/usr/bin/bash")
+	t.Setenv("PSModulePath", "C:\\modules")
+	t.Setenv("ComSpec", "C:\\Windows\\system32\\cmd.exe")
+	assert.Equal(t, "bash", detectShell())
+}
+
+func TestDetectShell_PSModulePath_Pwsh(t *testing.T) {
+	origGoos := goosFunc
+	origParent := parentProcessNameFunc
+	t.Cleanup(func() {
+		goosFunc = origGoos
+		parentProcessNameFunc = origParent
+	})
+
+	goosFunc = func() string { return "windows" }
+	parentProcessNameFunc = func() string { return "pwsh.exe" }
+
+	t.Setenv("SHELL", "")
+	t.Setenv("PSModulePath", `C:\Users\test\Documents\PowerShell\Modules`)
+	t.Setenv("ComSpec", `C:\Windows\system32\cmd.exe`)
+
+	assert.Equal(t, "pwsh", detectShell())
+}
+
+func TestDetectShell_PSModulePath_WindowsPowerShell(t *testing.T) {
+	origGoos := goosFunc
+	origParent := parentProcessNameFunc
+	t.Cleanup(func() {
+		goosFunc = origGoos
+		parentProcessNameFunc = origParent
+	})
+
+	goosFunc = func() string { return "windows" }
+	parentProcessNameFunc = func() string { return "powershell.exe" }
+
+	t.Setenv("SHELL", "")
+	t.Setenv("PSModulePath", `C:\Users\test\Documents\PowerShell\Modules`)
+	t.Setenv("ComSpec", `C:\Windows\system32\cmd.exe`)
+
+	assert.Equal(t, "powershell", detectShell())
+}
+
+func TestDetectShell_GitBashOnWindows(t *testing.T) {
+	// Git Bash sets $SHELL, so it takes precedence.
+	t.Setenv("SHELL", "/usr/bin/bash")
+	t.Setenv("PSModulePath", "")
+	t.Setenv("ComSpec", `C:\Windows\system32\cmd.exe`)
+
+	assert.Equal(t, "bash", detectShell())
+}
+
+func TestDetectShell_CmdExeFallback(t *testing.T) {
+	origGoos := goosFunc
+	t.Cleanup(func() { goosFunc = origGoos })
+
+	goosFunc = func() string { return "windows" }
+
+	t.Setenv("SHELL", "")
+	t.Setenv("PSModulePath", "")
+	// Use forward slashes so filepath.Base works correctly on all platforms.
+	t.Setenv("ComSpec", "C:/Windows/system32/cmd.exe")
+
+	assert.Equal(t, "cmd.exe", detectShell())
+}
+
+func TestDetectPowerShellVariant_Pwsh(t *testing.T) {
+	orig := parentProcessNameFunc
+	t.Cleanup(func() { parentProcessNameFunc = orig })
+
+	parentProcessNameFunc = func() string { return "pwsh.exe" }
+	assert.Equal(t, "pwsh", detectPowerShellVariant())
+}
+
+func TestDetectPowerShellVariant_WindowsPowerShell(t *testing.T) {
+	orig := parentProcessNameFunc
+	t.Cleanup(func() { parentProcessNameFunc = orig })
+
+	parentProcessNameFunc = func() string { return "powershell.exe" }
+	assert.Equal(t, "powershell", detectPowerShellVariant())
+}
+
+func TestDetectPowerShellVariant_Unknown(t *testing.T) {
+	orig := parentProcessNameFunc
+	t.Cleanup(func() { parentProcessNameFunc = orig })
+
+	parentProcessNameFunc = func() string { return "" }
+	assert.Equal(t, "pwsh", detectPowerShellVariant())
+}
+
+func TestDetectPowerShellVariant_UnexpectedParent(t *testing.T) {
+	orig := parentProcessNameFunc
+	t.Cleanup(func() { parentProcessNameFunc = orig })
+
+	parentProcessNameFunc = func() string { return "explorer.exe" }
+	assert.Equal(t, "pwsh", detectPowerShellVariant())
+}
+
+func TestExecute_ShellField(t *testing.T) {
+	t.Setenv("SHELL", "/usr/bin/bash")
+
+	p := New()
+	out, err := p.Execute(context.Background(), nil)
+	require.NoError(t, err)
+
+	result := out.Data.(map[string]any)
+	assert.Equal(t, "bash", result["shell"])
 }

--- a/pkg/provider/builtin/metadataprovider/shell_other.go
+++ b/pkg/provider/builtin/metadataprovider/shell_other.go
@@ -1,0 +1,12 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package metadataprovider
+
+// parentProcessName is a no-op on non-Windows platforms.
+// On Unix, $SHELL is the authoritative source for the user's shell.
+func parentProcessName() string {
+	return ""
+}

--- a/pkg/provider/builtin/metadataprovider/shell_windows.go
+++ b/pkg/provider/builtin/metadataprovider/shell_windows.go
@@ -1,0 +1,47 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package metadataprovider
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// ppidFunc returns the parent process ID. Overridable for testing.
+var ppidFunc = os.Getppid
+
+// parentProcessName returns the executable name of the parent process
+// on Windows using the Toolhelp32 snapshot API.
+// Returns an empty string if the parent process cannot be determined.
+func parentProcessName() string {
+	ppid := uint32(ppidFunc())
+	if ppid == 0 {
+		return ""
+	}
+
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(snap) //nolint:errcheck
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	err = windows.Process32First(snap, &entry)
+	for err == nil {
+		if entry.ProcessID == ppid {
+			name := windows.UTF16ToString(entry.ExeFile[:])
+			return strings.TrimSpace(name)
+		}
+		err = windows.Process32Next(snap, &entry)
+	}
+
+	return ""
+}

--- a/pkg/provider/run.go
+++ b/pkg/provider/run.go
@@ -114,6 +114,11 @@ func ValidateInputKeys(inputs map[string]any, desc *Descriptor) error {
 // capability, validates inputs, sets up the execution context, and calls
 // Execute.  This is the shared domain entry point used by both the CLI
 // command and the MCP tool.
+//
+// When no explicit capability is requested, RunProvider auto-promotes to
+// action mode if the resolved operation is a write operation and the
+// provider supports CapabilityAction.  This allows CLI and MCP callers to
+// run write operations without explicitly specifying --capability action.
 func RunProvider(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	if opts.Provider == nil {
 		return nil, fmt.Errorf("provider is required")
@@ -128,6 +133,20 @@ func RunProvider(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	capability, err := ResolveCapability(desc, opts.Capability)
 	if err != nil {
 		return nil, err
+	}
+
+	// Auto-promote to action when the caller did not explicitly request a
+	// capability and the default (typically "from") would block a write
+	// operation.  This is safe because RunProvider is only called from
+	// direct invocation contexts (CLI, MCP) where there is no resolver
+	// phase to protect.
+	if opts.Capability == "" && capability != CapabilityAction {
+		operation, _ := opts.Inputs["operation"].(string)
+		if operation != "" && desc.IsWriteOperation(operation) {
+			if descriptorHasCapability(desc, CapabilityAction) {
+				capability = CapabilityAction
+			}
+		}
 	}
 
 	// Validate input keys against schema
@@ -156,4 +175,14 @@ func RunProvider(ctx context.Context, opts RunOptions) (*RunResult, error) {
 		DryRun:     result.DryRun,
 		Duration:   elapsed.String(),
 	}, nil
+}
+
+// descriptorHasCapability reports whether the descriptor lists the given capability.
+func descriptorHasCapability(desc *Descriptor, target Capability) bool {
+	for _, c := range desc.Capabilities {
+		if c == target {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/provider/run_test.go
+++ b/pkg/provider/run_test.go
@@ -271,6 +271,126 @@ func TestRunProvider_WarningsAndMetadata(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// RunProvider write-operation auto-promote
+// ---------------------------------------------------------------------------
+
+func newWriteClassifierTestProvider(caps []Capability, writeOps []string, execFn func(context.Context, any) (*Output, error)) *mockExecutableProvider {
+	version, _ := semver.NewVersion("1.0.0")
+	return &mockExecutableProvider{
+		descriptor: &Descriptor{
+			Name:            "github",
+			APIVersion:      "v1",
+			Version:         version,
+			Description:     "Test provider with write operations",
+			Capabilities:    caps,
+			WriteOperations: writeOps,
+		},
+		executeFunc: execFn,
+	}
+}
+
+func TestRunProvider_AutoPromotesWriteOpToAction(t *testing.T) {
+	prov := newWriteClassifierTestProvider(
+		[]Capability{CapabilityFrom, CapabilityAction},
+		[]string{"create_issue"},
+		func(_ context.Context, _ any) (*Output, error) {
+			return &Output{Data: map[string]any{"id": 42}}, nil
+		},
+	)
+
+	result, err := RunProvider(context.Background(), RunOptions{
+		Provider: prov,
+		Inputs:   map[string]any{"operation": "create_issue", "title": "test"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "action", result.Capability)
+}
+
+func TestRunProvider_ReadOpStaysInFrom(t *testing.T) {
+	prov := newWriteClassifierTestProvider(
+		[]Capability{CapabilityFrom, CapabilityAction},
+		[]string{"create_issue"},
+		func(_ context.Context, _ any) (*Output, error) {
+			return &Output{Data: map[string]any{"issues": []string{}}}, nil
+		},
+	)
+
+	result, err := RunProvider(context.Background(), RunOptions{
+		Provider: prov,
+		Inputs:   map[string]any{"operation": "list_issues"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "from", result.Capability)
+}
+
+func TestRunProvider_ExplicitCapabilitySkipsAutoPromote(t *testing.T) {
+	prov := newWriteClassifierTestProvider(
+		[]Capability{CapabilityFrom, CapabilityAction},
+		[]string{"create_issue"},
+		nil,
+	)
+
+	// Explicitly requesting "from" for a write op should NOT auto-promote.
+	// The executor's ValidateWriteOperation will block it.
+	_, err := RunProvider(context.Background(), RunOptions{
+		Provider:   prov,
+		Inputs:     map[string]any{"operation": "create_issue"},
+		Capability: "from",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+}
+
+func TestRunProvider_NoActionCapabilityNoPromotion(t *testing.T) {
+	// Provider supports only "from" -- cannot promote.
+	prov := newWriteClassifierTestProvider(
+		[]Capability{CapabilityFrom},
+		[]string{"create_issue"},
+		nil,
+	)
+
+	_, err := RunProvider(context.Background(), RunOptions{
+		Provider: prov,
+		Inputs:   map[string]any{"operation": "create_issue"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+}
+
+func TestRunProvider_NilWriteOpsNoPromotion(t *testing.T) {
+	// Provider with nil WriteOperations (no classification) -- should not
+	// auto-promote; the operation runs in the default "from" capability.
+	prov := newWriteClassifierTestProvider(
+		[]Capability{CapabilityFrom, CapabilityAction},
+		nil,
+		func(_ context.Context, _ any) (*Output, error) {
+			return &Output{Data: map[string]any{"ok": true}}, nil
+		},
+	)
+
+	result, err := RunProvider(context.Background(), RunOptions{
+		Provider: prov,
+		Inputs:   map[string]any{"operation": "create_issue"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "from", result.Capability)
+}
+
+// ---------------------------------------------------------------------------
+// descriptorHasCapability
+// ---------------------------------------------------------------------------
+
+func TestDescriptorHasCapability(t *testing.T) {
+	desc := &Descriptor{
+		Name:         "test",
+		Capabilities: []Capability{CapabilityFrom, CapabilityAction},
+	}
+	assert.True(t, descriptorHasCapability(desc, CapabilityFrom))
+	assert.True(t, descriptorHasCapability(desc, CapabilityAction))
+	assert.False(t, descriptorHasCapability(desc, CapabilityTransform))
+}
+
+// ---------------------------------------------------------------------------
 // Benchmarks
 // ---------------------------------------------------------------------------
 

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -838,6 +838,24 @@ func (e *Executor) executeResolvePhase(ctx context.Context, phase *ResolvePhase)
 			}
 		}
 
+		// Handle forEach iteration on resolve sources
+		if source.ForEach != nil {
+			result, calls, err := e.executeForEachSource(ctx, &source, i)
+			providerCallCount += calls
+			if err != nil {
+				lgr.V(1).Info("forEach source failed",
+					"source", i+1,
+					logKeyProvider, source.Provider,
+					"error", err)
+				if source.OnError == ErrorBehaviorFail {
+					return nil, providerCallCount, fmt.Errorf("source %d (%s) forEach failed: %w", i+1, source.Provider, err)
+				}
+				lastErr = err
+				continue
+			}
+			return result, providerCallCount, nil
+		}
+
 		// Execute provider in resolve (from) mode
 		value, err := e.executeProvider(provider.WithExecutionMode(ctx, provider.CapabilityFrom), source.Provider, source.Inputs)
 		providerCallCount++
@@ -1146,6 +1164,163 @@ func (e *Executor) executeForEachTransform(ctx context.Context, transform *Provi
 
 	// All succeeded - filter out nil entries for skipped items unless keepSkipped is set
 	if transform.When != nil && !transform.ForEach.KeepSkipped {
+		filtered := results[:0]
+		for _, r := range results {
+			if r != nil {
+				filtered = append(filtered, r)
+			}
+		}
+		return filtered, providerCallCount, nil
+	}
+	return results, providerCallCount, nil
+}
+
+// executeForEachSource executes a resolve source with forEach iteration.
+// Unlike transform forEach, resolve forEach has no __self and requires forEach.in.
+func (e *Executor) executeForEachSource(ctx context.Context, source *ProviderSource, sourceIndex int) (any, int, error) {
+	lgr := logger.FromContext(ctx)
+	resolverCtx, _ := FromContext(ctx)
+	resolverData := resolverCtx.ToMap()
+
+	// forEach.in is required for resolve sources (no __self to default to)
+	if source.ForEach.In == nil {
+		return nil, 0, fmt.Errorf("source %d: forEach.in is required on resolve steps (no __self available)", sourceIndex+1)
+	}
+
+	// Resolve the input array
+	resolved, err := source.ForEach.In.Resolve(ctx, resolverData, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("source %d: failed to resolve forEach.in: %w", sourceIndex+1, err)
+	}
+	inputArray, ok := toSlice(resolved)
+	if !ok {
+		return nil, 0, &ForEachTypeError{
+			Step:       sourceIndex,
+			ActualType: fmt.Sprintf("%T", resolved),
+		}
+	}
+
+	// Handle empty array
+	if len(inputArray) == 0 {
+		lgr.V(1).Info("forEach: empty input array, returning []",
+			"source", sourceIndex+1,
+			logKeyProvider, source.Provider)
+		return []any{}, 0, nil
+	}
+
+	lgr.V(1).Info("executing forEach resolve source",
+		"source", sourceIndex+1,
+		logKeyProvider, source.Provider,
+		"itemCount", len(inputArray),
+		"concurrency", source.ForEach.Concurrency)
+
+	// Create result slice and error tracking
+	results := make([]any, len(inputArray))
+	errors := make([]error, len(inputArray))
+	providerCallCount := 0
+	var providerCallCountMu sync.Mutex
+
+	// Create semaphore for concurrency control
+	var sem chan struct{}
+	if source.ForEach.Concurrency > 0 {
+		sem = make(chan struct{}, source.ForEach.Concurrency)
+	}
+
+	var wg sync.WaitGroup
+	for idx, item := range inputArray {
+		wg.Add(1)
+		go func(i int, itm any) {
+			defer wg.Done()
+
+			// Acquire semaphore if concurrency limited
+			if sem != nil {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+			}
+
+			// Build iteration context
+			iterCtx := &IterationContext{
+				Item:       itm,
+				Index:      i,
+				ItemAlias:  source.ForEach.Item,
+				IndexAlias: source.ForEach.Index,
+			}
+
+			// Check when condition with iteration variables (no __self in resolve phase)
+			if source.When != nil {
+				shouldExecute, err := e.evaluateConditionWithIterationContext(ctx, source.When, nil, iterCtx)
+				if err != nil {
+					errors[i] = fmt.Errorf("when condition evaluation failed: %w", err)
+					return
+				}
+				if !shouldExecute {
+					lgr.V(2).Info("skipping forEach iteration due to when condition",
+						"source", sourceIndex+1,
+						"index", i)
+					results[i] = nil
+					return
+				}
+			}
+
+			// Execute provider with iteration context (resolve/from mode)
+			result, err := e.executeProviderWithIterationContext(provider.WithExecutionMode(ctx, provider.CapabilityFrom), source.Provider, source.Inputs, nil, iterCtx)
+			providerCallCountMu.Lock()
+			providerCallCount++
+			providerCallCountMu.Unlock()
+
+			if err != nil {
+				errors[i] = err
+				lgr.V(1).Info("forEach iteration failed",
+					"source", sourceIndex+1,
+					"index", i,
+					"error", err)
+			} else {
+				results[i] = result
+			}
+		}(idx, item)
+	}
+
+	wg.Wait()
+
+	// Check for errors
+	var hasErrors bool
+	for _, err := range errors {
+		if err != nil {
+			hasErrors = true
+			break
+		}
+	}
+
+	if hasErrors {
+		if source.OnError == ErrorBehaviorContinue {
+			outputResults := make([]any, len(inputArray))
+			for i := range inputArray {
+				if errors[i] != nil {
+					outputResults[i] = ForEachIterationResult{
+						Index: i,
+						Error: errors[i].Error(),
+						Item:  inputArray[i],
+					}
+				} else {
+					outputResults[i] = ForEachIterationResult{
+						Index: i,
+						Data:  results[i],
+						Item:  inputArray[i],
+					}
+				}
+			}
+			return outputResults, providerCallCount, nil
+		}
+		// Return first error
+		for i, err := range errors {
+			if err != nil {
+				return nil, providerCallCount, fmt.Errorf("source %d forEach iteration %d failed: %w", sourceIndex+1, i, err)
+			}
+		}
+	}
+
+	// All succeeded - filter out nil entries for skipped items unless keepSkipped is set
+	if source.When != nil && !source.ForEach.KeepSkipped {
 		filtered := results[:0]
 		for _, r := range results {
 			if r != nil {

--- a/pkg/resolver/foreach_test.go
+++ b/pkg/resolver/foreach_test.go
@@ -871,6 +871,435 @@ func TestForEach_ChainedForEach(t *testing.T) {
 	assert.Equal(t, []any{3, 5, 7}, arr)
 }
 
+func TestForEachResolve_BasicIteration(t *testing.T) {
+	registry := newMockRegistry()
+
+	// Register provider that fetches "data" for each item
+	err := registry.Register(&mockProvider{
+		name: "http",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			url, _ := inputs["url"].(string)
+			return &provider.Output{Data: map[string]any{"url": url, "status": 200}}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	// Register static provider for the source array
+	err = registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "urls",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"https://a.com", "https://b.com", "https://c.com"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "fetched",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "http",
+						ForEach: &ForEachClause{
+							In:   &ValueRef{Resolver: stringPtr("urls")},
+							Item: "url",
+						},
+						Inputs: map[string]*ValueRef{
+							"url": {Expr: exprPtr("url")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx, err = executor.Execute(ctx, resolvers, nil)
+	require.NoError(t, err)
+
+	result, _ := FromContext(ctx)
+	value, ok := result.Get("fetched")
+	require.True(t, ok)
+
+	arr, ok := value.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 3)
+
+	first, ok := arr[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://a.com", first["url"])
+	assert.Equal(t, 200, first["status"])
+}
+
+func TestForEachResolve_RequiresIn(t *testing.T) {
+	registry := newMockRegistry()
+
+	err := registry.Register(&mockProvider{
+		name: "http",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: "ok"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "fetched",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "http",
+						ForEach:  &ForEachClause{Item: "x"},
+						Inputs: map[string]*ValueRef{
+							"url": {Literal: "https://example.com"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err = executor.Execute(ctx, resolvers, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forEach.in is required on resolve steps")
+}
+
+func TestForEachResolve_EmptyArray(t *testing.T) {
+	registry := newMockRegistry()
+
+	err := registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register(&mockProvider{
+		name: "http",
+		executeFunc: func(_ context.Context, _ map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: "should not be called"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "items",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "results",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "http",
+						ForEach: &ForEachClause{
+							In:   &ValueRef{Resolver: stringPtr("items")},
+							Item: "x",
+						},
+						Inputs: map[string]*ValueRef{
+							"url": {Expr: exprPtr("x")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx, err = executor.Execute(ctx, resolvers, nil)
+	require.NoError(t, err)
+
+	result, _ := FromContext(ctx)
+	value, ok := result.Get("results")
+	require.True(t, ok)
+
+	arr, ok := value.([]any)
+	require.True(t, ok)
+	assert.Empty(t, arr)
+}
+
+func TestForEachResolve_ConcurrencyLimit(t *testing.T) {
+	registry := newMockRegistry()
+
+	var maxConcurrent atomic.Int32
+	var currentConcurrent atomic.Int32
+
+	err := registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register(&mockProvider{
+		name: "slow",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			cur := currentConcurrent.Add(1)
+			defer currentConcurrent.Add(-1)
+
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+
+			time.Sleep(20 * time.Millisecond)
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "items",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{1, 2, 3, 4, 5}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "results",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "slow",
+						ForEach: &ForEachClause{
+							In:          &ValueRef{Resolver: stringPtr("items")},
+							Item:        "x",
+							Concurrency: 2,
+						},
+						Inputs: map[string]*ValueRef{
+							"value": {Expr: exprPtr("x")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err = executor.Execute(ctx, resolvers, nil)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, maxConcurrent.Load(), int32(2), "concurrency should be limited to 2")
+}
+
+func TestForEachResolve_FallbackChain(t *testing.T) {
+	registry := newMockRegistry()
+
+	err := registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register(&mockProvider{
+		name: "failing",
+		executeFunc: func(_ context.Context, _ map[string]any) (*provider.Output, error) {
+			return nil, fmt.Errorf("network error")
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "items",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"a", "b"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "result",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						// forEach source that fails - should continue to fallback
+						Provider: "failing",
+						ForEach: &ForEachClause{
+							In:   &ValueRef{Resolver: stringPtr("items")},
+							Item: "x",
+						},
+						// Default onError for resolve is continue (fallback chain)
+						Inputs: map[string]*ValueRef{
+							"url": {Expr: exprPtr("x")},
+						},
+					},
+					{
+						// Fallback source
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"fallback"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx, err = executor.Execute(ctx, resolvers, nil)
+	require.NoError(t, err)
+
+	result, _ := FromContext(ctx)
+	value, ok := result.Get("result")
+	require.True(t, ok)
+	assert.Equal(t, []any{"fallback"}, value)
+}
+
+func TestForEachResolve_DependencyExtraction(t *testing.T) {
+	resolver := &Resolver{
+		Name: "fetched",
+		Resolve: &ResolvePhase{
+			With: []ProviderSource{
+				{
+					Provider: "http",
+					ForEach: &ForEachClause{
+						In:   &ValueRef{Resolver: stringPtr("moduleList")},
+						Item: "mod",
+					},
+					Inputs: map[string]*ValueRef{
+						"url": {Expr: exprPtr("mod.url")},
+					},
+				},
+			},
+		},
+	}
+
+	deps := ExtractDependencies(resolver, nil)
+	assert.Contains(t, deps, "moduleList")
+}
+
+func TestForEachResolve_OnErrorFail(t *testing.T) {
+	registry := newMockRegistry()
+
+	err := registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register(&mockProvider{
+		name: "failing",
+		executeFunc: func(_ context.Context, _ map[string]any) (*provider.Output, error) {
+			return nil, fmt.Errorf("provider error")
+		},
+	})
+	require.NoError(t, err)
+
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		{
+			Name: "items",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"a", "b"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "result",
+			Type: TypeArray,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "failing",
+						OnError:  ErrorBehaviorFail,
+						ForEach: &ForEachClause{
+							In:   &ValueRef{Resolver: stringPtr("items")},
+							Item: "x",
+						},
+						Inputs: map[string]*ValueRef{
+							"url": {Expr: exprPtr("x")},
+						},
+					},
+					{
+						// This fallback should NOT be reached
+						Provider: "static",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"fallback"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err = executor.Execute(ctx, resolvers, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forEach failed")
+}
+
 // Helper function to create expression pointers
 func exprPtr(s string) *celexp.Expression {
 	expr := celexp.Expression(s)

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -171,6 +171,14 @@ func extractDepsFromValueRef(ref *ValueRef, deps map[string]bool) {
 // extractDepsFromLiteral recursively extracts dependencies from literal values
 // that may contain CEL expression strings or Go template syntax
 func extractDepsFromLiteral(literal any, deps map[string]bool) {
+	extractDepsFromLiteralWithExclusions(literal, deps, nil)
+}
+
+// extractDepsFromLiteralWithExclusions works like extractDepsFromLiteral but
+// allows excluding certain names from being treated as resolver dependencies.
+// This is used when a sibling "data" map provides template context variables
+// that should not be interpreted as resolver references.
+func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]bool) {
 	switch v := literal.(type) {
 	case string:
 		// Check if the string contains CEL-like expressions (_.something or _["something"] patterns)
@@ -180,24 +188,51 @@ func extractDepsFromLiteral(literal any, deps map[string]bool) {
 		// Check if the string contains Go template syntax ({{ and }})
 		// This handles cases like go-template provider inputs with {{.resolverName}} patterns
 		if strings.Contains(v, "{{") && strings.Contains(v, "}}") {
-			extractDepsFromTemplate(v, deps)
+			if len(exclude) > 0 {
+				extractDepsFromTemplateWithExclusions(v, deps, exclude)
+			} else {
+				extractDepsFromTemplate(v, deps)
+			}
 		}
 	case map[string]any:
-		// Recursively check map values
-		for _, mapVal := range v {
-			extractDepsFromLiteral(mapVal, deps)
+		// Check for go-template provider pattern: if this map has a "template"
+		// string and a "data" map, exclude data keys from template references.
+		// This prevents false-positive resolver dependencies when the template
+		// accesses variables provided by the data input (e.g., {{.config}}).
+		var dataKeys map[string]bool
+		if dataMap, ok := v["data"].(map[string]any); ok {
+			dataKeys = make(map[string]bool, len(dataMap))
+			for k := range dataMap {
+				dataKeys[k] = true
+			}
+		}
+		// Recursively check map values, passing data keys as exclusions
+		// for template strings in the same map
+		for key, mapVal := range v {
+			if key == "template" && dataKeys != nil {
+				extractDepsFromLiteralWithExclusions(mapVal, deps, dataKeys)
+			} else {
+				extractDepsFromLiteralWithExclusions(mapVal, deps, exclude)
+			}
 		}
 	case []any:
 		// Recursively check array elements
 		for _, arrVal := range v {
-			extractDepsFromLiteral(arrVal, deps)
+			extractDepsFromLiteralWithExclusions(arrVal, deps, exclude)
 		}
 	}
 }
 
-// extractDepsFromTemplate extracts resolver references from Go templates
-// Uses the gotmpl package's GetReferences function for proper template parsing
+// extractDepsFromTemplate extracts resolver references from Go templates.
+// Uses the gotmpl package's GetReferences function for proper template parsing.
 func extractDepsFromTemplate(tmplContent string, deps map[string]bool) {
+	extractDepsFromTemplateWithExclusions(tmplContent, deps, nil)
+}
+
+// extractDepsFromTemplateWithExclusions extracts resolver references from Go templates,
+// skipping any variable names present in the exclude set. This is used when template
+// variables are provided by a sibling data input rather than resolvers.
+func extractDepsFromTemplateWithExclusions(tmplContent string, deps, exclude map[string]bool) {
 	// Use the gotmpl package to properly parse template references
 	refs, err := gotmpl.GetGoTemplateReferences(tmplContent, "", "")
 	if err != nil {
@@ -208,6 +243,7 @@ func extractDepsFromTemplate(tmplContent string, deps map[string]bool) {
 	// Extract resolver names from paths that reference data
 	for _, ref := range refs {
 		path := ref.Path
+		var varName string
 		// Handle different path patterns from template parsing
 		// The parser returns paths like:
 		// - "._.resolverName" for {{ ._.resolverName }} (ValueRef tmpl pattern)
@@ -216,35 +252,33 @@ func extractDepsFromTemplate(tmplContent string, deps map[string]bool) {
 		switch {
 		case strings.HasPrefix(path, "._."):
 			// Extract "resolverName" from "._.resolverName"
-			varName := strings.TrimPrefix(path, "._.")
+			varName = strings.TrimPrefix(path, "._.")
 			// Only take the first segment if there are nested accesses
 			if idx := strings.Index(varName, "."); idx != -1 {
 				varName = varName[:idx]
 			}
-			deps[varName] = true
 		case strings.HasPrefix(path, ".__"):
 			// Skip special variables like __self, __item, __index - they are not dependencies
 			continue
 		case strings.HasPrefix(path, "._"):
 			// Handle _.resolverName pattern (without leading dot after _.)
-			varName := strings.TrimPrefix(path, "._")
+			varName = strings.TrimPrefix(path, "._")
 			// Only take the first segment if there are nested accesses
 			if idx := strings.Index(varName, "."); idx != -1 {
 				varName = varName[:idx]
 			}
-			deps[varName] = true
 		case strings.HasPrefix(path, "."):
 			// Handle direct root-level access like ".resolverName" used by go-template provider
 			// This pattern is used when resolver data is at the root level of template data
-			varName := strings.TrimPrefix(path, ".")
+			varName = strings.TrimPrefix(path, ".")
 			// Only take the first segment if there are nested accesses (e.g., ".config.host" -> "config")
 			if idx := strings.Index(varName, "."); idx != -1 {
 				varName = varName[:idx]
 			}
-			// Skip empty names (from "." alone)
-			if varName != "" {
-				deps[varName] = true
-			}
+		}
+
+		if varName != "" && !exclude[varName] {
+			deps[varName] = true
 		}
 	}
 }
@@ -318,14 +352,84 @@ func extractDepsFromResolvePhase(phase *ResolvePhase, deps map[string]bool, look
 			extractDepsFromExpression(string(*source.When.Expr), deps)
 		}
 
+		// Extract from forEach.In (if using forEach with custom source)
+		if source.ForEach != nil && source.ForEach.In != nil {
+			extractDepsFromValueRef(source.ForEach.In, deps)
+		}
+
 		// Try provider-specific extraction first
 		if extractDepsFromProviderInputs(source.Provider, source.Inputs, deps, lookup) {
 			continue
 		}
 
-		// Fall back to generic extraction from inputs
-		for _, input := range source.Inputs {
-			extractDepsFromValueRef(input, deps)
+		// Fall back to generic extraction from inputs.
+		// Collect data keys to exclude from template reference extraction.
+		// When a provider has both a "data" map and a "template" string,
+		// template references matching data keys are local context, not resolver deps.
+		dataKeys := extractDataKeys(source.Inputs)
+		for key, input := range source.Inputs {
+			if len(dataKeys) > 0 && key == "template" {
+				extractDepsFromValueRefWithExclusions(input, deps, dataKeys)
+			} else {
+				extractDepsFromValueRef(input, deps)
+			}
+		}
+	}
+}
+
+// extractDataKeys returns a set of top-level keys from the "data" input if it
+// is a literal map. This allows template references like {{.config}} to be
+// recognized as local context rather than resolver dependencies.
+func extractDataKeys(inputs map[string]*ValueRef) map[string]bool {
+	dataRef, ok := inputs["data"]
+	if !ok || dataRef == nil || dataRef.Literal == nil {
+		return nil
+	}
+	dataMap, ok := dataRef.Literal.(map[string]any)
+	if !ok {
+		return nil
+	}
+	keys := make(map[string]bool, len(dataMap))
+	for k := range dataMap {
+		keys[k] = true
+	}
+	return keys
+}
+
+// extractDepsFromValueRefWithExclusions works like extractDepsFromValueRef but
+// excludes names in the exclude set from being treated as resolver dependencies.
+func extractDepsFromValueRefWithExclusions(ref *ValueRef, deps, exclude map[string]bool) {
+	if ref == nil {
+		return
+	}
+
+	// Direct resolver reference - never excluded
+	if ref.Resolver != nil {
+		deps[*ref.Resolver] = true
+		return
+	}
+
+	// Expression - never excluded (CEL uses _.resolverName, not data keys)
+	if ref.Expr != nil {
+		extractDepsFromExpression(string(*ref.Expr), deps)
+		return
+	}
+
+	// Template - apply exclusions
+	if ref.Tmpl != nil {
+		extractDepsFromTemplateWithExclusions(string(*ref.Tmpl), deps, exclude)
+		return
+	}
+
+	// Literal string with template syntax
+	if ref.Literal != nil {
+		if s, ok := ref.Literal.(string); ok {
+			if strings.Contains(s, "_.") || strings.Contains(s, "_[") {
+				extractDepsFromExpression(s, deps)
+			}
+			if strings.Contains(s, "{{") && strings.Contains(s, "}}") {
+				extractDepsFromTemplateWithExclusions(s, deps, exclude)
+			}
 		}
 	}
 }
@@ -359,8 +463,13 @@ func extractDepsFromTransformPhase(phase *TransformPhase, deps map[string]bool, 
 		}
 
 		// Fall back to generic extraction from inputs
-		for _, input := range transform.Inputs {
-			extractDepsFromValueRef(input, deps)
+		dataKeys := extractDataKeys(transform.Inputs)
+		for key, input := range transform.Inputs {
+			if len(dataKeys) > 0 && key == "template" {
+				extractDepsFromValueRefWithExclusions(input, deps, dataKeys)
+			} else {
+				extractDepsFromValueRef(input, deps)
+			}
 		}
 	}
 }

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -1177,3 +1177,125 @@ func TestExtractDepsFromProviderInputs_NilFallback(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractDepsFromTemplateWithExclusions(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		exclude map[string]bool
+		want    []string
+	}{
+		{
+			name:    "no exclusions",
+			tmpl:    "{{ .config }} {{ .region }}",
+			exclude: nil,
+			want:    []string{"config", "region"},
+		},
+		{
+			name:    "exclude data key",
+			tmpl:    "{{ .config.host }}:{{ .region }}",
+			exclude: map[string]bool{"config": true},
+			want:    []string{"region"},
+		},
+		{
+			name:    "exclude all keys",
+			tmpl:    "{{ toYaml .config }}",
+			exclude: map[string]bool{"config": true},
+			want:    []string{},
+		},
+		{
+			name:    "underscore refs not affected by exclusions",
+			tmpl:    "{{ ._.environment }} {{ .config }}",
+			exclude: map[string]bool{"config": true},
+			want:    []string{"environment"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := make(map[string]bool)
+			extractDepsFromTemplateWithExclusions(tt.tmpl, deps, tt.exclude)
+
+			wantMap := make(map[string]bool)
+			for _, dep := range tt.want {
+				wantMap[dep] = true
+			}
+
+			assert.Equal(t, wantMap, deps, "extracted dependencies should match")
+		})
+	}
+}
+
+func TestExtractDataKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputs map[string]*ValueRef
+		want   map[string]bool
+	}{
+		{
+			name:   "no data input",
+			inputs: map[string]*ValueRef{"template": {Literal: "{{ .name }}"}},
+			want:   nil,
+		},
+		{
+			name: "data input with map literal",
+			inputs: map[string]*ValueRef{
+				"template": {Literal: "{{ .config }}"},
+				"data":     {Literal: map[string]any{"config": map[string]any{"port": 8080}, "name": "test"}},
+			},
+			want: map[string]bool{"config": true, "name": true},
+		},
+		{
+			name: "data input is not a map",
+			inputs: map[string]*ValueRef{
+				"data": {Literal: "not a map"},
+			},
+			want: nil,
+		},
+		{
+			name: "data input is resolver ref",
+			inputs: map[string]*ValueRef{
+				"data": {Resolver: stringPtr("myresolver")},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDataKeys(tt.inputs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractDeps_GoTemplateDataExclusion(t *testing.T) {
+	// Integration test: a resolver using go-template with data input should
+	// not create false dependencies on data keys.
+	resolver := &Resolver{
+		Name: "my-template",
+		Resolve: &ResolvePhase{
+			With: []ProviderSource{
+				{
+					Provider: "go-template",
+					Inputs: map[string]*ValueRef{
+						"name":     {Literal: "test"},
+						"template": {Literal: "{{ toYaml .config }} {{ .appName }}"},
+						"data": {Literal: map[string]any{
+							"config":  map[string]any{"port": 8080},
+							"appName": "myapp",
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	deps := extractDependencies(resolver, nil)
+
+	// config and appName are provided by data, not resolvers
+	for _, dep := range deps {
+		assert.NotEqual(t, "config", dep, "config should not be a dependency (provided by data)")
+		assert.NotEqual(t, "appName", dep, "appName should not be a dependency (provided by data)")
+	}
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -210,6 +210,7 @@ type ProviderSource struct {
 	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
 	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Source-level condition"`
 	OnError  ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Behavior when provider fails (continue, fail). Defaults to continue (fallback chain semantics). Use fail to stop on first error." example:"continue" default:"continue"`
+	ForEach  *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element. Requires forEach.in (no __self in resolve phase)."`
 }
 
 // ProviderTransform represents a single transform step

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -207,13 +207,22 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	// For bundles (including catalog bundles): use the bundle extraction directory.
 	// For stdin or unbundled catalog references: leave empty (falls back to CWD).
 	var solutionDir string
-	if bundleDir != "" {
+	isCatalogRef := strings.HasPrefix(sol.GetPath(), "catalog:")
+	switch {
+	case bundleDir != "":
 		solutionDir = bundleDir
-	} else if path != "-" && !strings.HasPrefix(sol.GetPath(), "catalog:") {
+	case path != "-" && !isCatalogRef:
 		absPath, absErr := provider.AbsFromContext(ctx, path)
 		if absErr == nil {
 			solutionDir = filepath.Dir(absPath)
 		}
+	case isCatalogRef:
+		// Unbundled catalog solutions have no local directory tree.
+		// Providers that reference relative paths (e.g. directory provider)
+		// will resolve against CWD, which is likely not the intended base.
+		lgr.V(1).Info("solution loaded from catalog without bundle; relative paths in providers will resolve against CWD. "+
+			"If this is unintended, run 'catalog pull' first to extract files locally.",
+			"path", sol.GetPath())
 	}
 
 	// Build cleanup function

--- a/pkg/solution/soltesting/discovery.go
+++ b/pkg/solution/soltesting/discovery.go
@@ -24,6 +24,9 @@ type SolutionTests struct {
 	Config *TestConfig `json:"config,omitempty"`
 	// FilePath is the absolute path to the solution file.
 	FilePath string `json:"filePath"`
+	// BundleIncludes contains the bundle.include patterns from the solution spec.
+	// These are resolved and copied into every test sandbox.
+	BundleIncludes []string `json:"bundleIncludes,omitempty"`
 	// DetectedFiles contains file patterns auto-detected from resolver specs
 	// (e.g., directory provider paths). Used to populate builtin test files.
 	DetectedFiles []string `json:"detectedFiles,omitempty"`
@@ -110,7 +113,10 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 			Name string `yaml:"name"`
 		} `yaml:"metadata"`
 		Compose []string `yaml:"compose"`
-		Spec    struct {
+		Bundle  struct {
+			Include []string `yaml:"include"`
+		} `yaml:"bundle"`
+		Spec struct {
 			Testing   *TestSuite `yaml:"testing"`
 			Resolvers yaml.Node  `yaml:"resolvers"`
 		} `yaml:"spec"`
@@ -209,11 +215,12 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 	}
 
 	return &SolutionTests{
-		SolutionName:  doc.Metadata.Name,
-		Cases:         doc.Spec.Testing.Cases,
-		Config:        doc.Spec.Testing.Config,
-		FilePath:      absPath,
-		DetectedFiles: detectFileDependencies(resolverSpecs),
+		SolutionName:   doc.Metadata.Name,
+		Cases:          doc.Spec.Testing.Cases,
+		Config:         doc.Spec.Testing.Config,
+		FilePath:       absPath,
+		BundleIncludes: doc.Bundle.Include,
+		DetectedFiles:  detectFileDependencies(resolverSpecs),
 	}, nil
 }
 
@@ -279,10 +286,12 @@ func FilterTests(solutions []SolutionTests, opts FilterOptions) []SolutionTests 
 
 		if len(filtered) > 0 {
 			result = append(result, SolutionTests{
-				SolutionName: st.SolutionName,
-				Cases:        filtered,
-				Config:       st.Config,
-				FilePath:     st.FilePath,
+				SolutionName:   st.SolutionName,
+				Cases:          filtered,
+				Config:         st.Config,
+				FilePath:       st.FilePath,
+				BundleIncludes: st.BundleIncludes,
+				DetectedFiles:  st.DetectedFiles,
 			})
 		}
 	}

--- a/pkg/solution/soltesting/discovery_test.go
+++ b/pkg/solution/soltesting/discovery_test.go
@@ -268,6 +268,27 @@ func TestFilterTests_NoFilters(t *testing.T) {
 	assert.Len(t, result[0].Cases, 2)
 }
 
+func TestFilterTests_PreservesMetadataFields(t *testing.T) {
+	solutions := []soltesting.SolutionTests{
+		{
+			SolutionName:   "my-solution",
+			FilePath:       "/path/to/solution.yaml",
+			BundleIncludes: []string{"templates/**", "config.yaml"},
+			DetectedFiles:  []string{"data/seed.json"},
+			Cases: map[string]*soltesting.TestCase{
+				"test1": {Name: "test1", Command: []string{"x"}},
+			},
+		},
+	}
+
+	result := soltesting.FilterTests(solutions, soltesting.FilterOptions{})
+
+	require.Len(t, result, 1)
+	assert.Equal(t, []string{"templates/**", "config.yaml"}, result[0].BundleIncludes)
+	assert.Equal(t, []string{"data/seed.json"}, result[0].DetectedFiles)
+	assert.Equal(t, "/path/to/solution.yaml", result[0].FilePath)
+}
+
 func TestSortedTestNames(t *testing.T) {
 	st := soltesting.SolutionTests{
 		Cases: map[string]*soltesting.TestCase{

--- a/pkg/solution/soltesting/helpers_test.go
+++ b/pkg/solution/soltesting/helpers_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package soltesting
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeFileEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    *TestConfig
+		testFiles []string
+		want      []string
+	}{
+		{
+			name:      "nil config",
+			config:    nil,
+			testFiles: []string{"a.txt"},
+			want:      []string{"a.txt"},
+		},
+		{
+			name:      "empty config files",
+			config:    &TestConfig{},
+			testFiles: []string{"b.txt"},
+			want:      []string{"b.txt"},
+		},
+		{
+			name:      "config files only",
+			config:    &TestConfig{Files: []string{"shared.txt"}},
+			testFiles: nil,
+			want:      []string{"shared.txt"},
+		},
+		{
+			name:      "both merged config first",
+			config:    &TestConfig{Files: []string{"shared.txt"}},
+			testFiles: []string{"local.txt"},
+			want:      []string{"shared.txt", "local.txt"},
+		},
+		{
+			name:      "both empty",
+			config:    &TestConfig{},
+			testFiles: nil,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeFileEntries(tc.config, tc.testFiles)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestAttachCommandOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil output", func(t *testing.T) {
+		t.Parallel()
+		result := &TestResult{}
+		attachCommandOutput(result, nil)
+		assert.Empty(t, result.Stdout)
+		assert.Empty(t, result.Stderr)
+	})
+
+	t.Run("populated output", func(t *testing.T) {
+		t.Parallel()
+		result := &TestResult{}
+		attachCommandOutput(result, &CommandOutput{
+			Stdout: "hello",
+			Stderr: "oops",
+		})
+		assert.Equal(t, "hello", result.Stdout)
+		assert.Equal(t, "oops", result.Stderr)
+	})
+}
+
+func TestReportFailures_IncludesStderr(t *testing.T) {
+	t.Parallel()
+
+	results := []TestResult{
+		{
+			Solution: "sol-a",
+			Test:     "test-1",
+			Status:   StatusFail,
+			Message:  "exit code 1",
+			Stderr:   "something went wrong",
+		},
+	}
+
+	var buf bytes.Buffer
+	reportFailures(results, &buf, false)
+	output := buf.String()
+
+	require.Contains(t, output, "Failures:")
+	assert.Contains(t, output, "sol-a/test-1: exit code 1")
+	assert.Contains(t, output, "stderr: something went wrong")
+}
+
+func TestReportFailures_NoStderrWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	results := []TestResult{
+		{
+			Solution: "sol-a",
+			Test:     "test-1",
+			Status:   StatusFail,
+			Message:  "exit code 1",
+		},
+	}
+
+	var buf bytes.Buffer
+	reportFailures(results, &buf, false)
+	output := buf.String()
+
+	assert.NotContains(t, output, "stderr:")
+}
+
+func TestBuildReportData_IncludesStdoutStderr(t *testing.T) {
+	t.Parallel()
+
+	results := []TestResult{
+		{
+			Solution: "sol-a",
+			Test:     "test-1",
+			Status:   StatusFail,
+			Message:  "exit code 1",
+			Stdout:   "output text",
+			Stderr:   "error text",
+		},
+	}
+
+	data := buildReportData(results, 0)
+
+	require.Len(t, data.Results, 1)
+	assert.Equal(t, "output text", data.Results[0].Stdout)
+	assert.Equal(t, "error text", data.Results[0].Stderr)
+}

--- a/pkg/solution/soltesting/reporter.go
+++ b/pkg/solution/soltesting/reporter.go
@@ -93,6 +93,8 @@ type testResultOutput struct {
 	Status       Status            `json:"status"`
 	Duration     string            `json:"duration"`
 	Message      string            `json:"message,omitempty"`
+	Stdout       string            `json:"stdout,omitempty"`
+	Stderr       string            `json:"stderr,omitempty"`
 	Assertions   []assertionOutput `json:"assertions,omitempty"`
 	RetryAttempt int               `json:"retryAttempt,omitempty"`
 	SandboxPath  string            `json:"sandboxPath,omitempty"`
@@ -117,6 +119,8 @@ func buildReportData(results []TestResult, elapsed time.Duration) reportData {
 			Status:       r.Status,
 			Duration:     format.Duration(r.Duration),
 			Message:      r.Message,
+			Stdout:       r.Stdout,
+			Stderr:       r.Stderr,
 			RetryAttempt: r.RetryAttempt,
 			SandboxPath:  r.SandboxPath,
 		}
@@ -222,6 +226,10 @@ func reportFailures(results []TestResult, w io.Writer, verbose bool) {
 			if !a.Passed {
 				fmt.Fprintf(w, "    [%s] %s: %s\n", a.Type, a.Input, a.Message)
 			}
+		}
+		// Show stderr from the inner command when available.
+		if f.Stderr != "" {
+			fmt.Fprintf(w, "    stderr: %s\n", strings.TrimRight(f.Stderr, "\n"))
 		}
 	}
 }

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -496,7 +496,23 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 	}
 
 	// Create sandbox
-	sandbox, err := NewSandbox(st.FilePath, nil, tc.Files)
+	// Merge config-level files with per-test files (per-test entries appended last).
+	sandboxFiles := mergeFileEntries(st.Config, tc.Files)
+
+	// Resolve bundle include patterns to actual file paths.
+	var bundleFiles []string
+	if len(st.BundleIncludes) > 0 {
+		resolved, resolveErr := resolveFileEntries(solutionDir, st.BundleIncludes)
+		if resolveErr != nil {
+			result.Status = StatusError
+			result.Message = fmt.Sprintf("resolving bundle files: %s", resolveErr)
+			result.Duration = time.Since(start)
+			return result
+		}
+		bundleFiles = resolved
+	}
+
+	sandbox, err := NewSandbox(st.FilePath, bundleFiles, sandboxFiles)
 	if err != nil {
 		result.Status = StatusError
 		result.Message = fmt.Sprintf("sandbox creation failed: %s", err)
@@ -558,6 +574,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 		default:
 			result.Message = fmt.Sprintf("command failed with exit code %d", cmdOutput.ExitCode)
 		}
+		attachCommandOutput(&result, cmdOutput)
 		result.Duration = time.Since(start)
 		return result
 	}
@@ -583,6 +600,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 			if !match {
 				result.Status = StatusFail
 				result.Message = fmt.Sprintf("snapshot mismatch:\n%s", diff)
+				attachCommandOutput(&result, cmdOutput)
 				result.Duration = time.Since(start)
 				return result
 			}
@@ -598,6 +616,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 			if !ar.Passed {
 				result.Status = StatusFail
 				result.Message = "one or more assertions failed"
+				attachCommandOutput(&result, cmdOutput)
 				result.Duration = time.Since(start)
 				return result
 			}
@@ -862,6 +881,35 @@ func (r *Runner) runInitSteps(ctx context.Context, steps []InitStep, workDir str
 	}
 
 	return nil
+}
+
+// mergeFileEntries merges config-level files with per-test files.
+// Config files come first; per-test files are appended.
+func mergeFileEntries(config *TestConfig, testFiles []string) []string {
+	var configFiles []string
+	if config != nil {
+		configFiles = config.Files
+	}
+	if len(configFiles) == 0 {
+		return testFiles
+	}
+	if len(testFiles) == 0 {
+		return configFiles
+	}
+	merged := make([]string, 0, len(configFiles)+len(testFiles))
+	merged = append(merged, configFiles...)
+	merged = append(merged, testFiles...)
+	return merged
+}
+
+// attachCommandOutput copies stdout/stderr from the command output to the test
+// result so failed tests include the inner command's diagnostic output.
+func attachCommandOutput(result *TestResult, cmdOutput *CommandOutput) {
+	if cmdOutput == nil {
+		return
+	}
+	result.Stdout = cmdOutput.Stdout
+	result.Stderr = cmdOutput.Stderr
 }
 
 // buildEnvMap builds the environment variable map for a test.

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -6,12 +6,16 @@ package soltesting
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"gopkg.in/yaml.v3"
 )
+
+// filesBaseTemplateName is the name of the generated template case for shared files.
+const filesBaseTemplateName = "_files-base"
 
 // ScaffoldResult holds the generated test scaffold for a solution.
 type ScaffoldResult struct {
@@ -56,14 +60,23 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 		addActionTests(result, input.Workflow)
 	}
 
-	// Auto-populate discovered file dependencies on all generated test cases
+	// Auto-populate discovered file dependencies.
+	// Generate a _files-base template case so all test cases inherit shared
+	// file dependencies via extends rather than duplicating the list.
 	if len(input.FileDependencies) > 0 {
 		sorted := make([]string, len(input.FileDependencies))
 		copy(sorted, input.FileDependencies)
+		normalizeFilePaths(sorted)
 		sort.Strings(sorted)
 
-		for _, tc := range result.Cases {
-			tc.Files = sorted
+		result.Cases[filesBaseTemplateName] = &TestCase{
+			Description: "Shared file dependencies for all test cases",
+			Files:       sorted,
+		}
+		for name, tc := range result.Cases {
+			if name != filesBaseTemplateName {
+				tc.Extends = []string{filesBaseTemplateName}
+			}
 		}
 	}
 
@@ -185,7 +198,7 @@ func addActionTests(result *ScaffoldResult, wf *action.Workflow) {
 		tc := &TestCase{
 			Description: fmt.Sprintf("Verify action %q executes successfully", name),
 			Command:     []string{"run", "action"},
-			Args:        []string{"--action", name},
+			Args:        []string{name},
 			Tags:        []string{"actions"},
 		}
 
@@ -202,6 +215,14 @@ func addActionTests(result *ScaffoldResult, wf *action.Workflow) {
 		exitCodeZero := 0
 		tc.ExitCode = &exitCodeZero
 		result.Cases[testName] = tc
+	}
+}
+
+// normalizeFilePaths converts backslash separators to forward slashes in-place
+// so generated paths work on all platforms.
+func normalizeFilePaths(paths []string) {
+	for i, p := range paths {
+		paths[i] = strings.ReplaceAll(p, "\\", "/")
 	}
 }
 

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -107,6 +107,10 @@ func TestScaffold_WithActions(t *testing.T) {
 	// Action tests should include provider tag
 	assert.Contains(t, result.Cases["action-build"].Tags, "exec")
 	assert.Contains(t, result.Cases["action-build"].Tags, "actions")
+
+	// Action name should be a positional arg, not a flag
+	assert.Equal(t, []string{"build"}, result.Cases["action-build"].Args)
+	assert.Equal(t, []string{"test"}, result.Cases["action-test"].Args)
 }
 
 func TestScaffold_ConditionalAction(t *testing.T) {
@@ -211,7 +215,7 @@ func exprPtr(s string) *celexp.Expression {
 	return &e
 }
 
-func TestScaffold_FileDependenciesPopulatedOnAllCases(t *testing.T) {
+func TestScaffold_FileDependenciesUseTemplate(t *testing.T) {
 	input := &ScaffoldInput{
 		Resolvers: map[string]*resolver.Resolver{
 			"region": {
@@ -227,10 +231,38 @@ func TestScaffold_FileDependenciesPopulatedOnAllCases(t *testing.T) {
 
 	result := Scaffold(input)
 
-	// Every generated case should have the file dependencies
+	// Multiple cases => _files-base template should be generated
+	require.Contains(t, result.Cases, "_files-base")
+	tmpl := result.Cases["_files-base"]
+	assert.Equal(t, []string{"data/config.json", "templates/main.yaml"}, tmpl.Files)
+
+	// All non-template cases should extend _files-base and have no inline files
 	for name, tc := range result.Cases {
-		assert.Equal(t, []string{"data/config.json", "templates/main.yaml"}, tc.Files,
-			"test case %q should have sorted file dependencies", name)
+		if name == "_files-base" {
+			continue
+		}
+		assert.Equal(t, []string{"_files-base"}, tc.Extends,
+			"test case %q should extend _files-base", name)
+		assert.Nil(t, tc.Files,
+			"test case %q should not have inline files", name)
+	}
+}
+
+func TestScaffold_NormalizeBackslashPaths(t *testing.T) {
+	input := &ScaffoldInput{
+		FileDependencies: []string{
+			"templates\\.github\\copilot.md.tpl",
+			"templates\\.github\\instructions\\terraform.md.tpl",
+		},
+	}
+
+	result := Scaffold(input)
+
+	// Single case (3 builtins) => template used; check paths are normalized
+	tmpl := result.Cases["_files-base"]
+	require.NotNil(t, tmpl)
+	for _, f := range tmpl.Files {
+		assert.NotContains(t, f, "\\", "paths should use forward slashes: %s", f)
 	}
 }
 

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -299,6 +299,11 @@ type TestConfig struct {
 	// Cleanup contains suite-level teardown steps run once after all tests complete, even on failure.
 	Cleanup []InitStep `json:"cleanup,omitempty" yaml:"cleanup,omitempty" doc:"Suite-level teardown steps. Run once after all tests complete, even on failure" maxItems:"50"`
 
+	// Files lists shared file paths, globs, or directories copied into every test sandbox.
+	// These are merged with per-test files; per-test entries are appended after config files.
+	// Duplicates are deduplicated during sandbox creation (first-seen-wins).
+	Files []string `json:"files,omitempty" yaml:"files,omitempty" doc:"Shared files copied into every test sandbox" maxItems:"50"`
+
 	// Services defines background services started before tests and stopped after.
 	// Currently supports "http" type which starts a mock HTTP server.
 	Services []ServiceConfig `json:"services,omitempty" yaml:"services,omitempty" doc:"Background services started before tests" maxItems:"10"`
@@ -623,6 +628,10 @@ type TestResult struct {
 	RetryAttempt int `json:"retryAttempt,omitempty"`
 	// SandboxPath is the sandbox directory path (when --keep-sandbox is set).
 	SandboxPath string `json:"sandboxPath,omitempty"`
+	// Stdout is the captured stdout from the test command (included on failure).
+	Stdout string `json:"stdout,omitempty"`
+	// Stderr is the captured stderr from the test command (included on failure).
+	Stderr string `json:"stderr,omitempty"`
 }
 
 // AssertionResult captures the outcome of a single assertion.

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -424,7 +424,7 @@ func (o *OutputOptions) Snapshot(data any) (string, error) {
 }
 
 // Write outputs data in the configured format with kvx support.
-// It handles automatic fallback to JSON when output is piped,
+// It handles automatic fallback to plain text when output is piped,
 // CEL expression filtering, and interactive TUI mode.
 func (o *OutputOptions) Write(data any) error {
 	// Quiet mode: no output

--- a/pkg/terminal/output/output.go
+++ b/pkg/terminal/output/output.go
@@ -69,12 +69,19 @@ func WarningMessage(msg string, noColor bool) string {
 
 // ErrorMessage returns an error message string, optionally prefixed with a styled error icon.
 // If noColor is true, the message is returned without styling or icon.
-// Otherwise, the message is prefixed with a styled "❌" icon.
+// Otherwise, the message is prefixed with a styled "❌" icon and the text is rendered in red.
+// Multi-line messages are styled per-line to avoid double-spacing on Windows
+// (lipgloss inserts \r\n for each embedded newline on Windows terminals).
 func ErrorMessage(msg string, noColor bool) string {
 	if noColor {
 		return msg
 	}
-	return styles.ErrorStyle.Render("❌") + msg
+	icon := styles.ErrorStyle.Render("❌")
+	lines := strings.Split(msg, "\n")
+	for i, line := range lines {
+		lines[i] = styles.ErrorTextStyle.Render(line)
+	}
+	return icon + strings.Join(lines, "\n")
 }
 
 // InfoMessage formats an informational message for terminal output.

--- a/pkg/terminal/styles/styles.go
+++ b/pkg/terminal/styles/styles.go
@@ -23,6 +23,11 @@ var (
 			PaddingLeft(1).
 			PaddingRight(1)
 
+	// ErrorTextStyle styles the error message body (red, not bold).
+	// Used alongside ErrorStyle which styles the icon.
+	ErrorTextStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FF0000")) // Red
+
 	InfoStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#00FFFF")). // Cyan
 			PaddingLeft(1).

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -464,7 +464,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|compose-demo/workflow|compose-demo/resolvers"
 
         {
           find examples/solutions -name '*.yaml'
@@ -1350,52 +1350,170 @@ tasks:
         echo "Dry run complete. Config is valid."
 
   tag:
-    desc: "Create a git tag for release (usage: task tag VERSION=v1.0.0)"
+    desc: "Create a signed git tag for release (usage: task tag [VERSION=v1.0.0] [DRY_RUN=true])"
+    interactive: true
     silent: true
-    vars:
-      VERSION: '{{.VERSION | default ""}}'
     preconditions:
-      - sh: '[ -n "{{.VERSION}}" ]'
-        msg: "VERSION is required. Usage: task tag VERSION=v1.0.0"
-      - sh: 'echo "{{.VERSION}}" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$"'
-        msg: "VERSION must be in semver format (e.g., v1.0.0, v1.0.0-beta.1)"
-      - sh: '[ -z "$(git status --porcelain)" ]'
-        msg: "Working directory is not clean. Commit or stash changes first."
-      - sh: '! git rev-parse "refs/tags/{{.VERSION}}" >/dev/null 2>&1'
-        msg: "Tag {{.VERSION}} already exists. Delete it first: git tag -d {{.VERSION}}"
+      - sh: 'command -v git-cliff >/dev/null 2>&1'
+        msg: "git-cliff is required for version suggestion. Install: brew install git-cliff"
     cmds:
       - |
-        echo "Creating signed tag {{.VERSION}}..."
-        git tag -s "{{.VERSION}}" -m "Release {{.VERSION}}"
-        echo "Tag {{.VERSION}} created locally."
+        set -euo pipefail
+
+        VERSION='{{ .VERSION | default "" }}'
+        DRY_RUN='{{ .DRY_RUN | default "false" }}'
+        BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+        DIRTY="$(git status --porcelain)"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "── dry-run mode ──────────────────────────────────────────────"
+        fi
+
+        # ── Warn if not on main ──────────────────────────────────────────────
+        if [ "$BRANCH" != "main" ]; then
+          echo "⚠  WARNING: You are on branch '$BRANCH', not 'main'."
+          if [ "$DRY_RUN" != "true" ]; then
+            printf "   Continue anyway? [y/N] "
+            read -r answer
+            case "$answer" in
+              [yY]*) ;;
+              *) echo "Aborted."; exit 1 ;;
+            esac
+          fi
+        fi
+
+        # ── Pull latest ──────────────────────────────────────────────────────
+        echo "Fetching latest from origin..."
+        git fetch --tags --quiet
+        LOCAL="$(git rev-parse HEAD)"
+        REMOTE="$(git rev-parse "origin/$BRANCH" 2>/dev/null || echo "")"
+        if [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
+          echo "⚠  WARNING: Local HEAD differs from origin/$BRANCH."
+          echo "   Local:  $LOCAL"
+          echo "   Remote: $REMOTE"
+          if [ "$DRY_RUN" != "true" ]; then
+            printf "   Continue without pulling? [y/N] "
+            read -r answer
+            case "$answer" in
+              [yY]*) ;;
+              *) echo "Aborted. Run 'git pull' first."; exit 1 ;;
+            esac
+          fi
+        else
+          echo "✓ Local HEAD matches origin/$BRANCH"
+        fi
+
+        # ── Suggest version via git-cliff ────────────────────────────────────
+        SUGGESTED="$(git-cliff --bumped-version 2>/dev/null || echo "")"
+        if [ -z "$VERSION" ]; then
+          if [ -n "$SUGGESTED" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              VERSION="$SUGGESTED"
+              echo "✓ Suggested version: $VERSION (auto-accepted in dry-run)"
+            else
+              printf "Suggested version: %s — accept? [Y/n] " "$SUGGESTED"
+              read -r answer
+              case "$answer" in
+                [nN]*) printf "Enter version (e.g. v1.2.3): "; read -r VERSION ;;
+                *) VERSION="$SUGGESTED" ;;
+              esac
+            fi
+          else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "✗ Could not determine version automatically."
+              echo "  Pass VERSION= to specify one."
+              exit 1
+            fi
+            printf "Could not determine version automatically.\nEnter version (e.g. v1.2.3): "
+            read -r VERSION
+          fi
+        else
+          if [ -n "$SUGGESTED" ] && [ "$VERSION" != "$SUGGESTED" ]; then
+            echo "ℹ  git-cliff suggests $SUGGESTED (you specified $VERSION)"
+          fi
+        fi
+
+        # ── Validate version format ──────────────────────────────────────────
+        if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          echo "ERROR: '$VERSION' is not valid semver (expected v1.2.3 or v1.2.3-beta.1)"
+          exit 1
+        fi
+
+        # ── Dirty metadata ───────────────────────────────────────────────────
+        if [ -n "$DIRTY" ]; then
+          DIRTY_META="+dirty"
+          echo "⚠  WARNING: Working directory has uncommitted changes."
+          echo "   Tag will include metadata: ${VERSION}${DIRTY_META}"
+          if [ "$DRY_RUN" != "true" ]; then
+            printf "   Continue? [y/N] "
+            read -r answer
+            case "$answer" in
+              [yY]*) VERSION="${VERSION}${DIRTY_META}" ;;
+              *) echo "Aborted. Commit or stash changes first."; exit 1 ;;
+            esac
+          else
+            VERSION="${VERSION}${DIRTY_META}"
+          fi
+        fi
+
+        # ── Check tag doesn't already exist ──────────────────────────────────
+        if git tag -l "$VERSION" | grep -q .; then
+          echo "ERROR: Tag $VERSION already exists. Delete it first: git tag -d $VERSION"
+          exit 1
+        fi
+
+        # ── Changelog preview ────────────────────────────────────────────────
+        CHANGELOG="$(git-cliff --unreleased --strip header 2>/dev/null || echo "")"
+        if [ -n "$CHANGELOG" ]; then
+          echo ""
+          echo "── Changelog since last tag ───────────────────────────────────"
+          echo "$CHANGELOG"
+          echo "───────────────────────────────────────────────────────────────"
+        fi
+
+        # ── Dry-run summary ──────────────────────────────────────────────────
+        if [ "$DRY_RUN" = "true" ]; then
+          echo ""
+          echo "── Summary (dry-run) ─────────────────────────────────────────"
+          echo "  Version:  $VERSION"
+          echo "  Branch:   $BRANCH"
+          echo "  Commit:   $(git rev-parse --short=12 HEAD)"
+          echo "  Dirty:    $([ -n "$DIRTY" ] && echo 'yes' || echo 'no')"
+          echo "  Signing:  $(git config --get gpg.format 2>/dev/null || echo 'gpg') ($(git config --get user.signingkey 2>/dev/null | head -c 16)...)"
+          echo ""
+          echo "  Would run: git tag -s \"$VERSION\" -m \"Release $VERSION\""
+          echo "──────────────────────────────────────────────────────────────"
+          exit 0
+        fi
+
+        # ── Create signed tag ────────────────────────────────────────────────
         echo ""
-        echo "To push the tag:"
-        echo "  git push origin {{.VERSION}}"
+        echo "Creating signed tag $VERSION..."
+        git tag -s "$VERSION" -m "Release $VERSION"
+        echo "✓ Tag $VERSION created locally."
         echo ""
-        echo "To build the release:"
+        echo "Next steps:"
+        echo "  git push origin $VERSION"
         echo "  task release"
 
   tag-push:
-    desc: "Create and push a git tag (usage: task tag-push VERSION=v1.0.0)"
+    desc: "Create and push a signed git tag (usage: task tag-push [VERSION=v1.0.0])"
+    interactive: true
     silent: true
-    vars:
-      VERSION: '{{.VERSION | default ""}}'
-    preconditions:
-      - sh: '[ -n "{{.VERSION}}" ]'
-        msg: "VERSION is required. Usage: task tag-push VERSION=v1.0.0"
-      - sh: 'echo "{{.VERSION}}" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$"'
-        msg: "VERSION must be in semver format (e.g., v1.0.0, v1.0.0-beta.1)"
-      - sh: '[ -z "$(git status --porcelain)" ]'
-        msg: "Working directory is not clean. Commit or stash changes first."
-      - sh: '! git rev-parse "refs/tags/{{.VERSION}}" >/dev/null 2>&1'
-        msg: "Tag {{.VERSION}} already exists. Delete it first: git tag -d {{.VERSION}}"
     cmds:
+      - task: tag
+        vars:
+          VERSION: '{{.VERSION | default ""}}'
       - |
-        echo "Creating signed tag {{.VERSION}}..."
-        git tag -s "{{.VERSION}}" -m "Release {{.VERSION}}"
-        echo "Tag {{.VERSION}} created and pushing to origin..."
-        git push origin "{{.VERSION}}"
-        echo "Tag {{.VERSION}} pushed."
+        set -euo pipefail
+        # Determine the tag that was just created (latest local tag)
+        VERSION='{{ .VERSION | default "" }}'
+        if [ -z "$VERSION" ]; then
+          VERSION="$(git tag -l 'v[0-9]*' --sort=-v:refname | head -n1)"
+        fi
+        echo "Pushing tag $VERSION to origin..."
+        git push origin "$VERSION"
+        echo "✓ Tag $VERSION pushed."
 
   # ──────────────────────────────────────────────────────────────────────────────
   # Utilities

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -7019,11 +7019,13 @@ func TestIntegration_RenderSolution_PositionalPathRejected(t *testing.T) {
 	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
 }
 
-func TestIntegration_RunResolver_PositionalPathRejected(t *testing.T) {
+func TestIntegration_RunResolver_PositionalArgsAreNames(t *testing.T) {
 	t.Parallel()
-	_, stderr, exitCode := runScafctl(t, "run", "resolver", "./my-solution.yaml")
-	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "local file paths must use -f/--file flag")
+	// With the new behavior, positional args are treated as resolver names.
+	// ./my-solution.yaml is treated as a resolver name, not a file path.
+	// The command should NOT produce a "local file paths must use -f/--file" error.
+	_, stderr, _ := runScafctl(t, "run", "resolver", "./my-solution.yaml")
+	assert.NotContains(t, stderr, "local file paths must use -f/--file flag")
 }
 
 func TestIntegration_SolutionDiff_PositionalPathRejected(t *testing.T) {


### PR DESCRIPTION

- pass Go template builtins (index, len, printf, etc.) and
  extension functions to parse.Parse in GetReferences so templates
  using these functions parse correctly for variable detection
- exclude data-input keys from go template dependency extraction
  so resolvers with both data and template inputs do not create
  false dependency edges
- fix unused-resolver lint false positive for CEL expression inputs
  by scanning plain string literals for _.resolverName patterns
- add config.files field to test framework for shared sandbox files
  merged across all test cases in a suite
- auto-copy bundle.include files into test sandboxes so bundled
  solutions resolve correctly during functional tests
- preserve BundleIncludes and DetectedFiles through FilterTests
  so bundle files reach executeTest after filtering
- capture stdout/stderr on failed tests and display stderr in
  failure reports for faster debugging
- generate _files-base template for scaffold file dependencies
  when multiple test cases exist, avoiding duplication
- normalize backslash file paths to forward slashes in scaffold
  output for cross-platform compatibility
- fix scaffold action test args from --action flag to positional
  arg matching current CLI syntax
- fix TestConfig.Files doc comment to accurately describe
  first-seen-wins dedup behavior
- add shell, os, and arch fields to metadata provider output for
  portable cross-platform solution logic
- render error message text per-line to prevent double-spacing on
  Windows terminals caused by lipgloss \r\n insertion
- catalog list --name no longer implies --all-versions; users must
  pass --all-versions explicitly to see all versions
- fix catalog list remote ref to respect --all-versions flag
  instead of always expanding versions
- catalog index push/show uses remoteCatalog.Name() as table header
  instead of cliParams.BinaryName
- gate catalog index progress/summary lines behind --verbose for
  composability in piped and scripted workflows
- correct misleading comment in kvx output.go: non-TTY fallback is
  plain text, not JSON
- add directory-not-found error pattern in errexplain with catalog
  pull workaround hint
- log warning when unbundled catalog solution leaves solutionDir
  empty (relative paths resolve against CWD)
- rewrite tag/tag-push tasks with git-cliff version suggestion,
  dry-run mode, branch/remote safety checks
- fix broken links and add missing examples in resolver, action,
  and root example READMEs
- update provider-reference docs with metadata os/arch/shell fields

BREAKING CHANGE: catalog list --name now shows only the latest
version by default; pass --all-versions to see all versions

Closes https://github.com/oakwood-commons/scafctl/issues/181
Closes https://github.com/oakwood-commons/scafctl/issues/297