### PR TITLE
feat(testing): add inputs, mocks, baseDir, and per-test services to soltesting

### DIFF
--- a/examples/solutions/k8s-clusters/solution.yaml
+++ b/examples/solutions/k8s-clusters/solution.yaml
@@ -143,7 +143,7 @@ spec:
           - provider: file
             inputs:
               operation: read
-              path: examples/solutions/k8s-clusters/cluster-manifest.yaml.tmpl
+              path: cluster-manifest.yaml.tmpl
 
     # Render the template once per cluster using a forEach transform.
     # The go-template provider receives __item (the current cluster object)

--- a/examples/solutions/template-directory/solution.yaml
+++ b/examples/solutions/template-directory/solution.yaml
@@ -56,7 +56,7 @@ spec:
           - provider: directory
             inputs:
               operation: list
-              path: examples/solutions/template-directory/templates
+              path: templates
               recursive: true
               filterGlob: "*.tpl"
               includeContent: true

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -271,10 +271,13 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	}
 	defer cleanup()
 
-	// Set the solution directory for child-solution path resolution.
+	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.
-	// When SolutionDirectory is set, also set WorkingDirectory so that providers
-	// like file/exec continue to resolve paths against the caller's CWD.
+	//
+	// WorkingDirectory is intentionally NOT set for the resolver-phase context.
+	// AbsFromContext checks WorkingDirectory before SolutionDirectory, so setting
+	// both causes WorkingDirectory to win and SolutionDirectory to be ignored.
+	// The action phase sets WorkingDirectory separately via actionCtx.
 	//
 	// For bundle runs (catalog: prefix with non-empty solutionDir), only set
 	// SolutionDirectory so resolver paths resolve against the bundle extraction
@@ -287,12 +290,10 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		if baseDirErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("--base-dir: %w", baseDirErr), exitcode.InvalidInput)
 		}
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, absBaseDir)
 	case isBundleRun:
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	case solutionDir != "":
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	}
 

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -478,6 +479,16 @@ func (o *sharedResolverOptions) executeResolvers(
 	if o.SkipTransform {
 		executorOpts = append(executorOpts, resolver.WithSkipTransform(true))
 	}
+
+	// Load mocked resolvers from context or environment (set by test runner).
+	mockedResolvers, err := loadMockedResolvers(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading mocked resolvers: %w", err)
+	}
+	if len(mockedResolvers) > 0 {
+		executorOpts = append(executorOpts, resolver.WithMockedResolvers(mockedResolvers))
+	}
+
 	executor := resolver.NewExecutor(resolverAdapter, executorOpts...)
 
 	// Attach solution metadata to the context so providers (e.g., metadata) can access it.
@@ -823,4 +834,38 @@ func extractParameterKeys(resolvers []*resolver.Resolver) []string {
 		}
 	}
 	return keys
+}
+
+// mockedResolversEnvSuffix is the suffix appended to the binary-name-derived
+// env var prefix to form the full environment variable name for mocked resolvers.
+// The full name is {SAFE_PREFIX}_MOCKED_RESOLVERS_FILE.
+const mockedResolversEnvSuffix = "_MOCKED_RESOLVERS_FILE"
+
+// loadMockedResolvers reads the mocked resolvers JSON file. It first checks
+// the context (set by the in-process test runner), then falls back to the
+// environment variable (set by the subprocess test runner).
+// Returns nil if neither source is set.
+func loadMockedResolvers(ctx context.Context) (map[string]any, error) {
+	// Prefer context-based path (race-free for in-process execution).
+	path, ok := settings.MockedResolversFileFromContext(ctx)
+	if !ok {
+		// Fall back to env var for subprocess execution.
+		envVar := settings.SafeEnvPrefix(settings.BinaryNameFromContext(ctx)) + mockedResolversEnvSuffix
+		path = os.Getenv(envVar)
+	}
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path comes from test runner context or env var, not user input
+	if err != nil {
+		return nil, fmt.Errorf("reading mocked resolvers file %q: %w", path, err)
+	}
+
+	var mocks map[string]any
+	if err := json.Unmarshal(data, &mocks); err != nil {
+		return nil, fmt.Errorf("parsing mocked resolvers file: %w", err)
+	}
+
+	return mocks, nil
 }

--- a/pkg/cmd/scafctl/run/common_coverage_test.go
+++ b/pkg/cmd/scafctl/run/common_coverage_test.go
@@ -6,6 +6,7 @@ package run
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -629,4 +630,67 @@ func TestResolveVersionConstraintForFile_RejectsFilePaths(t *testing.T) {
 			assert.Contains(t, err.Error(), "--version can only be used with catalog names")
 		})
 	}
+}
+
+// ── loadMockedResolvers tests ─────────────────────────────────────────────────
+
+func TestLoadMockedResolvers_Unset(t *testing.T) {
+	ctx := context.Background()
+	mocks, err := loadMockedResolvers(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, mocks)
+}
+
+func TestLoadMockedResolvers_ValidFile_ViaEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"greeting":"hello","count":42}`), 0o644))
+
+	envVar := settings.SafeEnvPrefix(settings.CliBinaryName) + mockedResolversEnvSuffix
+	t.Setenv(envVar, path)
+	ctx := context.Background()
+	mocks, err := loadMockedResolvers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", mocks["greeting"])
+	assert.Equal(t, float64(42), mocks["count"])
+}
+
+func TestLoadMockedResolvers_ValidFile_ViaContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"greeting":"hello"}`), 0o644))
+
+	ctx := settings.WithMockedResolversFile(context.Background(), path)
+	mocks, err := loadMockedResolvers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", mocks["greeting"])
+}
+
+func TestLoadMockedResolvers_ContextTakesPrecedence(t *testing.T) {
+	ctxPath := filepath.Join(t.TempDir(), "ctx-mocks.json")
+	envPath := filepath.Join(t.TempDir(), "env-mocks.json")
+	require.NoError(t, os.WriteFile(ctxPath, []byte(`{"source":"context"}`), 0o644))
+	require.NoError(t, os.WriteFile(envPath, []byte(`{"source":"env"}`), 0o644))
+
+	envVar := settings.SafeEnvPrefix(settings.CliBinaryName) + mockedResolversEnvSuffix
+	t.Setenv(envVar, envPath)
+	ctx := settings.WithMockedResolversFile(context.Background(), ctxPath)
+	mocks, err := loadMockedResolvers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "context", mocks["source"], "context should take precedence over env var")
+}
+
+func TestLoadMockedResolvers_MissingFile(t *testing.T) {
+	ctx := settings.WithMockedResolversFile(context.Background(), "/nonexistent/path.json")
+	_, err := loadMockedResolvers(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading")
+}
+
+func TestLoadMockedResolvers_InvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte(`not json`), 0o644))
+
+	ctx := settings.WithMockedResolversFile(context.Background(), path)
+	_, err := loadMockedResolvers(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing")
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -332,13 +332,6 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 			exitcode.InvalidInput)
 	}
 
-	// Capture the caller's working directory before preparing the solution,
-	// which may chdir into a bundle extraction directory.
-	originalCwd, err := provider.GetWorkingDirectory(ctx)
-	if err != nil {
-		return o.exitWithCode(ctx, fmt.Errorf("failed to get working directory: %w", err), exitcode.GeneralError)
-	}
-
 	// Prepare solution: load, set up registry, handle bundles
 	sol, reg, solutionDir, cleanup, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
@@ -346,10 +339,12 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	}
 	defer cleanup()
 
-	// Set the solution directory for child-solution path resolution.
+	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.
-	// When SolutionDirectory is set, also set WorkingDirectory so that providers
-	// like file/exec continue to resolve paths against the caller's CWD.
+	//
+	// WorkingDirectory is intentionally NOT set for the resolver-phase context.
+	// AbsFromContext checks WorkingDirectory before SolutionDirectory, so setting
+	// both causes WorkingDirectory to win and SolutionDirectory to be ignored.
 	//
 	// For bundle runs (catalog: prefix with non-empty solutionDir), only set
 	// SolutionDirectory so resolver paths resolve against the bundle extraction
@@ -362,12 +357,10 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		if baseDirErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("--base-dir: %w", baseDirErr), exitcode.InvalidInput)
 		}
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, absBaseDir)
 	case isBundleRun:
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	case solutionDir != "":
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	}
 

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -375,17 +375,17 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	}
 	defer cleanup()
 
-	// Set the solution directory for resolver path resolution.
+	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.
-	// When SolutionDirectory is set for file-based runs, also set WorkingDirectory
-	// on the resolver context so that providers like file/exec continue to resolve
-	// paths against the caller's CWD (AbsFromContext checks WorkingDirectory
-	// before SolutionDirectory).
+	//
+	// WorkingDirectory is intentionally NOT set for the resolver-phase context.
+	// AbsFromContext checks WorkingDirectory before SolutionDirectory, so setting
+	// both causes WorkingDirectory to win and SolutionDirectory to be ignored.
+	// The action phase sets WorkingDirectory separately via actionCtx.
 	//
 	// For bundle runs (solutionDir == bundleDir), only set SolutionDirectory so
 	// resolver-phase paths (e.g. reading bundled files) resolve against the bundle
-	// extraction directory. Action-phase paths are handled separately via
-	// actionCtx which sets WorkingDirectory to originalCwd.
+	// extraction directory.
 	//
 	// For unbundled catalog runs, solutionDir is empty and paths fall back to the
 	// process CWD.
@@ -396,12 +396,10 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		if baseDirErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("--base-dir: %w", baseDirErr), exitcode.InvalidInput)
 		}
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, absBaseDir)
 	case isBundleRun:
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	case solutionDir != "":
-		ctx = provider.WithWorkingDirectory(ctx, originalCwd)
 		ctx = provider.WithSolutionDirectory(ctx, solutionDir)
 	}
 

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -279,6 +279,7 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 
 	runner := &soltesting.Runner{
 		BinaryPath:      binaryPath,
+		BinaryName:      settings.BinaryNameFromContext(ctx),
 		Concurrency:     concurrency,
 		FailFast:        opts.FailFast,
 		UpdateSnapshots: opts.UpdateSnapshots,
@@ -395,6 +396,7 @@ func runWatchMode(ctx context.Context, opts *FunctionalOptions, w *writer.Writer
 
 	runner := &soltesting.Runner{
 		BinaryPath:      binaryPath,
+		BinaryName:      settings.BinaryNameFromContext(ctx),
 		Concurrency:     concurrency,
 		FailFast:        opts.FailFast,
 		UpdateSnapshots: opts.UpdateSnapshots,

--- a/pkg/provider/builtin/httpprovider/pagination.go
+++ b/pkg/provider/builtin/httpprovider/pagination.go
@@ -247,9 +247,12 @@ func (p *HTTPProvider) executePaginated(
 			"page":       pageCount,
 		}
 
-		// Collect items from this page
+		// Collect items from this page.
+		// Use evaluateCELForPagination so that "no such key" errors (e.g.,
+		// the API returns a different envelope on the last page) are treated
+		// as an empty result instead of a hard failure.
 		if pagCfg.CollectPath != "" {
-			items, err := evaluateCEL(ctx, pagCfg.CollectPath, responseCtx)
+			items, err := evaluateCELForPagination(ctx, pagCfg.CollectPath, responseCtx)
 			if err != nil {
 				return nil, fmt.Errorf("%s: page %d collectPath evaluation failed: %w", ProviderName, pageCount, err)
 			}
@@ -263,11 +266,20 @@ func (p *HTTPProvider) executePaginated(
 			allItems = append(allItems, bodyData)
 		}
 
-		// Check stopWhen condition
+		// Check stopWhen condition.
+		// Use evaluateCELForPagination so that "no such key" errors (e.g.,
+		// size(body.items) when the last page omits "items") are treated
+		// as a stop signal rather than a hard failure.
 		if pagCfg.StopWhen != "" {
-			shouldStop, err := evaluateCEL(ctx, pagCfg.StopWhen, responseCtx)
+			shouldStop, err := evaluateCELForPagination(ctx, pagCfg.StopWhen, responseCtx)
 			if err != nil {
 				return nil, fmt.Errorf("%s: page %d stopWhen evaluation failed: %w", ProviderName, pageCount, err)
+			}
+			// Treat nil (from "no such key") as a stop signal:
+			// if the expected field is missing, the page has no usable data.
+			if shouldStop == nil {
+				lgr.V(1).Info("pagination stopped: stopWhen field not found in response", "page", pageCount)
+				break
 			}
 			if boolVal, ok := shouldStop.(bool); ok && boolVal {
 				lgr.V(1).Info("pagination stopped by stopWhen condition", "page", pageCount)
@@ -634,16 +646,6 @@ func checkItemCountStop(responseCtx map[string]any, pagCfg *paginationConfig) bo
 	}
 
 	return false
-}
-
-// evaluateCEL evaluates a CEL expression with the response context.
-// The response data is available as top-level variables: statusCode, body, rawBody, headers, page.
-func evaluateCEL(ctx context.Context, expression string, responseCtx map[string]any) (any, error) {
-	result, err := celexp.EvaluateExpression(ctx, expression, nil, responseCtx)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
 }
 
 // evaluateCELForPagination evaluates a CEL expression for pagination control.

--- a/pkg/provider/builtin/httpprovider/pagination_test.go
+++ b/pkg/provider/builtin/httpprovider/pagination_test.go
@@ -1155,3 +1155,65 @@ func TestHTTPProvider_NonPaginated_StillWorks(t *testing.T) {
 	_, hasPages := data["pages"]
 	assert.False(t, hasPages, "non-paginated response should not have 'pages' field")
 }
+
+// TestHTTPProvider_Pagination_CollectPath_MissingKeyOnLastPage verifies that
+// collectPath tolerates "no such key" errors (e.g., API returns a different
+// envelope on the last page). Regression test for the pagination collectPath bug.
+func TestHTTPProvider_Pagination_CollectPath_MissingKeyOnLastPage(t *testing.T) {
+	pageCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		switch pageCount {
+		case 1:
+			// Page 1: normal response with items
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []any{
+					map[string]any{"id": 1},
+					map[string]any{"id": 2},
+				},
+			})
+		case 2:
+			// Page 2: response WITHOUT "items" key (different envelope)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": "no more data",
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL + "/items?page=1&pageSize=2",
+		"method": "GET",
+		"pagination": map[string]any{
+			"strategy":  "pageNumber",
+			"maxPages":  3,
+			"pageSize":  2,
+			"pageParam": "page",
+			// collectPath references body.items which does NOT exist on page 2
+			"collectPath": "body.items",
+			// stopWhen also references body.items — should treat missing key as stop
+			"stopWhen": "size(body.items) == 0",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err, "should not fail when collectPath key is missing on page 2")
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+	// Should have collected items from page 1
+	var collectedItems []map[string]any
+	err = json.Unmarshal([]byte(data["body"].(string)), &collectedItems)
+	require.NoError(t, err)
+	assert.Len(t, collectedItems, 2, "should have items from page 1 only")
+	// Should have stopped at page 2 (stopWhen treated missing key as stop)
+	assert.Equal(t, 2, data["pages"])
+}

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -65,6 +65,7 @@ type Executor struct {
 	validateAll      bool             // Continue execution and collect all errors instead of stopping at first
 	skipValidation   bool             // Skip the validation phase of all resolvers
 	skipTransform    bool             // Skip the transform and validation phases of all resolvers
+	mockedResolvers  map[string]any   // Pre-populated resolver values that skip execution
 }
 
 // ExecutorOption is a functional option for configuring the Executor
@@ -140,6 +141,16 @@ func WithSkipValidation(enabled bool) ExecutorOption {
 func WithSkipTransform(enabled bool) ExecutorOption {
 	return func(e *Executor) {
 		e.skipTransform = enabled
+	}
+}
+
+// WithMockedResolvers pre-populates resolver values so that the corresponding
+// resolvers skip execution entirely and return the mocked value. This enables
+// functional testing of downstream resolvers and CEL expressions without
+// hitting external APIs or services.
+func WithMockedResolvers(mocks map[string]any) ExecutorOption {
+	return func(e *Executor) {
+		e.mockedResolvers = mocks
 	}
 }
 
@@ -252,6 +263,17 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 	// Also add parameters directly to resolver context for CEL expressions
 	for key, value := range params {
 		resolverCtx.Set(key, value)
+	}
+
+	// Inject mocked resolver values. These resolvers will be skipped during
+	// execution (see executeResolver) and downstream resolvers can reference
+	// them normally via CEL expressions.
+	for name, value := range e.mockedResolvers {
+		resolverCtx.SetResult(name, &ExecutionResult{
+			Value:  value,
+			Status: ExecutionStatusSuccess,
+		})
+		lgr.V(1).Info("injected mocked resolver value", "resolver", name)
 	}
 
 	// Track failed resolvers for validate-all mode
@@ -559,6 +581,18 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 	resolverContext, cancelResolver := context.WithTimeout(ctx, timeout)
 	defer cancelResolver()
 
+	// Check if this resolver has a mocked value (injected via WithMockedResolvers).
+	// If so, the value is already in the resolver context; skip execution entirely.
+	// Note: we do NOT call OnResolverComplete here because the phase runner
+	// (executePhase) already emits the completion callback after executeResolver returns.
+	if resolverCtx.Has(r.Name) && e.isMocked(r.Name) {
+		mockedValue, _ := resolverCtx.Get(r.Name)
+		result.Value = mockedValue
+		result.Status = ExecutionStatusSuccess
+		resolverLgr.V(1).Info("resolver mocked — skipping execution")
+		return false, nil
+	}
+
 	// Check when condition
 	if r.When != nil {
 		shouldExecute, err := e.evaluateCondition(resolverContext, r.When)
@@ -713,7 +747,15 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 	return false, nil
 }
 
-// evaluateCondition evaluates a condition expression
+// isMocked returns true if the resolver name is in the mocked resolvers set.
+func (e *Executor) isMocked(name string) bool {
+	if e.mockedResolvers == nil {
+		return false
+	}
+	_, ok := e.mockedResolvers[name]
+	return ok
+}
+
 func (e *Executor) evaluateCondition(ctx context.Context, cond *Condition) (bool, error) {
 	if cond == nil || cond.Expr == nil {
 		return true, nil

--- a/pkg/resolver/executor_coverage_test.go
+++ b/pkg/resolver/executor_coverage_test.go
@@ -207,3 +207,24 @@ func BenchmarkOptionsFromAppConfig(b *testing.B) {
 		OptionsFromAppConfig(cfg)
 	}
 }
+
+// ── WithMockedResolvers tests ─────────────────────────────────────────────────
+
+func TestWithMockedResolvers_SetsField(t *testing.T) {
+	t.Parallel()
+	mocks := map[string]any{
+		"api-data":  []any{"item1", "item2"},
+		"api-count": 42,
+	}
+	executor := NewExecutor(nil, WithMockedResolvers(mocks))
+	require.NotNil(t, executor.mockedResolvers)
+	assert.Equal(t, 42, executor.mockedResolvers["api-count"])
+	assert.True(t, executor.isMocked("api-data"))
+	assert.False(t, executor.isMocked("not-mocked"))
+}
+
+func TestIsMocked_NilMap(t *testing.T) {
+	t.Parallel()
+	executor := NewExecutor(nil)
+	assert.False(t, executor.isMocked("anything"))
+}

--- a/pkg/settings/context.go
+++ b/pkg/settings/context.go
@@ -11,6 +11,7 @@ type contextKey string
 
 const (
 	settingsContextKey contextKey = "settings"
+	mockedResolversKey contextKey = "mocked_resolvers_file"
 )
 
 // IntoContext stores a Settings object in the context
@@ -32,4 +33,18 @@ func BinaryNameFromContext(ctx context.Context) string {
 		return s.BinaryName
 	}
 	return CliBinaryName
+}
+
+// WithMockedResolversFile stores the path to a mocked resolvers JSON file in the context.
+// Used by the test runner to pass mock data to in-process command execution without
+// relying on process-global environment variables.
+func WithMockedResolversFile(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, mockedResolversKey, path)
+}
+
+// MockedResolversFileFromContext returns the mocked resolvers file path from
+// context, if set. Returns empty string and false when not present.
+func MockedResolversFileFromContext(ctx context.Context) (string, bool) {
+	val, ok := ctx.Value(mockedResolversKey).(string)
+	return val, ok && val != ""
 }

--- a/pkg/settings/context_test.go
+++ b/pkg/settings/context_test.go
@@ -193,3 +193,29 @@ func TestIntoContext_FromContext_roundtrip(t *testing.T) {
 		})
 	}
 }
+
+func TestMockedResolversFileContext_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := WithMockedResolversFile(context.Background(), "/tmp/mocks.json")
+	path, ok := MockedResolversFileFromContext(ctx)
+	if !ok || path != "/tmp/mocks.json" {
+		t.Errorf("MockedResolversFileFromContext = (%q, %v); want (/tmp/mocks.json, true)", path, ok)
+	}
+}
+
+func TestMockedResolversFileContext_Missing(t *testing.T) {
+	t.Parallel()
+	_, ok := MockedResolversFileFromContext(context.Background())
+	if ok {
+		t.Error("MockedResolversFileFromContext should return false for empty context")
+	}
+}
+
+func TestMockedResolversFileContext_EmptyString(t *testing.T) {
+	t.Parallel()
+	ctx := WithMockedResolversFile(context.Background(), "")
+	_, ok := MockedResolversFileFromContext(ctx)
+	if ok {
+		t.Error("MockedResolversFileFromContext should return false for empty path")
+	}
+}

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -206,13 +206,23 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	// For file-based loading: use the file's parent directory.
 	// For bundles (including catalog bundles): use the bundle extraction directory.
 	// For stdin or unbundled catalog references: leave empty (falls back to CWD).
+	//
+	// Prefer sol.GetPath() over the original `path` argument because when
+	// auto-discovery is performed inside GetWithBundle (path == ""), the
+	// original path stays empty while the solution object carries the resolved
+	// file path set by FromLocalFileSystem. Fall back to `path` for callers
+	// that use custom getters (e.g. test mocks) that don't call SetPath.
 	var solutionDir string
-	isCatalogRef := strings.HasPrefix(sol.GetPath(), "catalog:")
+	resolvedPath := sol.GetPath()
+	if resolvedPath == "" {
+		resolvedPath = path
+	}
+	isCatalogRef := strings.HasPrefix(resolvedPath, "catalog:")
 	switch {
 	case bundleDir != "":
 		solutionDir = bundleDir
-	case path != "-" && !isCatalogRef:
-		absPath, absErr := provider.AbsFromContext(ctx, path)
+	case resolvedPath != "" && resolvedPath != "-" && !isCatalogRef:
+		absPath, absErr := provider.AbsFromContext(ctx, resolvedPath)
 		if absErr == nil {
 			solutionDir = filepath.Dir(absPath)
 		}

--- a/pkg/solution/soltesting/inheritance.go
+++ b/pkg/solution/soltesting/inheritance.go
@@ -169,6 +169,16 @@ func mergeTestCase(dst, src *TestCase) {
 		}
 	}
 
+	// inputs: merged map, src wins on key conflict
+	if len(src.Inputs) > 0 {
+		if dst.Inputs == nil {
+			dst.Inputs = make(map[string]string)
+		}
+		for k, v := range src.Inputs {
+			dst.Inputs[k] = v
+		}
+	}
+
 	// Scalar fields: src wins if set
 	if src.Description != "" {
 		dst.Description = src.Description
@@ -196,6 +206,24 @@ func mergeTestCase(dst, src *TestCase) {
 	}
 	if src.Retries > 0 {
 		dst.Retries = src.Retries
+	}
+	if src.BaseDir != "" {
+		dst.BaseDir = src.BaseDir
+	}
+
+	// services: appended (dst first, then src)
+	if len(src.Services) > 0 {
+		dst.Services = append(dst.Services, src.Services...)
+	}
+
+	// mocks: merged map, src wins on key conflict
+	if len(src.Mocks) > 0 {
+		if dst.Mocks == nil {
+			dst.Mocks = make(map[string]any)
+		}
+		for k, v := range src.Mocks {
+			dst.Mocks[k] = v
+		}
 	}
 }
 

--- a/pkg/solution/soltesting/inheritance_test.go
+++ b/pkg/solution/soltesting/inheritance_test.go
@@ -300,3 +300,124 @@ func TestExtendsChainString(t *testing.T) {
 	chain := soltesting.ExtendsChainString(tests, "child")
 	assert.Equal(t, "child -> _parent -> _grandparent", chain)
 }
+
+func TestResolveExtends_InputsMerge(t *testing.T) {
+	tests := map[string]*soltesting.TestCase{
+		"_base": {
+			Name:    "_base",
+			Command: []string{"run", "resolver"},
+			Inputs: map[string]string{
+				"env":    "dev",
+				"region": "us-west-2",
+			},
+		},
+		"child": {
+			Name:    "child",
+			Extends: []string{"_base"},
+			Inputs: map[string]string{
+				"env": "prod",  // override
+				"app": "myapp", // new key
+			},
+			Assertions: []soltesting.Assertion{
+				{Contains: "ok"},
+			},
+		},
+	}
+
+	require.NoError(t, soltesting.ResolveExtends(tests))
+
+	child := tests["child"]
+	assert.Equal(t, "prod", child.Inputs["env"])         // child overrides parent
+	assert.Equal(t, "us-west-2", child.Inputs["region"]) // inherited from parent
+	assert.Equal(t, "myapp", child.Inputs["app"])        // child-only key
+}
+
+func TestResolveExtends_ServicesMerge(t *testing.T) {
+	tests := map[string]*soltesting.TestCase{
+		"_base": {
+			Name:    "_base",
+			Command: []string{"run", "resolver"},
+			Services: []soltesting.ServiceConfig{
+				{Name: "api", Type: "http"},
+			},
+		},
+		"child": {
+			Name:    "child",
+			Extends: []string{"_base"},
+			Services: []soltesting.ServiceConfig{
+				{Name: "db", Type: "http"},
+			},
+			Assertions: []soltesting.Assertion{
+				{Contains: "ok"},
+			},
+		},
+	}
+
+	require.NoError(t, soltesting.ResolveExtends(tests))
+
+	child := tests["child"]
+	assert.Len(t, child.Services, 2)
+	assert.Equal(t, "api", child.Services[0].Name)
+	assert.Equal(t, "db", child.Services[1].Name)
+}
+
+func TestResolveExtends_MocksMerge(t *testing.T) {
+	tests := map[string]*soltesting.TestCase{
+		"_base": {
+			Name:    "_base",
+			Command: []string{"run", "resolver"},
+			Mocks: map[string]any{
+				"token": "base-token",
+				"cfg":   "base-cfg",
+			},
+		},
+		"child": {
+			Name:    "child",
+			Extends: []string{"_base"},
+			Mocks: map[string]any{
+				"token": "child-token", // override
+				"extra": "child-extra", // new key
+			},
+			Assertions: []soltesting.Assertion{
+				{Contains: "ok"},
+			},
+		},
+	}
+
+	require.NoError(t, soltesting.ResolveExtends(tests))
+
+	child := tests["child"]
+	assert.Equal(t, "child-token", child.Mocks["token"]) // child overrides parent
+	assert.Equal(t, "base-cfg", child.Mocks["cfg"])      // inherited from parent
+	assert.Equal(t, "child-extra", child.Mocks["extra"]) // child-only key
+}
+
+func TestResolveExtends_BaseDirMerge(t *testing.T) {
+	tests := map[string]*soltesting.TestCase{
+		"_base": {
+			Name:    "_base",
+			Command: []string{"run", "resolver"},
+			BaseDir: "myapp",
+		},
+		"child-inherits": {
+			Name:    "child-inherits",
+			Extends: []string{"_base"},
+			Assertions: []soltesting.Assertion{
+				{Contains: "ok"},
+			},
+		},
+		"child-overrides": {
+			Name:    "child-overrides",
+			Extends: []string{"_base"},
+			BaseDir: "otherapp",
+			Assertions: []soltesting.Assertion{
+				{Contains: "ok"},
+			},
+		},
+	}
+
+	require.NoError(t, soltesting.ResolveExtends(tests))
+
+	assert.Equal(t, "myapp", tests["child-inherits"].BaseDir, "child should inherit BaseDir from parent")
+	assert.Equal(t, "otherapp", tests["child-overrides"].BaseDir, "child should override BaseDir")
+}

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -62,6 +63,11 @@ type Runner struct {
 	// Used only as a fallback when BinaryPath is empty (unit tests).
 	// Production code should always set BinaryPath instead.
 	NewCommand CommandBuilder
+	// BinaryName is the application name used for deriving env var prefixes
+	// (e.g., mocked-resolver env var). When empty, falls back to paths.AppName().
+	// Must match the name used by settings.BinaryNameFromContext inside the
+	// target binary so writer and reader agree on env var names.
+	BinaryName string
 	// Progress receives notifications as tests execute.
 	// When nil, no progress output is emitted.
 	Progress TestProgressCallback
@@ -72,6 +78,15 @@ func (r *Runner) emitTestStart(solution, test string) {
 	if r.Progress != nil {
 		r.Progress.OnTestStart(solution, test)
 	}
+}
+
+// appName returns the application name for env var derivation.
+// Prefers BinaryName if set, otherwise falls back to paths.AppName().
+func (r *Runner) appName() string {
+	if r.BinaryName != "" {
+		return r.BinaryName
+	}
+	return paths.AppName()
 }
 
 // emitTestComplete notifies the progress callback that a test has finished.
@@ -512,7 +527,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 		bundleFiles = resolved
 	}
 
-	sandbox, err := NewSandbox(st.FilePath, bundleFiles, sandboxFiles)
+	sandbox, err := r.createSandbox(st, tc, bundleFiles, sandboxFiles)
 	if err != nil {
 		result.Status = StatusError
 		result.Message = fmt.Sprintf("sandbox creation failed: %s", err)
@@ -525,9 +540,26 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 		result.SandboxPath = sandbox.Path()
 	}
 
+	// Start per-test services (stopped after the test completes).
+	var extraEnv map[string]string
+	if len(tc.Services) > 0 {
+		svcEnv, stopFn, svcErr := r.startPerTestServices(tc.Services)
+		if svcErr != nil {
+			result.Status = StatusError
+			result.Message = svcErr.Error()
+			result.Duration = time.Since(start)
+			return result
+		}
+		defer stopFn()
+
+		// Inject service env vars into extraEnv so buildEnvMap picks them up
+		// without mutating the shared TestCase (safe for retries and concurrency).
+		extraEnv = svcEnv
+	}
+
 	// Run test init steps
 	if len(tc.Init) > 0 {
-		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
+		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path(), extraEnv)
 		if err := r.runInitSteps(ctx, tc.Init, sandbox.Path(), envMap); err != nil {
 			result.Status = StatusError
 			result.Message = fmt.Sprintf("init step failed: %s", err)
@@ -545,7 +577,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 	}
 
 	// Build and execute the scafctl command in-process
-	cmdOutput, err := r.executeCommand(ctx, tc, st, sandbox)
+	cmdOutput, err := r.executeCommand(ctx, tc, st, sandbox, extraEnv)
 	if err != nil {
 		result.Status = StatusError
 		result.Message = fmt.Sprintf("command execution failed: %s", err)
@@ -625,7 +657,7 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 
 	// Run test cleanup steps
 	if len(tc.Cleanup) > 0 {
-		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
+		envMap := r.buildEnvMap(tc, st.Config, sandbox.Path(), extraEnv)
 		// Cleanup errors are not test failures, just log them
 		_ = r.runInitSteps(ctx, tc.Cleanup, sandbox.Path(), envMap)
 	}
@@ -635,18 +667,28 @@ func (r *Runner) executeTest(ctx context.Context, tc *TestCase, st *SolutionTest
 	return result
 }
 
-// executeCommand builds and runs a scafctl CLI command in-process.
-func (r *Runner) executeCommand(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
-	if r.BinaryPath != "" {
-		return r.executeCommandSubprocess(ctx, tc, st, sandbox)
+// createSandbox creates a test sandbox, choosing between flat and nested layout.
+// When tc.BaseDir is set, files are nested under that subdirectory so that
+// repo-root-relative paths in resolvers resolve correctly.
+func (r *Runner) createSandbox(st *SolutionTests, tc *TestCase, bundleFiles, sandboxFiles []string) (*Sandbox, error) {
+	if tc.BaseDir != "" {
+		return NewSandboxWithBaseDir(st.FilePath, tc.BaseDir, bundleFiles, sandboxFiles)
 	}
-	return r.executeCommandInProcess(ctx, tc, st, sandbox)
+	return NewSandbox(st.FilePath, bundleFiles, sandboxFiles)
+}
+
+// executeCommand builds and runs a scafctl CLI command in-process.
+func (r *Runner) executeCommand(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox, extraEnv map[string]string) (*CommandOutput, error) {
+	if r.BinaryPath != "" {
+		return r.executeCommandSubprocess(ctx, tc, st, sandbox, extraEnv)
+	}
+	return r.executeCommandInProcess(ctx, tc, st, sandbox, extraEnv)
 }
 
 // executeCommandSubprocess runs a scafctl CLI command as an isolated child process.
 // Each invocation gets its own process environment, so concurrent tests cannot
 // interfere with each other's env vars or global state.
-func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
+func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox, extraEnv map[string]string) (*CommandOutput, error) {
 	timeout := r.TestTimeout
 	if tc.Timeout != nil {
 		timeout = tc.Timeout.Duration
@@ -659,9 +701,10 @@ func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st 
 	}
 
 	// Build command args
-	args := make([]string, 0, len(tc.Command)+len(tc.Args)+4)
+	args := make([]string, 0, len(tc.Command)+len(tc.Args)+len(tc.Inputs)*2+4)
 	args = append(args, tc.Command...)
 	args = append(args, tc.Args...)
+	args = append(args, inputsToArgs(tc.Inputs)...)
 
 	// Auto-inject -f <sandbox-solution-path> unless injectFile is false
 	if tc.GetInjectFile() {
@@ -682,10 +725,22 @@ func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st 
 
 	// Build isolated environment: inherit parent env + overlay test env vars.
 	// Each subprocess gets its own copy, so no races.
-	envMap := r.buildEnvMap(tc, st.Config, sandbox.Path())
+	envMap := r.buildEnvMap(tc, st.Config, sandbox.Path(), extraEnv)
 	cmd.Env = os.Environ()
 	for k, v := range envMap {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	// Write mocked resolvers to a temp JSON file and set the env var so the
+	// child process picks them up via loadMockedResolvers().
+	if len(tc.Mocks) > 0 {
+		mocksFile, mocksErr := writeMocksFile(tc.Mocks)
+		if mocksErr != nil {
+			return nil, fmt.Errorf("writing mocks file: %w", mocksErr)
+		}
+		defer os.Remove(mocksFile)
+		envVar := settings.SafeEnvPrefix(r.appName()) + "_MOCKED_RESOLVERS_FILE"
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar, mocksFile))
 	}
 
 	// Execute
@@ -721,7 +776,7 @@ func (r *Runner) executeCommandSubprocess(ctx context.Context, tc *TestCase, st 
 // executeCommandInProcess runs a scafctl CLI command in the current process.
 // This path is used only when BinaryPath is empty (unit tests with mock commands).
 // It is NOT safe for concurrent execution because os.Setenv is process-global.
-func (r *Runner) executeCommandInProcess(ctx context.Context, tc *TestCase, _ *SolutionTests, sandbox *Sandbox) (*CommandOutput, error) {
+func (r *Runner) executeCommandInProcess(ctx context.Context, tc *TestCase, st *SolutionTests, sandbox *Sandbox, extraEnv map[string]string) (*CommandOutput, error) {
 	timeout := r.TestTimeout
 	if tc.Timeout != nil {
 		timeout = tc.Timeout.Duration
@@ -733,10 +788,18 @@ func (r *Runner) executeCommandInProcess(ctx context.Context, tc *TestCase, _ *S
 		defer cancel()
 	}
 
+	// Apply env vars (tc.Env, testConfig.Env, extraEnv) via os.Setenv.
+	// This is process-global, so the in-process path is NOT safe for
+	// concurrent execution. Subprocess execution should be used for that.
+	envMap := r.buildEnvMap(tc, st.Config, sandbox.Path(), extraEnv)
+	restore := setEnvVars(envMap)
+	defer restore()
+
 	// Build command args
-	args := make([]string, 0, len(tc.Command)+len(tc.Args)+4)
+	args := make([]string, 0, len(tc.Command)+len(tc.Args)+len(tc.Inputs)*2+4)
 	args = append(args, tc.Command...)
 	args = append(args, tc.Args...)
+	args = append(args, inputsToArgs(tc.Inputs)...)
 
 	// Auto-inject -f <sandbox-solution-path> unless injectFile is false
 	if tc.GetInjectFile() {
@@ -763,6 +826,18 @@ func (r *Runner) executeCommandInProcess(ctx context.Context, tc *TestCase, _ *S
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(&stdout)
 	rootCmd.SetErr(&stderr)
+
+	// Write mocked resolvers to a temp JSON file and inject via context so the
+	// in-process command picks them up via loadMockedResolvers(). Using context
+	// instead of os.Setenv avoids process-global state and potential races.
+	if len(tc.Mocks) > 0 {
+		mocksFile, mocksErr := writeMocksFile(tc.Mocks)
+		if mocksErr != nil {
+			return nil, fmt.Errorf("writing mocks file: %w", mocksErr)
+		}
+		defer os.Remove(mocksFile)
+		ctx = settings.WithMockedResolversFile(ctx, mocksFile)
+	}
 
 	// Execute command
 	cmdErr := rootCmd.ExecuteContext(ctx)
@@ -914,7 +989,7 @@ func attachCommandOutput(result *TestResult, cmdOutput *CommandOutput) {
 
 // buildEnvMap builds the environment variable map for a test.
 // Precedence: process env → testConfig.env → testCase.env → <BINARY>_SANDBOX_DIR.
-func (r *Runner) buildEnvMap(tc *TestCase, testConfig *TestConfig, sandboxPath string) map[string]any {
+func (r *Runner) buildEnvMap(tc *TestCase, testConfig *TestConfig, sandboxPath string, extraEnv map[string]string) map[string]any {
 	env := make(map[string]any)
 
 	// testConfig.env
@@ -929,10 +1004,39 @@ func (r *Runner) buildEnvMap(tc *TestCase, testConfig *TestConfig, sandboxPath s
 		env[k] = v
 	}
 
+	// extraEnv overrides (e.g., per-test service env vars)
+	for k, v := range extraEnv {
+		env[k] = v
+	}
+
 	// Always set sandbox dir
-	env[settings.SafeEnvPrefix(paths.AppName())+"_SANDBOX_DIR"] = sandboxPath
+	env[settings.SafeEnvPrefix(r.appName())+"_SANDBOX_DIR"] = sandboxPath
 
 	return env
+}
+
+// setEnvVars applies the given env map via os.Setenv and returns a restore
+// function that reverts each variable to its original value (or unsets it).
+// This is only used by the in-process execution path.
+func setEnvVars(envMap map[string]any) func() {
+	originals := make(map[string]*string, len(envMap))
+	for k, v := range envMap {
+		if prev, ok := os.LookupEnv(k); ok {
+			originals[k] = &prev
+		} else {
+			originals[k] = nil
+		}
+		os.Setenv(k, fmt.Sprintf("%v", v))
+	}
+	return func() {
+		for k, prev := range originals {
+			if prev != nil {
+				os.Setenv(k, *prev)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}
 }
 
 // mergeEnvForStep creates an env slice for shellexec combining the env map with step-level env.
@@ -955,6 +1059,47 @@ func mergeEnvForStep(envMap map[string]any, stepEnv map[string]string) []string 
 // composeExecMocks creates a single RunFunc that tries each MockExec in order.
 // The first mock that has a matching rule handles the command. If no mock matches
 // and a mock allows passthrough, the real shellexec.Run is called.
+// writeMocksFile writes a map of resolver mocks to a temp JSON file and returns its path.
+func writeMocksFile(mocks map[string]any) (string, error) {
+	data, err := json.Marshal(mocks)
+	if err != nil {
+		return "", fmt.Errorf("marshalling mocks: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "scafctl-mocks-*.json")
+	if err != nil {
+		return "", fmt.Errorf("creating temp mocks file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("writing mocks data: %w", err)
+	}
+
+	return f.Name(), nil
+}
+
+// inputsToArgs converts a map of parameter name→value pairs into a sorted
+// slice of -r key=value CLI arguments. Returns nil when inputs is empty.
+func inputsToArgs(inputs map[string]string) []string {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(inputs))
+	for k := range inputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	args := make([]string, 0, len(inputs)*2)
+	for _, k := range keys {
+		args = append(args, "-r", fmt.Sprintf("%s=%s", k, inputs[k]))
+	}
+	return args
+}
+
 func composeExecMocks(mocks []*mockexec.MockExec) shellexec.RunFunc {
 	fns := make([]shellexec.RunFunc, len(mocks))
 	for i, m := range mocks {
@@ -988,4 +1133,41 @@ func composeExecMocks(mocks []*mockexec.MockExec) shellexec.RunFunc {
 		}
 		return nil, fmt.Errorf("mockexec: no matching rule for command %q", fullCmd)
 	}
+}
+
+// startPerTestServices starts background services defined on a single test case.
+// It returns the service env vars, a stop function, and any startup error.
+func (r *Runner) startPerTestServices(services []ServiceConfig) (map[string]string, func(), error) {
+	var servers []*mockserver.Server
+	env := make(map[string]string)
+
+	stopFn := func() {
+		for _, srv := range servers {
+			_ = srv.Stop()
+		}
+	}
+
+	for _, svc := range services {
+		switch svc.Type {
+		case "http":
+			srv := mockserver.New(svc.Routes)
+			if err := srv.Start(); err != nil {
+				stopFn() // clean up any already-started servers
+				return nil, nil, fmt.Errorf("per-test service %q start failed: %w", svc.Name, err)
+			}
+			servers = append(servers, srv)
+
+			if svc.PortEnv != "" {
+				env[svc.PortEnv] = fmt.Sprintf("%d", srv.Port())
+			}
+			if svc.BaseURLEnv != "" {
+				env[svc.BaseURLEnv] = srv.BaseURL()
+			}
+		default:
+			stopFn()
+			return nil, nil, fmt.Errorf("per-test service %q: unsupported type %q (only http is supported)", svc.Name, svc.Type)
+		}
+	}
+
+	return env, stopFn, nil
 }

--- a/pkg/solution/soltesting/runner_coverage_test.go
+++ b/pkg/solution/soltesting/runner_coverage_test.go
@@ -231,3 +231,35 @@ func BenchmarkComposeExecMocks(b *testing.B) {
 		composeExecMocks([]*mockexec.MockExec{mock})
 	}
 }
+
+func TestSetEnvVars_AppliesAndRestores(t *testing.T) {
+	// Set a pre-existing var to verify restore
+	t.Setenv("SOLTESTING_EXISTING", "original")
+
+	envMap := map[string]any{
+		"SOLTESTING_EXISTING": "overridden",
+		"SOLTESTING_NEW":      "new-value",
+	}
+
+	restore := setEnvVars(envMap)
+
+	assert.Equal(t, "overridden", os.Getenv("SOLTESTING_EXISTING"))
+	assert.Equal(t, "new-value", os.Getenv("SOLTESTING_NEW"))
+
+	restore()
+
+	assert.Equal(t, "original", os.Getenv("SOLTESTING_EXISTING"))
+	_, exists := os.LookupEnv("SOLTESTING_NEW")
+	assert.False(t, exists, "new var should be unset after restore")
+}
+
+func TestRunnerAppName_DefaultFallback(t *testing.T) {
+	r := &Runner{}
+	// With no BinaryName set, should fall back to paths.AppName()
+	assert.NotEmpty(t, r.appName())
+}
+
+func TestRunnerAppName_ExplicitName(t *testing.T) {
+	r := &Runner{BinaryName: "mycli"}
+	assert.Equal(t, "mycli", r.appName())
+}

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -607,12 +607,33 @@ func TestBuildEnvMap(t *testing.T) {
 		},
 	}
 
-	env := r.buildEnvMap(tc, config, "/tmp/sandbox")
+	env := r.buildEnvMap(tc, config, "/tmp/sandbox", nil)
 
 	assert.Equal(t, "test-value", env["TEST_VAR"])
 	assert.Equal(t, "config-value", env["CONFIG_VAR"])
 	assert.Equal(t, "from-test", env["OVERRIDE"]) // test overrides config
 	assert.Equal(t, "/tmp/sandbox", env["SCAFCTL_SANDBOX_DIR"])
+}
+
+func TestBuildEnvMap_WithExtraEnv(t *testing.T) {
+	r := &Runner{}
+
+	tc := &TestCase{
+		Env: map[string]string{
+			"TC_VAR":  "from-tc",
+			"OVERLAP": "from-tc",
+		},
+	}
+	extraEnv := map[string]string{
+		"SVC_URL": "http://localhost:9999",
+		"OVERLAP": "from-extra",
+	}
+
+	env := r.buildEnvMap(tc, nil, "/tmp/sandbox", extraEnv)
+
+	assert.Equal(t, "from-tc", env["TC_VAR"])
+	assert.Equal(t, "http://localhost:9999", env["SVC_URL"])
+	assert.Equal(t, "from-extra", env["OVERLAP"], "extraEnv should override tc.Env")
 }
 
 func TestMergeEnvForStep(t *testing.T) {
@@ -1143,4 +1164,105 @@ func BenchmarkReportTable_ProgressShown(b *testing.B) {
 		buf.Reset()
 		_ = reportTable(results, &buf, false, 500*time.Millisecond, true)
 	}
+}
+
+// ── writeMocksFile tests ──────────────────────────────────────────────────────
+
+func TestWriteMocksFile_RoundTrip(t *testing.T) {
+	mocks := map[string]any{
+		"api-data":  []any{"item1", "item2"},
+		"api-count": float64(42),
+	}
+
+	path, err := writeMocksFile(mocks)
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	// Read back and verify
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var loaded map[string]any
+	require.NoError(t, json.Unmarshal(data, &loaded))
+
+	assert.Equal(t, float64(42), loaded["api-count"])
+	items, ok := loaded["api-data"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+}
+
+func TestWriteMocksFile_EmptyMocks(t *testing.T) {
+	path, err := writeMocksFile(map[string]any{})
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
+}
+
+func TestInputsToArgs_Nil(t *testing.T) {
+	assert.Nil(t, inputsToArgs(nil))
+}
+
+func TestInputsToArgs_Empty(t *testing.T) {
+	assert.Nil(t, inputsToArgs(map[string]string{}))
+}
+
+func TestInputsToArgs_Single(t *testing.T) {
+	result := inputsToArgs(map[string]string{"env": "prod"})
+	assert.Equal(t, []string{"-r", "env=prod"}, result)
+}
+
+func TestInputsToArgs_Multiple_Sorted(t *testing.T) {
+	result := inputsToArgs(map[string]string{
+		"region": "us-east-1",
+		"env":    "staging",
+		"app":    "myservice",
+	})
+	// Keys should be sorted alphabetically for deterministic output
+	assert.Equal(t, []string{
+		"-r", "app=myservice",
+		"-r", "env=staging",
+		"-r", "region=us-east-1",
+	}, result)
+}
+
+func TestStartPerTestServices_HTTP(t *testing.T) {
+	r := &Runner{}
+	services := []ServiceConfig{
+		{
+			Name:       "test-api",
+			Type:       "http",
+			PortEnv:    "TEST_PORT",
+			BaseURLEnv: "TEST_URL",
+			Routes:     nil, // no routes needed for startup test
+		},
+	}
+
+	env, stopFn, err := r.startPerTestServices(services)
+	require.NoError(t, err)
+	defer stopFn()
+
+	assert.NotEmpty(t, env["TEST_PORT"])
+	assert.Contains(t, env["TEST_URL"], "http://127.0.0.1:")
+}
+
+func TestStartPerTestServices_UnsupportedType(t *testing.T) {
+	r := &Runner{}
+	services := []ServiceConfig{
+		{Name: "bad", Type: "grpc"},
+	}
+
+	_, _, err := r.startPerTestServices(services)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type")
+}
+
+func TestStartPerTestServices_Empty(t *testing.T) {
+	r := &Runner{}
+	env, stopFn, err := r.startPerTestServices(nil)
+	require.NoError(t, err)
+	assert.Empty(t, env)
+	assert.NotNil(t, stopFn) // no-op stop function is still returned
 }

--- a/pkg/solution/soltesting/sandbox.go
+++ b/pkg/solution/soltesting/sandbox.go
@@ -37,6 +37,7 @@ type fileSnapshot struct {
 type Sandbox struct {
 	root         string
 	solutionPath string
+	baseDir      string // subdirectory prefix for nesting files
 	preSnapshot  map[string]fileSnapshot
 }
 
@@ -45,6 +46,42 @@ type Sandbox struct {
 // All paths are relative to solutionDir (the directory containing the solution file).
 // Symlinks and path traversal above the solution root are rejected.
 func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox, error) {
+	return newSandbox(solutionPath, "", bundleFiles, testFiles)
+}
+
+// NewSandboxWithBaseDir creates a sandbox where the solution and all related
+// files are nested under baseDir within the sandbox root. This preserves
+// directory structure for solutions that live in a subdirectory of a repository
+// and whose resolvers reference paths relative to the repository root.
+//
+// For example, with baseDir="cldctl":
+//   - solution.yaml  -> sandbox/cldctl/solution.yaml
+//   - output/data.json -> sandbox/cldctl/output/data.json
+//
+// The process working directory (cmd.Dir) should be set to sandbox.Path()
+// (the root), so repo-root-relative paths resolve correctly.
+func NewSandboxWithBaseDir(solutionPath, baseDir string, bundleFiles, testFiles []string) (*Sandbox, error) {
+	if err := validateBaseDir(baseDir); err != nil {
+		return nil, err
+	}
+	return newSandbox(solutionPath, baseDir, bundleFiles, testFiles)
+}
+
+// validateBaseDir rejects absolute paths and path-traversal attempts to prevent
+// files from being written outside the sandbox root.
+func validateBaseDir(baseDir string) error {
+	if filepath.IsAbs(baseDir) {
+		return fmt.Errorf("baseDir must be a relative path, got %q", baseDir)
+	}
+	cleaned := filepath.Clean(baseDir)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("baseDir must not traverse above sandbox root, got %q", baseDir)
+	}
+	return nil
+}
+
+// newSandbox is the internal constructor shared by NewSandbox and NewSandboxWithBaseDir.
+func newSandbox(solutionPath, baseDir string, bundleFiles, testFiles []string) (*Sandbox, error) {
 	solutionDir := filepath.Dir(solutionPath)
 	solutionBase := filepath.Base(solutionPath)
 
@@ -53,13 +90,21 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 		return nil, fmt.Errorf("creating sandbox temp dir: %w", err)
 	}
 
+	// When baseDir is set, nest all files under sandbox/<baseDir>/
+	// so repo-root-relative paths resolve correctly.
+	solutionRelPath := solutionBase
+	if baseDir != "" {
+		solutionRelPath = filepath.Join(baseDir, solutionBase)
+	}
+
 	s := &Sandbox{
 		root:         tmpDir,
-		solutionPath: filepath.Join(tmpDir, solutionBase),
+		solutionPath: filepath.Join(tmpDir, solutionRelPath),
+		baseDir:      baseDir,
 	}
 
 	// Copy the solution file itself
-	if err := s.copyFile(solutionDir, solutionBase); err != nil {
+	if err := s.copyFileWithPrefix(solutionDir, solutionBase, baseDir); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return nil, fmt.Errorf("copying solution file: %w", err)
 	}
@@ -71,7 +116,7 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 		return nil, fmt.Errorf("discovering compose files: %w", err)
 	}
 	for _, cf := range composeFiles {
-		if err := s.copyFile(solutionDir, cf); err != nil {
+		if err := s.copyFileWithPrefix(solutionDir, cf, baseDir); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying compose file %q: %w", cf, err)
 		}
@@ -79,7 +124,7 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 
 	// Copy bundle files
 	for _, f := range bundleFiles {
-		if err := s.copyFile(solutionDir, f); err != nil {
+		if err := s.copyFileWithPrefix(solutionDir, f, baseDir); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying bundle file %q: %w", f, err)
 		}
@@ -92,7 +137,7 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 		return nil, fmt.Errorf("resolving test files: %w", err)
 	}
 	for _, f := range expandedTestFiles {
-		if err := s.copyFile(solutionDir, f); err != nil {
+		if err := s.copyFileWithPrefix(solutionDir, f, baseDir); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying test file %q: %w", f, err)
 		}
@@ -121,10 +166,16 @@ func (s *Sandbox) CopyForTest(solutionDir string, testFiles []string) (*Sandbox,
 		return nil, fmt.Errorf("copying base sandbox: %w", err)
 	}
 
-	solutionBase := filepath.Base(s.solutionPath)
+	// Preserve the relative path from root to solution file
+	solutionRel, err := filepath.Rel(s.root, s.solutionPath)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("computing relative solution path: %w", err)
+	}
 	child := &Sandbox{
 		root:         tmpDir,
-		solutionPath: filepath.Join(tmpDir, solutionBase),
+		solutionPath: filepath.Join(tmpDir, solutionRel),
+		baseDir:      s.baseDir,
 	}
 
 	// Copy test-specific files from the original solution directory (with glob and directory expansion)
@@ -134,7 +185,7 @@ func (s *Sandbox) CopyForTest(solutionDir string, testFiles []string) (*Sandbox,
 		return nil, fmt.Errorf("resolving test files: %w", err)
 	}
 	for _, f := range expandedTestFiles {
-		if err := child.copyFile(solutionDir, f); err != nil {
+		if err := child.copyFileWithPrefix(solutionDir, f, s.baseDir); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return nil, fmt.Errorf("copying test file %q: %w", f, err)
 		}
@@ -265,6 +316,67 @@ func (s *Sandbox) copyFile(sourceDir, relPath string) error {
 	}
 
 	// Copy file contents
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening source %q: %w", srcPath, err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("creating destination %q: %w", dstPath, err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("copying %q: %w", relPath, err)
+	}
+
+	return nil
+}
+
+// copyFileWithPrefix copies a file from sourceDir/relPath into the sandbox,
+// nesting it under prefix/ when prefix is non-empty. This is used by
+// NewSandboxWithBaseDir to preserve directory structure.
+func (s *Sandbox) copyFileWithPrefix(sourceDir, relPath, prefix string) error {
+	if prefix == "" {
+		return s.copyFile(sourceDir, relPath)
+	}
+	// Reject path traversal
+	cleaned := filepath.Clean(relPath)
+	if strings.HasPrefix(cleaned, "..") || filepath.IsAbs(cleaned) {
+		return fmt.Errorf(
+			"path traversal rejected: %q — test files must be within the solution directory. "+
+				"Move or copy the file alongside solution.yaml, or use 'init' steps instead",
+			relPath,
+		)
+	}
+
+	srcPath := filepath.Join(sourceDir, cleaned)
+
+	// Reject symlinks
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		return fmt.Errorf("stat %q: %w", srcPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symlinks are not allowed: %q", relPath)
+	}
+	if info.IsDir() {
+		return fmt.Errorf(
+			"is a directory: %q — the 'files' property requires file paths or glob patterns "+
+				"(e.g., %q to copy the entire directory tree)",
+			relPath, relPath+"/**",
+		)
+	}
+
+	// Nest under prefix/
+	dstPath := filepath.Join(s.root, prefix, cleaned)
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return fmt.Errorf("creating directory for %q: %w", relPath, err)
+	}
+
 	src, err := os.Open(srcPath)
 	if err != nil {
 		return fmt.Errorf("opening source %q: %w", srcPath, err)

--- a/pkg/solution/soltesting/sandbox_test.go
+++ b/pkg/solution/soltesting/sandbox_test.go
@@ -401,3 +401,117 @@ func writeSandboxFile(t *testing.T, baseDir, relPath, content string) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
 	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
 }
+
+func TestNewSandboxWithBaseDir_NestsUnderSubdir(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "output/data.json", `{"result": true}`)
+
+	sb, err := soltesting.NewSandboxWithBaseDir(
+		filepath.Join(dir, "solution.yaml"),
+		"myapp",
+		nil,
+		[]string{"output/data.json"},
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	// Solution should be nested under myapp/
+	assert.Contains(t, sb.SolutionPath(), filepath.Join("myapp", "solution.yaml"))
+
+	// Solution file should exist at nested path
+	_, err = os.Stat(sb.SolutionPath())
+	assert.NoError(t, err)
+
+	// Data file should also be nested
+	nestedData := filepath.Join(sb.Path(), "myapp", "output", "data.json")
+	content, err := os.ReadFile(nestedData)
+	require.NoError(t, err)
+	assert.Equal(t, `{"result": true}`, string(content))
+
+	// File should NOT exist at sandbox root level
+	_, err = os.Stat(filepath.Join(sb.Path(), "output", "data.json"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestNewSandboxWithBaseDir_EmptyBaseDirIsSameAsNewSandbox(t *testing.T) {
+	dir := setupSandboxDir(t)
+
+	sb, err := soltesting.NewSandboxWithBaseDir(
+		filepath.Join(dir, "solution.yaml"),
+		"",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	defer sb.Cleanup()
+
+	// Solution should be at root level (no nesting)
+	assert.Equal(t, filepath.Join(sb.Path(), "solution.yaml"), sb.SolutionPath())
+}
+
+func TestNewSandboxWithBaseDir_CopyForTestPreservesBaseDir(t *testing.T) {
+	dir := setupSandboxDir(t)
+	writeSandboxFile(t, dir, "base.txt", "base content")
+	writeSandboxFile(t, dir, "extra.txt", "extra content")
+
+	// Create a base sandbox with baseDir
+	base, err := soltesting.NewSandboxWithBaseDir(
+		filepath.Join(dir, "solution.yaml"),
+		"sub",
+		nil,
+		[]string{"base.txt"},
+	)
+	require.NoError(t, err)
+	defer base.Cleanup()
+
+	// CopyForTest should preserve the baseDir nesting
+	child, err := base.CopyForTest(dir, []string{"extra.txt"})
+	require.NoError(t, err)
+	defer child.Cleanup()
+
+	// Solution should be nested in both
+	assert.Contains(t, child.SolutionPath(), filepath.Join("sub", "solution.yaml"))
+
+	// Both files should be nested under sub/
+	_, err = os.Stat(filepath.Join(child.Path(), "sub", "base.txt"))
+	assert.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(child.Path(), "sub", "extra.txt"))
+	assert.NoError(t, err)
+}
+
+func TestNewSandboxWithBaseDir_RejectsAbsolutePath(t *testing.T) {
+	dir := setupSandboxDir(t)
+	_, err := soltesting.NewSandboxWithBaseDir(
+		filepath.Join(dir, "solution.yaml"),
+		"/etc/evil",
+		nil,
+		nil,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a relative path")
+}
+
+func TestNewSandboxWithBaseDir_RejectsTraversal(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseDir string
+	}{
+		{"bare dotdot", ".."},
+		{"dotdot prefix", "../escape"},
+		{"nested dotdot", "foo/../../escape"},
+	}
+	dir := setupSandboxDir(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := soltesting.NewSandboxWithBaseDir(
+				filepath.Join(dir, "solution.yaml"),
+				tt.baseDir,
+				nil,
+				nil,
+			)
+			assert.Error(t, err, "baseDir %q should be rejected", tt.baseDir)
+			assert.Contains(t, err.Error(), "must not traverse")
+		})
+	}
+}

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -36,6 +36,12 @@ type ScaffoldInput struct {
 	// discovered through static analysis of provider inputs.
 	// These are automatically populated onto generated test cases.
 	FileDependencies []string
+
+	// SolutionSubdir is the subdirectory path of the solution file relative to
+	// the project root (e.g., "myapp" when the solution is at myapp/solution.yaml).
+	// When set, generated test cases include BaseDir so the test runner nests
+	// solution files under this subdirectory within the sandbox.
+	SolutionSubdir string
 }
 
 // Scaffold generates a skeleton test suite from the provided solution data.
@@ -76,6 +82,16 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 		for name, tc := range result.Cases {
 			if name != filesBaseTemplateName {
 				tc.Extends = []string{filesBaseTemplateName}
+			}
+		}
+	}
+
+	// When the solution lives in a subdirectory, set BaseDir on all non-template
+	// test cases so the runner nests solution files under this subdirectory within the sandbox.
+	if input.SolutionSubdir != "" {
+		for name, tc := range result.Cases {
+			if !strings.HasPrefix(name, "_") {
+				tc.BaseDir = input.SolutionSubdir
 			}
 		}
 	}
@@ -135,7 +151,7 @@ func addResolverTests(result *ScaffoldResult, resolvers map[string]*resolver.Res
 		// Generate a basic resolver output test
 		exitCodeZero := 0
 		testName := fmt.Sprintf("resolver-%s", name)
-		result.Cases[testName] = &TestCase{
+		tc := &TestCase{
 			Description: fmt.Sprintf("Verify resolver %q produces expected output", name),
 			Command:     []string{"run", "resolver"},
 			Args:        []string{"--resolver", name, "-o", "json"},
@@ -148,6 +164,14 @@ func addResolverTests(result *ScaffoldResult, resolvers map[string]*resolver.Res
 				},
 			},
 		}
+
+		// If the resolver uses a parameter provider, add an inputs entry with
+		// the default value (or a placeholder) so tests can override it.
+		if paramKey, paramDefault, ok := extractParameterDefault(r); ok {
+			tc.Inputs = map[string]string{paramKey: paramDefault}
+		}
+
+		result.Cases[testName] = tc
 
 		// If the resolver has validation rules, generate an expectFailure test
 		if r.Validate != nil && len(r.Validate.With) > 0 {
@@ -236,4 +260,52 @@ func ScaffoldToYAML(result *ScaffoldResult) ([]byte, error) {
 		},
 	}
 	return yaml.Marshal(wrapper)
+}
+
+// extractParameterDefault checks whether a resolver uses the "parameter"
+// provider and returns its parameter key, default value (or a placeholder),
+// and whether it was found.
+// The third return value is false if the resolver is not parameter-based.
+//
+// It detects defaults from two patterns:
+//  1. A static provider in the fallback chain after the parameter provider.
+//  2. No fallback -- returns "TODO" as a placeholder.
+func extractParameterDefault(r *resolver.Resolver) (string, string, bool) {
+	if r.Resolve == nil {
+		return "", "", false
+	}
+
+	hasParameter := false
+	paramKey := ""
+	for i, src := range r.Resolve.With {
+		if src.Provider == "parameter" {
+			hasParameter = true
+
+			// Extract the parameter key from inputs.key
+			if src.Inputs != nil {
+				if keyRef, ok := src.Inputs["key"]; ok && keyRef != nil {
+					if s, ok := keyRef.Literal.(string); ok && s != "" {
+						paramKey = s
+					}
+				}
+			}
+
+			// Check if next source in fallback chain is static with a literal value.
+			if paramKey != "" && i+1 < len(r.Resolve.With) {
+				next := r.Resolve.With[i+1]
+				if next.Provider == "static" && next.Inputs != nil {
+					if valRef, ok := next.Inputs["value"]; ok && valRef != nil {
+						if s, ok := valRef.Literal.(string); ok && s != "" {
+							return paramKey, s, true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if hasParameter && paramKey != "" {
+		return paramKey, "TODO", true
+	}
+	return "", "", false
 }

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -4,6 +4,7 @@
 package soltesting
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
@@ -273,4 +274,244 @@ func TestScaffold_EmptyFileDependenciesOmitted(t *testing.T) {
 		assert.Nil(t, tc.Files,
 			"test case %q should have nil Files when no dependencies discovered", name)
 	}
+}
+
+func TestScaffold_SolutionSubdirSetsBaseDir(t *testing.T) {
+	result := Scaffold(&ScaffoldInput{
+		SolutionSubdir: "myapp",
+	})
+
+	require.NotNil(t, result)
+
+	// Non-template cases should have BaseDir set
+	for name, tc := range result.Cases {
+		if strings.HasPrefix(name, "_") {
+			assert.Empty(t, tc.BaseDir, "template %q should not have BaseDir", name)
+		} else {
+			assert.Equal(t, "myapp", tc.BaseDir, "test case %q should have BaseDir", name)
+		}
+	}
+}
+
+func TestScaffold_NoSubdirNoBaseDir(t *testing.T) {
+	result := Scaffold(&ScaffoldInput{})
+
+	for name, tc := range result.Cases {
+		assert.Empty(t, tc.BaseDir, "test case %q should not have BaseDir when no subdir", name)
+	}
+}
+
+func TestScaffold_SolutionSubdirWithFileDeps(t *testing.T) {
+	result := Scaffold(&ScaffoldInput{
+		SolutionSubdir:   "nested/app",
+		FileDependencies: []string{"templates/main.yaml"},
+	})
+
+	// _files-base template should NOT have BaseDir
+	tmpl := result.Cases[filesBaseTemplateName]
+	require.NotNil(t, tmpl)
+	assert.Empty(t, tmpl.BaseDir)
+
+	// Non-template cases should have BaseDir
+	for name, tc := range result.Cases {
+		if name != filesBaseTemplateName {
+			assert.Equal(t, "nested/app", tc.BaseDir, "test case %q should have BaseDir", name)
+		}
+	}
+}
+
+func TestExtractParameterDefault_WithStaticFallback(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "parameter",
+					Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "env"},
+					},
+				},
+				{
+					Provider: "static",
+					Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "dev"},
+					},
+				},
+			},
+		},
+	}
+
+	key, val, ok := extractParameterDefault(r)
+	assert.True(t, ok)
+	assert.Equal(t, "env", key)
+	assert.Equal(t, "dev", val)
+}
+
+func TestExtractParameterDefault_NoFallback(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "parameter",
+					Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "env"},
+					},
+				},
+			},
+		},
+	}
+
+	key, val, ok := extractParameterDefault(r)
+	assert.True(t, ok)
+	assert.Equal(t, "env", key)
+	assert.Equal(t, "TODO", val)
+}
+
+func TestExtractParameterDefault_NonParameterProvider(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "static",
+					Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "hello"},
+					},
+				},
+			},
+		},
+	}
+
+	_, _, ok := extractParameterDefault(r)
+	assert.False(t, ok)
+}
+
+func TestExtractParameterDefault_NilResolve(t *testing.T) {
+	r := &resolver.Resolver{}
+	_, _, ok := extractParameterDefault(r)
+	assert.False(t, ok)
+}
+
+func TestExtractParameterDefault_EmptyKey(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "parameter",
+					// No inputs.key — paramKey will be empty
+				},
+			},
+		},
+	}
+	_, _, ok := extractParameterDefault(r)
+	assert.False(t, ok, "should return false when parameter key cannot be derived")
+}
+
+func TestExtractParameterDefault_EmptyKeyWithStaticFallback(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "parameter",
+					// No inputs.key — paramKey is empty
+				},
+				{
+					Provider: "static",
+					Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "default-val"},
+					},
+				},
+			},
+		},
+	}
+	_, _, ok := extractParameterDefault(r)
+	assert.False(t, ok, "should return false when parameter key is empty even with static fallback")
+}
+
+func TestExtractParameterDefault_KeyDiffersFromResolverName(t *testing.T) {
+	r := &resolver.Resolver{
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{
+					Provider: "parameter",
+					Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "environment"},
+					},
+				},
+				{
+					Provider: "static",
+					Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "staging"},
+					},
+				},
+			},
+		},
+	}
+
+	key, val, ok := extractParameterDefault(r)
+	assert.True(t, ok)
+	assert.Equal(t, "environment", key, "should use the parameter key, not the resolver name")
+	assert.Equal(t, "staging", val)
+}
+
+func TestScaffold_ParameterResolverGeneratesInputs(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"environment": {
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"key": {Literal: "environment"},
+							},
+						},
+						{
+							Provider: "static",
+							Inputs: map[string]*spec.ValueRef{
+								"value": {Literal: "dev"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	tc := result.Cases["resolver-environment"]
+	require.NotNil(t, tc)
+	// The Inputs key should be the parameter key ("environment"), not the resolver name
+	assert.Equal(t, map[string]string{"environment": "dev"}, tc.Inputs)
+}
+
+func TestScaffold_ParameterKeyDiffersFromResolverName(t *testing.T) {
+	input := &ScaffoldInput{
+		Resolvers: map[string]*resolver.Resolver{
+			"dbConfig": {
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{
+							Provider: "parameter",
+							Inputs: map[string]*spec.ValueRef{
+								"key": {Literal: "database_env"},
+							},
+						},
+						{
+							Provider: "static",
+							Inputs: map[string]*spec.ValueRef{
+								"value": {Literal: "dev"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := Scaffold(input)
+
+	tc := result.Cases["resolver-dbConfig"]
+	require.NotNil(t, tc)
+	// Key should be "database_env" (from parameter key), not "dbConfig" (resolver name)
+	assert.Equal(t, map[string]string{"database_env": "dev"}, tc.Inputs)
 }

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -12,6 +12,7 @@ package soltesting
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -424,6 +425,39 @@ type TestCase struct {
 
 	// Retries is the number of retry attempts for a failing test.
 	Retries int `json:"retries,omitempty" yaml:"retries,omitempty" doc:"Number of retry attempts for failing tests" maximum:"10"`
+
+	// BaseDir is an optional subdirectory path (relative to the sandbox root)
+	// that controls where the solution and its files are placed within the sandbox.
+	// When set, the sandbox nests all files under this subdirectory, preserving
+	// the directory structure so that repo-root-relative paths in resolvers
+	// resolve correctly.
+	//
+	// Example: if baseDir is "cldctl" and the solution references
+	// "./cldctl/output/data.json", the sandbox places the file at
+	// sandbox/cldctl/output/data.json and the solution at
+	// sandbox/cldctl/solution.yaml.
+	BaseDir string `json:"baseDir,omitempty" yaml:"baseDir,omitempty" doc:"Subdirectory within sandbox for nesting solution files" maxLength:"500"`
+
+	// Inputs maps parameter names to values. Each entry is translated to a
+	// -r key=value CLI argument appended after Args. This is a convenience
+	// shorthand so tests don't have to manually construct -r flags.
+	//
+	// Example:
+	//   inputs:
+	//     environment: prod
+	//     region: us-east-1
+	// is equivalent to: args: ["-r", "environment=prod", "-r", "region=us-east-1"]
+	Inputs map[string]string `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Parameter name to value map; translated to -r key=value args"`
+
+	// Mocks maps resolver names to canned values. Mocked resolvers skip
+	// execution entirely and return the specified value. This enables testing
+	// downstream resolvers and CEL expressions without hitting external APIs.
+	Mocks map[string]any `json:"mocks,omitempty" yaml:"mocks,omitempty" doc:"Resolver name to canned value map; mocked resolvers skip execution"`
+
+	// Services defines per-test background services that are started before
+	// and stopped after this specific test. These supplement (not replace)
+	// suite-level services defined in config.services.
+	Services []ServiceConfig `json:"services,omitempty" yaml:"services,omitempty" doc:"Per-test background services" maxItems:"10"`
 }
 
 // IsTemplate returns true if this test is a template (name starts with _).
@@ -482,9 +516,33 @@ func (tc *TestCase) Validate() error {
 		}
 	}
 
+	// Inputs + Args: reject resolver flags in Args when Inputs is also set
+	if len(tc.Inputs) > 0 {
+		for _, arg := range tc.Args {
+			if arg == "-r" || strings.HasPrefix(arg, "-r=") || arg == "--resolver" || strings.HasPrefix(arg, "--resolver=") {
+				errs = append(errs, "args must not contain resolver flags (-r/--resolver) when inputs is set; use inputs map instead")
+				break
+			}
+		}
+		for k := range tc.Inputs {
+			if k == "" {
+				errs = append(errs, "inputs key must not be empty")
+			}
+		}
+	}
+
 	// Retries validation
 	if tc.Retries < 0 || tc.Retries > MaxRetries {
 		errs = append(errs, fmt.Sprintf("retries must be between 0 and %d", MaxRetries))
+	}
+
+	// BaseDir validation: must be relative, no traversal above sandbox root
+	if tc.BaseDir != "" {
+		if filepath.IsAbs(tc.BaseDir) {
+			errs = append(errs, "baseDir must be a relative path")
+		} else if cleaned := filepath.Clean(tc.BaseDir); cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			errs = append(errs, "baseDir must not contain path traversal (..)")
+		}
 	}
 
 	// Field count limits

--- a/pkg/solution/soltesting/types_test.go
+++ b/pkg/solution/soltesting/types_test.go
@@ -386,6 +386,73 @@ func TestTestCase_Validate_NegativeTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "timeout must be positive")
 }
 
+func TestTestCase_Validate_BaseDirValid(t *testing.T) {
+	tc := &soltesting.TestCase{
+		Name:    "test",
+		Command: []string{"run", "resolver"},
+		BaseDir: "myapp",
+		Assertions: []soltesting.Assertion{
+			{Contains: "hello"},
+		},
+	}
+	err := tc.Validate()
+	assert.NoError(t, err)
+}
+
+func TestTestCase_Validate_BaseDirAbsoluteRejected(t *testing.T) {
+	tc := &soltesting.TestCase{
+		Name:    "test",
+		Command: []string{"run", "resolver"},
+		BaseDir: "/absolute/path",
+		Assertions: []soltesting.Assertion{
+			{Contains: "hello"},
+		},
+	}
+	err := tc.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "baseDir must be a relative path")
+}
+
+func TestTestCase_Validate_BaseDirTraversalRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseDir string
+	}{
+		{"parent dir", "../escape"},
+		{"bare dotdot", ".."},
+		{"nested traversal", "a/../../escape"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &soltesting.TestCase{
+				Name:    "test",
+				Command: []string{"run", "resolver"},
+				BaseDir: tt.baseDir,
+				Assertions: []soltesting.Assertion{
+					{Contains: "hello"},
+				},
+			}
+			err := tc.Validate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "baseDir must not contain path traversal")
+		})
+	}
+}
+
+func TestTestCase_Validate_BaseDirDotDotPrefix_NotTraversal(t *testing.T) {
+	tc := &soltesting.TestCase{
+		Name:    "test",
+		Command: []string{"run", "resolver"},
+		BaseDir: "..hidden",
+		Assertions: []soltesting.Assertion{
+			{Contains: "hello"},
+		},
+	}
+	err := tc.Validate()
+	assert.NoError(t, err, "directory names starting with .. but not a traversal segment should be allowed")
+}
+
 // --- Assertion.Validate tests ---
 
 func TestAssertion_Validate_ExactlyOneRequired(t *testing.T) {
@@ -681,4 +748,60 @@ func TestSkipValue_MarshalYAML_Expression(t *testing.T) {
 	data, err := yaml.Marshal(sv)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "os == 'linux'")
+}
+
+func TestValidate_InputsWithResolverFlags_InArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"standalone -r", []string{"-r", "env=prod"}},
+		{"-r= form", []string{"-r=env=prod"}},
+		{"--resolver", []string{"--resolver", "env=prod"}},
+		{"--resolver= form", []string{"--resolver=env=prod"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &soltesting.TestCase{
+				Name:    "bad-combo",
+				Command: []string{"run", "resolver"},
+				Args:    tt.args,
+				Inputs:  map[string]string{"env": "prod"},
+				Assertions: []soltesting.Assertion{
+					{Contains: "ok"},
+				},
+			}
+			err := tc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "resolver flags")
+		})
+	}
+}
+
+func TestValidate_InputsEmptyKey(t *testing.T) {
+	tc := &soltesting.TestCase{
+		Name:    "empty-key",
+		Command: []string{"run", "resolver"},
+		Inputs:  map[string]string{"": "val"},
+		Assertions: []soltesting.Assertion{
+			{Contains: "ok"},
+		},
+	}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inputs key must not be empty")
+}
+
+func TestValidate_InputsValid(t *testing.T) {
+	tc := &soltesting.TestCase{
+		Name:    "valid-inputs",
+		Command: []string{"run", "resolver"},
+		Inputs:  map[string]string{"env": "prod", "region": "us-east-1"},
+		Assertions: []soltesting.Assertion{
+			{Contains: "ok"},
+		},
+	}
+	err := tc.Validate()
+	assert.NoError(t, err)
 }

--- a/tests/integration/solutions/providers/per-test-services/solution.yaml
+++ b/tests/integration/solutions/providers/per-test-services/solution.yaml
@@ -1,0 +1,106 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-per-test-services
+  version: 1.0.0
+  description: |
+    Functional tests for per-test service overrides.
+    Verifies that individual test cases can start their own HTTP mock services
+    independent of suite-level services.
+
+spec:
+  resolvers:
+    apiData:
+      description: Fetches data from the mock API
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.testApiUrl + '/api/data'"
+              method: GET
+              autoParseJson: true
+
+    testApiUrl:
+      description: Base URL of mock server from env
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: TEST_API_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults, resolve-defaults]
+
+    cases:
+      _base:
+        description: Base template with private IP config for mock servers
+        command: [run, resolver]
+        args: ["-o", "json", "--config", "config.yaml"]
+        init:
+          - command: "printf 'httpClient:\\n  allowPrivateIPs: true\\n' > config.yaml"
+        assertions:
+          - expression: __exitCode == 0
+
+      success-response:
+        description: Per-test service returns a success response
+        extends: [_base]
+        services:
+          - name: test-api
+            type: http
+            baseUrlEnv: TEST_API_URL
+            routes:
+              - path: /api/data
+                method: GET
+                status: 200
+                body: '{"status":"ok","items":[1,2,3]}'
+                headers:
+                  Content-Type: application/json
+        assertions:
+          - expression: __output.apiData.body.status == "ok"
+            message: Per-test service should return the configured response
+          - expression: size(__output.apiData.body.items) == 3
+
+      error-response:
+        description: Per-test service returns an error response
+        extends: [_base]
+        services:
+          - name: test-api
+            type: http
+            baseUrlEnv: TEST_API_URL
+            routes:
+              - path: /api/data
+                method: GET
+                status: 500
+                body: '{"error":"internal server error"}'
+                headers:
+                  Content-Type: application/json
+        assertions:
+          - expression: __output.apiData.body.error == "internal server error"
+            message: Per-test service should return the error response
+
+      empty-response:
+        description: Per-test service returns an empty list
+        extends: [_base]
+        services:
+          - name: test-api
+            type: http
+            baseUrlEnv: TEST_API_URL
+            routes:
+              - path: /api/data
+                method: GET
+                status: 200
+                body: '{"status":"empty","items":[]}'
+                headers:
+                  Content-Type: application/json
+        assertions:
+          - expression: __output.apiData.body.status == "empty"
+          - expression: size(__output.apiData.body.items) == 0

--- a/tests/integration/solutions/resolvers/basedir/solution.yaml
+++ b/tests/integration/solutions/resolvers/basedir/solution.yaml
@@ -1,0 +1,53 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-basedir
+  version: 1.0.0
+  description: |
+    Functional tests for the baseDir test case field.
+    Verifies that baseDir nests solution files under a subdirectory
+    within the sandbox so the solution runs from the correct location.
+
+spec:
+  resolvers:
+    greeting:
+      description: Static greeting
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello from basedir test
+
+    computed:
+      description: Derived from greeting to verify resolver chaining works in sandbox
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.greeting + " (nested)"'
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      with-basedir:
+        description: Verify solution executes correctly when nested via baseDir
+        command: [run, resolver]
+        args: ["-o", "json"]
+        baseDir: myapp
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.greeting == "hello from basedir test"
+            message: Static resolver should work in nested sandbox
+          - expression: __output.computed == "hello from basedir test (nested)"
+            message: Chained resolver should work in nested sandbox
+
+      without-basedir:
+        description: Verify solution works without baseDir (sanity check)
+        command: [run, resolver]
+        args: ["-o", "json", "greeting"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.greeting == "hello from basedir test"

--- a/tests/integration/solutions/resolvers/inputs/solution.yaml
+++ b/tests/integration/solutions/resolvers/inputs/solution.yaml
@@ -1,0 +1,85 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-inputs-field
+  version: 1.0.0
+  description: |
+    Functional tests for the inputs test case field.
+    Verifies that the inputs map is translated to -r key=value CLI arguments
+    for the parameter provider.
+
+spec:
+  resolvers:
+    environment:
+      description: Target environment from parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: environment
+          - provider: static
+            inputs:
+              value: dev
+
+    region:
+      description: Target region from parameter
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-west-2
+
+    endpoint:
+      description: Builds an endpoint URL from environment and region
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"https://" + _.environment + "." + _.region + ".example.com"'
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      _base:
+        description: Base template for input tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+
+      defaults:
+        description: Without inputs, parameters use their defaults
+        extends: [_base]
+        assertions:
+          - expression: __output.environment == "dev"
+          - expression: __output.region == "us-west-2"
+          - expression: __output.endpoint == "https://dev.us-west-2.example.com"
+
+      override-single:
+        description: Override a single parameter via inputs
+        extends: [_base]
+        inputs:
+          environment: staging
+        assertions:
+          - expression: __output.environment == "staging"
+            message: Inputs should override the default value
+          - expression: __output.region == "us-west-2"
+            message: Unset inputs should keep their defaults
+          - expression: __output.endpoint == "https://staging.us-west-2.example.com"
+
+      override-multiple:
+        description: Override multiple parameters via inputs
+        extends: [_base]
+        inputs:
+          environment: prod
+          region: eu-west-1
+        assertions:
+          - expression: __output.environment == "prod"
+          - expression: __output.region == "eu-west-1"
+          - expression: __output.endpoint == "https://prod.eu-west-1.example.com"

--- a/tests/integration/solutions/resolvers/mocks/solution.yaml
+++ b/tests/integration/solutions/resolvers/mocks/solution.yaml
@@ -1,0 +1,78 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-mocks
+  version: 1.0.0
+  description: |
+    Functional tests for resolver mocking.
+    Verifies that the mocks field on test cases allows canned values
+    to be injected, skipping real resolver execution.
+
+spec:
+  resolvers:
+    apiToken:
+      description: Simulates an API token that normally comes from an external source
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: real-token-value
+
+    greeting:
+      description: Uses apiToken to build a greeting
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '"Bearer " + _.apiToken'
+
+    combined:
+      description: Combines greeting with a static suffix
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.greeting + " (authenticated)"'
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      _base:
+        description: Base template for mock tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+
+      no-mocks:
+        description: Without mocks, resolvers run normally
+        extends: [_base]
+        assertions:
+          - expression: __output.apiToken == "real-token-value"
+          - expression: __output.greeting == "Bearer real-token-value"
+
+      mock-single-resolver:
+        description: Mock a single resolver and verify downstream uses the mocked value
+        extends: [_base]
+        mocks:
+          apiToken: mocked-token
+        assertions:
+          - expression: __output.apiToken == "mocked-token"
+            message: Mocked resolver should return canned value
+          - expression: __output.greeting == "Bearer mocked-token"
+            message: Downstream resolver should use the mocked value
+
+      mock-multiple-resolvers:
+        description: Mock multiple resolvers independently
+        extends: [_base]
+        mocks:
+          apiToken: override-token
+          greeting: Custom Greeting
+        assertions:
+          - expression: __output.apiToken == "override-token"
+          - expression: __output.greeting == "Custom Greeting"
+          - expression: __output.combined == "Custom Greeting (authenticated)"
+            message: Downstream should use the mocked greeting


### PR DESCRIPTION
- add Inputs field to TestCase for declarative -r key=value arg generation, with sorted keys for deterministic ordering
- add Mocks field to TestCase for resolver mocking via temp JSON file and SCAFCTL_MOCKED_RESOLVERS_FILE env var
- add BaseDir field to TestCase and NewSandboxWithBaseDir() for nesting sandbox files under a subdirectory prefix
- add Services field to TestCase for per-test HTTP mock servers with automatic lifecycle management
- add WithMockedResolvers executor option to skip resolver execution and return canned values
- add loadMockedResolvers to CLI run commands for subprocess mock injection
- wire inheritance merging for Inputs (map merge), Mocks (map merge), Services (append), and BaseDir (scalar override)
- update scaffold generator to detect parameter providers and populate Inputs with defaults, and set BaseDir for subdirectory solutions
- fix auto-discovered solution path resolution: only set SolutionDirectory (not WorkingDirectory) so file-path providers resolve relative to the solution file
- fix pagination collectPath and stopWhen to use evaluateCELForPagination, tolerating missing keys on last page
- remove unused evaluateCEL function (replaced by evaluateCELForPagination)
- fix tc.Env mutation safety: clone map before injecting service env vars to prevent stale state on retries

Closes #293
Closes #299