### PR TITLE
feat(cli)!: improve lint table layout and replace stripExtension with stripSuffix

### DIFF
--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -1,0 +1,147 @@
+# Lint stress-test solution -- intentionally triggers many lint rules.
+# Run: scafctl lint -f examples/solutions/lint-stress-test/solution.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-stress-test
+  description: Triggers many lint rules for testing table output
+
+spec:
+  resolvers:
+    # missing-provider
+    bad_provider:
+      type: string
+      resolve:
+        with:
+          - provider: nonexistent-provider
+            inputs:
+              value: hello
+
+    # invalid-expression (bad CEL in when)
+    guarded:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            when: "this is not valid cel %%!!"
+            inputs:
+              value: fallback
+
+    # unused-resolver + missing-description
+    orphan_value:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "nobody uses me"
+
+    # another unused-resolver + missing-description
+    orphan_two:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "also unused"
+
+    # long-timeout
+    slow_call:
+      type: string
+      description: This takes too long
+      timeout: 600s
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "slow"
+
+    # non-validation-provider in validate block
+    wrong_validate:
+      type: string
+      description: Uses wrong provider for validation
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "test"
+      validate:
+        with:
+          - provider: static
+            inputs:
+              value: "true"
+
+    # empty-transform-with
+    empty_transform:
+      type: string
+      description: Has empty transform
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "raw"
+      transform:
+        with: []
+
+    # empty-validate-with
+    empty_validate:
+      type: string
+      description: Has empty validate
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "raw"
+      validate:
+        with: []
+
+    # permissive-result-schema (no constraints)
+    loose_schema:
+      type: string
+      description: Result schema too loose
+      resultSchema:
+        type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "anything goes"
+
+    # missing-description (another one)
+    no_desc:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.bad_provider + _.guarded"
+
+    # used resolver so not everything is unused
+    main_output:
+      type: string
+      description: The main resolver
+      dependsOn:
+        - bad_provider
+        - guarded
+        - slow_call
+        - wrong_validate
+        - empty_transform
+        - empty_validate
+        - loose_schema
+        - no_desc
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "done"
+
+  workflow:
+    actions:
+      deploy:
+        description: Deploy action
+        steps:
+          - provider: exec
+            inputs:
+              command: "echo $USER_INPUT"

--- a/pkg/auth/entra/authcode_flow_test.go
+++ b/pkg/auth/entra/authcode_flow_test.go
@@ -446,12 +446,30 @@ func TestAuthCodeLogin_BrowserOpenFails_PrintsURL(t *testing.T) {
 	_ = callbackMessage
 }
 
-func TestDefaultFlowIsDeviceCode(t *testing.T) {
+func TestDefaultFlowIsInteractive(t *testing.T) {
+	// Verify that DefaultConfig() picks up the interactive default from
+	// embedded defaults.yaml without actually triggering a Login() call
+	// (which would open a real browser).
+	cfg := DefaultConfig()
+	assert.Equal(t, string(auth.FlowInteractive), cfg.DefaultFlow,
+		"embedded defaults.yaml should set defaultFlow to interactive")
+
+	// Verify DetectFlow uses the configured default when no explicit flow
+	// is set and no environment credentials are detected.
+	result := auth.DetectFlow("", nil, auth.Flow(cfg.DefaultFlow))
+	assert.Equal(t, auth.FlowInteractive, result.Flow,
+		"DetectFlow should resolve to interactive when that is the configured default")
+}
+
+func TestDefaultFlowOverrideDeviceCode(t *testing.T) {
 	store := secrets.NewMockStore()
 	mockHTTP := NewMockHTTPClient()
 
+	cfg := fastPollConfig()
+	cfg.DefaultFlow = string(auth.FlowDeviceCode)
+
 	handler, err := New(
-		WithConfig(fastPollConfig()),
+		WithConfig(cfg),
 		WithSecretStore(store),
 		WithHTTPClient(mockHTTP),
 	)
@@ -476,7 +494,6 @@ func TestDefaultFlowIsDeviceCode(t *testing.T) {
 
 	var callbackCalled bool
 	ctx := context.Background()
-	// Login with no explicit flow (empty Flow field) -- should use device code.
 	result, err := handler.Login(ctx, auth.LoginOptions{
 		Timeout: 10 * time.Second,
 		DeviceCodeCallback: func(userCode, verificationURI, message string) {
@@ -486,13 +503,12 @@ func TestDefaultFlowIsDeviceCode(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.True(t, callbackCalled, "device code callback should have been called for default flow")
+	assert.True(t, callbackCalled, "device code callback should have been called")
 
-	// Verify device code endpoint was called (first request)
 	requests := mockHTTP.GetRequests()
 	require.GreaterOrEqual(t, len(requests), 1)
 	assert.Contains(t, requests[0].Endpoint, "/devicecode",
-		"default flow should hit the device code endpoint, not the authorize endpoint")
+		"overridden flow should hit the device code endpoint")
 }
 
 func TestExchangeAuthCode_NoClientSecret(t *testing.T) {

--- a/pkg/auth/entra/config.go
+++ b/pkg/auth/entra/config.go
@@ -45,6 +45,11 @@ type Config struct {
 	// DefaultScopes are requested during initial login if not specified.
 	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" doc:"Default OAuth scopes"`
 
+	// DefaultFlow is the authentication flow used when no explicit flow is
+	// requested and no environment credentials are detected.
+	// Valid values: "interactive" (auth code + PKCE), "device_code".
+	DefaultFlow string `json:"defaultFlow,omitempty" yaml:"defaultFlow,omitempty" doc:"Default interactive auth flow"`
+
 	// MinPollInterval is the minimum interval between device code poll requests.
 	// Defaults to 5 seconds per OAuth 2.0 spec. Only set lower for testing.
 	MinPollInterval time.Duration `json:"-" yaml:"-"`
@@ -80,6 +85,9 @@ func DefaultConfig() *Config {
 		}
 		if len(d.DefaultScopes) > 0 {
 			cfg.DefaultScopes = d.DefaultScopes
+		}
+		if d.DefaultFlow != "" {
+			cfg.DefaultFlow = d.DefaultFlow
 		}
 	}
 

--- a/pkg/auth/entra/config_test.go
+++ b/pkg/auth/entra/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.NotNil(t, embedded, "defaults.yaml must contain auth.entra section")
 	assert.Equal(t, embedded.DefaultScopes, cfg.DefaultScopes)
 	assert.Equal(t, embedded.Authority, cfg.Authority)
+	assert.Equal(t, embedded.DefaultFlow, cfg.DefaultFlow, "DefaultFlow should come from embedded defaults.yaml")
 	assert.Equal(t, DefaultMinPollInterval, cfg.MinPollInterval)
 	assert.Equal(t, 5*time.Second, cfg.SlowDownIncrement)
 }
@@ -184,4 +186,31 @@ func BenchmarkQualifyScope(b *testing.B) {
 	for b.Loop() {
 		QualifyScope("User.Read")
 	}
+}
+
+func TestWithConfig_MergesDefaultFlow(t *testing.T) {
+	store := secrets.NewMockStore()
+
+	handler, err := New(
+		WithConfig(&Config{
+			DefaultFlow: "device_code",
+		}),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "device_code", handler.config.DefaultFlow)
+}
+
+func TestWithConfig_PreservesExistingDefaultFlow(t *testing.T) {
+	store := secrets.NewMockStore()
+
+	// Empty DefaultFlow should not overwrite the default from DefaultConfig().
+	handler, err := New(
+		WithConfig(&Config{
+			ClientID: "custom-client",
+		}),
+		WithSecretStore(store),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, handler.config.DefaultFlow, "DefaultFlow from defaults.yaml should be preserved")
 }

--- a/pkg/auth/entra/handler.go
+++ b/pkg/auth/entra/handler.go
@@ -88,6 +88,9 @@ func WithConfig(cfg *Config) Option {
 			if cfg.SlowDownIncrement > 0 {
 				h.config.SlowDownIncrement = cfg.SlowDownIncrement
 			}
+			if cfg.DefaultFlow != "" {
+				h.config.DefaultFlow = cfg.DefaultFlow
+			}
 		}
 	}
 }
@@ -249,28 +252,40 @@ func (h *Handler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Resu
 		return nil, err
 	}
 
-	// Check if workload identity flow is requested or detected (highest priority)
-	if opts.Flow == auth.FlowWorkloadIdentity || (opts.Flow == "" && HasWorkloadIdentityCredentials()) {
+	// Determine which flow to use. Priority:
+	//   1. Explicit --flow flag (opts.Flow)
+	//   2. Detected environment credentials (workload identity, service principal)
+	//   3. Configured default flow (h.config.DefaultFlow, set via defaults.yaml
+	//      or embedder config)
+	//   4. device_code (hard fallback)
+	defaultFlow := auth.Flow(h.config.DefaultFlow)
+	if defaultFlow == "" {
+		defaultFlow = auth.FlowDeviceCode
+	}
+
+	result := auth.DetectFlow(opts.Flow, []auth.CredentialDetector{
+		{
+			HasCredentials: HasWorkloadIdentityCredentials,
+			Flow:           auth.FlowWorkloadIdentity,
+			Description:    "workload identity credentials detected",
+		},
+		{
+			HasCredentials: HasServicePrincipalCredentials,
+			Flow:           auth.FlowServicePrincipal,
+			Description:    "service principal credentials detected",
+		},
+	}, defaultFlow)
+
+	switch result.Flow {
+	case auth.FlowWorkloadIdentity:
 		return h.workloadIdentityLogin(ctx, opts)
-	}
-
-	// Check if service principal flow is requested or detected
-	if opts.Flow == auth.FlowServicePrincipal || (opts.Flow == "" && HasServicePrincipalCredentials()) {
+	case auth.FlowServicePrincipal:
 		return h.servicePrincipalLogin(ctx, opts)
-	}
-
-	// Interactive (auth code + PKCE) only when explicitly requested.
-	// Auth code flow opens a browser tab that may not carry the device PRT
-	// (Primary Refresh Token) on non-Edge browsers, causing Conditional
-	// Access device-compliance failures.
-	if opts.Flow == auth.FlowInteractive {
+	case auth.FlowInteractive:
 		return h.authCodeLogin(ctx, opts)
+	default:
+		return h.deviceCodeLogin(ctx, opts)
 	}
-
-	// Default to device code flow -- microsoft.com/devicelogin inherits
-	// the browser's existing SSO session (including the PRT), so
-	// Conditional Access device compliance works in any browser.
-	return h.deviceCodeLogin(ctx, opts)
 }
 
 // Logout clears stored credentials and cached tokens.

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -111,28 +111,41 @@ func NewRemoteCatalog(cfg RemoteCatalogConfig) (*RemoteCatalog, error) {
 
 	if cfg.CredentialStore != nil {
 		if cfg.AuthHandler != nil {
-			// Composite credential function: try static credentials first,
-			// fall back to dynamic auth handler bridge
+			// Composite credential function: try auth handler bridge first
+			// (explicit user login), fall back to Docker/native credentials.
+			// This ensures a fresh `auth login <provider>` token is not
+			// shadowed by stale Docker config entries.
 			client.Credential = func(ctx context.Context, host string) (auth.Credential, error) {
+				username, password, bridgeErr := BridgeAuthToRegistry(ctx, cfg.AuthHandler, host, cfg.AuthScope)
+				if bridgeErr == nil {
+					// Auth handler bridge succeeded. Log a warning if Docker
+					// config also has credentials for this host, since those
+					// would have silently taken precedence before this fix.
+					if cfg.Logger.V(1).Enabled() {
+						if dockerCred, dockerSource, _ := cfg.CredentialStore.CredentialWithSource(ctx, host); dockerCred != auth.EmptyCredential {
+							cfg.Logger.V(1).Info("authProvider token used; Docker config credentials for this host were skipped",
+								"handler", cfg.AuthHandler.Name(),
+								"host", host,
+								"dockerSource", dockerSource)
+						}
+					}
+					rc.credentialSource.Store(fmt.Sprintf("%s auth handler token", cfg.AuthHandler.Name()))
+					return auth.Credential{
+						Username: username,
+						Password: password,
+					}, nil
+				}
+				cfg.Logger.V(1).Info("auth handler bridge failed, trying credential store",
+					"handler", cfg.AuthHandler.Name(),
+					"host", host,
+					"error", bridgeErr.Error())
+				// Fall back to credential store (Docker config, native store, etc.)
 				cred, source, err := cfg.CredentialStore.CredentialWithSource(ctx, host)
 				if err == nil && cred != auth.EmptyCredential {
 					rc.credentialSource.Store(source)
 					return cred, nil
 				}
-				// Fall back to auth handler bridge
-				username, password, bridgeErr := BridgeAuthToRegistry(ctx, cfg.AuthHandler, host, cfg.AuthScope)
-				if bridgeErr != nil {
-					cfg.Logger.V(1).Info("auth handler bridge failed, using anonymous",
-						"handler", cfg.AuthHandler.Name(),
-						"host", host,
-						"error", bridgeErr.Error())
-					return auth.EmptyCredential, nil
-				}
-				rc.credentialSource.Store(fmt.Sprintf("%s auth handler token", cfg.AuthHandler.Name()))
-				return auth.Credential{
-					Username: username,
-					Password: password,
-				}, nil
+				return auth.EmptyCredential, nil
 			}
 		} else {
 			client.Credential = func(ctx context.Context, host string) (auth.Credential, error) {
@@ -245,6 +258,31 @@ func isOCIAuthError(err error) bool {
 		strings.Contains(s, "403") ||
 		strings.Contains(s, "unauthorized") ||
 		strings.Contains(s, "denied")
+}
+
+// isOCIServerError returns true if the error looks like a registry
+// internal server error (HTTP 500). The match uses "status code 500" to
+// avoid false positives on port numbers like ":5000".
+func isOCIServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "status code 500") || strings.Contains(s, "INTERNAL_SERVER_ERROR")
+}
+
+// wrapWithCredentialHint enriches err with a credential diagnostic hint when
+// the registry returned a 500 and the catalog was using non-anonymous credentials.
+// Some registries (e.g. ACR) return 500 instead of 401 for expired tokens.
+func (c *RemoteCatalog) wrapWithCredentialHint(err error) error {
+	if err == nil || !isOCIServerError(err) {
+		return err
+	}
+	src := c.CredentialSource()
+	if src == "" {
+		return err
+	}
+	return fmt.Errorf("%w (hint: registry returned 500 while using %q credentials -- the token may be expired; try re-authenticating)", err, src)
 }
 
 // anonymousClient returns a plain auth.Client with no credentials.
@@ -489,7 +527,7 @@ func (c *RemoteCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, Artif
 		}
 		return data, info, nil
 	}
-	return data, info, err
+	return data, info, c.wrapWithCredentialHint(err)
 }
 
 func (c *RemoteCatalog) fetchInternal(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
@@ -569,7 +607,7 @@ func (c *RemoteCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]b
 		}
 		return data, bundle, info, nil
 	}
-	return data, bundle, info, err
+	return data, bundle, info, c.wrapWithCredentialHint(err)
 }
 
 func (c *RemoteCatalog) fetchWithBundleInternal(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
@@ -1231,7 +1269,7 @@ func (c *RemoteCatalog) ListTags(ctx context.Context, ref Reference) ([]TagInfo,
 		}
 		return tags, nil
 	}
-	return tags, err
+	return tags, c.wrapWithCredentialHint(err)
 }
 
 func (c *RemoteCatalog) listTagsFromRepo(ctx context.Context, repo *remote.Repository, ref Reference) ([]TagInfo, error) {
@@ -1476,7 +1514,7 @@ func (c *RemoteCatalog) CopyTo(ctx context.Context, ref Reference, target *Local
 		}
 		return info, nil
 	}
-	return info, err
+	return info, c.wrapWithCredentialHint(err)
 }
 
 func (c *RemoteCatalog) copyToInternal(ctx context.Context, ref Reference, target *LocalCatalog, opts CopyOptions) (ArtifactInfo, error) {

--- a/pkg/catalog/remote_test.go
+++ b/pkg/catalog/remote_test.go
@@ -947,3 +947,149 @@ func TestDiscoveredArtifact_ToAnnotations(t *testing.T) {
 		assert.Empty(t, ann)
 	})
 }
+
+func TestIsOCIServerError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"generic error", fmt.Errorf("network timeout"), false},
+		{"401 is not server error", fmt.Errorf("response status code 401"), false},
+		{"500 status", fmt.Errorf("response status code 500"), true},
+		{"INTERNAL_SERVER_ERROR keyword", fmt.Errorf("INTERNAL_SERVER_ERROR"), true},
+		{"nested 500", fmt.Errorf("failed: %w", fmt.Errorf("response status code 500: error")), true},
+		{"port 5000 is not server error", fmt.Errorf("connect to localhost:5000 failed"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isOCIServerError(tt.err))
+		})
+	}
+}
+
+func TestWrapWithCredentialHint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		t.Parallel()
+		cat := &RemoteCatalog{logger: logr.Discard()}
+		assert.NoError(t, cat.wrapWithCredentialHint(nil))
+	})
+
+	t.Run("non-500 error passes through", func(t *testing.T) {
+		t.Parallel()
+		cat := &RemoteCatalog{logger: logr.Discard()}
+		cat.credentialSource.Store("docker config static auth")
+		original := fmt.Errorf("network timeout")
+		result := cat.wrapWithCredentialHint(original)
+		assert.Equal(t, original, result)
+	})
+
+	t.Run("500 with anonymous creds passes through", func(t *testing.T) {
+		t.Parallel()
+		cat := &RemoteCatalog{logger: logr.Discard()}
+		// no credential source stored → anonymous
+		original := fmt.Errorf("response status code 500")
+		result := cat.wrapWithCredentialHint(original)
+		assert.Equal(t, original, result)
+	})
+
+	t.Run("500 with credentials adds hint", func(t *testing.T) {
+		t.Parallel()
+		cat := &RemoteCatalog{logger: logr.Discard()}
+		cat.credentialSource.Store("docker config static auth")
+		original := fmt.Errorf("response status code 500")
+		result := cat.wrapWithCredentialHint(original)
+		assert.ErrorIs(t, result, original)
+		assert.Contains(t, result.Error(), "hint:")
+		assert.Contains(t, result.Error(), "docker config static auth")
+		assert.Contains(t, result.Error(), "expired")
+	})
+}
+
+func TestAuthHandlerPrecedenceOverDockerConfig(t *testing.T) {
+	t.Parallel()
+
+	// Set up a mock auth handler that returns a valid token.
+	handler := scafctlauth.NewMockHandler("entra")
+	handler.GetTokenResult = &scafctlauth.Token{AccessToken: "fresh-entra-token"}
+	handler.StatusResult = &scafctlauth.Status{
+		Authenticated: true,
+		Claims:        &scafctlauth.Claims{Username: "testuser"},
+	}
+
+	// Set up a credential store with static Docker config creds for the same host.
+	credStore := &CredentialStore{
+		config: &dockerConfig{
+			Auths: map[string]dockerAuthEntry{
+				"myregistry.azurecr.io": {
+					Username: "stale-user",
+					Password: "stale-password",
+				},
+			},
+		},
+		logger: logr.Discard(),
+	}
+
+	// Create catalog with both credential store and auth handler.
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:            "test",
+		Registry:        "myregistry.azurecr.io",
+		Repository:      "org/repo",
+		CredentialStore: credStore,
+		AuthHandler:     handler,
+		Logger:          logr.Discard(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cat.client.Credential)
+
+	// Call the credential function and verify the auth handler is used, not Docker config.
+	cred, err := cat.client.Credential(context.Background(), "myregistry.azurecr.io")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-entra-token", cred.Password, "auth handler token should take precedence over Docker config")
+	assert.Equal(t, "entra auth handler token", cat.CredentialSource(), "credential source should indicate auth handler")
+}
+
+func TestAuthHandlerFallsBackToCredentialStore(t *testing.T) {
+	t.Parallel()
+
+	// Set up a mock auth handler that fails to produce a token.
+	handler := scafctlauth.NewMockHandler("entra")
+	handler.GetTokenErr = fmt.Errorf("token expired")
+
+	// Set up a credential store with valid static Docker config creds.
+	credStore := &CredentialStore{
+		config: &dockerConfig{
+			Auths: map[string]dockerAuthEntry{
+				"myregistry.azurecr.io": {
+					Username: "docker-user",
+					Password: "docker-password",
+				},
+			},
+		},
+		logger: logr.Discard(),
+	}
+
+	cat, err := NewRemoteCatalog(RemoteCatalogConfig{
+		Name:            "test",
+		Registry:        "myregistry.azurecr.io",
+		Repository:      "org/repo",
+		CredentialStore: credStore,
+		AuthHandler:     handler,
+		Logger:          logr.Discard(),
+	})
+	require.NoError(t, err)
+
+	// When auth handler fails, credential store should be used.
+	cred, err := cat.client.Credential(context.Background(), "myregistry.azurecr.io")
+	require.NoError(t, err)
+	assert.Equal(t, "docker-user", cred.Username, "should fall back to Docker config when auth handler fails")
+	assert.Equal(t, "docker-password", cred.Password)
+	assert.Equal(t, "docker config static auth", cat.CredentialSource())
+}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -108,13 +108,14 @@ func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDO
 		entraCfg.ClientID = cfg.Auth.Entra.ClientID
 		entraCfg.TenantID = cfg.Auth.Entra.TenantID
 		entraCfg.DefaultScopes = cfg.Auth.Entra.DefaultScopes
+		entraCfg.DefaultFlow = cfg.Auth.Entra.DefaultFlow
 	}
 
 	applyOverride(&entraCfg.TenantID, tenantOverride)
 	applyOverride(&entraCfg.ClientID, clientIDOverride)
 
 	var opts []entra.Option
-	if entraCfg.ClientID != "" || entraCfg.TenantID != "" || len(entraCfg.DefaultScopes) > 0 {
+	if entraCfg.ClientID != "" || entraCfg.TenantID != "" || len(entraCfg.DefaultScopes) > 0 || entraCfg.DefaultFlow != "" {
 		opts = append(opts, entra.WithConfig(entraCfg))
 	}
 	opts = append(opts, entra.WithLogger(*logger.FromContext(ctx)))

--- a/pkg/cmd/scafctl/catalog/remote.go
+++ b/pkg/cmd/scafctl/catalog/remote.go
@@ -140,7 +140,7 @@ func runRemoteAdd(ctx context.Context, opts *RemoteAddOptions) error {
 		}
 	}
 
-	mgr := appconfig.NewManager(opts.ConfigPath)
+	mgr := appconfig.NewManager(opts.ConfigPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	cfg, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)
@@ -236,7 +236,7 @@ func commandRemoteRemove(cliParams *settings.Run, ioStreams *terminal.IOStreams,
 func runRemoteRemove(ctx context.Context, opts *RemoteRemoveOptions) error {
 	w := writer.FromContext(ctx)
 
-	mgr := appconfig.NewManager(opts.ConfigPath)
+	mgr := appconfig.NewManager(opts.ConfigPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	cfg, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)
@@ -319,7 +319,7 @@ func commandRemoteSetDefault(cliParams *settings.Run, ioStreams *terminal.IOStre
 func runRemoteSetDefault(ctx context.Context, opts *RemoteSetDefaultOptions) error {
 	w := writer.FromContext(ctx)
 
-	mgr := appconfig.NewManager(opts.ConfigPath)
+	mgr := appconfig.NewManager(opts.ConfigPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	cfg, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)
@@ -419,7 +419,7 @@ func commandRemoteList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _
 func runRemoteList(ctx context.Context, configPath string, outputOpts *kvx.OutputOptions) error {
 	w := writer.FromContext(ctx)
 
-	mgr := appconfig.NewManager(configPath)
+	mgr := appconfig.NewManager(configPath, appconfig.ManagerOptionsFromContext(ctx)...)
 	cfg, err := mgr.Load()
 	if err != nil {
 		w.Errorf("%v", err)

--- a/pkg/cmd/scafctl/catalog/remote_test.go
+++ b/pkg/cmd/scafctl/catalog/remote_test.go
@@ -444,3 +444,46 @@ func TestRunRemoteList_Empty(t *testing.T) {
 	err = runRemoteList(ctx, configPath, outputOpts)
 	require.NoError(t, err)
 }
+
+// TestRunRemoteList_EmbedderConfigDefaults verifies that catalogs injected
+// via WithBaseConfig (the embedder pattern) appear in the listing when
+// ManagerOptionsFromContext propagates the options through the context.
+func TestRunRemoteList_EmbedderConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Empty on-disk config -- no catalogs defined by the user.
+	err := os.WriteFile(configPath, []byte(""), 0o600)
+	require.NoError(t, err)
+
+	// Embedder injects its own catalog via WithBaseConfig.
+	embedderDefaults := []byte(`
+catalogs:
+  - name: embedder-catalog
+    type: oci
+    url: oci://ghcr.io/embedder/catalog
+`)
+	configOpts := []appconfig.ManagerOption{
+		appconfig.WithBaseConfig(embedderDefaults),
+	}
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = appconfig.WithManagerOptions(ctx, configOpts)
+
+	outputOpts := kvxOutputForTest(ioStreams)
+
+	err = runRemoteList(ctx, configPath, outputOpts)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	assert.Contains(t, output, "embedder-catalog", "embedder catalog must appear in listing")
+	assert.Contains(t, output, "oci://ghcr.io/embedder/catalog")
+}

--- a/pkg/cmd/scafctl/config/config.go
+++ b/pkg/cmd/scafctl/config/config.go
@@ -48,6 +48,7 @@ func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 	cCmd.AddCommand(CommandGet(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandSet(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandUnset(cliParams, ioStreams, cmdPath))
+	cCmd.AddCommand(CommandReset(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandValidate(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandSchema(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandPaths(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/config/config_test.go
+++ b/pkg/cmd/scafctl/config/config_test.go
@@ -42,6 +42,7 @@ func TestCommandConfig(t *testing.T) {
 	assert.Contains(t, subCmdNames, "get")
 	assert.Contains(t, subCmdNames, "set")
 	assert.Contains(t, subCmdNames, "unset")
+	assert.Contains(t, subCmdNames, "reset")
 }
 
 func TestViewOptions_Run(t *testing.T) {

--- a/pkg/cmd/scafctl/config/reset.go
+++ b/pkg/cmd/scafctl/config/reset.go
@@ -1,0 +1,164 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	appconfig "github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// ResetOptions holds options for the config reset command.
+type ResetOptions struct {
+	IOStreams  *terminal.IOStreams
+	CliParams  *settings.Run
+	ConfigPath string
+	Force      bool
+	All        bool
+}
+
+// CommandReset creates the 'config reset' command.
+//
+//nolint:dupl // Cobra command boilerplate is intentionally similar across commands
+func CommandReset(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &ResetOptions{}
+
+	cCmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset configuration to defaults",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Reset the configuration file to defaults.
+
+			This removes the existing config file and re-creates it from the
+			defaults, whether they are embedded or supplied by the embedder.
+			User customizations will be lost.
+
+			Use --all to also clear cache and data directories (catalogs,
+			secrets, build cache, plugins, HTTP cache).
+
+			Requires --force to confirm.
+
+			Examples:
+			  # Reset config file to defaults
+			  scafctl config reset --force
+
+			  # Reset everything: config, cache, and data
+			  scafctl config reset --all --force
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.NoArgs,
+		RunE: func(cCmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
+			ctx := settings.IntoContext(cCmd.Context(), cliParams)
+
+			if lgr := logger.FromContext(cCmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			w := writer.FromContext(cCmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			opts.IOStreams = ioStreams
+			opts.CliParams = cliParams
+
+			if configFlag := cCmd.Root().Flag("config"); configFlag != nil && configFlag.Value.String() != "" {
+				opts.ConfigPath = configFlag.Value.String()
+			}
+
+			return opts.Run(ctx)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().BoolVar(&opts.Force, "force", false, "Confirm destructive reset")
+	cCmd.Flags().BoolVar(&opts.All, "all", false, "Also clear cache and data directories")
+
+	return cCmd
+}
+
+// Run executes the config reset command.
+func (o *ResetOptions) Run(ctx context.Context) error {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	if !o.Force {
+		err := fmt.Errorf("reset is destructive; pass --force to confirm")
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	configPath := o.ConfigPath
+	if configPath == "" {
+		var err error
+		configPath, err = paths.ConfigFile()
+		if err != nil {
+			err = fmt.Errorf("failed to determine config path: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.ConfigError)
+		}
+	}
+
+	// Remove existing config file.
+	if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+		err = fmt.Errorf("removing config file: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.ConfigError)
+	}
+
+	// Re-create from defaults. Use embedder defaults when available so
+	// that an embedding CLI (e.g. cldctl) resets to its own defaults
+	// rather than scafctl's built-in defaults.
+	baseDefaults := appconfig.BaseDefaultsFromContext(ctx)
+	var ensureErr error
+	if len(baseDefaults) > 0 {
+		ensureErr = appconfig.EnsureDefaultsWith(configPath, baseDefaults)
+	} else {
+		ensureErr = appconfig.EnsureDefaults(configPath)
+	}
+	if ensureErr != nil {
+		err := fmt.Errorf("writing default config: %w", ensureErr)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.ConfigError)
+	}
+
+	w.Successf("Reset config file: %s", configPath)
+
+	if o.All {
+		dirs := []struct {
+			name string
+			path string
+		}{
+			{"cache", paths.CacheDir()},
+			{"data", paths.DataDir()},
+			{"state", paths.StateDir()},
+		}
+
+		for _, d := range dirs {
+			if err := os.RemoveAll(d.path); err != nil {
+				err = fmt.Errorf("removing %s directory %s: %w", d.name, d.path, err)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+			w.Successf("Cleared %s directory: %s", d.name, d.path)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/scafctl/config/reset_test.go
+++ b/pkg/cmd/scafctl/config/reset_test.go
@@ -1,0 +1,282 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	appconfig "github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandReset_Registration(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}, false)
+
+	cmd := CommandReset(cliParams, ioStreams, "scafctl/config")
+	assert.Equal(t, "reset", cmd.Use)
+}
+
+func TestResetOptions_RequiresForce(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("custom: true"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      false,
+	}
+
+	err := opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestResetOptions_ResetsConfigFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("custom: true\nsettings:\n  noColor: true"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      true,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	// Config file should exist and contain defaults (not our custom value).
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "custom: true")
+}
+
+func TestResetOptions_AllSucceeds(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(""), 0o600))
+
+	// The --all flag removes real XDG cache/data/state dirs which we cannot
+	// inject in a unit test. This test validates the --force + --all
+	// combination succeeds without error.
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      true,
+		All:        true,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	// Config file should be recreated with defaults.
+	_, err = os.Stat(configPath)
+	require.NoError(t, err, "config file should exist after reset")
+}
+
+func TestResetOptions_NoExistingConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	// Don't create the file -- reset should still succeed.
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      true,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	// Config file should be created from defaults.
+	_, err = os.Stat(configPath)
+	require.NoError(t, err)
+}
+
+func TestResetOptions_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams := terminal.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}, false)
+
+	cmd := CommandReset(cliParams, ioStreams, "mycli/config")
+	assert.Equal(t, "reset", cmd.Use)
+	assert.NotContains(t, cmd.Long, "scafctl")
+}
+
+func TestResetOptions_UsesEmbedderDefaults(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("custom: true"), 0o600))
+
+	embedderDefaults := []byte(`auth:
+  entra:
+    clientId: embedder-client-id
+    tenantId: embedder-tenant
+catalogs:
+  - name: local
+    type: filesystem
+  - name: corp-registry
+    type: oci
+    url: oci://registry.corp.example.com/myorg
+settings:
+  defaultCatalog: corp-registry
+`)
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = appconfig.WithBaseDefaults(ctx, embedderDefaults)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      true,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "embedder-client-id", "reset should use embedder defaults")
+	assert.Contains(t, content, "embedder-tenant", "reset should use embedder defaults")
+	assert.Contains(t, content, "corp-registry", "reset should include embedder catalogs")
+	assert.NotContains(t, content, "custom: true", "user customizations should be removed")
+}
+
+func TestResetOptions_NilWriter(t *testing.T) {
+	t.Parallel()
+
+	// Run without a writer in context.
+	ctx := context.Background()
+	opts := &ResetOptions{Force: true}
+
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestResetOptions_RemoveError(t *testing.T) {
+	t.Parallel()
+
+	// Point configPath at an unremovable path (directory instead of file).
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "protected")
+	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "child"), 0o700))
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configDir, // directory, not a file -- os.Remove will fail
+		Force:      true,
+	}
+
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "removing config file")
+}
+
+func TestResetOptions_SuccessOutput(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	opts := &ResetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Force:      true,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Reset config file")
+}
+
+func BenchmarkCommandReset(b *testing.B) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CommandReset(cliParams, ioStreams, "scafctl/config")
+	}
+}

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -9,12 +9,8 @@ package lint
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/term"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/kvx/pkg/tui"
@@ -160,41 +156,16 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	return cmd
 }
 
-// findingsColumnHints builds column hints with a message width that fills the
-// available terminal width. Fixed columns (severity, rule, location) use static
-// caps; the message column expands to consume the remaining space.
-func findingsColumnHints(w io.Writer) map[string]tui.ColumnHint {
-	msgWidth := maxMessageWidth
-	if tw := termWidth(w); tw > 0 {
-		// Subtract fixed columns and overhead. The overhead covers borders,
-		// the row-number column, and inter-column gaps.
-		const fixedOverhead = 6
-		const minMsgWidth = 16
-		remaining := tw - 8 - maxRuleWidth - maxLocationWidth - fixedOverhead
-		if remaining < minMsgWidth {
-			remaining = minMsgWidth
-		}
-		if remaining != msgWidth {
-			msgWidth = remaining
-		}
-	}
+// findingsColumnHints returns column display hints for the findings table.
+// Fixed columns (severity, rule, location) use static width caps; the
+// message column is marked Flex so it absorbs remaining terminal width.
+func findingsColumnHints() map[string]tui.ColumnHint {
 	return map[string]tui.ColumnHint{
 		"severity": {MaxWidth: 8, DisplayName: "Severity"},
 		"ruleName": {MaxWidth: maxRuleWidth, DisplayName: "Rule"},
 		"location": {MaxWidth: maxLocationWidth, DisplayName: "Location"},
-		"message":  {MaxWidth: msgWidth, DisplayName: "Message"},
+		"message":  {DisplayName: "Message", Flex: true},
 	}
-}
-
-// termWidth returns the terminal width for the given writer, or 0 if unknown.
-func termWidth(w io.Writer) int {
-	if f, ok := w.(*os.File); ok {
-		fd := f.Fd()
-		if width, _, err := term.GetSize(int(fd)); err == nil && width > 0 { //nolint:gosec // fd is a valid file descriptor, not user input
-			return width
-		}
-	}
-	return 0
 }
 
 func runLint(ctx context.Context, opts *Options) error {
@@ -266,7 +237,7 @@ func runLint(ctx context.Context, opts *Options) error {
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(opts.CliParams.NoColor),
 		kvx.WithOutputAppName(opts.BinaryName+" lint"),
-		kvx.WithOutputColumnHints(findingsColumnHints(opts.IOStreams.Out)),
+		kvx.WithOutputColumnHints(findingsColumnHints()),
 		kvx.WithOutputColumnOrder([]string{"severity", "ruleName", "location", "message"}),
 	)
 	kvxOpts.IOStreams = opts.IOStreams
@@ -320,9 +291,8 @@ func projectFindings(findings []*pkglint.Finding) []any {
 // fit comfortably in an 80-column terminal. The message column fills
 // remaining space and is the first to be truncated on narrow terminals.
 const (
-	maxRuleWidth     = 25
-	maxLocationWidth = 25
-	maxMessageWidth  = 40
+	maxRuleWidth     = 20
+	maxLocationWidth = 20
 )
 
 func getRegistry(ctx context.Context) *provider.Registry {

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -161,7 +161,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 }
 
 // findingsColumnHints builds column hints with a message width that fills the
-// available terminal width. Fixed columns (severity, location, rule) use static
+// available terminal width. Fixed columns (severity, rule, location) use static
 // caps; the message column expands to consume the remaining space.
 func findingsColumnHints(w io.Writer) map[string]tui.ColumnHint {
 	msgWidth := maxMessageWidth
@@ -170,7 +170,7 @@ func findingsColumnHints(w io.Writer) map[string]tui.ColumnHint {
 		// the row-number column, and inter-column gaps.
 		const fixedOverhead = 6
 		const minMsgWidth = 16
-		remaining := tw - 8 - maxLocationWidth - maxRuleWidth - fixedOverhead
+		remaining := tw - 8 - maxRuleWidth - maxLocationWidth - fixedOverhead
 		if remaining < minMsgWidth {
 			remaining = minMsgWidth
 		}
@@ -180,9 +180,9 @@ func findingsColumnHints(w io.Writer) map[string]tui.ColumnHint {
 	}
 	return map[string]tui.ColumnHint{
 		"severity": {MaxWidth: 8, DisplayName: "Severity"},
+		"ruleName": {MaxWidth: maxRuleWidth, DisplayName: "Rule"},
 		"location": {MaxWidth: maxLocationWidth, DisplayName: "Location"},
 		"message":  {MaxWidth: msgWidth, DisplayName: "Message"},
-		"ruleName": {MaxWidth: maxRuleWidth, DisplayName: "Rule"},
 	}
 }
 
@@ -267,7 +267,7 @@ func runLint(ctx context.Context, opts *Options) error {
 		kvx.WithOutputNoColor(opts.CliParams.NoColor),
 		kvx.WithOutputAppName(opts.BinaryName+" lint"),
 		kvx.WithOutputColumnHints(findingsColumnHints(opts.IOStreams.Out)),
-		kvx.WithOutputColumnOrder([]string{"severity", "location", "message", "ruleName"}),
+		kvx.WithOutputColumnOrder([]string{"severity", "ruleName", "location", "message"}),
 	)
 	kvxOpts.IOStreams = opts.IOStreams
 
@@ -307,32 +307,23 @@ func projectFindings(findings []*pkglint.Finding) []any {
 	for i, f := range findings {
 		rows[i] = map[string]any{
 			"severity": string(f.Severity),
-			"location": truncate(f.Location, maxLocationWidth),
+			"location": f.Location,
 			"message":  f.Message,
-			"ruleName": truncate(f.RuleName, maxRuleWidth),
+			"ruleName": f.RuleName,
 		}
 	}
 	return rows
 }
 
 // Column width limits for table rendering. Values are chosen so the four
-// visible columns (severity≤7 + location + message + rule + separators)
-// fit comfortably in an 80-column terminal.
+// visible columns (severity + rule + location + message + separators)
+// fit comfortably in an 80-column terminal. The message column fills
+// remaining space and is the first to be truncated on narrow terminals.
 const (
-	maxLocationWidth = 15
-	maxMessageWidth  = 32
-	maxRuleWidth     = 12
+	maxRuleWidth     = 25
+	maxLocationWidth = 25
+	maxMessageWidth  = 40
 )
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return s[:maxLen]
-	}
-	return s[:maxLen-3] + "..."
-}
 
 func getRegistry(ctx context.Context) *provider.Registry {
 	reg, err := builtin.DefaultRegistry(ctx)

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -111,12 +111,12 @@ func BenchmarkCommandLint(b *testing.B) {
 func TestFindingsColumnHints_ReturnsAllColumns(t *testing.T) {
 	t.Parallel()
 	hints := findingsColumnHints(nil)
-	for _, col := range []string{"severity", "location", "message", "ruleName"} {
+	for _, col := range []string{"severity", "ruleName", "location", "message"} {
 		assert.Contains(t, hints, col, "column %q must be present", col)
 	}
 	assert.Equal(t, 8, hints["severity"].MaxWidth)
-	assert.Equal(t, maxLocationWidth, hints["location"].MaxWidth)
 	assert.Equal(t, maxRuleWidth, hints["ruleName"].MaxWidth)
+	assert.Equal(t, maxLocationWidth, hints["location"].MaxWidth)
 }
 
 func TestFindingsColumnHints_DefaultMessageWidth(t *testing.T) {
@@ -147,43 +147,6 @@ func TestProjectFindings_Empty(t *testing.T) {
 	t.Parallel()
 	rows := projectFindings(nil)
 	assert.Empty(t, rows)
-}
-
-// ── truncate tests ───────────────────────────────────────────────────────────
-
-func TestTruncate_Short(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "abc", truncate("abc", 10))
-}
-
-func TestTruncate_Exact(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "abcde", truncate("abcde", 5))
-}
-
-func TestTruncate_Long(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "abcdefghij...", truncate("abcdefghijklmnop", 13))
-}
-
-func TestTruncate_MaxLenZero(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "", truncate("abc", 0))
-}
-
-func TestTruncate_MaxLenOne(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "a", truncate("abc", 1))
-}
-
-func TestTruncate_MaxLenTwo(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "ab", truncate("abc", 2))
-}
-
-func TestTruncate_MaxLenThree(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "abc", truncate("abcde", 3))
 }
 
 // ── termWidth tests ──────────────────────────────────────────────────────────

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -4,7 +4,6 @@
 package lint
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -110,20 +109,14 @@ func BenchmarkCommandLint(b *testing.B) {
 
 func TestFindingsColumnHints_ReturnsAllColumns(t *testing.T) {
 	t.Parallel()
-	hints := findingsColumnHints(nil)
+	hints := findingsColumnHints()
 	for _, col := range []string{"severity", "ruleName", "location", "message"} {
 		assert.Contains(t, hints, col, "column %q must be present", col)
 	}
 	assert.Equal(t, 8, hints["severity"].MaxWidth)
 	assert.Equal(t, maxRuleWidth, hints["ruleName"].MaxWidth)
 	assert.Equal(t, maxLocationWidth, hints["location"].MaxWidth)
-}
-
-func TestFindingsColumnHints_DefaultMessageWidth(t *testing.T) {
-	t.Parallel()
-	// With a nil writer, termWidth returns 0, so message stays at default.
-	hints := findingsColumnHints(nil)
-	assert.Equal(t, maxMessageWidth, hints["message"].MaxWidth)
+	assert.True(t, hints["message"].Flex, "message column must be flex")
 }
 
 // ── projectFindings tests ────────────────────────────────────────────────────
@@ -147,19 +140,6 @@ func TestProjectFindings_Empty(t *testing.T) {
 	t.Parallel()
 	rows := projectFindings(nil)
 	assert.Empty(t, rows)
-}
-
-// ── termWidth tests ──────────────────────────────────────────────────────────
-
-func TestTermWidth_NilWriter(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, 0, termWidth(nil))
-}
-
-func TestTermWidth_NonFileWriter(t *testing.T) {
-	t.Parallel()
-	var buf bytes.Buffer
-	assert.Equal(t, 0, termWidth(&buf))
 }
 
 // ── runLint integration tests ────────────────────────────────────────────────

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -382,6 +382,9 @@ func Root(opts *RootOptions) *cobra.Command {
 			ctx = input.WithInput(ctx, in)
 			ctx = config.WithConfig(ctx, cfg)
 			ctx = config.WithManagerOptions(ctx, configOpts)
+			if len(opts.ConfigDefaults) > 0 {
+				ctx = config.WithBaseDefaults(ctx, opts.ConfigDefaults)
+			}
 
 			// ── Resolve --cwd flag and inject into context ──
 			// This must happen before any path resolution so that downstream
@@ -430,6 +433,7 @@ func Root(opts *RootOptions) *cobra.Command {
 					ClientID:      cfg.Auth.Entra.ClientID,
 					TenantID:      cfg.Auth.Entra.TenantID,
 					DefaultScopes: cfg.Auth.Entra.DefaultScopes,
+					DefaultFlow:   cfg.Auth.Entra.DefaultFlow,
 				}))
 			}
 			entraOpts = append(entraOpts, entra.WithLogger(*lgr))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -574,6 +574,25 @@ func TestWithConfig_And_FromContext(t *testing.T) {
 	assert.Equal(t, cfg, FromContext(ctx2))
 }
 
+func TestWithBaseDefaults_And_BaseDefaultsFromContext(t *testing.T) {
+	ctx := t.Context()
+	assert.Nil(t, BaseDefaultsFromContext(ctx))
+
+	data := []byte("auth:\n  entra:\n    clientId: test\n")
+	ctx2 := WithBaseDefaults(ctx, data)
+	assert.Equal(t, data, BaseDefaultsFromContext(ctx2))
+}
+
+func TestWithManagerOptions_And_ManagerOptionsFromContext(t *testing.T) {
+	ctx := t.Context()
+	assert.Nil(t, ManagerOptionsFromContext(ctx))
+
+	opts := []ManagerOption{WithEnvPrefix("TEST")}
+	ctx2 := WithManagerOptions(ctx, opts)
+	got := ManagerOptionsFromContext(ctx2)
+	assert.Len(t, got, 1)
+}
+
 func TestManager_Set_AllBranches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -13,6 +13,9 @@ type configContextKey struct{}
 // managerOptsContextKey is the context key for storing ManagerOptions.
 type managerOptsContextKey struct{}
 
+// baseDefaultsContextKey is the context key for storing embedder defaults bytes.
+type baseDefaultsContextKey struct{}
+
 // WithConfig returns a new context with the Config stored in it.
 func WithConfig(ctx context.Context, cfg *Config) context.Context {
 	return context.WithValue(ctx, configContextKey{}, cfg)
@@ -37,4 +40,19 @@ func WithManagerOptions(ctx context.Context, opts []ManagerOption) context.Conte
 func ManagerOptionsFromContext(ctx context.Context) []ManagerOption {
 	opts, _ := ctx.Value(managerOptsContextKey{}).([]ManagerOption)
 	return opts
+}
+
+// WithBaseDefaults stores the raw embedder defaults YAML bytes in the context.
+// Commands that need to write defaults to disk (e.g. config reset) use these
+// bytes so that the on-disk file matches the embedder's runtime defaults.
+func WithBaseDefaults(ctx context.Context, data []byte) context.Context {
+	return context.WithValue(ctx, baseDefaultsContextKey{}, data)
+}
+
+// BaseDefaultsFromContext retrieves the embedder defaults YAML bytes from the
+// context. Returns nil when no embedder defaults were stored (i.e. plain
+// scafctl usage).
+func BaseDefaultsFromContext(ctx context.Context) []byte {
+	data, _ := ctx.Value(baseDefaultsContextKey{}).([]byte)
+	return data
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -57,19 +57,32 @@ func EmbeddedCatalogDefaults() []CatalogConfig {
 // config file exists. When a config file already exists, it merges in any
 // missing catalog entries without overwriting values the user has customised.
 func EnsureDefaults(configPath string) error {
+	return EnsureDefaultsWith(configPath, defaultsYAML)
+}
+
+// EnsureDefaultsWith is like EnsureDefaults but uses caller-supplied defaults
+// bytes instead of the embedded defaults.yaml. Embedders use this to bootstrap
+// the on-disk config from their own product-specific defaults so the config
+// file matches their runtime ConfigDefaults.
+//
+// Behavior:
+//   - If config does not exist, write the supplied defaults verbatim.
+//   - If config exists, merge missing catalog entries and settings according
+//     to the same rules as EnsureDefaults (reserved-catalog protection, etc.).
+func EnsureDefaultsWith(configPath string, customDefaults []byte) error {
 	if _, err := os.Stat(configPath); err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("checking config file: %w", err)
 		}
-		// No config file -- write the full embedded defaults.
+		// No config file -- write the full defaults.
 		if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 			return fmt.Errorf("creating config directory: %w", err)
 		}
-		return writeDefaultsFile(configPath, defaultsYAML)
+		return writeDefaultsFile(configPath, customDefaults)
 	}
 
 	// Config exists -- merge missing defaults into it.
-	return mergeDefaults(configPath)
+	return mergeDefaults(configPath, customDefaults)
 }
 
 // writeDefaultsFile writes data with 0600 permissions.
@@ -80,10 +93,10 @@ func writeDefaultsFile(path string, data []byte) error {
 	return nil
 }
 
-// mergeDefaults reads the existing config and the embedded defaults, then adds
+// mergeDefaults reads the existing config and the provided defaults, then adds
 // any missing catalog entries (by name) from the defaults. Existing entries
 // are never modified.
-func mergeDefaults(configPath string) error {
+func mergeDefaults(configPath string, defsYAML []byte) error {
 	existingData, err := os.ReadFile(configPath) //nolint:gosec // config path from trusted source
 	if err != nil {
 		return fmt.Errorf("reading existing config: %w", err)
@@ -93,8 +106,8 @@ func mergeDefaults(configPath string) error {
 	if err := yaml.Unmarshal(existingData, &existing); err != nil {
 		return fmt.Errorf("parsing existing config: %w", err)
 	}
-	if err := yaml.Unmarshal(defaultsYAML, &defs); err != nil {
-		return fmt.Errorf("parsing embedded defaults: %w", err)
+	if err := yaml.Unmarshal(defsYAML, &defs); err != nil {
+		return fmt.Errorf("parsing provided defaults: %w", err)
 	}
 	if existing == nil {
 		existing = make(map[string]any)

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -15,6 +15,7 @@ auth:
     clientId: 04b07795-8ddb-461a-bbee-02f9e1bf7b46
     tenantId: common
     authority: https://login.microsoftonline.com
+    defaultFlow: interactive
     defaultScopes:
       - openid
       - profile

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -175,6 +175,105 @@ func BenchmarkEnsureDefaults(b *testing.B) {
 	}
 }
 
+func TestEnsureDefaultsWith_CreatesFileFromCustomDefaults(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	embedderDefaults := []byte(`auth:
+  entra:
+    clientId: embedder-client-id
+    tenantId: embedder-tenant
+    defaultFlow: device_code
+catalogs:
+  - name: local
+    type: filesystem
+  - name: corp-registry
+    type: oci
+    url: oci://registry.corp.example.com/myorg
+settings:
+  defaultCatalog: corp-registry
+`)
+
+	err := EnsureDefaultsWith(path, embedderDefaults)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "embedder-client-id")
+	assert.Contains(t, content, "embedder-tenant")
+	assert.Contains(t, content, "corp-registry")
+	assert.NotContains(t, content, "official", "embedder defaults should not include scafctl official catalog")
+}
+
+func TestEnsureDefaultsWith_MergesCustomDefaults(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Existing config with user's custom catalog.
+	existing := "catalogs:\n  - name: my-team\n    type: oci\n    url: oci://team.example.com\n"
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	embedderDefaults := []byte(`catalogs:
+  - name: local
+    type: filesystem
+  - name: corp-registry
+    type: oci
+    url: oci://registry.corp.example.com/myorg
+settings:
+  defaultCatalog: corp-registry
+`)
+
+	err := EnsureDefaultsWith(path, embedderDefaults)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	// Embedder catalogs should be merged.
+	assert.Contains(t, content, "corp-registry")
+	assert.Contains(t, content, "local")
+	// User's catalog must be preserved.
+	assert.Contains(t, content, "my-team")
+	// defaultCatalog should be set from embedder defaults.
+	assert.Contains(t, content, "defaultCatalog")
+}
+
+func TestEnsureDefaultsWith_PreservesReservedCatalogProtection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// User tried to override "local" catalog.
+	existing := "catalogs:\n  - name: local\n    type: oci\n    url: oci://evil.example.com\n"
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	embedderDefaults := []byte(`catalogs:
+  - name: local
+    type: filesystem
+`)
+
+	err := EnsureDefaultsWith(path, embedderDefaults)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	catalogs := toSlice(cfg["catalogs"])
+	for _, c := range catalogs {
+		m, _ := c.(map[string]any)
+		if m["name"] == "local" {
+			assert.Equal(t, "filesystem", m["type"], "reserved catalog must be enforced from embedder defaults")
+		}
+	}
+}
+
 func TestMergeDefaultCatalogEntries_DisableOfficialCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/sanitize.go
+++ b/pkg/config/sanitize.go
@@ -48,6 +48,7 @@ type SanitizedEntraAuth struct {
 	ClientID      string   `json:"clientId,omitempty" yaml:"clientId,omitempty" doc:"Entra ID application client ID" maxLength:"256" example:"00000000-0000-0000-0000-000000000000"`
 	TenantID      string   `json:"tenantId,omitempty" yaml:"tenantId,omitempty" doc:"Entra ID tenant ID" maxLength:"256" example:"00000000-0000-0000-0000-000000000000"`
 	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" doc:"Default OAuth scopes" maxItems:"20"`
+	DefaultFlow   string   `json:"defaultFlow,omitempty" yaml:"defaultFlow,omitempty" doc:"Default interactive auth flow" maxLength:"32" example:"device_code"`
 }
 
 // SanitizedGitHubAuth contains only non-sensitive GitHub auth fields.
@@ -104,6 +105,7 @@ func SanitizeConfig(cfg *Config) SanitizedConfig {
 			ClientID:      cfg.Auth.Entra.ClientID,
 			TenantID:      cfg.Auth.Entra.TenantID,
 			DefaultScopes: cfg.Auth.Entra.DefaultScopes,
+			DefaultFlow:   cfg.Auth.Entra.DefaultFlow,
 		}
 	}
 	if cfg.Auth.GitHub != nil {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -419,6 +419,13 @@ type EntraAuthConfig struct {
 
 	// DefaultScopes are requested during login if not specified on command line.
 	DefaultScopes []string `json:"defaultScopes,omitempty" yaml:"defaultScopes,omitempty" mapstructure:"defaultScopes" doc:"Default OAuth scopes" maxItems:"20"`
+
+	// DefaultFlow is the authentication flow used when no explicit flow is
+	// requested and no environment credentials (service principal, workload
+	// identity) are detected. Valid values: "interactive", "device_code".
+	// Embedders can override this via WithBaseConfig to change the default
+	// for their CLI.
+	DefaultFlow string `json:"defaultFlow,omitempty" yaml:"defaultFlow,omitempty" mapstructure:"defaultFlow" doc:"Default interactive auth flow" enum:"interactive,device_code" maxLength:"32" example:"interactive"`
 }
 
 // GitHubAuthConfig contains GitHub-specific configuration.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -414,6 +414,31 @@ func buildInstructions(name, supplemental string) string {
 	return base + "\n\n" + supplemental
 }
 
+// resolveConfig returns the effective configuration by checking, in order:
+//  1. s.config (set during NewServer via WithServerConfig)
+//  2. config.FromContext(s.ctx) (set during PersistentPreRun)
+//  3. config.Global() (loads from disk)
+//
+// This ensures catalog-related handlers see the same config as get_config,
+// even when the MCP server was created without an explicit config reference
+// (e.g. config file doesn't exist at startup but is created later).
+func (s *Server) resolveConfig() *config.Config {
+	if s.config != nil {
+		return s.config
+	}
+	if s.ctx != nil {
+		if cfg := config.FromContext(s.ctx); cfg != nil {
+			return cfg
+		}
+	}
+	cfg, err := config.Global()
+	if err != nil {
+		s.logger.V(1).Info("failed to load global config", "error", err)
+		return nil
+	}
+	return cfg
+}
+
 // NewServer creates a new MCP server with all tools and resources registered.
 func NewServer(opts ...ServerOption) (*Server, error) {
 	cfg := &serverConfig{

--- a/pkg/mcp/tools_catalog_search.go
+++ b/pkg/mcp/tools_catalog_search.go
@@ -236,7 +236,8 @@ func (s *Server) listRemoteCatalogs(catalogFilter string) []search.SolutionEntry
 // registered OCI catalog, specific name = that catalog only.
 // "local" should not reach here.
 func (s *Server) buildRemoteCatalogs(catalogFilter string) []*catalog.RemoteCatalog {
-	if s.config == nil {
+	cfg := s.resolveConfig()
+	if cfg == nil {
 		return nil
 	}
 
@@ -250,24 +251,24 @@ func (s *Server) buildRemoteCatalogs(catalogFilter string) []*catalog.RemoteCata
 	switch {
 	case catalogFilter == "":
 		// Default: search only the default catalog (or official if no default is set).
-		if catCfg, ok := s.config.GetDefaultCatalog(); ok && catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" {
+		if catCfg, ok := cfg.GetDefaultCatalog(); ok && catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" {
 			targets = append(targets, *catCfg)
 		} else {
 			// Fall back to the official catalog when no explicit default is configured.
-			if catCfg, ok := s.config.GetCatalog(config.CatalogNameOfficial); ok &&
+			if catCfg, ok := cfg.GetCatalog(config.CatalogNameOfficial); ok &&
 				catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" &&
-				!s.config.Settings.DisableOfficialCatalog {
+				!cfg.Settings.DisableOfficialCatalog {
 				targets = append(targets, *catCfg)
 			}
 		}
 	case strings.EqualFold(catalogFilter, "all"):
 		// Explicit "all": search every registered OCI catalog.
-		for _, catCfg := range s.config.Catalogs {
+		for _, catCfg := range cfg.Catalogs {
 			if catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" {
 				if catCfg.Name == config.CatalogNameLocal {
 					continue
 				}
-				if catCfg.Name == config.CatalogNameOfficial && s.config.Settings.DisableOfficialCatalog {
+				if catCfg.Name == config.CatalogNameOfficial && cfg.Settings.DisableOfficialCatalog {
 					continue
 				}
 				targets = append(targets, catCfg)
@@ -275,7 +276,7 @@ func (s *Server) buildRemoteCatalogs(catalogFilter string) []*catalog.RemoteCata
 		}
 	default:
 		// Specific catalog by name.
-		if catCfg, ok := s.config.GetCatalog(catalogFilter); ok && catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" {
+		if catCfg, ok := cfg.GetCatalog(catalogFilter); ok && catCfg.Type == config.CatalogTypeOCI && catCfg.URL != "" {
 			targets = append(targets, *catCfg)
 		}
 	}
@@ -303,17 +304,18 @@ func (s *Server) listRegisteredCatalogs() []search.CatalogInfo {
 		Type: "filesystem",
 	})
 
-	if s.config == nil {
+	cfg := s.resolveConfig()
+	if cfg == nil {
 		return catalogs
 	}
 
-	defaultCatalog := s.config.Settings.DefaultCatalog
+	defaultCatalog := cfg.Settings.DefaultCatalog
 
-	for _, catCfg := range s.config.Catalogs {
+	for _, catCfg := range cfg.Catalogs {
 		if catCfg.Name == config.CatalogNameLocal {
 			continue
 		}
-		if catCfg.Name == config.CatalogNameOfficial && s.config.Settings.DisableOfficialCatalog {
+		if catCfg.Name == config.CatalogNameOfficial && cfg.Settings.DisableOfficialCatalog {
 			continue
 		}
 

--- a/pkg/mcp/tools_catalog_search_test.go
+++ b/pkg/mcp/tools_catalog_search_test.go
@@ -189,6 +189,51 @@ func TestHandleCatalogListRegistered_WithConfig(t *testing.T) {
 	assert.Equal(t, float64(3), body["count"].(float64))
 }
 
+func TestHandleCatalogListRegistered_FallsBackToContextConfig(t *testing.T) {
+	// Simulate the case where WithServerConfig was not called (s.config is nil)
+	// but the config is available in the parent context.
+	cfg := &config.Config{
+		Catalogs: []config.CatalogConfig{
+			{Name: config.CatalogNameLocal, Type: config.CatalogTypeFilesystem},
+			{Name: "corp-registry", Type: config.CatalogTypeOCI, URL: "oci://registry.corp.example.com/solutions"},
+			{Name: config.CatalogNameOfficial, Type: config.CatalogTypeOCI, URL: "oci://ghcr.io/oakwood-commons"},
+		},
+		Settings: config.Settings{
+			DefaultCatalog: "corp-registry",
+		},
+	}
+
+	parentCtx := config.WithConfig(context.Background(), cfg)
+	srv, err := NewServer(
+		WithServerVersion("test"),
+		WithServerContext(parentCtx),
+		// Intentionally NOT passing WithServerConfig -- simulates the nil-config case.
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "catalog_list_registered"
+
+	result, err := srv.handleCatalogListRegistered(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var body map[string]any
+	unmarshalResult(t, result, &body)
+	assert.Equal(t, float64(3), body["count"].(float64),
+		"should return all catalogs from context config, not just local")
+
+	// Verify corp-registry is included.
+	catalogList := body["catalogs"].([]any)
+	names := make([]string, len(catalogList))
+	for i, c := range catalogList {
+		names[i] = c.(map[string]any)["name"].(string)
+	}
+	assert.Contains(t, names, "corp-registry")
+	assert.Contains(t, names, config.CatalogNameOfficial)
+	assert.Contains(t, names, config.CatalogNameLocal)
+}
+
 func TestHandleCatalogListRegistered_OfficialDisabled(t *testing.T) {
 	cfg := &config.Config{
 		Catalogs: []config.CatalogConfig{

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -44,19 +44,12 @@ func (s *Server) registerConfigTools() {
 
 // handleGetConfig returns the current configuration (with sensitive fields redacted).
 func (s *Server) handleGetConfig(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	cfg := s.config
+	cfg := s.resolveConfig()
 	if cfg == nil {
-		cfg = config.FromContext(s.ctx)
-	}
-	if cfg == nil {
-		var err error
-		cfg, err = config.Global()
-		if err != nil {
-			return newStructuredError(ErrCodeConfigError, fmt.Sprintf("no configuration available: %v", err),
-				WithSuggestion("Run 'scafctl config init' to create a default configuration"),
-				WithRelatedTools("get_config_paths"),
-			), nil
-		}
+		return newStructuredError(ErrCodeConfigError, "no configuration available",
+			WithSuggestion(fmt.Sprintf("Run '%s config init' to create a default configuration", s.name)),
+			WithRelatedTools("get_config_paths"),
+		), nil
 	}
 
 	sanitized := config.SanitizeConfig(cfg)

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -607,6 +607,13 @@ func (p *FileProvider) executeWriteTree(ctx context.Context, absBasePath string,
 			outputPath = transformed
 		}
 
+		if outputPath == "" || outputPath == "." {
+			if outputPathTmpl != "" {
+				return nil, fmt.Errorf("entries[%d]: path %q resolves to empty after applying stripSuffix %q and outputPath template %q", i, entry.path, stripSuffix, outputPathTmpl)
+			}
+			return nil, fmt.Errorf("entries[%d]: path %q resolves to empty after applying stripSuffix %q", i, entry.path, stripSuffix)
+		}
+
 		absDest := filepath.Join(absBasePath, outputPath)
 		if !isSubPath(absBasePath, absDest) {
 			return nil, fmt.Errorf("path traversal detected: entries[%d] path %q resolves outside basePath %q", i, outputPath, absBasePath)
@@ -938,6 +945,7 @@ func (p *FileProvider) executeDryRunWriteTree(ctx context.Context, absBasePath s
 	}
 
 	outputPathTmpl, _ := inputs["outputPath"].(string)
+	stripSuffix, _ := inputs["stripSuffix"].(string)
 
 	// Invocation-level conflict inputs.
 	invOnConflict, _ := inputs["onConflict"].(string)
@@ -950,12 +958,22 @@ func (p *FileProvider) executeDryRunWriteTree(ctx context.Context, absBasePath s
 
 	for i, entry := range entries {
 		outputPath := entry.path
+		if stripSuffix != "" {
+			outputPath = strings.TrimSuffix(outputPath, stripSuffix)
+		}
 		if outputPathTmpl != "" {
-			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, entry.path)
+			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, outputPath)
 			if tmplErr != nil {
 				return nil, fmt.Errorf("%s: outputPath template failed for entries[%d] (%s): %w", ProviderName, i, entry.path, tmplErr)
 			}
 			outputPath = transformed
+		}
+
+		if outputPath == "" || outputPath == "." {
+			if outputPathTmpl != "" {
+				return nil, fmt.Errorf("%s: entries[%d]: path %q resolves to empty after applying stripSuffix %q and outputPath template %q", ProviderName, i, entry.path, stripSuffix, outputPathTmpl)
+			}
+			return nil, fmt.Errorf("%s: entries[%d]: path %q resolves to empty after applying stripSuffix %q", ProviderName, i, entry.path, stripSuffix)
 		}
 
 		absDest := filepath.Join(absBasePath, outputPath)

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -134,12 +134,11 @@ func NewFileProvider() *FileProvider {
 						"Has no effect on other strategies or the write operation.",
 					schemahelper.WithExample(false),
 					schemahelper.WithDefault(false)),
-				"stripExtension": schemahelper.BoolProp(
-					"Strip the final file extension from each entry path before writing (write-tree only). "+
-						"For example, 'main.go.tmpl' becomes 'main.go'. "+
+				"stripSuffix": schemahelper.StringProp(
+					"Strip the given suffix from each entry path before writing (write-tree only). "+
+						"For example, with stripSuffix '.tmpl', 'main.go.tmpl' becomes 'main.go'. "+
 						"Applied before outputPath template if both are set.",
-					schemahelper.WithExample(true),
-					schemahelper.WithDefault(false)),
+					schemahelper.WithExample(".tmpl")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -566,7 +565,7 @@ func (p *FileProvider) executeWriteTree(ctx context.Context, absBasePath string,
 	}
 
 	outputPathTmpl, _ := inputs["outputPath"].(string)
-	stripExtension, _ := inputs["stripExtension"].(bool)
+	stripSuffix, _ := inputs["stripSuffix"].(string)
 
 	// Parse permissions — default to 0600 (owner read/write only).
 	fileMode := os.FileMode(0o600)
@@ -597,13 +596,8 @@ func (p *FileProvider) executeWriteTree(ctx context.Context, absBasePath string,
 	resolved := make([]resolvedEntry, 0, len(entries))
 	for i, entry := range entries {
 		outputPath := entry.path
-		if stripExtension {
-			base := filepath.Base(outputPath)
-			ext := filepath.Ext(outputPath)
-			// Only strip if the extension is not the entire basename (e.g. skip dotfiles like ".env").
-			if ext != "" && base != ext {
-				outputPath = strings.TrimSuffix(outputPath, ext)
-			}
+		if stripSuffix != "" {
+			outputPath = strings.TrimSuffix(outputPath, stripSuffix)
 		}
 		if outputPathTmpl != "" {
 			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, outputPath)

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -847,7 +847,72 @@ func TestFileProvider_WriteTree_StripSuffixNoMatch(t *testing.T) {
 	assert.Equal(t, []string{"main.go"}, paths)
 }
 
-func TestFileProvider_WriteTree_OutputPathStripExtension(t *testing.T) {
+func TestFileProvider_WriteTree_StripSuffixEmptyPath(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": ".env", "content": "SECRET=val"},
+		},
+		"stripSuffix": ".env",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolves to empty")
+	assert.Contains(t, err.Error(), ".env")
+}
+
+func TestFileProvider_WriteTree_StripSuffixEmptyPathDryRun(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": ".env", "content": "SECRET=val"},
+		},
+		"stripSuffix": ".env",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolves to empty")
+}
+
+func TestFileProvider_WriteTree_StripSuffixDryRunMatchesLive(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithDryRun(context.Background(), true)
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "main.go.tmpl", "content": "package main"},
+			map[string]any{"path": "util.go.tmpl", "content": "package util"},
+		},
+		"stripSuffix": ".tmpl",
+	}
+
+	result, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	data := result.Data.(map[string]any)
+	dryRunPaths := data["paths"].([]string)
+	assert.Equal(t, []string{"main.go", "util.go"}, dryRunPaths,
+		"dry-run paths should reflect stripSuffix application")
+}
+
+func TestFileProvider_WriteTree_OutputPathStemExtraction(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
 

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -763,7 +763,7 @@ func TestFileProvider_WriteTree_BasicNestedDirs(t *testing.T) {
 	assert.Equal(t, "nested", string(b3))
 }
 
-func TestFileProvider_WriteTree_StripExtensionBool(t *testing.T) {
+func TestFileProvider_WriteTree_StripSuffix(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
 
@@ -777,7 +777,7 @@ func TestFileProvider_WriteTree_StripExtensionBool(t *testing.T) {
 			map[string]any{"path": "noext", "content": "plain"},
 			map[string]any{"path": ".env", "content": "SECRET=val"},
 		},
-		"stripExtension": true,
+		"stripSuffix": ".tpl",
 	}
 
 	result, err := p.Execute(ctx, inputs)
@@ -786,19 +786,20 @@ func TestFileProvider_WriteTree_StripExtensionBool(t *testing.T) {
 	data := result.Data.(map[string]any)
 	assert.Equal(t, 4, data["filesWritten"])
 	paths := data["paths"].([]string)
-	assert.Equal(t, []string{"deployment.yaml", "configs/app.conf", "noext", ".env"}, paths)
+	// Only .tpl is stripped; .tmpl and others are untouched
+	assert.Equal(t, []string{"deployment.yaml", "configs/app.conf.tmpl", "noext", ".env"}, paths)
 
 	b, err := os.ReadFile(filepath.Join(tmpDir, "deployment.yaml"))
 	require.NoError(t, err)
 	assert.Equal(t, "apiVersion: apps/v1", string(b))
 
-	// Verify dotfile .env was NOT stripped
+	// .env is untouched since it doesn't end with .tpl
 	envContent, err := os.ReadFile(filepath.Join(tmpDir, ".env"))
 	require.NoError(t, err)
 	assert.Equal(t, "SECRET=val", string(envContent))
 }
 
-func TestFileProvider_WriteTree_StripExtensionWithOutputPath(t *testing.T) {
+func TestFileProvider_WriteTree_StripSuffixWithOutputPath(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
 
@@ -809,8 +810,8 @@ func TestFileProvider_WriteTree_StripExtensionWithOutputPath(t *testing.T) {
 		"entries": []any{
 			map[string]any{"path": "src/main.go.tmpl", "content": "package main"},
 		},
-		"stripExtension": true,
-		"outputPath":     "out/{{ .__fileName }}",
+		"stripSuffix": ".tmpl",
+		"outputPath":  "out/{{ .__fileName }}",
 	}
 
 	result, err := p.Execute(ctx, inputs)
@@ -818,9 +819,32 @@ func TestFileProvider_WriteTree_StripExtensionWithOutputPath(t *testing.T) {
 	require.NoError(t, err)
 	data := result.Data.(map[string]any)
 	paths := data["paths"].([]string)
-	// stripExtension applied first: main.go.tmpl -> main.go
+	// stripSuffix applied first: main.go.tmpl -> main.go
 	// Then outputPath template sees __fileName as main.go
 	assert.Equal(t, []string{"out/main.go"}, paths)
+}
+
+func TestFileProvider_WriteTree_StripSuffixNoMatch(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "main.go", "content": "package main"},
+		},
+		"stripSuffix": ".tmpl",
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	// No match — path is unchanged
+	assert.Equal(t, []string{"main.go"}, paths)
 }
 
 func TestFileProvider_WriteTree_OutputPathStripExtension(t *testing.T) {

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -464,7 +464,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|compose-demo/workflow|compose-demo/resolvers"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|compose-demo/workflow|compose-demo/resolvers"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1798,6 +1798,41 @@ func TestIntegration_ConfigSchema(t *testing.T) {
 	assert.Contains(t, stdout, "properties")
 }
 
+func TestIntegration_ConfigReset_RequiresForce(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("custom: true"), 0o600))
+
+	_, stderr, exitCode := runScafctl(t, "--config", configPath, "config", "reset")
+
+	assert.NotEqual(t, 0, exitCode, "should fail without --force")
+	assert.Contains(t, stderr, "--force")
+
+	// Config should be untouched.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "custom: true")
+}
+
+func TestIntegration_ConfigReset_HappyPath(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("custom: true"), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t, "--config", configPath, "config", "reset", "--force")
+
+	assert.Equal(t, 0, exitCode, "should succeed with --force")
+	combined := stdout + stderr
+	assert.Contains(t, combined, "Reset config file")
+
+	// Config should be recreated with defaults (not our custom value).
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "custom: true")
+}
+
 // ============================================================================
 // Secrets Command Tests (basic, non-destructive)
 // ============================================================================


### PR DESCRIPTION
Lint table:
- reorder columns to severity | rule | location | message
- mark message column as Flex so it absorbs remaining terminal
  width, fixing list-view fallback on narrow terminals
- reduce rule and location column caps from 25 to 20 chars
- remove manual terminal-width calculation and termWidth helper
- stop pre-truncating data in projectFindings so list view
  shows full values; table view uses column hints instead
- remove dead truncate() function and its tests
- add lint-stress-test example solution for testing output

File provider
- replace boolean stripExtension with string stripSuffix
  so users can specify which suffix to strip (e.g. ".tmpl")
- simplifies logic: just strings.TrimSuffix, no dotfile guard

file provider write-tree input
stripExtension (bool) replaced by stripSuffix (string)