### PR TITLE
feat(cli)!: simplify test UX, add build --base-dir, and fix multiple issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ __debug*
 issues/
 # Bubble Tea debug logs
 tea_debug.log
+# Embedded examples (populated at build time)
+pkg/examples/files/*
+!pkg/examples/files/.gitkeep

--- a/pkg/auth/gcp/device_code_flow.go
+++ b/pkg/auth/gcp/device_code_flow.go
@@ -67,8 +67,12 @@ func (h *Handler) deviceCodeLogin(ctx context.Context, opts auth.LoginOptions) (
 	defer cancel()
 
 	// Step 1: Request device code from Google
+	isDefaultClient := clientID == DefaultADCClientID
 	deviceCode, err := h.requestGCPDeviceCode(ctx, clientID, scopes)
 	if err != nil {
+		if isDefaultClient {
+			return nil, fmt.Errorf("device code request failed with default ADC client (configure auth.gcp.client_id and auth.gcp.client_secret for device code support): %w", err)
+		}
 		return nil, fmt.Errorf("device code request failed: %w", err)
 	}
 

--- a/pkg/auth/gcp/device_code_flow_test.go
+++ b/pkg/auth/gcp/device_code_flow_test.go
@@ -363,3 +363,28 @@ func BenchmarkDeviceCodeLogin(b *testing.B) {
 		})
 	}
 }
+
+func TestDeviceCodeLogin_DefaultClientFailureMessage(t *testing.T) {
+	t.Parallel()
+	store := secrets.NewMockStore()
+	mockHTTP := NewMockHTTPClient()
+
+	// Device code request fails (e.g., default ADC client doesn't support device code)
+	mockHTTP.AddResponse(403, TokenErrorResponse{
+		Error:            "access_denied",
+		ErrorDescription: "device code not supported",
+	})
+
+	// No custom client ID — will use DefaultADCClientID
+	handler, err := New(WithSecretStore(store), WithHTTPClient(mockHTTP))
+	require.NoError(t, err)
+
+	_, err = handler.deviceCodeLogin(context.Background(), auth.LoginOptions{
+		Flow:    auth.FlowDeviceCode,
+		Timeout: 10 * time.Second,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default ADC client")
+	assert.Contains(t, err.Error(), "auth.gcp.client_id")
+	assert.Contains(t, err.Error(), "auth.gcp.client_secret")
+}

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -47,6 +47,7 @@ type SolutionOptions struct {
 	SkipTests       bool
 	IgnorePreflight bool
 	AllowDevVersion bool
+	BaseDir         string
 	CliParams       *settings.Run
 	IOStreams       *terminal.IOStreams
 
@@ -215,6 +216,7 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 	cmd.Flags().BoolVar(&options.SkipTests, "skip-tests", false, "Skip functional test pre-flight check")
 	cmd.Flags().BoolVar(&options.IgnorePreflight, "ignore-preflight", false, "Run pre-flight checks but proceed even if they fail")
 	cmd.Flags().BoolVar(&options.AllowDevVersion, "allow-dev-version", false, "Allow build without metadata.version set")
+	cmd.Flags().StringVar(&options.BaseDir, "base-dir", "", "Override base directory for resolving relative paths in the solution (default: solution file's directory)")
 
 	return cmd
 }
@@ -254,15 +256,22 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 	}
 	w.Verbosef("Parsed solution: %s (apiVersion: %s)", sol.Metadata.Name, sol.APIVersion)
 
-	// Determine bundle root (directory containing the solution file, or cwd for stdin)
+	// Determine bundle root (--base-dir flag, directory containing the solution file, or cwd for stdin)
 	var bundleRoot string
-	if opts.File == "-" {
+	switch {
+	case opts.BaseDir != "":
+		bundleRoot, err = filepath.Abs(opts.BaseDir)
+		if err != nil {
+			w.Errorf("--base-dir: %v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+	case opts.File == "-":
 		bundleRoot, err = os.Getwd()
 		if err != nil {
 			w.Errorf("failed to determine working directory: %v", err)
 			return exitcode.WithCode(err, exitcode.GeneralError)
 		}
-	} else {
+	default:
 		absFile, absErr := provider.AbsFromContext(ctx, opts.File)
 		if absErr != nil {
 			w.Errorf("failed to resolve path: %v", absErr)

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -60,6 +60,7 @@ func TestCommandBuildSolution_Flags(t *testing.T) {
 		{"skip-tests", "false"},
 		{"ignore-preflight", "false"},
 		{"allow-dev-version", "false"},
+		{"base-dir", ""},
 	}
 
 	for _, tc := range flagTests {
@@ -607,6 +608,42 @@ spec: {}
 	require.NoError(t, err)
 	assert.Contains(t, outBuf.String(), "Dry run:")
 	assert.Contains(t, outBuf.String(), "stdin-solution@1.0.0")
+}
+
+func TestRunBuildSolution_BaseDirOverridesBundleRoot(t *testing.T) {
+	t.Parallel()
+
+	// Create solution file in one directory and a separate base-dir
+	solDir := t.TempDir()
+	baseDir := t.TempDir()
+	solFile := filepath.Join(solDir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: basedir-test
+  version: 1.0.0
+spec: {}
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		BaseDir:       baseDir,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Dry run:")
+	assert.Contains(t, buf.String(), "basedir-test@1.0.0")
 }
 
 func TestRunBuildSolution_StdinImpliesNoBundle(t *testing.T) {

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -380,7 +380,7 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	}
 
 	// Resolve capability
-	capability, err := o.resolveCapability(desc)
+	capability, err := o.resolveCapability(desc, inputs)
 	if err != nil {
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -471,7 +471,7 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 // resolveCapability determines which capability to use for execution.
 // If --capability is specified, validates and uses it.
 // Otherwise, defaults to the first declared capability.
-func (o *ProviderOptions) resolveCapability(desc *provider.Descriptor) (provider.Capability, error) {
+func (o *ProviderOptions) resolveCapability(desc *provider.Descriptor, inputs map[string]any) (provider.Capability, error) {
 	if o.Capability != "" {
 		requested := provider.Capability(o.Capability)
 		if !requested.IsValid() {
@@ -495,6 +495,17 @@ func (o *ProviderOptions) resolveCapability(desc *provider.Descriptor) (provider
 	// Default to first capability
 	if len(desc.Capabilities) == 0 {
 		return "", fmt.Errorf("provider %q declares no capabilities", desc.Name)
+	}
+
+	// Auto-escalate to action capability when the operation is a write operation.
+	// This lets `run provider` execute write operations (e.g., create_issue)
+	// without requiring an explicit --capability=action flag.
+	if operation, _ := inputs["operation"].(string); operation != "" && desc.IsWriteOperation(operation) {
+		for _, c := range desc.Capabilities {
+			if c == provider.CapabilityAction {
+				return provider.CapabilityAction, nil
+			}
+		}
 	}
 
 	return desc.Capabilities[0], nil

--- a/pkg/cmd/scafctl/run/provider_coverage_test.go
+++ b/pkg/cmd/scafctl/run/provider_coverage_test.go
@@ -99,7 +99,7 @@ func TestResolveCapability_Default(t *testing.T) {
 		Capabilities: []provider.Capability{provider.CapabilityFrom, provider.CapabilityTransform},
 	}
 
-	capability, err := opts.resolveCapability(desc)
+	capability, err := opts.resolveCapability(desc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, provider.CapabilityFrom, capability)
 }
@@ -116,7 +116,7 @@ func TestResolveCapability_Explicit(t *testing.T) {
 		Capabilities: []provider.Capability{provider.CapabilityFrom, provider.CapabilityTransform},
 	}
 
-	capability, err := opts.resolveCapability(desc)
+	capability, err := opts.resolveCapability(desc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, provider.CapabilityTransform, capability)
 }
@@ -133,7 +133,7 @@ func TestResolveCapability_ExplicitNotSupported(t *testing.T) {
 		Capabilities: []provider.Capability{provider.CapabilityFrom}, // no action
 	}
 
-	_, err := opts.resolveCapability(desc)
+	_, err := opts.resolveCapability(desc, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support capability")
 }
@@ -150,7 +150,7 @@ func TestResolveCapability_Invalid(t *testing.T) {
 		Capabilities: []provider.Capability{provider.CapabilityFrom},
 	}
 
-	_, err := opts.resolveCapability(desc)
+	_, err := opts.resolveCapability(desc, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid capability")
 }
@@ -165,9 +165,62 @@ func TestResolveCapability_NoCapabilities(t *testing.T) {
 		Capabilities: nil, // empty
 	}
 
-	_, err := opts.resolveCapability(desc)
+	_, err := opts.resolveCapability(desc, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "declares no capabilities")
+}
+
+// TestResolveCapability_WriteOpAutoEscalates verifies auto-escalation to action
+// when the operation is a write operation and the provider supports action.
+func TestResolveCapability_WriteOpAutoEscalates(t *testing.T) {
+	t.Parallel()
+
+	opts := &ProviderOptions{}
+	desc := &provider.Descriptor{
+		Name:            "test-provider",
+		Capabilities:    []provider.Capability{provider.CapabilityFrom, provider.CapabilityAction},
+		WriteOperations: []string{"create_issue", "delete_issue"},
+	}
+	inputs := map[string]any{"operation": "create_issue"}
+
+	capability, err := opts.resolveCapability(desc, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, provider.CapabilityAction, capability)
+}
+
+// TestResolveCapability_WriteOpNoActionCap falls through to default when
+// provider does not support the action capability.
+func TestResolveCapability_WriteOpNoActionCap(t *testing.T) {
+	t.Parallel()
+
+	opts := &ProviderOptions{}
+	desc := &provider.Descriptor{
+		Name:            "test-provider",
+		Capabilities:    []provider.Capability{provider.CapabilityFrom},
+		WriteOperations: []string{"create_issue"},
+	}
+	inputs := map[string]any{"operation": "create_issue"}
+
+	capability, err := opts.resolveCapability(desc, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, provider.CapabilityFrom, capability, "should fall back to first capability")
+}
+
+// TestResolveCapability_ReadOpNoEscalation verifies no escalation for read ops.
+func TestResolveCapability_ReadOpNoEscalation(t *testing.T) {
+	t.Parallel()
+
+	opts := &ProviderOptions{}
+	desc := &provider.Descriptor{
+		Name:            "test-provider",
+		Capabilities:    []provider.Capability{provider.CapabilityFrom, provider.CapabilityAction},
+		WriteOperations: []string{"create_issue"},
+	}
+	inputs := map[string]any{"operation": "list_issues"}
+
+	capability, err := opts.resolveCapability(desc, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, provider.CapabilityFrom, capability, "read ops should not escalate")
 }
 
 // ── Benchmarks ────────────────────────────────────────────────────────────────
@@ -181,7 +234,7 @@ func BenchmarkResolveCapability_Default(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = opts.resolveCapability(desc)
+		_, _ = opts.resolveCapability(desc, nil)
 	}
 }
 

--- a/pkg/cmd/scafctl/test/test.go
+++ b/pkg/cmd/scafctl/test/test.go
@@ -5,19 +5,26 @@ package test
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
 
 // CommandTest creates the 'test' command that runs and manages functional tests.
+// When invoked without a subcommand, it defaults to running functional tests
+// (equivalent to 'test functional').
 func CommandTest(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cCmd := &cobra.Command{
-		Use:     "test",
+		Use:     "test [reference]",
 		Aliases: []string{"t"},
-		Short:   "Run and manage functional tests",
+		Short:   "Run functional tests (default) or manage test suites",
 		Long: fmt.Sprintf(`Run and manage functional tests for %s solutions.
+
+When invoked without a subcommand, runs functional tests (same as 'test functional').
 
 SUBCOMMANDS:
   functional  Run functional tests against solutions
@@ -29,9 +36,32 @@ scafctl commands against them and checking the output. Tests are defined
 inline in solution YAML under spec.testing.cases or in separate test files
 under a tests/ directory.`, path),
 		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, "test")
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+
+			opts := &FunctionalOptions{
+				IOStreams: ioStreams,
+				CliParams: cliParams,
+				Verbose:   cliParams.Verbose,
+			}
+			opts.AppName = cliParams.BinaryName
+
+			if len(args) > 0 {
+				if err := get.ValidatePositionalRef(args[0], opts.File, cliParams.BinaryName+" test"); err != nil {
+					opts.positionalPathErr = err
+				} else {
+					opts.File = args[0]
+				}
+			}
+
+			ctx = writer.WithWriter(ctx, writer.New(ioStreams, cliParams))
+			return runFunctional(ctx, opts)
+		},
 	}
 
-	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+	cmdPath := filepath.Join(path, cCmd.Name())
 	cCmd.AddCommand(CommandFunctional(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandInit(cliParams, ioStreams, cmdPath))
 	cCmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/test/test_test.go
+++ b/pkg/cmd/scafctl/test/test_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -19,11 +20,12 @@ func TestCommandTest(t *testing.T) {
 	cmd := CommandTest(cliParams, ioStreams, "scafctl")
 
 	require.NotNil(t, cmd)
-	assert.Equal(t, "test", cmd.Use)
+	assert.Equal(t, "test [reference]", cmd.Use)
 	assert.Contains(t, cmd.Aliases, "t")
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotEmpty(t, cmd.Long)
 	assert.True(t, cmd.SilenceUsage)
+	assert.NotNil(t, cmd.RunE, "parent test command should have RunE (defaults to functional)")
 
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 3, "should have 3 subcommands: functional, init, list")
@@ -37,12 +39,31 @@ func TestCommandTest(t *testing.T) {
 	assert.Contains(t, cmdNames, "list")
 }
 
-func TestCommandTest_NoRunE(t *testing.T) {
+func TestCommandTest_DefaultsToFunctional(t *testing.T) {
 	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 
-	cmd := CommandTest(cliParams, ioStreams, "scafctl")
-	assert.Nil(t, cmd.RunE, "parent test command should not have RunE")
+	cmd := CommandTest(cliParams, ioStreams, "mycli")
+	assert.NotNil(t, cmd.RunE, "parent test command should have RunE that defaults to functional")
+	assert.Contains(t, cmd.Long, "without a subcommand")
+}
+
+func TestCommandTest_RunE_NoSolutionFile(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandTest(cliParams, ioStreams, "mycli")
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no solution path provided")
+
+	// Verify EntryPointSettings.Path was set via filepath.Join
+	assert.Equal(t, filepath.Join("mycli", "test"), cliParams.EntryPointSettings.Path)
+	assert.Equal(t, "mycli", cliParams.BinaryName)
 }
 
 func BenchmarkCommandTest(b *testing.B) {

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -42,7 +43,7 @@ func Scan(category string) ([]Example, error) {
 	}
 
 	var items []Example
-	err = fs.WalkDir(examplesFS, root, func(path string, d fs.DirEntry, walkErr error) error {
+	err = fs.WalkDir(examplesFS, root, func(fpath string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -50,16 +51,24 @@ func Scan(category string) ([]Example, error) {
 			return nil
 		}
 
-		// Only include YAML files
-		ext := filepath.Ext(path)
+		// Only include YAML files (use path.Ext for forward-slash paths from embed.FS)
+		ext := path.Ext(fpath)
 		if ext != ".yaml" && ext != ".yml" {
 			return nil
 		}
 
-		// Get the relative path from the root
-		relPath, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
+		// Get the relative path from the root.
+		// embed.FS always uses forward slashes, so use strings-based trimming
+		// instead of filepath.Rel which produces OS-native separators on Windows.
+		relPath := strings.TrimPrefix(fpath, root+"/")
+		if relPath == fpath {
+			// Fallback for OS filesystem where paths may use native separators
+			var relErr error
+			relPath, relErr = filepath.Rel(root, fpath)
+			if relErr != nil {
+				return relErr
+			}
+			relPath = filepath.ToSlash(relPath)
 		}
 
 		// Determine category from the first directory component
@@ -106,22 +115,24 @@ func Scan(category string) ([]Example, error) {
 }
 
 // Read returns the contents of an example file.
-func Read(path string) (string, error) {
+func Read(exPath string) (string, error) {
 	examplesFS, root, err := getExamplesFS()
 	if err != nil {
 		return "", err
 	}
 
+	// Normalize to forward slashes (embed.FS always uses forward slashes)
+	cleanPath := path.Clean(filepath.ToSlash(exPath))
+
 	// Security: ensure the path doesn't escape
-	cleanPath := filepath.Clean(path)
 	if strings.Contains(cleanPath, "..") {
 		return "", fmt.Errorf("path must not contain '..'")
 	}
 
-	fullPath := filepath.Join(root, cleanPath)
+	fullPath := path.Join(root, cleanPath)
 	content, err := fs.ReadFile(examplesFS, fullPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read example %q: %w", path, err)
+		return "", fmt.Errorf("failed to read example %q: %w", exPath, err)
 	}
 
 	return string(content), nil
@@ -215,7 +226,7 @@ func findExamplesDir() (string, error) {
 }
 
 // DescriptionFromPath generates a human-readable description from a file path.
-func DescriptionFromPath(path string) string {
+func DescriptionFromPath(exPath string) string {
 	descriptions := map[string]string{
 		// Solutions
 		"solutions/comprehensive/solution.yaml":      "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
@@ -296,13 +307,14 @@ func DescriptionFromPath(path string) string {
 		"providers/security-example.yaml":            "Security hardening patterns across providers",
 	}
 
-	if desc, ok := descriptions[path]; ok {
+	if desc, ok := descriptions[exPath]; ok {
 		return desc
 	}
 
-	// Fallback: generate from filename
-	name := filepath.Base(path)
-	name = strings.TrimSuffix(name, filepath.Ext(name))
+	// Fallback: generate from filename.
+	// Use path.Base/path.Ext (forward-slash) since relPaths are normalized to forward slashes.
+	name := path.Base(exPath)
+	name = strings.TrimSuffix(name, path.Ext(name))
 	name = strings.ReplaceAll(name, "-", " ")
 	name = strings.ReplaceAll(name, "_", " ")
 	return strings.Title(name) + " example" //nolint:staticcheck // strings.Title is fine for simple cases

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -92,6 +92,30 @@ func TestRead_ValidExample(t *testing.T) {
 	assert.NotEmpty(t, content, "example content should not be empty")
 }
 
+func TestRead_BackslashPathNormalized(t *testing.T) {
+	t.Parallel()
+	items, err := Scan("")
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	// Simulate a Windows-style backslash path
+	backslashPath := strings.ReplaceAll(items[0].Path, "/", "\\")
+	content, err := Read(backslashPath)
+	require.NoError(t, err)
+	assert.NotEmpty(t, content, "should read example with backslash path")
+}
+
+func TestScan_PathsUseForwardSlashes(t *testing.T) {
+	t.Parallel()
+	items, err := Scan("")
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	for _, item := range items {
+		assert.NotContains(t, item.Path, "\\", "example paths should use forward slashes, got %q", item.Path)
+	}
+}
+
 func TestRead_NonexistentFile(t *testing.T) {
 	t.Parallel()
 	_, err := Read("nonexistent/file.yaml")

--- a/pkg/schema/validate.go
+++ b/pkg/schema/validate.go
@@ -6,6 +6,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -84,23 +85,140 @@ func parseValidationErrors(err error) []Violation {
 }
 
 // parseSchemaErrorLine attempts to extract a path and message from a validation error line.
-// The google/jsonschema-go library formats errors with path info in various ways.
+// The google/jsonschema-go library formats errors as chains of "validating X:" prefixes
+// followed by the actual error message. This function collapses that chain into a dot-path.
 func parseSchemaErrorLine(line string) (path, message string) {
-	// Try to extract path from common patterns like:
-	//   "/path/to/field: error message"
-	//   "at /path/to/field: error message"
 	line = strings.TrimPrefix(line, "- ")
 	line = strings.TrimPrefix(line, "at ")
+
+	// Handle "validating X: validating Y: ... actual message" chains
+	if strings.HasPrefix(line, "validating ") {
+		return parseValidatingChain(line)
+	}
 
 	if idx := strings.Index(line, ": "); idx > 0 {
 		candidate := line[:idx]
 		// JSON pointer paths start with /
 		if strings.HasPrefix(candidate, "/") {
-			return jsonPointerToDotPath(candidate), line[idx+2:]
+			return jsonPointerToDotPath(candidate), cleanSchemaMessage(line[idx+2:])
 		}
 	}
 
-	return "", line
+	return "", cleanSchemaMessage(line)
+}
+
+// validatingPrefix is the prefix used by google/jsonschema-go in error chains.
+const validatingPrefix = "validating "
+
+// parseValidatingChain collapses a "validating X: validating Y: ... message" chain
+// into a dot-path and final message. It skips schema URLs, $defs type references,
+// and structural JSON pointer segments (properties, additionalProperties, items).
+func parseValidatingChain(line string) (string, string) {
+	var segments []string
+	remaining := line
+
+	for strings.HasPrefix(remaining, validatingPrefix) {
+		remaining = remaining[len(validatingPrefix):]
+
+		colonIdx := strings.Index(remaining, ": ")
+		if colonIdx < 0 {
+			// No more colons — the rest is the message
+			break
+		}
+
+		segment := remaining[:colonIdx]
+		remaining = remaining[colonIdx+2:]
+
+		// Skip schema URLs
+		if strings.HasPrefix(segment, "http://") || strings.HasPrefix(segment, "https://") {
+			continue
+		}
+
+		// Handle JSON pointer segments (e.g., /properties/spec, /$defs/SolutionSpec/properties/resolvers)
+		if strings.HasPrefix(segment, "/") {
+			parts := strings.Split(strings.TrimPrefix(segment, "/"), "/")
+			// Extract only property-name segments, skipping structural parts
+			skipNext := false
+			for _, part := range parts {
+				if skipNext {
+					// Skip the type name after $defs
+					skipNext = false
+					continue
+				}
+				switch part {
+				case "$defs":
+					skipNext = true // next segment is a type name
+				case "properties", "additionalProperties", "items":
+					// structural — skip
+				default:
+					segments = appendDedupe(segments, part)
+				}
+			}
+			continue
+		}
+
+		// Skip CamelCase type names (schema type references like SolutionSpec, ResolverResolver)
+		if len(segment) > 0 && segment[0] >= 'A' && segment[0] <= 'Z' {
+			continue
+		}
+
+		// Keep lowercase property names as path segments
+		if segment != "" {
+			segments = appendDedupe(segments, segment)
+		}
+	}
+
+	dotPath := strings.Join(segments, ".")
+	message := cleanSchemaMessage(remaining)
+
+	return dotPath, message
+}
+
+// appendDedupe appends s to the slice only if it differs from the last element.
+func appendDedupe(slice []string, s string) []string {
+	if len(slice) > 0 && slice[len(slice)-1] == s {
+		return slice
+	}
+	return append(slice, s)
+}
+
+// defsPattern matches JSON schema $defs references like:
+//
+//	$defs/SolutionSpec/properties/resolvers/additionalProperties
+//	#/$defs/Resolver/properties/resolve
+var defsPattern = regexp.MustCompile(`#?/?\$defs/[A-Za-z0-9_]+(?:/[A-Za-z0-9_\[\]]+)*`)
+
+// additionalPropsPattern matches "unexpected additional properties [\"key1\", \"key2\"]"
+// and rewrites it to the cleaner "unknown key \"key1\", \"key2\"" format.
+var additionalPropsPattern = regexp.MustCompile(`unexpected additional properties \[([^\]]+)\]`)
+
+// cleanSchemaMessage strips verbose $defs/... references and rewrites common
+// schema validation phrases to produce cleaner, user-facing output.
+func cleanSchemaMessage(msg string) string {
+	cleaned := defsPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		// Extract the last meaningful segment as a simplified reference
+		parts := strings.Split(match, "/")
+		// Find last non-structural segment (skip "properties", "additionalProperties", "items", "$defs")
+		for i := len(parts) - 1; i >= 0; i-- {
+			p := parts[i]
+			switch p {
+			case "properties", "additionalProperties", "items", "$defs", "#":
+				continue
+			default:
+				return p
+			}
+		}
+		return match
+	})
+	// Collapse multiple spaces that may result from replacements
+	for strings.Contains(cleaned, "  ") {
+		cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+	}
+
+	// Rewrite "unexpected additional properties" to "unknown key"
+	cleaned = additionalPropsPattern.ReplaceAllString(cleaned, "unknown key $1")
+
+	return strings.TrimSpace(cleaned)
 }
 
 // jsonPointerToDotPath converts a JSON pointer (e.g., "/spec/resolvers/env") to

--- a/pkg/schema/validate_test.go
+++ b/pkg/schema/validate_test.go
@@ -218,3 +218,129 @@ func TestPatchSchema_JSONSchemaType(t *testing.T) {
 	assert.Equal(t, "object", def["type"], "JsonschemaSchema should be type object")
 	assert.Nil(t, def["additionalProperties"], "JsonschemaSchema should not restrict additional properties")
 }
+
+func TestCleanSchemaMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips full $defs path",
+			input: "doesn't match schema $defs/SolutionSpec/properties/resolvers/additionalProperties",
+			want:  "doesn't match schema resolvers",
+		},
+		{
+			name:  "strips #/$defs path",
+			input: "value doesn't match #/$defs/Resolver/properties/resolve",
+			want:  "value doesn't match resolve",
+		},
+		{
+			name:  "no $defs unchanged",
+			input: "missing required field",
+			want:  "missing required field",
+		},
+		{
+			name:  "multiple $defs references",
+			input: "at $defs/A/properties/x or $defs/B/properties/y",
+			want:  "at x or y",
+		},
+		{
+			name:  "unexpected additional properties rewritten",
+			input: `unexpected additional properties ["s"]`,
+			want:  `unknown key "s"`,
+		},
+		{
+			name:  "multiple additional properties",
+			input: `unexpected additional properties ["foo", "bar"]`,
+			want:  `unknown key "foo", "bar"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, cleanSchemaMessage(tc.input))
+		})
+	}
+}
+
+func TestParseValidatingChain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantP   string
+		wantMsg string
+	}{
+		{
+			name:    "full chain with $defs",
+			input:   `validating https://scafctl.dev/schemas/v1/solution.json: validating /properties/spec: validating /$defs/SolutionSpec: validating /$defs/SolutionSpec/properties/resolvers: validating /$defs/SolutionSpec/properties/resolvers/additionalProperties: validating /$defs/ResolverResolver: validating /$defs/ResolverResolver/properties/resolve: validating /$defs/ResolverResolvePhase: unexpected additional properties ["s"]`,
+			wantP:   "spec.resolvers.resolve",
+			wantMsg: `unknown key "s"`,
+		},
+		{
+			name:    "simple properties chain",
+			input:   `validating https://example.com/schema.json: validating /properties/metadata: missing required field`,
+			wantP:   "metadata",
+			wantMsg: "missing required field",
+		},
+		{
+			name:    "deduplicates consecutive segments",
+			input:   `validating /properties/spec: validating /$defs/X/properties/spec: some error`,
+			wantP:   "spec",
+			wantMsg: "some error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path, msg := parseValidatingChain(tc.input)
+			assert.Equal(t, tc.wantP, path)
+			assert.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}
+
+func TestValidateSolutionAgainstSchema_UnknownKey(t *testing.T) {
+	resetSolutionSchemaOnce()
+
+	data := map[string]any{
+		"apiVersion": "scafctl.io/v1",
+		"kind":       "Solution",
+		"metadata": map[string]any{
+			"name":    "test-solution",
+			"version": "1.0.0",
+		},
+		"spec": map[string]any{
+			"resolvers": map[string]any{
+				"env": map[string]any{
+					"name": "env",
+					"resolve": map[string]any{
+						"s": "bad-key",
+						"with": []any{
+							map[string]any{
+								"provider": "parameter",
+								"inputs":   map[string]any{"name": "environment"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	violations, err := ValidateSolutionAgainstSchema(data)
+	require.NoError(t, err)
+	require.NotEmpty(t, violations)
+
+	v := violations[0]
+	assert.Equal(t, "spec.resolvers.resolve", v.Path, "should produce dot-path, not validating chain")
+	assert.Contains(t, v.Message, `unknown key "s"`, "should use 'unknown key' not 'unexpected additional properties'")
+	assert.NotContains(t, v.Message, "validating", "should not contain 'validating' prefix")
+	assert.NotContains(t, v.Message, "$defs", "should not contain $defs references")
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -122,6 +122,7 @@ tasks:
         rm -rf dist/
         rm -rf build/
         rm -rf bin/
+        rm -rf pkg/examples/files/*
 
         echo "  📋 Cleaning task cache..."
         rm -rf .task/
@@ -585,8 +586,20 @@ tasks:
   # Build
   # ──────────────────────────────────────────────────────────────────────────────
 
+  embed-examples:
+    desc: "Copy examples into pkg/examples/files for go:embed"
+    internal: true
+    sources:
+      - examples/**/*
+    generates:
+      - pkg/examples/files/**/*
+    cmds:
+      - |
+        rm -rf pkg/examples/files/*
+        cp -R examples/* pkg/examples/files/
+
   build:
-    deps: [mod, git-unshallow-clone]
+    deps: [mod, git-unshallow-clone, embed-examples]
     desc: "Build the CLI"
     silent: true
     sources:
@@ -607,7 +620,7 @@ tasks:
         platforms: [darwin]
 
   build-container-image:
-    deps: [mod, git-unshallow-clone]
+    deps: [mod, git-unshallow-clone, embed-examples]
     desc: "Build the container image layer"
     sources:
       - "**/*.go"


### PR DESCRIPTION
- default `test` command to run functional tests without requiring the `functional` subcommand
- add --base-dir flag to `build solution` for overriding the bundle root directory used for template and static file resolution
- auto-escalate `run provider` to action capability for write operations without requiring explicit --capability=action
- return actionable error when GCP device-code flow fails with the default ADC OAuth client
- strip verbose $defs/... paths from schema validation messages to produce cleaner lint output
- embed examples into the binary at build time via new embed-examples task so get_example works in distributed builds

BREAKING CHANGE: `test` command Use field changed from "test" to "test [reference]" and now executes functional tests by default when invoked without a subcommand

Closes #320
Closes #318
Closes #313
Closes #308
Closes #294
Closes #286
