### PR TITLE
feat: batch improvements across auth, catalog, lint, templates, and validation

### DIFF
--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -283,7 +283,13 @@ func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.T
 	if scope == "" {
 		scope = strings.Join(h.cfg.Scopes, " ")
 	}
+
+	// Use the last login flow if available, falling back to resolveDefaultFlow.
+	// This ensures GetToken uses the same cache key as the flow used during Login.
 	flow := h.resolveDefaultFlow()
+	if meta, metaErr := h.loadMetadata(ctx); metaErr == nil && meta != nil && meta.LastLoginFlow != "" {
+		flow = meta.LastLoginFlow
+	}
 
 	// Try cached token
 	if !opts.ForceRefresh && h.tokenCache != nil {
@@ -340,9 +346,10 @@ type tokenResponse struct {
 }
 
 type handlerMetadata struct {
-	Claims    *auth.Claims `json:"claims"`
-	ExpiresAt time.Time    `json:"expiresAt"`
-	Scopes    []string     `json:"scopes"`
+	Claims        *auth.Claims `json:"claims"`
+	ExpiresAt     time.Time    `json:"expiresAt"`
+	Scopes        []string     `json:"scopes"`
+	LastLoginFlow auth.Flow    `json:"lastLoginFlow,omitempty"`
 }
 
 type exchangeResult struct {
@@ -757,7 +764,7 @@ func (h *Handler) storeTokens(ctx context.Context, resp *tokenResponse, claims *
 			return fmt.Errorf("store refresh token: %w", err)
 		}
 	}
-	meta := &handlerMetadata{Claims: claims, ExpiresAt: expiresAt, Scopes: scopes}
+	meta := &handlerMetadata{Claims: claims, ExpiresAt: expiresAt, Scopes: scopes, LastLoginFlow: flow}
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("marshal metadata: %w", err)

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -800,3 +800,25 @@ func BenchmarkValidateConfig(b *testing.B) {
 		_ = ValidateConfig(cfg)
 	}
 }
+
+func TestHandler_GetToken_LastLoginFlowCacheLookup(t *testing.T) {
+	// Scenario: resolveDefaultFlow() returns FlowInteractive (authorizeURL is set),
+	// but user logged in with FlowClientCredentials. Without the fix, GetToken
+	// would look up the wrong cache key and return ErrNotAuthenticated.
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, _ := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.AuthorizeURL = srv.URL + "/authorize" // makes resolveDefaultFlow() return FlowInteractive
+		cfg.ClientSecret = "test-secret"          // enables client_credentials
+	})
+
+	// Login with client_credentials (different from resolveDefaultFlow)
+	_, err := h.Login(context.Background(), auth.LoginOptions{Flow: auth.FlowClientCredentials})
+	require.NoError(t, err)
+
+	// GetToken should find the cached token using LastLoginFlow from metadata
+	token, err := h.GetToken(context.Background(), auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "cc-access-token", token.AccessToken)
+}

--- a/pkg/cmd/scafctl/catalog/delete.go
+++ b/pkg/cmd/scafctl/catalog/delete.go
@@ -5,15 +5,16 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
-	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/input"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,8 @@ import (
 // DeleteOptions holds options for the delete command.
 type DeleteOptions struct {
 	Reference string
+	All       bool   // Delete all local artifacts (--all)
+	Force     bool   // Skip confirmation prompt (--force)
 	Catalog   string // Target catalog for remote delete (URL or config name, --catalog)
 	Kind      string // Artifact kind override (--kind)
 	Insecure  bool
@@ -40,7 +43,7 @@ func CommandDelete(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 		Aliases:      []string{"rm", "remove"},
 		Short:        "Delete an artifact from the catalog",
 		SilenceUsage: true,
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Doc(`
 			Delete an artifact from the local or remote catalog.
 
 			You must specify the exact version to delete.
@@ -48,23 +51,45 @@ func CommandDelete(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			For local artifacts, use the simple name@version format.
 			For remote artifacts, use the full registry path or specify --catalog.
 
+			Use --all to delete all artifacts from the local catalog.
+
 			Examples:
 			  # Delete from local catalog
 			  scafctl catalog delete my-solution@1.0.0
+
+			  # Delete all local artifacts
+			  scafctl catalog delete --all
+
+			  # Delete all local artifacts (skip confirmation)
+			  scafctl catalog delete --all --force
 
 			  # Delete from remote registry (full reference)
 			  scafctl catalog delete ghcr.io/myorg/scafctl/solutions/my-solution@1.0.0
 
 			  # Delete from a configured catalog
 			  scafctl catalog delete my-solution@1.0.0 --catalog myregistry
-		`),
-		Args: flags.RequireArg("name@version", cliParams.BinaryName+" catalog delete my-solution@1.0.0"),
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.All {
+				if len(args) > 0 {
+					return exitcode.Errorf("--all cannot be used with positional arguments")
+				}
+				if options.Catalog != "" {
+					return exitcode.Errorf("--all only applies to the local catalog; cannot be combined with --catalog")
+				}
+				return runDeleteAll(cmd.Context(), options)
+			}
+			if len(args) != 1 {
+				return exitcode.Errorf("requires exactly 1 argument: %s catalog delete my-solution@1.0.0", cliParams.BinaryName)
+			}
 			options.Reference = args[0]
 			return runDelete(cmd.Context(), options)
 		},
 	}
 
+	cmd.Flags().BoolVar(&options.All, "all", false, "Delete all artifacts from the local catalog")
+	cmd.Flags().BoolVarP(&options.Force, "force", "f", false, "Skip confirmation prompt")
 	cmd.Flags().StringVarP(&options.Catalog, "catalog", "c", "", catalogFlagUsage)
 	cmd.Flags().StringVar(&options.Kind, "kind", "", "Artifact kind override (solution, provider, auth-handler)")
 	cmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Allow insecure HTTP connections")
@@ -132,6 +157,74 @@ func runDelete(ctx context.Context, opts *DeleteOptions) error {
 	}
 
 	w.Successf("Deleted %s", ref.String())
+
+	return nil
+}
+
+// runDeleteAll deletes all artifacts from the local catalog.
+func runDeleteAll(ctx context.Context, opts *DeleteOptions) error {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
+	// Confirm action (skip in force mode or quiet mode)
+	if !opts.Force && !opts.CliParams.IsQuiet {
+		in := input.FromContext(ctx)
+		if in == nil {
+			return fmt.Errorf("input not initialized in context")
+		}
+		confirmed, err := in.Confirm(input.NewConfirmOptions().
+			WithPrompt("Delete all artifacts from the local catalog?").
+			WithDefault(false))
+		if err != nil {
+			err := fmt.Errorf("failed to read confirmation: %w", err)
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.GeneralError)
+		}
+		if !confirmed {
+			w.Info("Delete cancelled")
+			return nil
+		}
+	}
+
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err != nil {
+		w.Errorf("failed to open catalog: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	allKinds := []catalog.ArtifactKind{
+		catalog.ArtifactKindSolution,
+		catalog.ArtifactKindProvider,
+		catalog.ArtifactKindAuthHandler,
+	}
+
+	var deleted, failed int
+	for _, kind := range allKinds {
+		artifacts, listErr := localCatalog.List(ctx, kind, "")
+		if listErr != nil {
+			lgr.V(1).Info("failed to list artifacts", "kind", kind, "error", listErr)
+			failed++
+			continue
+		}
+		for _, info := range artifacts {
+			if delErr := localCatalog.Delete(ctx, info.Reference); delErr != nil {
+				lgr.V(1).Info("failed to delete artifact", "ref", info.Reference.String(), "error", delErr)
+				failed++
+				continue
+			}
+			deleted++
+		}
+	}
+
+	if failed > 0 {
+		w.Warningf("Failed to delete %d artifact(s); check logs for details", failed)
+	}
+
+	if deleted == 0 && failed == 0 {
+		w.Infof("No artifacts in local catalog")
+	} else if deleted > 0 {
+		w.Successf("Deleted %d artifact(s) from local catalog", deleted)
+	}
 
 	return nil
 }

--- a/pkg/cmd/scafctl/catalog/delete_test.go
+++ b/pkg/cmd/scafctl/catalog/delete_test.go
@@ -40,6 +40,7 @@ func TestCommandDelete_Flags(t *testing.T) {
 		{"catalog"},
 		{"kind"},
 		{"insecure"},
+		{"force"},
 	}
 
 	for _, tt := range flagTests {
@@ -73,7 +74,7 @@ func TestCommandDelete_RequiresExactlyOneArg(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required argument: <name@version>")
+	assert.Contains(t, err.Error(), "requires exactly 1 argument")
 }
 
 func TestCommandDelete_VersionRequired(t *testing.T) {
@@ -161,6 +162,57 @@ func TestLooksLikeRemoteReference(t *testing.T) {
 			assert.Equal(t, tt.expected, result, "looksLikeRemoteReference(%q)", tt.ref)
 		})
 	}
+}
+
+func TestCommandDelete_AllFlag(t *testing.T) {
+	// Cannot use t.Parallel with t.Setenv
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandDelete(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	cmd.SetArgs([]string{"--all", "--force"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestCommandDelete_AllWithArgs(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandDelete(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	cmd.SetArgs([]string{"--all", "my-solution@1.0.0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be used with positional arguments")
+}
+
+func TestCommandDelete_AllWithCatalog(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandDelete(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetContext(newCatalogTestCtx(t))
+	cmd.SetArgs([]string{"--all", "--catalog", "myregistry"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all only applies to the local catalog; cannot be combined with --catalog")
+}
+
+func TestRunDeleteAll_EmptyCatalog(t *testing.T) {
+	// Set XDG_DATA_HOME to a temp dir so NewLocalCatalog creates an empty catalog
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	ctx := newCatalogTestCtx(t)
+
+	err := runDeleteAll(ctx, &DeleteOptions{Force: true, CliParams: settings.NewCliParams()})
+	require.NoError(t, err)
 }
 
 func BenchmarkLooksLikeRemoteReference(b *testing.B) {

--- a/pkg/gotmpl/ext/collections/safelen.go
+++ b/pkg/gotmpl/ext/collections/safelen.go
@@ -1,0 +1,68 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package collections
+
+import (
+	"fmt"
+	"reflect"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// SafeLenFunc returns an ExtFunction that provides a nil-safe len override.
+// Unlike the built-in Go template len, this function returns 0 for nil values
+// instead of panicking.
+func SafeLenFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "len",
+		Description: "Returns the length of a string, slice, array, map, or channel. " +
+			"Unlike the built-in Go template len, this version returns 0 for nil values " +
+			"instead of panicking.",
+		Custom: true,
+		Examples: []gotmpl.Example{
+			{
+				Description: "Get length of a list",
+				Template:    `{{ len .items }}`,
+			},
+			{
+				Description: "Safe nil check",
+				Template:    `{{ eq (len .maybeNil) 0 }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"len": SafeLen,
+		},
+	}
+}
+
+// SafeLen returns the length of the value, or 0 if the value is nil.
+// It supports strings, slices, arrays, maps, channels, and pointers to any of these types.
+func SafeLen(v any) (int, error) {
+	if v == nil {
+		return 0, nil
+	}
+
+	rv := reflect.ValueOf(v)
+
+	// Dereference pointers so *[N]T, *[]T, *map, etc. work like builtins.
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return 0, nil
+		}
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() { //nolint:exhaustive // only length-able types are relevant
+	case reflect.String, reflect.Array:
+		return rv.Len(), nil
+	case reflect.Slice, reflect.Map, reflect.Chan:
+		if rv.IsNil() {
+			return 0, nil
+		}
+		return rv.Len(), nil
+	default:
+		return 0, fmt.Errorf("len: cannot determine length of type %T", v)
+	}
+}

--- a/pkg/gotmpl/ext/collections/safelen_test.go
+++ b/pkg/gotmpl/ext/collections/safelen_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeLen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected int
+		wantErr  bool
+	}{
+		{name: "nil value", input: nil, expected: 0},
+		{name: "empty string", input: "", expected: 0},
+		{name: "non-empty string", input: "hello", expected: 5},
+		{name: "empty slice", input: []any{}, expected: 0},
+		{name: "non-empty slice", input: []any{1, 2, 3}, expected: 3},
+		{name: "nil slice", input: ([]string)(nil), expected: 0},
+		{name: "empty map", input: map[string]any{}, expected: 0},
+		{name: "non-empty map", input: map[string]any{"a": 1, "b": 2}, expected: 2},
+		{name: "nil map", input: (map[string]any)(nil), expected: 0},
+		{name: "array", input: [3]int{1, 2, 3}, expected: 3},
+		{name: "pointer to array", input: &[3]int{1, 2, 3}, expected: 3},
+		{name: "pointer to slice", input: func() any { s := []string{"a", "b"}; return &s }(), expected: 2},
+		{name: "nil pointer", input: (*[3]int)(nil), expected: 0},
+		{name: "integer (unsupported)", input: 42, wantErr: true},
+		{name: "bool (unsupported)", input: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := SafeLen(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSafeLenFunc_Metadata(t *testing.T) {
+	t.Parallel()
+	f := SafeLenFunc()
+	assert.Equal(t, "len", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.Contains(t, f.Func, "len")
+}
+
+func BenchmarkSafeLen(b *testing.B) {
+	inputs := []struct {
+		name  string
+		value any
+	}{
+		{"nil", nil},
+		{"string", "hello world"},
+		{"slice", []int{1, 2, 3, 4, 5}},
+		{"map", map[string]int{"a": 1, "b": 2}},
+	}
+
+	for _, tt := range inputs {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				SafeLen(tt.value) //nolint:errcheck // benchmark
+			}
+		})
+	}
+}

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -80,6 +80,7 @@ func Custom() gotmpl.ExtFunctionList {
 		// Collection / list-filtering functions
 		collections.WhereFunc(),
 		collections.SelectFunc(),
+		collections.SafeLenFunc(),
 
 		// Inline CEL evaluation
 		celeval.CelFunc(),

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -176,6 +176,14 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				"reserved-name")
 		}
 
+		if strings.Contains(name, "-") {
+			result.addFinding(SeverityInfo, "naming", location,
+				fmt.Sprintf("resolver name '%s' contains hyphens — use underscores for CEL compatibility (e.g., '%s')",
+					name, strings.ReplaceAll(name, "-", "_")),
+				"Hyphens in resolver names require quoting in CEL expressions. Use underscores for direct access: _.my_resolver",
+				"hyphenated-name")
+		}
+
 		// A resolver with a validate block exists for its side effect (aborting
 		// execution on validation failure), so it is "used" even if no other
 		// resolver or action references it.

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -553,3 +553,42 @@ func TestLintResolvers_CELExpressionInputNotFlaggedUnused(t *testing.T) {
 		}
 	}
 }
+
+func TestLintResolvers_HyphenatedName(t *testing.T) {
+	reg := provider.NewRegistry()
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"my-resolver": {
+			Description: "has hyphens",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static"},
+				},
+			},
+		},
+		"my_resolver": {
+			Description: "uses underscores",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static"},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := map[string]bool{"my-resolver": true, "my_resolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	var hyphenFindings []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "hyphenated-name" {
+			hyphenFindings = append(hyphenFindings, f)
+		}
+	}
+
+	require.Len(t, hyphenFindings, 1)
+	assert.Contains(t, hyphenFindings[0].Message, "my-resolver")
+	assert.Contains(t, hyphenFindings[0].Message, "my_resolver")
+	assert.Equal(t, SeverityInfo, hyphenFindings[0].Severity)
+}

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -85,7 +85,7 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 				"template": schemahelper.StringProp("Go template content to render (required for 'render' operation). Resolver data is available as the root context (e.g., .name, .config.host). Use {{.fieldName}} to access values.",
 					schemahelper.WithExample("Hello, {{.name}}!"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(65536))),
-				"name": schemahelper.StringProp("Name for the template, used in error messages and logging. Required for 'render', optional for 'render-tree' (defaults to 'render-tree').",
+				"name": schemahelper.StringProp("Optional name for the template, used in error messages and logging. Defaults to 'template' for 'render' and 'render-tree' for the batch operation.",
 					schemahelper.WithExample("greeting-template"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
 				"missingKey": schemahelper.StringProp("Behavior when a map key is missing: 'default' (prints <no value>), 'zero' (returns zero value), 'error' (stops with error)",
@@ -335,10 +335,10 @@ func (p *GoTemplateProvider) executeRender(ctx context.Context, inputs map[strin
 		return nil, fmt.Errorf("%s: template is required and must be a string", ProviderName)
 	}
 
-	// Extract name (required)
-	templateName, ok := inputs["name"].(string)
-	if !ok || templateName == "" {
-		return nil, fmt.Errorf("%s: name is required and must be a string", ProviderName)
+	// Extract name (optional, defaults to "template")
+	templateName, _ := inputs["name"].(string)
+	if templateName == "" {
+		templateName = "template"
 	}
 
 	// Parse shared rendering options
@@ -419,6 +419,9 @@ func (p *GoTemplateProvider) executeDryRun(inputs map[string]any) (*provider.Out
 
 	templateStr, _ := inputs["template"].(string)
 	templateName, _ := inputs["name"].(string)
+	if templateName == "" {
+		templateName = "template"
+	}
 
 	// Truncate template for display if too long
 	displayTemplate := templateStr

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -70,6 +70,26 @@ func TestGoTemplateProvider_Execute_WithName(t *testing.T) {
 	assert.Equal(t, "my-template", output.Metadata["templateName"])
 }
 
+func TestGoTemplateProvider_Execute_DefaultName(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"greeting": "Hi",
+	})
+
+	inputs := map[string]any{
+		"template": "{{.greeting}}, world!",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	assert.Equal(t, "Hi, world!", output.Data)
+	assert.Equal(t, "template", output.Metadata["templateName"])
+}
+
 func TestGoTemplateProvider_Execute_Conditional(t *testing.T) {
 	p := NewGoTemplateProvider()
 	ctx := context.Background()
@@ -284,11 +304,12 @@ func TestGoTemplateProvider_Execute_MissingName(t *testing.T) {
 	p := NewGoTemplateProvider()
 	ctx := context.Background()
 
-	_, err := p.Execute(ctx, map[string]any{
+	output, err := p.Execute(ctx, map[string]any{
 		"template": "Hello",
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "name is required")
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", output.Data)
+	assert.Equal(t, "template", output.Metadata["templateName"])
 }
 
 func TestGoTemplateProvider_Execute_EmptyTemplate(t *testing.T) {

--- a/pkg/provider/builtin/validationprovider/validation.go
+++ b/pkg/provider/builtin/validationprovider/validation.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
@@ -22,6 +24,7 @@ const ProviderName = "validation"
 // ValidationProvider provides validation operations using regex patterns and CEL expressions.
 type ValidationProvider struct {
 	descriptor *provider.Descriptor
+	tmplSvc    *gotmpl.Service // cached template service for resolveMessage
 }
 
 // NewValidationProvider creates a new validation provider instance.
@@ -55,7 +58,7 @@ func NewValidationProvider() *ValidationProvider {
 				"failWhen": schemahelper.StringProp("CEL expression that triggers a validation failure when true (has access to __self and _ for resolver data). Reads naturally for error conditions. Mutually exclusive with expression",
 					schemahelper.WithExample("__self.statusCode == 401"),
 					schemahelper.WithMaxLength(1000)),
-				"message": schemahelper.StringProp("Custom error message to display when validation fails",
+				"message": schemahelper.StringProp("Custom error message. Supports dynamic messages with 'expr:' prefix (CEL) or 'tmpl:' prefix (Go template). Plain strings are used as-is",
 					schemahelper.WithExample("Value must be a valid email address"),
 					schemahelper.WithMaxLength(1000)),
 			}),
@@ -128,6 +131,7 @@ inputs:
 				},
 			},
 		},
+		tmplSvc: gotmpl.NewService(nil),
 	}
 }
 
@@ -206,10 +210,9 @@ func (p *ValidationProvider) Execute(ctx context.Context, input any) (*provider.
 			return nil, fmt.Errorf("%s: invalid match pattern: %w", ProviderName, err)
 		}
 		if !matched {
-			// Get custom message from inputs if provided
 			message := fmt.Sprintf("value does not match pattern: %s", matchPattern)
 			if customMsg, ok := inputs["message"].(string); ok && customMsg != "" {
-				message = customMsg
+				message = resolveMessage(ctx, customMsg, resolverData, valueAny, p.tmplSvc)
 			}
 			return nil, fmt.Errorf("%s: %s", ProviderName, message)
 		}
@@ -225,10 +228,9 @@ func (p *ValidationProvider) Execute(ctx context.Context, input any) (*provider.
 			return nil, fmt.Errorf("%s: invalid notMatch pattern: %w", ProviderName, err)
 		}
 		if matched {
-			// Get custom message from inputs if provided
 			message := fmt.Sprintf("value matches forbidden pattern: %s", notMatchPattern)
 			if customMsg, ok := inputs["message"].(string); ok && customMsg != "" {
-				message = customMsg
+				message = resolveMessage(ctx, customMsg, resolverData, valueAny, p.tmplSvc)
 			}
 			return nil, fmt.Errorf("%s: %s", ProviderName, message)
 		}
@@ -272,7 +274,6 @@ func (p *ValidationProvider) Execute(ctx context.Context, input any) (*provider.
 		}
 
 		if !valid {
-			// Get custom message from inputs if provided
 			var message string
 			if invertResult {
 				message = fmt.Sprintf("error condition met: %s", celExpr)
@@ -280,7 +281,7 @@ func (p *ValidationProvider) Execute(ctx context.Context, input any) (*provider.
 				message = fmt.Sprintf("expression evaluated to false: %s", celExpr)
 			}
 			if customMsg, ok := inputs["message"].(string); ok && customMsg != "" {
-				message = customMsg
+				message = resolveMessage(ctx, customMsg, resolverData, valueAny, p.tmplSvc)
 			}
 			return nil, fmt.Errorf("%s: %s", ProviderName, message)
 		}
@@ -294,4 +295,47 @@ func (p *ValidationProvider) Execute(ctx context.Context, input any) (*provider.
 			"details": "all validations passed",
 		},
 	}, nil
+}
+
+// resolveMessage evaluates a message string that may contain an expr: or tmpl: prefix.
+// If the message starts with "expr:", the remainder is evaluated as a CEL expression.
+// If the message starts with "tmpl:", the remainder is evaluated as a Go template.
+// Otherwise, the message is returned as-is.
+func resolveMessage(ctx context.Context, message string, resolverData map[string]any, self any, tmplSvc *gotmpl.Service) string {
+	switch {
+	case strings.HasPrefix(message, "expr:"):
+		expr := strings.TrimPrefix(message, "expr:")
+		result, err := celexp.EvaluateExpression(ctx, strings.TrimSpace(expr), resolverData, map[string]any{
+			celexp.VarSelf: self,
+		})
+		if err != nil {
+			logger.FromContext(ctx).V(1).Info("dynamic message evaluation failed, using raw message", "prefix", "expr", "error", err)
+			return strings.TrimPrefix(message, "expr:") // fall back to stripped message on error
+		}
+		if s, ok := result.(string); ok {
+			return s
+		}
+		return fmt.Sprintf("%v", result)
+
+	case strings.HasPrefix(message, "tmpl:"):
+		tmplContent := strings.TrimPrefix(message, "tmpl:")
+		data := make(map[string]any)
+		for k, v := range resolverData {
+			data[k] = v
+		}
+		data[celexp.VarSelf] = self
+		result, err := tmplSvc.Execute(ctx, gotmpl.TemplateOptions{
+			Content: strings.TrimSpace(tmplContent),
+			Name:    "validation-message",
+			Data:    data,
+		})
+		if err != nil {
+			logger.FromContext(ctx).V(1).Info("dynamic message evaluation failed, using raw message", "prefix", "tmpl", "error", err)
+			return strings.TrimPrefix(message, "tmpl:") // fall back to stripped message on error
+		}
+		return result.Output
+
+	default:
+		return message
+	}
 }

--- a/pkg/provider/builtin/validationprovider/validation_test.go
+++ b/pkg/provider/builtin/validationprovider/validation_test.go
@@ -379,3 +379,55 @@ func TestValidationProvider_Execute_NoCriteria_IncludesFailWhen(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failWhen")
 }
+
+func TestValidationProvider_Execute_ExprMessage(t *testing.T) {
+	p := NewValidationProvider()
+
+	ctx := provider.WithResolverContext(context.Background(), map[string]any{
+		"task": "deploy",
+	})
+	inputs := map[string]any{
+		"value":      "invalid",
+		"expression": "__self == \"valid\"",
+		"message":    "expr: \"Value '\" + __self + \"' is not valid for task '\" + _.task + \"'\"",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Value 'invalid' is not valid for task 'deploy'")
+}
+
+func TestValidationProvider_Execute_TmplMessage(t *testing.T) {
+	p := NewValidationProvider()
+
+	ctx := provider.WithResolverContext(context.Background(), map[string]any{
+		"env": "prod",
+	})
+	inputs := map[string]any{
+		"value":      "bad",
+		"expression": "__self == \"good\"",
+		"message":    "tmpl: Value '{{.__self}}' is invalid in {{.env}}",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Value 'bad' is invalid in prod")
+}
+
+func TestValidationProvider_Execute_PlainMessage(t *testing.T) {
+	p := NewValidationProvider()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"value":      "bad",
+		"expression": "__self == \"good\"",
+		"message":    "plain error message",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plain error message")
+}


### PR DESCRIPTION
- add nil-safe len template function override that returns 0 instead of panicking on nil values
- persist last login flow in oauth2 metadata so GetToken uses the correct cache key regardless of resolveDefaultFlow
- add --all flag to catalog delete for removing all local artifacts, with --catalog conflict validation
- warn on hyphenated resolver names that require quoting in CEL expressions
- make gotmpl provider name input optional, defaulting to "template"
- support expr: and tmpl: prefixes in validation message field for dynamic error messages with fallback logging
- add benchmarks for SafeLen and tests for runDeleteAll

Closes #332
Closes #333
Closes #202
Closes #255
Closes #238
Closes #220