### PR TITLE
fix(engine): scope-aware template dependency scanner

### DIFF
--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -656,6 +656,11 @@ func extractRefsFromTemplate(tmpl *gotmpl.GoTemplatingContent, refs map[string]s
 	}
 
 	for _, ref := range tmplRefs {
+		// Skip scoped references inside {{ with }}/{{ range }} bodies
+		if ref.Scoped {
+			continue
+		}
+
 		// Template references come as .__actions.name.field or __actions.name.field
 		path := ref.Path
 		if strings.HasPrefix(path, ".__actions.") || strings.HasPrefix(path, "__actions.") {

--- a/pkg/gotmpl/refs.go
+++ b/pkg/gotmpl/refs.go
@@ -19,6 +19,15 @@ type TemplateReference struct {
 
 	// Position is the line:column position in the template (if available)
 	Position string
+
+	// Scoped indicates the reference is inside a {{ with }} or {{ range }} body
+	// where dot has been rebound. Scoped references refer to fields of the
+	// narrowed context, not the root data.
+	//
+	// Deduplication: if the same path appears both scoped and unscoped, the
+	// entry is marked Scoped=false (unscoped wins) so that dependency
+	// extractors do not miss a real top-level reference.
+	Scoped bool
 }
 
 // goTemplateBuiltins lists the function names that text/template provides
@@ -79,13 +88,13 @@ func (s *Service) GetReferences(ctx context.Context, opts TemplateOptions) ([]Te
 	}
 
 	references := make([]TemplateReference, 0)
-	visited := make(map[string]bool)
+	visited := make(map[string]int) // path → index in references slice
 
 	// Walk the parse tree to extract data references
 	// parse.Parse returns a map of tree names to trees
 	for _, tree := range trees {
 		if tree.Root != nil {
-			walkNodes(tree.Root, &references, visited)
+			walkNodes(tree.Root, &references, visited, 0)
 		}
 	}
 
@@ -107,8 +116,11 @@ func GetGoTemplateReferences(templateContent, leftDelim, rightDelim string) ([]T
 	})
 }
 
-// walkNodes recursively walks the template parse tree to find data references
-func walkNodes(node parse.Node, references *[]TemplateReference, visited map[string]bool) {
+// walkNodes recursively walks the template parse tree to find data references.
+// scopeDepth tracks how many {{ with }} or {{ range }} bodies we are inside.
+// When scopeDepth > 0, dot has been rebound, so field references are scoped
+// to the narrowed context rather than the root data.
+func walkNodes(node parse.Node, references *[]TemplateReference, visited map[string]int, scopeDepth int) {
 	if node == nil {
 		return
 	}
@@ -117,106 +129,157 @@ func walkNodes(node parse.Node, references *[]TemplateReference, visited map[str
 	case *parse.ListNode:
 		if n != nil {
 			for _, child := range n.Nodes {
-				walkNodes(child, references, visited)
+				walkNodes(child, references, visited, scopeDepth)
 			}
 		}
 
 	case *parse.ActionNode:
 		if n.Pipe != nil {
-			walkPipe(n.Pipe, references, visited, n.Pos)
+			walkPipe(n.Pipe, references, visited, n.Pos, scopeDepth)
 		}
 
 	case *parse.IfNode:
 		if n.Pipe != nil {
-			walkPipe(n.Pipe, references, visited, n.Pos)
+			walkPipe(n.Pipe, references, visited, n.Pos, scopeDepth)
 		}
-		walkNodes(n.List, references, visited)
+		walkNodes(n.List, references, visited, scopeDepth)
 		if n.ElseList != nil {
-			walkNodes(n.ElseList, references, visited)
+			walkNodes(n.ElseList, references, visited, scopeDepth)
 		}
 
 	case *parse.RangeNode:
+		// The pipe is evaluated in the outer scope (dot is still the parent).
 		if n.Pipe != nil {
-			walkPipe(n.Pipe, references, visited, n.Pos)
+			walkPipe(n.Pipe, references, visited, n.Pos, scopeDepth)
 		}
-		walkNodes(n.List, references, visited)
+		// The body has dot rebound to each element.
+		walkNodes(n.List, references, visited, scopeDepth+1)
+		// The else clause runs when the collection is empty; dot is NOT rebound.
 		if n.ElseList != nil {
-			walkNodes(n.ElseList, references, visited)
+			walkNodes(n.ElseList, references, visited, scopeDepth)
 		}
 
 	case *parse.WithNode:
+		// The pipe is evaluated in the outer scope (dot is still the parent).
 		if n.Pipe != nil {
-			walkPipe(n.Pipe, references, visited, n.Pos)
+			walkPipe(n.Pipe, references, visited, n.Pos, scopeDepth)
 		}
-		walkNodes(n.List, references, visited)
+		// The body has dot rebound to the pipe value.
+		walkNodes(n.List, references, visited, scopeDepth+1)
+		// The else clause runs when the value is falsy; dot is NOT rebound.
 		if n.ElseList != nil {
-			walkNodes(n.ElseList, references, visited)
+			walkNodes(n.ElseList, references, visited, scopeDepth)
 		}
 
 	case *parse.TemplateNode:
 		if n.Pipe != nil {
-			walkPipe(n.Pipe, references, visited, n.Pos)
+			walkPipe(n.Pipe, references, visited, n.Pos, scopeDepth)
 		}
 	}
 }
 
 // walkPipe walks a pipe node to extract field references
-func walkPipe(pipe *parse.PipeNode, references *[]TemplateReference, visited map[string]bool, pos parse.Pos) {
+func walkPipe(pipe *parse.PipeNode, references *[]TemplateReference, visited map[string]int, pos parse.Pos, scopeDepth int) {
 	if pipe == nil {
 		return
 	}
 
 	for _, cmd := range pipe.Cmds {
-		walkCommand(cmd, references, visited, pos)
+		walkCommand(cmd, references, visited, pos, scopeDepth)
 	}
 }
 
 // walkCommand walks a command node to extract field references
-func walkCommand(cmd *parse.CommandNode, references *[]TemplateReference, visited map[string]bool, pos parse.Pos) {
+func walkCommand(cmd *parse.CommandNode, references *[]TemplateReference, visited map[string]int, pos parse.Pos, scopeDepth int) {
 	if cmd == nil {
 		return
 	}
 
 	for _, arg := range cmd.Args {
-		walkArg(arg, references, visited, pos)
+		walkArg(arg, references, visited, pos, scopeDepth)
 	}
 }
 
-// walkArg walks an argument node to extract field references
-func walkArg(arg parse.Node, references *[]TemplateReference, visited map[string]bool, pos parse.Pos) {
+// addOrUpgradeRef adds a new reference or upgrades an existing scoped
+// reference to unscoped when the same path is encountered at root scope.
+func addOrUpgradeRef(references *[]TemplateReference, visited map[string]int, path, position string, scoped bool) {
+	if idx, ok := visited[path]; ok {
+		// Path already seen. If the existing ref is scoped but this one is not,
+		// upgrade to unscoped so dependency extractors don't miss it.
+		if !scoped && (*references)[idx].Scoped {
+			(*references)[idx].Scoped = false
+		}
+
+		return
+	}
+
+	visited[path] = len(*references)
+	*references = append(*references, TemplateReference{
+		Path:     path,
+		Position: position,
+		Scoped:   scoped,
+	})
+}
+
+// walkArg walks an argument node to extract field references.
+// When scopeDepth > 0, references are marked as Scoped because dot has been
+// rebound by a {{ with }} or {{ range }} block.
+func walkArg(arg parse.Node, references *[]TemplateReference, visited map[string]int, pos parse.Pos, scopeDepth int) {
+	scoped := scopeDepth > 0
+
 	switch n := arg.(type) {
 	case *parse.FieldNode:
 		// This is a field reference like .User.Name or .Items
 		path := buildFieldPath(n.Ident)
-		if !visited[path] && !isTemplateVariable(path) {
-			visited[path] = true
-			*references = append(*references, TemplateReference{
-				Path:     path,
-				Position: fmt.Sprintf("pos:%d", pos),
-			})
+		if !isTemplateVariable(path) {
+			addOrUpgradeRef(references, visited, path, fmt.Sprintf("pos:%d", pos), scoped)
+		}
+
+	case *parse.VariableNode:
+		// Variable nodes represent $, $.Field, $var, $var.Field.
+		// $ (root variable) refers to the root data even inside with/range,
+		// so $.Field references are recorded as unscoped data references.
+		// Other variables ($var, $var.Field) are user-defined pipeline
+		// variables and are not data references.
+		if len(n.Ident) >= 2 && n.Ident[0] == "$" {
+			path := "." + strings.Join(n.Ident[1:], ".")
+			if !isTemplateVariable(path) {
+				addOrUpgradeRef(references, visited, path, fmt.Sprintf("pos:%d", pos), false)
+			}
 		}
 
 	case *parse.ChainNode:
 		// Handle chained field access
 		if n.Node != nil {
-			walkArg(n.Node, references, visited, pos)
+			walkArg(n.Node, references, visited, pos, scopeDepth)
 		}
 		if len(n.Field) > 0 {
+			// Check if the chain is rooted at a variable node ($var.Field or $.Field).
+			if vn, ok := n.Node.(*parse.VariableNode); ok {
+				if len(vn.Ident) == 1 && vn.Ident[0] == "$" {
+					// $ always refers to the root data, even inside with/range,
+					// so $.resolver must be recorded as unscoped.
+					path := "." + strings.Join(n.Field, ".")
+					if !isTemplateVariable(path) {
+						addOrUpgradeRef(references, visited, path, fmt.Sprintf("pos:%d", pos), false)
+					}
+				}
+				// For any other variable ($var.Field), skip entirely -- these
+				// are user-defined pipeline variables, not data references.
+				break
+			}
+
 			// Extract the base path from the chain's base node
 			basePath := extractBasePath(n.Node)
 			path := basePath + "." + strings.Join(n.Field, ".")
-			if !visited[path] && !isTemplateVariable(path) {
-				visited[path] = true
-				*references = append(*references, TemplateReference{
-					Path:     path,
-					Position: fmt.Sprintf("pos:%d", pos),
-				})
+			if !isTemplateVariable(path) {
+				addOrUpgradeRef(references, visited, path, fmt.Sprintf("pos:%d", pos), scoped)
 			}
 		}
 
 	case *parse.PipeNode:
 		// Handle nested pipes
-		walkPipe(n, references, visited, pos)
+		walkPipe(n, references, visited, pos, scopeDepth)
 	}
 }
 

--- a/pkg/gotmpl/refs_test.go
+++ b/pkg/gotmpl/refs_test.go
@@ -384,3 +384,108 @@ func TestWalkArg_PipeNodeArg(t *testing.T) {
 	// The nested PipeNode branch should find .Name
 	assert.Contains(t, paths, ".Name")
 }
+
+func TestGetGoTemplateReferences_ScopeAwareness(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		wantScoped   []string // paths that should be marked Scoped=true
+		wantUnscoped []string // paths that should be marked Scoped=false
+	}{
+		{
+			name:         "with block scopes inner references",
+			template:     `{{ with .platformAssets.body.data }}{{ .kubeNamespaces }}{{ end }}`,
+			wantUnscoped: []string{".platformAssets.body.data"},
+			wantScoped:   []string{".kubeNamespaces"},
+		},
+		{
+			name:         "range block scopes inner references",
+			template:     `{{ range .Items }}{{ .Name }}{{ end }}`,
+			wantUnscoped: []string{".Items"},
+			wantScoped:   []string{".Name"},
+		},
+		{
+			name:         "if block does not scope references",
+			template:     `{{ if .Show }}{{ .Content }}{{ end }}`,
+			wantUnscoped: []string{".Show", ".Content"},
+			wantScoped:   nil,
+		},
+		{
+			name: "nested with/range increases scope depth",
+			template: `{{ with .config }}
+				{{ range .items }}{{ .name }}{{ end }}
+			{{ end }}`,
+			wantUnscoped: []string{".config"},
+			wantScoped:   []string{".items", ".name"},
+		},
+		{
+			name:         "with else clause is not scoped",
+			template:     `{{ with .data }}{{ .field }}{{ else }}{{ .fallback }}{{ end }}`,
+			wantUnscoped: []string{".data", ".fallback"},
+			wantScoped:   []string{".field"},
+		},
+		{
+			name:         "range else clause is not scoped",
+			template:     `{{ range .items }}{{ .name }}{{ else }}{{ .empty }}{{ end }}`,
+			wantUnscoped: []string{".items", ".empty"},
+			wantScoped:   []string{".name"},
+		},
+		{
+			name: "issue 334 reproduction",
+			template: `{{ with .platformAssets.body.data }}
+Namespaces: {{ .kubeNamespaces }}
+{{ end }}`,
+			wantUnscoped: []string{".platformAssets.body.data"},
+			wantScoped:   []string{".kubeNamespaces"},
+		},
+		{
+			name:         "same path scoped then unscoped upgrades to unscoped",
+			template:     `{{ with .cfg }}{{ .name }}{{ end }}{{ .name }}`,
+			wantUnscoped: []string{".cfg", ".name"},
+			wantScoped:   nil,
+		},
+		{
+			name:         "same path unscoped then scoped stays unscoped",
+			template:     `{{ .host }}{{ with .cfg }}{{ .host }}{{ end }}`,
+			wantUnscoped: []string{".host", ".cfg"},
+			wantScoped:   nil,
+		},
+		{
+			name:         "dollar root variable is unscoped inside with",
+			template:     `{{ with .cfg }}{{ $.resolver }}{{ end }}`,
+			wantUnscoped: []string{".cfg", ".resolver"},
+			wantScoped:   nil,
+		},
+		{
+			name:         "dollar root variable is unscoped inside range",
+			template:     `{{ range .items }}{{ $.global.name }}{{ end }}`,
+			wantUnscoped: []string{".items", ".global.name"},
+			wantScoped:   nil,
+		},
+		{
+			name:         "user variable chain is not recorded as reference",
+			template:     `{{ range $i, $v := .items }}{{ $v.name }}{{ end }}`,
+			wantUnscoped: []string{".items"},
+			wantScoped:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := GetGoTemplateReferences(tt.template, "", "")
+			require.NoError(t, err)
+
+			var scoped, unscoped []string
+			for _, ref := range refs {
+				if ref.Scoped {
+					scoped = append(scoped, ref.Path)
+				} else {
+					unscoped = append(unscoped, ref.Path)
+				}
+			}
+
+			assert.ElementsMatch(t, tt.wantUnscoped, unscoped, "unscoped references")
+			assert.ElementsMatch(t, tt.wantScoped, scoped, "scoped references")
+		})
+	}
+}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -658,6 +658,11 @@ func collectReferencedResolvers(sol *solution.Solution) map[string]bool {
 				tmplRefs, err := gotmpl.GetGoTemplateReferences(string(*vr.Tmpl), "", "")
 				if err == nil {
 					for _, ref := range tmplRefs {
+						// Skip scoped references inside {{ with }}/{{ range }} bodies
+						if ref.Scoped {
+							continue
+						}
+
 						name := resolverRefs.ExtractResolverName(ref.Path)
 						if name != "" {
 							refs[name] = true

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -1124,11 +1124,49 @@ CRITICAL RULES:
 - Document what was migrated and why in commit messages
 
 YAML FORMATTING RULES:
-- Multi-line CEL expressions MUST use block scalar format (>-), never single-quoted strings
-- When renaming resolvers (e.g., to param-<name>), update ALL dependsOn references to use the new name
-- When converting data.resolvers arrays, preserve ALL fields (name, type, value, cel, expression, etc.) — never drop fields silently
-- Use folded block scalar (>-) only for CEL or other single-line expressions longer than 80 characters
-- Use literal block scalar (|) for multi-line content (templates, scripts, JSON) where newlines must be preserved`, pathRef, inlineNote, migration, targetSection, pathRef, pathRef, pathRef, migrationGuide)
+
+1. CEL BLOCK SCALARS — Multi-line CEL expressions MUST use block scalar format, never single-quoted strings.
+   WRONG:
+     expression: 'cel.bind(vars, map.filter(x, x.size > 0))'
+   CORRECT:
+     expression: >-
+       cel.bind(vars, map.filter(x, x.size > 0))
+   Use >- (folded, strip) for CEL expressions. Use | (literal) for multi-line content where newlines matter (templates, scripts).
+
+2. DEPENDSON RENAMING — When renaming resolvers (e.g., to param-<name>), update ALL dependsOn references to use the new name.
+   WRONG (old name kept in dependsOn):
+     param-environment:
+       resolve: ...
+     deploy-config:
+       dependsOn: [environment]      # BUG: still uses old name
+   CORRECT:
+     param-environment:
+       resolve: ...
+     deploy-config:
+       dependsOn: [param-environment] # matches the new resolver name
+
+3. DATA.RESOLVERS ARRAY CONVERSION — When converting data.resolvers arrays, preserve ALL fields.
+   WRONG (drops value and cel fields):
+     resolve:
+       with:
+         - provider: static
+           inputs:
+             value:
+               items:
+                 - name: region
+                   type: string
+   CORRECT (all fields preserved):
+     resolve:
+       with:
+         - provider: static
+           inputs:
+             value:
+               items:
+                 - name: region
+                   type: string
+                   value: "us-east-1"
+                   cel: "env.region"
+   Never silently drop fields — every field in the source must appear in the output.`, pathRef, inlineNote, migration, targetSection, pathRef, pathRef, pathRef, migrationGuide)
 
 	return &mcp.GetPromptResult{
 		Description: fmt.Sprintf("Migrate solution (%s): %s", migration, pathRef),
@@ -1188,9 +1226,24 @@ func migrationTypeGuide(migration string) string {
 - Add display_name and description fields where missing
 - Standardize naming conventions (lowercase-with-hyphens)
 - Add type annotations to resolvers that are missing them
-- When renaming resolvers (e.g., prefixing with param-), update ALL dependsOn arrays to reference the new name
-- When converting data.resolvers from array format, preserve ALL fields including value, cel, expression, and any provider-specific inputs
-- Format multi-line CEL expressions as YAML block scalars (>-), never single-quoted strings
+
+CEL expression formatting:
+  When writing CEL expressions to YAML, ALWAYS use block scalar format:
+    expression: >-
+      cel.bind(vars, map.filter(x, x.size > 0))
+  NEVER use single-quoted strings for CEL:
+    expression: 'cel.bind(vars, ...)'   # WRONG
+
+Resolver renaming and dependsOn:
+  When renaming resolvers (e.g., prefixing with param-), update ALL dependsOn arrays to reference the new name.
+  Example: if "environment" is renamed to "param-environment", then dependsOn: [environment] must become dependsOn: [param-environment].
+  Search all resolvers and actions for dependsOn arrays referencing the old name.
+
+data.resolvers array conversion:
+  When converting data.resolvers from array format, preserve ALL fields including value, cel, expression, and any provider-specific inputs.
+  WRONG: only keeping name and type, dropping value/cel.
+  CORRECT: every field from the source array element must appear in the converted output.
+
 - Use literal block scalar (|) for multi-line content where newlines must be preserved`
 	default:
 		return fmt.Sprintf(`Migration: %s

--- a/pkg/mcp/tools_refs.go
+++ b/pkg/mcp/tools_refs.go
@@ -133,6 +133,11 @@ func extractGoTemplateRefs(content string) ([]string, error) {
 
 	var resolverPaths []string
 	for _, ref := range refs {
+		// Skip scoped references inside {{ with }}/{{ range }} bodies
+		if ref.Scoped {
+			continue
+		}
+
 		// Go template references start with "." — look for _.resolverName patterns
 		path := ref.Path
 		path = strings.TrimPrefix(path, ".")

--- a/pkg/mcp/tools_sprint7_test.go
+++ b/pkg/mcp/tools_sprint7_test.go
@@ -73,6 +73,71 @@ func TestHandleMigrateSolutionPrompt(t *testing.T) {
 		assert.Contains(t, text, "get_provider_schema")
 	})
 
+	t.Run("cel block scalar examples in prompt", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "upgrade-patterns",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+
+		// Bug 1: CEL expressions must show block scalar format examples
+		assert.Contains(t, text, "expression: >-", "should show correct block scalar format for CEL")
+		assert.Contains(t, text, "NEVER use single-quoted strings for CEL", "should warn against single-quoted CEL")
+	})
+
+	t.Run("dependsOn renaming examples in prompt", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "upgrade-patterns",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+
+		// Bug 2: dependsOn must show before/after rename examples
+		assert.Contains(t, text, "dependsOn: [param-environment]", "should show correct dependsOn after rename")
+		assert.Contains(t, text, "dependsOn: [environment]", "should show wrong dependsOn for contrast")
+	})
+
+	t.Run("data resolvers field preservation in prompt", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "upgrade-patterns",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+
+		// Bug 3: data.resolvers conversion must preserve all fields
+		assert.Contains(t, text, "preserve ALL fields", "should emphasize preserving all fields")
+		assert.Contains(t, text, "dropping value/cel", "should warn about dropping fields")
+	})
+
+	t.Run("yaml formatting rules contain examples", func(t *testing.T) {
+		request := mcp.GetPromptRequest{}
+		request.Params.Arguments = map[string]string{
+			"path":      "solution.yaml",
+			"migration": "add-composition",
+		}
+
+		result, err := srv.handleMigrateSolutionPrompt(context.Background(), request)
+		require.NoError(t, err)
+		text := result.Messages[0].Content.(mcp.TextContent).Text
+
+		// All migration types should include the YAML formatting rules with examples
+		assert.Contains(t, text, "CEL BLOCK SCALARS", "should include CEL block scalar rule")
+		assert.Contains(t, text, "DEPENDSON RENAMING", "should include dependsOn renaming rule")
+		assert.Contains(t, text, "DATA.RESOLVERS ARRAY CONVERSION", "should include data.resolvers rule")
+	})
+
 	t.Run("unknown migration type falls back to generic", func(t *testing.T) {
 		request := mcp.GetPromptRequest{}
 		request.Params.Arguments = map[string]string{

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -809,6 +809,12 @@ func extractDependencies(inputs map[string]any) []string {
 	// Extract the first segment of each reference path as the dependency name
 	// e.g., ".config.host" -> "config", "._.name" -> "name"
 	for _, ref := range refs {
+		// Skip scoped references — they refer to fields inside {{ with }}/{{ range }}
+		// bodies where dot has been rebound, not to top-level resolvers.
+		if ref.Scoped {
+			continue
+		}
+
 		path := ref.Path
 		// Strip leading dot if present
 		path = strings.TrimPrefix(path, ".")

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -1265,6 +1265,36 @@ func TestExtractDependencies_DataKeyExclusion(t *testing.T) {
 	})
 }
 
+func TestExtractDependencies_ScopedReferences(t *testing.T) {
+	t.Run("with block scopes inner references", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": `{{ with .platformAssets.body.data }}{{ .kubeNamespaces }}{{ end }}`,
+		})
+		assert.Contains(t, deps, "platformAssets")
+		for _, d := range deps {
+			assert.NotEqual(t, "kubeNamespaces", d, "scoped ref should not be a dependency")
+		}
+	})
+
+	t.Run("range block scopes inner references", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": `{{ range .servers }}{{ .name }}{{ end }}`,
+		})
+		assert.Contains(t, deps, "servers")
+		for _, d := range deps {
+			assert.NotEqual(t, "name", d, "scoped ref should not be a dependency")
+		}
+	})
+
+	t.Run("if block does not scope references", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": `{{ if .enabled }}{{ .value }}{{ end }}`,
+		})
+		assert.Contains(t, deps, "enabled")
+		assert.Contains(t, deps, "value")
+	})
+}
+
 func TestGoTemplateProvider_UnderscoreAlias(t *testing.T) {
 	p := NewGoTemplateProvider()
 

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -242,6 +242,12 @@ func extractDepsFromTemplateWithExclusions(tmplContent string, deps, exclude map
 
 	// Extract resolver names from paths that reference data
 	for _, ref := range refs {
+		// Skip scoped references — they refer to fields inside {{ with }}/{{ range }}
+		// bodies where dot has been rebound, not to top-level resolvers.
+		if ref.Scoped {
+			continue
+		}
+
 		path := ref.Path
 		var varName string
 		// Handle different path patterns from template parsing

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -324,8 +324,9 @@ func TestExtractDependencies(t *testing.T) {
 						{
 							Provider: "go-template",
 							Inputs: map[string]*ValueRef{
-								// Note: Inside range blocks, {{.name}} refers to the element's field
-								// but the parser can't distinguish this context, so "name" is also extracted
+								// Inside range blocks, {{.name}} refers to the element's field,
+								// not a top-level resolver. The scope-aware parser correctly
+								// excludes it as a dependency.
 								"template": {Literal: "{{range .servers}}- {{.name}}{{end}}"},
 								"name":     {Literal: "range-template"},
 							},
@@ -333,9 +334,9 @@ func TestExtractDependencies(t *testing.T) {
 					},
 				},
 			},
-			// servers is extracted from .servers, name is extracted from .name inside range
-			// (even though .name refers to a field, not a resolver, the parser can't distinguish)
-			want: []string{"servers", "name"},
+			// Only "servers" is a root-level dependency.
+			// ".name" inside the range body is scoped to each element, not a resolver.
+			want: []string{"servers"},
 		},
 		{
 			name: "explicit dependsOn only",
@@ -681,6 +682,26 @@ func TestExtractDepsFromTemplate(t *testing.T) {
 			name: "__item and __index should not be extracted",
 			tmpl: "{{ .__item }} at {{ .__index }}",
 			want: []string{},
+		},
+		{
+			name: "with block scopes inner references",
+			tmpl: `{{ with .platformAssets.body.data }}{{ .kubeNamespaces }}{{ end }}`,
+			want: []string{"platformAssets"},
+		},
+		{
+			name: "range block scopes inner references",
+			tmpl: `{{ range .items }}{{ .name }}{{ end }}`,
+			want: []string{"items"},
+		},
+		{
+			name: "nested with/range blocks",
+			tmpl: `{{ with .config }}{{ range .servers }}{{ .host }}{{ end }}{{ end }}`,
+			want: []string{"config"},
+		},
+		{
+			name: "if block does not scope references",
+			tmpl: `{{ if .enabled }}{{ .value }}{{ end }}`,
+			want: []string{"enabled", "value"},
 		},
 	}
 

--- a/pkg/resolver/refs/refs.go
+++ b/pkg/resolver/refs/refs.go
@@ -58,6 +58,12 @@ func ExtractFromTemplate(content, leftDelim, rightDelim string) ([]string, error
 	var result []string
 
 	for _, ref := range templateRefs {
+		// Skip scoped references — they refer to fields inside {{ with }}/{{ range }}
+		// bodies where dot has been rebound, not to top-level resolvers.
+		if ref.Scoped {
+			continue
+		}
+
 		name := ExtractResolverName(ref.Path)
 		if name != "" && !seen[name] {
 			seen[name] = true

--- a/pkg/resolver/refs/refs_test.go
+++ b/pkg/resolver/refs/refs_test.go
@@ -173,3 +173,23 @@ func TestReadStdin_NilReader(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stdin is not available")
 }
+
+func TestExtractFromTemplate_ScopedReferences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with block excludes scoped refs", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ExtractFromTemplate(`{{ with ._.config.data }}{{ .host }}{{ end }}`, "{{", "}}")
+		require.NoError(t, err)
+		assert.Contains(t, refs, "config")
+		assert.NotContains(t, refs, "host")
+	})
+
+	t.Run("range block excludes scoped refs", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ExtractFromTemplate(`{{ range ._.servers }}{{ .name }}{{ end }}`, "{{", "}}")
+		require.NoError(t, err)
+		assert.Contains(t, refs, "servers")
+		assert.NotContains(t, refs, "name")
+	})
+}

--- a/pkg/spec/valueref.go
+++ b/pkg/spec/valueref.go
@@ -330,6 +330,11 @@ func (v *ValueRef) ReferencedVariables() map[string]struct{} {
 	if v.Tmpl != nil {
 		if refs, err := gotmpl.GetGoTemplateReferences(string(*v.Tmpl), "", ""); err == nil {
 			for _, ref := range refs {
+				// Skip scoped references inside {{ with }}/{{ range }} bodies
+				if ref.Scoped {
+					continue
+				}
+
 				path := strings.TrimPrefix(ref.Path, ".")
 				// Extract the root variable name (before the first dot)
 				if idx := strings.Index(path, "."); idx >= 0 {

--- a/pkg/spec/valueref_test.go
+++ b/pkg/spec/valueref_test.go
@@ -1279,3 +1279,13 @@ func BenchmarkValueRef_Resolve_NestedValueRefs(b *testing.B) {
 		}
 	}
 }
+
+func TestValueRef_ReferencedVariables_ScopedRefs(t *testing.T) {
+	tmpl := gotmpl.GoTemplatingContent(`{{ with .config.data }}{{ .host }}{{ end }}`)
+	vr := ValueRef{Tmpl: &tmpl}
+	vars := vr.ReferencedVariables()
+
+	assert.Contains(t, vars, "config", "root-level ref should be included")
+	_, hasHost := vars["host"]
+	assert.False(t, hasHost, "scoped ref inside {{ with }} should be excluded")
+}


### PR DESCRIPTION
- add Scoped field to TemplateReference to track {{ with }}/{{ range }} context depth during AST walking
- skip scoped references in all dependency extraction paths: gotmpl refs, resolver graph, gotmplprovider, resolver/refs, and spec/valueref
- add concrete BEFORE/AFTER examples to migrate_solution prompt for CEL block scalars, dependsOn renaming, and data.resolvers field preservation

Closes #334
Closes #289