### PR TITLE
feat(mcp): add list command for MCP tools and prompts

### DIFF
--- a/pkg/cmd/scafctl/mcp/list.go
+++ b/pkg/cmd/scafctl/mcp/list.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	mcpserver "github.com/oakwood-commons/scafctl/pkg/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+//go:embed list_schema.json
+var listSchemaJSON []byte
+
+// ListOptions holds the options for the list command.
+type ListOptions struct {
+	CliParams *settings.Run
+	IOStreams *terminal.IOStreams
+	Kind      string // "all", "tool", "prompt"
+	rootCmd   *cobra.Command
+
+	flags.KvxOutputFlags
+}
+
+// CommandList creates the `scafctl mcp list` command.
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	opts := &ListOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List MCP tools and prompts",
+		Long: fmt.Sprintf(`List all tools and prompts exposed by the %s MCP server.
+
+Shows the capabilities that AI agents can discover and invoke when
+connected to the MCP server. Each entry includes the name, kind
+(tool or prompt), source, and description. Additional fields like
+readOnly and destructive are available via -o json or -i.
+
+Use --kind to filter by capability type:
+  tool    Show only tools (callable operations)
+  prompt  Show only prompts (interaction templates)`, cliParams.BinaryName),
+		Example: fmt.Sprintf(`  # List all MCP capabilities
+  %[1]s mcp list
+
+  # List only tools
+  %[1]s mcp list --kind tool
+
+  # List only prompts
+  %[1]s mcp list --kind prompt
+
+  # Output as JSON
+  %[1]s mcp list -o json
+
+  # Output as YAML
+  %[1]s mcp list -o yaml
+
+  # Filter with CEL expression
+  %[1]s mcp list -e '_.filter(c, c.kind == "tool")'`, cliParams.BinaryName),
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			switch opts.Kind {
+			case "all", "tool", "prompt":
+				return nil
+			default:
+				return fmt.Errorf("invalid --kind value %q: must be all, tool, or prompt", opts.Kind)
+			}
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.rootCmd = cmd.Root()
+			return runList(cmd.Context(), opts)
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+	cmd.Flags().StringVar(&opts.Kind, "kind", "all", "Filter by kind: all, tool, prompt")
+
+	return cmd
+}
+
+func runList(ctx context.Context, opts *ListOptions) error {
+	srv, err := buildListServer(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	caps := srv.ListCapabilities()
+
+	// Apply kind filter
+	if opts.Kind != "all" && opts.Kind != "" {
+		kind := mcpserver.CapabilityKind(opts.Kind)
+		filtered := make([]mcpserver.Capability, 0, len(caps))
+		for _, c := range caps {
+			if c.Kind == kind {
+				filtered = append(filtered, c)
+			}
+		}
+		caps = filtered
+	}
+
+	columnOrder := []string{"kind", "name", "source", "description"}
+	columnHints := map[string]tui.ColumnHint{
+		"kind":        {MaxWidth: 8, Priority: 10},
+		"name":        {MaxWidth: 40, Priority: 9},
+		"source":      {MaxWidth: 8, Priority: 7},
+		"description": {Priority: 6},
+		"title":       {Hidden: true},
+		"readOnly":    {Hidden: true},
+		"destructive": {Hidden: true},
+	}
+
+	if w := writer.FromContext(ctx); w != nil && w.VerboseEnabled() {
+		w.Verbosef("Found %d capabilities (%s filter)", len(caps), opts.Kind)
+	}
+
+	kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(opts.CliParams.NoColor),
+		kvx.WithOutputAppName(opts.CliParams.BinaryName+" mcp list"),
+		kvx.WithIOStreams(opts.IOStreams),
+		kvx.WithOutputDisplaySchemaJSON(listSchemaJSON),
+		kvx.WithOutputColumnOrder(columnOrder),
+		kvx.WithOutputColumnHints(columnHints),
+	)
+
+	return kvxOpts.Write(caps)
+}
+
+func buildListServer(ctx context.Context, opts *ListOptions) (*mcpserver.Server, error) {
+	lgr := logger.FromContext(ctx)
+	cfg := config.FromContext(ctx)
+	authReg := auth.RegistryFromContext(ctx)
+
+	reg, err := builtin.DefaultRegistry(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initializing provider registry: %w", err)
+	}
+
+	serverOpts := []mcpserver.ServerOption{
+		mcpserver.WithServerLogger(*lgr),
+		mcpserver.WithServerRegistry(reg),
+		mcpserver.WithServerContext(ctx),
+		mcpserver.WithServerVersion(settings.VersionInformation.BuildVersion),
+	}
+	if s, ok := settings.FromContext(ctx); ok && s.BinaryName != "" {
+		serverOpts = append(serverOpts, mcpserver.WithServerName(s.BinaryName))
+	}
+	if cfg != nil {
+		serverOpts = append(serverOpts, mcpserver.WithServerConfig(cfg))
+	}
+	if authReg != nil {
+		serverOpts = append(serverOpts, mcpserver.WithServerAuthRegistry(authReg))
+	}
+	if opts.rootCmd != nil {
+		serverOpts = append(serverOpts, mcpserver.WithRootCommand(opts.rootCmd))
+	}
+
+	return mcpserver.NewServer(serverOpts...)
+}

--- a/pkg/cmd/scafctl/mcp/list_schema.json
+++ b/pkg/cmd/scafctl/mcp/list_schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MCP Capabilities",
+  "description": "Schema for MCP tools and prompts with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "⚡",
+  "x-kvx-collectionTitle": "MCP Capabilities",
+
+  "x-kvx-list": {
+    "titleField": "name",
+    "subtitleField": "description",
+    "subtitleMaxLines": 2,
+    "badgeFields": ["kind", "source"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "name",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["name", "kind", "source"],
+        "layout": "inline"
+      },
+      {
+        "title": "Description",
+        "fields": ["description"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Hints",
+        "fields": ["readOnly", "destructive"],
+        "layout": "table"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["name", "kind"],
+    "properties": {
+      "kind": {
+        "type": "string",
+        "title": "Kind",
+        "description": "Capability type (tool or prompt)"
+      },
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "description": "Capability name"
+      },
+      "title": {
+        "type": "string",
+        "title": "Title",
+        "description": "Display title"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "What this capability does"
+      },
+      "source": {
+        "type": "string",
+        "title": "Source",
+        "description": "Where the capability was registered (core or plugin)"
+      },
+      "readOnly": {
+        "type": "boolean",
+        "title": "Read-Only",
+        "description": "Whether the capability only reads data"
+      },
+      "destructive": {
+        "type": "boolean",
+        "title": "Destructive",
+        "description": "Whether the capability can destroy data"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/mcp/list_test.go
+++ b/pkg/cmd/scafctl/mcp/list_test.go
@@ -1,0 +1,251 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	mcpserver "github.com/oakwood-commons/scafctl/pkg/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandList(t *testing.T) {
+	t.Run("creates command with correct flags", func(t *testing.T) {
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		ioStreams := &terminal.IOStreams{}
+		cmd := CommandList(cliParams, ioStreams, "scafctl/mcp")
+
+		assert.Equal(t, "list", cmd.Use)
+		assert.Contains(t, cmd.Aliases, "ls")
+		assert.NotEmpty(t, cmd.Short)
+		assert.NotEmpty(t, cmd.Long)
+		assert.NotEmpty(t, cmd.Example)
+		assert.True(t, cmd.SilenceUsage)
+
+		// Verify kind flag
+		kindFlag := cmd.Flags().Lookup("kind")
+		require.NotNil(t, kindFlag)
+		assert.Equal(t, "all", kindFlag.DefValue)
+
+		// Verify output flag
+		outputFlag := cmd.Flags().Lookup("output")
+		require.NotNil(t, outputFlag)
+	})
+
+	t.Run("has RunE set", func(t *testing.T) {
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		ioStreams := &terminal.IOStreams{}
+		cmd := CommandList(cliParams, ioStreams, "scafctl/mcp")
+
+		assert.NotNil(t, cmd.RunE, "expected RunE to be set")
+	})
+
+	t.Run("non-default binary name in help text", func(t *testing.T) {
+		cliParams := &settings.Run{BinaryName: "mycli"}
+		ioStreams := &terminal.IOStreams{}
+		cmd := CommandList(cliParams, ioStreams, "mycli/mcp")
+
+		assert.Contains(t, cmd.Long, "mycli")
+		assert.Contains(t, cmd.Example, "mycli")
+		assert.NotContains(t, cmd.Long, "scafctl")
+	})
+}
+
+func TestCommandMCPContainsList(t *testing.T) {
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+	ioStreams := &terminal.IOStreams{}
+	cmd := CommandMCP(cliParams, ioStreams, "scafctl")
+
+	var listFound bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "list" {
+			listFound = true
+			break
+		}
+	}
+	assert.True(t, listFound, "expected 'list' subcommand")
+}
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	var stdout bytes.Buffer
+	ioStreams := terminal.IOStreams{Out: &stdout, ErrOut: &bytes.Buffer{}}
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+	w := writer.New(&ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.Get(-1))
+	return ctx
+}
+
+func TestRunList_JSONOutput(t *testing.T) {
+	ctx := testContext(t)
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: &settings.Run{BinaryName: "scafctl"},
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "all",
+	}
+	opts.Output = "json"
+	opts.FormatExplicit = true
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	var caps []mcpserver.Capability
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &caps))
+	assert.NotEmpty(t, caps)
+
+	// Verify both tools and prompts are present
+	var hasTools, hasPrompts bool
+	for _, c := range caps {
+		if c.Kind == mcpserver.CapabilityTool {
+			hasTools = true
+		}
+		if c.Kind == mcpserver.CapabilityPrompt {
+			hasPrompts = true
+		}
+	}
+	assert.True(t, hasTools, "should contain tools")
+	assert.True(t, hasPrompts, "should contain prompts")
+}
+
+func TestRunList_KindFilter(t *testing.T) {
+	ctx := testContext(t)
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: &settings.Run{BinaryName: "scafctl"},
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "prompt",
+	}
+	opts.Output = "json"
+	opts.FormatExplicit = true
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	var caps []mcpserver.Capability
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &caps))
+	require.NotEmpty(t, caps)
+
+	for _, c := range caps {
+		assert.Equal(t, mcpserver.CapabilityPrompt, c.Kind,
+			"all results should be prompts when --kind=prompt")
+	}
+}
+
+func TestRunList_EmbedderBinaryName(t *testing.T) {
+	var stdout bytes.Buffer
+	ioStreams := terminal.IOStreams{Out: &stdout, ErrOut: &bytes.Buffer{}}
+	cliParams := &settings.Run{BinaryName: "mycli"}
+	w := writer.New(&ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.Get(-1))
+	ctx = settings.IntoContext(ctx, cliParams)
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: cliParams,
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "all",
+	}
+	opts.Output = "json"
+	opts.FormatExplicit = true
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	var caps []mcpserver.Capability
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &caps))
+	assert.NotEmpty(t, caps, "should list capabilities with custom binary name")
+}
+
+func TestCommandList_InvalidKind(t *testing.T) {
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+	ioStreams := &terminal.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	cmd := CommandList(cliParams, ioStreams, "scafctl/mcp")
+	cmd.SetArgs([]string{"--kind", "invalid"})
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --kind value")
+}
+
+func TestRunList_TableOutput(t *testing.T) {
+	ctx := testContext(t)
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: &settings.Run{BinaryName: "scafctl"},
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "all",
+	}
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "kind")
+	assert.Contains(t, output, "name")
+	assert.Contains(t, output, "source")
+}
+
+func TestRunList_ToolKindFilter(t *testing.T) {
+	ctx := testContext(t)
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: &settings.Run{BinaryName: "scafctl"},
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "tool",
+	}
+	opts.Output = "json"
+	opts.FormatExplicit = true
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	var caps []mcpserver.Capability
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &caps))
+	require.NotEmpty(t, caps)
+
+	for _, c := range caps {
+		assert.Equal(t, mcpserver.CapabilityTool, c.Kind,
+			"all results should be tools when --kind=tool")
+	}
+}
+
+func TestRunList_VerboseOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+	cliParams := &settings.Run{BinaryName: "scafctl", Verbose: true}
+	w := writer.New(&ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.Get(-1))
+
+	var outBuf bytes.Buffer
+	opts := &ListOptions{
+		CliParams: cliParams,
+		IOStreams: &terminal.IOStreams{Out: &outBuf, ErrOut: &bytes.Buffer{}},
+		Kind:      "all",
+	}
+	opts.Output = "json"
+	opts.FormatExplicit = true
+
+	err := runList(ctx, opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Found")
+	assert.Contains(t, stderr.String(), "capabilities")
+}

--- a/pkg/cmd/scafctl/mcp/mcp.go
+++ b/pkg/cmd/scafctl/mcp/mcp.go
@@ -20,5 +20,6 @@ func CommandMCP(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(CommandServe(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cmd.Use)))
+	cmd.AddCommand(CommandList(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cmd.Use)))
 	return cmd
 }

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -17,9 +17,7 @@ import (
 func TestRoot_CommandProperties(t *testing.T) {
 	t.Parallel()
 	cmd := Root(nil)
-	if cmd == nil {
-		t.Fatal("Root() returned nil")
-	}
+	require.NotNil(t, cmd)
 	if cmd.Use != "scafctl" {
 		t.Errorf("Root().Use = %q, want %q", cmd.Use, "scafctl")
 	}
@@ -59,16 +57,12 @@ func TestRoot_HiddenFlags(t *testing.T) {
 	t.Parallel()
 	cmd := Root(nil)
 	pprofFlag := cmd.PersistentFlags().Lookup("pprof")
-	if pprofFlag == nil {
-		t.Fatal("Expected 'pprof' flag to exist")
-	}
+	require.NotNil(t, pprofFlag, "Expected 'pprof' flag to exist")
 	if !pprofFlag.Hidden {
 		t.Error("Expected 'pprof' flag to be hidden")
 	}
 	pprofOutFlag := cmd.PersistentFlags().Lookup("pprof-output-dir")
-	if pprofOutFlag == nil {
-		t.Fatal("Expected 'pprof-output-dir' flag to exist")
-	}
+	require.NotNil(t, pprofOutFlag, "Expected 'pprof-output-dir' flag to exist")
 	if !pprofOutFlag.Hidden {
 		t.Error("Expected 'pprof-output-dir' flag to be hidden")
 	}
@@ -233,9 +227,7 @@ func TestRoot_CustomBinaryNameUpdatesSolutionDiscovery(t *testing.T) {
 	cmd := Root(&RootOptions{
 		BinaryName: "cldctl",
 	})
-	if cmd == nil {
-		t.Fatal("Root() with custom BinaryName returned nil")
-	}
+	require.NotNil(t, cmd)
 	if cmd.Use != "cldctl" {
 		t.Errorf("Root().Use = %q, want %q", cmd.Use, "cldctl")
 	}

--- a/pkg/mcp/capabilities.go
+++ b/pkg/mcp/capabilities.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -139,4 +140,101 @@ func (s *Server) elicitMissingParams(ctx context.Context, paramNames []string, d
 	}
 
 	return values
+}
+
+// CapabilityKind distinguishes tools from prompts.
+type CapabilityKind string
+
+const (
+	// CapabilityTool is an MCP tool (callable by agents).
+	CapabilityTool CapabilityKind = "tool"
+	// CapabilityPrompt is an MCP prompt (template for agent interactions).
+	CapabilityPrompt CapabilityKind = "prompt"
+)
+
+// CapabilitySource identifies where a capability was registered.
+type CapabilitySource string
+
+const (
+	// SourceCore marks capabilities registered by scafctl itself.
+	SourceCore CapabilitySource = "core"
+	// SourcePlugin marks capabilities registered by plugins or embedders.
+	SourcePlugin CapabilitySource = "plugin"
+)
+
+// Capability describes a single MCP tool or prompt.
+type Capability struct {
+	Kind        CapabilityKind   `json:"kind"        yaml:"kind"`
+	Name        string           `json:"name"        yaml:"name"`
+	Title       string           `json:"title"       yaml:"title"`
+	Description string           `json:"description" yaml:"description"`
+	Source      CapabilitySource `json:"source"      yaml:"source"`
+	ReadOnly    bool             `json:"readOnly"    yaml:"readOnly"`
+	Destructive bool             `json:"destructive" yaml:"destructive"`
+}
+
+// ListCapabilities returns all tools and tracked prompts registered on
+// the server. Prompts must be registered via Server.AddPrompt (or the
+// internal addCorePrompt) to appear; prompts added directly through
+// MCPServer().AddPrompt() are not tracked.
+// Core capabilities are tagged with SourceCore; embedder/plugin
+// capabilities are tagged with SourcePlugin.
+// The contextual tool filter is applied, so results match what MCP
+// clients would discover at runtime.
+func (s *Server) ListCapabilities() []Capability {
+	// Tools — apply the same contextual filter used by the MCP protocol
+	registered := s.mcpServer.ListTools()
+	caps := make([]Capability, 0, len(registered)+len(s.prompts))
+	allTools := make([]mcp.Tool, 0, len(registered))
+	for _, st := range registered {
+		allTools = append(allTools, st.Tool)
+	}
+
+	filterFn := contextualToolFilter(s)
+	visible := filterFn(context.Background(), allTools)
+
+	for _, t := range visible {
+		source := SourcePlugin
+		if _, ok := s.coreTools[t.Name]; ok {
+			source = SourceCore
+		}
+		c := Capability{
+			Kind:        CapabilityTool,
+			Name:        t.Name,
+			Title:       t.Annotations.Title,
+			Description: t.Description,
+			Source:      source,
+		}
+		if t.Annotations.ReadOnlyHint != nil {
+			c.ReadOnly = *t.Annotations.ReadOnlyHint
+		}
+		if t.Annotations.DestructiveHint != nil {
+			c.Destructive = *t.Annotations.DestructiveHint
+		}
+		caps = append(caps, c)
+	}
+
+	// Prompts — sourced from our tracked list
+	for _, p := range s.prompts {
+		source := SourcePlugin
+		if _, ok := s.corePrompts[p.Name]; ok {
+			source = SourceCore
+		}
+		caps = append(caps, Capability{
+			Kind:        CapabilityPrompt,
+			Name:        p.Name,
+			Description: p.Description,
+			Source:      source,
+			ReadOnly:    true,
+		})
+	}
+
+	sort.Slice(caps, func(i, j int) bool {
+		if caps[i].Kind != caps[j].Kind {
+			return caps[i].Kind < caps[j].Kind
+		}
+		return caps[i].Name < caps[j].Name
+	})
+
+	return caps
 }

--- a/pkg/mcp/capabilities_test.go
+++ b/pkg/mcp/capabilities_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCapabilities(t *testing.T) {
+	t.Run("returns tools and prompts", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		caps := srv.ListCapabilities()
+		require.NotEmpty(t, caps)
+
+		var tools, prompts int
+		for _, c := range caps {
+			switch c.Kind {
+			case CapabilityTool:
+				tools++
+			case CapabilityPrompt:
+				prompts++
+			}
+		}
+
+		assert.Greater(t, tools, 0, "should have at least one tool")
+		assert.Greater(t, prompts, 0, "should have at least one prompt")
+	})
+
+	t.Run("all capabilities have source core", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		for _, c := range srv.ListCapabilities() {
+			assert.Equal(t, SourceCore, c.Source, "capability %s should be core", c.Name)
+		}
+	})
+
+	t.Run("sorted by kind then name", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		caps := srv.ListCapabilities()
+		for i := 1; i < len(caps); i++ {
+			if caps[i].Kind == caps[i-1].Kind {
+				assert.LessOrEqual(t, caps[i-1].Name, caps[i].Name,
+					"capabilities should be sorted by name within kind")
+			} else {
+				assert.Less(t, string(caps[i-1].Kind), string(caps[i].Kind),
+					"tool kind should sort before prompt kind")
+			}
+		}
+	})
+
+	t.Run("prompts are tracked via addPrompt", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		caps := srv.ListCapabilities()
+		var promptNames []string
+		for _, c := range caps {
+			if c.Kind == CapabilityPrompt {
+				promptNames = append(promptNames, c.Name)
+			}
+		}
+
+		assert.Contains(t, promptNames, "create_solution")
+		assert.Contains(t, promptNames, "debug_solution")
+		assert.Contains(t, promptNames, "add_resolver")
+	})
+
+	t.Run("tool annotations are populated", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		caps := srv.ListCapabilities()
+		// Find a known read-only tool
+		for _, c := range caps {
+			if c.Kind == CapabilityTool && c.Name == "evaluate_cel" {
+				assert.True(t, c.ReadOnly, "evaluate_cel should be read-only")
+				assert.False(t, c.Destructive, "evaluate_cel should not be destructive")
+				return
+			}
+		}
+		t.Fatal("evaluate_cel tool not found")
+	})
+
+	t.Run("non-default binary name", func(t *testing.T) {
+		srv, err := NewServer(WithServerName("mycli"))
+		require.NoError(t, err)
+
+		caps := srv.ListCapabilities()
+		require.NotEmpty(t, caps, "should still list capabilities with custom binary name")
+	})
+}
+
+func TestListCapabilities_EmbedderTools(t *testing.T) {
+	t.Run("embedder tools via MCPServer are tagged as plugin", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		// Simulate an embedder adding a tool directly via MCPServer()
+		srv.MCPServer().AddTool(mcp.NewTool("mycli_deploy",
+			mcp.WithDescription("Deploy the application"),
+		), func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("ok"), nil
+		})
+
+		caps := srv.ListCapabilities()
+
+		var found bool
+		for _, c := range caps {
+			if c.Name == "mycli_deploy" {
+				found = true
+				assert.Equal(t, SourcePlugin, c.Source, "embedder tool should be plugin")
+				assert.Equal(t, CapabilityTool, c.Kind)
+				break
+			}
+		}
+		assert.True(t, found, "embedder tool should appear in capabilities")
+	})
+
+	t.Run("core tools remain tagged as core alongside embedder tools", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		srv.MCPServer().AddTool(mcp.NewTool("mycli_custom",
+			mcp.WithDescription("Custom embedder tool"),
+		), func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("ok"), nil
+		})
+
+		caps := srv.ListCapabilities()
+
+		var coreCount, pluginCount int
+		for _, c := range caps {
+			if c.Kind == CapabilityTool {
+				switch c.Source {
+				case SourceCore:
+					coreCount++
+				case SourcePlugin:
+					pluginCount++
+				}
+			}
+		}
+		assert.Greater(t, coreCount, 0, "should still have core tools")
+		assert.Equal(t, 1, pluginCount, "should have exactly one plugin tool")
+	})
+}
+
+func TestListCapabilities_EmbedderPrompts(t *testing.T) {
+	t.Run("embedder prompts via AddPrompt are tagged as plugin", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		// Simulate an embedder adding a prompt via the public API
+		srv.AddPrompt(mcp.NewPrompt("mycli_onboard",
+			mcp.WithPromptDescription("Onboard a new user"),
+		), func(_ context.Context, _ mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return &mcp.GetPromptResult{}, nil
+		})
+
+		caps := srv.ListCapabilities()
+
+		var found bool
+		for _, c := range caps {
+			if c.Name == "mycli_onboard" {
+				found = true
+				assert.Equal(t, SourcePlugin, c.Source, "embedder prompt should be plugin")
+				assert.Equal(t, CapabilityPrompt, c.Kind)
+				break
+			}
+		}
+		assert.True(t, found, "embedder prompt should appear in capabilities")
+	})
+
+	t.Run("core prompts remain tagged as core alongside embedder prompts", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+
+		srv.AddPrompt(mcp.NewPrompt("mycli_custom_prompt",
+			mcp.WithPromptDescription("Custom embedder prompt"),
+		), func(_ context.Context, _ mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return &mcp.GetPromptResult{}, nil
+		})
+
+		caps := srv.ListCapabilities()
+
+		var corePrompts, pluginPrompts int
+		for _, c := range caps {
+			if c.Kind == CapabilityPrompt {
+				switch c.Source {
+				case SourceCore:
+					corePrompts++
+				case SourcePlugin:
+					pluginPrompts++
+				}
+			}
+		}
+		assert.Greater(t, corePrompts, 0, "should still have core prompts")
+		assert.Equal(t, 1, pluginPrompts, "should have exactly one plugin prompt")
+	})
+}

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -60,7 +60,7 @@ func (s *Server) registerPrompts() {
 	replaceName := s.replaceName
 
 	// create_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("create_solution",
 			mcp.WithPromptDescription(replaceName("Guide for creating a new scafctl solution YAML file from scratch. Provides the solution schema, examples, and step-by-step instructions.")),
 			mcp.WithPromptIcons(promptIcons["create"]),
@@ -80,7 +80,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// debug_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("debug_solution",
 			mcp.WithPromptDescription(replaceName("Help debug a scafctl solution that isn't working as expected. Inspects the solution, lints it, and suggests fixes.")),
 			mcp.WithPromptIcons(promptIcons["debug"]),
@@ -96,7 +96,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// add_resolver prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("add_resolver",
 			mcp.WithPromptDescription("Guide for adding a new resolver to an existing solution. Shows available providers, schema, and patterns."),
 			mcp.WithPromptIcons(promptIcons["create"]),
@@ -112,7 +112,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// add_action prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("add_action",
 			mcp.WithPromptDescription("Guide for adding a new action to an existing solution's workflow. Shows available action providers, schema, and patterns."),
 			mcp.WithPromptIcons(promptIcons["create"]),
@@ -128,7 +128,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// update_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("update_solution",
 			mcp.WithPromptDescription(replaceName("Guide for modifying an existing scafctl solution. Inspects the current state, makes targeted changes, then validates with lint and preview.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
@@ -145,7 +145,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// add_tests prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("add_tests",
 			mcp.WithPromptDescription(replaceName("Guide for writing functional tests for a scafctl solution. Walks through test schema, assertions, snapshots, and test patterns.")),
 			mcp.WithPromptIcons(promptIcons["create"]),
@@ -161,7 +161,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// compose_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("compose_solution",
 			mcp.WithPromptDescription(replaceName("Guide for designing a multi-file composed solution using scafctl's composition system. Breaks a solution into reusable partial YAML files that get merged at build time.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
@@ -178,7 +178,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// fix_lint prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("fix_lint",
 			mcp.WithPromptDescription(replaceName("Guide for fixing lint findings in a scafctl solution. Lints the solution, explains each finding, and applies targeted fixes in priority order (errors first, then warnings).")),
 			mcp.WithPromptIcons(promptIcons["debug"]),
@@ -194,7 +194,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// prepare_execution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("prepare_execution",
 			mcp.WithPromptDescription(replaceName("Prepare a scafctl solution for execution. Validates, previews, and generates the exact CLI command — without actually running it. Use this when you're ready to run a solution but want to verify everything first.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
@@ -210,7 +210,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// analyze_execution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("analyze_execution",
 			mcp.WithPromptDescription(replaceName("Analyze a completed scafctl execution by inspecting the snapshot. Identifies failures, regressions, and suggests fixes. Optionally compares against a known-good snapshot.")),
 			mcp.WithPromptIcons(promptIcons["analyze"]),
@@ -229,7 +229,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// migrate_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("migrate_solution",
 			mcp.WithPromptDescription(replaceName("Guide for structurally refactoring a scafctl solution. Supports adding composition, extracting templates, splitting into multiple files, adding tests, and upgrading to newer patterns.")),
 			mcp.WithPromptIcons(promptIcons["guide"]),
@@ -249,7 +249,7 @@ func (s *Server) registerPrompts() {
 	)
 
 	// optimize_solution prompt
-	s.mcpServer.AddPrompt(
+	s.addCorePrompt(
 		mcp.NewPrompt("optimize_solution",
 			mcp.WithPromptDescription(replaceName("Analyze a scafctl solution for performance, readability, and quality improvements. Identifies parallelization opportunities, unnecessary dependencies, naming issues, and missing test coverage.")),
 			mcp.WithPromptIcons(promptIcons["analyze"]),

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -36,6 +36,19 @@ type Server struct {
 	name      string
 	rootCmd   *cobra.Command
 
+	// prompts tracks registered prompts for listing. The mcp-go SDK
+	// does not expose a public ListPrompts method, so we maintain our
+	// own slice during registration.
+	prompts []mcp.Prompt
+
+	// coreTools tracks tool names registered by scafctl itself.
+	// Tools not in this set are tagged as plugin/embedder tools.
+	coreTools map[string]struct{}
+
+	// corePrompts tracks prompt names registered by scafctl itself.
+	// Prompts not in this set are tagged as plugin/embedder prompts.
+	corePrompts map[string]struct{}
+
 	// sseServer is the SSE transport server (nil for stdio).
 	sseServer *server.SSEServer
 	// httpServer is the Streamable HTTP transport server (nil for stdio).
@@ -482,13 +495,15 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	}
 
 	s := &Server{
-		ctx:      mcpCtx,
-		version:  cfg.version,
-		name:     cfg.name,
-		registry: cfg.registry,
-		authReg:  cfg.authReg,
-		config:   cfg.config,
-		rootCmd:  cfg.rootCmd,
+		ctx:         mcpCtx,
+		version:     cfg.version,
+		name:        cfg.name,
+		registry:    cfg.registry,
+		authReg:     cfg.authReg,
+		config:      cfg.config,
+		rootCmd:     cfg.rootCmd,
+		coreTools:   make(map[string]struct{}, 64),
+		corePrompts: make(map[string]struct{}, 16),
 	}
 	if cfg.logger != nil {
 		s.logger = *cfg.logger
@@ -612,6 +627,14 @@ func (s *Server) Handler(opts ...server.StreamableHTTPOption) http.Handler {
 
 // MCPServer returns the underlying mcp-go MCPServer.
 // This is useful for advanced operations like sending notifications.
+//
+// Embedders can call MCPServer().AddTool() to register custom tools;
+// these are automatically listed by ListCapabilities with SourcePlugin.
+//
+// Note: prompts added via MCPServer().AddPrompt() will NOT appear in
+// ListCapabilities because the mcp-go SDK does not expose a ListPrompts
+// method. Use [Server.AddPrompt] instead to register prompts that should
+// be discoverable.
 func (s *Server) MCPServer() *server.MCPServer {
 	return s.mcpServer
 }
@@ -806,6 +829,28 @@ func (s *Server) registerTools() {
 // registerResources registers all MCP resources on the server.
 func (s *Server) registerResources() {
 	s.registerResourceTemplates()
+}
+
+// addTool registers a tool with the MCP server and tracks it as a core
+// tool for listing via ListCapabilities. Embedders that call
+// MCPServer().AddTool() directly will have their tools listed as plugin.
+func (s *Server) addTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
+	s.mcpServer.AddTool(tool, handler)
+	s.coreTools[tool.Name] = struct{}{}
+}
+
+// AddPrompt registers a prompt with the MCP server and tracks it for
+// listing via ListCapabilities. Embedders should use this instead of
+// MCPServer().AddPrompt() to ensure the prompt appears in listings.
+func (s *Server) AddPrompt(prompt mcp.Prompt, handler server.PromptHandlerFunc) {
+	s.mcpServer.AddPrompt(prompt, handler)
+	s.prompts = append(s.prompts, prompt)
+}
+
+// addCorePrompt registers a prompt and marks it as a core prompt.
+func (s *Server) addCorePrompt(prompt mcp.Prompt, handler server.PromptHandlerFunc) {
+	s.AddPrompt(prompt, handler)
+	s.corePrompts[prompt.Name] = struct{}{}
 }
 
 // registerAllPrompts registers all MCP prompts on the server.

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -41,7 +41,7 @@ func (s *Server) registerActionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(previewActionTool, s.handlePreviewAction)
+	s.addTool(previewActionTool, s.handlePreviewAction)
 }
 
 // handlePreviewAction shows what each action would do with fully resolved inputs.

--- a/pkg/mcp/tools_api.go
+++ b/pkg/mcp/tools_api.go
@@ -29,7 +29,7 @@ func (s *Server) registerAPITools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithRawOutputSchema(outputSchemaOpenAPISpec),
 	)
-	s.mcpServer.AddTool(getOpenAPISpecTool, s.handleGetOpenAPISpec)
+	s.addTool(getOpenAPISpecTool, s.handleGetOpenAPISpec)
 
 	getAPIEndpointsTool := mcp.NewTool("list_api_endpoints",
 		mcp.WithDescription("List all available REST API endpoints with their HTTP method, path, summary, and tags. Provides a quick overview of the scafctl API surface without the full OpenAPI spec."),
@@ -41,7 +41,7 @@ func (s *Server) registerAPITools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithRawOutputSchema(outputSchemaAPIEndpoints),
 	)
-	s.mcpServer.AddTool(getAPIEndpointsTool, s.handleListAPIEndpoints)
+	s.addTool(getAPIEndpointsTool, s.handleListAPIEndpoints)
 }
 
 // handleGetOpenAPISpec generates the full OpenAPI spec without starting the server.

--- a/pkg/mcp/tools_auth.go
+++ b/pkg/mcp/tools_auth.go
@@ -23,7 +23,7 @@ func (s *Server) registerAuthTools() {
 		mcp.WithOpenWorldHintAnnotation(true),
 		mcp.WithRawOutputSchema(outputSchemaAuthStatus),
 	)
-	s.mcpServer.AddTool(authStatusTool, s.handleAuthStatus)
+	s.addTool(authStatusTool, s.handleAuthStatus)
 
 	listAuthHandlersTool := mcp.NewTool("list_auth_handlers",
 		mcp.WithDescription("List all registered auth handlers with their supported flows and capabilities. Unlike auth_status which shows credential state, this tool shows what handlers are available and what they support (device-code, interactive, service-principal, workload-identity, PAT, metadata flows). Use this to understand which auth methods are available before attempting login."),
@@ -34,7 +34,7 @@ func (s *Server) registerAuthTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
-	s.mcpServer.AddTool(listAuthHandlersTool, s.handleListAuthHandlers)
+	s.addTool(listAuthHandlersTool, s.handleListAuthHandlers)
 }
 
 // authHandlerStatus represents the status of a single auth handler.

--- a/pkg/mcp/tools_catalog.go
+++ b/pkg/mcp/tools_catalog.go
@@ -29,7 +29,7 @@ func (s *Server) registerCatalogTools() {
 			mcp.Description("Filter by name (exact match)"),
 		),
 	)
-	s.mcpServer.AddTool(catalogListTool, s.handleCatalogList)
+	s.addTool(catalogListTool, s.handleCatalogList)
 
 	catalogInspectTool := mcp.NewTool("catalog_inspect",
 		mcp.WithDescription("Show detailed metadata about a specific catalog artifact. Returns kind, name, version, digest, size, creation time, and annotations. Use 'catalog_list' first to discover available artifacts, then inspect a specific one for details."),
@@ -49,7 +49,7 @@ func (s *Server) registerCatalogTools() {
 			mcp.Enum("solution", "provider", "auth-handler"),
 		),
 	)
-	s.mcpServer.AddTool(catalogInspectTool, s.handleCatalogInspect)
+	s.addTool(catalogInspectTool, s.handleCatalogInspect)
 }
 
 // handleCatalogList lists entries in the local catalog.

--- a/pkg/mcp/tools_catalog_multiplatform.go
+++ b/pkg/mcp/tools_catalog_multiplatform.go
@@ -32,7 +32,7 @@ func (s *Server) registerCatalogMultiPlatformTools() {
 			mcp.Enum("provider", "auth-handler"),
 		),
 	)
-	s.mcpServer.AddTool(listPlatformsTool, s.handleCatalogListPlatforms)
+	s.addTool(listPlatformsTool, s.handleCatalogListPlatforms)
 
 	buildPluginTool := mcp.NewTool("build_plugin",
 		mcp.WithDescription("Build a multi-platform plugin artifact into the local catalog as an OCI image index. Each platform entry maps an OS/architecture pair to a local binary path. Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64. Use this to package cross-compiled plugin binaries for distribution."),
@@ -66,7 +66,7 @@ func (s *Server) registerCatalogMultiPlatformTools() {
 			mcp.Description("Working directory for path resolution. When set, relative platform binary paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(buildPluginTool, s.handleBuildPlugin)
+	s.addTool(buildPluginTool, s.handleBuildPlugin)
 }
 
 // handleCatalogListPlatforms lists platforms for a multi-platform catalog artifact.

--- a/pkg/mcp/tools_catalog_search.go
+++ b/pkg/mcp/tools_catalog_search.go
@@ -46,7 +46,7 @@ func (s *Server) registerCatalogSearchTools() {
 			mcp.Description("Catalog name to search. Omit for default catalog, use 'all' to search all registered catalogs, or 'local' for local only"),
 		),
 	)
-	s.mcpServer.AddTool(catalogSearchTool, s.handleCatalogSearch)
+	s.addTool(catalogSearchTool, s.handleCatalogSearch)
 
 	catalogListSolutionsTool := mcp.NewTool("catalog_list_solutions",
 		mcp.WithDescription(fmt.Sprintf(
@@ -65,7 +65,7 @@ func (s *Server) registerCatalogSearchTools() {
 			mcp.Description("Catalog name to list from. Omit for default catalog, use 'all' for all registered catalogs, or 'local' for local only"),
 		),
 	)
-	s.mcpServer.AddTool(catalogListSolutionsTool, s.handleCatalogListSolutions)
+	s.addTool(catalogListSolutionsTool, s.handleCatalogListSolutions)
 
 	catalogListRegisteredTool := mcp.NewTool("catalog_list_registered",
 		mcp.WithDescription("List all registered catalogs with their type, registry, and default status. Use this to discover which catalogs are available for search and listing."),
@@ -76,7 +76,7 @@ func (s *Server) registerCatalogSearchTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
-	s.mcpServer.AddTool(catalogListRegisteredTool, s.handleCatalogListRegistered)
+	s.addTool(catalogListRegisteredTool, s.handleCatalogListRegistered)
 }
 
 // handleCatalogSearch searches catalogs for solutions.

--- a/pkg/mcp/tools_cel.go
+++ b/pkg/mcp/tools_cel.go
@@ -40,7 +40,7 @@ func (s *Server) registerCELTools() {
 			mcp.Description("Search functions by name or description (substring match). More flexible than 'name' which only matches function names."),
 		),
 	)
-	s.mcpServer.AddTool(listCELFunctionsTool, s.handleListCELFunctions)
+	s.addTool(listCELFunctionsTool, s.handleListCELFunctions)
 
 	// evaluate_cel
 	evaluateCELTool := mcp.NewTool("evaluate_cel",
@@ -66,7 +66,7 @@ func (s *Server) registerCELTools() {
 			mcp.Description("Path to a YAML/JSON file to load as root data (alternative to 'data')"),
 		),
 	)
-	s.mcpServer.AddTool(evaluateCELTool, s.handleEvaluateCEL)
+	s.addTool(evaluateCELTool, s.handleEvaluateCEL)
 }
 
 // handleListCELFunctions lists available CEL functions.

--- a/pkg/mcp/tools_cli.go
+++ b/pkg/mcp/tools_cli.go
@@ -35,7 +35,7 @@ func (s *Server) registerCLITools() {
 			mcp.Description("Space-separated command path (e.g. \"run solution\", \"catalog list\"). Omit to list all commands."),
 		),
 	)
-	s.mcpServer.AddTool(getCommandHelpTool, s.handleGetCommandHelp)
+	s.addTool(getCommandHelpTool, s.handleGetCommandHelp)
 }
 
 // handleGetCommandHelp returns structured CLI help.

--- a/pkg/mcp/tools_concepts.go
+++ b/pkg/mcp/tools_concepts.go
@@ -31,7 +31,7 @@ func (s *Server) registerConceptTools() {
 			mcp.Description("Filter concepts by category (e.g., 'resolvers', 'testing', 'providers', 'actions')"),
 		),
 	)
-	s.mcpServer.AddTool(tool, s.handleExplainConcepts)
+	s.addTool(tool, s.handleExplainConcepts)
 }
 
 // handleExplainConcepts handles the explain_concepts MCP tool.

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -27,7 +27,7 @@ func (s *Server) registerConfigTools() {
 			mcp.Description("Optional section to retrieve: 'catalogs', 'settings', 'logging', 'httpClient', 'cel', 'resolver', 'action', 'auth', 'build'. Omit to return the full configuration."),
 		),
 	)
-	s.mcpServer.AddTool(getConfigTool, s.handleGetConfig)
+	s.addTool(getConfigTool, s.handleGetConfig)
 
 	getConfigPathsTool := mcp.NewTool("get_config_paths",
 		mcp.WithDescription("Return all XDG-compliant filesystem paths used by scafctl. Shows config, data, cache, state, catalog, secrets, plugins, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout."),
@@ -39,7 +39,7 @@ func (s *Server) registerConfigTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithRawOutputSchema(outputSchemaGetConfigPaths),
 	)
-	s.mcpServer.AddTool(getConfigPathsTool, s.handleGetConfigPaths)
+	s.addTool(getConfigPathsTool, s.handleGetConfigPaths)
 }
 
 // handleGetConfig returns the current configuration (with sensitive fields redacted).

--- a/pkg/mcp/tools_diff.go
+++ b/pkg/mcp/tools_diff.go
@@ -35,7 +35,7 @@ func (s *Server) registerDiffTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(diffSolutionTool, s.handleDiffSolution)
+	s.addTool(diffSolutionTool, s.handleDiffSolution)
 }
 
 // handleDiffSolution compares two solutions structurally.

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -52,7 +52,7 @@ func (s *Server) registerDryRunTools() {
 			mcp.Description("Include materialized inputs in the report for each action. Useful for debugging what values were resolved for each provider input."),
 		),
 	)
-	s.mcpServer.AddTool(dryRunTool, s.handleDryRunSolution)
+	s.addTool(dryRunTool, s.handleDryRunSolution)
 }
 
 // handleDryRunSolution performs a full dry-run of a solution using the shared dryrun package.

--- a/pkg/mcp/tools_errors.go
+++ b/pkg/mcp/tools_errors.go
@@ -28,7 +28,7 @@ func (s *Server) registerErrorTools() {
 			mcp.Description("The error message text to explain. Can be a full error string or snippet from resolver execution, validation, CEL evaluation, or any scafctl operation."),
 		),
 	)
-	s.mcpServer.AddTool(explainErrorTool, s.handleExplainError)
+	s.addTool(explainErrorTool, s.handleExplainError)
 }
 
 // handleExplainError parses an error message and returns a structured explanation.

--- a/pkg/mcp/tools_examples.go
+++ b/pkg/mcp/tools_examples.go
@@ -27,7 +27,7 @@ func (s *Server) registerExampleTools() {
 			mcp.Enum("solutions", "resolvers", "actions", "providers", "exec", "config", "mcp", "snapshots", "catalog", "auth", "eval", "plugins", "telemetry"),
 		),
 	)
-	s.mcpServer.AddTool(listExamplesTool, s.handleListExamples)
+	s.addTool(listExamplesTool, s.handleListExamples)
 
 	// get_example — read an example file's contents
 	getExampleTool := mcp.NewTool("get_example",
@@ -43,7 +43,7 @@ func (s *Server) registerExampleTools() {
 			mcp.Description("Path of the example file (as returned by list_examples, e.g., 'solutions/email-notifier/solution.yaml')"),
 		),
 	)
-	s.mcpServer.AddTool(getExampleTool, s.handleGetExample)
+	s.addTool(getExampleTool, s.handleGetExample)
 }
 
 // handleListExamples lists available example files.

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -30,7 +30,7 @@ func (s *Server) registerLintTools() {
 			mcp.Description("Filter by category (e.g., 'structure', 'naming', 'provider', 'expression', 'schema'). Omit to list all."),
 		),
 	)
-	s.mcpServer.AddTool(listLintRulesTool, s.handleListLintRules)
+	s.addTool(listLintRulesTool, s.handleListLintRules)
 
 	// explain_lint_rule
 	explainLintRuleTool := mcp.NewTool("explain_lint_rule",
@@ -47,7 +47,7 @@ func (s *Server) registerLintTools() {
 			mcp.Description("The lint rule name to explain (e.g., 'unused-resolver', 'invalid-expression', 'missing-provider')"),
 		),
 	)
-	s.mcpServer.AddTool(explainLintRuleTool, s.handleExplainLintRule)
+	s.addTool(explainLintRuleTool, s.handleExplainLintRule)
 }
 
 // lintRuleSummary is a compact view of a lint rule for listing.

--- a/pkg/mcp/tools_plugin.go
+++ b/pkg/mcp/tools_plugin.go
@@ -27,7 +27,7 @@ func (s *Server) registerPluginTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
-	s.mcpServer.AddTool(listPluginsTool, s.handleListPlugins)
+	s.addTool(listPluginsTool, s.handleListPlugins)
 
 	pluginCachePathTool := mcp.NewTool("get_plugin_cache_path",
 		mcp.WithDescription(fmt.Sprintf(
@@ -41,7 +41,7 @@ func (s *Server) registerPluginTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
-	s.mcpServer.AddTool(pluginCachePathTool, s.handleGetPluginCachePath)
+	s.addTool(pluginCachePathTool, s.handleGetPluginCachePath)
 
 	// list_official_providers
 	listOfficialProvidersTool := mcp.NewTool("list_official_providers",
@@ -61,7 +61,7 @@ func (s *Server) registerPluginTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
-	s.mcpServer.AddTool(listOfficialProvidersTool, s.handleListOfficialProviders)
+	s.addTool(listOfficialProvidersTool, s.handleListOfficialProviders)
 }
 
 // handleListPlugins lists cached plugin binaries.

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -32,7 +32,7 @@ func (s *Server) registerProviderTools() {
 			mcp.Description("Filter by category"),
 		),
 	)
-	s.mcpServer.AddTool(listProvidersTool, s.handleListProviders)
+	s.addTool(listProvidersTool, s.handleListProviders)
 
 	// get_provider_schema
 	getProviderSchemaTool := mcp.NewTool("get_provider_schema",
@@ -48,7 +48,7 @@ func (s *Server) registerProviderTools() {
 			mcp.Description("Provider name (e.g., http, static, file, cel, parameter)"),
 		),
 	)
-	s.mcpServer.AddTool(getProviderSchemaTool, s.handleGetProviderSchema)
+	s.addTool(getProviderSchemaTool, s.handleGetProviderSchema)
 
 	// get_provider_output_shape
 	getProviderOutputShapeTool := mcp.NewTool("get_provider_output_shape",
@@ -68,7 +68,7 @@ func (s *Server) registerProviderTools() {
 			mcp.Enum("from", "transform", "validation", "authentication", "action"),
 		),
 	)
-	s.mcpServer.AddTool(getProviderOutputShapeTool, s.handleGetProviderOutputShape)
+	s.addTool(getProviderOutputShapeTool, s.handleGetProviderOutputShape)
 
 	// run_provider
 	runProviderTool := mcp.NewTool("run_provider",
@@ -100,7 +100,7 @@ func (s *Server) registerProviderTools() {
 			mcp.Description("Preview what would happen without executing. Defaults to false."),
 		),
 	)
-	s.mcpServer.AddTool(runProviderTool, s.handleRunProvider)
+	s.addTool(runProviderTool, s.handleRunProvider)
 }
 
 // providerItem is a structured response for provider listings.

--- a/pkg/mcp/tools_refs.go
+++ b/pkg/mcp/tools_refs.go
@@ -40,7 +40,7 @@ func (s *Server) registerRefsTools() {
 			mcp.Description("Working directory for path resolution. When set, relative file paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(extractRefssTool, s.handleExtractResolverRefs)
+	s.addTool(extractRefssTool, s.handleExtractResolverRefs)
 }
 
 // handleExtractResolverRefs extracts resolver references from expressions.

--- a/pkg/mcp/tools_run.go
+++ b/pkg/mcp/tools_run.go
@@ -59,7 +59,7 @@ func (s *Server) registerRunTools() {
 			mcp.Description("Include execution metadata (timing, phases, providers) in the response."),
 		),
 	)
-	s.mcpServer.AddTool(runSolutionTool, s.handleRunSolution)
+	s.addTool(runSolutionTool, s.handleRunSolution)
 }
 
 // handleRunSolution executes a solution through the domain layer.

--- a/pkg/mcp/tools_scaffold.go
+++ b/pkg/mcp/tools_scaffold.go
@@ -41,7 +41,7 @@ func (s *Server) registerScaffoldTools() {
 			mcp.WithStringItems(),
 		),
 	)
-	s.mcpServer.AddTool(scaffoldSolutionTool, s.handleScaffoldSolution)
+	s.addTool(scaffoldSolutionTool, s.handleScaffoldSolution)
 }
 
 // handleScaffoldSolution generates a skeleton solution YAML.

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -30,7 +30,7 @@ func (s *Server) registerSchemaTools() {
 			mcp.Description("Optional: get schema for a specific field path (dot-separated, e.g., 'metadata', 'spec.resolvers', 'spec.workflow.actions'). Omit to get the full schema."),
 		),
 	)
-	s.mcpServer.AddTool(getSolutionSchemaTool, s.handleGetSolutionSchema)
+	s.addTool(getSolutionSchemaTool, s.handleGetSolutionSchema)
 
 	// explain_kind — introspect any registered kind (solution, resolver, action, etc.)
 	explainKindTool := mcp.NewTool("explain_kind",
@@ -49,7 +49,7 @@ func (s *Server) registerSchemaTools() {
 			mcp.Description("Optional field path to drill into (dot-separated, e.g., 'metadata', 'resolve.with')"),
 		),
 	)
-	s.mcpServer.AddTool(explainKindTool, s.handleExplainKind)
+	s.addTool(explainKindTool, s.handleExplainKind)
 }
 
 // handleGetSolutionSchema returns the full JSON Schema for a solution YAML file.

--- a/pkg/mcp/tools_snapshot.go
+++ b/pkg/mcp/tools_snapshot.go
@@ -34,7 +34,7 @@ func (s *Server) registerSnapshotTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(showSnapshotTool, s.handleShowSnapshot)
+	s.addTool(showSnapshotTool, s.handleShowSnapshot)
 
 	diffSnapshotsTool := mcp.NewTool("diff_snapshots",
 		mcp.WithDescription("Compare two resolver execution snapshots and show differences. Identifies resolvers with changed values, status changes (success→failure), additions, and removals. Useful for detecting regressions between runs or understanding the impact of solution changes."),
@@ -60,7 +60,7 @@ func (s *Server) registerSnapshotTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(diffSnapshotsTool, s.handleDiffSnapshots)
+	s.addTool(diffSnapshotsTool, s.handleDiffSnapshots)
 }
 
 // handleShowSnapshot loads a snapshot file and returns structured data.

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -49,7 +49,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Filter solutions by name (substring match). Omit to list all."),
 		),
 	)
-	s.mcpServer.AddTool(listSolutionsTool, s.handleListSolutions)
+	s.addTool(listSolutionsTool, s.handleListSolutions)
 
 	// inspect_solution
 	inspectSolutionTool := mcp.NewTool("inspect_solution",
@@ -69,7 +69,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(inspectSolutionTool, s.handleInspectSolution)
+	s.addTool(inspectSolutionTool, s.handleInspectSolution)
 
 	// lint_solution
 	lintSolutionTool := mcp.NewTool("lint_solution",
@@ -93,7 +93,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(lintSolutionTool, s.handleLintSolution)
+	s.addTool(lintSolutionTool, s.handleLintSolution)
 
 	// render_solution
 	renderSolutionTool := mcp.NewTool("render_solution",
@@ -123,7 +123,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(renderSolutionTool, s.handleRenderSolution)
+	s.addTool(renderSolutionTool, s.handleRenderSolution)
 
 	// preview_resolvers
 	previewResolversTool := mcp.NewTool("preview_resolvers",
@@ -152,7 +152,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(previewResolversTool, s.handlePreviewResolvers)
+	s.addTool(previewResolversTool, s.handlePreviewResolvers)
 
 	// run_solution_tests
 	runSolutionTestsTool := mcp.NewTool("run_solution_tests",
@@ -186,7 +186,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(runSolutionTestsTool, s.handleRunSolutionTests)
+	s.addTool(runSolutionTestsTool, s.handleRunSolutionTests)
 
 	// get_run_command
 	getRunCommandTool := mcp.NewTool("get_run_command",
@@ -215,7 +215,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(getRunCommandTool, s.handleGetRunCommand)
+	s.addTool(getRunCommandTool, s.handleGetRunCommand)
 }
 
 // handleListSolutions lists available solutions from the local catalog.

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -48,7 +48,7 @@ func (s *Server) registerTemplateTools() {
 			mcp.Enum("default", "zero", "error"),
 		),
 	)
-	s.mcpServer.AddTool(evaluateGoTemplateTool, s.handleEvaluateGoTemplate)
+	s.addTool(evaluateGoTemplateTool, s.handleEvaluateGoTemplate)
 
 	// validate_expression
 	validateExpressionTool := mcp.NewTool("validate_expression",
@@ -75,7 +75,7 @@ func (s *Server) registerTemplateTools() {
 			mcp.Description("Right delimiter for Go templates (default: '}}')"),
 		),
 	)
-	s.mcpServer.AddTool(validateExpressionTool, s.handleValidateExpression)
+	s.addTool(validateExpressionTool, s.handleValidateExpression)
 
 	// validate_expressions (batch)
 	validateExpressionsTool := mcp.NewTool("validate_expressions",
@@ -99,7 +99,7 @@ func (s *Server) registerTemplateTools() {
 			}),
 		),
 	)
-	s.mcpServer.AddTool(validateExpressionsTool, s.handleValidateExpressions)
+	s.addTool(validateExpressionsTool, s.handleValidateExpressions)
 
 	// list_go_template_functions
 	listGoTemplateFunctionsTool := mcp.NewTool("list_go_template_functions",
@@ -120,7 +120,7 @@ func (s *Server) registerTemplateTools() {
 			mcp.Description("Get details for a specific function by name (substring match)"),
 		),
 	)
-	s.mcpServer.AddTool(listGoTemplateFunctionsTool, s.handleListGoTemplateFunctions)
+	s.addTool(listGoTemplateFunctionsTool, s.handleListGoTemplateFunctions)
 }
 
 // handleEvaluateGoTemplate evaluates a Go template against provided data.

--- a/pkg/mcp/tools_testing.go
+++ b/pkg/mcp/tools_testing.go
@@ -35,7 +35,7 @@ func (s *Server) registerTestingTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(genTestTool, s.handleGenerateTestScaffold)
+	s.addTool(genTestTool, s.handleGenerateTestScaffold)
 
 	// list_tests
 	listTestsTool := mcp.NewTool("list_tests",
@@ -62,7 +62,7 @@ func (s *Server) registerTestingTools() {
 			mcp.Description("Working directory for path resolution. When set, relative paths resolve against this directory instead of the process CWD."),
 		),
 	)
-	s.mcpServer.AddTool(listTestsTool, s.handleListTests)
+	s.addTool(listTestsTool, s.handleListTests)
 }
 
 // handleGenerateTestScaffold generates a starter test scaffold for a solution.

--- a/pkg/mcp/tools_version.go
+++ b/pkg/mcp/tools_version.go
@@ -22,7 +22,7 @@ func (s *Server) registerVersionTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithRawOutputSchema(outputSchemaVersion),
 	)
-	s.mcpServer.AddTool(getVersionTool, s.handleGetVersion)
+	s.addTool(getVersionTool, s.handleGetVersion)
 }
 
 // handleGetVersion returns the scafctl version information.

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6858,6 +6858,74 @@ func TestIntegration_MCPServeInfo_ExplainConcepts(t *testing.T) {
 	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool to be registered")
 }
 
+func TestIntegration_MCPListHelp(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "list", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "List all tools and prompts")
+	assert.Contains(t, stdout, "--kind")
+	assert.Contains(t, stdout, "--output")
+}
+
+func TestIntegration_MCPList(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "list", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+
+	var caps []struct {
+		Kind   string `json:"kind"`
+		Name   string `json:"name"`
+		Source string `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &caps))
+	assert.NotEmpty(t, caps, "should list capabilities")
+
+	var hasTools, hasPrompts bool
+	for _, c := range caps {
+		if c.Kind == "tool" {
+			hasTools = true
+		}
+		if c.Kind == "prompt" {
+			hasPrompts = true
+		}
+		assert.NotEmpty(t, c.Name, "capability should have a name")
+		assert.Equal(t, "core", c.Source, "all default capabilities should be core")
+	}
+	assert.True(t, hasTools, "should contain tools")
+	assert.True(t, hasPrompts, "should contain prompts")
+}
+
+func TestIntegration_MCPListKindFilter(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "list", "--kind", "prompt", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+
+	var caps []struct {
+		Kind string `json:"kind"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &caps))
+	assert.NotEmpty(t, caps)
+
+	for _, c := range caps {
+		assert.Equal(t, "prompt", c.Kind, "all results should be prompts")
+	}
+}
+
+func TestIntegration_MCPListInvalidKind(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runScafctl(t, "mcp", "list", "--kind", "invalid")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "invalid --kind value")
+}
+
 // ============================================================================
 // Snapshot Command Tests
 // ============================================================================


### PR DESCRIPTION
- add `mcp list` command with kvx table output by default, -i interactive TUI, and display schema for rich detail
- support --kind flag to filter by tool or prompt
- support structured output via -o json/yaml/table
- add Capability, CapabilityKind, and CapabilitySource domain types with ListCapabilities() on Server
- track core vs embedder tools: core tools registered via addTool() are tagged SourceCore, embedder tools added via MCPServer().AddTool() are automatically tagged SourcePlugin
- track registered prompts via addPrompt() wrapper so they appear alongside tools in the listing
- use settings.Run.BinaryName throughout for embedder support
- fix SA5011 staticcheck warnings in root_test.go by replacing manual nil checks with require.NotNil
