### PR TITLE
feat(provider): show official providers in get/list and fix Windows plugin cache

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -156,7 +156,7 @@ Following kubectl conventions, use singular or plural forms:
 # List all solutions in the catalog
 scafctl get solutions
 
-# List all providers
+# List all providers (built-in + official)
 scafctl get providers
 
 # Get a specific solution
@@ -164,6 +164,8 @@ scafctl get solution example
 ~~~
 
 Both singular and plural forms without a name will list all resources of that kind.
+
+The `get providers` output includes a `source` column indicating whether each provider is `builtin` (compiled in) or `official` (auto-fetched from the OCI catalog). When filters (`--capability`, `--category`) are active, only built-in providers are shown since official providers do not expose capability/category metadata.
 ---
 
 ## Rendering a Solution

--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -24,20 +24,21 @@ Providers are never invoked implicitly. A provider runs only when explicitly ref
 
 | Feature | Status | Location |
 |---------|--------|----------|
-| Provider Interface | ✅ Implemented | `pkg/provider/provider.go` |
-| Descriptor with schemas | ✅ Implemented | `pkg/provider/provider.go` |
-| All 5 Capabilities | ✅ Implemented | `from`, `transform`, `validation`, `authentication`, `action` |
-| Execution Context | ✅ Implemented | `pkg/provider/context.go` |
-| Input Resolution (literal, rslvr, expr, tmpl) | ✅ Implemented | `pkg/provider/inputs.go` |
-| Schema Validation | ✅ Implemented | `pkg/provider/validation.go` |
-| Executor Lifecycle | ✅ Implemented | `pkg/provider/executor.go` |
-| In-Memory Metrics (`--show-metrics`) | ✅ Implemented | `pkg/provider/metrics.go` |
-| Prometheus Metrics | ✅ Implemented | `pkg/metrics/metrics.go` |
-| Registry with versioning | ✅ Implemented | `pkg/provider/registry.go` |
-| Built-in Providers | ✅ Implemented | `pkg/provider/builtin/` |
-| Capability-required output fields | ✅ Implemented | `CapabilityRequiredOutputFields` |
-| Secret handling (`SensitiveFields`) | ✅ Implemented | Redaction via `SecretMask` |
-| Iteration Context | ✅ Implemented | `__item`, `__index`, aliases |
+| Provider Interface | Implemented | `pkg/provider/provider.go` |
+| Descriptor with schemas | Implemented | `pkg/provider/provider.go` |
+| All 5 Capabilities | Implemented | `from`, `transform`, `validation`, `authentication`, `action` |
+| Execution Context | Implemented | `pkg/provider/context.go` |
+| Input Resolution (literal, rslvr, expr, tmpl) | Implemented | `pkg/provider/inputs.go` |
+| Schema Validation | Implemented | `pkg/provider/validation.go` |
+| Executor Lifecycle | Implemented | `pkg/provider/executor.go` |
+| In-Memory Metrics (`--show-metrics`) | Implemented | `pkg/provider/metrics.go` |
+| Prometheus Metrics | Implemented | `pkg/metrics/metrics.go` |
+| Registry with versioning | Implemented | `pkg/provider/registry.go` |
+| Built-in Providers | Implemented | `pkg/provider/builtin/` |
+| Official Provider Registry | Implemented | `pkg/provider/official/` |
+| Capability-required output fields | Implemented | `CapabilityRequiredOutputFields` |
+| Secret handling (`SensitiveFields`) | Implemented | Redaction via `SecretMask` |
+| Iteration Context | Implemented | `__item`, `__index`, aliases |
 
 ---
 
@@ -64,7 +65,7 @@ A provider is not responsible for:
 
 ## Execution Context
 
-> **Status**: ✅ Implemented in `pkg/provider/context.go`
+> **Status**: Implemented in `pkg/provider/context.go`
 
 Providers are invoked with a resolved execution context.
 
@@ -103,7 +104,7 @@ Both default names and aliases are available simultaneously in the context.
 
 ## Execution Lifecycle
 
-> **Status**: ✅ Implemented in `pkg/provider/executor.go`
+> **Status**: Implemented in `pkg/provider/executor.go`
 
 Providers follow a strict execution pipeline to ensure consistent behavior and validation:
 
@@ -156,13 +157,13 @@ This validation happens in the `Executor`, not in individual providers. Provider
 
 ## Observability & Metrics
 
-> **Status**: ✅ Implemented
+> **Status**: Implemented
 
 Provider execution is instrumented for observability at two levels:
 
 ### In-Memory Metrics (CLI Output)
 
-> **Status**: ✅ Implemented in `pkg/provider/metrics.go`
+> **Status**: Implemented in `pkg/provider/metrics.go`
 
 When running with `--show-metrics`, scafctl collects per-provider execution statistics:
 
@@ -191,7 +192,7 @@ scafctl run solution -f solution.yaml --show-metrics
 
 ### Prometheus Metrics (Observability)
 
-> **Status**: ✅ Implemented in `pkg/metrics/metrics.go`
+> **Status**: Implemented in `pkg/metrics/metrics.go`
 
 Provider metrics are also exported as Prometheus metrics for integration with monitoring systems:
 
@@ -349,7 +350,7 @@ desc := &provider.Descriptor{
 
 ## Provider Capabilities
 
-> **Status**: ✅ Implemented - All 5 capability types active
+> **Status**: Implemented - All 5 capability types active
 
 Providers declare their supported execution contexts through capabilities. Capabilities indicate which parts of the scafctl execution model a provider can participate in.
 
@@ -674,7 +675,7 @@ This interface is illustrative. The exact implementation may evolve, but the con
 
 ## Input Resolution
 
-> **Status**: ✅ Implemented in `pkg/provider/inputs.go`
+> **Status**: Implemented in `pkg/provider/inputs.go`
 
 Provider inputs are resolved by scafctl before execution.
 
@@ -918,6 +919,23 @@ actions:
 ~~~
 
 Action orchestration, dependencies, iteration, and conditional execution are handled outside the provider.
+
+---
+
+## Provider Sources
+
+Providers are classified by source:
+
+| Source | Description | Location |
+|--------|-------------|----------|
+| `builtin` | Compiled into the binary, always available | `pkg/provider/builtin/` |
+| `official` | Auto-fetched from OCI catalog on first use | `pkg/provider/official/` |
+
+The `get providers` command and MCP `list_providers` tool include both sources in their output. Each provider item includes a `source` field indicating its origin.
+
+When looking up a specific provider (`get provider <name>` or `get_provider_schema`), scafctl checks the built-in registry first, then falls back to the official registry. Official providers that are not yet cached locally are auto-fetched on first use in a solution.
+
+The official provider registry can be disabled via `settings.disableOfficialProviders: true` in the configuration file.
 
 ---
 
@@ -1384,7 +1402,7 @@ expiresIn: "55m30s"
 
 ## Security Considerations
 
-> **Status**: ✅ Implemented
+> **Status**: Implemented
 
 Providers handle sensitive data through structured security mechanisms:
 
@@ -1461,7 +1479,7 @@ Providers with `CapabilityAuthentication` have additional requirements:
 
 ## Context Propagation
 
-> **Status**: ✅ Implemented in `pkg/provider/context.go`
+> **Status**: Implemented in `pkg/provider/context.go`
 
 Providers receive and should respect standard Go context patterns:
 
@@ -1580,7 +1598,7 @@ func (p *APIProvider) Execute(ctx context.Context, input any) (*Output, error) {
 
 ## Trace Instrumentation
 
-> **Status**: ✅ Implemented in `pkg/provider/executor.go`
+> **Status**: Implemented in `pkg/provider/executor.go`
 
 Every provider execution is wrapped in an OpenTelemetry span, giving end-to-end visibility across resolver phases and provider calls.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -244,7 +244,7 @@ scafctl render solution -f solution.yaml
 # Show resolver dependency graph
 scafctl run resolver --graph -f solution.yaml
 
-# List available providers
+# List available providers (built-in + official)
 scafctl get provider
 
 # Get details about a specific provider
@@ -302,7 +302,7 @@ scafctl render solution -f solution.yaml
 # Show resolver dependency graph
 scafctl run resolver --graph -f solution.yaml
 
-# List available providers
+# List available providers (built-in + official)
 scafctl get provider
 
 # Get details about a specific provider

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -323,7 +323,7 @@ spec:
 
 ### List Available Providers
 
-No files needed — this tool lists the built-in providers.
+No files needed -- this tool lists both built-in and official providers.
 
 > [!NOTE]
 > **You:** "What solution providers are available?"
@@ -333,27 +333,31 @@ The AI calls `list_providers` and returns something like:
 ```
 Here are the available solution providers:
 
-| Name        | Category    | Capabilities       |
-|-------------|-------------|--------------------|
-| cel         | transform   | from, transform    |
-| debug       | utility     | action             |
-| directory   | data        | from               |
-| env         | data        | from               |
-| exec        | action      | from, action       |
-| file        | data        | from               |
-| git         | data        | from               |
-| go-template | transform   | from, transform    |
-| hcl         | data        | from, transform    |
-| http        | data        | from, action       |
-| identity    | auth        | from               |
-| parameter   | data        | from               |
-| secret      | data        | from               |
-| sleep       | utility     | action             |
-| static      | data        | from, action       |
-| validation  | validation  | validation         |
+| Name        | Source   | Category    | Capabilities       |
+|-------------|----------|-------------|--------------------|
+| cel         | builtin  | transform   | from, transform    |
+| debug       | builtin  | utility     | action             |
+| file        | builtin  | data        | from               |
+| go-template | builtin  | transform   | from, transform    |
+| http        | builtin  | data        | from, action       |
+| message     | builtin  | utility     | action             |
+| parameter   | builtin  | data        | from               |
+| static      | builtin  | data        | from, action       |
+| validation  | builtin  | validation  | validation         |
+| directory   | official |             |                    |
+| env         | official |             |                    |
+| exec        | official |             |                    |
+| git         | official |             |                    |
+| github      | official |             |                    |
+| hcl         | official |             |                    |
+| identity    | official |             |                    |
+| metadata    | official |             |                    |
+| secret      | official |             |                    |
+| sleep       | official |             |                    |
 
-16 providers available. Use `get_provider_schema` with a specific
-provider name to see its full input schema and examples.
+19 providers available (9 built-in, 10 official). Use `get_provider_schema`
+with a specific provider name to see its full input schema and examples.
+Official providers are auto-fetched from the OCI catalog on first use.
 ```
 
 ### Inspect a Solution
@@ -599,7 +603,7 @@ Resolution order:
 
 ### Get Provider Schema
 
-No files needed — you specify the provider by name.
+No files needed -- you specify the provider by name. If the provider is not found in the built-in registry, scafctl falls back to the official provider registry and returns catalog metadata (name, source, catalog reference, version).
 
 > [!NOTE]
 > **You:** "What inputs does the `exec` provider accept?"

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -560,6 +560,10 @@ scafctl get providers
 {{% /tab %}}
 {{< /tabs >}}
 
+This lists all available providers with their source (`builtin` or `official`), category, and capabilities. Official providers are auto-fetched from the OCI catalog on first use -- no manual installation required.
+
+> **Note:** When `--capability` or `--category` filters are active, only built-in providers are shown since official providers do not expose this metadata.
+
 ### View Provider Details
 
 {{< tabs "run-provider-tutorial-cmd-16" >}}
@@ -575,7 +579,7 @@ scafctl get provider http
 {{% /tab %}}
 {{< /tabs >}}
 
-This shows the provider's schema, capabilities, examples, and auto-generated CLI usage examples.
+This shows the provider's schema, capabilities, examples, and auto-generated CLI usage examples. If the provider is not found in the built-in registry, scafctl falls back to the official provider registry and displays catalog information.
 
 ### Dynamic Help for Provider Inputs
 

--- a/pkg/cmd/scafctl/get/provider/provider.go
+++ b/pkg/cmd/scafctl/get/provider/provider.go
@@ -15,9 +15,11 @@ import (
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -122,6 +124,7 @@ type Summary struct {
 	Name         string `json:"name" yaml:"name" required:"true"`
 	DisplayName  string `json:"displayName" yaml:"displayName"`
 	Version      string `json:"version" yaml:"version"`
+	Source       string `json:"source" yaml:"source"`
 	Category     string `json:"category" yaml:"category"`
 	Capabilities string `json:"capabilities" yaml:"capabilities"`
 	Description  string `json:"description" yaml:"description"`
@@ -131,24 +134,42 @@ type Summary struct {
 
 // RunListProviders lists all providers
 func (o *Options) RunListProviders(ctx context.Context) error {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
 	if o.BinaryName == "" {
 		o.BinaryName = settings.CliBinaryName
 	}
 
 	reg := o.getRegistry(ctx)
 	providers := reg.ListProviders()
+	lgr.V(1).Info("loaded built-in provider registry", "count", len(providers))
+	if w != nil {
+		w.Verbosef("Found %d built-in providers", len(providers))
+	}
 
 	// Apply filters
 	filtered := o.filterProviders(providers)
+	lgr.V(2).Info("applied filters to built-in providers",
+		"capability", o.Capability,
+		"category", o.Category,
+		"before", len(providers),
+		"after", len(filtered),
+	)
+	if w != nil && (o.Capability != "" || o.Category != "") {
+		w.Verbosef("After filtering (capability=%q, category=%q): %d providers", o.Capability, o.Category, len(filtered))
+	}
 
 	// Build structured output for kvx
 	output := make([]Summary, 0, len(filtered))
 	for _, p := range filtered {
 		desc := p.Descriptor()
+		lgr.V(3).Info("including built-in provider", "name", desc.Name)
 		output = append(output, Summary{
 			Name:         desc.Name,
 			DisplayName:  desc.DisplayName,
 			Version:      desc.Version.String(),
+			Source:       "builtin",
 			Description:  desc.Description,
 			Capabilities: strings.Join(CapabilitiesToStrings(desc.Capabilities), ", "),
 			Category:     desc.Category,
@@ -157,14 +178,54 @@ func (o *Options) RunListProviders(ctx context.Context) error {
 		})
 	}
 
+	// Include official providers only when no filters are active
+	// (official providers don't expose capability/category metadata).
+	if o.Capability == "" && o.Category == "" {
+		output = o.appendOfficialProviders(ctx, output)
+	}
+
+	if w != nil {
+		w.Verbosef("Total providers: %d", len(output))
+	}
+	lgr.V(1).Info("total providers to display", "count", len(output))
+
 	return o.writeOutput(ctx, output)
 }
 
 // RunGetProvider gets details about a specific provider
 func (o *Options) RunGetProvider(ctx context.Context, name string) error {
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("looking up provider", "name", name)
+
 	reg := o.getRegistry(ctx)
 	p, ok := reg.Get(name)
 	if !ok {
+		lgr.V(1).Info("provider not found in built-in registry, checking official registry", "name", name)
+		// Check if it's an official provider
+		if officialReg := official.RegistryFromContext(ctx); officialReg != nil {
+			if op, found := officialReg.Get(name); found {
+				lgr.V(1).Info("found provider in official registry", "name", name, "catalogRef", op.CatalogRef)
+
+				// Structured output for -o flag (including quiet) or interactive mode.
+				// Quiet mode is handled by kvx (produces no output), consistent with built-in providers.
+				if (o.Output != "" && o.Output != "auto") || o.Interactive {
+					detail := official.Detail(op)
+					return o.writeOutput(ctx, detail)
+				}
+
+				// Default: human-readable text
+				w := writer.FromContext(ctx)
+				if w != nil {
+					w.Plainlnf("Provider %q is an official plugin provider (catalog: %s, version: %s).\n"+
+						"It is auto-fetched on first use in a solution. Use 'plugins install' to pre-fetch.", name, op.CatalogRef, op.DefaultVersion)
+				}
+				return nil
+			}
+			lgr.V(1).Info("provider not found in official registry either", "name", name)
+		} else {
+			lgr.V(1).Info("official registry not available in context")
+		}
+
 		err := fmt.Errorf("provider %q not found", name)
 		if w := writer.FromContext(ctx); w != nil {
 			w.Errorf("%v", err)
@@ -172,6 +233,7 @@ func (o *Options) RunGetProvider(ctx context.Context, name string) error {
 		return exitcode.WithCode(err, exitcode.FileNotFound)
 	}
 
+	lgr.V(1).Info("found provider in built-in registry", "name", name)
 	desc := p.Descriptor()
 
 	// Default: custom formatted view (unless -o is specified)
@@ -181,6 +243,7 @@ func (o *Options) RunGetProvider(ctx context.Context, name string) error {
 
 	// Structured output for -o flag
 	output := BuildProviderDetail(*desc)
+	output["source"] = "builtin"
 	return o.writeOutput(ctx, output)
 }
 
@@ -436,15 +499,51 @@ func CapabilitiesToStrings(caps []provider.Capability) []string {
 
 // getRegistry returns the provider registry
 func (o *Options) getRegistry(ctx context.Context) *provider.Registry {
+	lgr := logger.FromContext(ctx)
+
 	if o.registry != nil {
+		lgr.V(2).Info("using injected test registry")
 		return o.registry
 	}
 
 	reg, err := builtin.DefaultRegistry(ctx)
 	if err != nil {
+		lgr.V(1).Info("failed to load default registry, falling back to global", "error", err)
 		return provider.GetGlobalRegistry()
 	}
+	lgr.V(2).Info("using default built-in registry")
 	return reg
+}
+
+// appendOfficialProviders appends official plugin providers from context to the output slice.
+func (o *Options) appendOfficialProviders(ctx context.Context, output []Summary) []Summary {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
+	items := official.ListItems(ctx)
+	if items == nil {
+		lgr.V(1).Info("official provider registry not available in context")
+		if w != nil {
+			w.Verbosef("Official provider registry not available (check config: settings.disableOfficialProviders)")
+		}
+		return output
+	}
+
+	lgr.V(1).Info("loaded official provider registry", "count", len(items))
+	if w != nil {
+		w.Verbosef("Found %d official plugin providers (auto-fetched on first use)", len(items))
+	}
+	for _, item := range items {
+		lgr.V(3).Info("including official provider", "name", item.Name)
+		output = append(output, Summary{
+			Name:        item.Name,
+			DisplayName: item.DisplayName,
+			Version:     item.Version,
+			Source:      item.Source,
+			Description: item.Description,
+		})
+	}
+	return output
 }
 
 // writeOutput writes the output using kvx
@@ -456,9 +555,10 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 		kvx.WithOutputAppName(o.BinaryName+" get provider"),
 		kvx.WithOutputDisplaySchemaJSON(providerSchemaJSON),
 		kvx.WithIOStreams(o.IOStreams),
-		kvx.WithOutputColumnOrder([]string{"name", "description"}),
+		kvx.WithOutputColumnOrder([]string{"name", "source", "description"}),
 		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
 			"name":         {MaxWidth: 20, Priority: 10},
+			"source":       {MaxWidth: 10, Priority: 8},
 			"displayName":  {Hidden: true},
 			"version":      {Hidden: true},
 			"category":     {Hidden: true},

--- a/pkg/cmd/scafctl/get/provider/provider_schema.json
+++ b/pkg/cmd/scafctl/get/provider/provider_schema.json
@@ -20,7 +20,7 @@
     "sections": [
       {
         "title": "",
-        "fields": ["name", "version", "category"],
+        "fields": ["name", "version", "source", "category"],
         "layout": "inline"
       },
       {
@@ -59,6 +59,11 @@
         "type": "string",
         "title": "Version",
         "description": "Semantic version of the provider"
+      },
+      "source": {
+        "type": "string",
+        "title": "Source",
+        "description": "Provider source (builtin or official)"
       },
       "description": {
         "type": "string",

--- a/pkg/cmd/scafctl/get/provider/provider_test.go
+++ b/pkg/cmd/scafctl/get/provider/provider_test.go
@@ -6,12 +6,14 @@ package provider
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -747,5 +749,297 @@ func TestOptions_getRegistry(t *testing.T) {
 
 		result := options.getRegistry(context.Background())
 		assert.NotNil(t, result)
+	})
+}
+
+func TestOptions_RunListProviders_IncludesOfficialProviders(t *testing.T) {
+	t.Run("includes_official_providers_when_registry_in_context", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+		mp := newMockProvider("builtin-prov", "A built-in provider", []provider.Capability{provider.CapabilityFrom})
+		_ = reg.Register(mp)
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+			{Name: "git", CatalogRef: "git", DefaultVersion: "latest"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunListProviders(ctx)
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "builtin-prov")
+		assert.Contains(t, output, "exec")
+		assert.Contains(t, output, "git")
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &items))
+		sources := make(map[string]bool)
+		for _, item := range items {
+			if s, ok := item["source"].(string); ok {
+				sources[s] = true
+			}
+		}
+		assert.True(t, sources["builtin"], "expected at least one builtin provider")
+		assert.True(t, sources["official"], "expected at least one official provider")
+	})
+
+	t.Run("shows_only_builtins_when_official_registry_not_in_context", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+		mp := newMockProvider("builtin-prov", "A built-in provider", []provider.Capability{provider.CapabilityFrom})
+		_ = reg.Register(mp)
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		err := options.RunListProviders(ctx)
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "builtin-prov")
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &items))
+		for _, item := range items {
+			assert.NotEqual(t, "official", item["source"], "should not contain official providers without registry")
+		}
+	})
+
+	t.Run("excludes_official_providers_when_capability_filter_set", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+		mp := newMockProvider("builtin-prov", "A built-in provider", []provider.Capability{provider.CapabilityFrom})
+		_ = reg.Register(mp)
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			Capability:     "from",
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunListProviders(ctx)
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "builtin-prov")
+		assert.NotContains(t, output, "exec")
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &items))
+		for _, item := range items {
+			assert.NotEqual(t, "official", item["source"], "should not contain official providers when capability filter set")
+		}
+	})
+
+	t.Run("excludes_official_providers_when_category_filter_set", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+		mp := newMockProvider("builtin-prov", "A built-in provider", []provider.Capability{provider.CapabilityFrom})
+		mp.descriptor.Category = "network"
+		_ = reg.Register(mp)
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			Category:       "network",
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunListProviders(ctx)
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "builtin-prov")
+		assert.NotContains(t, output, "exec")
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &items))
+		for _, item := range items {
+			assert.NotEqual(t, "official", item["source"], "should not contain official providers when category filter set")
+		}
+	})
+}
+
+func TestOptions_RunGetProvider_FallsBackToOfficialRegistry(t *testing.T) {
+	t.Run("shows_info_for_official_provider_not_in_builtin_registry", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "exec")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "exec")
+		assert.Contains(t, output, "Official plugin provider")
+	})
+
+	t.Run("returns_error_when_provider_not_in_any_registry", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("shows_plain_text_for_official_provider_with_default_output", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams: ioStreams,
+			CliParams: cliParams,
+			registry:  reg,
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "oci://catalog/exec", DefaultVersion: "v1.2.0"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "exec")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "official plugin provider")
+		assert.Contains(t, output, "oci://catalog/exec")
+		assert.Contains(t, output, "v1.2.0")
+	})
+
+	t.Run("shows_only_name_for_official_provider_with_quiet_output", func(t *testing.T) {
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "quiet"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "oci://catalog/exec", DefaultVersion: "v1.2.0"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "exec")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Empty(t, output, "quiet mode should produce no output for official providers, consistent with built-ins")
 	})
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -559,7 +559,14 @@ func Root(opts *RootOptions) *cobra.Command {
 				if officialReg == nil {
 					officialReg = official.NewRegistry()
 				}
+				source := "default"
+				if opts.OfficialProviders != nil {
+					source = "embedder"
+				}
+				lgr.V(1).Info("official provider registry enabled", "count", officialReg.Len(), "source", source)
 				ctx = official.WithRegistry(ctx, officialReg)
+			} else {
+				lgr.V(1).Info("official provider registry disabled via config")
 			}
 
 			cCmd.SetContext(ctx)

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 )
 
@@ -17,7 +18,7 @@ import (
 func (s *Server) registerProviderTools() {
 	// list_providers
 	listProvidersTool := mcp.NewTool("list_providers",
-		mcp.WithDescription("List all available solution providers (e.g. http, static, file, cel, exec, directory). Solution providers are the building blocks of solutions — they fetch data, transform values, validate inputs, and execute actions. Returns name, description, capabilities, and category for each provider. To get full input/output schemas, examples, and CLI usage for a specific provider, call get_provider_schema with the provider name."),
+		mcp.WithDescription("List all available solution providers (e.g. http, static, file, cel, exec, directory). Solution providers are the building blocks of solutions -- they fetch data, transform values, validate inputs, and execute actions. Returns name, displayName, description, source, capabilities, category, and version for each provider. The 'source' field indicates whether a provider is 'builtin' or 'official' (auto-fetched from catalog). Official providers may have empty capabilities and category fields. To get full input/output schemas, examples, and CLI usage for a specific provider, call get_provider_schema with the provider name."),
 		mcp.WithTitleAnnotation("List Providers"),
 		mcp.WithToolIcons(toolIcons["provider"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -108,6 +109,7 @@ type providerItem struct {
 	Name         string   `json:"name"`
 	DisplayName  string   `json:"displayName,omitempty"`
 	Description  string   `json:"description,omitempty"`
+	Source       string   `json:"source"`
 	Category     string   `json:"category,omitempty"`
 	Capabilities []string `json:"capabilities"`
 	Version      string   `json:"version,omitempty"`
@@ -147,6 +149,7 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 			Name:         d.Name,
 			DisplayName:  d.DisplayName,
 			Description:  d.Description,
+			Source:       "builtin",
 			Category:     d.Category,
 			Capabilities: caps,
 			Deprecated:   d.IsDeprecated,
@@ -156,6 +159,21 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 			item.Version = d.Version.String()
 		}
 		items = append(items, item)
+	}
+
+	// Include official plugin providers only when no filters are active
+	// (official providers don't expose capability/category metadata).
+	if capability == "" && category == "" {
+		for _, oi := range official.ListItems(s.ctx) {
+			items = append(items, providerItem{
+				Name:         oi.Name,
+				DisplayName:  oi.DisplayName,
+				Description:  oi.Description,
+				Source:       oi.Source,
+				Capabilities: oi.Capabilities,
+				Version:      oi.Version,
+			})
+		}
 	}
 
 	result, err := mcp.NewToolResultJSON(items)
@@ -184,12 +202,21 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 
 	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
 	if err != nil {
+		// Check official provider registry before returning error
+		if officialReg := official.RegistryFromContext(s.ctx); officialReg != nil {
+			if op, found := officialReg.Get(name); found {
+				detail := official.Detail(op)
+				detail["schemaAvailable"] = false
+				detail["hint"] = "Full schema, examples, and capabilities are unavailable until the plugin is fetched. Run 'plugins install " + op.CatalogRef + "' to fetch it."
+				return mcp.NewToolResultJSON(detail)
+			}
+		}
 		// Build a helpful error with available provider names
 		availableNames := ""
 		if s.registry != nil {
 			names := s.registry.List()
 			if len(names) > 0 {
-				availableNames = fmt.Sprintf(". Available providers: %v", names)
+				availableNames = fmt.Sprintf(". Available built-in providers: %v", names)
 			}
 		}
 		return newStructuredError(ErrCodeNotFound, fmt.Sprintf("provider %q not found%s", name, availableNames),
@@ -206,6 +233,7 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 	// - CLI usage examples
 	// - version, capabilities, category, tags, links, maintainers
 	detail := provdetail.BuildProviderDetail(*desc)
+	detail["source"] = "builtin"
 
 	return mcp.NewToolResultJSON(detail)
 }

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +145,50 @@ func TestHandleListProviders(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
 	})
+
+	t.Run("includes official providers from context", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+			{Name: "git", CatalogRef: "git", DefaultVersion: "latest"},
+		})
+		ctx := official.WithRegistry(context.Background(), officialReg)
+
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_providers"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListProviders(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var items []providerItem
+		require.NoError(t, json.Unmarshal([]byte(text), &items))
+
+		// Should have built-ins plus official providers
+		foundExec := false
+		foundGit := false
+		for _, item := range items {
+			if item.Name == "exec" && item.Source == "official" {
+				foundExec = true
+			}
+			if item.Name == "git" && item.Source == "official" {
+				foundGit = true
+			}
+		}
+		assert.True(t, foundExec, "expected official 'exec' provider in output")
+		assert.True(t, foundGit, "expected official 'git' provider in output")
+	})
 }
 
 func TestHandleGetProviderSchema(t *testing.T) {
@@ -207,6 +252,39 @@ func TestHandleGetProviderSchema(t *testing.T) {
 		result, err := srv.handleGetProviderSchema(context.Background(), request)
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
+	})
+
+	t.Run("falls back to official registry for unknown builtin", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"},
+		})
+		ctx := official.WithRegistry(context.Background(), officialReg)
+
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "get_provider_schema"
+		request.Params.Arguments = map[string]any{
+			"name": "exec",
+		}
+
+		result, err := srv.handleGetProviderSchema(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var desc map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &desc))
+		assert.Equal(t, "exec", desc["name"])
+		assert.Equal(t, "official", desc["source"])
 	})
 }
 

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -18,11 +19,14 @@ import (
 //
 // Cache layout:
 //
-//	<cacheDir>/<name>/<version>/<os>-<arch>/<name>
+//	<cacheDir>/<name>/<version>/<os>-<arch>/<name>[.exe]
+//
+// On Windows platforms, the binary has a ".exe" extension.
 //
 // Example:
 //
 //	~/.cache/scafctl/plugins/aws-provider/1.5.3/darwin-arm64/aws-provider
+//	~/.cache/scafctl/plugins/aws-provider/1.5.3/windows-amd64/aws-provider.exe
 type Cache struct {
 	// dir is the root directory for cached plugin binaries.
 	dir string
@@ -50,11 +54,31 @@ func (c *Cache) Get(name, version, platform, expectedDigest string) (string, boo
 
 	info, err := os.Stat(p)
 	if err != nil || info.IsDir() {
-		return "", false
+		// Migration fallback: check legacy path without .exe for existing Windows caches.
+		// Only attempt migration when the new path genuinely doesn't exist (not for
+		// permission errors or other transient failures).
+		if platformIsWindows(platform) && os.IsNotExist(err) {
+			legacy := c.legacyBinaryPath(name, version, platform)
+			if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
+				// Rename legacy binary to new .exe path for future lookups.
+				if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr != nil {
+					return "", false
+				}
+				if os.Rename(legacy, p) == nil {
+					info = li
+				} else {
+					return "", false
+				}
+			} else {
+				return "", false
+			}
+		} else {
+			return "", false
+		}
 	}
 
-	// Verify executable permission
-	if info.Mode()&0o111 == 0 {
+	// Verify executable permission (skip on Windows where permission bits are not meaningful)
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		return "", false
 	}
 
@@ -92,7 +116,28 @@ func (c *Cache) GetLatestCached(name, platform string) (string, string, bool) {
 		v := entry.Name()
 		p := c.binaryPath(name, v, platform)
 		info, err := os.Stat(p)
-		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		if err != nil || info.IsDir() {
+			// Migration fallback: check legacy path without .exe for older Windows caches.
+			if platformIsWindows(platform) && os.IsNotExist(err) {
+				legacy := c.legacyBinaryPath(name, v, platform)
+				if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
+					if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr == nil {
+						if os.Rename(legacy, p) == nil {
+							info = li
+						} else {
+							continue
+						}
+					} else {
+						continue
+					}
+				} else {
+					continue
+				}
+			} else {
+				continue
+			}
+		}
+		if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 			continue
 		}
 		parsed, parseErr := semver.NewVersion(v)
@@ -129,8 +174,11 @@ func (c *Cache) Put(name, version, platform string, data []byte) (string, error)
 	}
 
 	// Check if already cached (another process may have finished first).
-	if info, err := os.Stat(p); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
-		return p, nil
+	// On Windows, permission bits are not meaningful so skip the execute check.
+	if info, err := os.Stat(p); err == nil && !info.IsDir() {
+		if runtime.GOOS == "windows" || info.Mode()&0o111 != 0 {
+			return p, nil
+		}
 	}
 
 	// Write to a uniquely-named temp file then rename for atomicity.
@@ -205,12 +253,17 @@ func (c *Cache) List() ([]CachedPlugin, error) {
 				if !platformEntry.IsDir() {
 					continue
 				}
-				binaryPath := filepath.Join(c.dir, nameEntry.Name(), versionEntry.Name(), platformEntry.Name(), nameEntry.Name())
+				platform := strings.ReplaceAll(platformEntry.Name(), "-", "/")
+				bin := nameEntry.Name()
+				if platformIsWindows(platform) {
+					bin += ".exe"
+				}
+				binaryPath := filepath.Join(c.dir, nameEntry.Name(), versionEntry.Name(), platformEntry.Name(), bin)
 				if info, err := os.Stat(binaryPath); err == nil && !info.IsDir() {
 					results = append(results, CachedPlugin{
 						Name:     nameEntry.Name(),
 						Version:  versionEntry.Name(),
-						Platform: strings.ReplaceAll(platformEntry.Name(), "-", "/"),
+						Platform: platform,
 						Path:     binaryPath,
 						Size:     info.Size(),
 					})
@@ -232,8 +285,23 @@ type CachedPlugin struct {
 }
 
 // binaryPath returns the expected path for a cached plugin binary.
+// On Windows platforms, the binary name gets a ".exe" extension.
 func (c *Cache) binaryPath(name, version, platform string) string {
+	bin := name
+	if platformIsWindows(platform) {
+		bin += ".exe"
+	}
+	return filepath.Join(c.dir, name, version, PlatformCacheKey(platform), bin)
+}
+
+// legacyBinaryPath returns the pre-fix path without .exe extension (used for migration).
+func (c *Cache) legacyBinaryPath(name, version, platform string) string {
 	return filepath.Join(c.dir, name, version, PlatformCacheKey(platform), name)
+}
+
+// platformIsWindows returns true if the platform string targets Windows.
+func platformIsWindows(platform string) bool {
+	return strings.HasPrefix(platform, "windows/") || strings.HasPrefix(platform, "windows-")
 }
 
 // fileDigest computes the sha256 digest of a file.

--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,9 @@ func TestCache_PutAndGet(t *testing.T) {
 	// Verify file exists and is executable
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	assert.True(t, info.Mode()&0o111 != 0, "file should be executable")
+	if runtime.GOOS != "windows" {
+		assert.True(t, info.Mode()&0o111 != 0, "file should be executable")
+	}
 
 	// Get without digest
 	gotPath, ok := cache.Get(name, version, platform, "")
@@ -98,6 +101,46 @@ func TestCache_ListEmptyDir(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestCache_BinaryPath_WindowsExeExtension(t *testing.T) {
+	cache := NewCache("/tmp/plugins")
+
+	// Windows platform should get .exe extension
+	winPath := cache.binaryPath("myplugin", "1.0.0", "windows/amd64")
+	assert.Equal(t, "myplugin.exe", filepath.Base(winPath))
+
+	// Linux platform should NOT get .exe extension
+	linuxPath := cache.binaryPath("myplugin", "1.0.0", "linux/amd64")
+	assert.Equal(t, "myplugin", filepath.Base(linuxPath))
+
+	// Darwin platform should NOT get .exe extension
+	darwinPath := cache.binaryPath("myplugin", "1.0.0", "darwin/arm64")
+	assert.Equal(t, "myplugin", filepath.Base(darwinPath))
+}
+
+func TestCache_PutAndGet_WindowsPlatform(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache := NewCache(tmpDir)
+
+	data := []byte("MZ fake PE binary")
+	name := "test-plugin"
+	version := "1.0.0"
+	platform := "windows/amd64"
+
+	// Put
+	path, err := cache.Put(name, version, platform, data)
+	require.NoError(t, err)
+	assert.Contains(t, path, "test-plugin.exe")
+	assert.Contains(t, path, "windows-amd64")
+
+	// Verify the file has the .exe extension on disk
+	assert.Equal(t, "test-plugin.exe", filepath.Base(path))
+
+	// Get should find it
+	gotPath, ok := cache.Get(name, version, platform, "")
+	assert.True(t, ok)
+	assert.Equal(t, path, gotPath)
+}
+
 func TestCache_Remove(t *testing.T) {
 	tmpDir := t.TempDir()
 	cache := NewCache(tmpDir)
@@ -149,6 +192,10 @@ func TestCache_GetLatestCached_Empty(t *testing.T) {
 }
 
 func TestCache_GetLatestCached_NonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support Unix file permission bits")
+	}
+
 	tmpDir := t.TempDir()
 	cache := NewCache(tmpDir)
 
@@ -190,4 +237,53 @@ func TestCache_GetLatestCached_SemverBeatsLexicographic(t *testing.T) {
 	_, version, ok := cache.GetLatestCached("myplugin", "linux/amd64")
 	require.True(t, ok)
 	assert.Equal(t, "0.10.0", version, "should pick 0.10.0 (semver) not 0.9.0 (lexicographic)")
+}
+
+func TestCache_Get_MigrationFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache := NewCache(tmpDir)
+
+	name := "test-plugin"
+	version := "1.0.0"
+	platform := "windows/amd64"
+	data := []byte("MZ fake PE binary")
+
+	// Simulate a legacy cache entry: binary at old path without .exe.
+	legacyDir := filepath.Join(tmpDir, name, version, "windows-amd64")
+	require.NoError(t, os.MkdirAll(legacyDir, 0o755))
+	legacyPath := filepath.Join(legacyDir, name) // no .exe
+	require.NoError(t, os.WriteFile(legacyPath, data, 0o755))
+
+	// Get should find the legacy binary and rename it to the .exe path.
+	gotPath, ok := cache.Get(name, version, platform, "")
+	require.True(t, ok, "Get should succeed via migration fallback")
+	assert.Contains(t, gotPath, "test-plugin.exe", "returned path should have .exe extension")
+
+	// The legacy path should no longer exist.
+	_, err := os.Stat(legacyPath)
+	assert.True(t, os.IsNotExist(err), "legacy binary should be removed after migration")
+
+	// The new path should exist.
+	_, err = os.Stat(gotPath)
+	require.NoError(t, err, "migrated binary should exist at new path")
+
+	// Verify content is preserved.
+	content, err := os.ReadFile(gotPath)
+	require.NoError(t, err)
+	assert.Equal(t, data, content)
+}
+
+func TestCache_Get_MigrationFallback_NotTriggeredForNonWindows(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache := NewCache(tmpDir)
+
+	name := "test-plugin"
+	version := "1.0.0"
+	platform := "linux/amd64"
+
+	// Create a binary at the legacy path (no .exe, same as normal linux path).
+	// For linux, binaryPath == legacyBinaryPath, so this is just a normal Get.
+	// If the binary doesn't exist at the expected path, Get returns false — no fallback.
+	_, ok := cache.Get(name, version, platform, "")
+	assert.False(t, ok, "Get should return false for missing linux binary")
 }

--- a/pkg/plugin/platform_test.go
+++ b/pkg/plugin/platform_test.go
@@ -52,3 +52,22 @@ func TestPlatformCacheKey(t *testing.T) {
 	assert.Equal(t, "linux-amd64", PlatformCacheKey("linux/amd64"))
 	assert.Equal(t, "darwin-arm64", PlatformCacheKey("darwin/arm64"))
 }
+
+func TestPlatformIsWindows(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{"windows/amd64", true},
+		{"windows/arm64", true},
+		{"windows-amd64", true},
+		{"linux/amd64", false},
+		{"darwin/arm64", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			assert.Equal(t, tt.want, platformIsWindows(tt.platform))
+		})
+	}
+}

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/celprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/debugprovider"
@@ -38,7 +39,9 @@ func DefaultRegistry(ctx context.Context) (*provider.Registry, error) {
 }
 
 // registerAllToRegistry registers all built-in providers to the given registry.
-func registerAllToRegistry(_ context.Context, reg *provider.Registry) error {
+func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
+	lgr := logger.FromContext(ctx)
+
 	providers := []provider.Provider{
 		httpprovider.NewHTTPProvider(),
 		celprovider.NewCelProvider(),
@@ -51,10 +54,15 @@ func registerAllToRegistry(_ context.Context, reg *provider.Registry) error {
 		parameterprovider.NewParameterProvider(),
 	}
 
+	lgr.V(2).Info("registering built-in providers", "count", len(providers))
+
 	var errs []error
 	for _, p := range providers {
 		if regErr := reg.Register(p); regErr != nil {
+			lgr.V(1).Info("failed to register built-in provider", "name", p.Descriptor().Name, "error", regErr)
 			errs = append(errs, regErr)
+		} else {
+			lgr.V(3).Info("registered built-in provider", "name", p.Descriptor().Name)
 		}
 	}
 
@@ -62,6 +70,7 @@ func registerAllToRegistry(_ context.Context, reg *provider.Registry) error {
 		return fmt.Errorf("failed to register %d provider(s): %w", len(errs), errs[0])
 	}
 
+	lgr.V(2).Info("all built-in providers registered successfully", "count", len(providers))
 	return nil
 }
 

--- a/pkg/provider/official/listing.go
+++ b/pkg/provider/official/listing.go
@@ -1,0 +1,55 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package official
+
+import "context"
+
+// ListItem is a structured representation of an official provider for
+// listing purposes. Both CLI and MCP surfaces use this to avoid
+// duplicating the display/description logic.
+type ListItem struct {
+	Name         string   `json:"name" yaml:"name"`
+	DisplayName  string   `json:"displayName" yaml:"displayName"`
+	Description  string   `json:"description" yaml:"description"`
+	Source       string   `json:"source" yaml:"source"`
+	Version      string   `json:"version,omitempty" yaml:"version,omitempty"`
+	Capabilities []string `json:"capabilities" yaml:"capabilities"`
+}
+
+// ListItems returns the listing items for all official providers in the
+// registry found in ctx. Returns nil if no registry is available.
+func ListItems(ctx context.Context) []ListItem {
+	reg := RegistryFromContext(ctx)
+	if reg == nil {
+		return nil
+	}
+
+	names := reg.Names()
+	items := make([]ListItem, 0, len(names))
+	for _, name := range names {
+		p, _ := reg.Get(name)
+		items = append(items, ListItem{
+			Name:         p.Name,
+			DisplayName:  p.Name,
+			Description:  "Official plugin provider (auto-fetched from catalog: " + p.CatalogRef + ")",
+			Source:       "official",
+			Version:      p.DefaultVersion,
+			Capabilities: []string{},
+		})
+	}
+	return items
+}
+
+// Detail returns a map with the structured detail payload for a single
+// official provider. Used by both CLI structured output and MCP
+// get_provider_schema fallback.
+func Detail(p Provider) map[string]any {
+	return map[string]any{
+		"name":        p.Name,
+		"source":      "official",
+		"catalogRef":  p.CatalogRef,
+		"version":     p.DefaultVersion,
+		"description": "Official plugin provider. Auto-fetched from catalog on first use. Use 'plugins install' to pre-fetch.",
+	}
+}

--- a/pkg/provider/official/listing_test.go
+++ b/pkg/provider/official/listing_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package official
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListItems_NilRegistry(t *testing.T) {
+	ctx := context.Background()
+	items := ListItems(ctx)
+	assert.Nil(t, items)
+}
+
+func TestListItems_WithRegistry(t *testing.T) {
+	reg := NewRegistryFrom([]Provider{
+		{Name: "alpha", CatalogRef: "alpha-ref", DefaultVersion: "v1.0.0"},
+		{Name: "beta", CatalogRef: "beta-ref", DefaultVersion: "latest"},
+	})
+	ctx := WithRegistry(context.Background(), reg)
+
+	items := ListItems(ctx)
+	require.Len(t, items, 2)
+
+	// Items are returned in sorted name order (Names() sorts)
+	assert.Equal(t, "alpha", items[0].Name)
+	assert.Equal(t, "alpha", items[0].DisplayName)
+	assert.Equal(t, "official", items[0].Source)
+	assert.Equal(t, "v1.0.0", items[0].Version)
+	assert.Contains(t, items[0].Description, "alpha-ref")
+	assert.Empty(t, items[0].Capabilities)
+
+	assert.Equal(t, "beta", items[1].Name)
+	assert.Equal(t, "latest", items[1].Version)
+}
+
+func TestListItems_DefaultRegistry(t *testing.T) {
+	reg := NewRegistry()
+	ctx := WithRegistry(context.Background(), reg)
+
+	items := ListItems(ctx)
+	assert.Len(t, items, 10)
+
+	for _, item := range items {
+		assert.Equal(t, "official", item.Source)
+		assert.NotEmpty(t, item.Name)
+		assert.NotEmpty(t, item.Description)
+	}
+}
+
+func TestDetail(t *testing.T) {
+	p := Provider{
+		Name:           "exec",
+		CatalogRef:     "exec",
+		DefaultVersion: "latest",
+	}
+
+	detail := Detail(p)
+	assert.Equal(t, "exec", detail["name"])
+	assert.Equal(t, "official", detail["source"])
+	assert.Equal(t, "exec", detail["catalogRef"])
+	assert.Equal(t, "latest", detail["version"])
+	assert.NotEmpty(t, detail["description"])
+}
+
+func TestDetail_CustomProvider(t *testing.T) {
+	p := Provider{
+		Name:           "aws",
+		CatalogRef:     "aws-provider",
+		DefaultVersion: ">=1.0.0",
+	}
+
+	detail := Detail(p)
+	assert.Equal(t, "aws", detail["name"])
+	assert.Equal(t, "official", detail["source"])
+	assert.Equal(t, "aws-provider", detail["catalogRef"])
+	assert.Equal(t, ">=1.0.0", detail["version"])
+}
+
+func BenchmarkListItems(b *testing.B) {
+	reg := NewRegistry()
+	ctx := WithRegistry(context.Background(), reg)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		ListItems(ctx)
+	}
+}
+
+func BenchmarkDetail(b *testing.B) {
+	p := Provider{Name: "exec", CatalogRef: "exec", DefaultVersion: "latest"}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		Detail(p)
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -251,7 +251,7 @@ func TestIntegration_GetProvider(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "get", "provider")
 
 	assert.Equal(t, 0, exitCode)
-	// Should list built-in providers (7 remain after extraction)
+	// Should list built-in providers
 	assert.Contains(t, stdout, "http")
 	assert.Contains(t, stdout, "cel")
 	assert.Contains(t, stdout, "file")
@@ -259,6 +259,10 @@ func TestIntegration_GetProvider(t *testing.T) {
 	assert.Contains(t, stdout, "debug")
 	assert.Contains(t, stdout, "go-template")
 	assert.Contains(t, stdout, "message")
+	// Should also list official plugin providers
+	assert.Contains(t, stdout, "exec")
+	assert.Contains(t, stdout, "git")
+	assert.Contains(t, stdout, "directory")
 }
 
 func TestIntegration_GetProviderJSON(t *testing.T) {


### PR DESCRIPTION
- add official provider registry to get providers output with source field (builtin/official)
- fall back to official registry in get provider <name> and MCP get_provider_schema when provider not found in built-in registry
- fix plugin cache on Windows: append .exe to binary path, skip Unix permission checks, add migration fallback for legacy caches
- add quiet mode handling for official provider in RunGetProvider
- add structured logging throughout provider listing and cache ops
- update docs (design, tutorials) to document provider sources, source column, and official fallback behavior
- add integration test assertions for official providers in output
