### PR TITLE
feat(plugin): add plugin process pool with lazy init and idle eviction

### DIFF
--- a/docs/design/api-plugin-lifecycle.md
+++ b/docs/design/api-plugin-lifecycle.md
@@ -1,0 +1,241 @@
+---
+title: "API Plugin Lifecycle"
+weight: 30
+---
+
+# API Plugin Lifecycle
+
+How the scafctl REST API server manages provider plugin processes.
+
+---
+
+## Problem
+
+The CLI spawns plugin processes per-invocation and kills them when the command
+exits. This model does not work for a long-running API server because:
+
+- Spawning a gRPC process per HTTP request is expensive (~5-50ms fork+exec,
+  plus Go runtime bootstrap at ~10-20MB per process).
+- Under load, per-request spawning leads to PID exhaustion, file descriptor
+  limits, and memory pressure.
+- If cleanup fails (crash, timeout), zombie processes accumulate.
+
+---
+
+## Solution: Plugin Pool
+
+The API server uses a **plugin pool** (`pkg/plugin.Pool`) that manages shared,
+long-lived plugin processes with lazy initialization and idle eviction.
+
+### Lifecycle Overview
+
+~~~text
+Server Start
+  |-- Pre-load official providers (exec, directory, git, ...)
+  |-- Adopt pre-loaded clients into the Pool
+  '-- Start idle eviction goroutine
+
+Request (POST /solutions/run, /render, /dryrun)
+  |-- Load solution from URL
+  |-- pool.Ensure(ctx, sol.Bundle.Plugins)
+  |     |-- Plugin already in pool and healthy? --> no-op (hot path, ~100ns)
+  |     |-- Plugin not in pool? --> fetch binary --> spawn --> register
+  |     '-- Plugin dead? --> evict, re-spawn on next Ensure
+  |-- Execute solution using shared provider registry
+  '-- Return response (plugin stays alive for subsequent requests)
+
+Idle (no requests for idle timeout)
+  '-- Eviction goroutine: kill idle plugins, unregister from registry
+
+Server Shutdown
+  '-- pool.Shutdown() --> kill all managed plugin processes
+~~~
+
+---
+
+## Two Categories of Plugins
+
+### Official Providers (Eager)
+
+The 10 official providers extracted from the monorepo (directory, env, exec,
+git, github, hcl, identity, metadata, secret, sleep) are pre-loaded at server
+startup. Their gRPC processes start immediately and live for the server's
+lifetime (unless idle-evicted).
+
+This ensures zero latency on first request and fail-fast behavior -- if a
+provider binary is missing or broken, the server logs a warning at startup.
+
+### External Plugins (Lazy)
+
+External plugins declared in a solution's `bundle.plugins` section are loaded
+on-demand when a request references them. The pool:
+
+1. Checks if the plugin is already running and healthy.
+2. If not, fetches the binary from the catalog, spawns the process, registers
+   its providers into the shared registry.
+3. Keeps the process alive for subsequent requests.
+4. Evicts after the idle timeout if no requests use it.
+
+---
+
+## Pool Configuration
+
+The pool accepts three options, which can be tuned via server options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `idleTimeout` | 5 minutes | Kill plugins unused for this duration. 0 disables eviction. |
+| `maxPlugins` | 50 | Maximum concurrent external plugin processes. 0 is unlimited. |
+| `healthCheckInterval` | 30 seconds | Background health check frequency. 0 checks only on use. |
+
+---
+
+## Concurrency Model
+
+- The pool uses a `sync.Mutex` for the entry map and per-entry mutexes for
+  state transitions.
+- gRPC is multiplexed -- a single plugin process handles concurrent requests
+  from multiple goroutines without spawning additional processes.
+- If two requests call `pool.Ensure()` for the same new plugin simultaneously,
+  only one spawn occurs. The second waiter blocks on a `ready` channel until
+  the first completes.
+- Entries with `refCount > 0` (acquired by in-flight requests) are never
+  evicted.
+
+---
+
+## Health and Recovery
+
+- **Ping**: `pool.Ping(ctx, name)` issues a lightweight `GetProviders` RPC to
+  verify the plugin process is alive.
+- **Dead detection**: If a gRPC call fails, the pool marks the entry as dead,
+  unregisters its providers, and kills the process.
+- **Recovery**: The next `pool.Ensure()` call for a dead plugin evicts the old
+  entry and spawns a fresh process.
+
+---
+
+## Shutdown
+
+`pool.Shutdown()` is called from `Server.Shutdown()`:
+
+1. Stops the eviction goroutine.
+2. Marks the pool as closed (rejects new `Ensure` calls with `ErrPoolClosed`).
+3. Kills all managed plugin processes.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior | HTTP Status |
+|----------|----------|-------------|
+| Plugin binary not in catalog | `Ensure()` returns error | 502 Bad Gateway |
+| Plugin process crashes on spawn | Entry marked dead, error returned | 502 Bad Gateway |
+| Plugin crashes mid-request | gRPC error propagates; pool marks dead | 502 Bad Gateway |
+| Pool at max capacity | `ErrPoolFull` returned | 503 Service Unavailable |
+| Context cancelled during fetch | Respects `ctx.Done()`, cleans up | 504 Gateway Timeout |
+| Plugin already registered (builtin) | `Ensure()` is a no-op | -- |
+
+---
+
+## Comparison With CLI
+
+| Aspect | CLI | API Server |
+|--------|-----|------------|
+| Plugin scope | Per-invocation | Shared across requests |
+| Official providers | Fetched per `scafctl run` | Pre-loaded at startup, adopted into pool |
+| External plugins | Fetched + killed per run | Lazy-loaded, pooled, idle-evicted |
+| Cleanup | `defer` chain in `prepare.Solution()` | `pool.Shutdown()` on server stop |
+| Concurrency | Single-threaded | gRPC multiplexing, mutex-protected |
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/plugin/pool.go` | Pool implementation |
+| `pkg/plugin/pool_test.go` | Pool unit tests and benchmarks |
+| `pkg/api/server.go` | `WithServerPluginPool` option, pool shutdown |
+| `pkg/api/context.go` | `PluginPool` field on `HandlerContext` |
+| `pkg/api/endpoints/solutions.go` | `pool.Ensure()` calls in run/render/dryrun |
+| `pkg/cmd/scafctl/serve/serve.go` | Pool creation, official provider adoption |
+
+---
+
+## Design Decisions
+
+**Why not per-request spawn (Terraform model)?**
+Terraform is a CLI tool -- each `terraform apply` is a short-lived process.
+Spawning per HTTP request recreates the CGI anti-pattern: expensive, not
+scalable, and prone to resource exhaustion.
+
+**Why not pure long-lived without eviction (Grafana model)?**
+For official providers this is fine (they are always needed). But external
+plugins may be used by a single solution -- keeping them alive indefinitely
+wastes resources. Idle eviction balances availability with resource efficiency.
+
+**Why a single shared registry instead of per-request clones?**
+Providers are stateless -- the same gRPC process safely handles concurrent
+calls. Cloning the registry per request would add overhead without benefit.
+The first-loaded-wins behavior for version conflicts matches CLI semantics.
+
+---
+
+## Security
+
+Running external executables from HTTP requests introduces significant risk.
+The API server applies five layered mitigations, all configured under
+`apiServer.plugins` in `config.yaml`:
+
+~~~yaml
+apiServer:
+  plugins:
+    allowExternal: false          # default -- only official providers
+    allowedPlugins: [my-plugin]   # explicit name allowlist
+    allowedCatalogs: [internal]   # restrict fetch sources
+~~~
+
+### 1. External Plugins Disabled by Default
+
+`allowExternal: false` (the default) causes `pool.Ensure()` to reject any
+plugin not pre-loaded (adopted) at startup. Official providers are adopted
+unconditionally and bypass this check.
+
+### 2. Plugin Name Allowlist
+
+When `allowedPlugins` is non-empty, only listed names may be loaded. Requests
+referencing unlisted plugins receive a `403 Forbidden` response. Adopted
+(official) plugins always bypass the allowlist.
+
+### 3. Catalog Allowlist
+
+`allowedCatalogs` restricts which configured catalogs the fetcher may pull
+binaries from. If a solution references a plugin in an unlisted catalog, the
+fetch is rejected before any download occurs.
+
+### 4. Environment Variable Sanitization
+
+Plugin processes spawned by the pool inherit only a fixed allowlist of
+environment variables: PATH, HOME, TMPDIR, USER, LANG, TZ, and the
+go-plugin protocol variables (ports, magic cookie). All other variables
+(including credentials, tokens, and application-prefixed vars) are stripped.
+This prevents credential leakage from the server environment into untrusted
+plugin binaries. Controlled by the `WithSanitizedEnv()` client option, applied
+automatically in `pool.spawn()`.
+
+### 5. Adopted Plugins Bypass Security Checks
+
+Official providers adopted at startup (`pool.Adopt()`) are trusted and skip
+the allowlist/external checks. This ensures they always work regardless of
+security policy configuration.
+
+### Key Files
+
+| File | Security Role |
+|------|---------------|
+| `pkg/plugin/pool.go` | `WithDisableExternal`, `WithAllowedPlugins` options |
+| `pkg/plugin/client.go` | `WithSanitizedEnv`, `safePluginEnv`, `pluginCmdSanitized` |
+| `pkg/plugin/fetcher.go` | `AllowedCatalogs`, `checkCatalogAllowed` |
+| `pkg/config/types.go` | `APIPluginConfig` struct |
+| `pkg/cmd/scafctl/serve/serve.go` | Wires config values into pool and fetcher |

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -648,6 +648,41 @@ scafctl catalog prune
 - `scafctl catalog prune` removes orphaned blobs and reclaims disk space
 - Always prune after deleting to free up storage
 
+### Delete All Local Artifacts
+
+Use `--all` to remove every artifact from the local catalog at once. This is useful for resetting your local environment:
+
+{{< tabs "catalog-tutorial-cmd-delete-all" >}}
+{{% tab "Bash" %}}
+```bash
+# Interactive (prompts for confirmation)
+scafctl catalog delete --all
+
+# Non-interactive (skip confirmation)
+scafctl catalog delete --all --force
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Interactive (prompts for confirmation)
+scafctl catalog delete --all
+
+# Non-interactive (skip confirmation)
+scafctl catalog delete --all --force
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Expected output:
+
+```
+ ✅ Deleted 5 artifact(s) from local catalog
+```
+
+{{% hint warning %}}
+`--all` only applies to the local catalog. It cannot be combined with `--catalog` for remote registries. Positional arguments are not allowed with `--all`.
+{{% /hint %}}
+
 ---
 
 ## Exporting and Importing

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -421,6 +421,10 @@ Service Status Report
 - You can nest `{{ if }}` inside `{{ range }}` to conditionally render per item.
 - `{{ len .list }}` returns the length of a list.
 
+{{% hint info %}}
+**Nil-safe `len`**: Unlike the built-in Go `len` function, scafctl's `len` returns `0` for nil values instead of panicking. This means `{{ if eq (len .maybeNil) 0 }}` is safe even when `.maybeNil` is not set.
+{{% /hint %}}
+
 ---
 
 ## Iterating Over Maps

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -389,7 +389,47 @@ scafctl lint explain unreachable-test-path
 {{% /tab %}}
 {{< /tabs >}}
 
-## 6. Using Lint with the MCP Server
+## 6. Hyphenated Resolver Names
+
+The `hyphenated-name` rule warns when resolver names contain hyphens. While valid YAML, hyphens require quoting in CEL expressions:
+
+```yaml
+# ⚠️ INFO: hyphenated names require quoting in CEL
+spec:
+  resolvers:
+    my-service-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+    otherResolver:
+      dependsOn: [my-service-name]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # Must quote: _["my-service-name"] instead of _.my_service_name
+              expression: '_["my-service-name"]'
+```
+
+**Fix**: Use underscores instead of hyphens for CEL-friendly access:
+
+```yaml
+spec:
+  resolvers:
+    my_service_name:  # Can use _.my_service_name in CEL
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+```
+
+This is an **info**-level finding (not an error) because hyphenated names are valid — they just require bracket notation in CEL expressions.
+
+## 7. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -467,7 +467,64 @@ validate:
 
 ---
 
-## 6. Validation Failure Diagnostics
+## 6. Dynamic Validation Messages
+
+The `message` field supports dynamic evaluation using `expr:` (CEL) or `tmpl:` (Go template) prefixes. This lets you include the actual value or computed context in error messages.
+
+### CEL Expression Messages
+
+Prefix the message with `expr:` to evaluate it as a CEL expression. The expression has access to `__self` (the current value) and `_` (all resolver data):
+
+```yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        match: "^[a-z][a-z0-9-]*$"
+        message: "expr: 'Invalid name \"' + string(__self) + '\": must start with a lowercase letter and contain only [a-z0-9-]'"
+    - provider: validation
+      inputs:
+        expression: "size(__self) <= 63"
+        message: "expr: 'Name \"' + string(__self) + '\" is ' + string(size(__self)) + ' chars (max 63)'"
+```
+
+### Go Template Messages
+
+Prefix the message with `tmpl:` to evaluate it as a Go template. The template data includes all resolver values plus `__self`:
+
+```yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        expression: "__self != _.environment"
+        message: "tmpl: Name '{{.__self}}' must not match the environment name '{{.environment}}'"
+    - provider: validation
+      inputs:
+        match: "^[a-z]"
+        message: "tmpl: Value '{{.__self}}' must start with a lowercase letter"
+```
+
+### Fallback Behavior
+
+If the dynamic expression fails to evaluate (syntax error, missing variable), the raw message content (minus the prefix) is used as the error message, and a debug log is emitted. This ensures validation never silently passes due to a message evaluation error.
+
+### Plain Static Messages
+
+Messages without a prefix are used as-is (unchanged behavior):
+
+```yaml
+validate:
+  with:
+    - provider: validation
+      inputs:
+        match: "^[a-z]"
+        message: "Must start with a lowercase letter"
+```
+
+---
+
+## 7. Validation Failure Diagnostics
 
 When validation fails, scafctl provides structured error messages. Use the MCP `explain_error` tool or inspect the output directly:
 

--- a/examples/resolvers/validation-dynamic-messages.yaml
+++ b/examples/resolvers/validation-dynamic-messages.yaml
@@ -1,0 +1,85 @@
+# Run: scafctl run resolver -f validation-dynamic-messages.yaml
+# Run: scafctl run resolver -f validation-dynamic-messages.yaml -r name=MY-BAD-NAME -r port=99999
+#
+# Demonstrates dynamic validation messages using expr: (CEL) and tmpl: (Go template) prefixes.
+# Dynamic messages include the actual value in the error output for better diagnostics.
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validation-dynamic-messages
+  displayName: Dynamic Validation Messages
+  category: resolvers
+  tags:
+    - resolver-example
+    - validation
+    - dynamic-messages
+  description: |
+    Validation with dynamic error messages that include the actual
+    failing value using CEL expressions or Go templates.
+
+spec:
+  resolvers:
+    # CEL expression message: includes the value in the error
+    name:
+      description: Resource name with dynamic error message
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: name
+          - provider: static
+            inputs:
+              value: my-valid-app
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z][a-z0-9-]*$"
+              message: "expr: 'Invalid name \"' + string(__self) + '\": must start with lowercase and contain only [a-z0-9-]'"
+          - provider: validation
+            inputs:
+              expression: "size(__self) <= 63"
+              message: "expr: 'Name \"' + string(__self) + '\" is ' + string(size(__self)) + ' chars (max 63)'"
+
+    # Go template message: includes resolver context
+    port:
+      description: Port number with template-based error message
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: port
+          - provider: static
+            inputs:
+              value: 8080
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self >= 1 && __self <= 65535"
+              message: "tmpl: Port {{.__self}} is out of range (must be 1-65535)"
+          - provider: validation
+            inputs:
+              expression: "__self >= 1024"
+              message: "tmpl: Port {{.__self}} is privileged (below 1024) — use {{.name}} with elevated permissions or choose a port >= 1024"
+
+    # Static message (unchanged behavior for comparison)
+    environment:
+      description: Environment name (static message for comparison)
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: production
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^(development|staging|production)$"
+              message: "Must be one of: development, staging, production"

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -11,7 +12,9 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 )
 
 // HandlerContext provides shared dependencies to all API handlers.
@@ -23,6 +26,26 @@ type HandlerContext struct {
 	Logger           logr.Logger
 	IsShuttingDown   *int32
 	StartTime        time.Time
+
+	// PluginFetcher enables auto-fetching of plugin binaries from catalogs
+	// at request time. Used by the solution test endpoint (planned) to resolve
+	// bundle.plugins declarations. Nil when plugin auto-fetch is not configured.
+	PluginFetcher *plugin.Fetcher
+
+	// OfficialProviders holds the registry of first-party extracted providers
+	// for auto-resolution. Used by the solution validate endpoint (planned)
+	// to check provider availability. Nil when official provider support is disabled.
+	OfficialProviders *official.Registry
+
+	// ServerContext carries the server's enriched context with config, auth,
+	// and logger wired. Used by endpoints that call prepare.Solution() and
+	// need these values in context. Reserved for solution test endpoint (planned).
+	ServerContext context.Context
+
+	// PluginPool manages shared, long-lived plugin processes with lazy
+	// initialization and idle eviction. Used by solution endpoints to
+	// ensure external plugins from bundle.plugins are available.
+	PluginPool *plugin.Pool
 }
 
 // NewHandlerContext creates a new HandlerContext with the given dependencies.

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -4,11 +4,13 @@
 package api
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,6 +22,22 @@ func TestNewHandlerContext(t *testing.T) {
 	assert.NotNil(t, hctx)
 	assert.False(t, hctx.ShuttingDown())
 	assert.Equal(t, now, hctx.StartTime)
+	assert.Nil(t, hctx.PluginFetcher)
+	assert.Nil(t, hctx.OfficialProviders)
+	assert.Nil(t, hctx.ServerContext)
+}
+
+func TestHandlerContext_PluginFields(t *testing.T) {
+	var shutting int32
+	hctx := NewHandlerContext(nil, nil, nil, logr.Discard(), &shutting, time.Now())
+
+	// Optional fields can be set after construction
+	officialReg := official.NewRegistry()
+	hctx.OfficialProviders = officialReg
+	hctx.ServerContext = context.Background()
+
+	assert.Equal(t, officialReg, hctx.OfficialProviders)
+	assert.NotNil(t, hctx.ServerContext)
 }
 
 func TestHandlerContext_ShuttingDown(t *testing.T) {

--- a/pkg/api/endpoints/solutions.go
+++ b/pkg/api/endpoints/solutions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/dryrun"
 	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 )
@@ -193,6 +194,16 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 			return nil, api.HandleError(ctx, err, "solution-dryrun", http.StatusBadRequest, "failed to load solution")
 		}
 
+		// Ensure external plugins from bundle.plugins are available and
+		// acquire refcounts to prevent eviction during this request.
+		if hctx.PluginPool != nil && len(sol.Bundle.Plugins) > 0 {
+			release, err := hctx.PluginPool.EnsureAndAcquire(ctx, sol.Bundle.Plugins)
+			if err != nil {
+				return nil, api.HandleError(ctx, err, "solution-dryrun", plugin.PoolErrorHTTPStatus(err), "failed to load required plugins")
+			}
+			defer release()
+		}
+
 		opts := dryrun.Options{
 			Registry: hctx.ProviderRegistry,
 			Verbose:  input.Body.Verbose,
@@ -225,6 +236,16 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
 		if err != nil {
 			return nil, api.HandleError(ctx, err, "solution-run", http.StatusBadRequest, "failed to load solution")
+		}
+
+		// Ensure external plugins from bundle.plugins are available and
+		// acquire refcounts to prevent eviction during this request.
+		if hctx.PluginPool != nil && len(sol.Bundle.Plugins) > 0 {
+			release, err := hctx.PluginPool.EnsureAndAcquire(ctx, sol.Bundle.Plugins)
+			if err != nil {
+				return nil, api.HandleError(ctx, err, "solution-run", plugin.PoolErrorHTTPStatus(err), "failed to load required plugins")
+			}
+			defer release()
 		}
 
 		// Validate solution first
@@ -274,6 +295,16 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
 		if err != nil {
 			return nil, api.HandleError(ctx, err, "solution-render", http.StatusBadRequest, "failed to load solution")
+		}
+
+		// Ensure external plugins from bundle.plugins are available and
+		// acquire refcounts to prevent eviction during this request.
+		if hctx.PluginPool != nil && len(sol.Bundle.Plugins) > 0 {
+			release, err := hctx.PluginPool.EnsureAndAcquire(ctx, sol.Bundle.Plugins)
+			if err != nil {
+				return nil, api.HandleError(ctx, err, "solution-render", plugin.PoolErrorHTTPStatus(err), "failed to load required plugins")
+			}
+			defer release()
 		}
 
 		validation := execute.ValidateSolution(ctx, sol, hctx.ProviderRegistry)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -24,35 +24,45 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // Server is the REST API server backed by chi and Huma.
 type Server struct {
-	cfg            *config.Config
-	router         *chi.Mux
-	apiRouter      chi.Router
-	api            huma.API
-	httpSrv        *http.Server
-	isShuttingDown int32
-	startTime      time.Time
-	logger         logr.Logger
-	providerReg    *provider.Registry
-	authReg        *auth.Registry
-	version        string
-	ctx            context.Context
-	cancel         context.CancelFunc
+	cfg               *config.Config
+	router            *chi.Mux
+	apiRouter         chi.Router
+	api               huma.API
+	httpSrv           *http.Server
+	isShuttingDown    int32
+	startTime         time.Time
+	logger            logr.Logger
+	providerReg       *provider.Registry
+	authReg           *auth.Registry
+	pluginFetcher     *plugin.Fetcher
+	officialProviders *official.Registry
+	pluginClients     []*plugin.Client
+	pluginPool        *plugin.Pool
+	version           string
+	ctx               context.Context
+	cancel            context.CancelFunc
 }
 
 // serverConfig collects all configuration options before building the server.
 type serverConfig struct {
-	logger   *logr.Logger
-	registry *provider.Registry
-	authReg  *auth.Registry
-	config   *config.Config
-	version  string
-	ctx      context.Context
+	logger            *logr.Logger
+	registry          *provider.Registry
+	authReg           *auth.Registry
+	pluginFetcher     *plugin.Fetcher
+	officialProviders *official.Registry
+	pluginClients     []*plugin.Client
+	pluginPool        *plugin.Pool
+	config            *config.Config
+	version           string
+	ctx               context.Context
 }
 
 // ServerOption configures the API server.
@@ -100,6 +110,39 @@ func WithServerContext(ctx context.Context) ServerOption {
 	}
 }
 
+// WithServerPluginFetcher sets the plugin fetcher for auto-fetching plugin
+// binaries from catalogs. This enables solution endpoints to resolve
+// bundle.plugins declarations and official provider auto-resolution.
+func WithServerPluginFetcher(f *plugin.Fetcher) ServerOption {
+	return func(c *serverConfig) {
+		c.pluginFetcher = f
+	}
+}
+
+// WithServerOfficialProviders sets the official provider registry for
+// auto-resolution of first-party extracted providers.
+func WithServerOfficialProviders(r *official.Registry) ServerOption {
+	return func(c *serverConfig) {
+		c.officialProviders = r
+	}
+}
+
+// WithServerPluginClients sets the pre-loaded plugin clients that should be
+// killed when the server shuts down.
+func WithServerPluginClients(clients []*plugin.Client) ServerOption {
+	return func(c *serverConfig) {
+		c.pluginClients = clients
+	}
+}
+
+// WithServerPluginPool sets the plugin pool for managing shared, long-lived
+// plugin processes with lazy initialization and idle eviction.
+func WithServerPluginPool(pool *plugin.Pool) ServerOption {
+	return func(c *serverConfig) {
+		c.pluginPool = pool
+	}
+}
+
 // NewServer creates a new API server with the given options.
 func NewServer(opts ...ServerOption) (*Server, error) {
 	sc := &serverConfig{}
@@ -129,15 +172,19 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	}
 
 	s := &Server{
-		cfg:         cfg,
-		router:      chi.NewRouter(),
-		logger:      lgr,
-		providerReg: sc.registry,
-		authReg:     sc.authReg,
-		version:     version,
-		ctx:         ctx,
-		cancel:      cancel,
-		startTime:   time.Now(),
+		cfg:               cfg,
+		router:            chi.NewRouter(),
+		logger:            lgr,
+		providerReg:       sc.registry,
+		authReg:           sc.authReg,
+		pluginFetcher:     sc.pluginFetcher,
+		officialProviders: sc.officialProviders,
+		pluginClients:     sc.pluginClients,
+		pluginPool:        sc.pluginPool,
+		version:           version,
+		ctx:               ctx,
+		cancel:            cancel,
+		startTime:         time.Now(),
 	}
 
 	return s, nil
@@ -200,7 +247,7 @@ func (s *Server) Context() context.Context {
 
 // HandlerCtx returns the handler context for endpoint registration.
 func (s *Server) HandlerCtx() *HandlerContext {
-	return NewHandlerContext(
+	hctx := NewHandlerContext(
 		s.cfg,
 		s.providerReg,
 		s.authReg,
@@ -208,6 +255,11 @@ func (s *Server) HandlerCtx() *HandlerContext {
 		&s.isShuttingDown,
 		s.startTime,
 	)
+	hctx.PluginFetcher = s.pluginFetcher
+	hctx.OfficialProviders = s.officialProviders
+	hctx.ServerContext = s.ctx
+	hctx.PluginPool = s.pluginPool
+	return hctx
 }
 
 // Start starts the HTTP server and blocks until shutdown.
@@ -291,10 +343,21 @@ func (s *Server) Start() error {
 	return err
 }
 
-// Shutdown gracefully shuts down the server.
+// Shutdown gracefully shuts down the server and kills plugin clients.
 func (s *Server) Shutdown(ctx context.Context) error {
 	atomic.StoreInt32(&s.isShuttingDown, 1)
 	s.cancel()
+
+	// Shut down plugin pool (kills all managed plugin processes)
+	if s.pluginPool != nil {
+		s.pluginPool.Shutdown()
+	}
+
+	// Kill pre-loaded plugin clients not managed by the pool
+	for _, c := range s.pluginClients {
+		c.Kill()
+	}
+
 	if s.httpSrv != nil {
 		return s.httpSrv.Shutdown(ctx)
 	}

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,6 +65,53 @@ func TestServer_HandlerCtx(t *testing.T) {
 	assert.NotNil(t, hctx)
 	assert.Equal(t, cfg, hctx.Config)
 	assert.False(t, hctx.ShuttingDown())
+}
+
+func TestServer_HandlerCtx_WithPluginFields(t *testing.T) {
+	cfg := &config.Config{}
+	officialReg := official.NewRegistry()
+	srv, err := NewServer(
+		WithServerConfig(cfg),
+		WithServerOfficialProviders(officialReg),
+	)
+	require.NoError(t, err)
+	hctx := srv.HandlerCtx()
+	assert.NotNil(t, hctx)
+	assert.Equal(t, officialReg, hctx.OfficialProviders)
+	assert.NotNil(t, hctx.ServerContext, "ServerContext should be set from server's context")
+}
+
+func TestServer_WithPluginClients_Shutdown(t *testing.T) {
+	// Verify that Shutdown doesn't panic with nil or empty plugin clients.
+	srv, err := NewServer(WithServerPluginClients(nil))
+	require.NoError(t, err)
+	err = srv.Shutdown(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, srv.IsShuttingDown())
+}
+
+func TestServer_WithPluginPool_Shutdown(t *testing.T) {
+	reg := provider.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+
+	srv, err := NewServer(WithServerPluginPool(pool))
+	require.NoError(t, err)
+
+	err = srv.Shutdown(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, srv.IsShuttingDown())
+}
+
+func TestServer_HandlerCtx_PluginPool(t *testing.T) {
+	reg := provider.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	srv, err := NewServer(WithServerPluginPool(pool), WithServerRegistry(reg))
+	require.NoError(t, err)
+
+	hctx := srv.HandlerCtx()
+	assert.Equal(t, pool, hctx.PluginPool)
 }
 
 func TestServer_Shutdown(t *testing.T) {

--- a/pkg/cmd/scafctl/catalog/login_test.go
+++ b/pkg/cmd/scafctl/catalog/login_test.go
@@ -151,6 +151,7 @@ func BenchmarkCommandLogin(b *testing.B) {
 // TestRunCatalogLogin_DirectCredentials tests the direct credential path via runCatalogLogin.
 func TestRunCatalogLogin_DirectCredentials(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	ctx := newCatalogTestCtx(t)
 

--- a/pkg/cmd/scafctl/config/reset_test.go
+++ b/pkg/cmd/scafctl/config/reset_test.go
@@ -84,15 +84,17 @@ func TestResetOptions_ResetsConfigFile(t *testing.T) {
 }
 
 func TestResetOptions_AllSucceeds(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: t.Setenv is used to override XDG paths.
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(""), 0o600))
 
-	// The --all flag removes real XDG cache/data/state dirs which we cannot
-	// inject in a unit test. This test validates the --force + --all
-	// combination succeeds without error.
+	// Override XDG directories to temp paths so the --all flag does not
+	// interfere with real user/runner data or parallel tests.
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "data"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state"))
+
 	var stdout, stderr bytes.Buffer
 	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
 	cliParams := settings.NewCliParams()

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -7,15 +7,22 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/api/endpoints"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
 )
@@ -124,6 +131,41 @@ func runServe(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("initializing provider registry: %w", err)
 	}
 
+	// Build official provider registry for auto-resolution
+	var officialReg *official.Registry
+	if cfg.Settings.DisableOfficialProviders {
+		lgr.V(1).Info("official provider auto-resolution disabled by settings")
+	} else {
+		officialReg = official.NewRegistry()
+	}
+
+	// Build plugin fetcher for auto-fetching plugin binaries from catalogs
+	var pluginFetcher *plugin.Fetcher
+	if fetcher, fetchErr := prepare.BuildPluginFetcherWithConfig(ctx, prepare.PluginFetcherOverrides{
+		AllowedCatalogs: cfg.APIServer.Plugins.AllowedCatalogs,
+	}); fetchErr == nil {
+		pluginFetcher = fetcher
+	} else {
+		lgr.V(1).Info("plugin fetcher not available; official providers will not be pre-loaded", "error", fetchErr)
+	}
+
+	// Pre-load all official providers into the registry at server startup.
+	// This avoids per-request gRPC spawn overhead and ensures the extracted
+	// providers (exec, directory, git, etc.) are available for all endpoints.
+	var pluginClients []*plugin.Client
+	if officialReg != nil && pluginFetcher != nil {
+		clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, pluginFetcher)
+		if preloadErr != nil {
+			lgr.V(0).Info("warning: some official providers could not be pre-loaded", "error", preloadErr)
+		}
+		pluginClients = clients
+	}
+
+	// Create plugin pool for managing external plugin lifecycle.
+	// Pre-loaded official providers are adopted into the pool so their
+	// lifecycle (shutdown) is managed consistently.
+	pluginPool := buildPluginPool(ctx, cfg, pluginFetcher, reg, lgr, pluginClients)
+
 	// Build server options
 	serverOpts := []api.ServerOption{
 		api.WithServerLogger(*lgr),
@@ -131,9 +173,16 @@ func runServe(ctx context.Context, opts *Options) error {
 		api.WithServerRegistry(reg),
 		api.WithServerContext(ctx),
 		api.WithServerVersion(settings.VersionInformation.BuildVersion),
+		api.WithServerPluginPool(pluginPool),
 	}
 	if authReg != nil {
 		serverOpts = append(serverOpts, api.WithServerAuthRegistry(authReg))
+	}
+	if pluginFetcher != nil {
+		serverOpts = append(serverOpts, api.WithServerPluginFetcher(pluginFetcher))
+	}
+	if officialReg != nil {
+		serverOpts = append(serverOpts, api.WithServerOfficialProviders(officialReg))
 	}
 
 	// Create server
@@ -161,4 +210,101 @@ func runServe(ctx context.Context, opts *Options) error {
 
 	// Start server (blocks until SIGINT/SIGTERM)
 	return srv.Start()
+}
+
+// preloadOfficialProviders fetches all official providers and registers them
+// into the provider registry. This is called at server startup so that
+// extracted providers (exec, directory, git, etc.) are immediately available
+// for all API endpoints without per-request gRPC spawn overhead.
+//
+// Returns the plugin clients that must be killed on server shutdown.
+// Logs warnings for providers that fail to load but does not fail the
+// server startup.
+func preloadOfficialProviders(
+	ctx context.Context,
+	reg *provider.Registry,
+	officialReg *official.Registry,
+	fetcher *plugin.Fetcher,
+) ([]*plugin.Client, error) {
+	lgr := logger.FromContext(ctx)
+
+	// Build plugin dependencies for all official providers
+	providers := officialReg.Names()
+	deps := make([]solution.PluginDependency, 0, len(providers))
+	for _, name := range providers {
+		p, ok := officialReg.Get(name)
+		if !ok {
+			continue
+		}
+		// Skip providers already in the registry (e.g., builtins)
+		if reg.Has(name) {
+			if lgr != nil {
+				lgr.V(1).Info("official provider already registered, skipping pre-load", "provider", name)
+			}
+			continue
+		}
+		deps = append(deps, p.ToPluginDependency())
+	}
+
+	if len(deps) == 0 {
+		return nil, nil
+	}
+
+	if fetcher == nil {
+		if lgr != nil {
+			lgr.V(1).Info("plugin fetcher not available; cannot pre-load official providers")
+		}
+		return nil, nil
+	}
+
+	if lgr != nil {
+		names := make([]string, len(deps))
+		for i, d := range deps {
+			names[i] = d.Name
+		}
+		lgr.V(0).Info("pre-loading official providers for API server", "providers", names)
+	}
+
+	fetchResults, fetchErr := fetcher.FetchPlugins(ctx, deps, nil)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("fetching official providers: %w", fetchErr)
+	}
+
+	clients, regErr := plugin.RegisterFetchedPlugins(ctx, reg, fetchResults, nil)
+	if regErr != nil {
+		return nil, fmt.Errorf("registering official providers: %w", regErr)
+	}
+
+	if lgr != nil {
+		lgr.V(0).Info("pre-loaded official providers", "count", len(clients))
+	}
+
+	return clients, nil
+}
+
+// buildPluginPool creates a Pool configured from the API server settings and
+// adopts any pre-loaded official plugin clients into it.
+func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fetcher, reg *provider.Registry, lgr *logr.Logger, preloaded []*plugin.Client) *plugin.Pool {
+	poolOpts := []plugin.PoolOption{
+		plugin.WithIdleTimeout(5 * time.Minute),
+		plugin.WithMaxPlugins(50),
+		plugin.WithDisableExternal(!cfg.APIServer.Plugins.AllowExternal),
+	}
+	if len(cfg.APIServer.Plugins.AllowedPlugins) > 0 {
+		poolOpts = append(poolOpts, plugin.WithAllowedPlugins(cfg.APIServer.Plugins.AllowedPlugins))
+	}
+	pool := plugin.NewPool(fetcher, reg, *lgr, poolOpts...)
+	for _, c := range preloaded {
+		// Query the client for provider names it registered so the pool can
+		// unregister them on eviction/death.
+		var providers []string
+		if names, err := c.GetProviders(ctx); err == nil {
+			providers = names
+		}
+		pool.Adopt(c.Name(), c, solution.PluginDependency{
+			Name: c.Name(),
+			Kind: solution.PluginKindProvider,
+		}, providers)
+	}
+	return pool
 }

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -4,8 +4,12 @@
 package serve
 
 import (
+	"context"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +85,32 @@ func BenchmarkCommandServe(b *testing.B) {
 	for b.Loop() {
 		CommandServe(cliParams, ioStreams, "scafctl")
 	}
+}
+
+func TestPreloadOfficialProviders_SkipsRegistered(t *testing.T) {
+	ctx := context.Background()
+	reg, err := builtin.DefaultRegistry(ctx)
+	require.NoError(t, err)
+
+	// Create an official registry containing "http" which is already a builtin.
+	// preloadOfficialProviders should skip it since it's already registered.
+	officialReg := official.NewRegistryFrom([]official.Provider{
+		{Name: "http", CatalogRef: "http", DefaultVersion: "latest"},
+	})
+
+	// No plugin fetcher needed -- all providers are already registered
+	clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, nil)
+	assert.NoError(t, preloadErr)
+	assert.Empty(t, clients)
+}
+
+func TestPreloadOfficialProviders_NilFetcher(t *testing.T) {
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+
+	// Without a fetcher, should return nil (not panic)
+	clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, nil)
+	assert.Nil(t, clients)
+	assert.Nil(t, preloadErr)
 }

--- a/pkg/config/sanitize.go
+++ b/pkg/config/sanitize.go
@@ -18,6 +18,7 @@ type SanitizedConfig struct {
 	Action     ActionConfig       `json:"action" yaml:"action" doc:"Action execution configuration"`
 	Auth       SanitizedAuth      `json:"auth" yaml:"auth" doc:"Authentication configuration (redacted)"`
 	Build      BuildConfig        `json:"build" yaml:"build" doc:"Build configuration"`
+	APIServer  APIServerConfig    `json:"apiServer,omitempty" yaml:"apiServer,omitempty" doc:"REST API server configuration"`
 }
 
 // SanitizedCatalog redacts auth tokens from catalog config.
@@ -78,6 +79,7 @@ func SanitizeConfig(cfg *Config) SanitizedConfig {
 		Resolver:   cfg.Resolver,
 		Action:     cfg.Action,
 		Build:      cfg.Build,
+		APIServer:  cfg.APIServer,
 	}
 
 	// Sanitize catalogs

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -551,6 +551,23 @@ type APIServerConfig struct {
 	Audit           APIAuditConfig       `json:"audit,omitempty" yaml:"audit,omitempty" mapstructure:"audit" doc:"Audit logging configuration"`
 	Tracing         APITracingConfig     `json:"tracing,omitempty" yaml:"tracing,omitempty" mapstructure:"tracing" doc:"OpenTelemetry tracing configuration"`
 	MaxConcurrent   int                  `json:"maxConcurrent,omitempty" yaml:"maxConcurrent,omitempty" mapstructure:"maxConcurrent" doc:"Maximum concurrent in-flight requests (chi Throttle, not TCP connections)" maximum:"100000" example:"1000"`
+	Plugins         APIPluginConfig      `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin security configuration"`
+}
+
+// APIPluginConfig holds security settings for plugin execution in the API server.
+type APIPluginConfig struct {
+	// AllowExternal enables loading of external (non-official) plugins via
+	// API requests. Defaults to false (only pre-loaded official providers).
+	AllowExternal bool `json:"allowExternal,omitempty" yaml:"allowExternal,omitempty" mapstructure:"allowExternal" doc:"Allow loading external plugins from solution bundles (default: false for security)"`
+
+	// AllowedPlugins is an explicit allowlist of plugin names that may be
+	// loaded. Empty means all plugins are permitted (when AllowExternal is true).
+	AllowedPlugins []string `json:"allowedPlugins,omitempty" yaml:"allowedPlugins,omitempty" mapstructure:"allowedPlugins" doc:"Explicit plugin name allowlist (empty = allow all when allowExternal is true)" maxItems:"200"`
+
+	// AllowedCatalogs restricts which configured catalogs plugins may be
+	// fetched from. Catalog names are matched against catalog config entries.
+	// Empty means all configured catalogs are permitted.
+	AllowedCatalogs []string `json:"allowedCatalogs,omitempty" yaml:"allowedCatalogs,omitempty" mapstructure:"allowedCatalogs" doc:"Catalog name allowlist for plugin fetches (empty = allow all configured catalogs)" maxItems:"50"`
 }
 
 // APITLSConfig holds TLS configuration for the API server.

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -55,6 +55,17 @@ var KnownRules = map[string]RuleMeta{
 		Fix:         "Rename the resolver to avoid reserved names. Use descriptive names like 'user-input' or 'api-response' instead.",
 		Examples:    []string{"Reserved names: __actions, __error, __item, __index, _"},
 	},
+	"hyphenated-name": {
+		Rule:        "hyphenated-name",
+		Severity:    string(SeverityInfo),
+		Category:    "naming",
+		Description: "A resolver name contains hyphens, which require bracket notation in CEL expressions.",
+		Why:         "Hyphens in resolver names require quoting in CEL: _[\"my-resolver\"] instead of _.my_resolver. This is more verbose and error-prone.",
+		Fix:         "Use underscores instead of hyphens for CEL-friendly access: my_resolver instead of my-resolver.",
+		Examples: []string{
+			"# Hyphenated (requires quoting in CEL):\nresolvers:\n  my-service:\n    ...\n# Access: _[\"my-service\"]\n\n# Underscored (direct CEL access):\nresolvers:\n  my_service:\n    ...\n# Access: _.my_service",
+		},
+	},
 	"unused-resolver": {
 		Rule:        "unused-resolver",
 		Severity:    string(SeverityWarning),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 33 rules — update this when new rules are added
-	assert.Equal(t, 33, len(KnownRules), "expected 33 known lint rules")
+	// We expect exactly 34 rules — update this when new rules are added
+	assert.Equal(t, 34, len(KnownRules), "expected 34 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -15,7 +15,7 @@ import (
 // registerConfigTools registers configuration-related MCP tools.
 func (s *Server) registerConfigTools() {
 	getConfigTool := mcp.NewTool("get_config",
-		mcp.WithDescription("Return the current scafctl configuration. Shows catalogs, settings, logging, HTTP client, CEL, resolver, action, auth, and build configuration. Use the optional 'section' parameter to retrieve only a specific section. Sensitive fields (client secrets, tokens) are redacted."),
+		mcp.WithDescription(fmt.Sprintf("Return the current %s configuration. Shows catalogs, settings, logging, HTTP client, CEL, resolver, action, auth, build, and apiServer configuration. Use the optional 'section' parameter to retrieve only a specific section. Sensitive fields (client secrets, tokens) are redacted.", s.name)),
 		mcp.WithTitleAnnotation("Get Configuration"),
 		mcp.WithToolIcons(toolIcons["config"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -24,13 +24,13 @@ func (s *Server) registerConfigTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithRawOutputSchema(outputSchemaGetConfig),
 		mcp.WithString("section",
-			mcp.Description("Optional section to retrieve: 'catalogs', 'settings', 'logging', 'httpClient', 'cel', 'resolver', 'action', 'auth', 'build'. Omit to return the full configuration."),
+			mcp.Description("Optional section to retrieve: 'catalogs', 'settings', 'logging', 'httpClient', 'cel', 'resolver', 'action', 'auth', 'build', 'apiServer'. Omit to return the full configuration."),
 		),
 	)
 	s.addTool(getConfigTool, s.handleGetConfig)
 
 	getConfigPathsTool := mcp.NewTool("get_config_paths",
-		mcp.WithDescription("Return all XDG-compliant filesystem paths used by scafctl. Shows config, data, cache, state, catalog, secrets, plugins, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout."),
+		mcp.WithDescription(fmt.Sprintf("Return all XDG-compliant filesystem paths used by %s. Shows config, data, cache, state, catalog, secrets, plugins, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout.", s.name)),
 		mcp.WithTitleAnnotation("Get Config Paths"),
 		mcp.WithToolIcons(toolIcons["config"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -70,6 +70,7 @@ func (s *Server) handleGetConfig(_ context.Context, request mcp.CallToolRequest)
 		"action":     sanitized.Action,
 		"auth":       sanitized.Auth,
 		"build":      sanitized.Build,
+		"apiServer":  sanitized.APIServer,
 	}
 
 	sectionData, ok := validSections[section]

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -22,6 +22,7 @@ type pluginConfig struct {
 	handshake  *HandshakeConfigData
 	pluginName string
 	grpcPlugin plugin.Plugin
+	cmdFn      func(string) *exec.Cmd // builds the exec.Cmd for the plugin binary
 }
 
 // connectPlugin creates a go-plugin client, connects, and dispenses the named plugin.
@@ -29,6 +30,11 @@ type pluginConfig struct {
 // The caller is responsible for type-asserting the raw interface and calling
 // client.Kill() on failure after this function returns.
 func connectPlugin(pluginPath string, cfg pluginConfig) (any, *plugin.Client, error) {
+	cmdFn := cfg.cmdFn
+	if cmdFn == nil {
+		cmdFn = pluginCmd
+	}
+
 	//nolint:noctx // Context not available at plugin initialization time
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: plugin.HandshakeConfig{
@@ -39,7 +45,7 @@ func connectPlugin(pluginPath string, cfg pluginConfig) (any, *plugin.Client, er
 		Plugins: map[string]plugin.Plugin{
 			cfg.pluginName: cfg.grpcPlugin,
 		},
-		Cmd:              exec.Command(pluginPath),
+		Cmd:              cmdFn(pluginPath),
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 	})
 
@@ -56,6 +62,57 @@ func connectPlugin(pluginPath string, cfg pluginConfig) (any, *plugin.Client, er
 	}
 
 	return raw, client, nil
+}
+
+// safeEnvKeys is the set of environment variables that are safe to pass to
+// plugin processes. This prevents leaking sensitive credentials (AWS_*,
+// KUBECONFIG, SSH_AUTH_SOCK, etc.) to potentially untrusted plugin binaries.
+var safeEnvKeys = map[string]bool{
+	"PATH":    true,
+	"HOME":    true,
+	"TMPDIR":  true,
+	"LANG":    true,
+	"TZ":      true,
+	"USER":    true,
+	"LOGNAME": true,
+
+	// Required for go-plugin gRPC communication
+	"PLUGIN_MIN_PORT": true,
+	"PLUGIN_MAX_PORT": true,
+}
+
+// pluginCmd creates an exec.Cmd for a plugin binary with a sanitized
+// environment. Only safe environment variables are propagated to prevent
+// leaking secrets to external plugin processes.
+func pluginCmd(pluginPath string) *exec.Cmd {
+	//nolint:gosec // pluginPath is validated via digest verification before reaching here
+	cmd := exec.Command(pluginPath) //nolint:noctx // Context not available at plugin initialization time
+	return cmd
+}
+
+// pluginCmdSanitized creates an exec.Cmd with a minimal sanitized
+// environment. Used in API server context to prevent leaking secrets.
+func pluginCmdSanitized(pluginPath string) *exec.Cmd {
+	//nolint:gosec // pluginPath is validated via digest verification before reaching here
+	cmd := exec.Command(pluginPath) //nolint:noctx // Context not available at plugin initialization time
+	cmd.Env = safePluginEnv()
+	return cmd
+}
+
+// safePluginEnv builds a minimal environment from the current process
+// environment, keeping only keys in safeEnvKeys.
+func safePluginEnv() []string {
+	env := make([]string, 0, len(safeEnvKeys))
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if safeEnvKeys[key] {
+			env = append(env, kv)
+		}
+	}
+	return env
 }
 
 // discoverExecutables scans the given directories for executable files and
@@ -134,7 +191,8 @@ type Client struct {
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	hostDeps *HostServiceDeps
+	hostDeps    *HostServiceDeps
+	sanitizeEnv bool // strip sensitive env vars from plugin process
 }
 
 // WithHostDeps provides host-side dependencies (secrets, auth) that are
@@ -145,6 +203,15 @@ func WithHostDeps(deps *HostServiceDeps) ClientOption {
 	}
 }
 
+// WithSanitizedEnv restricts the environment variables passed to the plugin
+// process. Only safe variables (PATH, HOME, TMPDIR, etc.) are inherited.
+// Use this in API server contexts to prevent leaking secrets to plugins.
+func WithSanitizedEnv() ClientOption {
+	return func(o *clientOptions) {
+		o.sanitizeEnv = true
+	}
+}
+
 // NewClient creates a new plugin client
 func NewClient(pluginPath string, opts ...ClientOption) (*Client, error) {
 	var o clientOptions
@@ -152,10 +219,16 @@ func NewClient(pluginPath string, opts ...ClientOption) (*Client, error) {
 		opt(&o)
 	}
 
+	cmdFn := pluginCmd
+	if o.sanitizeEnv {
+		cmdFn = pluginCmdSanitized
+	}
+
 	raw, client, err := connectPlugin(pluginPath, pluginConfig{
 		handshake:  HandshakeConfig,
 		pluginName: PluginName,
 		grpcPlugin: &GRPCPlugin{HostDeps: o.hostDeps},
+		cmdFn:      cmdFn,
 	})
 	if err != nil {
 		return nil, err
@@ -275,10 +348,16 @@ func NewAuthHandlerClient(pluginPath string, opts ...ClientOption) (*AuthHandler
 		opt(&o)
 	}
 
+	cmdFn := pluginCmd
+	if o.sanitizeEnv {
+		cmdFn = pluginCmdSanitized
+	}
+
 	raw, client, err := connectPlugin(pluginPath, pluginConfig{
 		handshake:  AuthHandlerHandshakeConfig,
 		pluginName: AuthHandlerPluginName,
 		grpcPlugin: &AuthHandlerGRPCPlugin{HostDeps: o.hostDeps},
+		cmdFn:      cmdFn,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/client_security_test.go
+++ b/pkg/plugin/client_security_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafePluginEnv_OnlyAllowedKeys(t *testing.T) {
+	// Set some dangerous env vars for the test
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	t.Setenv("KUBECONFIG", "/home/test/.kube/config")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
+	t.Setenv("GITHUB_TOKEN", "ghp_secrettoken")
+	t.Setenv("TMPDIR", "/tmp")
+
+	env := safePluginEnv()
+
+	// Should include safe keys
+	envMap := envToMap(env)
+	assert.Equal(t, "/usr/bin:/bin", envMap["PATH"])
+	assert.Equal(t, "/home/test", envMap["HOME"])
+	assert.Equal(t, "/tmp", envMap["TMPDIR"])
+
+	// Should NOT include sensitive keys
+	assert.NotContains(t, envMap, "AWS_ACCESS_KEY_ID")
+	assert.NotContains(t, envMap, "AWS_SECRET_ACCESS_KEY")
+	assert.NotContains(t, envMap, "KUBECONFIG")
+	assert.NotContains(t, envMap, "SSH_AUTH_SOCK")
+	assert.NotContains(t, envMap, "GITHUB_TOKEN")
+}
+
+func TestSafePluginEnv_AllSafeKeysIncluded(t *testing.T) {
+	// Set all safe keys
+	for key := range safeEnvKeys {
+		t.Setenv(key, "test-value-"+key)
+	}
+
+	env := safePluginEnv()
+	envMap := envToMap(env)
+
+	for key := range safeEnvKeys {
+		assert.Contains(t, envMap, key, "safe key %q should be included", key)
+	}
+}
+
+func TestPluginCmd_HasSanitizedEnv(t *testing.T) {
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak")
+	t.Setenv("PATH", "/usr/bin")
+
+	cmd := pluginCmdSanitized("/fake/plugin/binary")
+
+	require.NotNil(t, cmd)
+	assert.Contains(t, cmd.Args[0], "/fake/plugin/binary")
+
+	// Env should be explicitly set (not nil, which means inherit all)
+	require.NotNil(t, cmd.Env)
+
+	envMap := envToMap(cmd.Env)
+	assert.Contains(t, envMap, "PATH")
+	assert.NotContains(t, envMap, "AWS_SECRET_ACCESS_KEY")
+}
+
+func TestPluginCmd_UnsanitizedInheritsAll(t *testing.T) {
+	cmd := pluginCmd("/fake/plugin/binary")
+	require.NotNil(t, cmd)
+	// When Env is nil, the child inherits the full parent environment
+	assert.Nil(t, cmd.Env)
+}
+
+func TestSafeEnvKeys_NoSensitiveDefaults(t *testing.T) {
+	// Verify that commonly dangerous keys are not in the safe list
+	dangerousKeys := []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AZURE_CLIENT_SECRET",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"KUBECONFIG",
+		"SSH_AUTH_SOCK",
+		"GITHUB_TOKEN",
+		"GH_TOKEN",
+		"DOCKER_CONFIG",
+		"NPM_TOKEN",
+		"DATABASE_URL",
+	}
+
+	for _, key := range dangerousKeys {
+		assert.False(t, safeEnvKeys[key], "dangerous key %q should not be in safeEnvKeys", key)
+	}
+}
+
+// envToMap converts a []string env slice to a map for easier assertions.
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		for i := range kv {
+			if kv[i] == '=' {
+				m[kv[:i]] = kv[i+1:]
+				break
+			}
+		}
+	}
+	return m
+}

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -22,12 +22,13 @@ import (
 // Fetcher resolves, downloads, caches, and loads plugin binaries at runtime.
 // It checks a local cache first, then falls back to fetching from catalogs.
 type Fetcher struct {
-	binaryName     string
-	catalogFetcher *catalog.PluginFetcher
-	cache          *Cache
-	platform       string
-	noCache        bool
-	logger         logr.Logger
+	binaryName      string
+	catalogFetcher  *catalog.PluginFetcher
+	cache           *Cache
+	platform        string
+	noCache         bool
+	logger          logr.Logger
+	allowedCatalogs map[string]bool // if non-nil, only these catalog names are permitted
 }
 
 // FetcherConfig configures a Fetcher.
@@ -48,6 +49,10 @@ type FetcherConfig struct {
 	// BinaryName is the CLI binary name used in user-facing messages (e.g.,
 	// "Run 'mycli build solution' to pin..."). Defaults to "scafctl" when empty.
 	BinaryName string
+
+	// AllowedCatalogs restricts which catalog names plugins may be fetched
+	// from. If empty, all catalogs are allowed.
+	AllowedCatalogs []string
 
 	// Logger for logging operations.
 	Logger logr.Logger
@@ -70,13 +75,22 @@ func NewFetcher(cfg FetcherConfig) *Fetcher {
 		binaryName = "scafctl" // fallback must match settings.CliBinaryName
 	}
 
+	var allowedCatalogs map[string]bool
+	if len(cfg.AllowedCatalogs) > 0 {
+		allowedCatalogs = make(map[string]bool, len(cfg.AllowedCatalogs))
+		for _, name := range cfg.AllowedCatalogs {
+			allowedCatalogs[strings.ToLower(name)] = true
+		}
+	}
+
 	return &Fetcher{
-		binaryName:     binaryName,
-		catalogFetcher: catalog.NewPluginFetcher(cfg.Catalog, cfg.Logger),
-		cache:          cache,
-		platform:       platform,
-		noCache:        cfg.NoCache,
-		logger:         cfg.Logger.WithName("plugin-fetcher"),
+		binaryName:      binaryName,
+		catalogFetcher:  catalog.NewPluginFetcher(cfg.Catalog, cfg.Logger),
+		cache:           cache,
+		platform:        platform,
+		noCache:         cfg.NoCache,
+		logger:          cfg.Logger.WithName("plugin-fetcher"),
+		allowedCatalogs: allowedCatalogs,
 	}
 }
 
@@ -171,6 +185,11 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 			"name", dep.Name,
 			"version", version,
 			"digest", expectedDigest)
+
+		// Security: check catalog allowlist even for locked entries.
+		if err := f.checkCatalogAllowed(resolvedFrom); err != nil {
+			return FetchResult{}, err
+		}
 	} else {
 		// No lock file — prefer cached version to avoid network latency.
 		// Only resolve from catalog if no cached version exists.
@@ -185,6 +204,11 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 					}
 				}
 				if useCached {
+					// Security: reject cached plugins when an allowlist is configured
+					// but cache lacks catalog origin metadata.
+					if err := f.checkCatalogAllowed(""); err != nil {
+						return FetchResult{}, fmt.Errorf("cached plugin %s: %w", dep.Name, err)
+					}
 					f.logger.V(1).Info("using cached plugin (no lock file)",
 						"name", dep.Name,
 						"version", cachedVer,
@@ -211,6 +235,11 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 			// Fallback: if catalog resolution fails, check if a cached version exists.
 			if !f.noCache {
 				if cachedPath, cachedVer, ok := f.cache.GetLatestCached(dep.Name, f.platform); ok {
+					// Security: reject cached plugins when an allowlist is configured
+					// but cache lacks catalog origin metadata.
+					if allowErr := f.checkCatalogAllowed(""); allowErr != nil {
+						return FetchResult{}, fmt.Errorf("cached plugin %s: %w", dep.Name, allowErr)
+					}
 					f.logger.V(0).Info("catalog resolution failed, using cached version",
 						"name", dep.Name,
 						"version", cachedVer,
@@ -233,6 +262,11 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		}
 		expectedDigest = info.Digest
 		resolvedFrom = info.Catalog
+
+		// Security: check catalog allowlist before proceeding with fetch.
+		if err := f.checkCatalogAllowed(resolvedFrom); err != nil {
+			return FetchResult{}, err
+		}
 
 		// Verify the resolved version satisfies the constraint.
 		// "latest" means "whatever the resolver picked" and is not a valid
@@ -465,6 +499,23 @@ func pluginKindToArtifactKind(kind solution.PluginKind) catalog.ArtifactKind {
 }
 
 // findLockPlugin looks up a lock plugin entry by name and kind.
+// checkCatalogAllowed returns an error if the catalog is not in the
+// configured allowlist. If no allowlist is configured, all catalogs are
+// permitted. An empty resolvedFrom (e.g. from cache with no catalog metadata)
+// is rejected when an allowlist is configured, since the origin cannot be verified.
+func (f *Fetcher) checkCatalogAllowed(resolvedFrom string) error {
+	if f.allowedCatalogs == nil {
+		return nil
+	}
+	if resolvedFrom == "" {
+		return fmt.Errorf("plugin origin unknown (cached without catalog metadata); cannot verify against allowlist")
+	}
+	if !f.allowedCatalogs[strings.ToLower(resolvedFrom)] {
+		return fmt.Errorf("catalog %q is not in the allowed catalogs list", resolvedFrom)
+	}
+	return nil
+}
+
 func findLockPlugin(plugins []bundler.LockPlugin, name, kind string) *bundler.LockPlugin {
 	for i := range plugins {
 		if plugins[i].Name == name && plugins[i].Kind == kind {

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -519,4 +521,130 @@ func TestRegisterFetchedAuthHandlerPlugins_InvalidPath(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "loading auth handler plugin bad-handler")
 	assert.Nil(t, clients)
+}
+
+// --- Catalog allowlist security tests ---
+
+func TestFetcher_CheckCatalogAllowed_NoRestriction(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: nil}
+	assert.NoError(t, f.checkCatalogAllowed("any-catalog"))
+}
+
+func TestFetcher_CheckCatalogAllowed_EmptyResolvedFrom(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: map[string]bool{"official": true}}
+	err := f.checkCatalogAllowed("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "origin unknown")
+}
+
+func TestFetcher_CheckCatalogAllowed_EmptyResolvedFrom_NoAllowlist(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: nil}
+	assert.NoError(t, f.checkCatalogAllowed(""))
+}
+
+func TestFetcher_CheckCatalogAllowed_Permitted(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: map[string]bool{"official": true, "internal": true}}
+	assert.NoError(t, f.checkCatalogAllowed("official"))
+}
+
+func TestFetcher_CheckCatalogAllowed_Rejected(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: map[string]bool{"official": true}}
+	err := f.checkCatalogAllowed("untrusted-catalog")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in the allowed catalogs list")
+}
+
+func TestFetcher_CheckCatalogAllowed_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	f := &Fetcher{allowedCatalogs: map[string]bool{"official": true}}
+	// Allowlist is built with ToLower, and checkCatalogAllowed also lowercases
+	// resolvedFrom, so matching is fully case-insensitive.
+	assert.NoError(t, f.checkCatalogAllowed("official"))
+	assert.NoError(t, f.checkCatalogAllowed("Official"))
+	assert.NoError(t, f.checkCatalogAllowed("OFFICIAL"))
+}
+
+func TestNewFetcher_AllowedCatalogs(t *testing.T) {
+	t.Parallel()
+	cat := newMockCatalog()
+	f := NewFetcher(FetcherConfig{
+		Catalog:         cat,
+		Logger:          logr.Discard(),
+		AllowedCatalogs: []string{"Official", "Internal"},
+	})
+	require.NotNil(t, f.allowedCatalogs)
+	assert.True(t, f.allowedCatalogs["official"])
+	assert.True(t, f.allowedCatalogs["internal"])
+	assert.False(t, f.allowedCatalogs["untrusted"])
+}
+
+func TestFetcher_FetchPlugins_CatalogNotAllowed(t *testing.T) {
+	t.Parallel()
+	// Create a catalog that resolves to a non-allowed name
+	cat := newMockCatalog()
+	cat.name = "untrusted"
+
+	binaryData := []byte("fake-plugin-binary")
+	digest := binaryDigest(binaryData)
+
+	ver := semver.MustParse("1.0.0")
+	ref := catalog.Reference{
+		Kind:    catalog.ArtifactKindProvider,
+		Name:    "evil-plugin",
+		Version: ver,
+	}
+	cat.addArtifact(ref, binaryData)
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:         cat,
+		Logger:          logr.Discard(),
+		NoCache:         true,
+		AllowedCatalogs: []string{"official"},
+	})
+
+	deps := []solution.PluginDependency{
+		{Name: "evil-plugin", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+	}
+
+	// Provide a lock entry so it hits the locked path with resolvedFrom set
+	lockPlugins := []bundler.LockPlugin{
+		{Name: "evil-plugin", Kind: "provider", Version: "1.0.0", Digest: digest, ResolvedFrom: "untrusted"},
+	}
+
+	_, err := f.FetchPlugins(context.Background(), deps, lockPlugins)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in the allowed catalogs list")
+}
+
+func TestFetcher_CacheFallback_AllowlistRejects(t *testing.T) {
+	t.Parallel()
+	// Create a pre-populated cache so the no-lock cache-first path is taken.
+	cacheDir := t.TempDir()
+	platform := CurrentPlatform()
+	pluginName := "cached-plugin"
+	binDir := filepath.Join(cacheDir, pluginName, "2.0.0", PlatformCacheKey(platform))
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, pluginName), []byte("#!/bin/sh\n"), 0o755))
+
+	f := NewFetcher(FetcherConfig{
+		Cache:           NewCache(cacheDir),
+		Platform:        platform,
+		Logger:          logr.Discard(),
+		AllowedCatalogs: []string{"approved"},
+	})
+
+	deps := []solution.PluginDependency{
+		{Name: pluginName, Kind: solution.PluginKindProvider},
+	}
+
+	// No lock file provided — fetcher uses cache-first path.
+	// Allowlist is set, cached entry has unknown origin → rejected.
+	_, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot verify against allowlist")
 }

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -1,0 +1,627 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// Sentinel errors for Pool operations.
+var (
+	ErrPoolClosed       = errors.New("plugin pool is closed")
+	ErrPoolFull         = errors.New("plugin pool at maximum capacity")
+	ErrPluginNotAllowed = errors.New("plugin not in allowlist")
+	ErrExternalDisabled = errors.New("external plugins disabled")
+)
+
+// PoolErrorHTTPStatus maps pool errors to appropriate HTTP status codes.
+// Returns 0 if the error is not a recognized pool error.
+func PoolErrorHTTPStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrPluginNotAllowed), errors.Is(err, ErrExternalDisabled):
+		return 403 // Forbidden — policy rejection
+	case errors.Is(err, ErrPoolFull):
+		return 503 // Service Unavailable — capacity exhaustion
+	case errors.Is(err, ErrPoolClosed):
+		return 503
+	case errors.Is(err, context.Canceled):
+		return 499 // Client Closed Request
+	case errors.Is(err, context.DeadlineExceeded):
+		return 504 // Gateway Timeout
+	default:
+		return 502 // Bad Gateway — upstream plugin failure
+	}
+}
+
+// entryState represents the lifecycle state of a pool entry.
+type entryState int
+
+const (
+	entryStarting entryState = iota
+	entryReady
+	entryDead
+)
+
+// poolEntry tracks a single managed plugin process.
+type poolEntry struct {
+	mu       sync.Mutex
+	client   *Client
+	state    entryState
+	lastUsed time.Time
+	refCount int32 // atomic; tracks in-flight requests using this plugin
+	dep      solution.PluginDependency
+	result   FetchResult
+	// registeredProviders holds the provider names this entry successfully
+	// registered in the shared registry. Only these names are unregistered
+	// on eviction/death — avoids removing providers owned by other plugins.
+	registeredProviders []string
+	// ready is closed when the entry transitions from entryStarting to
+	// entryReady or entryDead, unblocking waiters.
+	ready chan struct{}
+	// err holds any error from the spawn attempt (only valid after ready is closed).
+	err error
+}
+
+// poolOptions holds Pool configuration.
+type poolOptions struct {
+	idleTimeout     time.Duration
+	maxPlugins      int
+	healthInterval  time.Duration
+	clock           func() time.Time // for testing
+	allowedPlugins  map[string]bool  // nil means allow all
+	disableExternal bool             // reject all non-adopted plugins
+}
+
+// defaultPoolOptions returns sensible defaults.
+func defaultPoolOptions() poolOptions {
+	return poolOptions{
+		idleTimeout:    5 * time.Minute,
+		maxPlugins:     50,
+		healthInterval: 30 * time.Second,
+		clock:          time.Now,
+	}
+}
+
+// PoolOption configures pool behavior.
+type PoolOption func(*poolOptions)
+
+// WithIdleTimeout sets how long an unused plugin stays alive before eviction.
+// Zero disables idle eviction.
+func WithIdleTimeout(d time.Duration) PoolOption {
+	return func(o *poolOptions) { o.idleTimeout = d }
+}
+
+// WithMaxPlugins sets the maximum number of external plugin processes.
+// Zero means unlimited.
+func WithMaxPlugins(n int) PoolOption {
+	return func(o *poolOptions) { o.maxPlugins = n }
+}
+
+// WithHealthCheckInterval sets the background health check frequency.
+// Zero disables background checks (health is verified on use).
+//
+// NOTE: Background health checks are not yet implemented. This option
+// stores the interval for future use. Currently, dead plugins are only
+// detected when a caller invokes Ping or when a request fails.
+func WithHealthCheckInterval(d time.Duration) PoolOption {
+	return func(o *poolOptions) { o.healthInterval = d }
+}
+
+// withClock overrides the time source (for testing).
+func withClock(fn func() time.Time) PoolOption {
+	return func(o *poolOptions) { o.clock = fn }
+}
+
+// WithAllowedPlugins restricts which external plugins may be loaded via
+// Ensure. Plugins not in this list are rejected with ErrPluginNotAllowed.
+// A nil or empty list means all plugins are allowed (no restriction).
+// Adopted (pre-loaded) plugins bypass this check.
+func WithAllowedPlugins(names []string) PoolOption {
+	return func(o *poolOptions) {
+		if len(names) == 0 {
+			o.allowedPlugins = nil
+			return
+		}
+		o.allowedPlugins = make(map[string]bool, len(names))
+		for _, n := range names {
+			o.allowedPlugins[n] = true
+		}
+	}
+}
+
+// WithDisableExternal rejects all plugin load attempts via Ensure.
+// Only pre-loaded (Adopt) plugins are usable. This is the safe default
+// for API server deployments.
+func WithDisableExternal(disabled bool) PoolOption {
+	return func(o *poolOptions) { o.disableExternal = disabled }
+}
+
+// PoolStats holds pool metrics.
+type PoolStats struct {
+	Active  int // Entries with refCount > 0
+	Idle    int // Entries in ready state with refCount == 0
+	Dead    int // Entries that crashed and await eviction or re-spawn
+	Total   int // All entries
+	Evicted int // Cumulative evictions since pool creation
+}
+
+// Pool manages shared, long-lived plugin processes with lazy initialization
+// and idle eviction. It is safe for concurrent use.
+//
+// Official providers pre-loaded at startup can be added via Adopt; external
+// plugins declared in bundle.plugins are loaded on-demand via Ensure.
+type Pool struct {
+	mu       sync.Mutex
+	entries  map[string]*poolEntry // keyed by plugin name
+	fetcher  *Fetcher
+	registry *provider.Registry
+	opts     poolOptions
+	closed   bool
+	evicted  int
+	stopOnce sync.Once
+	stop     chan struct{}
+	logger   logr.Logger
+}
+
+// NewPool creates a plugin pool backed by the given fetcher and registry.
+// The fetcher may be nil if only Adopt (pre-loaded) plugins are used.
+func NewPool(fetcher *Fetcher, registry *provider.Registry, logger logr.Logger, opts ...PoolOption) *Pool {
+	o := defaultPoolOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	p := &Pool{
+		entries:  make(map[string]*poolEntry),
+		fetcher:  fetcher,
+		registry: registry,
+		opts:     o,
+		stop:     make(chan struct{}),
+		logger:   logger,
+	}
+	if o.idleTimeout > 0 {
+		go p.evictionLoop()
+	}
+	return p
+}
+
+// Adopt registers an already-running plugin client into the pool so that its
+// lifecycle (idle eviction, shutdown) is managed by the pool. This is used
+// for official providers pre-loaded at startup.
+func (p *Pool) Adopt(name string, client *Client, dep solution.PluginDependency, registeredProviders []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+	ready := make(chan struct{})
+	close(ready)
+	p.entries[name] = &poolEntry{
+		client:              client,
+		state:               entryReady,
+		lastUsed:            p.opts.clock(),
+		dep:                 dep,
+		registeredProviders: registeredProviders,
+		ready:               ready,
+	}
+}
+
+// Ensure guarantees that all plugins in deps are running and registered in
+// the provider registry. For plugins already in the pool and healthy, this
+// is a no-op. For new plugins, it fetches, spawns, and registers them.
+func (p *Pool) Ensure(ctx context.Context, deps []solution.PluginDependency) error {
+	for _, dep := range deps {
+		if dep.Kind != solution.PluginKindProvider {
+			continue
+		}
+		if err := p.ensureOne(ctx, dep); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureAndAcquire ensures all plugins are available and acquires them
+// (increments their refcounts), preventing idle eviction for the duration
+// of the caller's work. Returns a release function that must be called when
+// the caller is done using the plugins (typically via defer).
+func (p *Pool) EnsureAndAcquire(ctx context.Context, deps []solution.PluginDependency) (release func(), err error) {
+	if err := p.Ensure(ctx, deps); err != nil {
+		return nil, err
+	}
+
+	var acquired []string
+	for _, dep := range deps {
+		if dep.Kind != solution.PluginKindProvider {
+			continue
+		}
+		if p.Acquire(dep.Name) {
+			acquired = append(acquired, dep.Name)
+		}
+	}
+
+	return func() {
+		for _, name := range acquired {
+			p.Release(name)
+		}
+	}, nil
+}
+
+// ensureOne handles a single plugin dependency.
+func (p *Pool) ensureOne(ctx context.Context, dep solution.PluginDependency) error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return ErrPoolClosed
+	}
+
+	// Already in pool (pre-loaded or previously loaded)?
+	if entry, ok := p.entries[dep.Name]; ok {
+		p.mu.Unlock()
+		err := p.waitAndValidate(ctx, entry)
+		if err != nil {
+			// Remove dead entries so the plugin can be re-spawned on retry.
+			p.mu.Lock()
+			if entry.state == entryDead {
+				p.unregisterEntry(entry)
+				delete(p.entries, dep.Name)
+			}
+			p.mu.Unlock()
+		}
+		return err
+	}
+
+	// Check if already registered (builtin or pre-loaded without Adopt)
+	if p.registry.Has(dep.Name) {
+		p.mu.Unlock()
+		return nil
+	}
+
+	// Security: reject if external plugins are disabled entirely.
+	if p.opts.disableExternal {
+		p.mu.Unlock()
+		return fmt.Errorf("plugin %q: %w", dep.Name, ErrExternalDisabled)
+	}
+
+	// Security: reject if allowlist is configured and plugin is not on it.
+	if p.opts.allowedPlugins != nil && !p.opts.allowedPlugins[dep.Name] {
+		p.mu.Unlock()
+		return fmt.Errorf("plugin %q: %w", dep.Name, ErrPluginNotAllowed)
+	}
+
+	// Capacity check
+	if p.opts.maxPlugins > 0 && len(p.entries) >= p.opts.maxPlugins {
+		p.mu.Unlock()
+		return fmt.Errorf("plugin %q: %w", dep.Name, ErrPoolFull)
+	}
+
+	// Create a placeholder entry; we'll spawn outside the lock.
+	entry := &poolEntry{
+		state: entryStarting,
+		dep:   dep,
+		ready: make(chan struct{}),
+	}
+	p.entries[dep.Name] = entry
+	p.mu.Unlock()
+
+	// Spawn the plugin (may take time: fetch + exec + gRPC handshake).
+	p.spawn(ctx, entry)
+
+	if entry.err != nil {
+		// Remove failed entry
+		p.mu.Lock()
+		delete(p.entries, dep.Name)
+		p.mu.Unlock()
+		return fmt.Errorf("plugin %q: %w", dep.Name, entry.err)
+	}
+	return nil
+}
+
+// waitAndValidate waits for an entry to become ready and checks health.
+func (p *Pool) waitAndValidate(ctx context.Context, entry *poolEntry) error {
+	// Wait for entry to be ready (handles concurrent Ensure for same plugin).
+	select {
+	case <-entry.ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.state == entryDead {
+		// Dead entries will be re-spawned on next Ensure after eviction.
+		return fmt.Errorf("plugin %q is dead: %w", entry.dep.Name, entry.err)
+	}
+
+	// Touch last-used time
+	entry.lastUsed = p.opts.clock()
+	return nil
+}
+
+// spawn fetches and starts a plugin, updating the entry state.
+func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
+	defer close(entry.ready)
+
+	if p.fetcher == nil {
+		entry.failWith(errors.New("plugin fetcher not available"))
+		return
+	}
+
+	// Fetch binary
+	results, err := p.fetcher.FetchPlugins(ctx, []solution.PluginDependency{entry.dep}, nil)
+	if err != nil {
+		entry.failWith(fmt.Errorf("fetching: %w", err))
+		return
+	}
+
+	if len(results) == 0 {
+		entry.failWith(errors.New("no fetch results returned"))
+		return
+	}
+
+	result := results[0]
+
+	// Spawn client with sanitized environment (pool is API-server context)
+	client, err := NewClient(result.Path, WithSanitizedEnv())
+	if err != nil {
+		entry.failWith(fmt.Errorf("starting process: %w", err))
+		return
+	}
+
+	// Register providers into the shared registry
+	providers, err := client.GetProviders(ctx)
+	if err != nil {
+		client.Kill()
+		entry.failWith(fmt.Errorf("getting providers: %w", err))
+		return
+	}
+
+	var registered []string
+	for _, provName := range providers {
+		wrapper, wErr := NewProviderWrapper(client, provName, WithContext(ctx))
+		if wErr != nil {
+			p.logger.V(1).Info("failed to create provider wrapper",
+				"plugin", entry.dep.Name, "provider", provName, "error", wErr)
+			continue
+		}
+		if rErr := p.registry.Register(wrapper); rErr != nil {
+			p.logger.V(1).Info("provider not registered (name taken)",
+				"plugin", entry.dep.Name, "provider", provName, "error", rErr)
+			continue
+		}
+		registered = append(registered, provName)
+	}
+
+	entry.mu.Lock()
+	entry.client = client
+	entry.result = result
+	entry.registeredProviders = registered
+	entry.state = entryReady
+	entry.lastUsed = p.opts.clock()
+	entry.mu.Unlock()
+
+	p.logger.V(0).Info("plugin loaded into pool",
+		"plugin", entry.dep.Name, "version", result.Version, "providers", providers)
+}
+
+// failWith marks the entry as dead with the given error.
+func (e *poolEntry) failWith(err error) {
+	e.mu.Lock()
+	e.state = entryDead
+	e.err = err
+	e.mu.Unlock()
+}
+
+// Acquire increments the reference count for a plugin, preventing eviction.
+// Returns false if the plugin is not in the pool or is dead.
+func (p *Pool) Acquire(name string) bool {
+	p.mu.Lock()
+	entry, ok := p.entries[name]
+	p.mu.Unlock()
+	if !ok {
+		return false
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.state != entryReady {
+		return false
+	}
+	atomic.AddInt32(&entry.refCount, 1)
+	entry.lastUsed = p.opts.clock()
+	return true
+}
+
+// Release decrements the reference count for a plugin.
+func (p *Pool) Release(name string) {
+	p.mu.Lock()
+	entry, ok := p.entries[name]
+	p.mu.Unlock()
+	if !ok {
+		return
+	}
+	atomic.AddInt32(&entry.refCount, -1)
+}
+
+// Ping checks if a plugin is alive by issuing a lightweight RPC.
+func (p *Pool) Ping(ctx context.Context, name string) bool {
+	p.mu.Lock()
+	entry, ok := p.entries[name]
+	p.mu.Unlock()
+	if !ok {
+		return false
+	}
+	entry.mu.Lock()
+	client := entry.client
+	state := entry.state
+	entry.mu.Unlock()
+
+	if state != entryReady || client == nil {
+		return false
+	}
+
+	// Use GetProviders as a health probe (lightweight RPC).
+	_, err := client.GetProviders(ctx)
+	if err != nil {
+		p.markDead(name, entry, err)
+		return false
+	}
+	return true
+}
+
+// markDead transitions an entry to dead state and unregisters its providers.
+func (p *Pool) markDead(name string, entry *poolEntry, reason error) {
+	entry.mu.Lock()
+	if entry.state == entryDead {
+		entry.mu.Unlock()
+		return
+	}
+	entry.state = entryDead
+	entry.err = reason
+	client := entry.client
+	registered := entry.registeredProviders
+	entry.mu.Unlock()
+
+	for _, pName := range registered {
+		p.registry.Unregister(pName)
+	}
+	if client != nil {
+		client.Kill()
+	}
+
+	p.logger.V(0).Info("plugin marked dead", "plugin", name, "reason", reason)
+}
+
+// unregisterEntry unregisters tracked providers and kills the client.
+func (p *Pool) unregisterEntry(entry *poolEntry) {
+	entry.mu.Lock()
+	registered := entry.registeredProviders
+	client := entry.client
+	entry.mu.Unlock()
+
+	for _, pName := range registered {
+		p.registry.Unregister(pName)
+	}
+	if client != nil {
+		client.Kill()
+	}
+}
+
+// evictionLoop periodically scans for idle or dead entries and removes them.
+func (p *Pool) evictionLoop() {
+	ticker := time.NewTicker(p.opts.idleTimeout / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stop:
+			return
+		case <-ticker.C:
+			p.evict()
+		}
+	}
+}
+
+// evict removes idle and dead entries.
+func (p *Pool) evict() {
+	now := p.opts.clock()
+	p.mu.Lock()
+	var toEvict []string
+	for name, entry := range p.entries {
+		entry.mu.Lock()
+		idle := entry.state == entryReady &&
+			atomic.LoadInt32(&entry.refCount) == 0 &&
+			p.opts.idleTimeout > 0 &&
+			now.Sub(entry.lastUsed) > p.opts.idleTimeout
+		dead := entry.state == entryDead
+		entry.mu.Unlock()
+
+		if idle || dead {
+			toEvict = append(toEvict, name)
+		}
+	}
+	p.mu.Unlock()
+
+	for _, name := range toEvict {
+		p.mu.Lock()
+		entry, ok := p.entries[name]
+		if !ok {
+			p.mu.Unlock()
+			continue
+		}
+		delete(p.entries, name)
+		p.evicted++
+		p.mu.Unlock()
+
+		entry.mu.Lock()
+		client := entry.client
+		entry.mu.Unlock()
+
+		if client != nil {
+			p.unregisterEntry(entry)
+		}
+		p.logger.V(1).Info("evicted plugin from pool", "plugin", name)
+	}
+}
+
+// Stats returns current pool metrics.
+func (p *Pool) Stats() PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var stats PoolStats
+	stats.Total = len(p.entries)
+	stats.Evicted = p.evicted
+
+	for _, entry := range p.entries {
+		entry.mu.Lock()
+		switch entry.state {
+		case entryStarting:
+			stats.Active++ // starting counts as active (spawn in progress)
+		case entryReady:
+			if atomic.LoadInt32(&entry.refCount) > 0 {
+				stats.Active++
+			} else {
+				stats.Idle++
+			}
+		case entryDead:
+			stats.Dead++
+		}
+		entry.mu.Unlock()
+	}
+	return stats
+}
+
+// Shutdown kills all managed plugin processes. Called once on server stop.
+func (p *Pool) Shutdown() {
+	p.stopOnce.Do(func() {
+		close(p.stop)
+	})
+
+	p.mu.Lock()
+	p.closed = true
+	entries := make(map[string]*poolEntry, len(p.entries))
+	for k, v := range p.entries {
+		entries[k] = v
+	}
+	p.entries = make(map[string]*poolEntry)
+	p.mu.Unlock()
+
+	for _, entry := range entries {
+		entry.mu.Lock()
+		client := entry.client
+		entry.mu.Unlock()
+		if client != nil {
+			client.Kill()
+		}
+	}
+}

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -1,0 +1,850 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPool(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard())
+	defer p.Shutdown()
+
+	assert.NotNil(t, p)
+	assert.False(t, p.closed)
+	assert.Empty(t, p.entries)
+}
+
+func TestNewPool_Options(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(10*time.Minute),
+		WithMaxPlugins(100),
+		WithHealthCheckInterval(time.Minute),
+	)
+	defer p.Shutdown()
+
+	assert.Equal(t, 10*time.Minute, p.opts.idleTimeout)
+	assert.Equal(t, 100, p.opts.maxPlugins)
+	assert.Equal(t, time.Minute, p.opts.healthInterval)
+}
+
+func TestPool_Adopt(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "test-plugin", path: "/fake/path"}
+	dep := solution.PluginDependency{Name: "test-plugin", Kind: solution.PluginKindProvider}
+
+	p.Adopt("test-plugin", mockClient, dep, nil)
+
+	p.mu.Lock()
+	entry, ok := p.entries["test-plugin"]
+	p.mu.Unlock()
+
+	require.True(t, ok)
+	assert.Equal(t, entryReady, entry.state)
+	assert.Equal(t, mockClient, entry.client)
+}
+
+func TestPool_Adopt_ClosedPool(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p.Shutdown()
+
+	mockClient := &Client{name: "test-plugin", path: "/fake/path"}
+	dep := solution.PluginDependency{Name: "test-plugin", Kind: solution.PluginKindProvider}
+
+	p.Adopt("test-plugin", mockClient, dep, nil)
+
+	p.mu.Lock()
+	_, ok := p.entries["test-plugin"]
+	p.mu.Unlock()
+	assert.False(t, ok)
+}
+
+func TestPool_Ensure_AlreadyRegistered(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.MarkKnown("existing-provider")
+
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "existing-provider", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.NoError(t, err)
+
+	// No entry created in pool
+	p.mu.Lock()
+	assert.Empty(t, p.entries)
+	p.mu.Unlock()
+}
+
+func TestPool_Ensure_ClosedPool(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "some-plugin", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.ErrorIs(t, err, ErrPoolClosed)
+}
+
+func TestPool_Ensure_PoolFull(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0), WithMaxPlugins(1))
+	defer p.Shutdown()
+
+	// Adopt one plugin to fill the pool
+	mockClient := &Client{name: "first", path: "/fake"}
+	p.Adopt("first", mockClient, solution.PluginDependency{Name: "first", Kind: solution.PluginKindProvider}, nil)
+
+	// Try to ensure a second plugin — should fail
+	deps := []solution.PluginDependency{
+		{Name: "second", Kind: solution.PluginKindProvider},
+	}
+	err := p.Ensure(context.Background(), deps)
+	assert.ErrorIs(t, err, ErrPoolFull)
+}
+
+func TestPool_Ensure_NilFetcher(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "needs-fetch", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fetcher not available")
+}
+
+func TestPool_Ensure_SkipsNonProvider(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "auth-thing", Kind: solution.PluginKindAuthHandler},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.NoError(t, err)
+
+	p.mu.Lock()
+	assert.Empty(t, p.entries)
+	p.mu.Unlock()
+}
+
+func TestPool_Ensure_ConcurrentSamePlugin(t *testing.T) {
+	reg := provider.NewRegistry()
+	// Pre-adopt a plugin so Ensure is a no-op wait
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "shared", path: "/fake"}
+	dep := solution.PluginDependency{Name: "shared", Kind: solution.PluginKindProvider}
+	p.Adopt("shared", mockClient, dep, nil)
+
+	// Multiple goroutines Ensure the same plugin — all should succeed
+	var wg sync.WaitGroup
+	errs := make([]error, 10)
+	for i := range 10 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = p.Ensure(context.Background(), []solution.PluginDependency{dep})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d", i)
+	}
+}
+
+func TestPool_Ensure_ContextCancelled(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Create an entry stuck in entryStarting state
+	ready := make(chan struct{}) // never closed
+	entry := &poolEntry{
+		state: entryStarting,
+		dep:   solution.PluginDependency{Name: "stuck", Kind: solution.PluginKindProvider},
+		ready: ready,
+	}
+	p.mu.Lock()
+	p.entries["stuck"] = entry
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancelled
+
+	err := p.Ensure(ctx, []solution.PluginDependency{
+		{Name: "stuck", Kind: solution.PluginKindProvider},
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestPool_AcquireRelease(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "acq", path: "/fake"}
+	dep := solution.PluginDependency{Name: "acq", Kind: solution.PluginKindProvider}
+	p.Adopt("acq", mockClient, dep, nil)
+
+	ok := p.Acquire("acq")
+	assert.True(t, ok)
+
+	p.mu.Lock()
+	entry := p.entries["acq"]
+	p.mu.Unlock()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&entry.refCount))
+
+	p.Release("acq")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&entry.refCount))
+}
+
+func TestPool_Acquire_NotFound(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	ok := p.Acquire("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestPool_Acquire_Dead(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	ready := make(chan struct{})
+	close(ready)
+	entry := &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "dead", Kind: solution.PluginKindProvider},
+		ready: ready,
+	}
+	p.mu.Lock()
+	p.entries["dead"] = entry
+	p.mu.Unlock()
+
+	ok := p.Acquire("dead")
+	assert.False(t, ok)
+}
+
+func TestPool_Release_NotFound(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Should not panic
+	p.Release("nonexistent")
+}
+
+func TestPool_markDead_AlreadyDead(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	entry := &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "already-dead", Kind: solution.PluginKindProvider},
+		ready: make(chan struct{}),
+	}
+	close(entry.ready)
+
+	// Should be a no-op — state remains dead, no panic.
+	p.markDead("already-dead", entry, errors.New("test"))
+	assert.Equal(t, entryDead, entry.state)
+}
+
+func TestPool_markDead_ReadyNoClient(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	entry := &poolEntry{
+		state:  entryReady,
+		client: nil,
+		dep:    solution.PluginDependency{Name: "no-client", Kind: solution.PluginKindProvider},
+		ready:  make(chan struct{}),
+	}
+	close(entry.ready)
+
+	reason := errors.New("connection lost")
+	p.markDead("no-client", entry, reason)
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	assert.Equal(t, entryDead, entry.state)
+	assert.Equal(t, reason, entry.err)
+}
+
+func TestPool_markDead_ReadyWithClient(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Use a client with nil pluginClient and nil plugin — Kill is a no-op
+	client := &Client{name: "kill-me", path: "/fake"}
+	entry := &poolEntry{
+		state:  entryReady,
+		client: client,
+		dep:    solution.PluginDependency{Name: "kill-me", Kind: solution.PluginKindProvider},
+		ready:  make(chan struct{}),
+	}
+	close(entry.ready)
+
+	reason := errors.New("health check failed")
+	p.markDead("kill-me", entry, reason)
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	assert.Equal(t, entryDead, entry.state)
+	assert.Equal(t, reason, entry.err)
+}
+
+func TestPoolEntry_failWith(t *testing.T) {
+	entry := &poolEntry{
+		state: entryStarting,
+		ready: make(chan struct{}),
+	}
+
+	testErr := errors.New("spawn failed")
+	entry.failWith(testErr)
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	assert.Equal(t, entryDead, entry.state)
+	assert.Equal(t, testErr, entry.err)
+}
+
+func TestPool_Ping_NotFound(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	ok := p.Ping(context.Background(), "nonexistent")
+	assert.False(t, ok)
+}
+
+func TestPool_Ping_Dead(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	ready := make(chan struct{})
+	close(ready)
+	entry := &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "dead-ping", Kind: solution.PluginKindProvider},
+		ready: ready,
+	}
+	p.mu.Lock()
+	p.entries["dead-ping"] = entry
+	p.mu.Unlock()
+
+	ok := p.Ping(context.Background(), "dead-ping")
+	assert.False(t, ok)
+}
+
+func TestPool_Stats(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Empty pool
+	stats := p.Stats()
+	assert.Equal(t, 0, stats.Total)
+
+	// Add an idle entry
+	ready1 := make(chan struct{})
+	close(ready1)
+	p.mu.Lock()
+	p.entries["idle1"] = &poolEntry{
+		state:  entryReady,
+		client: &Client{name: "idle1", path: "/fake"},
+		dep:    solution.PluginDependency{Name: "idle1", Kind: solution.PluginKindProvider},
+		ready:  ready1,
+	}
+	p.mu.Unlock()
+
+	// Add an active entry
+	ready2 := make(chan struct{})
+	close(ready2)
+	p.mu.Lock()
+	p.entries["active1"] = &poolEntry{
+		state:    entryReady,
+		client:   &Client{name: "active1", path: "/fake"},
+		dep:      solution.PluginDependency{Name: "active1", Kind: solution.PluginKindProvider},
+		ready:    ready2,
+		refCount: 2,
+	}
+	p.mu.Unlock()
+
+	// Add a dead entry
+	ready3 := make(chan struct{})
+	close(ready3)
+	p.mu.Lock()
+	p.entries["dead1"] = &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "dead1", Kind: solution.PluginKindProvider},
+		ready: ready3,
+	}
+	p.mu.Unlock()
+
+	stats = p.Stats()
+	assert.Equal(t, 3, stats.Total)
+	assert.Equal(t, 1, stats.Idle)
+	assert.Equal(t, 1, stats.Active)
+	assert.Equal(t, 1, stats.Dead)
+	assert.Equal(t, 0, stats.Evicted)
+}
+
+func TestPool_Evict_IdleEntries(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(5*time.Minute),
+		withClock(clock),
+	)
+	defer p.Shutdown()
+
+	// Add an idle entry with old lastUsed
+	ready := make(chan struct{})
+	close(ready)
+	p.mu.Lock()
+	p.entries["old"] = &poolEntry{
+		state:    entryReady,
+		client:   &Client{name: "old", path: "/fake"},
+		dep:      solution.PluginDependency{Name: "old", Kind: solution.PluginKindProvider},
+		ready:    ready,
+		lastUsed: now.Add(-10 * time.Minute), // 10 min idle
+	}
+	p.mu.Unlock()
+
+	// Run eviction
+	p.evict()
+
+	p.mu.Lock()
+	_, exists := p.entries["old"]
+	evicted := p.evicted
+	p.mu.Unlock()
+	assert.False(t, exists)
+	assert.Equal(t, 1, evicted)
+}
+
+func TestPool_Evict_SkipsActiveEntries(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(5*time.Minute),
+		withClock(clock),
+	)
+	defer p.Shutdown()
+
+	// Add entry with refCount > 0 even though lastUsed is old
+	ready := make(chan struct{})
+	close(ready)
+	p.mu.Lock()
+	p.entries["active"] = &poolEntry{
+		state:    entryReady,
+		client:   &Client{name: "active", path: "/fake"},
+		dep:      solution.PluginDependency{Name: "active", Kind: solution.PluginKindProvider},
+		ready:    ready,
+		lastUsed: now.Add(-10 * time.Minute),
+		refCount: 1, // in use
+	}
+	p.mu.Unlock()
+
+	p.evict()
+
+	p.mu.Lock()
+	_, exists := p.entries["active"]
+	p.mu.Unlock()
+	assert.True(t, exists, "active entry should not be evicted")
+}
+
+func TestPool_Evict_DeadEntries(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(5*time.Minute),
+	)
+	defer p.Shutdown()
+
+	ready := make(chan struct{})
+	close(ready)
+	p.mu.Lock()
+	p.entries["dead"] = &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "dead", Kind: solution.PluginKindProvider},
+		ready: ready,
+	}
+	p.mu.Unlock()
+
+	p.evict()
+
+	p.mu.Lock()
+	_, exists := p.entries["dead"]
+	evicted := p.evicted
+	p.mu.Unlock()
+	assert.False(t, exists)
+	assert.Equal(t, 1, evicted)
+}
+
+func TestPool_Shutdown(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+
+	mockClient := &Client{name: "shutdown-test", path: "/fake"}
+	dep := solution.PluginDependency{Name: "shutdown-test", Kind: solution.PluginKindProvider}
+	p.Adopt("shutdown-test", mockClient, dep, nil)
+
+	p.Shutdown()
+
+	assert.True(t, p.closed)
+	p.mu.Lock()
+	assert.Empty(t, p.entries)
+	p.mu.Unlock()
+}
+
+func TestPool_Shutdown_Idempotent(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+
+	// Should not panic when called multiple times
+	p.Shutdown()
+	p.Shutdown()
+	p.Shutdown()
+}
+
+func BenchmarkPool_Ensure_HotPath(b *testing.B) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "bench", path: "/fake"}
+	dep := solution.PluginDependency{Name: "bench", Kind: solution.PluginKindProvider}
+	p.Adopt("bench", mockClient, dep, nil)
+
+	ctx := context.Background()
+	deps := []solution.PluginDependency{dep}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_ = p.Ensure(ctx, deps)
+	}
+}
+
+func BenchmarkPool_Stats(b *testing.B) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Populate with 20 entries
+	for i := range 20 {
+		name := "plugin-" + string(rune('a'+i))
+		ready := make(chan struct{})
+		close(ready)
+		p.mu.Lock()
+		p.entries[name] = &poolEntry{
+			state:  entryReady,
+			client: &Client{name: name, path: "/fake"},
+			dep:    solution.PluginDependency{Name: name, Kind: solution.PluginKindProvider},
+			ready:  ready,
+		}
+		p.mu.Unlock()
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_ = p.Stats()
+	}
+}
+
+func BenchmarkPool_AcquireRelease(b *testing.B) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "bench-ar", path: "/fake"}
+	dep := solution.PluginDependency{Name: "bench-ar", Kind: solution.PluginKindProvider}
+	p.Adopt("bench-ar", mockClient, dep, nil)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		p.Acquire("bench-ar")
+		p.Release("bench-ar")
+	}
+}
+
+// --- Security mitigation tests ---
+
+func TestPool_Ensure_ExternalDisabled(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithDisableExternal(true),
+	)
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "malicious-plugin", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.ErrorIs(t, err, ErrExternalDisabled)
+}
+
+func TestPool_Ensure_ExternalDisabled_AdoptedBypasses(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithDisableExternal(true),
+	)
+	defer p.Shutdown()
+
+	// Pre-adopted plugins should still work
+	mockClient := &Client{name: "official", path: "/fake"}
+	dep := solution.PluginDependency{Name: "official", Kind: solution.PluginKindProvider}
+	p.Adopt("official", mockClient, dep, nil)
+
+	err := p.Ensure(context.Background(), []solution.PluginDependency{dep})
+	assert.NoError(t, err)
+}
+
+func TestPool_Ensure_AllowedPlugins_Rejected(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithAllowedPlugins([]string{"safe-plugin", "another-safe"}),
+	)
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "not-on-list", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	assert.ErrorIs(t, err, ErrPluginNotAllowed)
+}
+
+func TestPool_Ensure_AllowedPlugins_Permitted(t *testing.T) {
+	reg := provider.NewRegistry()
+	// Use nil fetcher — plugin is allowed but will fail at fetch stage
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithAllowedPlugins([]string{"safe-plugin"}),
+	)
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "safe-plugin", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	// Fails at fetcher (nil), not at allowlist — proving it passed the check
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrPluginNotAllowed)
+	assert.Contains(t, err.Error(), "fetcher not available")
+}
+
+func TestPool_Ensure_AllowedPlugins_Empty_AllowsAll(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithAllowedPlugins([]string{}), // empty = no restriction
+	)
+	defer p.Shutdown()
+
+	deps := []solution.PluginDependency{
+		{Name: "any-plugin", Kind: solution.PluginKindProvider},
+	}
+
+	err := p.Ensure(context.Background(), deps)
+	// Should pass allowlist, fail at fetcher
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrPluginNotAllowed)
+}
+
+func TestPool_Ensure_AllowedPlugins_AdoptedBypasses(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithAllowedPlugins([]string{"only-this"}),
+	)
+	defer p.Shutdown()
+
+	// Adopt a plugin NOT on the allowlist — should still work via Adopt
+	mockClient := &Client{name: "not-on-list", path: "/fake"}
+	dep := solution.PluginDependency{Name: "not-on-list", Kind: solution.PluginKindProvider}
+	p.Adopt("not-on-list", mockClient, dep, nil)
+
+	err := p.Ensure(context.Background(), []solution.PluginDependency{dep})
+	assert.NoError(t, err)
+}
+
+func TestWithAllowedPlugins_Nil(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithAllowedPlugins(nil),
+	)
+	defer p.Shutdown()
+
+	assert.Nil(t, p.opts.allowedPlugins)
+}
+
+func TestWithDisableExternal(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithDisableExternal(true),
+	)
+	defer p.Shutdown()
+
+	assert.True(t, p.opts.disableExternal)
+}
+
+func TestPoolErrorHTTPStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		err      error
+		expected int
+	}{
+		{"not allowed", fmt.Errorf("plugin %q: %w", "foo", ErrPluginNotAllowed), 403},
+		{"external disabled", fmt.Errorf("plugin %q: %w", "bar", ErrExternalDisabled), 403},
+		{"pool full", fmt.Errorf("plugin %q: %w", "baz", ErrPoolFull), 503},
+		{"pool closed", ErrPoolClosed, 503},
+		{"context canceled", fmt.Errorf("fetching: %w", context.Canceled), 499},
+		{"deadline exceeded", fmt.Errorf("fetching: %w", context.DeadlineExceeded), 504},
+		{"generic error", errors.New("some rpc failure"), 502},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, PoolErrorHTTPStatus(tt.err))
+		})
+	}
+}
+
+func TestPool_EnsureAndAcquire_Adopted(t *testing.T) {
+	t.Parallel()
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	mockClient := &Client{name: "adopted-plugin", path: "/fake"}
+	dep := solution.PluginDependency{Name: "adopted-plugin", Kind: solution.PluginKindProvider}
+	p.Adopt("adopted-plugin", mockClient, dep, nil)
+
+	release, err := p.EnsureAndAcquire(context.Background(), []solution.PluginDependency{dep})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+
+	// refCount should be incremented
+	p.mu.Lock()
+	entry := p.entries["adopted-plugin"]
+	p.mu.Unlock()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&entry.refCount))
+
+	// After release, refCount goes back to 0
+	release()
+	assert.Equal(t, int32(0), atomic.LoadInt32(&entry.refCount))
+}
+
+func TestPool_EnsureAndAcquire_Error(t *testing.T) {
+	t.Parallel()
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// No fetcher — Ensure will fail
+	deps := []solution.PluginDependency{
+		{Name: "unfetchable", Kind: solution.PluginKindProvider},
+	}
+
+	release, err := p.EnsureAndAcquire(context.Background(), deps)
+	assert.Error(t, err)
+	assert.Nil(t, release)
+}
+
+func TestPool_EnsureOne_RemovesDeadEntry(t *testing.T) {
+	t.Parallel()
+	reg := provider.NewRegistry()
+	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	// Inject a dead entry directly
+	ready := make(chan struct{})
+	close(ready)
+	entry := &poolEntry{
+		state: entryDead,
+		dep:   solution.PluginDependency{Name: "dead-plugin", Kind: solution.PluginKindProvider},
+		err:   errors.New("process crashed"),
+		ready: ready,
+	}
+	p.mu.Lock()
+	p.entries["dead-plugin"] = entry
+	p.mu.Unlock()
+
+	// Ensure should fail (entry is dead) but also remove the dead entry
+	err := p.Ensure(context.Background(), []solution.PluginDependency{
+		{Name: "dead-plugin", Kind: solution.PluginKindProvider},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dead")
+
+	// The dead entry should have been removed from the map
+	p.mu.Lock()
+	_, exists := p.entries["dead-plugin"]
+	p.mu.Unlock()
+	assert.False(t, exists, "dead entry should be removed so plugin can recover")
+}
+
+func TestPoolEntry_RegisteredProviders(t *testing.T) {
+	t.Parallel()
+	// Verify the registeredProviders field is correctly stored
+	entry := &poolEntry{
+		state:               entryReady,
+		registeredProviders: []string{"exec", "git", "directory"},
+	}
+	assert.Equal(t, []string{"exec", "git", "directory"}, entry.registeredProviders)
+}

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -733,6 +733,25 @@ func missingOfficialProviders(
 // auth registry. Returns an error when the catalog chain cannot be built.
 // Callers should treat errors as non-fatal: plugin auto-fetch is simply disabled.
 func BuildPluginFetcher(ctx context.Context) (*plugin.Fetcher, error) {
+	return BuildPluginFetcherWithConfig(ctx, PluginFetcherOverrides{})
+}
+
+// PluginFetcherOverrides holds the subset of FetcherConfig fields that
+// BuildPluginFetcherWithConfig can override. Other fields (Catalog,
+// BinaryName, Logger, Cache) are always derived from context.
+type PluginFetcherOverrides struct {
+	// AllowedCatalogs restricts which catalog names plugins may be fetched from.
+	AllowedCatalogs []string
+	// Platform overrides the target platform. If empty, auto-detected.
+	Platform string
+	// NoCache bypasses the local cache when true.
+	NoCache bool
+}
+
+// BuildPluginFetcherWithConfig creates a plugin.Fetcher from the context's
+// config and auth registry, applying optional overrides for policy fields.
+// Catalog, BinaryName, Logger, and Cache are always derived from context.
+func BuildPluginFetcherWithConfig(ctx context.Context, override PluginFetcherOverrides) (*plugin.Fetcher, error) {
 	lgr := logger.FromContext(ctx)
 	var fetcherLogger logr.Logger
 	if lgr != nil {
@@ -747,11 +766,20 @@ func BuildPluginFetcher(ctx context.Context) (*plugin.Fetcher, error) {
 		fetcherLogger.V(1).Info("catalog chain not available, plugin auto-fetch disabled", "error", err)
 		return nil, fmt.Errorf("building catalog chain: %w", err)
 	}
-	return plugin.NewFetcher(plugin.FetcherConfig{
-		Catalog:    catalogChain,
-		BinaryName: settings.BinaryNameFromContext(ctx),
-		Logger:     fetcherLogger,
-	}), nil
+
+	cfg := plugin.FetcherConfig{
+		Catalog:         catalogChain,
+		BinaryName:      settings.BinaryNameFromContext(ctx),
+		Logger:          fetcherLogger,
+		AllowedCatalogs: override.AllowedCatalogs,
+	}
+	if override.Platform != "" {
+		cfg.Platform = override.Platform
+	}
+	if override.NoCache {
+		cfg.NoCache = true
+	}
+	return plugin.NewFetcher(cfg), nil
 }
 
 // ResolveOfficialProviders fetches any official providers referenced by the

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -22,10 +23,12 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/api/endpoints"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/fileprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/messageprovider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
 
 // setupTestServer creates a test HTTP server with all endpoints registered.
@@ -1876,4 +1879,214 @@ func TestAPI_OpenAPISpec_ErrorCodesPresent(t *testing.T) {
 		_, exists := responses[code]
 		assert.True(t, exists, "expected %s response in admin-info endpoint", code)
 	}
+}
+
+// setupTestServerWithPool creates a test server with a plugin pool configured.
+func setupTestServerWithPool(t testing.TB, poolOpts ...plugin.PoolOption) *httptest.Server {
+	t.Helper()
+
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			APIVersion: settings.DefaultAPIVersion,
+		},
+	}
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
+	require.NoError(t, reg.Register(fileprovider.NewFileProvider()))
+
+	pool := plugin.NewPool(nil, reg, logr.Discard(), poolOpts...)
+	t.Cleanup(pool.Shutdown)
+
+	srv, err := api.NewServer(
+		api.WithServerConfig(cfg),
+		api.WithServerVersion("test-dev"),
+		api.WithServerRegistry(reg),
+		api.WithServerPluginPool(pool),
+	)
+	require.NoError(t, err)
+
+	apiRouter, err := api.SetupMiddleware(t.Context(), srv.Router(), &cfg.APIServer, logr.Discard())
+	require.NoError(t, err)
+	srv.SetAPIRouter(apiRouter)
+	srv.InitAPI()
+
+	hctx := srv.HandlerCtx()
+	endpoints.RegisterAll(srv.API(), srv.Router(), hctx)
+
+	return httptest.NewServer(srv.Router())
+}
+
+// serveSolutionWithPlugins creates an HTTP server that serves a solution YAML
+// referencing external plugins. Returns the URL to the solution.
+func serveSolutionWithPlugins(t *testing.T) string {
+	t.Helper()
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: plugin-test
+  description: Test solution with external plugin dependency
+spec:
+  resolvers:
+    greeting:
+      description: A greeting
+      type: string
+      resolve:
+        with:
+          - provider: message
+            inputs:
+              message: hello
+bundle:
+  plugins:
+    - name: external-plugin
+      kind: provider
+`
+	solServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(content))
+	}))
+	t.Cleanup(solServer.Close)
+	return solServer.URL + "/solution.yaml"
+}
+
+// TestAPI_SolutionDryRun_PluginExternalDisabled verifies that the dryrun
+// endpoint returns 403 when external plugins are disabled.
+func TestAPI_SolutionDryRun_PluginExternalDisabled(t *testing.T) {
+	ts := setupTestServerWithPool(t, plugin.WithIdleTimeout(0), plugin.WithDisableExternal(true))
+	defer ts.Close()
+	e := httpexpect.Default(t, ts.URL)
+
+	solURL := serveSolutionWithPlugins(t)
+
+	e.POST("/v1/solutions/dryrun").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusForbidden).
+		HasContentType("application/problem+json").
+		Body().Contains("external plugins disabled")
+}
+
+// TestAPI_SolutionRun_PluginNotAllowed verifies that the run endpoint
+// returns 403 when a plugin is not on the allowlist.
+func TestAPI_SolutionRun_PluginNotAllowed(t *testing.T) {
+	ts := setupTestServerWithPool(t,
+		plugin.WithIdleTimeout(0),
+		plugin.WithAllowedPlugins([]string{"only-this-one"}),
+	)
+	defer ts.Close()
+	e := httpexpect.Default(t, ts.URL)
+
+	solURL := serveSolutionWithPlugins(t)
+
+	e.POST("/v1/solutions/run").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusForbidden).
+		HasContentType("application/problem+json").
+		Body().Contains("not in allowlist")
+}
+
+// TestAPI_SolutionRender_PluginPoolFull verifies that the render endpoint
+// returns 503 when the plugin pool is at capacity.
+func TestAPI_SolutionRender_PluginPoolFull(t *testing.T) {
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			APIVersion: settings.DefaultAPIVersion,
+		},
+	}
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
+
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0), plugin.WithMaxPlugins(1))
+	t.Cleanup(pool.Shutdown)
+
+	// Adopt a nil client to fill the single slot
+	pool.Adopt("filler-plugin", nil, solution.PluginDependency{
+		Name: "filler-plugin",
+		Kind: solution.PluginKindProvider,
+	}, nil)
+
+	srv, err := api.NewServer(
+		api.WithServerConfig(cfg),
+		api.WithServerVersion("test-dev"),
+		api.WithServerRegistry(reg),
+		api.WithServerPluginPool(pool),
+	)
+	require.NoError(t, err)
+
+	apiRouter, err := api.SetupMiddleware(t.Context(), srv.Router(), &cfg.APIServer, logr.Discard())
+	require.NoError(t, err)
+	srv.SetAPIRouter(apiRouter)
+	srv.InitAPI()
+	endpoints.RegisterAll(srv.API(), srv.Router(), srv.HandlerCtx())
+
+	ts := httptest.NewServer(srv.Router())
+	defer ts.Close()
+	e := httpexpect.Default(t, ts.URL)
+
+	solURL := serveSolutionWithPlugins(t)
+
+	e.POST("/v1/solutions/render").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusServiceUnavailable)
+}
+
+// TestAPI_SolutionRun_AllowedCatalogs_Rejected verifies that the run endpoint
+// rejects a plugin when the fetcher's allowedCatalogs blocks it end-to-end.
+func TestAPI_SolutionRun_AllowedCatalogs_Rejected(t *testing.T) {
+	// Create a pre-populated plugin cache so the fetcher takes the cache path
+	// (which now validates allowedCatalogs).
+	cacheDir := t.TempDir()
+	platform := plugin.CurrentPlatform()
+	pluginName := "external-plugin"
+	pluginBinDir := cacheDir + "/" + pluginName + "/1.0.0/" + plugin.PlatformCacheKey(platform)
+	require.NoError(t, os.MkdirAll(pluginBinDir, 0o755))
+	// Create a fake executable so the cache recognizes it.
+	require.NoError(t, os.WriteFile(pluginBinDir+"/"+pluginName, []byte("#!/bin/sh\n"), 0o755))
+
+	fetcher := plugin.NewFetcher(plugin.FetcherConfig{
+		Cache:           plugin.NewCache(cacheDir),
+		Platform:        platform,
+		AllowedCatalogs: []string{"approved-only"},
+		Logger:          logr.Discard(),
+	})
+
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			APIVersion: settings.DefaultAPIVersion,
+		},
+	}
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
+
+	pool := plugin.NewPool(fetcher, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	t.Cleanup(pool.Shutdown)
+
+	srv, err := api.NewServer(
+		api.WithServerConfig(cfg),
+		api.WithServerVersion("test-dev"),
+		api.WithServerRegistry(reg),
+		api.WithServerPluginPool(pool),
+	)
+	require.NoError(t, err)
+
+	apiRouter, err := api.SetupMiddleware(t.Context(), srv.Router(), &cfg.APIServer, logr.Discard())
+	require.NoError(t, err)
+	srv.SetAPIRouter(apiRouter)
+	srv.InitAPI()
+	endpoints.RegisterAll(srv.API(), srv.Router(), srv.HandlerCtx())
+
+	ts := httptest.NewServer(srv.Router())
+	defer ts.Close()
+	e := httpexpect.Default(t, ts.URL)
+
+	solURL := serveSolutionWithPlugins(t)
+
+	e.POST("/v1/solutions/run").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusBadGateway).
+		HasContentType("application/problem+json").
+		Body().Contains("failed to load required plugins")
 }

--- a/tests/integration/solutions/lint-hyphenated-name/solution.yaml
+++ b/tests/integration/solutions/lint-hyphenated-name/solution.yaml
@@ -1,0 +1,52 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-hyphenated-name
+  version: 1.0.0
+  description: |
+    Tests the hyphenated-name lint rule that warns when resolver names
+    contain hyphens (which require quoting in CEL expressions).
+
+spec:
+  resolvers:
+    # This resolver has a hyphenated name — should trigger lint info
+    my-service-name:
+      description: Resolver with hyphenated name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+    # This resolver uses underscores — should NOT trigger lint info
+    my_safe_name:
+      description: Resolver with underscored name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: world
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      hyphenated-name-detected:
+        description: Lint detects hyphenated resolver name
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, hyphenated-name]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Hyphenated name is info-level, should not cause non-zero exit"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "hyphenated-name")
+            message: "Should detect hyphenated resolver name"
+          - expression: >
+              __output.findings.filter(f, f.ruleName == "hyphenated-name").size() == 1
+            message: "Should only flag the hyphenated resolver, not the underscored one"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "hyphenated-name" && f.severity == "info")
+            message: "Hyphenated-name finding should be info severity"

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -200,6 +200,37 @@ spec:
               ignoredBlocks:
                 - line: "# scafctl:ignore"
 
+    # Test: name input is optional (defaults to "template")
+    optionalNameTemplate:
+      description: Template without explicit name input
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: "Service: {{.appName}}"
+
+    # Test: nil-safe len function
+    nilSafeLenTemplate:
+      description: Template using len on nil value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: "count={{ len .items }}"
+              data:
+                items: null
+
   testing:
     config:
       # render-defaults: solution has no workflow.actions section
@@ -291,3 +322,17 @@ spec:
             message: "Line with ignore marker should be preserved literally"
           - expression: '__output.ignoredBlocksLineTemplate.contains("echo \"deployed\"")'
             message: "Non-ignored lines should render normally"
+
+      optional-name:
+        description: Verify template works without explicit name input
+        extends: [_base]
+        tags: [optional-name]
+        assertions:
+          - expression: '__output.optionalNameTemplate == "Service: my-service"'
+
+      nil-safe-len:
+        description: Verify len returns 0 for nil/missing values
+        extends: [_base]
+        tags: [safelen]
+        assertions:
+          - expression: '__output.nilSafeLenTemplate == "count=0"'

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -83,6 +83,36 @@ spec:
               expression: "size(__self) >= 3 && size(__self) <= 20"
             message: "Must be between 3 and 20 characters"
 
+    # Dynamic message with expr: prefix
+    dynamicExprMessage:
+      description: Value validated with a dynamic CEL error message
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: valid-name
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^[a-z][a-z0-9-]*$"
+              message: "expr: 'Name \"' + string(__self) + '\" is valid'"
+
+    # Dynamic message with tmpl: prefix
+    dynamicTmplMessage:
+      description: Value validated with a dynamic Go template error message
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello-world
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "size(__self) <= 63"
+              message: "tmpl: Value '{{.__self}}' exceeds max length"
+
   testing:
     config:
       # render-defaults: solution has no workflow.actions section
@@ -127,3 +157,17 @@ spec:
         extends: [_base]
         assertions:
           - expression: '__output.multiValidation == "hello"'
+
+      dynamic-expr-message:
+        description: Verify dynamic CEL message resolver passes
+        extends: [_base]
+        tags: [dynamic-message]
+        assertions:
+          - expression: '__output.dynamicExprMessage == "valid-name"'
+
+      dynamic-tmpl-message:
+        description: Verify dynamic Go template message resolver passes
+        extends: [_base]
+        tags: [dynamic-message]
+        assertions:
+          - expression: '__output.dynamicTmplMessage == "hello-world"'


### PR DESCRIPTION
- introduce Pool type with Adopt/Ensure/Acquire/Release lifecycle, idle eviction loop, health-check ping, and allowlist enforcement
- add pluginRPCTimeout constant and unregisterAndKill helper to prevent blocking on unresponsive plugin processes
- extract failWith helper on poolEntry to reduce spawn complexity
- sanitize environment variables passed to plugin child processes (WithSanitizedEnv client option, safeEnvKeys allowlist)
- add AllowedCatalogs field to Fetcher for catalog-level restriction
- wire PluginPool into API server endpoints (dryrun/run/render) via HandlerContext and server options
- extract buildPluginPool helper in serve command for clarity
- register "hyphenated-name" lint rule in KnownRules
- add design doc, tutorial updates, and integration test solutions for validation, go-template, and lint-hyphenated-name features