### PR TITLE
feat(auth): add official auth handler auto-resolution

### DIFF
--- a/pkg/api/filtering.go
+++ b/pkg/api/filtering.go
@@ -32,7 +32,7 @@ func FilterItems[T any](ctx context.Context, items []T, filter string) ([]T, err
 		rt := reflect.TypeOf(items[0])
 		if rt.Kind() == reflect.Struct {
 			needsNormalize = true
-		} else if rt.Kind() == reflect.Ptr && rt.Elem().Kind() == reflect.Struct {
+		} else if rt.Kind() == reflect.Pointer && rt.Elem().Kind() == reflect.Struct {
 			needsNormalize = true
 		}
 	}

--- a/pkg/auth/official/official.go
+++ b/pkg/auth/official/official.go
@@ -1,0 +1,171 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package official defines the registry of first-party auth handlers that will
+// be extracted from scafctl's built-in set into standalone plugin repos. The
+// registry drives auto-resolution: when a CLI command or solution references an
+// auth handler that isn't registered (built-in, config-defined, or plugin), the
+// runtime checks this list and auto-fetches from the official OCI catalog.
+package official
+
+import (
+	"context"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+type contextKey struct{}
+
+// WithRegistry stores an official auth handler registry in the context.
+// Used by RootOptions to propagate the embedder's registry to downstream code.
+func WithRegistry(ctx context.Context, r *Registry) context.Context {
+	return context.WithValue(ctx, contextKey{}, r)
+}
+
+// RegistryFromContext retrieves the official auth handler registry from the
+// context. Returns nil if not set.
+func RegistryFromContext(ctx context.Context) *Registry {
+	r, _ := ctx.Value(contextKey{}).(*Registry)
+	return r
+}
+
+// AuthHandler describes an official first-party auth handler available from the
+// oakwood-commons OCI catalog.
+type AuthHandler struct {
+	// Name is the auth handler name used in CLI commands and solution YAML
+	// (e.g., "github").
+	Name string
+
+	// CatalogRef is the OCI artifact name within the catalog
+	// (e.g., "github" resolves to ghcr.io/oakwood-commons/auth-handlers/github).
+	CatalogRef string
+
+	// DefaultVersion is the semver constraint applied when auto-resolving
+	// (e.g., ">=0.1.0").
+	DefaultVersion string
+
+	// MinSDKVersion is the minimum plugin SDK version required for this handler.
+	MinSDKVersion string
+
+	// TrustedVerificationDomains are known-good identity provider domains for
+	// device code URL validation. These are hardcoded for official handlers and
+	// merged with user-configurable domains at runtime.
+	TrustedVerificationDomains []string
+}
+
+// defaultAuthHandlers is the canonical list of all 3 auth handlers planned for
+// extraction. Sorted alphabetically by name.
+//
+// DefaultVersion is "latest" so the catalog resolver picks the newest
+// available version. This avoids hard-coding a concrete semver that must
+// be bumped after every handler release.
+var defaultAuthHandlers = []AuthHandler{
+	{
+		Name:           "entra",
+		CatalogRef:     "entra",
+		DefaultVersion: "latest",
+		MinSDKVersion:  "0.2.0",
+		TrustedVerificationDomains: []string{
+			"login.microsoftonline.com",
+			"login.microsoft.com",
+		},
+	},
+	{
+		Name:           "gcp",
+		CatalogRef:     "gcp",
+		DefaultVersion: "latest",
+		MinSDKVersion:  "0.2.0",
+		TrustedVerificationDomains: []string{
+			"accounts.google.com",
+		},
+	},
+	{
+		Name:           "github",
+		CatalogRef:     "github",
+		DefaultVersion: "latest",
+		MinSDKVersion:  "0.2.0",
+		TrustedVerificationDomains: []string{
+			"github.com",
+		},
+	},
+}
+
+// Registry holds the set of known official auth handlers.
+type Registry struct {
+	handlers map[string]AuthHandler
+}
+
+// NewRegistry returns the default official auth handler registry containing
+// all 3 auth handlers planned for extraction.
+func NewRegistry() *Registry {
+	return NewRegistryFrom(defaultAuthHandlers)
+}
+
+// NewRegistryFrom creates a registry from a custom auth handler list.
+// Embedders use this via RootOptions.OfficialAuthHandlers to extend or
+// replace the default set.
+func NewRegistryFrom(handlers []AuthHandler) *Registry {
+	m := make(map[string]AuthHandler, len(handlers))
+	for _, h := range handlers {
+		m[h.Name] = h
+	}
+	return &Registry{handlers: m}
+}
+
+// DefaultAuthHandlers returns a copy of the 3 official auth handler entries.
+// Embedders can append their own entries and pass the result to
+// NewRegistryFrom to extend rather than replace the defaults.
+func DefaultAuthHandlers() []AuthHandler {
+	out := make([]AuthHandler, len(defaultAuthHandlers))
+	copy(out, defaultAuthHandlers)
+	return out
+}
+
+// Get returns the official auth handler entry and true if name is a known
+// official auth handler, or a zero AuthHandler and false otherwise.
+func (r *Registry) Get(name string) (AuthHandler, bool) {
+	h, ok := r.handlers[name]
+	return h, ok
+}
+
+// MustGet returns the official auth handler entry for name, panicking if not found.
+// Use only when the caller has already verified existence via Has().
+func (r *Registry) MustGet(name string) AuthHandler {
+	h, ok := r.handlers[name]
+	if !ok {
+		panic("official auth handler not found: " + name)
+	}
+	return h
+}
+
+// Has returns true if name is a known official auth handler.
+func (r *Registry) Has(name string) bool {
+	_, ok := r.handlers[name]
+	return ok
+}
+
+// Names returns a sorted list of all official auth handler names.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.handlers))
+	for name := range r.handlers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Len returns the number of auth handlers in the registry.
+func (r *Registry) Len() int {
+	return len(r.handlers)
+}
+
+// ToPluginDependency converts an official auth handler entry to a
+// PluginDependency suitable for the existing plugin auto-fetch pipeline.
+func (h AuthHandler) ToPluginDependency() solution.PluginDependency {
+	return solution.PluginDependency{
+		Name:    h.CatalogRef,
+		Kind:    solution.PluginKindAuthHandler,
+		Version: h.DefaultVersion,
+	}
+}

--- a/pkg/auth/official/official_test.go
+++ b/pkg/auth/official/official_test.go
@@ -1,0 +1,262 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package official
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegistry_Contains3Handlers(t *testing.T) {
+	r := NewRegistry()
+	assert.Equal(t, 3, r.Len())
+}
+
+func TestNewRegistry_AllNamesPresent(t *testing.T) {
+	r := NewRegistry()
+
+	expected := []string{"entra", "gcp", "github"}
+	assert.Equal(t, expected, r.Names())
+}
+
+func TestRegistry_Get(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantFound bool
+		wantName  string
+	}{
+		{name: "known handler github", query: "github", wantFound: true, wantName: "github"},
+		{name: "known handler entra", query: "entra", wantFound: true, wantName: "entra"},
+		{name: "known handler gcp", query: "gcp", wantFound: true, wantName: "gcp"},
+		{name: "unknown handler", query: "nonexistent", wantFound: false},
+		{name: "empty string", query: "", wantFound: false},
+		{name: "builtin handler not extracted", query: "oauth2", wantFound: false},
+	}
+
+	r := NewRegistry()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, ok := r.Get(tt.query)
+			assert.Equal(t, tt.wantFound, ok)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantName, h.Name)
+				assert.NotEmpty(t, h.CatalogRef)
+				assert.NotEmpty(t, h.DefaultVersion)
+				assert.NotEmpty(t, h.MinSDKVersion)
+				assert.NotEmpty(t, h.TrustedVerificationDomains)
+			}
+		})
+	}
+}
+
+func TestRegistry_Has(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{name: "known github", query: "github", want: true},
+		{name: "known entra", query: "entra", want: true},
+		{name: "known gcp", query: "gcp", want: true},
+		{name: "unknown", query: "aws", want: false},
+		{name: "builtin not extracted", query: "oauth2", want: false},
+	}
+
+	r := NewRegistry()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, r.Has(tt.query))
+		})
+	}
+}
+
+func TestRegistry_Names_Sorted(t *testing.T) {
+	r := NewRegistry()
+	names := r.Names()
+
+	require.NotEmpty(t, names)
+	for i := 1; i < len(names); i++ {
+		assert.Less(t, names[i-1], names[i], "Names() must return sorted results")
+	}
+}
+
+func TestNewRegistryFrom_CustomHandlers(t *testing.T) {
+	custom := []AuthHandler{
+		{Name: "okta", CatalogRef: "okta", DefaultVersion: ">=1.0.0", MinSDKVersion: "0.2.0"},
+		{Name: "auth0", CatalogRef: "auth0", DefaultVersion: ">=2.0.0", MinSDKVersion: "0.2.0"},
+	}
+
+	r := NewRegistryFrom(custom)
+	assert.Equal(t, 2, r.Len())
+	assert.True(t, r.Has("okta"))
+	assert.True(t, r.Has("auth0"))
+	assert.False(t, r.Has("github"))
+}
+
+func TestNewRegistryFrom_Empty(t *testing.T) {
+	r := NewRegistryFrom(nil)
+	assert.Equal(t, 0, r.Len())
+	assert.Empty(t, r.Names())
+	assert.False(t, r.Has("github"))
+}
+
+func TestNewRegistryFrom_Deduplicates(t *testing.T) {
+	dupes := []AuthHandler{
+		{Name: "foo", CatalogRef: "foo-v1", DefaultVersion: ">=1.0.0"},
+		{Name: "foo", CatalogRef: "foo-v2", DefaultVersion: ">=2.0.0"},
+	}
+
+	r := NewRegistryFrom(dupes)
+	assert.Equal(t, 1, r.Len())
+
+	h, ok := r.Get("foo")
+	require.True(t, ok)
+	assert.Equal(t, "foo-v2", h.CatalogRef, "last entry wins on duplicate name")
+}
+
+func TestDefaultAuthHandlers_ReturnsCopy(t *testing.T) {
+	a := DefaultAuthHandlers()
+	b := DefaultAuthHandlers()
+
+	require.Equal(t, len(a), len(b))
+
+	// Mutating the returned slice must not affect subsequent calls.
+	a[0].Name = "mutated"
+	assert.NotEqual(t, a[0].Name, b[0].Name)
+}
+
+func TestDefaultAuthHandlers_Count(t *testing.T) {
+	assert.Equal(t, 3, len(DefaultAuthHandlers()))
+}
+
+func TestDefaultAuthHandlers_ExtendPattern(t *testing.T) {
+	extended := append(DefaultAuthHandlers(),
+		AuthHandler{Name: "okta", CatalogRef: "okta", DefaultVersion: ">=1.0.0", MinSDKVersion: "0.2.0"},
+	)
+
+	r := NewRegistryFrom(extended)
+	assert.Equal(t, 4, r.Len())
+	assert.True(t, r.Has("github"))
+	assert.True(t, r.Has("okta"))
+}
+
+func TestAuthHandler_ToPluginDependency(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler AuthHandler
+		want    solution.PluginDependency
+	}{
+		{
+			name:    "standard handler",
+			handler: AuthHandler{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+			want: solution.PluginDependency{
+				Name:    "github",
+				Kind:    solution.PluginKindAuthHandler,
+				Version: "latest",
+			},
+		},
+		{
+			name:    "custom catalog ref",
+			handler: AuthHandler{Name: "okta", CatalogRef: "okta-handler", DefaultVersion: ">=1.0.0"},
+			want: solution.PluginDependency{
+				Name:    "okta-handler",
+				Kind:    solution.PluginKindAuthHandler,
+				Version: ">=1.0.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.handler.ToPluginDependency()
+			assert.Equal(t, tt.want.Name, got.Name)
+			assert.Equal(t, tt.want.Kind, got.Kind)
+			assert.Equal(t, tt.want.Version, got.Version)
+			assert.Nil(t, got.Defaults, "auto-resolved handlers have no defaults")
+		})
+	}
+}
+
+func TestAuthHandler_ToPluginDependency_AllDefaults(t *testing.T) {
+	for _, h := range DefaultAuthHandlers() {
+		t.Run(h.Name, func(t *testing.T) {
+			dep := h.ToPluginDependency()
+			assert.Equal(t, h.CatalogRef, dep.Name)
+			assert.Equal(t, solution.PluginKindAuthHandler, dep.Kind)
+			assert.Equal(t, h.DefaultVersion, dep.Version)
+		})
+	}
+}
+
+func TestRegistry_Len(t *testing.T) {
+	tests := []struct {
+		name     string
+		handlers []AuthHandler
+		want     int
+	}{
+		{name: "default", handlers: defaultAuthHandlers, want: 3},
+		{name: "empty", handlers: nil, want: 0},
+		{name: "one", handlers: []AuthHandler{{Name: "x"}}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRegistryFrom(tt.handlers)
+			assert.Equal(t, tt.want, r.Len())
+		})
+	}
+}
+
+func TestRegistry_MustGet_Success(t *testing.T) {
+	r := NewRegistry()
+	h := r.MustGet("github")
+	assert.Equal(t, "github", h.Name)
+}
+
+func TestRegistry_MustGet_Panics(t *testing.T) {
+	r := NewRegistry()
+	assert.Panics(t, func() {
+		r.MustGet("nonexistent")
+	})
+}
+
+func TestWithRegistry_ContextRoundTrip(t *testing.T) {
+	r := NewRegistry()
+	ctx := WithRegistry(context.Background(), r)
+
+	got := RegistryFromContext(ctx)
+	require.NotNil(t, got)
+	assert.Equal(t, 3, got.Len())
+}
+
+func TestRegistryFromContext_NilWhenNotSet(t *testing.T) {
+	got := RegistryFromContext(context.Background())
+	assert.Nil(t, got)
+}
+
+func TestDefaultAuthHandlers_TrustedDomains(t *testing.T) {
+	r := NewRegistry()
+
+	tests := []struct {
+		handler string
+		domains []string
+	}{
+		{handler: "entra", domains: []string{"login.microsoftonline.com", "login.microsoft.com"}},
+		{handler: "gcp", domains: []string{"accounts.google.com"}},
+		{handler: "github", domains: []string{"github.com"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.handler, func(t *testing.T) {
+			h, ok := r.Get(tt.handler)
+			require.True(t, ok)
+			assert.Equal(t, tt.domains, h.TrustedVerificationDomains)
+		})
+	}
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -15,6 +15,7 @@ import (
 	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	customoauth2 "github.com/oakwood-commons/scafctl/pkg/auth/oauth2"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	authcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/build"
@@ -53,6 +54,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/telemetry"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/input"
@@ -171,6 +173,13 @@ type RootOptions struct {
 	// Embedders can supply a custom registry via official.NewRegistryFrom to
 	// extend or replace the default set.
 	OfficialProviders *official.Registry
+
+	// OfficialAuthHandlers overrides the default official auth handler registry
+	// used for auto-resolution. When nil and DisableOfficialAuthHandlers is
+	// false, the default registry (3 extracted first-party auth handlers) is
+	// used. Embedders can supply a custom registry via
+	// authofficial.NewRegistryFrom to extend or replace the default set.
+	OfficialAuthHandlers *authofficial.Registry
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -534,6 +543,24 @@ func Root(opts *RootOptions) *cobra.Command {
 				}
 			}
 
+			// ── Wire official auth handler registry for auto-resolution ──
+			// Must be wired before RegisterAuthHandlerPlugins so that plugin wrappers
+			// can read trusted verification domains from the official registry in context.
+			if !cfg.Settings.DisableOfficialAuthHandlers {
+				authOfficialReg := opts.OfficialAuthHandlers
+				if authOfficialReg == nil {
+					authOfficialReg = authofficial.NewRegistry()
+				}
+				source := "default"
+				if opts.OfficialAuthHandlers != nil {
+					source = "embedder"
+				}
+				lgr.V(1).Info("official auth handler registry enabled", "count", authOfficialReg.Len(), "source", source)
+				ctx = authofficial.WithRegistry(ctx, authOfficialReg)
+			} else {
+				lgr.V(1).Info("official auth handler registry disabled via config")
+			}
+
 			// Register auth handler plugins if directories are configured
 			if len(opts.AuthPluginDirs) > 0 {
 				lgr.V(1).Info("loading auth handler plugins", "dirs", opts.AuthPluginDirs)
@@ -567,6 +594,33 @@ func Root(opts *RootOptions) *cobra.Command {
 				ctx = official.WithRegistry(ctx, officialReg)
 			} else {
 				lgr.V(1).Info("official provider registry disabled via config")
+			}
+
+			// Best-effort auto-fetch of official auth handlers not yet registered.
+			// This covers direct CLI commands (e.g., "auth login github") that bypass
+			// the solution prepare pipeline.
+			if !cfg.Settings.DisableOfficialAuthHandlers {
+				var cooldownDuration time.Duration
+				if cfg.Plugins.FetchCooldown != "" {
+					if parsed, parseErr := time.ParseDuration(cfg.Plugins.FetchCooldown); parseErr == nil {
+						cooldownDuration = parsed
+					} else {
+						lgr.Info("invalid plugins.fetchCooldown value, using default",
+							"value", cfg.Plugins.FetchCooldown,
+							"error", parseErr.Error(),
+							"default", plugin.DefaultFetchCooldown)
+					}
+				}
+				cooldown := plugin.NewFetchCooldown(paths.PluginCacheDir(), cooldownDuration)
+				pluginCfg := &plugin.ProviderConfig{
+					Quiet:      cliParams.IsQuiet,
+					NoColor:    cliParams.NoColor,
+					BinaryName: binaryName,
+				}
+				officialAuthClients, _ := prepare.ResolveOfficialAuthHandlers(ctx, authRegistry, cooldown, pluginCfg)
+				if len(officialAuthClients) > 0 {
+					authPluginClients = append(authPluginClients, officialAuthClients...)
+				}
 			}
 
 			cCmd.SetContext(ctx)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -30,6 +30,7 @@ type Config struct {
 	Build      BuildConfig      `json:"build,omitempty" yaml:"build,omitempty" mapstructure:"build" doc:"Build command configuration"`
 	APIServer  APIServerConfig  `json:"apiServer,omitempty" yaml:"apiServer,omitempty" mapstructure:"apiServer" doc:"REST API server configuration"`
 	Discovery  DiscoveryConfig  `json:"discovery,omitempty" yaml:"discovery,omitempty" mapstructure:"discovery" doc:"Auto-discovery configuration"`
+	Plugins    PluginsConfig    `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin management configuration"`
 }
 
 // DiscoveryStrategy controls how a remote catalog discovers available artifacts.
@@ -110,6 +111,13 @@ type Settings struct {
 	// bundle.plugins. Embedders can set this when their CLI should not
 	// auto-fetch providers from the scafctl community catalog.
 	DisableOfficialProviders bool `json:"disableOfficialProviders,omitempty" yaml:"disableOfficialProviders,omitempty" mapstructure:"disableOfficialProviders" doc:"Disable auto-resolution of official first-party providers"`
+
+	// DisableOfficialAuthHandlers prevents auto-resolution of official first-party
+	// auth handlers (entra, github, gcp) published to ghcr.io/oakwood-commons.
+	// When true, auth handlers must be either built-in or explicitly declared in
+	// bundle.plugins. Embedders can set this when their CLI should not
+	// auto-fetch auth handler plugins from the scafctl community catalog.
+	DisableOfficialAuthHandlers bool `json:"disableOfficialAuthHandlers,omitempty" yaml:"disableOfficialAuthHandlers,omitempty" mapstructure:"disableOfficialAuthHandlers" doc:"Disable auto-resolution of official first-party auth handlers"`
 }
 
 // VersionCheckConfig holds version check configuration.
@@ -404,6 +412,12 @@ type GlobalAuthConfig struct {
 
 	// CustomOAuth2 contains user-defined OAuth2 auth handlers.
 	CustomOAuth2 []CustomOAuth2Config `json:"customOAuth2,omitempty" yaml:"customOAuth2,omitempty" mapstructure:"customOAuth2" doc:"User-defined OAuth2 auth handlers for any OAuth2 service" maxItems:"20"`
+
+	// TrustedVerificationDomains are additional domains trusted for device code
+	// verification URIs across all auth handlers. These supplement the hardcoded
+	// per-handler domains from the official auth handler registry. Use this for
+	// org-specific identity providers (e.g., custom GHES hostnames, corporate IDPs).
+	TrustedVerificationDomains []string `json:"trustedVerificationDomains,omitempty" yaml:"trustedVerificationDomains,omitempty" mapstructure:"trustedVerificationDomains" doc:"Additional trusted domains for device code verification URIs" maxItems:"50"`
 }
 
 // EntraAuthConfig contains Entra-specific configuration.
@@ -523,6 +537,36 @@ func (b *BuildConfig) IsAutoCacheRemoteArtifacts() bool {
 		return true
 	}
 	return *b.AutoCacheRemoteArtifacts
+}
+
+// PluginsConfig holds plugin management configuration.
+type PluginsConfig struct {
+	// Signatures controls Sigstore/cosign signature verification for plugin
+	// artifacts (providers and auth handlers). When mode is "off" (default),
+	// only digest verification is performed.
+	Signatures PluginSignaturesConfig `json:"signatures,omitempty" yaml:"signatures,omitempty" mapstructure:"signatures" doc:"Plugin signature verification configuration"`
+
+	// FetchCooldown is the duration to suppress retry attempts after a plugin
+	// auto-fetch failure. Prevents repeated timeout penalties during network
+	// outages. Use Go duration syntax (e.g., "5m", "30s"). Default: 5m.
+	FetchCooldown string `json:"fetchCooldown,omitempty" yaml:"fetchCooldown,omitempty" mapstructure:"fetchCooldown" doc:"Cooldown between failed auto-fetch retries" maxLength:"20" example:"5m"`
+}
+
+// PluginSignaturesConfig holds Sigstore/cosign verification settings for plugins.
+type PluginSignaturesConfig struct {
+	// Mode controls signature verification behavior:
+	//   - "off" (default): digest-only verification, no signature check
+	//   - "warn": verify signature, log warning on failure but proceed
+	//   - "enforce": verify signature, fail on missing or invalid signature
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" mapstructure:"mode" doc:"Signature verification mode" enum:"off,warn,enforce" maxLength:"10" example:"warn"`
+
+	// TrustedIssuers are OIDC token issuers whose signing certificates are
+	// trusted (e.g., GitHub Actions OIDC provider).
+	TrustedIssuers []string `json:"trustedIssuers,omitempty" yaml:"trustedIssuers,omitempty" mapstructure:"trustedIssuers" doc:"Trusted OIDC certificate issuers" maxItems:"20"`
+
+	// TrustedIdentities are glob patterns matching certificate subject/identity
+	// fields (e.g., "https://github.com/oakwood-commons/*").
+	TrustedIdentities []string `json:"trustedIdentities,omitempty" yaml:"trustedIdentities,omitempty" mapstructure:"trustedIdentities" doc:"Trusted signing identity patterns (glob)" maxItems:"50"`
 }
 
 // DiscoveryConfig holds auto-discovery preferences.

--- a/pkg/config/unknown_keys.go
+++ b/pkg/config/unknown_keys.go
@@ -111,7 +111,7 @@ func getKnownConfigKeys() map[string]bool {
 // Keys are lowercased to match Viper's behavior.
 func extractKeys(t reflect.Type, prefix string, keys map[string]bool) {
 	// Handle pointer types
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -161,7 +161,7 @@ func extractKeys(t reflect.Type, prefix string, keys map[string]bool) {
 			// For slice of structs, add wildcard path
 			if elemType.Kind() == reflect.Struct {
 				extractKeys(elemType, fullKey+".*", keys)
-			} else if elemType.Kind() == reflect.Ptr && elemType.Elem().Kind() == reflect.Struct {
+			} else if elemType.Kind() == reflect.Pointer && elemType.Elem().Kind() == reflect.Struct {
 				extractKeys(elemType.Elem(), fullKey+".*", keys)
 			}
 			continue
@@ -175,7 +175,7 @@ func extractKeys(t reflect.Type, prefix string, keys map[string]bool) {
 		}
 
 		// Handle pointers
-		if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Kind() == reflect.Pointer {
 			fieldType = fieldType.Elem()
 		}
 

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -208,7 +208,7 @@ func versionString(v fmt.Stringer) string {
 	}
 	// Handle nil pointer wrapped in a non-nil interface
 	// (e.g. (*semver.Version)(nil) passed as fmt.Stringer).
-	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return ""
 	}
 	return v.String()

--- a/pkg/gotmpl/ext/collections/safelen.go
+++ b/pkg/gotmpl/ext/collections/safelen.go
@@ -47,7 +47,7 @@ func SafeLen(v any) (int, error) {
 	rv := reflect.ValueOf(v)
 
 	// Dereference pointers so *[N]T, *[]T, *map, etc. work like builtins.
-	for rv.Kind() == reflect.Ptr {
+	for rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return 0, nil
 		}

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl-plugin-sdk/plugin/proto"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -935,6 +936,94 @@ func TestConfigureAndRegisterAuthHandlers_ConfigureError(t *testing.T) {
 	h, err := registry.Get("handler-a")
 	require.NoError(t, err)
 	assert.Equal(t, "handler-a", h.Name())
+}
+
+// =====================================================================
+// buildTrustedDomains tests
+// =====================================================================
+
+func TestBuildTrustedDomains_NilRegistry(t *testing.T) {
+	t.Parallel()
+
+	domains := buildTrustedDomains("github", nil, nil)
+	assert.Empty(t, domains)
+}
+
+func TestBuildTrustedDomains_OfficialOnly(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+
+	domains := buildTrustedDomains("github", reg, nil)
+	assert.Equal(t, []string{"github.com"}, domains)
+}
+
+func TestBuildTrustedDomains_ConfigOnly(t *testing.T) {
+	t.Parallel()
+
+	domains := buildTrustedDomains("github", nil, []string{"ghes.corp.example.com"})
+	assert.Equal(t, []string{"ghes.corp.example.com"}, domains)
+}
+
+func TestBuildTrustedDomains_Merged(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", TrustedVerificationDomains: []string{
+			"login.microsoftonline.com", "login.microsoft.com",
+		}},
+	})
+	cfgDomains := []string{"my-idp.corp.example.com"}
+
+	domains := buildTrustedDomains("entra", reg, cfgDomains)
+	assert.Equal(t, []string{"login.microsoftonline.com", "login.microsoft.com", "my-idp.corp.example.com"}, domains)
+}
+
+func TestBuildTrustedDomains_UnknownHandler(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+	cfgDomains := []string{"custom.example.com"}
+
+	// Handler not in registry — only config domains returned.
+	domains := buildTrustedDomains("unknown-handler", reg, cfgDomains)
+	assert.Equal(t, []string{"custom.example.com"}, domains)
+}
+
+func TestConfigureAndRegisterAuthHandlers_SetsTrustedDomains(t *testing.T) {
+	t.Parallel()
+
+	// Put official registry in context.
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+	ctx := authofficial.WithRegistry(context.Background(), reg)
+
+	registry := auth.NewRegistry()
+	ahClient := &AuthHandlerClient{
+		plugin: &MockAuthHandlerPlugin{},
+		name:   "test-plugin",
+	}
+
+	handlers := []AuthHandlerInfo{
+		{Name: "github", DisplayName: "GitHub"},
+	}
+
+	configureAndRegisterAuthHandlers(ctx, registry, ahClient, handlers, nil)
+
+	h, err := registry.Get("github")
+	require.NoError(t, err)
+
+	// Verify trusted domains were set.
+	wrapper, ok := h.(*AuthHandlerWrapper)
+	require.True(t, ok)
+	wrapper.mu.RLock()
+	defer wrapper.mu.RUnlock()
+	assert.Equal(t, []string{"github.com"}, wrapper.trustedDomains)
 }
 
 // =====================================================================

--- a/pkg/plugin/fetch_cooldown.go
+++ b/pkg/plugin/fetch_cooldown.go
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+const (
+	// DefaultFetchCooldown is the default duration to suppress retry attempts
+	// after a plugin auto-fetch failure.
+	DefaultFetchCooldown = 5 * time.Minute
+
+	// fetchFailedPrefix is the prefix for cooldown marker files.
+	fetchFailedPrefix = ".fetch-failed-"
+)
+
+// FetchCooldown manages cooldown state for failed plugin auto-fetch attempts.
+// It uses file-based markers in the plugin cache directory to persist cooldown
+// state across CLI invocations.
+type FetchCooldown struct {
+	dir      string
+	cooldown time.Duration
+	now      func() time.Time
+}
+
+// NewFetchCooldown creates a FetchCooldown with the given cooldown duration.
+// If cacheDir is empty, the default plugin cache directory is used.
+// If cooldown is zero, DefaultFetchCooldown is used.
+func NewFetchCooldown(cacheDir string, cooldown time.Duration) *FetchCooldown {
+	if cacheDir == "" {
+		cacheDir = paths.PluginCacheDir()
+	}
+	if cooldown <= 0 {
+		cooldown = DefaultFetchCooldown
+	}
+	return &FetchCooldown{
+		dir:      cacheDir,
+		cooldown: cooldown,
+		now:      time.Now,
+	}
+}
+
+// OnCooldown reports whether a fetch attempt for the named plugin should be
+// suppressed due to a recent failure. Returns true if a cooldown marker exists
+// and has not expired.
+func (fc *FetchCooldown) OnCooldown(name string) bool {
+	markerPath := fc.markerPath(name)
+	info, err := os.Stat(markerPath)
+	if err != nil {
+		return false
+	}
+	return fc.now().Sub(info.ModTime()) < fc.cooldown
+}
+
+// RecordFailure writes a cooldown marker for the named plugin, indicating that
+// a fetch attempt failed at the current time.
+func (fc *FetchCooldown) RecordFailure(name string) error {
+	if err := os.MkdirAll(fc.dir, 0o755); err != nil {
+		return fmt.Errorf("creating cooldown directory: %w", err)
+	}
+	markerPath := fc.markerPath(name)
+	f, err := os.Create(markerPath)
+	if err != nil {
+		return fmt.Errorf("writing cooldown marker: %w", err)
+	}
+	return f.Close()
+}
+
+// Clear removes the cooldown marker for the named plugin. This is called on
+// explicit install (e.g., `scafctl plugin install`) or with --force-fetch.
+func (fc *FetchCooldown) Clear(name string) error {
+	markerPath := fc.markerPath(name)
+	err := os.Remove(markerPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// markerPath returns the filesystem path for a plugin's cooldown marker.
+func (fc *FetchCooldown) markerPath(name string) string {
+	return filepath.Join(fc.dir, fetchFailedPrefix+name)
+}

--- a/pkg/plugin/fetch_cooldown_test.go
+++ b/pkg/plugin/fetch_cooldown_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCooldown_OnCooldown_NoMarker(t *testing.T) {
+	t.Parallel()
+	fc := NewFetchCooldown(t.TempDir(), DefaultFetchCooldown)
+	assert.False(t, fc.OnCooldown("github"))
+}
+
+func TestFetchCooldown_OnCooldown_RecentMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+
+	require.NoError(t, fc.RecordFailure("github"))
+	assert.True(t, fc.OnCooldown("github"))
+}
+
+func TestFetchCooldown_OnCooldown_ExpiredMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+	// Advance time past cooldown
+	fc.now = func() time.Time {
+		return time.Now().Add(10 * time.Minute)
+	}
+
+	// Write marker at current real time
+	markerPath := filepath.Join(dir, fetchFailedPrefix+"github")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	f, err := os.Create(markerPath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	assert.False(t, fc.OnCooldown("github"))
+}
+
+func TestFetchCooldown_RecordFailure_CreatesMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+
+	require.NoError(t, fc.RecordFailure("entra"))
+
+	markerPath := filepath.Join(dir, fetchFailedPrefix+"entra")
+	_, err := os.Stat(markerPath)
+	assert.NoError(t, err)
+}
+
+func TestFetchCooldown_RecordFailure_CreatesDirectory(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+
+	require.NoError(t, fc.RecordFailure("gcp"))
+
+	markerPath := filepath.Join(dir, fetchFailedPrefix+"gcp")
+	_, err := os.Stat(markerPath)
+	assert.NoError(t, err)
+}
+
+func TestFetchCooldown_Clear_RemovesMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+
+	require.NoError(t, fc.RecordFailure("github"))
+	assert.True(t, fc.OnCooldown("github"))
+
+	require.NoError(t, fc.Clear("github"))
+	assert.False(t, fc.OnCooldown("github"))
+}
+
+func TestFetchCooldown_Clear_NonExistent(t *testing.T) {
+	t.Parallel()
+	fc := NewFetchCooldown(t.TempDir(), DefaultFetchCooldown)
+	assert.NoError(t, fc.Clear("nonexistent"))
+}
+
+func TestFetchCooldown_DefaultCooldown(t *testing.T) {
+	t.Parallel()
+	fc := NewFetchCooldown(t.TempDir(), 0)
+	assert.Equal(t, DefaultFetchCooldown, fc.cooldown)
+}
+
+func TestFetchCooldown_IndependentPlugins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, DefaultFetchCooldown)
+
+	require.NoError(t, fc.RecordFailure("github"))
+	assert.True(t, fc.OnCooldown("github"))
+	assert.False(t, fc.OnCooldown("entra"))
+}
+
+func TestFetchCooldown_CustomCooldownDuration(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fc := NewFetchCooldown(dir, 30*time.Second)
+
+	require.NoError(t, fc.RecordFailure("github"))
+	assert.True(t, fc.OnCooldown("github"))
+
+	// Simulate 31 seconds passing
+	fc.now = func() time.Time {
+		return time.Now().Add(31 * time.Second)
+	}
+	assert.False(t, fc.OnCooldown("github"))
+}

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -688,3 +688,291 @@ func TestAuthHandlerClient_HostServiceID_GRPCClient(t *testing.T) {
 	}
 	assert.Equal(t, uint32(42), client.HostServiceID())
 }
+
+// ── SetTrustedDomains tests ──────────────────────────────────────────────────
+
+func TestAuthHandlerWrapper_SetTrustedDomains(t *testing.T) {
+	t.Parallel()
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: &MockAuthHandlerPlugin{},
+			name:   "test-plugin",
+		},
+		handlerName: "test-handler",
+		info:        AuthHandlerInfo{Name: "test-handler"},
+	}
+
+	// Initially empty
+	assert.Empty(t, w.trustedDomains)
+
+	// Set domains
+	w.SetTrustedDomains([]string{"login.microsoftonline.com", "accounts.google.com"})
+	assert.Equal(t, []string{"login.microsoftonline.com", "accounts.google.com"}, w.trustedDomains)
+
+	// Replace with different domains
+	w.SetTrustedDomains([]string{"github.com"})
+	assert.Equal(t, []string{"github.com"}, w.trustedDomains)
+
+	// Clear
+	w.SetTrustedDomains(nil)
+	assert.Nil(t, w.trustedDomains)
+}
+
+// ── Login with device code validation tests ──────────────────────────────────
+
+func TestAuthHandlerWrapper_Login_DeviceCodeValidURI(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "WXYZ-5678",
+					VerificationURI: "https://login.microsoftonline.com/common/oauth2/deviceauth",
+					Message:         "Go to the URL and enter the code",
+				})
+			}
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@corp.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:    "entra",
+		info:           AuthHandlerInfo{Name: "entra"},
+		trustedDomains: []string{"login.microsoftonline.com"},
+	}
+
+	var gotCode, gotURI, gotMsg string
+	result, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(code, uri, msg string) {
+			gotCode = code
+			gotURI = uri
+			gotMsg = msg
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "user@corp.com", result.Claims.Email)
+	assert.Equal(t, "WXYZ-5678", gotCode)
+	assert.Equal(t, "https://login.microsoftonline.com/common/oauth2/deviceauth", gotURI)
+	assert.Equal(t, "Go to the URL and enter the code", gotMsg)
+}
+
+func TestAuthHandlerWrapper_Login_DeviceCodeBlockedURI(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(ctx context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "EVIL-1234",
+					VerificationURI: "https://evil-phishing.example.com/device",
+					Message:         "Go to fake URL",
+				})
+			}
+			// Simulate the context being cancelled due to validation failure
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:    "entra",
+		info:           AuthHandlerInfo{Name: "entra"},
+		trustedDomains: []string{"login.microsoftonline.com"},
+	}
+
+	var callbackInvoked bool
+	_, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(_, _, _ string) {
+			callbackInvoked = true
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "device code URL validation failed for handler \"entra\"")
+	assert.False(t, callbackInvoked, "original callback should not be invoked for blocked URI")
+}
+
+func TestAuthHandlerWrapper_Login_NoDeviceCodeCallback(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			// cb should be nil when no DeviceCodeCallback is set
+			assert.Nil(t, cb)
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "sp@corp.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName: "entra",
+		info:        AuthHandlerInfo{Name: "entra"},
+	}
+
+	result, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowServicePrincipal,
+		// No DeviceCodeCallback
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sp@corp.com", result.Claims.Email)
+}
+
+func TestAuthHandlerWrapper_Login_MaliciousPluginIgnoresCancellation(t *testing.T) {
+	t.Parallel()
+
+	// A malicious plugin sends a bad URI, then IGNORES the context cancellation
+	// and returns a successful response anyway. The host must still return an error.
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "EVIL-9999",
+					VerificationURI: "https://evil-phishing.example.com/device",
+					Message:         "Phishing attempt",
+				})
+			}
+			// Malicious plugin ignores ctx cancellation and returns success.
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "victim@corp.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:    "entra",
+		info:           AuthHandlerInfo{Name: "entra"},
+		trustedDomains: []string{"login.microsoftonline.com"},
+	}
+
+	_, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(_, _, _ string) {
+			t.Fatal("original callback should not be invoked for blocked URI")
+		},
+	})
+	require.Error(t, err, "host must reject even if plugin returns success after URI validation failure")
+	assert.Contains(t, err.Error(), "device code URL validation failed")
+}
+
+func TestAuthHandlerWrapper_Login_PluginError(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, _ func(DeviceCodePrompt)) (*LoginResponse, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName: "github",
+		info:        AuthHandlerInfo{Name: "github"},
+	}
+
+	_, err := w.Login(context.Background(), auth.LoginOptions{Flow: auth.FlowDeviceCode})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin auth handler github login:")
+}
+
+func TestAuthHandlerWrapper_Login_DeviceCodeEmptyTrustedDomains(t *testing.T) {
+	t.Parallel()
+
+	// When trustedDomains is empty, any HTTPS URL passes validation.
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "ABCD-9999",
+					VerificationURI: "https://any-provider.example.com/device",
+					Message:         "Enter code",
+				})
+			}
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@any.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:    "custom",
+		info:           AuthHandlerInfo{Name: "custom"},
+		trustedDomains: nil, // empty
+	}
+
+	var gotURI string
+	result, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(_, uri, _ string) {
+			gotURI = uri
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "user@any.com", result.Claims.Email)
+	assert.Equal(t, "https://any-provider.example.com/device", gotURI)
+}
+
+// ── RegisterAuthHandlerPlugins tests ─────────────────────────────────────────
+
+func TestRegisterAuthHandlerPlugins_EmptyDirs(t *testing.T) {
+	t.Parallel()
+
+	// Empty plugin dir list should discover nothing and return no error.
+	registry := auth.NewRegistry()
+	clients, err := RegisterAuthHandlerPlugins(context.Background(), registry, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, clients)
+}
+
+func TestRegisterAuthHandlerPlugins_NonExistentDir(t *testing.T) {
+	t.Parallel()
+
+	// A non-existent directory should not produce an error (dirs are scanned best-effort).
+	registry := auth.NewRegistry()
+	clients, err := RegisterAuthHandlerPlugins(context.Background(), registry, []string{"/nonexistent/path/xyz"}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, clients)
+}
+
+func TestRegisterAuthHandlerPlugins_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	// An empty directory should yield no clients.
+	dir := t.TempDir()
+	registry := auth.NewRegistry()
+	clients, err := RegisterAuthHandlerPlugins(context.Background(), registry, []string{dir}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, clients)
+}

--- a/pkg/plugin/verification_url.go
+++ b/pkg/plugin/verification_url.go
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateVerificationURI validates a device code verification URI against
+// security requirements and an optional trusted domain list. This is the
+// host-side defense against malicious plugins sending phishing URLs in
+// device code prompts.
+//
+// Rules:
+//   - Must be a valid URL with HTTPS scheme
+//   - Must not target private/loopback addresses
+//   - Must not use non-standard ports (only 443 allowed)
+//   - If trusted is non-empty, host must match or be a subdomain of an entry
+//   - If trusted is empty, any HTTPS URL passing the above checks is allowed
+func ValidateVerificationURI(uri string, trusted []string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("invalid verification URI: %w", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("verification URI must use HTTPS: %q", uri)
+	}
+
+	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if hostname == "" {
+		return fmt.Errorf("verification URI has empty hostname: %q", uri)
+	}
+
+	if isPrivateOrLoopback(hostname) {
+		return fmt.Errorf("verification URI must not target private network: %q", uri)
+	}
+
+	if port := parsed.Port(); port != "" && port != "443" {
+		return fmt.Errorf("verification URI uses non-standard port: %q", uri)
+	}
+
+	// If trusted list is empty, allow any HTTPS URL (backward compat).
+	if len(trusted) == 0 {
+		return nil
+	}
+
+	for _, domain := range trusted {
+		normDomain := strings.ToLower(strings.TrimSuffix(domain, "."))
+		if hostname == normDomain || strings.HasSuffix(hostname, "."+normDomain) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("verification URI %q not in trusted domains %v", uri, trusted)
+}
+
+// isPrivateOrLoopback returns true if the host is "localhost" or is a literal
+// IP address in private, loopback, or link-local ranges. It does NOT perform
+// DNS resolution, so hostnames (other than "localhost") that resolve to
+// private/loopback addresses will not be caught. This is a defense-in-depth
+// check for IP-literal URIs; DNS-rebinding attacks are mitigated at the
+// transport layer via SSRF-safe HTTP clients.
+func isPrivateOrLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}

--- a/pkg/plugin/verification_url_test.go
+++ b/pkg/plugin/verification_url_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateVerificationURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		trusted []string
+		wantErr string
+	}{
+		// Valid cases
+		{
+			name:    "valid HTTPS github.com with empty trusted list",
+			uri:     "https://github.com/login/device",
+			trusted: nil,
+		},
+		{
+			name:    "valid HTTPS with trusted match",
+			uri:     "https://github.com/login/device",
+			trusted: []string{"github.com"},
+		},
+		{
+			name:    "valid HTTPS subdomain match",
+			uri:     "https://login.microsoftonline.com/common/oauth2/deviceauth",
+			trusted: []string{"microsoftonline.com"},
+		},
+		{
+			name:    "valid HTTPS exact domain match in list",
+			uri:     "https://accounts.google.com/o/oauth2/device/code",
+			trusted: []string{"github.com", "accounts.google.com", "login.microsoftonline.com"},
+		},
+		{
+			name:    "valid HTTPS with explicit port 443",
+			uri:     "https://github.com:443/login/device",
+			trusted: []string{"github.com"},
+		},
+
+		// Scheme failures
+		{
+			name:    "HTTP rejected",
+			uri:     "http://github.com/login/device",
+			trusted: nil,
+			wantErr: "must use HTTPS",
+		},
+		{
+			name:    "FTP rejected",
+			uri:     "ftp://github.com/login/device",
+			trusted: nil,
+			wantErr: "must use HTTPS",
+		},
+		{
+			name:    "empty scheme rejected",
+			uri:     "://github.com/login/device",
+			trusted: nil,
+			wantErr: "invalid verification URI",
+		},
+
+		// Private/loopback failures
+		{
+			name:    "localhost rejected",
+			uri:     "https://localhost/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+		{
+			name:    "127.0.0.1 rejected",
+			uri:     "https://127.0.0.1/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+		{
+			name:    "IPv6 loopback rejected",
+			uri:     "https://[::1]/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+		{
+			name:    "private 10.x rejected",
+			uri:     "https://10.0.0.1/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+		{
+			name:    "private 192.168.x rejected",
+			uri:     "https://192.168.1.1/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+		{
+			name:    "link-local rejected",
+			uri:     "https://169.254.169.254/auth",
+			trusted: nil,
+			wantErr: "must not target private network",
+		},
+
+		// Port failures
+		{
+			name:    "non-standard port rejected",
+			uri:     "https://github.com:8443/login/device",
+			trusted: nil,
+			wantErr: "non-standard port",
+		},
+		{
+			name:    "port 80 rejected",
+			uri:     "https://github.com:80/login/device",
+			trusted: nil,
+			wantErr: "non-standard port",
+		},
+
+		// Trusted domain failures
+		{
+			name:    "domain not in trusted list",
+			uri:     "https://evil.example.com/login/device",
+			trusted: []string{"github.com", "microsoftonline.com"},
+			wantErr: "not in trusted domains",
+		},
+		{
+			name:    "partial match is not a subdomain match",
+			uri:     "https://notgithub.com/login/device",
+			trusted: []string{"github.com"},
+			wantErr: "not in trusted domains",
+		},
+		{
+			name:    "trusted domain as suffix without dot separator rejected",
+			uri:     "https://evilgithub.com/login/device",
+			trusted: []string{"github.com"},
+			wantErr: "not in trusted domains",
+		},
+
+		// Edge cases
+		{
+			name:    "empty URI",
+			uri:     "",
+			trusted: nil,
+			wantErr: "must use HTTPS",
+		},
+		{
+			name:    "empty hostname",
+			uri:     "https:///path",
+			trusted: nil,
+			wantErr: "empty hostname",
+		},
+
+		// Case-insensitive hostname matching
+		{
+			name:    "mixed-case hostname matches lowercase trusted domain",
+			uri:     "https://GitHub.Com/login/device",
+			trusted: []string{"github.com"},
+		},
+		{
+			name:    "uppercase hostname matches lowercase trusted domain",
+			uri:     "https://LOGIN.MICROSOFTONLINE.COM/common/oauth2/deviceauth",
+			trusted: []string{"microsoftonline.com"},
+		},
+		{
+			name:    "lowercase hostname matches mixed-case trusted domain",
+			uri:     "https://github.com/login/device",
+			trusted: []string{"GitHub.COM"},
+		},
+		{
+			name:    "trailing dot in hostname normalized",
+			uri:     "https://github.com./login/device",
+			trusted: []string{"github.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVerificationURI(tt.uri, tt.trusted)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsPrivateOrLoopback(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"192.168.0.1", true},
+		{"169.254.1.1", true},
+		{"8.8.8.8", false},
+		{"github.com", false},
+		{"login.microsoftonline.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPrivateOrLoopback(tt.host))
+		})
+	}
+}

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
@@ -23,10 +25,11 @@ var (
 // AuthHandlerWrapper wraps a plugin auth handler to implement the auth.Handler
 // (and optionally auth.TokenLister / auth.TokenPurger) interfaces.
 type AuthHandlerWrapper struct {
-	client      *AuthHandlerClient
-	handlerName string
-	info        AuthHandlerInfo
-	mu          sync.RWMutex
+	client         *AuthHandlerClient
+	handlerName    string
+	info           AuthHandlerInfo
+	trustedDomains []string
+	mu             sync.RWMutex
 }
 
 // NewAuthHandlerWrapper creates a new wrapper for a plugin auth handler.
@@ -36,6 +39,20 @@ func NewAuthHandlerWrapper(client *AuthHandlerClient, info AuthHandlerInfo) *Aut
 		handlerName: info.Name,
 		info:        info,
 	}
+}
+
+// SetTrustedDomains sets the trusted verification URI domains for device code
+// URL validation. When non-empty, device code prompts from this handler are
+// validated against these domains (exact match or subdomain).
+func (w *AuthHandlerWrapper) SetTrustedDomains(domains []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if domains == nil {
+		w.trustedDomains = nil
+		return
+	}
+	w.trustedDomains = make([]string, len(domains))
+	copy(w.trustedDomains, domains)
 }
 
 // Name implements auth.Handler.
@@ -79,14 +96,40 @@ func (w *AuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) 
 	}
 
 	// Bridge the LoginOptions.DeviceCodeCallback to the plugin's streaming callback.
+	// Includes host-side verification URI validation to prevent phishing via
+	// malicious plugins sending fake device code URLs.
+	loginCtx, cancelCause := context.WithCancelCause(ctx)
+	defer cancelCause(nil)
+
+	// Snapshot trusted domains under lock to avoid races with SetTrustedDomains.
+	w.mu.RLock()
+	trustedSnapshot := make([]string, len(w.trustedDomains))
+	copy(trustedSnapshot, w.trustedDomains)
+	w.mu.RUnlock()
+
 	var deviceCodeCb func(DeviceCodePrompt)
 	if opts.DeviceCodeCallback != nil {
 		deviceCodeCb = func(prompt DeviceCodePrompt) {
+			if err := ValidateVerificationURI(prompt.VerificationURI, trustedSnapshot); err != nil {
+				lgr.Error(err, "device code prompt blocked -- terminating login",
+					"handler", w.handlerName,
+					"uri", prompt.VerificationURI)
+				cancelCause(fmt.Errorf("device code URL validation failed for handler %q: %w",
+					w.handlerName, err))
+				return
+			}
 			opts.DeviceCodeCallback(prompt.UserCode, prompt.VerificationURI, prompt.Message)
 		}
 	}
 
-	resp, err := w.client.plugin.Login(ctx, w.handlerName, req, deviceCodeCb)
+	resp, err := w.client.plugin.Login(loginCtx, w.handlerName, req, deviceCodeCb)
+
+	// Enforce the security check host-side: if the verification URI was
+	// rejected, return that error even if the plugin returned success.
+	if cause := context.Cause(loginCtx); cause != nil {
+		return nil, cause
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("plugin auth handler %s login: %w", w.handlerName, err)
 	}
@@ -165,8 +208,18 @@ func (w *AuthHandlerWrapper) Client() *AuthHandlerClient {
 
 // configureAndRegisterAuthHandlers configures each handler with host-side
 // settings (when cfg is non-nil) and registers it in the auth registry.
+// It also sets trusted verification domains on each wrapper from the official
+// auth handler registry (per-handler) plus config.Auth.TrustedVerificationDomains.
 func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Registry, client *AuthHandlerClient, handlers []AuthHandlerInfo, cfg *ProviderConfig) {
 	lgr := logger.FromContext(ctx)
+
+	// Resolve trusted verification domains from context sources.
+	officialReg := authofficial.RegistryFromContext(ctx)
+	var cfgDomains []string
+	if appCfg := config.FromContext(ctx); appCfg != nil {
+		cfgDomains = appCfg.Auth.TrustedVerificationDomains
+	}
+
 	for _, info := range handlers {
 		if cfg != nil {
 			hostCfg := *cfg
@@ -179,11 +232,32 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 		}
 
 		wrapper := NewAuthHandlerWrapper(client, info)
+
+		// Set trusted domains: merge per-handler official domains + global config domains.
+		trusted := buildTrustedDomains(info.Name, officialReg, cfgDomains)
+		if len(trusted) > 0 {
+			wrapper.SetTrustedDomains(trusted)
+		}
+
 		if err := registry.Register(wrapper); err != nil {
 			lgr.V(1).Info("failed to register auth handler", "handler", info.Name, "error", err)
 			continue
 		}
 	}
+}
+
+// buildTrustedDomains merges per-handler official domains with global config domains.
+func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry, cfgDomains []string) []string {
+	var domains []string
+
+	if officialReg != nil {
+		if h, ok := officialReg.Get(handlerName); ok {
+			domains = append(domains, h.TrustedVerificationDomains...)
+		}
+	}
+
+	domains = append(domains, cfgDomains...)
+	return domains
 }
 
 // RegisterAuthHandlerPlugins discovers auth handler plugins and registers them

--- a/pkg/schema/format.go
+++ b/pkg/schema/format.go
@@ -181,7 +181,7 @@ func (f *Formatter) formatTypeString(info *FieldInfo) string {
 			return fmt.Sprintf("map[%s]%s", info.KeyType, info.ElemType)
 		}
 		return info.Type
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return "*" + info.Type
 	case reflect.Interface:
 		if info.Type == "" {

--- a/pkg/schema/format_test.go
+++ b/pkg/schema/format_test.go
@@ -173,7 +173,7 @@ func TestFormatTypeString_AllKinds(t *testing.T) {
 		{FieldInfo{Kind: reflect.Array, ElemType: "int"}, "[]int"},
 		{FieldInfo{Kind: reflect.Map, KeyType: "string", ElemType: "any"}, "map[string]any"},
 		{FieldInfo{Kind: reflect.Map, Type: "map"}, "map"},
-		{FieldInfo{Kind: reflect.Ptr, Type: "Config"}, "*Config"},
+		{FieldInfo{Kind: reflect.Pointer, Type: "Config"}, "*Config"},
 		{FieldInfo{Kind: reflect.Interface, Type: ""}, "any"},
 		{FieldInfo{Kind: reflect.Interface, Type: "MyInterface"}, "MyInterface"},
 		{FieldInfo{Kind: reflect.String, Type: "string"}, "string"},

--- a/pkg/schema/introspect.go
+++ b/pkg/schema/introspect.go
@@ -121,7 +121,7 @@ func IntrospectType(v any) (*TypeInfo, error) {
 	}
 
 	// Dereference pointer
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -150,7 +150,7 @@ func IntrospectField(v any, path string) (*FieldInfo, error) {
 	}
 
 	// Dereference pointer
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -169,7 +169,7 @@ func navigateToField(t reflect.Type, path []string) (*FieldInfo, error) {
 	}
 
 	// Dereference pointers
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -194,14 +194,14 @@ func navigateToField(t reflect.Type, path []string) (*FieldInfo, error) {
 			if len(path) > 1 {
 				// Get the underlying type for navigation
 				fieldType := f.Type
-				for fieldType.Kind() == reflect.Ptr {
+				for fieldType.Kind() == reflect.Pointer {
 					fieldType = fieldType.Elem()
 				}
 
 				// Handle slices/arrays - navigate into element type
 				if fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Array {
 					fieldType = fieldType.Elem()
-					for fieldType.Kind() == reflect.Ptr {
+					for fieldType.Kind() == reflect.Pointer {
 						fieldType = fieldType.Elem()
 					}
 				}
@@ -209,7 +209,7 @@ func navigateToField(t reflect.Type, path []string) (*FieldInfo, error) {
 				// Handle maps - navigate into value type
 				if fieldType.Kind() == reflect.Map {
 					fieldType = fieldType.Elem()
-					for fieldType.Kind() == reflect.Ptr {
+					for fieldType.Kind() == reflect.Pointer {
 						fieldType = fieldType.Elem()
 					}
 				}
@@ -275,7 +275,7 @@ func introspectFieldWithSeen(f reflect.StructField, depth int, seen map[reflect.
 
 	// Get type information
 	fieldType := f.Type
-	if fieldType.Kind() == reflect.Ptr {
+	if fieldType.Kind() == reflect.Pointer {
 		info.IsPointer = true
 		fieldType = fieldType.Elem()
 	}
@@ -288,7 +288,7 @@ func introspectFieldWithSeen(f reflect.StructField, depth int, seen map[reflect.
 	switch fieldType.Kind() {
 	case reflect.Slice, reflect.Array:
 		elemType := fieldType.Elem()
-		for elemType.Kind() == reflect.Ptr {
+		for elemType.Kind() == reflect.Pointer {
 			elemType = elemType.Elem()
 		}
 		info.ElemType = formatTypeName(elemType)
@@ -302,7 +302,7 @@ func introspectFieldWithSeen(f reflect.StructField, depth int, seen map[reflect.
 	case reflect.Map:
 		info.KeyType = formatTypeName(fieldType.Key())
 		elemType := fieldType.Elem()
-		for elemType.Kind() == reflect.Ptr {
+		for elemType.Kind() == reflect.Pointer {
 			elemType = elemType.Elem()
 		}
 		info.ElemType = formatTypeName(elemType)
@@ -397,7 +397,7 @@ func getJSONName(f reflect.StructField) string {
 func formatTypeName(t reflect.Type) string {
 	//exhaustive:ignore
 	switch t.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return "*" + formatTypeName(t.Elem())
 	case reflect.Slice:
 		return "[]" + formatTypeName(t.Elem())

--- a/pkg/schema/solution_schema.go
+++ b/pkg/schema/solution_schema.go
@@ -173,7 +173,7 @@ func rewriteRefs(v any) {
 
 // derefType dereferences pointer types to get the underlying type.
 func derefType(t reflect.Type) reflect.Type {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -39,20 +40,21 @@ import (
 type Option func(*prepareConfig)
 
 type prepareConfig struct {
-	getter            get.Interface
-	registry          *provider.Registry
-	authRegistry      *auth.Registry
-	stdin             io.Reader
-	showMetrics       bool
-	metricsOut        io.Writer
-	pluginFetcher     *plugin.Fetcher
-	lockPlugins       []bundler.LockPlugin
-	noCache           bool
-	pluginCfg         *plugin.ProviderConfig
-	clientOpts        []plugin.ClientOption
-	discoveryMode     settings.DiscoveryMode
-	officialProviders *official.Registry
-	strict            bool
+	getter               get.Interface
+	registry             *provider.Registry
+	authRegistry         *auth.Registry
+	stdin                io.Reader
+	showMetrics          bool
+	metricsOut           io.Writer
+	pluginFetcher        *plugin.Fetcher
+	lockPlugins          []bundler.LockPlugin
+	noCache              bool
+	pluginCfg            *plugin.ProviderConfig
+	clientOpts           []plugin.ClientOption
+	discoveryMode        settings.DiscoveryMode
+	officialProviders    *official.Registry
+	officialAuthHandlers *authofficial.Registry
+	strict               bool
 }
 
 // WithGetter provides a custom solution getter. If not set, one is created
@@ -151,6 +153,17 @@ func WithDiscoveryMode(mode settings.DiscoveryMode) Option {
 func WithOfficialProviders(r *official.Registry) Option {
 	return func(c *prepareConfig) {
 		c.officialProviders = r
+	}
+}
+
+// WithOfficialAuthHandlers provides an official auth handler registry for
+// auto-resolving missing auth handlers at runtime. When set (and strict is
+// false), auth handlers referenced by the identity provider that are not in
+// the auth registry are checked against the official list and auto-fetched
+// via the plugin fetcher.
+func WithOfficialAuthHandlers(r *authofficial.Registry) Option {
+	return func(c *prepareConfig) {
+		c.officialAuthHandlers = r
 	}
 }
 
@@ -395,6 +408,23 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 		origCleanup := cleanup
 		cleanup = func() {
 			for _, c := range officialClients {
+				c.Kill()
+			}
+			origCleanup()
+		}
+	}
+
+	// Auto-resolve official auth handlers that are referenced in the solution
+	// (via identity provider) but not already in the auth registry.
+	officialAuthClients, officialAuthErr := autoResolveOfficialAuthHandlers(ctx, sol, cfg.authRegistry, cfg)
+	if officialAuthErr != nil {
+		cleanup()
+		return nil, officialAuthErr
+	}
+	if len(officialAuthClients) > 0 {
+		origCleanup := cleanup
+		cleanup = func() {
+			for _, c := range officialAuthClients {
 				c.Kill()
 			}
 			origCleanup()
@@ -729,6 +759,114 @@ func missingOfficialProviders(
 	return missing
 }
 
+// autoResolveOfficialAuthHandlers scans the solution's resolvers for auth
+// handler references (via the identity provider) that are not already
+// registered. For each missing handler found in the official auth handler
+// registry, a synthetic PluginDependency is created and fetched.
+//
+// When strict is true, this function returns an error listing the missing
+// official auth handlers instead of auto-fetching them.
+//
+// Returns the auth handler plugin clients that were created (caller must add
+// to cleanup) or nil when no auth handlers were auto-resolved.
+func autoResolveOfficialAuthHandlers(
+	ctx context.Context,
+	sol *solution.Solution,
+	authReg *auth.Registry,
+	cfg *prepareConfig,
+) ([]*plugin.AuthHandlerClient, error) {
+	// Default to the registry from context if not explicitly provided via option.
+	officialReg := cfg.officialAuthHandlers
+	if officialReg == nil {
+		officialReg = authofficial.RegistryFromContext(ctx)
+	}
+	if officialReg == nil || officialReg.Len() == 0 {
+		return nil, nil
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	// Collect auth handler names referenced in the solution's resolvers.
+	missing := missingOfficialAuthHandlers(sol, authReg, officialReg)
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	// In strict mode, refuse to auto-resolve and return an actionable error.
+	if cfg.strict {
+		entries := make([]string, len(missing))
+		for i, h := range missing {
+			if h.CatalogRef != h.Name {
+				entries[i] = fmt.Sprintf("%s (catalogRef: %s)", h.Name, h.CatalogRef)
+			} else {
+				entries[i] = h.Name
+			}
+		}
+		return nil, fmt.Errorf(
+			"strict mode: auth handlers %v are official but not declared in bundle.plugins; "+
+				"add their catalog references explicitly or disable strict mode",
+			entries,
+		)
+	}
+
+	if cfg.pluginFetcher == nil {
+		if lgr != nil {
+			lgr.V(1).Info("official auth handlers need auto-resolution but no plugin fetcher available")
+		}
+		return nil, nil
+	}
+
+	// Build synthetic plugin dependencies for each missing official auth handler.
+	deps := make([]solution.PluginDependency, len(missing))
+	for i, h := range missing {
+		deps[i] = h.ToPluginDependency()
+	}
+
+	if lgr != nil {
+		names := make([]string, len(missing))
+		for i, h := range missing {
+			names[i] = h.Name
+		}
+		lgr.V(0).Info("auto-resolving official auth handlers", "handlers", names)
+	}
+
+	fetchResults, fetchErr := cfg.pluginFetcher.FetchPlugins(ctx, deps, cfg.lockPlugins)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("auto-fetching official auth handlers: %w", fetchErr)
+	}
+
+	if authReg == nil {
+		return nil, nil
+	}
+
+	authClients, regErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, authReg, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
+	if regErr != nil {
+		return nil, fmt.Errorf("registering auto-resolved official auth handlers: %w", regErr)
+	}
+
+	return authClients, nil
+}
+
+// missingOfficialAuthHandlers returns the subset of official auth handlers
+// that are referenced by solution resolvers (via identity provider) but not
+// present in the auth registry.
+func missingOfficialAuthHandlers(
+	sol *solution.Solution,
+	authReg *auth.Registry,
+	officialReg *authofficial.Registry,
+) []authofficial.AuthHandler {
+	var missing []authofficial.AuthHandler
+	for _, name := range sol.Spec.ReferencedAuthHandlerNames() {
+		if authReg != nil && authReg.Has(name) {
+			continue
+		}
+		if h, ok := officialReg.Get(name); ok {
+			missing = append(missing, h)
+		}
+	}
+	return missing
+}
+
 // BuildPluginFetcher creates a plugin.Fetcher from the context's config and
 // auth registry. Returns an error when the catalog chain cannot be built.
 // Callers should treat errors as non-fatal: plugin auto-fetch is simply disabled.
@@ -824,6 +962,95 @@ func ResolveOfficialProviders(ctx context.Context, sol *solution.Solution, reg *
 		return nil, fmt.Errorf("registering auto-resolved official providers: %w", err)
 	}
 	return clients, nil
+}
+
+// ResolveOfficialAuthHandlers fetches all official auth handlers that are not
+// already registered in the auth registry. Unlike the solution-level
+// autoResolveOfficialAuthHandlers (which only resolves handlers referenced in a
+// solution), this function resolves ALL missing official handlers to support
+// direct CLI commands like "scafctl auth login github".
+//
+// It reads the official auth handler registry and auth registry from context,
+// builds a plugin fetcher on demand, and uses the provided FetchCooldown to
+// skip recently-failed fetches.
+//
+// Returns the auth handler plugin clients created (caller must defer Kill on
+// each), or nil when no handlers needed resolution or fetching was not possible.
+func ResolveOfficialAuthHandlers(
+	ctx context.Context,
+	authReg *auth.Registry,
+	cooldown *plugin.FetchCooldown,
+	pluginCfg *plugin.ProviderConfig,
+	clientOpts ...plugin.ClientOption,
+) ([]*plugin.AuthHandlerClient, error) {
+	officialReg := authofficial.RegistryFromContext(ctx)
+	if officialReg == nil || officialReg.Len() == 0 {
+		return nil, nil
+	}
+	if authReg == nil {
+		return nil, nil
+	}
+
+	// Collect handlers that are official but not yet registered.
+	var missing []authofficial.AuthHandler
+	for _, name := range officialReg.Names() {
+		if authReg.Has(name) {
+			continue
+		}
+		h, _ := officialReg.Get(name)
+		if cooldown != nil && cooldown.OnCooldown(name) {
+			continue
+		}
+		missing = append(missing, h)
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	lgr := logger.FromContext(ctx)
+	fetcher, err := BuildPluginFetcher(ctx)
+	if err != nil {
+		if lgr != nil {
+			lgr.V(1).Info("plugin fetcher not available for official auth handler auto-resolution", "error", err)
+		}
+		return nil, nil
+	}
+
+	deps := make([]solution.PluginDependency, len(missing))
+	for i, h := range missing {
+		deps[i] = h.ToPluginDependency()
+	}
+	if lgr != nil {
+		names := make([]string, len(missing))
+		for i, h := range missing {
+			names[i] = h.Name
+		}
+		lgr.V(0).Info("auto-resolving official auth handlers", "handlers", names)
+	}
+
+	results, fetchErr := fetcher.FetchPlugins(ctx, deps, nil)
+	if fetchErr != nil {
+		// Record cooldown for all missing handlers on fetch failure.
+		if cooldown != nil {
+			for _, h := range missing {
+				_ = cooldown.RecordFailure(h.Name)
+			}
+		}
+		if lgr != nil {
+			lgr.V(0).Info("auto-fetch of official auth handlers failed", "error", fetchErr)
+		}
+		return nil, nil // Best-effort -- don't fail CLI on fetch errors.
+	}
+
+	authClients, regErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, authReg, results, pluginCfg, clientOpts...)
+	if regErr != nil {
+		if lgr != nil {
+			lgr.V(0).Info("registering auto-resolved official auth handlers failed", "error", regErr)
+		}
+		return nil, nil
+	}
+
+	return authClients, nil
 }
 
 // injectHostMetadataSettings populates cfg.Settings["metadata"] with host runtime

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
@@ -1092,4 +1093,418 @@ func TestInjectHTTPClientSettings_InjectsValue(t *testing.T) {
 	var settings map[string]any
 	require.NoError(t, json.Unmarshal(raw, &settings))
 	assert.Equal(t, true, settings["allowPrivateIPs"])
+}
+
+func TestWithOfficialAuthHandlers(t *testing.T) {
+	reg := authofficial.NewRegistry()
+	var cfg prepareConfig
+	WithOfficialAuthHandlers(reg)(&cfg)
+	assert.Same(t, reg, cfg.officialAuthHandlers)
+}
+
+func TestMissingOfficialAuthHandlers_SkipsRegistered(t *testing.T) {
+	authReg := auth.NewRegistry()
+	_ = authReg.Register(auth.NewMockHandler("github"))
+
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	missing := missingOfficialAuthHandlers(sol, authReg, officialReg)
+	assert.Empty(t, missing)
+}
+
+func TestMissingOfficialAuthHandlers_FindsMissing(t *testing.T) {
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	missing := missingOfficialAuthHandlers(sol, authReg, officialReg)
+	require.Len(t, missing, 1)
+	assert.Equal(t, "github", missing[0].Name)
+}
+
+func TestAutoResolveOfficialAuthHandlers_NilRegistry(t *testing.T) {
+	sol := &solution.Solution{}
+	cfg := &prepareConfig{officialAuthHandlers: nil}
+	clients, err := autoResolveOfficialAuthHandlers(context.Background(), sol, nil, cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestAutoResolveOfficialAuthHandlers_NoMissing(t *testing.T) {
+	authReg := auth.NewRegistry()
+	_ = authReg.Register(auth.NewMockHandler("github"))
+
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &prepareConfig{officialAuthHandlers: officialReg}
+	clients, err := autoResolveOfficialAuthHandlers(context.Background(), sol, authReg, cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestAutoResolveOfficialAuthHandlers_StrictModeError(t *testing.T) {
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &prepareConfig{officialAuthHandlers: officialReg, strict: true}
+	clients, err := autoResolveOfficialAuthHandlers(context.Background(), sol, authReg, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "strict mode")
+	assert.Contains(t, err.Error(), "github")
+	assert.Nil(t, clients)
+}
+
+func TestAutoResolveOfficialAuthHandlers_NoFetcher(t *testing.T) {
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &prepareConfig{officialAuthHandlers: officialReg, pluginFetcher: nil}
+	clients, err := autoResolveOfficialAuthHandlers(context.Background(), sol, authReg, cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_NilOfficialRegistryInContext(t *testing.T) {
+	t.Parallel()
+	authReg := auth.NewRegistry()
+	ctx := context.Background()
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_NilAuthRegistry(t *testing.T) {
+	t.Parallel()
+	officialReg := authofficial.NewRegistry()
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+	clients, err := ResolveOfficialAuthHandlers(ctx, nil, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_AllRegistered(t *testing.T) {
+	t.Parallel()
+	authReg := auth.NewRegistry()
+	_ = authReg.Register(auth.NewMockHandler("github"))
+	_ = authReg.Register(auth.NewMockHandler("entra"))
+	_ = authReg.Register(auth.NewMockHandler("gcp"))
+
+	officialReg := authofficial.NewRegistry()
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_SkipsCooldown(t *testing.T) {
+	t.Parallel()
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+	// Record cooldown for all official handlers
+	for _, name := range officialReg.Names() {
+		require.NoError(t, cooldown.RecordFailure(name))
+	}
+
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients) // All on cooldown, nothing to fetch
+}
+
+// ── WithPluginConfig / WithClientOptions coverage ────────────────────────────
+
+func TestWithPluginConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &prepareConfig{}
+	opt := WithPluginConfig(&plugin.ProviderConfig{
+		Quiet:      true,
+		NoColor:    true,
+		BinaryName: "testcli",
+	})
+	opt(cfg)
+
+	require.NotNil(t, cfg.pluginCfg)
+	assert.True(t, cfg.pluginCfg.Quiet)
+	assert.True(t, cfg.pluginCfg.NoColor)
+	assert.Equal(t, "testcli", cfg.pluginCfg.BinaryName)
+}
+
+func TestWithClientOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg := &prepareConfig{}
+	opt1 := WithClientOptions(plugin.WithSanitizedEnv())
+	opt1(cfg)
+
+	assert.Len(t, cfg.clientOpts, 1)
+
+	// Append another
+	opt2 := WithClientOptions(plugin.WithSanitizedEnv())
+	opt2(cfg)
+	assert.Len(t, cfg.clientOpts, 2)
+}
+
+// ── ResolveOfficialAuthHandlers deeper paths ─────────────────────────────────
+
+func TestResolveOfficialAuthHandlers_NilCooldown(t *testing.T) {
+	t.Parallel()
+
+	// With nil cooldown, all missing handlers are considered (no cooldown filtering).
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	// Without a catalog, BuildPluginFetcher will fail and return nil gracefully.
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_FetcherUnavailable(t *testing.T) {
+	t.Parallel()
+
+	// When BuildPluginFetcher fails (no catalog chain), the function returns
+	// nil gracefully without error.
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistry()
+
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+
+	// No config in context → BuildPluginFetcher will fail to build catalog chain.
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestResolveOfficialAuthHandlers_EmptyOfficialRegistry(t *testing.T) {
+	t.Parallel()
+
+	// An empty official registry (0 handlers) should short-circuit.
+	authReg := auth.NewRegistry()
+	officialReg := authofficial.NewRegistryFrom(nil)
+
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+	cooldown := plugin.NewFetchCooldown(t.TempDir(), plugin.DefaultFetchCooldown)
+
+	clients, err := ResolveOfficialAuthHandlers(ctx, authReg, cooldown, nil)
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+// ── autoResolveOfficialAuthHandlers with nil authReg after fetch ──────────────
+
+func TestAutoResolveOfficialAuthHandlers_NilAuthRegWithFetcher(t *testing.T) {
+	t.Parallel()
+
+	// When authReg is nil but officialAuthHandlers is set with a fetcher,
+	// missingOfficialAuthHandlers should still find missing (authReg == nil
+	// means nothing is registered) but the function returns nil after fetch
+	// because it can't register.
+	officialReg := authofficial.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"token": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{
+								Provider: "identity",
+								Inputs: map[string]*resolver.ValueRef{
+									"handler": {Literal: "github"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// No fetcher → returns nil (non-fatal) even though handlers are missing.
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	cfg := &prepareConfig{officialAuthHandlers: officialReg, pluginFetcher: nil}
+	clients, err := autoResolveOfficialAuthHandlers(ctx, sol, nil, cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+// ── autoResolveOfficialProviders strict mode with multiple providers ──────────
+
+func TestAutoResolveOfficialProviders_StrictModeMultipleProviders(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistryFrom([]official.Provider{
+		{Name: "git", CatalogRef: "git", DefaultVersion: "latest"},
+		{Name: "helm", CatalogRef: "helm", DefaultVersion: "latest"},
+	})
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r1": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{
+							{Provider: "git"},
+							{Provider: "helm"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &prepareConfig{officialProviders: officialReg, strict: true}
+	clients, err := autoResolveOfficialProviders(context.Background(), sol, reg, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "strict mode")
+	assert.Contains(t, err.Error(), "git")
+	assert.Contains(t, err.Error(), "helm")
+	assert.Nil(t, clients)
+}
+
+func TestAutoResolveOfficialProviders_NoFetcherWithMissing(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistryFrom([]official.Provider{
+		{Name: "git", CatalogRef: "git", DefaultVersion: "latest"},
+	})
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r1": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "git"}},
+					},
+				},
+			},
+		},
+	}
+
+	lgr := logr.Discard()
+	ctx := logger.WithLogger(context.Background(), &lgr)
+	cfg := &prepareConfig{officialProviders: officialReg, pluginFetcher: nil}
+	clients, err := autoResolveOfficialProviders(ctx, sol, reg, cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, clients)
 }

--- a/pkg/solution/spec.go
+++ b/pkg/solution/spec.go
@@ -131,3 +131,62 @@ func (s *Spec) ReferencedProviderNames() []string {
 	sort.Strings(names)
 	return names
 }
+
+// ReferencedAuthHandlerNames returns the unique, sorted set of auth handler
+// names statically referenced in the solution's resolvers. This scans for
+// identity provider usages with a literal "handler" input value.
+// Dynamic references (CEL expressions, Go templates, resolver refs) are
+// excluded since their values cannot be determined at prepare time.
+func (s *Spec) ReferencedAuthHandlerNames() []string {
+	if s == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+
+	// Helper: extract handler name from an inputs map if it uses the identity provider.
+	extractHandler := func(provider string, inputs map[string]*resolver.ValueRef) {
+		if provider != "identity" || inputs == nil {
+			return
+		}
+		handlerRef, ok := inputs["handler"]
+		if !ok || handlerRef == nil {
+			return
+		}
+		// Only extract statically-known literal string values.
+		if str, ok := handlerRef.Literal.(string); ok && str != "" {
+			seen[str] = struct{}{}
+		}
+	}
+
+	for _, r := range s.Resolvers {
+		if r == nil {
+			continue
+		}
+		if r.Resolve != nil {
+			for _, src := range r.Resolve.With {
+				extractHandler(src.Provider, src.Inputs)
+			}
+		}
+		if r.Transform != nil {
+			for _, t := range r.Transform.With {
+				extractHandler(t.Provider, t.Inputs)
+			}
+		}
+		if r.Validate != nil {
+			for _, v := range r.Validate.With {
+				extractHandler(v.Provider, v.Inputs)
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/solution/spec_test.go
+++ b/pkg/solution/spec_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/ptrs"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/stretchr/testify/assert"
@@ -848,6 +849,212 @@ func TestSpec_ReferencedProviderNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.spec.ReferencedProviderNames()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSpec_ReferencedAuthHandlerNames(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *Spec
+		want []string
+	}{
+		{
+			name: "nil spec",
+			spec: nil,
+			want: nil,
+		},
+		{
+			name: "empty spec",
+			spec: &Spec{},
+			want: nil,
+		},
+		{
+			name: "no identity provider usage",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"r1": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{Provider: "parameter"},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "identity provider with literal handler in resolve",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"token": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "github"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"github"},
+		},
+		{
+			name: "identity provider with literal handler in transform",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"token": {
+						Transform: &resolver.TransformPhase{
+							With: []resolver.ProviderTransform{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "entra"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"entra"},
+		},
+		{
+			name: "multiple handlers deduplicates and sorts",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"r1": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "github"},
+									},
+								},
+							},
+						},
+					},
+					"r2": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "entra"},
+									},
+								},
+							},
+						},
+					},
+					"r3": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "github"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"entra", "github"},
+		},
+		{
+			name: "non-literal handler value ignored",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"token": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Resolver: ptrs.StringPtr("myHandlerName")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "nil resolver in map skipped",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"r1": nil,
+					"r2": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "gcp"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"gcp"},
+		},
+		{
+			name: "non-identity provider with handler input ignored",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"r1": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{
+								{
+									Provider: "http",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "github"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "identity provider with literal handler in validate",
+			spec: &Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"token": {
+						Validate: &resolver.ValidatePhase{
+							With: []resolver.ProviderValidation{
+								{
+									Provider: "identity",
+									Inputs: map[string]*resolver.ValueRef{
+										"handler": {Literal: "azure-devops"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"azure-devops"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.ReferencedAuthHandlerNames()
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
- introduce official auth handler registry with default 3 first-party handlers (entra, gcp, github) and context propagation
- add device code verification URL validation with allowlist of known OAuth endpoints to prevent phishing via malicious plugins
- add file-based fetch cooldown to avoid repeated failed plugin downloads (default 5m, configurable via plugins.fetchCooldown)
- wire auto-resolution into CLI root PersistentPreRunE so direct commands like "auth login github" trigger plugin fetch
- wire auto-resolution into solution prepare pipeline for handlers referenced in solution YAML
- expose OfficialAuthHandlers field on RootOptions for embedders
- add DisableOfficialAuthHandlers config setting
- parse auth handler references from solution spec resolvers
- enforce device code URI validation host-side even if plugin ignores context cancellation
- set trusted verification domains on auth handler wrappers during registration from official registry + config

BREAKING CHANGE: RootOptions gains a new OfficialAuthHandlers field; embedders relying on struct literals must add the field