### PR TITLE
feat(spec)!: add source, annotations to solution metadata and wire plugin auth

### DIFF
--- a/pkg/catalog/annotations.go
+++ b/pkg/catalog/annotations.go
@@ -99,6 +99,17 @@ func (b *AnnotationBuilder) SetTags(tags []string) *AnnotationBuilder {
 	return b
 }
 
+// SetMap merges all entries from the given map, skipping empty values.
+// Existing keys are overwritten.
+func (b *AnnotationBuilder) SetMap(m map[string]string) *AnnotationBuilder {
+	for k, v := range m {
+		if v != "" {
+			b.annotations[k] = v
+		}
+	}
+	return b
+}
+
 // Build returns the annotation map.
 func (b *AnnotationBuilder) Build() map[string]string {
 	return b.annotations

--- a/pkg/catalog/annotations_test.go
+++ b/pkg/catalog/annotations_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotationBuilder_SetMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges user annotations", func(t *testing.T) {
+		t.Parallel()
+		ann := NewAnnotationBuilder().
+			SetMap(map[string]string{"team": "platform", "env": "prod"}).
+			Build()
+		assert.Equal(t, "platform", ann["team"])
+		assert.Equal(t, "prod", ann["env"])
+	})
+
+	t.Run("skips empty values", func(t *testing.T) {
+		t.Parallel()
+		ann := NewAnnotationBuilder().
+			SetMap(map[string]string{"team": "platform", "empty": ""}).
+			Build()
+		assert.Equal(t, "platform", ann["team"])
+		assert.NotContains(t, ann, "empty")
+	})
+
+	t.Run("nil map is safe", func(t *testing.T) {
+		t.Parallel()
+		ann := NewAnnotationBuilder().
+			SetMap(nil).
+			Build()
+		assert.Empty(t, ann)
+	})
+
+	t.Run("engine keys override user annotations", func(t *testing.T) {
+		t.Parallel()
+		ann := NewAnnotationBuilder().
+			SetMap(map[string]string{AnnotationDisplayName: "User Name"}).
+			Set(AnnotationDisplayName, "Engine Name").
+			Build()
+		assert.Equal(t, "Engine Name", ann[AnnotationDisplayName])
+	})
+}

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -988,12 +988,17 @@ type DiscoveredArtifact struct {
 	Links       []DiscoveredLink `json:"links,omitempty"       yaml:"links,omitempty"       doc:"Related links" maxItems:"10"`
 	Providers   []string         `json:"providers,omitempty"   yaml:"providers,omitempty"   doc:"Providers used by the solution" maxItems:"50"`
 	Parameters  []string         `json:"parameters,omitempty"  yaml:"parameters,omitempty"  doc:"Parameter resolver names (user inputs)" maxItems:"50"`
+
+	Source      string            `json:"source,omitempty"      yaml:"source,omitempty"      doc:"Source repository URL" maxLength:"500"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" doc:"Free-form key-value annotations"`
 }
 
 // ToAnnotations converts enriched metadata fields into an OCI annotation map.
 // Only non-empty fields are included.
 func (d DiscoveredArtifact) ToAnnotations() map[string]string {
 	return NewAnnotationBuilder().
+		SetMap(d.Annotations).
+		Set(AnnotationSource, d.Source).
 		Set(AnnotationDisplayName, d.DisplayName).
 		Set(AnnotationDescription, d.Description).
 		Set(AnnotationCategory, d.Category).

--- a/pkg/catalog/remote_test.go
+++ b/pkg/catalog/remote_test.go
@@ -919,12 +919,16 @@ func TestDiscoveredArtifact_ToAnnotations(t *testing.T) {
 			Description: "A test app",
 			Category:    "deployment",
 			Tags:        []string{"go", "cloud"},
+			Source:      "https://github.com/example/my-app",
+			Annotations: map[string]string{"team": "platform"},
 		}
 		ann := d.ToAnnotations()
 		assert.Equal(t, "My Application", ann[AnnotationDisplayName])
 		assert.Equal(t, "A test app", ann[AnnotationDescription])
 		assert.Equal(t, "deployment", ann[AnnotationCategory])
 		assert.Equal(t, "go,cloud", ann[AnnotationTags])
+		assert.Equal(t, "https://github.com/example/my-app", ann[AnnotationSource])
+		assert.Equal(t, "platform", ann["team"])
 	})
 
 	t.Run("omits empty fields", func(t *testing.T) {
@@ -938,6 +942,18 @@ func TestDiscoveredArtifact_ToAnnotations(t *testing.T) {
 		assert.NotContains(t, ann, AnnotationDescription)
 		assert.NotContains(t, ann, AnnotationCategory)
 		assert.NotContains(t, ann, AnnotationTags)
+	})
+
+	t.Run("user annotations do not override engine keys", func(t *testing.T) {
+		t.Parallel()
+		d := DiscoveredArtifact{
+			Name:        "conflict",
+			DisplayName: "Engine Name",
+			Annotations: map[string]string{AnnotationDisplayName: "User Name", "custom": "value"},
+		}
+		ann := d.ToAnnotations()
+		assert.Equal(t, "Engine Name", ann[AnnotationDisplayName], "engine-set key must win")
+		assert.Equal(t, "value", ann["custom"])
 	})
 
 	t.Run("returns empty map when no metadata", func(t *testing.T) {

--- a/pkg/catalog/search/search.go
+++ b/pkg/catalog/search/search.go
@@ -177,6 +177,8 @@ func EnrichArtifacts(ctx context.Context, lgr logr.Logger, rc catalog.Catalog, a
 		a.DisplayName = sol.Metadata.DisplayName
 		a.Category = sol.Metadata.Category
 		a.Tags = sol.Metadata.Tags
+		a.Source = sol.Metadata.Source
+		a.Annotations = sol.Metadata.Annotations
 
 		// Extended metadata for MCP and rich discovery.
 		for _, m := range sol.Metadata.Maintainers {
@@ -461,4 +463,6 @@ func copyEnrichedMetadata(dst *catalog.DiscoveredArtifact, src catalog.Discovere
 	dst.Links = src.Links
 	dst.Providers = src.Providers
 	dst.Parameters = src.Parameters
+	dst.Source = src.Source
+	dst.Annotations = src.Annotations
 }

--- a/pkg/catalog/search/search_test.go
+++ b/pkg/catalog/search/search_test.go
@@ -508,6 +508,8 @@ func TestCopyEnrichedMetadata(t *testing.T) {
 		Links:       []catalog.DiscoveredLink{{Name: "docs", URL: "https://example.com"}},
 		Providers:   []string{"http"},
 		Parameters:  []string{"env"},
+		Source:      "https://github.com/example/repo",
+		Annotations: map[string]string{"team": "platform"},
 	}
 
 	dst := &catalog.DiscoveredArtifact{Name: "target"}
@@ -521,4 +523,6 @@ func TestCopyEnrichedMetadata(t *testing.T) {
 	assert.Equal(t, []catalog.DiscoveredLink{{Name: "docs", URL: "https://example.com"}}, dst.Links)
 	assert.Equal(t, []string{"http"}, dst.Providers)
 	assert.Equal(t, []string{"env"}, dst.Parameters)
+	assert.Equal(t, "https://github.com/example/repo", dst.Source)
+	assert.Equal(t, map[string]string{"team": "platform"}, dst.Annotations)
 }

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -474,13 +474,20 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 
 	// Store the artifact (handles dedup vs traditional, plus build cache)
 	w.Verbose("Storing artifact in local catalog")
+	// Prefer metadata.source (repo URL); fall back to the build file path
+	// so OCI provenance is never blank.
+	source := sol.Metadata.Source
+	if source == "" {
+		source = opts.File
+	}
 	storeResult, err := builder.StoreSolutionArtifact(ctx, localCatalog, name, version, content, br, builder.StoreOptions{
 		Force:            opts.Force,
-		Source:           opts.File,
+		Source:           source,
 		DisplayName:      sol.Metadata.DisplayName,
 		Description:      sol.Metadata.Description,
 		Category:         sol.Metadata.Category,
 		Tags:             sol.Metadata.Tags,
+		Annotations:      sol.Metadata.Annotations,
 		ArtifactCacheDir: paths.ArtifactCacheDir(),
 		ArtifactCacheTTL: settings.DefaultArtifactCacheTTL,
 	})

--- a/pkg/cmd/scafctl/catalog/index.go
+++ b/pkg/cmd/scafctl/catalog/index.go
@@ -378,7 +378,8 @@ func matchesSearch(a catalog.DiscoveredArtifact, query string) bool {
 	return strings.Contains(strings.ToLower(a.Name), query) ||
 		strings.Contains(strings.ToLower(a.DisplayName), query) ||
 		strings.Contains(strings.ToLower(a.Description), query) ||
-		strings.Contains(strings.ToLower(a.Category), query)
+		strings.Contains(strings.ToLower(a.Category), query) ||
+		strings.Contains(strings.ToLower(a.Source), query)
 }
 
 // writeIndexList writes the index artifact list using kvx output options.

--- a/pkg/cmd/scafctl/catalog/index_test.go
+++ b/pkg/cmd/scafctl/catalog/index_test.go
@@ -404,11 +404,13 @@ func TestMatchesSearch(t *testing.T) {
 		DisplayName: "Hello World Starter",
 		Description: "A minimal getting-started solution",
 		Category:    "templates",
+		Source:      "https://github.com/example/hello-world",
 	}
 
 	assert.True(t, matchesSearch(a, "hello"))
 	assert.True(t, matchesSearch(a, "starter"))
 	assert.True(t, matchesSearch(a, "minimal"))
 	assert.True(t, matchesSearch(a, "templates"))
+	assert.True(t, matchesSearch(a, "github.com/example"))
 	assert.False(t, matchesSearch(a, "nonexistent"))
 }

--- a/pkg/cmd/scafctl/explain/solution.go
+++ b/pkg/cmd/scafctl/explain/solution.go
@@ -6,6 +6,7 @@ package explain
 import (
 	"context"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -124,6 +125,20 @@ func (o *SolutionOptions) printSolutionExplanation(w *writer.Writer, exp *Soluti
 	w.Plainlnf("  Version:    %s", exp.Version)
 	if exp.Category != "" {
 		w.Plainlnf("  Category:   %s", exp.Category)
+	}
+	if exp.Source != "" {
+		w.Plainlnf("  Source:     %s", exp.Source)
+	}
+	if len(exp.Annotations) > 0 {
+		w.Plainln("  Annotations:")
+		keys := make([]string, 0, len(exp.Annotations))
+		for k := range exp.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			w.Plainlnf("    %s: %s", k, exp.Annotations[k])
+		}
 	}
 	w.Plainln("")
 

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -623,7 +623,8 @@ func (o *SolutionOptions) getRegistry(ctx context.Context) *provider.Registry {
 // the solution that are missing from the registry. Returns plugin clients
 // that should be closed when done.
 func (o *SolutionOptions) autoResolveOfficialProviders(ctx context.Context, sol *solution.Solution, reg *provider.Registry) []*plugin.Client {
-	clients, err := prepare.ResolveOfficialProviders(ctx, sol, reg)
+	clientOpts := plugin.AuthClientOptsFromContext(ctx)
+	clients, err := prepare.ResolveOfficialProviders(ctx, sol, reg, clientOpts...)
 	if err != nil {
 		lgr := logger.FromContext(ctx)
 		if lgr != nil {

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -600,6 +600,12 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 	}
 	opts = o.appendClientPluginOptions(opts)
 
+	// Wire auth host deps so that plugin providers can request auth tokens
+	// from the host process via gRPC HostService.
+	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
+		opts = append(opts, prepare.WithClientOptions(authOpts...))
+	}
+
 	if o.discoveryMode != settings.DiscoveryModeDefault {
 		opts = append(opts, prepare.WithDiscoveryMode(o.discoveryMode))
 	}
@@ -982,7 +988,8 @@ func autoResolveProviderByName(ctx context.Context, name string, reg *provider.R
 	pluginCfg := &plugin.ProviderConfig{
 		BinaryName: settings.BinaryNameFromContext(ctx),
 	}
-	clients, err := plugin.RegisterFetchedPlugins(ctx, reg, results, pluginCfg)
+	clientOpts := plugin.AuthClientOptsFromContext(ctx)
+	clients, err := plugin.RegisterFetchedPlugins(ctx, reg, results, pluginCfg, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("registering provider %q: %w", name, err)
 	}

--- a/pkg/cmd/scafctl/run/provider.go
+++ b/pkg/cmd/scafctl/run/provider.go
@@ -350,6 +350,7 @@ func (o *ProviderOptions) Run(ctx context.Context) error {
 	if logger.IsDebugLevel(o.CliParams.MinLogLevel) {
 		clientOpts = append(clientOpts, plugin.WithDebugLogging())
 	}
+	clientOpts = append(clientOpts, plugin.AuthClientOptsFromContext(ctx)...)
 	if len(o.PluginDirs) > 0 {
 		lgr.V(1).Info("loading plugin providers", "dirs", o.PluginDirs)
 		clients, err := plugin.RegisterPluginProviders(ctx, reg, o.PluginDirs, pluginCfg, clientOpts...)

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -270,7 +270,9 @@ func preloadOfficialProviders(
 		return nil, fmt.Errorf("fetching official providers: %w", fetchErr)
 	}
 
-	clients, regErr := plugin.RegisterFetchedPlugins(ctx, reg, fetchResults, nil)
+	clientOpts := plugin.AuthClientOptsFromContext(ctx)
+
+	clients, regErr := plugin.RegisterFetchedPlugins(ctx, reg, fetchResults, nil, clientOpts...)
 	if regErr != nil {
 		return nil, fmt.Errorf("registering official providers: %w", regErr)
 	}

--- a/pkg/plugin/grpc_host.go
+++ b/pkg/plugin/grpc_host.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/oakwood-commons/scafctl-plugin-sdk/plugin/proto"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"google.golang.org/grpc"
@@ -477,4 +479,77 @@ func (c *HostServiceClient) GetAuthGroups(ctx context.Context, handler string) (
 		return nil, fmt.Errorf("host GetAuthGroups: %s", resp.Error)
 	}
 	return resp.Groups, nil
+}
+
+// HostDepsFromAuthRegistry builds a HostServiceDeps that delegates auth
+// callbacks to the given auth.Registry. Returns nil when the registry is nil,
+// so callers can safely pass the result to WithHostDeps without a nil check.
+func HostDepsFromAuthRegistry(authReg *auth.Registry) *HostServiceDeps {
+	if authReg == nil {
+		return nil
+	}
+	return &HostServiceDeps{
+		AuthTokenFunc: func(ctx context.Context, handler, scope string, minValidFor int64, forceRefresh bool) (*proto.GetAuthTokenResponse, error) {
+			// Resolve empty handler name to the default (first registered) handler.
+			if handler == "" {
+				handlers := authReg.List()
+				if len(handlers) == 0 {
+					return &proto.GetAuthTokenResponse{
+						Error: "no auth handlers registered",
+					}, nil
+				}
+				handler = handlers[0]
+			}
+			h, err := authReg.Get(handler)
+			if err != nil {
+				return &proto.GetAuthTokenResponse{
+					Error: fmt.Sprintf("auth handler %q: %v", handler, err),
+				}, nil
+			}
+			// Clamp to non-negative so a malicious/buggy plugin cannot
+			// bypass the DefaultMinValidFor fallback in token acquisition.
+			if minValidFor < 0 {
+				minValidFor = 0
+			}
+			token, err := h.GetToken(ctx, auth.TokenOptions{
+				Scope:        scope,
+				MinValidFor:  time.Duration(minValidFor) * time.Second,
+				ForceRefresh: forceRefresh,
+			})
+			if err != nil {
+				return &proto.GetAuthTokenResponse{
+					Error: fmt.Sprintf("get token from %q: %v", handler, err),
+				}, nil
+			}
+			return &proto.GetAuthTokenResponse{
+				AccessToken:   token.AccessToken,
+				TokenType:     token.TokenType,
+				ExpiresAtUnix: token.ExpiresAt.Unix(),
+				Scope:         token.Scope,
+			}, nil
+		},
+		AuthHandlersFunc: func(_ context.Context) ([]string, string, error) {
+			handlers := authReg.List()
+			var defaultHandler string
+			if len(handlers) > 0 {
+				defaultHandler = handlers[0]
+			}
+			return handlers, defaultHandler, nil
+		},
+	}
+}
+
+// AuthClientOptsFromContext extracts the auth registry from ctx and returns
+// ClientOption(s) that wire host-side auth deps into plugin clients.
+// Returns nil when no auth registry is available in the context.
+func AuthClientOptsFromContext(ctx context.Context) []ClientOption {
+	authReg := auth.RegistryFromContext(ctx)
+	if authReg == nil {
+		return nil
+	}
+	deps := HostDepsFromAuthRegistry(authReg)
+	if deps == nil {
+		return nil
+	}
+	return []ClientOption{WithHostDeps(deps)}
 }

--- a/pkg/plugin/grpc_host_deps_test.go
+++ b/pkg/plugin/grpc_host_deps_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostDepsFromAuthRegistry_NilRegistry(t *testing.T) {
+	deps := HostDepsFromAuthRegistry(nil)
+	assert.Nil(t, deps)
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("test-handler")
+	mock.GetTokenResult = &auth.Token{
+		AccessToken: "tok-123",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Scope:       "read",
+	}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	require.NotNil(t, deps)
+	require.NotNil(t, deps.AuthTokenFunc)
+
+	resp, err := deps.AuthTokenFunc(context.Background(), "test-handler", "read", 60, false)
+	require.NoError(t, err)
+	assert.Equal(t, "tok-123", resp.AccessToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "read", resp.Scope)
+	assert.Equal(t, time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC).Unix(), resp.ExpiresAtUnix)
+	assert.Empty(t, resp.Error)
+
+	// Verify ForceRefresh and MinValidFor are forwarded.
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "read", mock.GetTokenCalls[0].Scope)
+	assert.Equal(t, 60*time.Second, mock.GetTokenCalls[0].MinValidFor)
+	assert.False(t, mock.GetTokenCalls[0].ForceRefresh)
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_ForceRefresh(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	_, err := deps.AuthTokenFunc(context.Background(), "h", "", 0, true)
+	require.NoError(t, err)
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.True(t, mock.GetTokenCalls[0].ForceRefresh)
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_UnknownHandler(t *testing.T) {
+	reg := auth.NewRegistry()
+	deps := HostDepsFromAuthRegistry(reg)
+
+	resp, err := deps.AuthTokenFunc(context.Background(), "unknown", "", 0, false)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "unknown")
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_NegativeMinValidForClamped(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok", TokenType: "Bearer"}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	resp, err := deps.AuthTokenFunc(context.Background(), "h", "scope", -999, false)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "tok", resp.AccessToken)
+	// Negative value should be clamped to 0 (triggers DefaultMinValidFor in token acquisition).
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, time.Duration(0), mock.GetTokenCalls[0].MinValidFor)
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_EmptyHandlerResolvesToDefault(t *testing.T) {
+	reg := auth.NewRegistry()
+	mockA := auth.NewMockHandler("alpha")
+	mockA.GetTokenResult = &auth.Token{AccessToken: "alpha-tok", TokenType: "Bearer"}
+	mockB := auth.NewMockHandler("beta")
+	mockB.GetTokenResult = &auth.Token{AccessToken: "beta-tok", TokenType: "Bearer"}
+	require.NoError(t, reg.Register(mockA))
+	require.NoError(t, reg.Register(mockB))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	resp, err := deps.AuthTokenFunc(context.Background(), "", "scope", 0, false)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+	// List() returns sorted handlers; "alpha" is first, so it's the default.
+	assert.Equal(t, "alpha-tok", resp.AccessToken)
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_EmptyHandlerNoHandlers(t *testing.T) {
+	reg := auth.NewRegistry()
+	deps := HostDepsFromAuthRegistry(reg)
+
+	resp, err := deps.AuthTokenFunc(context.Background(), "", "", 0, false)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "no auth handlers registered")
+}
+
+func TestHostDepsFromAuthRegistry_TokenFunc_GetTokenError(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.GetTokenErr = fmt.Errorf("token expired")
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	resp, err := deps.AuthTokenFunc(context.Background(), "h", "", 0, false)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "token expired")
+}
+
+func TestHostDepsFromAuthRegistry_HandlersFunc(t *testing.T) {
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(auth.NewMockHandler("alpha")))
+	require.NoError(t, reg.Register(auth.NewMockHandler("beta")))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	require.NotNil(t, deps.AuthHandlersFunc)
+
+	handlers, defaultH, err := deps.AuthHandlersFunc(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, handlers, 2)
+	assert.Contains(t, handlers, "alpha")
+	assert.Contains(t, handlers, "beta")
+	assert.NotEmpty(t, defaultH)
+}
+
+func TestHostDepsFromAuthRegistry_HandlersFunc_Empty(t *testing.T) {
+	reg := auth.NewRegistry()
+	deps := HostDepsFromAuthRegistry(reg)
+
+	handlers, defaultH, err := deps.AuthHandlersFunc(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, handlers)
+	assert.Empty(t, defaultH)
+}
+
+func BenchmarkHostDepsFromAuthRegistry(b *testing.B) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("bench")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok", TokenType: "Bearer"}
+	_ = reg.Register(mock)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		deps := HostDepsFromAuthRegistry(reg)
+		_, _ = deps.AuthTokenFunc(context.Background(), "bench", "scope", 0, false)
+	}
+}
+
+func TestAuthClientOptsFromContext_NoRegistry(t *testing.T) {
+	ctx := context.Background()
+	opts := AuthClientOptsFromContext(ctx)
+	assert.Nil(t, opts)
+}
+
+func TestAuthClientOptsFromContext_WithRegistry(t *testing.T) {
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(auth.NewMockHandler("h")))
+	ctx := auth.WithRegistry(context.Background(), reg)
+
+	opts := AuthClientOptsFromContext(ctx)
+	assert.Len(t, opts, 1)
+}

--- a/pkg/solution/builder/store.go
+++ b/pkg/solution/builder/store.go
@@ -20,8 +20,8 @@ type StoreOptions struct {
 	// Force overwrites an existing version in the catalog.
 	Force bool `json:"force,omitempty" yaml:"force,omitempty" doc:"Overwrite existing version"`
 
-	// Source is the path to the solution file, recorded as an annotation.
-	Source string `json:"source,omitempty" yaml:"source,omitempty" doc:"Source file path for annotation"`
+	// Source is the origin of the solution (repository URL or file path), stored as org.opencontainers.image.source.
+	Source string `json:"source,omitempty" yaml:"source,omitempty" doc:"Source repository URL or file path"`
 
 	// DisplayName is the human-readable name, stored as an OCI annotation.
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"Human-readable display name"`
@@ -34,6 +34,10 @@ type StoreOptions struct {
 
 	// Tags are searchable keywords, stored as a comma-separated OCI annotation.
 	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Searchable tags"`
+
+	// Annotations is a free-form map merged into OCI annotations.
+	// Engine-set annotations take precedence over user-supplied ones.
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" doc:"User-supplied annotations"`
 
 	// ArtifactCacheDir is the path to the artifact cache directory.
 	// When non-empty, the corresponding artifact cache entry is invalidated
@@ -71,6 +75,7 @@ func StoreSolutionArtifact(ctx context.Context, localCatalog *catalog.LocalCatal
 	}
 
 	annotations := catalog.NewAnnotationBuilder().
+		SetMap(opts.Annotations).
 		Set(catalog.AnnotationSource, opts.Source).
 		Set(catalog.AnnotationDisplayName, opts.DisplayName).
 		Set(catalog.AnnotationDescription, opts.Description).

--- a/pkg/solution/inspect/inspect.go
+++ b/pkg/solution/inspect/inspect.go
@@ -40,6 +40,9 @@ type SolutionExplanation struct {
 	Actions   []ActionInfo   `json:"actions,omitempty" yaml:"actions,omitempty" doc:"Action configurations" maxItems:"1000"`
 	Finally   []ActionInfo   `json:"finally,omitempty" yaml:"finally,omitempty" doc:"Finally/cleanup actions" maxItems:"100"`
 
+	Source      string            `json:"source,omitempty" yaml:"source,omitempty" doc:"Source repository URL" maxLength:"500"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" doc:"Free-form key-value annotations"`
+
 	Tags        []string         `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Solution tags" maxItems:"50"`
 	Links       []LinkInfo       `json:"links,omitempty" yaml:"links,omitempty" doc:"Related links" maxItems:"50"`
 	Maintainers []MaintainerInfo `json:"maintainers,omitempty" yaml:"maintainers,omitempty" doc:"Solution maintainers" maxItems:"20"`
@@ -145,6 +148,12 @@ func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation {
 	}
 	if sol.Metadata.Category != "" {
 		exp.Category = sol.Metadata.Category
+	}
+	if sol.Metadata.Source != "" {
+		exp.Source = sol.Metadata.Source
+	}
+	if len(sol.Metadata.Annotations) > 0 {
+		exp.Annotations = sol.Metadata.Annotations
 	}
 
 	// Catalog info

--- a/pkg/solution/inspect/inspect_test.go
+++ b/pkg/solution/inspect/inspect_test.go
@@ -134,12 +134,16 @@ func TestBuildSolutionExplanation_WithDisplayName(t *testing.T) {
 	sol.Metadata.Description = "A test solution"
 	sol.Metadata.Category = "infra"
 	sol.Metadata.Tags = []string{"a", "b"}
+	sol.Metadata.Source = "https://github.com/example/sol"
+	sol.Metadata.Annotations = map[string]string{"team": "platform"}
 
 	exp := BuildSolutionExplanation(sol)
 	assert.Equal(t, "My Solution", exp.DisplayName)
 	assert.Equal(t, "A test solution", exp.Description)
 	assert.Equal(t, "infra", exp.Category)
 	assert.Equal(t, []string{"a", "b"}, exp.Tags)
+	assert.Equal(t, "https://github.com/example/sol", exp.Source)
+	assert.Equal(t, map[string]string{"team": "platform"}, exp.Annotations)
 }
 
 func TestBuildSolutionExplanation_WithLinks(t *testing.T) {

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -925,7 +925,7 @@ func BuildPluginFetcherWithConfig(ctx context.Context, override PluginFetcherOve
 // registry from context and builds a plugin fetcher on demand.
 // Returns the plugin clients created (caller must defer Kill on each), or nil
 // when no providers needed resolution or fetching failed non-fatally.
-func ResolveOfficialProviders(ctx context.Context, sol *solution.Solution, reg *provider.Registry) ([]*plugin.Client, error) {
+func ResolveOfficialProviders(ctx context.Context, sol *solution.Solution, reg *provider.Registry, clientOpts ...plugin.ClientOption) ([]*plugin.Client, error) {
 	officialReg := official.RegistryFromContext(ctx)
 	if officialReg == nil || officialReg.Len() == 0 {
 		return nil, nil
@@ -957,7 +957,7 @@ func ResolveOfficialProviders(ctx context.Context, sol *solution.Solution, reg *
 	if err != nil {
 		return nil, fmt.Errorf("auto-fetching official providers: %w", err)
 	}
-	clients, err := plugin.RegisterFetchedPlugins(ctx, reg, results, nil)
+	clients, err := plugin.RegisterFetchedPlugins(ctx, reg, results, nil, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("registering auto-resolved official providers: %w", err)
 	}
@@ -1080,6 +1080,7 @@ func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Soluti
 		Description string   `json:"description"`
 		Category    string   `json:"category"`
 		Tags        []string `json:"tags"`
+		Source      string   `json:"source,omitempty"`
 	}
 
 	solMeta := solutionMeta{}
@@ -1089,6 +1090,7 @@ func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Soluti
 		solMeta.Description = sol.Metadata.Description
 		solMeta.Category = sol.Metadata.Category
 		solMeta.Tags = sol.Metadata.Tags
+		solMeta.Source = sol.Metadata.Source
 		if sol.Metadata.Version != nil {
 			solMeta.Version = sol.Metadata.Version.String()
 		}

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -129,6 +129,13 @@ type Metadata struct {
 
 	// Banner is a URL or path to a banner image for the solution
 	Banner string `json:"banner,omitempty" yaml:"banner,omitempty" doc:"URL or path to the solution banner" maxLength:"500" pattern:"^((http|https|file):\\/\\/.+|[a-zA-Z0-9_-]+\\.(png|jpg|jpeg|svg|gif))$" required:"false"`
+
+	// Source is the URL to the solution's source code repository
+	Source string `json:"source,omitempty" yaml:"source,omitempty" doc:"URL to the solution source repository" maxLength:"500" required:"false"`
+
+	// Annotations is a free-form map of key-value metadata for tooling and humans.
+	// Not interpreted by the engine. Follows the Kubernetes annotation pattern.
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" doc:"Free-form key-value annotations" required:"false"`
 }
 
 // Catalog controls distribution and visibility of the solution.

--- a/pkg/solution/solution_test.go
+++ b/pkg/solution/solution_test.go
@@ -126,6 +126,26 @@ metadata:
 	}
 }
 
+func TestSolution_UnmarshalSourceAndAnnotations(t *testing.T) {
+	yamlBytes := []byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-solution
+  version: 1.0.0
+  source: https://github.com/example/test-solution
+  annotations:
+    team: platform
+    costCenter: "12345"
+`)
+	var s Solution
+	require.NoError(t, s.UnmarshalFromBytes(yamlBytes))
+	assert.Equal(t, "https://github.com/example/test-solution", s.Metadata.Source)
+	require.Len(t, s.Metadata.Annotations, 2)
+	assert.Equal(t, "platform", s.Metadata.Annotations["team"])
+	assert.Equal(t, "12345", s.Metadata.Annotations["costCenter"])
+}
+
 func TestSolution_ToJSON(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
- add Source and Annotations fields to solution Metadata struct
- add SetMap method to AnnotationBuilder for merging user annotations
- map source and annotations to OCI annotations during build, with engine-set keys taking precedence over user-supplied ones
- fall back to build file path when metadata.source is empty
- propagate source and annotations through catalog index enrichment, copyEnrichedMetadata, matchesSearch, and explain output
- add Source to runtime solutionMeta exposed to providers
- sort annotation keys in explain output for deterministic display
- add HostDepsFromAuthRegistry to build host-side auth deps from the auth registry for plugin gRPC callbacks
- add AuthClientOptsFromContext helper to eliminate duplicated auth-wiring across run, render, serve, and provider commands
- forward clientOpts through ResolveOfficialProviders for auth propagation to auto-resolved plugin providers

BREAKING CHANGE: StoreOptions.Source now holds the repository URL from metadata.source instead of the build file path. When metadata.source is empty, the file path is used as a fallback.

Closes #350
Closes #351
