### PR TITLE
feat(auth): add FlowDetector interface and plugin DetectAvailableFlows RPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oakwood-commons/scafctl
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/bubbletea/v2 v2.0.6
@@ -32,7 +32,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.4.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0
@@ -61,7 +61,7 @@ require (
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4
-	google.golang.org/grpc v1.80.0
+	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/oakwood-commons/kvx v0.12.0 h1:vGSUe/4WP0HXc4Hixh8nSVeNl9blTF0K+6/djG
 github.com/oakwood-commons/kvx v0.12.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.4.0 h1:Qxu3eBHS3DBcXV0NiRk+yapfk383Z5brXs2EV2Up3g8=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.4.0/go.mod h1:rTVtlxWjYBdgcUWEOrdQJF1jBEFtYLtSjZThx8nZEr0=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0 h1:NNFtY/dCNHO0ZwEQmW3kskA1a5u3ZtcHqBQpRG32HJg=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0/go.mod h1:nu15ohRNWoy6/XtQJW4wMxkdB9fhDQTQrT/GxBEwF9o=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -532,8 +532,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:Q9HWtNeE7tM9npdIsEvqXj1QJIvVoeAV3rtXtS715Cw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 h1:tEkOQcXgF6dH1G+MVKZrfpYvozGrzb91k6ha7jireSM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
+google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	sdkauth "github.com/oakwood-commons/scafctl-plugin-sdk/auth"
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
 )
 
 // Handler defines the interface for authentication handlers.
@@ -117,4 +118,21 @@ type FlowReporter interface {
 	// ActiveFlow returns the authentication flow currently in use.
 	// Returns an empty string if the flow cannot be determined.
 	ActiveFlow(ctx context.Context) Flow
+}
+
+// FlowAvailability reports whether a specific auth flow is available based on
+// environment credentials or configuration.
+type FlowAvailability = sdkplugin.FlowAvailability
+
+// FlowDetector is an optional interface for auth handlers that can report which
+// flows have pre-existing environment credentials (e.g., PAT in GITHUB_TOKEN,
+// workload identity in AZURE_FEDERATED_TOKEN_FILE). The CLI uses this for flow
+// auto-selection without importing handler-specific packages.
+//
+// Plugin auth handlers implement this via the SDK's DetectAvailableFlows RPC.
+// Built-in handlers (like oauth2) may optionally implement this interface.
+type FlowDetector interface {
+	// DetectAvailableFlows returns the availability of each supported auth flow
+	// based on the current environment (env vars, config files, metadata endpoints).
+	DetectAvailableFlows(ctx context.Context) ([]FlowAvailability, error)
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -15,6 +15,7 @@ import (
 	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
 	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	customoauth2 "github.com/oakwood-commons/scafctl/pkg/auth/oauth2"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	authcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/build"
@@ -171,6 +172,13 @@ type RootOptions struct {
 	// Embedders can supply a custom registry via official.NewRegistryFrom to
 	// extend or replace the default set.
 	OfficialProviders *official.Registry
+
+	// OfficialAuthHandlers overrides the default official auth handler registry
+	// used for auto-resolution. When nil and DisableOfficialAuthHandlers is
+	// false, the default registry (3 extracted first-party auth handlers) is
+	// used. Embedders can supply a custom registry via
+	// authofficial.NewRegistryFrom to extend or replace the default set.
+	OfficialAuthHandlers *authofficial.Registry
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -532,6 +540,27 @@ func Root(opts *RootOptions) *cobra.Command {
 						lgr.V(1).Info("warning: failed to register custom OAuth2 handler", "name", customCfg.Name, "error", regErr)
 					}
 				}
+			}
+
+			// ── Wire official auth handler registry for auto-resolution ──
+			// Same pattern as official providers. When the embedder provides a
+			// custom registry, use it. Otherwise, use the default registry
+			// unless disabled in config.
+			// NOTE: This must be wired before RegisterAuthHandlerPlugins so that
+			// configureAndRegisterAuthHandlers can read per-handler TrustedVerificationDomains.
+			if !cfg.Settings.DisableOfficialAuthHandlers {
+				officialAuthReg := opts.OfficialAuthHandlers
+				if officialAuthReg == nil {
+					officialAuthReg = authofficial.NewRegistry()
+				}
+				source := "default"
+				if opts.OfficialAuthHandlers != nil {
+					source = "embedder"
+				}
+				lgr.V(1).Info("official auth handler registry enabled", "count", officialAuthReg.Len(), "source", source)
+				ctx = authofficial.WithRegistry(ctx, officialAuthReg)
+			} else {
+				lgr.V(1).Info("official auth handler registry disabled via config")
 			}
 
 			// Register auth handler plugins if directories are configured

--- a/pkg/cmd/scafctl/root_coverage_test.go
+++ b/pkg/cmd/scafctl/root_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -406,4 +407,105 @@ func TestRoot_BinaryName_Empty(t *testing.T) {
 	t.Parallel()
 	cmd := Root(&RootOptions{BinaryName: ""})
 	assert.Equal(t, "scafctl", cmd.Use)
+}
+
+// TestRoot_OfficialAuthHandlerRegistry_Enabled verifies that the official auth
+// handler registry is wired into the context when not disabled.
+func TestRoot_OfficialAuthHandlerRegistry_Enabled(t *testing.T) {
+	t.Parallel()
+
+	var registryFromCtx *authofficial.Registry
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := Root(&RootOptions{
+		IOStreams: ioStreams,
+		PreRunHook: func(cmd *cobra.Command, _ []string) error {
+			registryFromCtx = authofficial.RegistryFromContext(cmd.Context())
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"version"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, registryFromCtx, "official auth handler registry should be set in context")
+	assert.Equal(t, 3, registryFromCtx.Len(), "default registry should contain 3 handlers")
+}
+
+// TestRoot_OfficialAuthHandlerRegistry_CustomEmbedder verifies that an
+// embedder-supplied registry is used instead of the default.
+func TestRoot_OfficialAuthHandlerRegistry_CustomEmbedder(t *testing.T) {
+	t.Parallel()
+
+	customRegistry := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "custom-handler", CatalogRef: "custom", DefaultVersion: "latest", MinSDKVersion: "0.1.0"},
+	})
+
+	var registryFromCtx *authofficial.Registry
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := Root(&RootOptions{
+		IOStreams:            ioStreams,
+		OfficialAuthHandlers: customRegistry,
+		PreRunHook: func(cmd *cobra.Command, _ []string) error {
+			registryFromCtx = authofficial.RegistryFromContext(cmd.Context())
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"version"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, registryFromCtx, "embedder registry should be set in context")
+	assert.Equal(t, 1, registryFromCtx.Len(), "embedder registry should contain 1 handler")
+	_, found := registryFromCtx.Get("custom-handler")
+	assert.True(t, found, "embedder registry should contain the custom handler")
+}
+
+// TestRoot_OfficialAuthHandlerRegistry_Disabled verifies that the official auth
+// handler registry is nil in context when disabled via config.
+func TestRoot_OfficialAuthHandlerRegistry_Disabled(t *testing.T) {
+	t.Parallel()
+
+	disabledCfg := []byte("settings:\n  disableOfficialAuthHandlers: true\n")
+
+	var registryFromCtx *authofficial.Registry
+	hookCalled := false
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := Root(&RootOptions{
+		IOStreams:      ioStreams,
+		ConfigDefaults: disabledCfg,
+		PreRunHook: func(cmd *cobra.Command, _ []string) error {
+			registryFromCtx = authofficial.RegistryFromContext(cmd.Context())
+			hookCalled = true
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"version"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.True(t, hookCalled, "PreRunHook should have been called")
+	assert.Nil(t, registryFromCtx, "official auth handler registry should be nil when disabled")
+}
+
+// TestRoot_OfficialAuthHandlerRegistry_Enabled_NonDefaultBinary verifies that the
+// registry is wired correctly when using a custom BinaryName (embedder scenario).
+func TestRoot_OfficialAuthHandlerRegistry_Enabled_NonDefaultBinary(t *testing.T) {
+	t.Parallel()
+
+	var registryFromCtx *authofficial.Registry
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := Root(&RootOptions{
+		IOStreams:  ioStreams,
+		BinaryName: "mycli",
+		PreRunHook: func(cmd *cobra.Command, _ []string) error {
+			registryFromCtx = authofficial.RegistryFromContext(cmd.Context())
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"version"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, registryFromCtx, "official auth handler registry should be set for custom binary")
+	assert.Equal(t, 3, registryFromCtx.Len())
 }

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -45,6 +45,8 @@ type mockAuthHandlerServiceClient struct {
 	purgeExpiredTokensErr    error
 	stopAuthHandlerResp      *proto.StopAuthHandlerResponse
 	stopAuthHandlerErr       error
+	detectAvailableFlowsResp *proto.DetectAvailableFlowsResponse
+	detectAvailableFlowsErr  error
 }
 
 func (m *mockAuthHandlerServiceClient) GetAuthHandlers(_ context.Context, _ *proto.GetAuthHandlersRequest, _ ...grpc.CallOption) (*proto.GetAuthHandlersResponse, error) {
@@ -84,6 +86,10 @@ func (m *mockAuthHandlerServiceClient) PurgeExpiredTokens(_ context.Context, _ *
 
 func (m *mockAuthHandlerServiceClient) StopAuthHandler(_ context.Context, _ *proto.StopAuthHandlerRequest, _ ...grpc.CallOption) (*proto.StopAuthHandlerResponse, error) {
 	return m.stopAuthHandlerResp, m.stopAuthHandlerErr
+}
+
+func (m *mockAuthHandlerServiceClient) DetectAvailableFlows(_ context.Context, _ *proto.DetectAvailableFlowsRequest, _ ...grpc.CallOption) (*proto.DetectAvailableFlowsResponse, error) {
+	return m.detectAvailableFlowsResp, m.detectAvailableFlowsErr
 }
 
 // --- Mock login stream ---
@@ -636,6 +642,90 @@ func TestAuthHandlerGRPCClient_StopAuthHandler_OtherError(t *testing.T) {
 }
 
 // =====================================================================
+// AuthHandlerGRPCClient DetectAvailableFlows tests
+// =====================================================================
+
+func TestAuthHandlerGRPCClient_DetectAvailableFlows_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		detectAvailableFlowsResp: &proto.DetectAvailableFlowsResponse{
+			Flows: []*proto.FlowAvailability{
+				{Flow: "pat", Available: true, Reason: "GITHUB_TOKEN is set"},
+				{Flow: "device_code", Available: false, Reason: ""},
+			},
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	flows, err := client.DetectAvailableFlows(context.Background(), "github")
+	require.NoError(t, err)
+	require.Len(t, flows, 2)
+
+	assert.Equal(t, auth.Flow("pat"), flows[0].Flow)
+	assert.True(t, flows[0].Available)
+	assert.Equal(t, "GITHUB_TOKEN is set", flows[0].Reason)
+
+	assert.Equal(t, auth.Flow("device_code"), flows[1].Flow)
+	assert.False(t, flows[1].Available)
+}
+
+func TestAuthHandlerGRPCClient_DetectAvailableFlows_ResponseError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		detectAvailableFlowsResp: &proto.DetectAvailableFlowsResponse{
+			Error: "detection failed: handler not configured",
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.DetectAvailableFlows(context.Background(), "github")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handler not configured")
+}
+
+func TestAuthHandlerGRPCClient_DetectAvailableFlows_Unimplemented(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		detectAvailableFlowsErr: status.Error(codes.Unimplemented, "not supported"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	flows, err := client.DetectAvailableFlows(context.Background(), "github")
+	require.NoError(t, err) // should degrade gracefully
+	assert.Empty(t, flows)  // empty result, no error
+	assert.NotNil(t, flows) // must be empty slice, not nil
+}
+
+func TestAuthHandlerGRPCClient_DetectAvailableFlows_OtherError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		detectAvailableFlowsErr: errors.New("transport error"),
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.DetectAvailableFlows(context.Background(), "github")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detect available flows RPC failed")
+}
+
+func TestAuthHandlerGRPCClient_DetectAvailableFlows_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		detectAvailableFlowsResp: &proto.DetectAvailableFlowsResponse{},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	flows, err := client.DetectAvailableFlows(context.Background(), "github")
+	require.NoError(t, err)
+	assert.Empty(t, flows)
+}
+
+// =====================================================================
 // AuthHandlerGRPCServer tests for uncovered server methods
 // =====================================================================
 
@@ -731,6 +821,46 @@ func TestAuthHandlerGRPCServer_PurgeExpiredTokens_Error(t *testing.T) {
 
 	_, err := server.PurgeExpiredTokens(context.Background(), &proto.PurgeExpiredTokensRequest{HandlerName: "test"})
 	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCServer_DetectAvailableFlows_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		detectFlowsFunc: func(_ context.Context, _ string) ([]FlowAvailability, error) {
+			return []FlowAvailability{
+				{Flow: "pat", Available: true, Reason: "GITHUB_TOKEN is set"},
+				{Flow: "device_code", Available: false},
+			}, nil
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	resp, err := server.DetectAvailableFlows(context.Background(), &proto.DetectAvailableFlowsRequest{HandlerName: "github"})
+	require.NoError(t, err)
+	require.Empty(t, resp.Error)
+	require.Len(t, resp.Flows, 2)
+	assert.Equal(t, "pat", resp.Flows[0].Flow)
+	assert.True(t, resp.Flows[0].Available)
+	assert.Equal(t, "GITHUB_TOKEN is set", resp.Flows[0].Reason)
+	assert.Equal(t, "device_code", resp.Flows[1].Flow)
+	assert.False(t, resp.Flows[1].Available)
+}
+
+func TestAuthHandlerGRPCServer_DetectAvailableFlows_Error(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		detectFlowsFunc: func(_ context.Context, _ string) ([]FlowAvailability, error) {
+			return nil, fmt.Errorf("detection failed")
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+
+	resp, err := server.DetectAvailableFlows(context.Background(), &proto.DetectAvailableFlowsRequest{HandlerName: "github"})
+	require.NoError(t, err) // gRPC error is communicated via response, not gRPC error
+	assert.Equal(t, "detection failed", resp.Error)
+	assert.Empty(t, resp.Flows)
 }
 
 // =====================================================================
@@ -1139,6 +1269,51 @@ func TestAuthHandlerWrapper_InjectAuth_EmptyTokenType(t *testing.T) {
 	assert.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
 }
 
+func TestAuthHandlerWrapper_DetectAvailableFlows_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{
+		detectFlowsFunc: func(_ context.Context, _ string) ([]FlowAvailability, error) {
+			return []FlowAvailability{
+				{Flow: "pat", Available: true, Reason: "GITHUB_TOKEN is set"},
+			}, nil
+		},
+	}
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "github",
+		info:        AuthHandlerInfo{Name: "github"},
+	}
+
+	flows, err := w.DetectAvailableFlows(context.Background())
+	require.NoError(t, err)
+	require.Len(t, flows, 1)
+	assert.Equal(t, auth.Flow("pat"), flows[0].Flow)
+	assert.True(t, flows[0].Available)
+}
+
+func TestAuthHandlerWrapper_DetectAvailableFlows_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{} // default returns nil, nil
+	w := &AuthHandlerWrapper{
+		client:      &AuthHandlerClient{plugin: mock, name: "p"},
+		handlerName: "h",
+		info:        AuthHandlerInfo{Name: "h"},
+	}
+
+	flows, err := w.DetectAvailableFlows(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, flows)
+}
+
+func TestAuthHandlerWrapper_ImplementsFlowDetector(t *testing.T) {
+	t.Parallel()
+
+	w := &AuthHandlerWrapper{}
+	var _ auth.FlowDetector = w // compile-time check
+}
+
 // =====================================================================
 // errAuthPlugin helper for error-path server tests
 // =====================================================================
@@ -1181,4 +1356,8 @@ func (e *errAuthPlugin) ConfigureAuthHandler(_ context.Context, _ string, _ Prov
 
 func (e *errAuthPlugin) StopAuthHandler(_ context.Context, _ string) error {
 	return e.err
+}
+
+func (e *errAuthPlugin) DetectAvailableFlows(_ context.Context, _ string) ([]FlowAvailability, error) {
+	return nil, e.err
 }

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -212,6 +212,25 @@ func (s *AuthHandlerGRPCServer) PurgeExpiredTokens(ctx context.Context, req *pro
 	}, nil
 }
 
+// DetectAvailableFlows implements the DetectAvailableFlows RPC.
+func (s *AuthHandlerGRPCServer) DetectAvailableFlows(ctx context.Context, req *proto.DetectAvailableFlowsRequest) (*proto.DetectAvailableFlowsResponse, error) {
+	flows, err := s.Impl.DetectAvailableFlows(ctx, req.HandlerName)
+	if err != nil {
+		//nolint:nilerr // Error is communicated via response, not gRPC error
+		return &proto.DetectAvailableFlowsResponse{Error: err.Error()}, nil
+	}
+
+	protoFlows := make([]*proto.FlowAvailability, len(flows))
+	for i, f := range flows {
+		protoFlows[i] = &proto.FlowAvailability{
+			Flow:      string(f.Flow),
+			Available: f.Available,
+			Reason:    f.Reason,
+		}
+	}
+	return &proto.DetectAvailableFlowsResponse{Flows: protoFlows}, nil
+}
+
 // ConfigureAuthHandler implements the ConfigureAuthHandler RPC.
 func (s *AuthHandlerGRPCServer) ConfigureAuthHandler(ctx context.Context, req *proto.ConfigureAuthHandlerRequest) (*proto.ConfigureAuthHandlerResponse, error) {
 	settings := make(map[string]json.RawMessage, len(req.Settings))
@@ -403,6 +422,35 @@ func (c *AuthHandlerGRPCClient) ConfigureAuthHandler(ctx context.Context, handle
 		return fmt.Errorf("configure auth handler failed: %s", resp.Error)
 	}
 	return nil
+}
+
+// DetectAvailableFlows implements AuthHandlerPlugin.DetectAvailableFlows.
+func (c *AuthHandlerGRPCClient) DetectAvailableFlows(ctx context.Context, handlerName string) ([]FlowAvailability, error) {
+	resp, err := c.client.DetectAvailableFlows(ctx, &proto.DetectAvailableFlowsRequest{
+		HandlerName: handlerName,
+	})
+	if err != nil {
+		// Older plugins (SDK <0.5.0) may not implement DetectAvailableFlows.
+		// Degrade gracefully: return empty list so the host falls back to
+		// default flow selection.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return []FlowAvailability{}, nil
+		}
+		return nil, fmt.Errorf("detect available flows RPC failed: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("detect available flows: %s", resp.Error)
+	}
+
+	flows := make([]FlowAvailability, len(resp.Flows))
+	for i, f := range resp.Flows {
+		flows[i] = FlowAvailability{
+			Flow:      auth.Flow(f.Flow),
+			Available: f.Available,
+			Reason:    f.Reason,
+		}
+	}
+	return flows, nil
 }
 
 // StopAuthHandler implements AuthHandlerPlugin.StopAuthHandler.

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -38,6 +38,10 @@ type TokenRequest = sdkplugin.TokenRequest
 // TokenResponse contains the result of a plugin GetToken call.
 type TokenResponse = sdkplugin.TokenResponse
 
+// FlowAvailability reports whether a specific auth flow is available based on
+// environment credentials or configuration.
+type FlowAvailability = sdkplugin.FlowAvailability
+
 // AuthHandlerPlugin is the interface that auth handler plugins must implement.
 type AuthHandlerPlugin = sdkplugin.AuthHandlerPlugin
 

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -17,18 +17,19 @@ import (
 
 // MockAuthHandlerPlugin implements AuthHandlerPlugin for testing.
 type MockAuthHandlerPlugin struct {
-	handlers     []AuthHandlerInfo
-	loginFunc    func(ctx context.Context, name string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
-	logoutFunc   func(ctx context.Context, name string) error
-	statusFunc   func(ctx context.Context, name string) (*auth.Status, error)
-	tokenFunc    func(ctx context.Context, name string, req TokenRequest) (*TokenResponse, error)
-	listFunc     func(ctx context.Context, name string) ([]*auth.CachedTokenInfo, error)
-	purgeFunc    func(ctx context.Context, name string) (int, error)
-	configureErr error
-	lastConfig   *ProviderConfig
-	stopErr      error
-	stopCalled   bool
-	stopHandler  string
+	handlers        []AuthHandlerInfo
+	loginFunc       func(ctx context.Context, name string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
+	logoutFunc      func(ctx context.Context, name string) error
+	statusFunc      func(ctx context.Context, name string) (*auth.Status, error)
+	tokenFunc       func(ctx context.Context, name string, req TokenRequest) (*TokenResponse, error)
+	listFunc        func(ctx context.Context, name string) ([]*auth.CachedTokenInfo, error)
+	purgeFunc       func(ctx context.Context, name string) (int, error)
+	detectFlowsFunc func(ctx context.Context, name string) ([]FlowAvailability, error)
+	configureErr    error
+	lastConfig      *ProviderConfig
+	stopErr         error
+	stopCalled      bool
+	stopHandler     string
 }
 
 func (m *MockAuthHandlerPlugin) GetAuthHandlers(ctx context.Context) ([]AuthHandlerInfo, error) {
@@ -138,6 +139,14 @@ func (m *MockAuthHandlerPlugin) StopAuthHandler(_ context.Context, handlerName s
 	m.stopCalled = true
 	m.stopHandler = handlerName
 	return m.stopErr
+}
+
+//nolint:revive // all params required by interface
+func (m *MockAuthHandlerPlugin) DetectAvailableFlows(ctx context.Context, handlerName string) ([]FlowAvailability, error) {
+	if m.detectFlowsFunc != nil {
+		return m.detectFlowsFunc(ctx, handlerName)
+	}
+	return nil, nil
 }
 
 func TestAuthHandlerGRPC_GetAuthHandlers(t *testing.T) {

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -17,9 +17,10 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ auth.Handler     = (*AuthHandlerWrapper)(nil)
-	_ auth.TokenLister = (*AuthHandlerWrapper)(nil)
-	_ auth.TokenPurger = (*AuthHandlerWrapper)(nil)
+	_ auth.Handler      = (*AuthHandlerWrapper)(nil)
+	_ auth.TokenLister  = (*AuthHandlerWrapper)(nil)
+	_ auth.TokenPurger  = (*AuthHandlerWrapper)(nil)
+	_ auth.FlowDetector = (*AuthHandlerWrapper)(nil)
 )
 
 // AuthHandlerWrapper wraps a plugin auth handler to implement the auth.Handler
@@ -199,6 +200,11 @@ func (w *AuthHandlerWrapper) ListCachedTokens(ctx context.Context) ([]*auth.Cach
 // PurgeExpiredTokens implements auth.TokenPurger.
 func (w *AuthHandlerWrapper) PurgeExpiredTokens(ctx context.Context) (int, error) {
 	return w.client.plugin.PurgeExpiredTokens(ctx, w.handlerName)
+}
+
+// DetectAvailableFlows implements auth.FlowDetector.
+func (w *AuthHandlerWrapper) DetectAvailableFlows(ctx context.Context) ([]auth.FlowAvailability, error) {
+	return w.client.plugin.DetectAvailableFlows(ctx, w.handlerName)
 }
 
 // Client returns the underlying plugin client.

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -938,9 +939,19 @@ func (r *Runner) checkExitCode(tc *TestCase, output *CommandOutput) bool {
 
 // evaluateSkipExpression evaluates a CEL skip expression.
 func (r *Runner) evaluateSkipExpression(ctx context.Context, expr string) (bool, error) {
+	// Use GOOS/GOARCH env vars if set (e.g., cross-compilation), otherwise
+	// fall back to runtime values so skip expressions work without env setup.
+	goOS := os.Getenv("GOOS")
+	if goOS == "" {
+		goOS = runtime.GOOS
+	}
+	goArch := os.Getenv("GOARCH")
+	if goArch == "" {
+		goArch = runtime.GOARCH
+	}
 	envVars := map[string]any{
-		"os":         os.Getenv("GOOS"),
-		"arch":       os.Getenv("GOARCH"),
+		"os":         goOS,
+		"arch":       goArch,
 		"subprocess": r.BinaryPath != "",
 	}
 

--- a/pkg/solution/soltesting/runner_coverage_test.go
+++ b/pkg/solution/soltesting/runner_coverage_test.go
@@ -5,7 +5,9 @@ package soltesting
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/shellexec"
@@ -80,6 +82,34 @@ func TestEvaluateSkipExpression_NonBoolResult(t *testing.T) {
 	_, err := runner.evaluateSkipExpression(ctx, `"string_value"`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must return bool")
+}
+
+func TestEvaluateSkipExpression_OSVariable(t *testing.T) {
+	t.Setenv("GOOS", "")
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	// os variable should equal runtime.GOOS when GOOS env var is not set
+	expr := fmt.Sprintf(`os == "%s"`, runtime.GOOS)
+	result, err := runner.evaluateSkipExpression(ctx, expr)
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestEvaluateSkipExpression_ArchVariable(t *testing.T) {
+	t.Setenv("GOARCH", "")
+	runner := &Runner{
+		IOStreams: &terminal.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+	}
+	ctx := context.Background()
+
+	// arch variable should equal runtime.GOARCH when GOARCH env var is not set
+	expr := fmt.Sprintf(`arch == "%s"`, runtime.GOARCH)
+	result, err := runner.evaluateSkipExpression(ctx, expr)
+	require.NoError(t, err)
+	assert.True(t, result)
 }
 
 func TestComposeExecMocks_MatchingRule(t *testing.T) {

--- a/tests/integration/solutions/providers/directory-security/solution.yaml
+++ b/tests/integration/solutions/providers/directory-security/solution.yaml
@@ -90,6 +90,8 @@ spec:
         description: Verify symlinks are silently skipped during listing
         extends: [_base]
         args: ["symlinkDir", "-o", "json"]
+        skip: 'os == "windows"'
+        skipReason: "Symlink creation requires elevated privileges or Developer Mode on Windows"
         init:
           - command: |
               mkdir -p symlink-test-dir


### PR DESCRIPTION
- add auth.FlowDetector interface for handlers to report which flows have pre-existing environment credentials (PAT, workload identity)
- add auth.FlowAvailability type alias from plugin SDK
- implement DetectAvailableFlows gRPC client/server with graceful degradation for older plugins (SDK <0.5.0)
- wire AuthHandlerWrapper as auth.FlowDetector
- add OfficialAuthHandlers field to RootOptions for embedder customization of the official auth handler registry
- wire official auth handler registry in root command (same pattern as official providers)
- fix soltesting skip expressions to fall back to runtime.GOOS and runtime.GOARCH when env vars are unset
- bump scafctl-plugin-sdk to v0.5.0 and grpc to v1.81.0