### PR TITLE
feat(mcp): auto-resolve official plugin providers on demand

### DIFF
--- a/pkg/api/endpoints/providers.go
+++ b/pkg/api/endpoints/providers.go
@@ -11,8 +11,35 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"github.com/oakwood-commons/scafctl/pkg/api"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
+
+// ensureAPIProvider attempts to auto-resolve an official plugin provider via
+// the plugin pool. Returns a release function (may be nil) and the resolved
+// provider, or an error if the provider cannot be loaded.
+func ensureAPIProvider(ctx context.Context, hctx *api.HandlerContext, name string) (provider.Provider, func(), error) {
+	if hctx.PluginPool == nil || hctx.OfficialProviders == nil {
+		return nil, nil, api.NotFoundError("provider", name)
+	}
+	op, found := hctx.OfficialProviders.Get(name)
+	if !found {
+		return nil, nil, api.NotFoundError("provider", name)
+	}
+	dep := op.ToPluginDependency()
+	release, err := hctx.PluginPool.EnsureAndAcquire(ctx, []solution.PluginDependency{dep})
+	if err != nil {
+		status := plugin.PoolErrorHTTPStatus(err)
+		return nil, nil, huma.NewError(status, fmt.Sprintf("failed to load plugin for provider %q: %v", name, err))
+	}
+	p, ok := hctx.ProviderRegistry.Get(name)
+	if !ok {
+		release()
+		return nil, nil, api.NotFoundError("provider", name)
+	}
+	return p, release, nil
+}
 
 // ProviderListItem represents a provider in API responses.
 type ProviderListItem struct {
@@ -101,7 +128,7 @@ func RegisterProviderEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Summary:     "Get provider details",
 		Description: "Returns detailed information about a specific provider.",
 		Tags:        []string{"Providers"},
-	}, hctx, http.StatusOK), func(_ context.Context, input *struct {
+	}, hctx, http.StatusOK), func(ctx context.Context, input *struct {
 		Name string `path:"name" maxLength:"255" doc:"Provider name"`
 	},
 	) (*ProviderDetailResponse, error) {
@@ -111,7 +138,13 @@ func RegisterProviderEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 
 		p, ok := hctx.ProviderRegistry.Get(input.Name)
 		if !ok {
-			return nil, api.NotFoundError("provider", input.Name)
+			// Try auto-resolving via the plugin pool
+			resolved, release, err := ensureAPIProvider(ctx, hctx, input.Name)
+			if err != nil {
+				return nil, err
+			}
+			defer release()
+			p = resolved
 		}
 
 		desc := p.Descriptor()
@@ -133,7 +166,7 @@ func RegisterProviderEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Summary:     "Get provider JSON schema",
 		Description: "Returns the input JSON schema for a specific provider.",
 		Tags:        []string{"Providers"},
-	}, hctx, http.StatusOK), func(_ context.Context, input *struct {
+	}, hctx, http.StatusOK), func(ctx context.Context, input *struct {
 		Name string `path:"name" maxLength:"255" doc:"Provider name"`
 	},
 	) (*ProviderSchemaResponse, error) {
@@ -143,7 +176,13 @@ func RegisterProviderEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 
 		p, ok := hctx.ProviderRegistry.Get(input.Name)
 		if !ok {
-			return nil, api.NotFoundError("provider", input.Name)
+			// Try auto-resolving via the plugin pool
+			resolved, release, err := ensureAPIProvider(ctx, hctx, input.Name)
+			if err != nil {
+				return nil, err
+			}
+			defer release()
+			p = resolved
 		}
 
 		desc := p.Descriptor()

--- a/pkg/api/endpoints/providers.go
+++ b/pkg/api/endpoints/providers.go
@@ -17,8 +17,9 @@ import (
 )
 
 // ensureAPIProvider attempts to auto-resolve an official plugin provider via
-// the plugin pool. Returns a release function (may be nil) and the resolved
-// provider, or an error if the provider cannot be loaded.
+// the plugin pool. On success, returns the resolved provider and a non-nil
+// release function that the caller must defer. Returns an error if the
+// provider cannot be loaded.
 func ensureAPIProvider(ctx context.Context, hctx *api.HandlerContext, name string) (provider.Provider, func(), error) {
 	if hctx.PluginPool == nil || hctx.OfficialProviders == nil {
 		return nil, nil, api.NotFoundError("provider", name)

--- a/pkg/api/endpoints/providers_test.go
+++ b/pkg/api/endpoints/providers_test.go
@@ -11,13 +11,16 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/go-logr/logr"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 )
 
@@ -213,4 +216,124 @@ func BenchmarkBuildProviderList(b *testing.B) {
 	for b.Loop() {
 		buildProviderList(reg)
 	}
+}
+
+func TestEnsureAPIProvider_NilPool(t *testing.T) {
+	hctx := &api.HandlerContext{
+		ProviderRegistry: provider.NewRegistry(),
+	}
+	_, _, err := ensureAPIProvider(context.Background(), hctx, "exec")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestEnsureAPIProvider_NilOfficialProviders(t *testing.T) {
+	reg := provider.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	hctx := &api.HandlerContext{
+		ProviderRegistry: reg,
+		PluginPool:       pool,
+	}
+	_, _, err := ensureAPIProvider(context.Background(), hctx, "exec")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestEnsureAPIProvider_UnknownProvider(t *testing.T) {
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	hctx := &api.HandlerContext{
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	_, _, err := ensureAPIProvider(context.Background(), hctx, "nonexistent-provider")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestEnsureAPIProvider_NoFetcher(t *testing.T) {
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	hctx := &api.HandlerContext{
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	_, _, err := ensureAPIProvider(context.Background(), hctx, "exec")
+	assert.Error(t, err)
+	// Pool returns a Huma error when fetcher is nil
+	assert.Contains(t, err.Error(), "exec")
+}
+
+func TestGetProvider_AutoResolve_Fallback(t *testing.T) {
+	// When pool has no fetcher, get-provider returns the pool error (502)
+	_, testAPI := humatest.New(t)
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	var shutting int32
+	hctx := &api.HandlerContext{
+		Config:            &config.Config{},
+		IsShuttingDown:    &shutting,
+		StartTime:         time.Now(),
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	RegisterProviderEndpoints(testAPI, hctx, "/v1")
+
+	resp := testAPI.Get("/v1/providers/exec")
+	assert.Equal(t, http.StatusBadGateway, resp.Code)
+}
+
+func TestGetProviderSchema_AutoResolve_Fallback(t *testing.T) {
+	// When pool has no fetcher, get-provider-schema returns the pool error (502)
+	_, testAPI := humatest.New(t)
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	var shutting int32
+	hctx := &api.HandlerContext{
+		Config:            &config.Config{},
+		IsShuttingDown:    &shutting,
+		StartTime:         time.Now(),
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	RegisterProviderEndpoints(testAPI, hctx, "/v1")
+
+	resp := testAPI.Get("/v1/providers/exec/schema")
+	assert.Equal(t, http.StatusBadGateway, resp.Code)
+}
+
+func TestGetProvider_NoPool_Returns404(t *testing.T) {
+	// When no pool is configured, unknown providers return 404
+	_, testAPI := humatest.New(t)
+	reg := provider.NewRegistry()
+
+	var shutting int32
+	hctx := &api.HandlerContext{
+		Config:           &config.Config{},
+		IsShuttingDown:   &shutting,
+		StartTime:        time.Now(),
+		ProviderRegistry: reg,
+	}
+	RegisterProviderEndpoints(testAPI, hctx, "/v1")
+
+	resp := testAPI.Get("/v1/providers/exec")
+	assert.Equal(t, http.StatusNotFound, resp.Code)
 }

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -224,7 +224,10 @@ func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.R
 
 	// Create plugin pool for lazy auto-resolution of official providers.
 	// MCP is interactive so we allow all official plugins by default.
+	// Disable env sanitization so plugins can access host credentials
+	// (SSH_AUTH_SOCK, GITHUB_TOKEN, etc.) during interactive sessions.
 	var poolOpts []plugin.PoolOption
+	poolOpts = append(poolOpts, plugin.WithSanitizeEnv(false))
 	// Wire auth host dependencies so plugins can use host auth
 	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -8,13 +8,18 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/go-logr/logr"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	mcpserver "github.com/oakwood-commons/scafctl/pkg/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
@@ -122,12 +127,18 @@ func runServe(ctx context.Context, opts *ServeOptions) error {
 		return fmt.Errorf("initializing provider registry: %w", err)
 	}
 
+	// Build the plugin pool for on-demand official provider auto-resolution.
+	pluginPool, poolCtx := buildMCPPluginPool(ctx, cfg, reg, lgr)
+	defer pluginPool.Shutdown()
+	ctx = poolCtx
+
 	// Build server options
 	serverOpts := []mcpserver.ServerOption{
 		mcpserver.WithServerLogger(*lgr),
 		mcpserver.WithServerRegistry(reg),
 		mcpserver.WithServerContext(ctx),
 		mcpserver.WithServerVersion(settings.VersionInformation.BuildVersion),
+		mcpserver.WithServerPluginPool(pluginPool),
 	}
 	if s, ok := settings.FromContext(ctx); ok && s.BinaryName != "" {
 		serverOpts = append(serverOpts, mcpserver.WithServerName(s.BinaryName))
@@ -186,4 +197,38 @@ func runServe(ctx context.Context, opts *ServeOptions) error {
 	default:
 		return fmt.Errorf("unsupported transport %q: use stdio, sse, or http", opts.Transport)
 	}
+}
+
+// buildMCPPluginPool creates the official provider registry, plugin fetcher,
+// and plugin pool for the MCP server. The returned context has the official
+// registry injected. Pool defaults (5m idle timeout, 50 max plugins) are used.
+func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.Registry, lgr *logr.Logger) (*plugin.Pool, context.Context) {
+	// Build official provider registry for auto-resolution
+	var officialReg *official.Registry
+	if cfg == nil || !cfg.Settings.DisableOfficialProviders {
+		officialReg = official.NewRegistry()
+		ctx = official.WithRegistry(ctx, officialReg)
+	} else {
+		lgr.V(1).Info("official provider auto-resolution disabled by settings")
+	}
+
+	// Build plugin fetcher for on-demand plugin loading
+	var pluginFetcher *plugin.Fetcher
+	if officialReg != nil {
+		if fetcher, fetchErr := prepare.BuildPluginFetcherWithConfig(ctx, prepare.PluginFetcherOverrides{}); fetchErr == nil {
+			pluginFetcher = fetcher
+		} else {
+			lgr.V(1).Info("plugin fetcher not available; official providers will only be available from cache", "error", fetchErr)
+		}
+	}
+
+	// Create plugin pool for lazy auto-resolution of official providers.
+	// MCP is interactive so we allow all official plugins by default.
+	var poolOpts []plugin.PoolOption
+	// Wire auth host dependencies so plugins can use host auth
+	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
+		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))
+	}
+	pool := plugin.NewPool(pluginFetcher, reg, *lgr, poolOpts...)
+	return pool, ctx
 }

--- a/pkg/cmd/scafctl/mcp/serve_test.go
+++ b/pkg/cmd/scafctl/mcp/serve_test.go
@@ -4,8 +4,13 @@
 package mcp
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -82,5 +87,45 @@ func TestServeOptions(t *testing.T) {
 		assert.Empty(t, opts.Transport)
 		assert.Empty(t, opts.LogFile)
 		assert.False(t, opts.Info)
+	})
+}
+
+func TestBuildMCPPluginPool(t *testing.T) {
+	t.Run("nil config enables official registry", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		pool, ctx := buildMCPPluginPool(context.Background(), nil, reg, &lgr)
+		defer pool.Shutdown()
+
+		// Official registry should be injected into context
+		officialReg := official.RegistryFromContext(ctx)
+		assert.NotNil(t, officialReg, "official registry should be in context")
+	})
+
+	t.Run("DisableOfficialProviders skips official registry", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		cfg := &config.Config{
+			Settings: config.Settings{DisableOfficialProviders: true},
+		}
+		pool, ctx := buildMCPPluginPool(context.Background(), cfg, reg, &lgr)
+		defer pool.Shutdown()
+
+		// Official registry should NOT be in context
+		officialReg := official.RegistryFromContext(ctx)
+		assert.Nil(t, officialReg, "official registry should not be in context when disabled")
+	})
+
+	t.Run("enabled config creates official registry", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		cfg := &config.Config{
+			Settings: config.Settings{DisableOfficialProviders: false},
+		}
+		pool, ctx := buildMCPPluginPool(context.Background(), cfg, reg, &lgr)
+		defer pool.Shutdown()
+
+		officialReg := official.RegistryFromContext(ctx)
+		assert.NotNil(t, officialReg, "official registry should be in context")
 	})
 }

--- a/pkg/cmd/scafctl/mcp/serve_test.go
+++ b/pkg/cmd/scafctl/mcp/serve_test.go
@@ -128,4 +128,14 @@ func TestBuildMCPPluginPool(t *testing.T) {
 		officialReg := official.RegistryFromContext(ctx)
 		assert.NotNil(t, officialReg, "official registry should be in context")
 	})
+
+	t.Run("pool does not sanitize env for MCP interactive sessions", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		pool, _ := buildMCPPluginPool(context.Background(), nil, reg, &lgr)
+		defer pool.Shutdown()
+
+		// MCP pools should not sanitize env so host credentials are available
+		assert.False(t, pool.SanitizeEnv(), "MCP pool should not sanitize env")
+	})
 }

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -295,6 +295,10 @@ func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fe
 	if len(cfg.APIServer.Plugins.AllowedPlugins) > 0 {
 		poolOpts = append(poolOpts, plugin.WithAllowedPlugins(cfg.APIServer.Plugins.AllowedPlugins))
 	}
+	// Wire auth host dependencies so plugins can use host auth
+	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
+		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))
+	}
 	pool := plugin.NewPool(fetcher, reg, *lgr, poolOpts...)
 	for _, c := range preloaded {
 		// Query the client for provider names it registered so the pool can

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -7,10 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,4 +118,70 @@ func TestPreloadOfficialProviders_NilFetcher(t *testing.T) {
 	clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, nil)
 	assert.Nil(t, clients)
 	assert.Nil(t, preloadErr)
+}
+
+func TestBuildPluginPool_AuthWiring(t *testing.T) {
+	// When an auth registry is in context, buildPluginPool should wire
+	// auth client options into the pool.
+	authReg := auth.NewRegistry()
+	ctx := auth.WithRegistry(context.Background(), authReg)
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{
+				AllowExternal: true,
+			},
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	defer pool.Shutdown()
+
+	// Pool should have been created (non-nil) with auth options forwarded.
+	// We can't inspect internal opts directly, but verify pool is functional.
+	assert.NotNil(t, pool)
+}
+
+func TestBuildPluginPool_SanitizesEnv(t *testing.T) {
+	// API server pools should sanitize env by default (the default is true).
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{
+				AllowExternal: false,
+			},
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	defer pool.Shutdown()
+
+	// API server pools sanitize env by default
+	assert.True(t, pool.SanitizeEnv())
+}
+
+func TestBuildPluginPool_AllowedPlugins(t *testing.T) {
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{
+				AllowExternal:  true,
+				AllowedPlugins: []string{"foo", "bar"},
+			},
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	defer pool.Shutdown()
+
+	// Verify that a non-allowed plugin is rejected
+	_, err := pool.EnsureAndAcquire(ctx, []solution.PluginDependency{
+		{Name: "not-allowed", Kind: solution.PluginKindProvider},
+	})
+	assert.ErrorIs(t, err, plugin.ErrPluginNotAllowed)
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -482,6 +483,12 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	// Guard against empty server name.
 	if strings.TrimSpace(cfg.name) == "" {
 		cfg.name = settings.CliBinaryName
+	}
+
+	// Validate that a registry is set when a plugin pool is configured,
+	// otherwise ensureProvider would panic on nil registry access.
+	if cfg.pluginPool != nil && cfg.registry == nil {
+		return nil, errors.New("WithServerPluginPool requires WithServerRegistry")
 	}
 
 	// Build the MCP context for tool handlers

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
@@ -49,6 +50,11 @@ type Server struct {
 	// Prompts not in this set are tagged as plugin/embedder prompts.
 	corePrompts map[string]struct{}
 
+	// pluginPool manages shared, long-lived plugin processes with lazy
+	// initialization and idle eviction. When set, provider tool handlers
+	// auto-resolve official plugins on demand.
+	pluginPool *plugin.Pool
+
 	// sseServer is the SSE transport server (nil for stdio).
 	sseServer *server.SSEServer
 	// httpServer is the Streamable HTTP transport server (nil for stdio).
@@ -72,12 +78,23 @@ type serverConfig struct {
 	errorLogger              *log.Logger
 	supplementalInstructions string
 	rootCmd                  *cobra.Command
+	pluginPool               *plugin.Pool
 }
 
 // WithRootCommand sets the cobra root command for CLI introspection tools.
 func WithRootCommand(cmd *cobra.Command) ServerOption {
 	return func(c *serverConfig) {
 		c.rootCmd = cmd
+	}
+}
+
+// WithServerPluginPool sets the plugin pool for auto-resolving official
+// plugin providers on demand. When set, provider tool handlers (run_provider,
+// get_provider_schema, get_provider_output_shape) will attempt to fetch and
+// load official plugins that are not yet in the provider registry.
+func WithServerPluginPool(pool *plugin.Pool) ServerOption {
+	return func(c *serverConfig) {
+		c.pluginPool = pool
 	}
 }
 
@@ -502,6 +519,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		authReg:     cfg.authReg,
 		config:      cfg.config,
 		rootCmd:     cfg.rootCmd,
+		pluginPool:  cfg.pluginPool,
 		coreTools:   make(map[string]struct{}, 64),
 		corePrompts: make(map[string]struct{}, 16),
 	}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/stretchr/testify/assert"
@@ -420,4 +421,22 @@ func TestHandler_ReturnsCachedInstance(t *testing.T) {
 	h1 := srv.Handler()
 	h2 := srv.Handler()
 	assert.Equal(t, h1, h2, "Handler() should return the same instance on subsequent calls")
+}
+
+func TestNewServer_PluginPoolRequiresRegistry(t *testing.T) {
+	reg := provider.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard())
+	defer pool.Shutdown()
+
+	t.Run("pool without registry returns error", func(t *testing.T) {
+		_, err := NewServer(WithServerPluginPool(pool))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "WithServerPluginPool requires WithServerRegistry")
+	})
+
+	t.Run("pool with registry succeeds", func(t *testing.T) {
+		srv, err := NewServer(WithServerPluginPool(pool), WithServerRegistry(reg))
+		require.NoError(t, err)
+		assert.NotNil(t, srv)
+	})
 }

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -6,13 +6,50 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 )
+
+// ensureProvider attempts to auto-resolve a provider that is not in the
+// registry by looking it up in the official provider registry and loading
+// it via the plugin pool. Returns a release function (may be nil) that the
+// caller must defer. Returns an error if the provider cannot be resolved.
+func (s *Server) ensureProvider(ctx context.Context, name string) (release func(), err error) {
+	if s.pluginPool == nil {
+		return nil, fmt.Errorf("provider %q not found and plugin pool not configured", name)
+	}
+	officialReg := official.RegistryFromContext(s.ctx)
+	if officialReg == nil {
+		return nil, fmt.Errorf("provider %q not found and official registry not available", name)
+	}
+	op, found := officialReg.Get(name)
+	if !found {
+		return nil, fmt.Errorf("provider %q is not a known official provider", name)
+	}
+	dep := op.ToPluginDependency()
+	rel, err := s.pluginPool.EnsureAndAcquire(ctx, []solution.PluginDependency{dep})
+	if err != nil {
+		return nil, fmt.Errorf("loading plugin for provider %q: %w", name, err)
+	}
+	return rel, nil
+}
+
+// providerSource returns "official" if the provider is in the official
+// registry, otherwise "builtin".
+func (s *Server) providerSource(name string) string {
+	if officialReg := official.RegistryFromContext(s.ctx); officialReg != nil {
+		if _, found := officialReg.Get(name); found {
+			return "official"
+		}
+	}
+	return "builtin"
+}
 
 // registerProviderTools registers all provider-related MCP tools.
 func (s *Server) registerProviderTools() {
@@ -190,7 +227,7 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 // input schema with required/optional annotations, output schemas, examples,
 // CLI usage, and capabilities. Uses the same structured format as
 // `scafctl get provider <name> -o json`.
-func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleGetProviderSchema(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
@@ -201,6 +238,14 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 	}
 
 	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
+	if err != nil {
+		// Try auto-resolving via the plugin pool before falling back
+		release, resolveErr := s.ensureProvider(ctx, name)
+		if resolveErr == nil {
+			defer release()
+			desc, err = inspect.LookupProvider(s.ctx, name, s.registry)
+		}
+	}
 	if err != nil {
 		// Check official provider registry before returning error
 		if officialReg := official.RegistryFromContext(s.ctx); officialReg != nil {
@@ -233,7 +278,7 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 	// - CLI usage examples
 	// - version, capabilities, category, tags, links, maintainers
 	detail := provdetail.BuildProviderDetail(*desc)
-	detail["source"] = "builtin"
+	detail["source"] = s.providerSource(name)
 
 	return mcp.NewToolResultJSON(detail)
 }
@@ -241,7 +286,7 @@ func (s *Server) handleGetProviderSchema(_ context.Context, request mcp.CallTool
 // handleGetProviderOutputShape returns the output schema for a provider, optionally
 // filtered by capability. This makes it easy for agents to discover what fields
 // resolver results contain after execution.
-func (s *Server) handleGetProviderOutputShape(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleGetProviderOutputShape(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
@@ -253,6 +298,14 @@ func (s *Server) handleGetProviderOutputShape(_ context.Context, request mcp.Cal
 	capability := request.GetString("capability", "")
 
 	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
+	if err != nil {
+		// Try auto-resolving via the plugin pool
+		release, resolveErr := s.ensureProvider(ctx, name)
+		if resolveErr == nil {
+			defer release()
+			desc, err = inspect.LookupProvider(s.ctx, name, s.registry)
+		}
+	}
 	if err != nil {
 		availableNames := ""
 		if s.registry != nil {
@@ -287,6 +340,7 @@ func (s *Server) handleGetProviderOutputShape(_ context.Context, request mcp.Cal
 			for c := range desc.OutputSchemas {
 				availableCaps = append(availableCaps, string(c))
 			}
+			sort.Strings(availableCaps)
 			return newStructuredError(ErrCodeNotFound,
 				fmt.Sprintf("provider %q has no output schema for capability %q. Available: %v", name, capability, availableCaps),
 				WithField("capability"),
@@ -307,7 +361,7 @@ func (s *Server) handleGetProviderOutputShape(_ context.Context, request mcp.Cal
 }
 
 // handleRunProvider executes a provider directly and returns structured output.
-func (s *Server) handleRunProvider(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleRunProvider(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("provider")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
@@ -340,6 +394,14 @@ func (s *Server) handleRunProvider(_ context.Context, request mcp.CallToolReques
 
 	prov, ok := s.registry.Get(name)
 	if !ok {
+		// Try auto-resolving via the plugin pool
+		release, resolveErr := s.ensureProvider(ctx, name)
+		if resolveErr == nil {
+			defer release()
+			prov, ok = s.registry.Get(name)
+		}
+	}
+	if !ok {
 		availableNames := ""
 		if names := s.registry.List(); len(names) > 0 {
 			availableNames = fmt.Sprintf(". Available providers: %v", names)
@@ -352,7 +414,7 @@ func (s *Server) handleRunProvider(_ context.Context, request mcp.CallToolReques
 		), nil
 	}
 
-	result, err := provider.RunProvider(s.ctx, provider.RunOptions{
+	result, err := provider.RunProvider(ctx, provider.RunOptions{
 		Provider:   prov,
 		Inputs:     inputs,
 		Capability: capability,

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -18,8 +18,8 @@ import (
 
 // ensureProvider attempts to auto-resolve a provider that is not in the
 // registry by looking it up in the official provider registry and loading
-// it via the plugin pool. Returns a release function (may be nil) that the
-// caller must defer. Returns an error if the provider cannot be resolved.
+// it via the plugin pool. On success, returns a non-nil release function
+// that the caller must defer. Returns an error if the provider cannot be resolved.
 func (s *Server) ensureProvider(ctx context.Context, name string) (release func(), err error) {
 	if s.pluginPool == nil {
 		return nil, fmt.Errorf("provider %q not found and plugin pool not configured", name)
@@ -396,10 +396,16 @@ func (s *Server) handleRunProvider(ctx context.Context, request mcp.CallToolRequ
 	if !ok {
 		// Try auto-resolving via the plugin pool
 		release, resolveErr := s.ensureProvider(ctx, name)
-		if resolveErr == nil {
-			defer release()
-			prov, ok = s.registry.Get(name)
+		if resolveErr != nil {
+			return newStructuredError(ErrCodeLoadFailed,
+				fmt.Sprintf("failed to load provider %q: %v", name, resolveErr),
+				WithField("provider"),
+				WithSuggestion("Check plugin pool configuration and provider availability"),
+				WithRelatedTools("list_providers"),
+			), nil
 		}
+		defer release()
+		prov, ok = s.registry.Get(name)
 	}
 	if !ok {
 		availableNames := ""

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -608,7 +608,7 @@ func TestEnsureProvider(t *testing.T) {
 }
 
 func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should still return NOT_FOUND
+	// When no pool is configured, unknown providers should return LOAD_FAILED
 	reg, err := builtin.DefaultRegistry(context.Background())
 	require.NoError(t, err)
 	srv, err := NewServer(
@@ -628,7 +628,8 @@ func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	text := result.Content[0].(mcp.TextContent).Text
-	assert.Contains(t, text, "NOT_FOUND")
+	assert.Contains(t, text, "LOAD_FAILED")
+	assert.Contains(t, text, "plugin pool not configured")
 }
 
 func TestHandleGetProviderSchema_AutoResolve_NoPool(t *testing.T) {

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/stretchr/testify/assert"
@@ -527,5 +530,279 @@ func TestHandleRunProvider(t *testing.T) {
 		var output map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text), &output))
 		assert.Equal(t, "message", output["provider"])
+	})
+}
+
+func TestEnsureProvider(t *testing.T) {
+	t.Run("returns error when pool is nil", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "plugin pool not configured")
+	})
+
+	t.Run("returns error when official registry not in context", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "official registry not available")
+	})
+
+	t.Run("returns error for unknown provider", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		officialReg := official.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "nonexistent-provider")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "not a known official provider")
+	})
+
+	t.Run("returns error when pool has no fetcher", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		officialReg := official.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "loading plugin")
+	})
+}
+
+func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "run_provider"
+	request.Params.Arguments = map[string]any{
+		"provider": "nonexistent",
+		"inputs":   map[string]any{},
+	}
+
+	result, err := srv.handleRunProvider(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderSchema_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_schema"
+	request.Params.Arguments = map[string]any{
+		"name": "nonexistent",
+	}
+
+	result, err := srv.handleGetProviderSchema(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name": "nonexistent",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_AllCapabilities(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name": "cel",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var output map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &output))
+	assert.Equal(t, "cel", output["provider"])
+	assert.NotNil(t, output["outputSchemas"], "expected outputSchemas for all capabilities")
+}
+
+func TestHandleGetProviderOutputShape_SingleCapability(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name":       "cel",
+		"capability": "transform",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var output map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &output))
+	assert.Equal(t, "cel", output["provider"])
+	assert.Equal(t, "transform", output["capability"])
+	assert.NotNil(t, output["outputSchema"])
+}
+
+func TestHandleGetProviderOutputShape_InvalidCapability(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name":       "cel",
+		"capability": "authentication",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_MissingName(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "INVALID_INPUT")
+}
+
+func TestProviderSource(t *testing.T) {
+	t.Run("returns builtin when no official registry", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		assert.Equal(t, "builtin", srv.providerSource("exec"))
+	})
+
+	t.Run("returns official for known official provider", func(t *testing.T) {
+		officialReg := official.NewRegistry()
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		// "exec" is a known official provider
+		assert.Equal(t, "official", srv.providerSource("exec"))
+	})
+
+	t.Run("returns builtin for unknown provider", func(t *testing.T) {
+		officialReg := official.NewRegistry()
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, "builtin", srv.providerSource("custom-provider"))
 	})
 }

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -81,6 +81,7 @@ type poolOptions struct {
 	allowedPlugins  map[string]bool  // nil means allow all
 	disableExternal bool             // reject all non-adopted plugins
 	clientOpts      []ClientOption   // extra options for spawned plugin clients
+	sanitizeEnv     bool             // prepend WithSanitizedEnv() on spawn
 }
 
 // defaultPoolOptions returns sensible defaults.
@@ -90,6 +91,7 @@ func defaultPoolOptions() poolOptions {
 		maxPlugins:     50,
 		healthInterval: 30 * time.Second,
 		clock:          time.Now,
+		sanitizeEnv:    true,
 	}
 }
 
@@ -152,6 +154,14 @@ func WithDisableExternal(disabled bool) PoolOption {
 // dependencies such as auth registries (via WithHostDeps).
 func WithClientOptions(opts ...ClientOption) PoolOption {
 	return func(o *poolOptions) { o.clientOpts = append(o.clientOpts, opts...) }
+}
+
+// WithSanitizeEnv controls whether spawned plugin clients get a sanitized
+// environment (true) or inherit the host environment (false). Defaults to true.
+// API server deployments should use true; MCP interactive sessions may use
+// false so plugins can access host credentials (SSH_AUTH_SOCK, tokens, etc.).
+func WithSanitizeEnv(sanitize bool) PoolOption {
+	return func(o *poolOptions) { o.sanitizeEnv = sanitize }
 }
 
 // PoolStats holds pool metrics.
@@ -379,10 +389,16 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 
 	result := results[0]
 
-	// Spawn client with sanitized environment (pool is API-server context)
-	clientOpts := make([]ClientOption, 1, 1+len(p.opts.clientOpts))
-	clientOpts[0] = WithSanitizedEnv()
-	clientOpts = append(clientOpts, p.opts.clientOpts...)
+	// Spawn client, optionally sanitizing the environment.
+	var clientOpts []ClientOption
+	if p.opts.sanitizeEnv {
+		clientOpts = make([]ClientOption, 1, 1+len(p.opts.clientOpts))
+		clientOpts[0] = WithSanitizedEnv()
+		clientOpts = append(clientOpts, p.opts.clientOpts...)
+	} else {
+		clientOpts = make([]ClientOption, 0, len(p.opts.clientOpts))
+		clientOpts = append(clientOpts, p.opts.clientOpts...)
+	}
 	client, err := NewClient(result.Path, clientOpts...)
 	if err != nil {
 		entry.failWith(fmt.Errorf("starting process: %w", err))
@@ -409,6 +425,13 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 			p.logger.V(1).Info("provider not registered (name taken)",
 				"plugin", entry.dep.Name, "provider", provName, "error", rErr)
 			continue
+		}
+		// Configure the provider so the plugin receives the host service ID.
+		// Without this call, the plugin cannot dial back to the host for auth
+		// tokens or other host services.
+		if cErr := wrapper.Configure(ctx, ProviderConfig{}); cErr != nil {
+			p.logger.V(1).Info("failed to configure plugin provider",
+				"plugin", entry.dep.Name, "provider", provName, "error", cErr)
 		}
 		registered = append(registered, provName)
 	}
@@ -610,6 +633,12 @@ func (p *Pool) Stats() PoolStats {
 		entry.mu.Unlock()
 	}
 	return stats
+}
+
+// SanitizeEnv reports whether this pool sanitizes the environment for spawned
+// plugin clients. See [WithSanitizeEnv].
+func (p *Pool) SanitizeEnv() bool {
+	return p.opts.sanitizeEnv
 }
 
 // Shutdown kills all managed plugin processes. Called once on server stop.

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -80,6 +80,7 @@ type poolOptions struct {
 	clock           func() time.Time // for testing
 	allowedPlugins  map[string]bool  // nil means allow all
 	disableExternal bool             // reject all non-adopted plugins
+	clientOpts      []ClientOption   // extra options for spawned plugin clients
 }
 
 // defaultPoolOptions returns sensible defaults.
@@ -144,6 +145,13 @@ func WithAllowedPlugins(names []string) PoolOption {
 // for API server deployments.
 func WithDisableExternal(disabled bool) PoolOption {
 	return func(o *poolOptions) { o.disableExternal = disabled }
+}
+
+// WithClientOptions sets additional ClientOption values that are passed to
+// every plugin client spawned by the pool. Use this to inject host-side
+// dependencies such as auth registries (via WithHostDeps).
+func WithClientOptions(opts ...ClientOption) PoolOption {
+	return func(o *poolOptions) { o.clientOpts = append(o.clientOpts, opts...) }
 }
 
 // PoolStats holds pool metrics.
@@ -372,7 +380,10 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 	result := results[0]
 
 	// Spawn client with sanitized environment (pool is API-server context)
-	client, err := NewClient(result.Path, WithSanitizedEnv())
+	clientOpts := make([]ClientOption, 1, 1+len(p.opts.clientOpts))
+	clientOpts[0] = WithSanitizedEnv()
+	clientOpts = append(clientOpts, p.opts.clientOpts...)
+	client, err := NewClient(result.Path, clientOpts...)
 	if err != nil {
 		entry.failWith(fmt.Errorf("starting process: %w", err))
 		return

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -43,6 +43,31 @@ func TestNewPool_Options(t *testing.T) {
 	assert.Equal(t, time.Minute, p.opts.healthInterval)
 }
 
+func TestNewPool_WithClientOptions(t *testing.T) {
+	reg := provider.NewRegistry()
+	opt1 := WithSanitizedEnv()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithClientOptions(opt1),
+	)
+	defer p.Shutdown()
+
+	assert.Len(t, p.opts.clientOpts, 1)
+}
+
+func TestNewPool_WithClientOptions_Multiple(t *testing.T) {
+	reg := provider.NewRegistry()
+	opt1 := WithSanitizedEnv()
+	opt2 := WithSanitizedEnv()
+	p := NewPool(nil, reg, logr.Discard(),
+		WithIdleTimeout(0),
+		WithClientOptions(opt1, opt2),
+	)
+	defer p.Shutdown()
+
+	assert.Len(t, p.opts.clientOpts, 2)
+}
+
 func TestPool_Adopt(t *testing.T) {
 	reg := provider.NewRegistry()
 	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -68,6 +68,28 @@ func TestNewPool_WithClientOptions_Multiple(t *testing.T) {
 	assert.Len(t, p.opts.clientOpts, 2)
 }
 
+func TestNewPool_WithSanitizeEnv(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	t.Run("defaults to true", func(t *testing.T) {
+		p := NewPool(nil, reg, logr.Discard())
+		defer p.Shutdown()
+		assert.True(t, p.SanitizeEnv())
+	})
+
+	t.Run("can be disabled", func(t *testing.T) {
+		p := NewPool(nil, reg, logr.Discard(), WithSanitizeEnv(false))
+		defer p.Shutdown()
+		assert.False(t, p.SanitizeEnv())
+	})
+
+	t.Run("can be explicitly enabled", func(t *testing.T) {
+		p := NewPool(nil, reg, logr.Discard(), WithSanitizeEnv(true))
+		defer p.Shutdown()
+		assert.True(t, p.SanitizeEnv())
+	})
+}
+
 func TestPool_Adopt(t *testing.T) {
 	reg := provider.NewRegistry()
 	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))


### PR DESCRIPTION
- add ensureProvider to MCP server for lazy plugin loading via the plugin pool and official provider registry
- add providerSource helper to detect official vs builtin source
- add WithServerPluginPool option to wire pool into MCP server
- add WithClientOptions pool option to forward host-side auth deps to spawned plugin clients
- add buildMCPPluginPool helper with DisableOfficialProviders config guard
- add ensureAPIProvider for API server endpoint fallback with proper HTTP status propagation from pool errors
- propagate request context through MCP handler signatures (handleGetProviderSchema, handleGetProviderOutputShape, handleRunProvider)
- sort capability names in error messages for deterministic output
- wire auth client options in API server buildPluginPool

Closes #353
