### PR TITLE
fix(plugin): pass solution directory to plugin providers for path res…

### DIFF
--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -737,8 +737,13 @@ func buildExecuteProviderRequest(ctx context.Context, providerName string, input
 	}
 
 	// Working directory
-	if dir, ok := provider.WorkingDirectoryFromContext(ctx); ok {
+	if dir, ok := provider.WorkingDirectoryFromContext(ctx); ok && dir != "" {
 		req.WorkingDirectory = dir
+	} else if solDir, ok := provider.SolutionDirectoryFromContext(ctx); ok && solDir != "" {
+		// When no explicit working directory is set (e.g., resolver phase),
+		// fall back to the solution directory so plugin providers resolve
+		// relative paths the same way builtin providers do.
+		req.WorkingDirectory = solDir
 	}
 
 	// Output directory

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -173,6 +173,45 @@ func TestGRPCServer_ExecuteProvider_ExtendedContext(t *testing.T) {
 	assert.Equal(t, []string{"go", "test"}, meta.Tags)
 }
 
+func TestBuildExecuteProviderRequest_SolutionDirectoryFallback(t *testing.T) {
+	t.Run("uses solution directory when working directory not set", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = provider.WithSolutionDirectory(ctx, "/path/to/solution")
+
+		req, err := buildExecuteProviderRequest(ctx, "test-provider", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/solution", req.WorkingDirectory)
+	})
+
+	t.Run("working directory takes precedence over solution directory", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = provider.WithWorkingDirectory(ctx, "/explicit/work")
+		ctx = provider.WithSolutionDirectory(ctx, "/path/to/solution")
+
+		req, err := buildExecuteProviderRequest(ctx, "test-provider", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Equal(t, "/explicit/work", req.WorkingDirectory)
+	})
+
+	t.Run("empty working directory falls through to solution directory", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = provider.WithWorkingDirectory(ctx, "")
+		ctx = provider.WithSolutionDirectory(ctx, "/path/to/solution")
+
+		req, err := buildExecuteProviderRequest(ctx, "test-provider", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/solution", req.WorkingDirectory)
+	})
+
+	t.Run("no directory set leaves working directory empty", func(t *testing.T) {
+		ctx := context.Background()
+
+		req, err := buildExecuteProviderRequest(ctx, "test-provider", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Empty(t, req.WorkingDirectory)
+	})
+}
+
 func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	ctx = provider.WithDryRun(ctx, true)


### PR DESCRIPTION
…olution

- fall back to SolutionDirectory when WorkingDirectory is not set in buildExecuteProviderRequest, matching AbsFromContext behavior
- add tests for fallback, precedence, and empty-context cases

Closes #360