### PR TITLE
feat: batch improvements for plugins, build, MCP, and remote cache

### DIFF
--- a/.github/prompts/integration-test.prompt.md
+++ b/.github/prompts/integration-test.prompt.md
@@ -1,0 +1,46 @@
+---
+description: "scafctl: Build the binary and run real CLI commands to verify changes work end-to-end."
+---
+Build the scafctl binary and run real CLI integration tests against it.
+Automated tests can pass while the actual CLI is broken. This prompt catches those gaps.
+
+## Steps
+
+1. **Build the binary**
+   ```
+   go build -ldflags "-s -w -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X main.BuildVersion=dev -X main.Commit=$(git rev-parse HEAD)" -o dist/scafctl ./cmd/scafctl/scafctl.go
+   ```
+
+2. **Identify what changed** -- use `git diff --name-only` to find modified packages and commands.
+
+3. **Run real commands** against the built binary (`./dist/scafctl`):
+   - Always use `--debug` to surface internal logging and catch silent failures.
+   - Use `--verbose` to verify verbose output paths work.
+   - Test the **happy path** first, then **error paths** (bad input, missing args, invalid flags).
+   - Use `--dry-run` where available to verify it short-circuits without side effects.
+   - Use `--help` on changed commands to verify flag registration and descriptions.
+   - For commands that write state (build, install, catalog), use isolated temp dirs:
+     ```
+     XDG_DATA_HOME=/tmp/scafctl-itest/data XDG_CACHE_HOME=/tmp/scafctl-itest/cache ./dist/scafctl ...
+     ```
+   - After writes, use read commands (catalog inspect, catalog list) to verify stored data.
+   - Clean up temp dirs when done.
+
+4. **Report results** as a table: command, result (pass/fail), and any issues found.
+
+5. **If a test reveals a bug**, fix the code, rebuild, and re-test that specific scenario.
+
+## What to test per command type
+
+- **CLI commands** (plugins install, build solution, etc.): flags, args, output format, exit codes
+- **MCP tools**: use the MCP server or unit tests -- MCP tools aren't directly CLI-testable
+- **Provider changes**: `./dist/scafctl run provider <name> ...` with real inputs
+- **Resolver changes**: `./dist/scafctl run resolver -f <solution> ...` with example solutions
+
+## Key things to watch for
+
+- Commands that silently succeed but produce wrong output
+- Flags that are registered but ignored in execution
+- Error messages that don't match what the code intends
+- `--verbose` / `--debug` output that crashes or shows stale info
+- Exit codes (0 for success, non-zero for errors)

--- a/pkg/catalog/annotations.go
+++ b/pkg/catalog/annotations.go
@@ -69,6 +69,12 @@ const (
 	// depends on the catalog implementation, so it must not be assumed to be
 	// descriptor-only or digest-stable.
 	AnnotationOrigin = "dev.scafctl.artifact.origin"
+
+	// AnnotationBuildCommit is the short git commit SHA at build time.
+	AnnotationBuildCommit = "dev.scafctl.build.commit"
+
+	// AnnotationBuildDirty indicates the working tree had uncommitted changes at build time.
+	AnnotationBuildDirty = "dev.scafctl.build.dirty"
 )
 
 // AnnotationBuilder helps construct annotation maps.

--- a/pkg/catalog/remote_resolver.go
+++ b/pkg/catalog/remote_resolver.go
@@ -29,6 +29,13 @@ type RemoteSolutionResolverConfig struct {
 	// Insecure allows HTTP connections to registries (for testing).
 	Insecure bool
 
+	// ArtifactCache enables caching of fetched remote solutions.
+	// When set, fetched artifacts are stored and served from cache within TTL.
+	ArtifactCache ArtifactCacher
+
+	// NoCache disables artifact caching even when ArtifactCache is set.
+	NoCache bool
+
 	// Logger for logging operations.
 	Logger logr.Logger
 }
@@ -41,6 +48,8 @@ type RemoteSolutionResolver struct {
 	authHandlerFunc func(registry string) scafctlauth.Handler
 	authScopeFunc   func(registry string) string
 	insecure        bool
+	artifactCache   ArtifactCacher
+	noCache         bool
 	logger          logr.Logger
 }
 
@@ -51,6 +60,8 @@ func NewRemoteSolutionResolver(cfg RemoteSolutionResolverConfig) *RemoteSolution
 		authHandlerFunc: cfg.AuthHandlerFunc,
 		authScopeFunc:   cfg.AuthScopeFunc,
 		insecure:        cfg.Insecure,
+		artifactCache:   cfg.ArtifactCache,
+		noCache:         cfg.NoCache,
 		logger:          cfg.Logger.WithName("remote-solution-resolver"),
 	}
 }
@@ -62,6 +73,22 @@ func (r *RemoteSolutionResolver) FetchRemoteSolution(ctx context.Context, rawRef
 	remoteRef, err := ParseRemoteReference(rawRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid remote reference %q: %w", rawRef, err)
+	}
+
+	// Check artifact cache before fetching from remote registry.
+	if !r.noCache && r.artifactCache != nil {
+		cacheKey := remoteRef.Registry + "/" + remoteRef.Repository + "/" + remoteRef.Name
+		cacheVersion := remoteRef.Tag
+		if cacheVersion == "" {
+			cacheVersion = "latest"
+		}
+		cached, cachedBundle, ok, cacheErr := r.artifactCache.Get(string(ArtifactKindSolution), cacheKey, cacheVersion)
+		if cacheErr != nil {
+			r.logger.V(1).Info("artifact cache get error (ignoring)", "error", cacheErr)
+		} else if ok {
+			r.logger.V(1).Info("artifact cache hit for remote solution", "ref", rawRef)
+			return cached, cachedBundle, nil
+		}
 	}
 
 	// Track whether the ref originally had an explicit kind path segment.
@@ -124,6 +151,19 @@ func (r *RemoteSolutionResolver) FetchRemoteSolution(ctx context.Context, rawRef
 		"version", info.Reference.Version,
 		"digest", info.Digest,
 		"hasBundle", len(bundleData) > 0)
+
+	// Store in artifact cache for future reuse.
+	// Use remoteRef.Tag as the version key to match the Get lookup above.
+	if !r.noCache && r.artifactCache != nil {
+		cacheKey := remoteRef.Registry + "/" + remoteRef.Repository + "/" + remoteRef.Name
+		putVersion := remoteRef.Tag
+		if putVersion == "" {
+			putVersion = "latest"
+		}
+		if putErr := r.artifactCache.Put(string(ArtifactKindSolution), cacheKey, putVersion, info.Digest, content, bundleData); putErr != nil {
+			r.logger.V(1).Info("artifact cache put error (ignoring)", "error", putErr)
+		}
+	}
 
 	return content, bundleData, nil
 }

--- a/pkg/catalog/remote_resolver_test.go
+++ b/pkg/catalog/remote_resolver_test.go
@@ -5,6 +5,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -113,4 +114,168 @@ func TestRemoteSolutionResolver_FetchRemoteSolution_WithAuthHandlerFunc(t *testi
 	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit@1.0.0")
 	require.Error(t, err)
 	assert.True(t, called, "auth handler func should have been called")
+}
+
+// remoteMockCacher is a test double for ArtifactCacher used by remote resolver tests.
+type remoteMockCacher struct {
+	getContent []byte
+	getBundle  []byte
+	hit        bool
+	getErr     error
+	getKind    string
+	getName    string
+	getVersion string
+	putErr     error
+	putCalled  bool
+	putKind    string
+	putName    string
+	putVersion string
+}
+
+func (m *remoteMockCacher) Get(kind, name, version string) ([]byte, []byte, bool, error) {
+	m.getKind = kind
+	m.getName = name
+	m.getVersion = version
+	return m.getContent, m.getBundle, m.hit, m.getErr
+}
+
+func (m *remoteMockCacher) Put(kind, name, version, _ string, _, _ []byte) error {
+	m.putCalled = true
+	m.putKind = kind
+	m.putName = name
+	m.putVersion = version
+	return m.putErr
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	mc := &remoteMockCacher{
+		getContent: []byte("cached-content"),
+		getBundle:  []byte("cached-bundle"),
+		hit:        true,
+	}
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		ArtifactCache: mc,
+		Insecure:      true,
+		Logger:        logr.Discard(),
+	})
+
+	content, bundle, err := resolver.FetchRemoteSolution(t.Context(), "localhost:9999/myorg/starter-kit@1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("cached-content"), content)
+	assert.Equal(t, []byte("cached-bundle"), bundle)
+	assert.False(t, mc.putCalled, "should not write to cache on hit")
+
+	// Verify correct cache key was passed.
+	assert.Equal(t, "solution", mc.getKind)
+	assert.Equal(t, "localhost:9999/myorg/starter-kit", mc.getName)
+	assert.Equal(t, "1.0.0", mc.getVersion)
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_CacheMiss(t *testing.T) {
+	t.Parallel()
+
+	mc := &remoteMockCacher{hit: false}
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		ArtifactCache: mc,
+		Insecure:      true,
+		Logger:        logr.Discard(),
+	})
+
+	// Cancel immediately so no network I/O occurs — we just verify the cache
+	// was checked and the fetch was attempted (not short-circuited).
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit@1.0.0")
+	require.Error(t, err, "should fail due to canceled context, not cache")
+	assert.NotContains(t, err.Error(), "invalid remote reference")
+
+	// Verify correct cache key was passed to Get.
+	assert.Equal(t, "solution", mc.getKind)
+	assert.Equal(t, "localhost:9999/myorg/starter-kit", mc.getName)
+	assert.Equal(t, "1.0.0", mc.getVersion)
+	assert.False(t, mc.putCalled, "Put should not be called when fetch fails")
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_NoCacheBypass(t *testing.T) {
+	t.Parallel()
+
+	mc := &remoteMockCacher{
+		getContent: []byte("should-not-return"),
+		hit:        true,
+	}
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		ArtifactCache: mc,
+		NoCache:       true,
+		Insecure:      true,
+		Logger:        logr.Discard(),
+	})
+
+	// Even though cache would hit, noCache bypasses it entirely.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit@1.0.0")
+	require.Error(t, err, "should attempt fetch (not return cached), then fail on canceled ctx")
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_NilCacheBackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	// No ArtifactCache set — should behave exactly as before (no panic, no cache).
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		Insecure: true,
+		Logger:   logr.Discard(),
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit@1.0.0")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid remote reference")
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_CacheGetError(t *testing.T) {
+	t.Parallel()
+
+	mc := &remoteMockCacher{
+		getErr: fmt.Errorf("disk full"),
+		hit:    false,
+	}
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		ArtifactCache: mc,
+		Insecure:      true,
+		Logger:        logr.Discard(),
+	})
+
+	// Cache Get error is logged and ignored — fetch proceeds normally.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit@1.0.0")
+	require.Error(t, err, "should fail on fetch, not on cache error")
+	assert.NotContains(t, err.Error(), "disk full")
+}
+
+func TestRemoteSolutionResolver_FetchRemoteSolution_CacheEmptyTagNormalized(t *testing.T) {
+	t.Parallel()
+
+	mc := &remoteMockCacher{hit: false}
+	resolver := NewRemoteSolutionResolver(RemoteSolutionResolverConfig{
+		ArtifactCache: mc,
+		Insecure:      true,
+		Logger:        logr.Discard(),
+	})
+
+	// Use a ref with no explicit tag — should normalize cache version to "latest".
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := resolver.FetchRemoteSolution(ctx, "localhost:9999/myorg/starter-kit")
+	require.Error(t, err, "should fail due to canceled context")
+
+	assert.Equal(t, "latest", mc.getVersion, "empty tag should be normalized to 'latest'")
 }

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/git"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -48,6 +49,8 @@ type SolutionOptions struct {
 	SkipTests       bool
 	IgnorePreflight bool
 	AllowDevVersion bool
+	AllowDirty      bool
+	NoGitMetadata   bool
 	BaseDir         string
 	CliParams       *settings.Run
 	IOStreams       *terminal.IOStreams
@@ -217,6 +220,8 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 	cmd.Flags().BoolVar(&options.SkipTests, "skip-tests", false, "Skip functional test pre-flight check")
 	cmd.Flags().BoolVar(&options.IgnorePreflight, "ignore-preflight", false, "Run pre-flight checks but proceed even if they fail")
 	cmd.Flags().BoolVar(&options.AllowDevVersion, "allow-dev-version", false, "Allow build without metadata.version set")
+	cmd.Flags().BoolVar(&options.AllowDirty, "allow-dirty", false, "Suppress warning when building from a dirty working tree")
+	cmd.Flags().BoolVar(&options.NoGitMetadata, "no-git-metadata", false, "Skip git commit and dirty-state annotations on the built artifact")
 	cmd.Flags().StringVar(&options.BaseDir, "base-dir", "", "Override base directory for resolving relative paths in the solution (default: solution file's directory)")
 
 	return cmd
@@ -326,6 +331,26 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		}
 		w.Infof("Set metadata.version, pass --version, or use %s build solution --allow-dev-version to build anyway", binaryName)
 		return exitcode.Errorf("dev version not allowed")
+	}
+
+	// Git metadata: detect dirty state and record commit info as annotations.
+	if !opts.NoGitMetadata {
+		repoStatus, gitErr := git.GetRepositoryStatus(ctx, bundleRoot)
+		if gitErr != nil {
+			lgr.V(1).Info("git metadata unavailable", "error", gitErr)
+		} else if repoStatus.IsRepo {
+			if repoStatus.IsDirty && !opts.AllowDirty {
+				w.Warningf("Building from a dirty working tree (uncommitted changes detected)")
+			}
+			if sol.Metadata.Annotations == nil {
+				sol.Metadata.Annotations = make(map[string]string)
+			}
+			sol.Metadata.Annotations[catalog.AnnotationBuildCommit] = repoStatus.Commit
+			if repoStatus.IsDirty {
+				sol.Metadata.Annotations[catalog.AnnotationBuildDirty] = "true"
+			}
+			w.Verbosef("Git metadata: commit=%s dirty=%v", repoStatus.Commit, repoStatus.IsDirty)
+		}
 	}
 
 	// Stamp resolved name and version into the solution so the stored

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -60,6 +61,8 @@ func TestCommandBuildSolution_Flags(t *testing.T) {
 		{"skip-tests", "false"},
 		{"ignore-preflight", "false"},
 		{"allow-dev-version", "false"},
+		{"allow-dirty", "false"},
+		{"no-git-metadata", "false"},
 		{"base-dir", ""},
 	}
 
@@ -601,6 +604,7 @@ spec: {}
 		CliParams:     settings.NewCliParams(),
 		DryRun:        true,
 		NoBundle:      true,
+		NoGitMetadata: true,
 		BundleMaxSize: "50MB",
 	}
 
@@ -663,4 +667,96 @@ func TestRunBuildSolution_StdinImpliesNoBundle(t *testing.T) {
 	f := cmd.Flags().Lookup("file")
 	require.NotNil(t, f)
 	assert.Contains(t, f.Usage, "stdin")
+}
+
+func TestRunBuildSolution_DirtyTreeWarns(t *testing.T) {
+	t.Parallel()
+
+	// Create a git repo with a dirty file.
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, string(out))
+	}
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "test")
+
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: dirty-test\n  version: 1.0.0\nspec: {}\n"
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+	runGit("add", ".")
+	runGit("commit", "-m", "initial")
+
+	// Make it dirty.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.txt"), []byte("dirty"), 0o644))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "dirty")
+}
+
+func TestRunBuildSolution_AllowDirtyProceeds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, string(out))
+	}
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "test")
+
+	solFile := filepath.Join(dir, "solution.yaml")
+	content := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: dirty-ok\n  version: 1.0.0\nspec: {}\n"
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+	runGit("add", ".")
+	runGit("commit", "-m", "initial")
+
+	// Make dirty.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.txt"), []byte("dirty"), 0o644))
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     settings.NewCliParams(),
+		DryRun:        true,
+		AllowDirty:    true,
+		BundleMaxSize: "50MB",
+	}
+
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "dirty-ok@1.0.0")
 }

--- a/pkg/cmd/scafctl/plugins/install.go
+++ b/pkg/cmd/scafctl/plugins/install.go
@@ -13,11 +13,13 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
@@ -35,6 +37,9 @@ type InstallOptions struct {
 	Platform  string
 	CacheDir  string
 	NoCache   bool
+	Kind      string
+	Version   string
+	DryRun    bool
 }
 
 // CommandInstall creates the install subcommand.
@@ -45,30 +50,39 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 	}
 
 	cmd := &cobra.Command{
-		Use:          "install",
-		Short:        "Pre-fetch plugin binaries declared in a solution",
+		Use:          "install [plugin-name ...]",
+		Short:        "Pre-fetch plugin binaries by name or from a solution",
 		SilenceUsage: true,
 		Long: strings.ReplaceAll(heredoc.Doc(`
-			Pre-fetch and cache plugin binaries declared in a solution's
-			bundle.plugins section.
+			Pre-fetch and cache plugin binaries. Plugins can be specified
+			by name (standalone mode) or loaded from a solution's
+			bundle.plugins section (solution mode).
 
-			This command resolves plugin version constraints against configured
-			catalogs, downloads the binaries, and stores them in the local
-			plugin cache. Subsequent 'scafctl run solution' invocations will
-			use the cached binaries without network access.
+			In standalone mode, plugin names are resolved against the
+			official provider and auth handler registries, then fetched
+			from the configured catalog.
 
 			Examples:
-			  # Install plugins for a solution
+			  # Install a single plugin by name
+			  scafctl plugins install github
+
+			  # Install multiple plugins
+			  scafctl plugins install github exec env
+
+			  # Install a specific version
+			  scafctl plugins install github --version ">=0.3.0"
+
+			  # Install an auth handler plugin
+			  scafctl plugins install github --kind auth-handler
+
+			  # Install plugins from a solution file
 			  scafctl plugins install -f solution.yaml
 
 			  # Install for a different platform (e.g., for CI)
 			  scafctl plugins install -f solution.yaml --platform linux/amd64
-
-			  # Use a custom cache directory
-			  scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
 		`), settings.CliBinaryName, cliParams.BinaryName),
-		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			w := writer.FromContext(cmd.Context())
 			if w == nil {
 				w = writer.New(ioStreams, cliParams)
@@ -80,7 +94,7 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 				ctx = logger.WithLogger(ctx, lgr)
 			}
 
-			return runInstall(ctx, opts)
+			return runInstall(ctx, opts, args)
 		},
 	}
 
@@ -88,45 +102,61 @@ func CommandInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 	cmd.Flags().StringVar(&opts.Platform, "platform", "", "Target platform (default: current, e.g., linux/amd64)")
 	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
 	cmd.Flags().BoolVar(&opts.NoCache, "no-cache", false, "Bypass the plugin cache and fetch directly from the catalog")
+	cmd.Flags().StringVar(&opts.Kind, "kind", "provider", "Plugin kind: provider or auth-handler")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "Version constraint for standalone plugins (e.g., \">=0.3.0\", \"latest\")")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be installed without fetching")
 
 	return cmd
 }
 
-func runInstall(ctx context.Context, opts *InstallOptions) error {
+func runInstall(ctx context.Context, opts *InstallOptions, args []string) error {
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
 	}
 	lgr := logger.FromContext(ctx)
 
-	// Auto-discover solution file if not provided
-	filePath := opts.File
-	if filePath == "" {
-		filePath = get.NewGetterFromContext(ctx).FindSolution()
-	}
-	if filePath == "" {
-		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f)")
-		w.Errorf("%s", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+	// Determine plugins: from positional args (standalone) or solution file.
+	var plugins []solution.PluginDependency
+	var lockPlugins []bundler.LockPlugin
+
+	if len(args) > 0 {
+		// Standalone mode: build dependencies from plugin names.
+		w.Verbosef("Standalone mode: resolving %d plugin name(s)", len(args))
+		resolved, err := resolveStandalonePlugins(ctx, args, opts.Kind, opts.Version)
+		if err != nil {
+			w.Errorf("%v", err)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		}
+		plugins = resolved
+	} else {
+		// Solution mode: load from file.
+		w.Verbosef("Solution mode: loading plugins from file")
+		var err error
+		plugins, lockPlugins, err = loadPluginsFromSolution(ctx, opts)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Load the solution
-	sol, err := loadSolution(filePath)
-	if err != nil {
-		w.Errorf("failed to load solution: %v", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
-	}
-
-	if len(sol.Bundle.Plugins) == 0 {
-		w.Infof("No plugins declared in solution — nothing to install.")
+	if len(plugins) == 0 {
 		return nil
 	}
 
-	// Load lock file if available
-	lockFile, _ := bundler.LoadLockFile(filepath.Join(filepath.Dir(filePath), bundler.DefaultLockFileName))
-	var lockPlugins []bundler.LockPlugin
-	if lockFile != nil {
-		lockPlugins = lockFile.Plugins
+	for _, p := range plugins {
+		w.Verbosef("  Plugin: %s (kind=%s, version=%s)", p.Name, p.Kind, p.Version)
+	}
+
+	if opts.DryRun {
+		w.Infof("Dry run: would install %d plugin(s):", len(plugins))
+		for _, p := range plugins {
+			ver := p.Version
+			if ver == "" {
+				ver = "latest"
+			}
+			w.Infof("  %s (%s) %s", p.Name, p.Kind, ver)
+		}
+		return nil
 	}
 
 	// Build catalog chain from config
@@ -155,9 +185,9 @@ func runInstall(ctx context.Context, opts *InstallOptions) error {
 	})
 
 	// Fetch all plugins
-	w.Infof("Installing %d plugin(s)...", len(sol.Bundle.Plugins))
+	w.Infof("Installing %d plugin(s)...", len(plugins))
 
-	results, err := fetcher.FetchPlugins(ctx, sol.Bundle.Plugins, lockPlugins)
+	results, err := fetcher.FetchPlugins(ctx, plugins, lockPlugins)
 	if err != nil {
 		w.Errorf("failed to install plugins: %v", err)
 		return exitcode.WithCode(err, exitcode.CatalogError)
@@ -186,4 +216,112 @@ func loadSolution(path string) (*solution.Solution, error) {
 		return nil, fmt.Errorf("parsing solution from %s: %w", path, err)
 	}
 	return &sol, nil
+}
+
+// resolveStandalonePlugins converts positional plugin name arguments into
+// PluginDependency entries by looking up each name in the official provider
+// and auth handler registries from context (falling back to default registries).
+// Names not found in any registry are still accepted -- catalog resolution
+// will determine if they exist.
+func resolveStandalonePlugins(ctx context.Context, names []string, kind, version string) ([]solution.PluginDependency, error) {
+	pluginKind := solution.PluginKind(kind)
+	if !pluginKind.IsValid() {
+		return nil, fmt.Errorf("invalid plugin kind %q (valid: provider, auth-handler)", kind)
+	}
+
+	provReg := official.RegistryFromContext(ctx)
+	if provReg == nil {
+		provReg = official.NewRegistry()
+	}
+	authReg := authofficial.RegistryFromContext(ctx)
+	if authReg == nil {
+		authReg = authofficial.NewRegistry()
+	}
+	deps := make([]solution.PluginDependency, 0, len(names))
+
+	for _, name := range names {
+		// Parse optional name@version syntax.
+		pluginName, pluginVersion := parseNameVersion(name)
+		if version != "" {
+			pluginVersion = version // --version flag overrides inline version
+		}
+
+		var dep solution.PluginDependency
+
+		switch pluginKind {
+		case solution.PluginKindProvider:
+			if p, ok := provReg.Get(pluginName); ok {
+				dep = p.ToPluginDependency()
+				if pluginVersion != "" {
+					dep.Version = pluginVersion
+				}
+			} else {
+				dep = solution.PluginDependency{
+					Name:    pluginName,
+					Kind:    solution.PluginKindProvider,
+					Version: pluginVersion,
+				}
+			}
+		case solution.PluginKindAuthHandler:
+			if h, ok := authReg.Get(pluginName); ok {
+				dep = h.ToPluginDependency()
+				if pluginVersion != "" {
+					dep.Version = pluginVersion
+				}
+			} else {
+				dep = solution.PluginDependency{
+					Name:    pluginName,
+					Kind:    solution.PluginKindAuthHandler,
+					Version: pluginVersion,
+				}
+			}
+		}
+
+		deps = append(deps, dep)
+	}
+
+	return deps, nil
+}
+
+// parseNameVersion splits "name@version" into (name, version).
+// If no "@" is present, returns (input, "").
+func parseNameVersion(s string) (string, string) {
+	if idx := strings.LastIndex(s, "@"); idx > 0 {
+		return s[:idx], s[idx+1:]
+	}
+	return s, ""
+}
+
+// loadPluginsFromSolution loads plugin dependencies from a solution file.
+func loadPluginsFromSolution(ctx context.Context, opts *InstallOptions) ([]solution.PluginDependency, []bundler.LockPlugin, error) {
+	w := writer.FromContext(ctx)
+
+	filePath := opts.File
+	if filePath == "" {
+		filePath = get.NewGetterFromContext(ctx).FindSolution()
+	}
+	if filePath == "" {
+		err := fmt.Errorf("no plugin names or solution file provided; use positional args or --file (-f)")
+		w.Errorf("%s", err)
+		return nil, nil, exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	sol, err := loadSolution(filePath)
+	if err != nil {
+		w.Errorf("failed to load solution: %v", err)
+		return nil, nil, exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	if len(sol.Bundle.Plugins) == 0 {
+		w.Infof("No plugins declared in solution — nothing to install.")
+		return nil, nil, nil
+	}
+
+	lockFile, _ := bundler.LoadLockFile(filepath.Join(filepath.Dir(filePath), bundler.DefaultLockFileName))
+	var lockPlugins []bundler.LockPlugin
+	if lockFile != nil {
+		lockPlugins = lockFile.Plugins
+	}
+
+	return sol.Bundle.Plugins, lockPlugins, nil
 }

--- a/pkg/cmd/scafctl/plugins/install_test.go
+++ b/pkg/cmd/scafctl/plugins/install_test.go
@@ -48,9 +48,9 @@ func TestRunInstall_NoFileProvided_NoAutoDiscover(t *testing.T) {
 		File:      "",
 	}
 
-	err := runInstall(ctx, opts)
+	err := runInstall(ctx, opts, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no solution path provided")
+	assert.Contains(t, err.Error(), "no plugin names or solution file provided")
 }
 
 func TestRunInstall_FileNotFound(t *testing.T) {
@@ -63,7 +63,7 @@ func TestRunInstall_FileNotFound(t *testing.T) {
 		File:      "/nonexistent/path/solution.yaml",
 	}
 
-	err := runInstall(ctx, opts)
+	err := runInstall(ctx, opts, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reading solution")
 }
@@ -83,7 +83,7 @@ func TestRunInstall_InvalidYAML(t *testing.T) {
 		File:      solFile,
 	}
 
-	err = runInstall(ctx, opts)
+	err = runInstall(ctx, opts, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing solution")
 }
@@ -110,7 +110,7 @@ spec:
 		File:      solFile,
 	}
 
-	err = runInstall(ctx, opts)
+	err = runInstall(ctx, opts, nil)
 	require.NoError(t, err, "no plugins declared should succeed with no-op")
 }
 
@@ -152,4 +152,116 @@ func TestLoadSolution_InvalidContent(t *testing.T) {
 	_, err = loadSolution(solFile)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing solution")
+}
+
+func TestResolveStandalonePlugins_OfficialProvider(t *testing.T) {
+	t.Parallel()
+
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"github"}, "provider", "")
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "provider", string(deps[0].Kind))
+	assert.NotEmpty(t, deps[0].Name)
+}
+
+func TestResolveStandalonePlugins_MultiplePlugins(t *testing.T) {
+	t.Parallel()
+
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"github", "exec", "env"}, "provider", "")
+	require.NoError(t, err)
+	assert.Len(t, deps, 3)
+}
+
+func TestResolveStandalonePlugins_VersionOverride(t *testing.T) {
+	t.Parallel()
+
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"github"}, "provider", ">=0.3.0")
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, ">=0.3.0", deps[0].Version)
+}
+
+func TestResolveStandalonePlugins_InlineVersion(t *testing.T) {
+	t.Parallel()
+
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"github@0.2.0"}, "provider", "")
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "0.2.0", deps[0].Version)
+}
+
+func TestResolveStandalonePlugins_UnknownPlugin(t *testing.T) {
+	t.Parallel()
+
+	// Unknown names should still produce a dependency (catalog will resolve or fail)
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"my-custom-plugin"}, "provider", "")
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "my-custom-plugin", deps[0].Name)
+	assert.Equal(t, "provider", string(deps[0].Kind))
+}
+
+func TestResolveStandalonePlugins_AuthHandler(t *testing.T) {
+	t.Parallel()
+
+	deps, err := resolveStandalonePlugins(t.Context(), []string{"github"}, "auth-handler", "")
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "auth-handler", string(deps[0].Kind))
+}
+
+func TestResolveStandalonePlugins_InvalidKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveStandalonePlugins(t.Context(), []string{"github"}, "invalid-kind", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid plugin kind")
+}
+
+func TestParseNameVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input   string
+		name    string
+		version string
+	}{
+		{"github", "github", ""},
+		{"github@0.2.0", "github", "0.2.0"},
+		{"github@>=0.3.0", "github", ">=0.3.0"},
+		{"my-plugin@latest", "my-plugin", "latest"},
+		{"@invalid", "@invalid", ""}, // edge: no name before @
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			name, version := parseNameVersion(tt.input)
+			assert.Equal(t, tt.name, name)
+			assert.Equal(t, tt.version, version)
+		})
+	}
+}
+
+func TestRunInstall_DryRun(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(t.Context(), w)
+
+	opts := &InstallOptions{
+		CliParams: settings.NewCliParams(),
+		IOStreams: ioStreams,
+		DryRun:    true, Kind: "provider",
+	}
+
+	err := runInstall(ctx, opts, []string{"github", "exec"})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Dry run")
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "exec")
 }

--- a/pkg/cmd/scafctl/plugins/plugins_test.go
+++ b/pkg/cmd/scafctl/plugins/plugins_test.go
@@ -36,7 +36,7 @@ func TestCommandInstall(t *testing.T) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	cmd := CommandInstall(cliParams, ioStreams, "scafctl/plugins")
 	require.NotNil(t, cmd)
-	assert.Equal(t, "install", cmd.Use)
+	assert.Equal(t, "install [plugin-name ...]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 }
@@ -53,6 +53,10 @@ func TestCommandInstall_Flags(t *testing.T) {
 		{"file", "file", ""},
 		{"platform", "platform", ""},
 		{"cache-dir", "cache-dir", ""},
+		{"no-cache", "no-cache", "false"},
+		{"kind", "kind", "provider"},
+		{"version", "version", ""},
+		{"dry-run", "dry-run", "false"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/git/status.go
+++ b/pkg/git/status.go
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package git provides utilities for inspecting Git repository state.
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// RepoStatus describes the state of a Git repository at a given path.
+type RepoStatus struct {
+	// IsRepo indicates whether the path is inside a git repository.
+	IsRepo bool
+
+	// IsDirty indicates whether the working tree has uncommitted changes.
+	IsDirty bool
+
+	// Commit is the short SHA of the HEAD commit (empty if not a repo).
+	Commit string
+}
+
+// GetRepositoryStatus inspects the git repository at dir and returns its status.
+// Returns a non-repo RepoStatus (IsRepo=false) if dir is not inside a git repository.
+// Returns an error only for unexpected failures (not for "not a repo").
+func GetRepositoryStatus(ctx context.Context, dir string) (*RepoStatus, error) {
+	// Verify dir exists before shelling out to git.
+	if _, statErr := os.Stat(dir); statErr != nil {
+		return nil, fmt.Errorf("checking directory %s: %w", dir, statErr)
+	}
+
+	// Check if inside a git repo.
+	revParseCmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	out, err := revParseCmd.Output()
+	if err != nil {
+		// Distinguish "not a git repo" from unexpected failures.
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("git not found on PATH: %w", err)
+		}
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("git check canceled: %w", ctx.Err())
+		}
+		// Non-zero exit from git rev-parse means not inside a work tree.
+		return &RepoStatus{IsRepo: false}, nil //nolint:nilerr // non-zero exit means not a repo
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		return &RepoStatus{IsRepo: false}, nil
+	}
+
+	// Get HEAD commit short SHA.
+	commitCmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--short", "HEAD")
+	commitOut, err := commitCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("getting HEAD commit: %w", err)
+	}
+	commit := strings.TrimSpace(string(commitOut))
+
+	// Check for uncommitted changes.
+	statusCmd := exec.CommandContext(ctx, "git", "-C", dir, "status", "--porcelain")
+	statusOut, err := statusCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("checking git status: %w", err)
+	}
+	isDirty := len(strings.TrimSpace(string(statusOut))) > 0
+
+	return &RepoStatus{
+		IsRepo:  true,
+		IsDirty: isDirty,
+		Commit:  commit,
+	}, nil
+}

--- a/pkg/git/status_test.go
+++ b/pkg/git/status_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initTestRepo creates a temporary git repo with one commit.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, string(out))
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	// Create initial commit.
+	f := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(f, []byte("hello"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "initial")
+
+	return dir
+}
+
+func TestGetRepositoryStatus_CleanRepo(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+
+	status, err := GetRepositoryStatus(t.Context(), dir)
+	require.NoError(t, err)
+	assert.True(t, status.IsRepo)
+	assert.False(t, status.IsDirty)
+	assert.NotEmpty(t, status.Commit)
+}
+
+func TestGetRepositoryStatus_DirtyRepo(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+
+	// Make the tree dirty.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("dirty"), 0o644))
+
+	status, err := GetRepositoryStatus(t.Context(), dir)
+	require.NoError(t, err)
+	assert.True(t, status.IsRepo)
+	assert.True(t, status.IsDirty)
+	assert.NotEmpty(t, status.Commit)
+}
+
+func TestGetRepositoryStatus_NotARepo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	status, err := GetRepositoryStatus(t.Context(), dir)
+	require.NoError(t, err)
+	assert.False(t, status.IsRepo)
+	assert.False(t, status.IsDirty)
+	assert.Empty(t, status.Commit)
+}
+
+func TestGetRepositoryStatus_CanceledContext(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := GetRepositoryStatus(ctx, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
+}
+
+func TestGetRepositoryStatus_DirNotExist(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetRepositoryStatus(t.Context(), "/nonexistent/path/that/does/not/exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking directory")
+}

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -5,10 +5,12 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
@@ -136,6 +138,11 @@ func (s *Server) registerProviderTools() {
 		),
 		mcp.WithBoolean("dry_run",
 			mcp.Description("Preview what would happen without executing. Defaults to false."),
+		),
+		mcp.WithString("expression",
+			mcp.Description("Optional CEL expression to filter/transform the provider output before returning. "+
+				"The result object is bound to '_' (e.g., '_.data', 'size(_.data)', '_.data.filter(x, x.status == \"open\")'). "+
+				"Use this to reduce large outputs to only the fields you need."),
 		),
 	)
 	s.addTool(runProviderTool, s.handleRunProvider)
@@ -433,5 +440,41 @@ func (s *Server) handleRunProvider(ctx context.Context, request mcp.CallToolRequ
 		), nil
 	}
 
+	// Apply optional CEL expression to transform/filter the result.
+	expression := request.GetString("expression", "")
+	if expression != "" {
+		// Convert struct to map for CEL access.
+		resultMap, marshalErr := structToMap(result)
+		if marshalErr != nil {
+			return newStructuredError(ErrCodeExecFailed,
+				fmt.Sprintf("failed to prepare result for CEL evaluation: %v", marshalErr),
+			), nil
+		}
+		transformed, celErr := celexp.EvaluateExpression(ctx, expression, resultMap, nil)
+		if celErr != nil {
+			return newStructuredError(ErrCodeExecFailed,
+				fmt.Sprintf("CEL expression evaluation failed: %v", celErr),
+				WithField("expression"),
+				WithSuggestion("Use validate_expression to check CEL syntax first"),
+				WithRelatedTools("validate_expression", "list_cel_functions"),
+			), nil
+		}
+		return mcp.NewToolResultJSON(transformed)
+	}
+
 	return mcp.NewToolResultJSON(result)
+}
+
+// structToMap converts a Go struct to a map[string]any via JSON round-trip
+// so that CEL expressions can access fields by name.
+func structToMap(v any) (map[string]any, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -531,6 +531,87 @@ func TestHandleRunProvider(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(text), &output))
 		assert.Equal(t, "message", output["provider"])
 	})
+
+	t.Run("applies CEL expression to result", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_provider"
+		request.Params.Arguments = map[string]any{
+			"provider":   "cel",
+			"inputs":     map[string]any{"expression": "'hello world'"},
+			"expression": "_.data",
+		}
+
+		result, err := srv.handleRunProvider(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		// The CEL expression '_.data' extracts just the data field
+		assert.Contains(t, text, "hello world")
+		// Should NOT contain the wrapper fields like "provider", "capability"
+		assert.NotContains(t, text, "\"provider\"")
+	})
+
+	t.Run("returns error for invalid CEL expression", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_provider"
+		request.Params.Arguments = map[string]any{
+			"provider":   "cel",
+			"inputs":     map[string]any{"expression": "'hello'"},
+			"expression": "_.nonexistent.deep.field",
+		}
+
+		result, err := srv.handleRunProvider(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "CEL expression evaluation failed")
+	})
+
+	t.Run("no expression returns full result", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_provider"
+		request.Params.Arguments = map[string]any{
+			"provider": "cel",
+			"inputs":   map[string]any{"expression": "'hello world'"},
+		}
+
+		result, err := srv.handleRunProvider(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		// Full result includes wrapper fields
+		assert.Equal(t, "cel", output["provider"])
+		assert.Equal(t, "transform", output["capability"])
+	})
 }
 
 func TestEnsureProvider(t *testing.T) {

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -480,6 +480,12 @@ func NewDefaultGetter(ctx context.Context, noCache bool) get.Interface {
 	if lgr != nil {
 		getterOpts = append(getterOpts, get.WithLogger(*lgr))
 
+		// Create shared artifact cache for both catalog and remote resolvers.
+		var artifactCache catalog.ArtifactCacher
+		if !noCache {
+			artifactCache = cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+		}
+
 		localCatalog, err := catalog.NewLocalCatalog(*lgr)
 		if err == nil {
 			// Build SolutionResolverOptions with optional artifact cache
@@ -487,8 +493,7 @@ func NewDefaultGetter(ctx context.Context, noCache bool) get.Interface {
 				catalog.WithResolverNoCache(noCache),
 				catalog.WithResolverRemoteCatalogs(catalog.RemoteCatalogsFromContext(ctx, *lgr)),
 			}
-			if !noCache {
-				artifactCache := cache.NewArtifactCache(paths.ArtifactCacheDir(), settings.DefaultArtifactCacheTTL)
+			if artifactCache != nil {
 				resolverOpts = append(resolverOpts, catalog.WithResolverArtifactCache(artifactCache))
 			}
 			catResolver := catalog.NewSolutionResolver(localCatalog, *lgr, resolverOpts...)
@@ -553,7 +558,9 @@ func NewDefaultGetter(ctx context.Context, noCache bool) get.Interface {
 				}
 				return ""
 			},
-			Logger: *lgr,
+			Logger:        *lgr,
+			ArtifactCache: artifactCache,
+			NoCache:       noCache,
 		})
 		getterOpts = append(getterOpts, get.WithRemoteResolver(remoteResolver))
 	}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6486,7 +6486,7 @@ func TestIntegration_Plugins_Install_AutoDiscoveryNoFile(t *testing.T) {
 	emptyDir := t.TempDir()
 	_, stderr, exitCode := runScafctlInDir(t, emptyDir, "plugins", "install")
 	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "no solution path provided")
+	assert.Contains(t, stderr, "no plugin names or solution file provided")
 }
 
 // TestIntegration_Plugins_Install_NoPlugins verifies install succeeds with a solution that has no plugins.
@@ -6533,6 +6533,30 @@ spec:
 	stdout, _, exitCode := runScafctlWithEnvInDir(t, tmpDir, env, "plugins", "install")
 	assert.Equal(t, 0, exitCode, "expected plugins install to auto-discover solution.yaml")
 	assert.Contains(t, stdout, "No plugins declared")
+}
+
+// TestIntegration_Plugins_Install_StandaloneDryRun verifies standalone mode with --dry-run.
+func TestIntegration_Plugins_Install_StandaloneDryRun(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_CACHE_HOME": tmpDir,
+		"XDG_DATA_HOME":  tmpDir,
+	}
+
+	stdout, _, exitCode := runScafctlWithEnv(t, env, "plugins", "install", "github", "--kind", "provider", "--dry-run")
+	assert.Equal(t, 0, exitCode, "expected dry-run to succeed")
+	assert.Contains(t, stdout, "Dry run")
+	assert.Contains(t, stdout, "github")
+}
+
+// TestIntegration_Plugins_Install_InvalidKind verifies error on invalid --kind flag.
+func TestIntegration_Plugins_Install_InvalidKind(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runScafctl(t, "plugins", "install", "github", "--kind", "invalid")
+	assert.NotEqual(t, 0, exitCode, "expected non-zero exit for invalid kind")
+	assert.Contains(t, stderr, "invalid plugin kind")
 }
 
 // TestIntegration_RunResolver_MetadataProvider runs the metadata provider and verifies output.


### PR DESCRIPTION
- add standalone plugin install by name with --kind, --version, and --dry-run flags (#357)
- add optional CEL expression parameter to MCP run_provider tool for result transformation (#358)
- enable artifact caching in RemoteSolutionResolver with shared cache from prepare.NewDefaultGetter (#359)
- detect git dirty state during build and record commit/dirty annotations on built artifacts (#172)
- add --allow-dirty and --no-git-metadata flags to build solution
- add pkg/git package for git repository status inspection
- add integration-test prompt for real CLI verification

Closes #357
Closes #358
Closes #359
Closes #172
