### PR TITLE
feat(lint): add inline suppression via YAML comments

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -102,6 +102,11 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintTests(sol, filePath, result)
 	lintProviderInputs(sol, result, registry)
 
+	// Apply suppression directives parsed from inline YAML comments.
+	suppressions := ParseDirectives(sol.RawContent(), filePath)
+	result.Findings = suppressions.Filter(result.Findings)
+	result.Findings = append(result.Findings, suppressions.UnusedFindings()...)
+
 	for _, f := range result.Findings {
 		switch f.Severity {
 		case SeverityError:

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -338,6 +338,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Preferred:\ntmpl: \"Deploying {{ .config.appName }}\"\n\n# Also works (via underscore alias):\ntmpl: \"Deploying {{ ._.config.appName }}\"",
 		},
 	},
+	"unused-suppression": {
+		Rule:        "unused-suppression",
+		Severity:    string(SeverityInfo),
+		Category:    "suppression",
+		Description: "A suppression directive (scafctl-lint-ignore/disable) did not match any lint finding.",
+		Why:         "Unused suppressions indicate stale comments left after fixing an issue, or misspelled rule names. Removing them keeps the codebase clean and prevents masking future issues.",
+		Fix:         "Remove the suppression comment or fix the rule name. Check for typos in the rule name after the colon.",
+		Examples: []string{
+			"# Line suppression:\n# scafctl-lint-ignore: exec-command-injection\n\n# Block suppression:\n# scafctl-lint-disable: exec-command-injection\n...\n# scafctl-lint-enable: exec-command-injection\n\n# File-level suppression:\n# scafctl-lint-disable-file: exec-command-injection",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 34 rules — update this when new rules are added
-	assert.Equal(t, 34, len(KnownRules), "expected 34 known lint rules")
+	// We expect exactly 35 rules — update this when new rules are added
+	assert.Equal(t, 35, len(KnownRules), "expected 35 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/lint/suppress.go
+++ b/pkg/lint/suppress.go
@@ -1,0 +1,418 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// DirectiveType represents the kind of suppression directive.
+type DirectiveType int
+
+const (
+	// DirectiveIgnore suppresses findings on the next line (or current line if inline).
+	DirectiveIgnore DirectiveType = iota
+
+	// DirectiveDisable starts a suppression block.
+	DirectiveDisable
+
+	// DirectiveEnable ends a suppression block.
+	DirectiveEnable
+
+	// DirectiveDisableFile suppresses findings for the entire file.
+	DirectiveDisableFile
+)
+
+const (
+	prefixIgnore      = "scafctl-lint-ignore"
+	prefixDisable     = "scafctl-lint-disable"
+	prefixEnable      = "scafctl-lint-enable"
+	prefixDisableFile = "scafctl-lint-disable-file"
+
+	// scannerMaxLine is the maximum line length for the scanner (1 MB).
+	scannerMaxLine = 1 << 20
+)
+
+// Directive represents a single suppression comment in the source YAML.
+type Directive struct {
+	Type   DirectiveType `json:"type" yaml:"type" doc:"Type of suppression directive" maximum:"3" example:"0"`
+	Rules  []string      `json:"rules" yaml:"rules" doc:"Rule names to suppress (empty means all)" maxItems:"50"`
+	Line   int           `json:"line" yaml:"line" doc:"Source line number of the directive" maximum:"1000000" example:"10"`
+	File   string        `json:"file,omitempty" yaml:"file,omitempty" doc:"Source file path" maxLength:"512"`
+	Inline bool          `json:"inline" yaml:"inline" doc:"Whether the directive is an inline comment"`
+}
+
+// SuppressionSet holds parsed directives and tracks which ones are consumed.
+type SuppressionSet struct {
+	directives []Directive
+	used       []bool
+}
+
+// ParseDirectives scans raw YAML bytes for suppression comments and returns
+// a SuppressionSet. The scanning is line-based (not yaml.Node based) to avoid
+// comment attachment quirks.
+func ParseDirectives(data []byte, file string) *SuppressionSet {
+	var directives []Directive
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), scannerMaxLine)
+
+	var inBlockScalar bool
+	var blockIndent int
+
+	for lineNum := 1; scanner.Scan(); lineNum++ {
+		raw := scanner.Text()
+		line := strings.TrimSpace(raw)
+
+		// Track block scalar context (| and > indicators).
+		if inBlockScalar {
+			if line == "" {
+				continue
+			}
+			indent := len(raw) - len(strings.TrimLeft(raw, " \t"))
+			if indent <= blockIndent {
+				inBlockScalar = false
+				// Fall through to parse this line normally.
+			} else {
+				continue
+			}
+		}
+
+		if !strings.HasPrefix(line, "#") && (strings.HasSuffix(line, "|") ||
+			strings.HasSuffix(line, ">") ||
+			strings.HasSuffix(line, "|-") ||
+			strings.HasSuffix(line, ">-") ||
+			strings.HasSuffix(line, "|+") ||
+			strings.HasSuffix(line, ">+")) {
+			inBlockScalar = true
+			blockIndent = len(raw) - len(strings.TrimLeft(raw, " \t"))
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") {
+			// Standalone comment line.
+			comment := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+			if d, ok := parseDirectiveComment(comment, lineNum, file, false); ok {
+				directives = append(directives, d)
+			}
+			continue
+		}
+
+		// Check for inline comment, skipping '#' inside quoted strings.
+		if idx := findInlineComment(line); idx >= 0 {
+			comment := strings.TrimSpace(line[idx+1:])
+			if d, ok := parseDirectiveComment(comment, lineNum, file, true); ok {
+				directives = append(directives, d)
+			}
+		}
+	}
+
+	// Ignore scanner errors — bytes.Reader cannot produce I/O errors, and
+	// lines exceeding scannerMaxLine are silently skipped (no directives lost
+	// since directives are short comment lines).
+
+	return &SuppressionSet{
+		directives: directives,
+		used:       make([]bool, len(directives)),
+	}
+}
+
+// findInlineComment returns the index of the '#' that starts an inline YAML
+// comment, or -1 if none is found. It skips '#' inside single- or
+// double-quoted scalars to avoid false positives.
+func findInlineComment(line string) int {
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				if inDouble && i > 0 && line[i-1] == '\\' {
+					continue // escaped quote
+				}
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble && i > 0 && line[i-1] == ' ' {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// parseDirectiveComment parses a comment string (without the leading '#') into
+// a Directive. Returns false if the comment is not a suppression directive.
+func parseDirectiveComment(comment string, line int, file string, inline bool) (Directive, bool) {
+	// Order matters: disable-file before disable (prefix match).
+	var dtype DirectiveType
+	var rest string
+
+	switch {
+	case strings.HasPrefix(comment, prefixDisableFile):
+		dtype = DirectiveDisableFile
+		rest = strings.TrimPrefix(comment, prefixDisableFile)
+	case strings.HasPrefix(comment, prefixDisable):
+		dtype = DirectiveDisable
+		rest = strings.TrimPrefix(comment, prefixDisable)
+	case strings.HasPrefix(comment, prefixEnable):
+		dtype = DirectiveEnable
+		rest = strings.TrimPrefix(comment, prefixEnable)
+	case strings.HasPrefix(comment, prefixIgnore):
+		dtype = DirectiveIgnore
+		rest = strings.TrimPrefix(comment, prefixIgnore)
+	default:
+		return Directive{}, false
+	}
+
+	// After the prefix, only ':' or end-of-string is valid.
+	rest = strings.TrimSpace(rest)
+	if rest != "" && rest[0] != ':' {
+		return Directive{}, false
+	}
+
+	rules := parseRuleList(rest)
+
+	return Directive{
+		Type:   dtype,
+		Rules:  rules,
+		Line:   line,
+		File:   file,
+		Inline: inline,
+	}, true
+}
+
+// parseRuleList parses the optional ": rule-a, rule-b" suffix after a directive prefix.
+// Returns nil (all rules) if no colon is present.
+func parseRuleList(rest string) []string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return nil // no colon → all rules
+	}
+	if !strings.HasPrefix(rest, ":") {
+		return nil
+	}
+	rest = strings.TrimPrefix(rest, ":")
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return nil
+	}
+
+	parts := strings.Split(rest, ",")
+	rules := make([]string, 0, len(parts))
+	for _, p := range parts {
+		r := strings.TrimSpace(p)
+		if r != "" {
+			rules = append(rules, r)
+		}
+	}
+	if len(rules) == 0 {
+		return nil
+	}
+	return rules
+}
+
+// Filter removes suppressed findings from the input slice and returns the
+// remaining findings. Directives that match at least one finding are marked
+// as used.
+func (ss *SuppressionSet) Filter(findings []*Finding) []*Finding {
+	if len(ss.directives) == 0 {
+		return findings
+	}
+
+	kept := make([]*Finding, 0, len(findings))
+	for _, f := range findings {
+		if ss.isSuppressed(f) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
+}
+
+// isSuppressed checks whether a finding is suppressed by any directive.
+func (ss *SuppressionSet) isSuppressed(f *Finding) bool {
+	for i := range ss.directives {
+		d := &ss.directives[i]
+
+		if !directiveMatchesRule(d, f.RuleName) {
+			continue
+		}
+
+		if !directiveMatchesFile(d, f) {
+			continue
+		}
+
+		switch d.Type {
+		case DirectiveDisableFile:
+			ss.used[i] = true
+			return true
+
+		case DirectiveIgnore:
+			if d.Inline {
+				// Inline directive suppresses only the current line.
+				if f.Line == d.Line {
+					ss.used[i] = true
+					return true
+				}
+			} else {
+				// Standalone comment suppresses its own line and the next line.
+				if f.Line == d.Line || f.Line == d.Line+1 {
+					ss.used[i] = true
+					return true
+				}
+			}
+
+		case DirectiveDisable:
+			// Find the matching enable directive (or EOF).
+			endLine := ss.findMatchingEnable(i)
+			if f.Line >= d.Line && f.Line <= endLine {
+				ss.used[i] = true
+				return true
+			}
+
+		case DirectiveEnable:
+			// Enable directives don't suppress — they end a disable block.
+		}
+	}
+	return false
+}
+
+// findMatchingEnable returns the line number of the matching enable directive
+// for the disable directive at index i. Returns a large number (EOF sentinel)
+// if no matching enable is found.
+func (ss *SuppressionSet) findMatchingEnable(disableIdx int) int {
+	d := &ss.directives[disableIdx]
+	for j := disableIdx + 1; j < len(ss.directives); j++ {
+		e := &ss.directives[j]
+		if e.Type != DirectiveEnable {
+			continue
+		}
+		if e.File != d.File {
+			continue
+		}
+		// Match when enable covers exactly the same rules as disable.
+		if rulesMatch(d.Rules, e.Rules) {
+			ss.used[j] = true
+			return e.Line
+		}
+	}
+	// No matching enable → suppress to EOF.
+	return 1<<31 - 1
+}
+
+// directiveMatchesRule checks if a directive applies to the given rule name.
+// A directive with no rules matches all rules.
+func directiveMatchesRule(d *Directive, ruleName string) bool {
+	if len(d.Rules) == 0 {
+		return true // all rules
+	}
+	for _, r := range d.Rules {
+		if r == ruleName {
+			return true
+		}
+	}
+	return false
+}
+
+// directiveMatchesFile checks if a directive applies to the same file as the finding.
+func directiveMatchesFile(d *Directive, f *Finding) bool {
+	// If the finding has no source file info, match on any directive.
+	if f.SourceFile == "" {
+		return true
+	}
+	// If the directive has no file info, match on any finding.
+	if d.File == "" {
+		return true
+	}
+	return d.File == f.SourceFile
+}
+
+// rulesMatch checks if two rule lists match exactly (same set of rules).
+// Empty list means "all rules", which only matches another empty list.
+func rulesMatch(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	// Build a set from a and check b against it.
+	set := make(map[string]struct{}, len(a))
+	for _, r := range a {
+		set[r] = struct{}{}
+	}
+	for _, r := range b {
+		if _, ok := set[r]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// rulesOverlap checks if two rule lists have overlap. Empty list means "all",
+// which overlaps with everything.
+func rulesOverlap(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return true
+	}
+	for _, ar := range a {
+		for _, br := range b {
+			if ar == br {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// UnusedFindings returns info-level findings for suppression directives that
+// did not match any lint finding. This helps detect stale or misspelled
+// suppression comments.
+func (ss *SuppressionSet) UnusedFindings() []*Finding {
+	var findings []*Finding
+	for i, d := range ss.directives {
+		if ss.used[i] {
+			continue
+		}
+
+		// Paired enable directives (used by a disable block) are already
+		// marked as used. Unpaired enables are reported below.
+		if d.Type == DirectiveEnable {
+			findings = append(findings, &Finding{
+				Severity:   SeverityInfo,
+				Category:   "suppression",
+				Location:   "directive",
+				Message:    "enable directive has no matching disable",
+				Suggestion: "Remove the stray enable comment or add a corresponding disable",
+				RuleName:   "unused-suppression",
+				Line:       d.Line,
+				SourceFile: d.File,
+			})
+			continue
+		}
+
+		ruleDesc := "all rules"
+		if len(d.Rules) > 0 {
+			ruleDesc = strings.Join(d.Rules, ", ")
+		}
+
+		findings = append(findings, &Finding{
+			Severity:   SeverityInfo,
+			Category:   "suppression",
+			Location:   "directive",
+			Message:    "suppression directive did not match any finding: " + ruleDesc,
+			Suggestion: "Remove the suppression comment or fix the rule name",
+			RuleName:   "unused-suppression",
+			Line:       d.Line,
+			SourceFile: d.File,
+		})
+	}
+	return findings
+}

--- a/pkg/lint/suppress_test.go
+++ b/pkg/lint/suppress_test.go
@@ -1,0 +1,652 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDirectives_IgnoreSingle(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-ignore: exec-command-injection\ncommand:\n  tmpl: 'echo hello'\n")
+	ss := ParseDirectives(yaml, "solution.yaml")
+
+	require.Len(t, ss.directives, 1)
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+	assert.Equal(t, []string{"exec-command-injection"}, ss.directives[0].Rules)
+	assert.Equal(t, 1, ss.directives[0].Line)
+	assert.Equal(t, "solution.yaml", ss.directives[0].File)
+	assert.False(t, ss.directives[0].Inline)
+}
+
+func TestParseDirectives_IgnoreMultipleRules(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-ignore: rule-a, rule-b\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1)
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+	assert.Equal(t, []string{"rule-a", "rule-b"}, ss.directives[0].Rules)
+}
+
+func TestParseDirectives_IgnoreAllRules(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-ignore\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1)
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+	assert.Nil(t, ss.directives[0].Rules, "no rules means all rules")
+}
+
+func TestParseDirectives_DisableEnable(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-disable: exec-command-injection\nstep1: a\nstep2: b\n# scafctl-lint-enable: exec-command-injection\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 2)
+	assert.Equal(t, DirectiveDisable, ss.directives[0].Type)
+	assert.Equal(t, 1, ss.directives[0].Line)
+	assert.Equal(t, DirectiveEnable, ss.directives[1].Type)
+	assert.Equal(t, 4, ss.directives[1].Line)
+}
+
+func TestParseDirectives_DisableFile(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-disable-file: exec-command-injection\napiVersion: scafctl.io/v1\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1)
+	assert.Equal(t, DirectiveDisableFile, ss.directives[0].Type)
+	assert.Equal(t, []string{"exec-command-injection"}, ss.directives[0].Rules)
+}
+
+func TestParseDirectives_NonDirectiveComments(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# This is a normal comment\n# Another comment\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives)
+}
+
+func TestParseDirectives_Empty(t *testing.T) {
+	t.Parallel()
+
+	ss := ParseDirectives(nil, "test.yaml")
+	assert.Empty(t, ss.directives)
+}
+
+func TestParseDirectives_MultipleDirectives(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-disable-file: rule-a\n# scafctl-lint-ignore: rule-b\nfoo: bar\n# scafctl-lint-disable: rule-c\nbar: baz\n# scafctl-lint-enable: rule-c\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 4)
+	assert.Equal(t, DirectiveDisableFile, ss.directives[0].Type)
+	assert.Equal(t, DirectiveIgnore, ss.directives[1].Type)
+	assert.Equal(t, DirectiveDisable, ss.directives[2].Type)
+	assert.Equal(t, DirectiveEnable, ss.directives[3].Type)
+}
+
+func TestParseDirectives_BlockScalarIgnored(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("script: |\n  # scafctl-lint-disable-file: rule-a\n  echo hello\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "directives inside block scalars must be ignored")
+}
+
+func TestParseDirectives_BlockScalarFolded(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("script: >\n  # scafctl-lint-ignore: rule-a\n  echo hello\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "directives inside folded block scalars must be ignored")
+}
+
+func TestParseDirectives_BlockScalarChomping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		literal string
+	}{
+		{"literal strip", "script: |-\n  # scafctl-lint-ignore: rule-a\n  echo\nfoo: bar\n"},
+		{"literal keep", "script: |+\n  # scafctl-lint-ignore: rule-a\n  echo\nfoo: bar\n"},
+		{"folded strip", "script: >-\n  # scafctl-lint-ignore: rule-a\n  echo\nfoo: bar\n"},
+		{"folded keep", "script: >+\n  # scafctl-lint-ignore: rule-a\n  echo\nfoo: bar\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ss := ParseDirectives([]byte(tt.literal), "test.yaml")
+			assert.Empty(t, ss.directives, "directives inside block scalars with chomping must be ignored")
+		})
+	}
+}
+
+func TestParseDirectives_AfterBlockScalar(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("script: |\n  echo hello\n# scafctl-lint-ignore: rule-a\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1, "directive after block scalar should be parsed")
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+	assert.Equal(t, 3, ss.directives[0].Line)
+}
+
+func TestParseDirectives_QuotedHashNotInlineComment(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("foo: 'literal # scafctl-lint-ignore: rule-a'\nbar: baz\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "# inside single-quoted scalar must not be parsed")
+}
+
+func TestParseDirectives_DoubleQuotedHashNotInlineComment(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("foo: \"literal # scafctl-lint-ignore: rule-a\"\nbar: baz\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "# inside double-quoted scalar must not be parsed")
+}
+
+func TestParseDirectives_RejectsSpaceThenJunk(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-ignore TODO\n# scafctl-lint-disable something\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "space-then-junk after prefix must be rejected")
+}
+
+func TestFilter_IgnoreSuppressesNextLine(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "test.yaml", Inline: false},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 6, SourceFile: "test.yaml"},
+		{RuleName: "other-rule", Line: 6, SourceFile: "test.yaml"},
+		{RuleName: "my-rule", Line: 10, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "other-rule", result[0].RuleName)
+	assert.Equal(t, "my-rule", result[1].RuleName)
+	assert.Equal(t, 10, result[1].Line)
+	assert.True(t, ss.used[0])
+}
+
+func TestFilter_IgnoreSuppressesSameLine(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "test.yaml", Inline: false},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 5, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	assert.Empty(t, result)
+}
+
+func TestFilter_InlineIgnoreOnlyCurrentLine(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "test.yaml", Inline: true},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 5, SourceFile: "test.yaml"},
+		{RuleName: "my-rule", Line: 6, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+
+	require.Len(t, result, 1, "inline ignore must not suppress next line")
+	assert.Equal(t, 6, result[0].Line)
+}
+
+func TestFilter_DisableEnableBlock(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveDisable, Rules: []string{"my-rule"}, Line: 3, File: "test.yaml"},
+			{Type: DirectiveEnable, Rules: []string{"my-rule"}, Line: 8, File: "test.yaml"},
+		},
+		used: make([]bool, 2),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 2, SourceFile: "test.yaml"},  // before block
+		{RuleName: "my-rule", Line: 5, SourceFile: "test.yaml"},  // inside block
+		{RuleName: "my-rule", Line: 10, SourceFile: "test.yaml"}, // after block
+	}
+
+	result := ss.Filter(findings)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, 2, result[0].Line)
+	assert.Equal(t, 10, result[1].Line)
+}
+
+func TestFilter_DisableEnableExactMatchRequired(t *testing.T) {
+	t.Parallel()
+
+	// disable: a,b should NOT be ended by enable: a (partial match).
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveDisable, Rules: []string{"rule-a", "rule-b"}, Line: 3, File: "test.yaml"},
+			{Type: DirectiveEnable, Rules: []string{"rule-a"}, Line: 8, File: "test.yaml"},
+		},
+		used: make([]bool, 2),
+	}
+
+	findings := []*Finding{
+		{RuleName: "rule-b", Line: 10, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	assert.Empty(t, result, "disable: a,b without matching enable should suppress to EOF")
+}
+
+func TestFilter_DisableWithoutEnable(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveDisable, Rules: []string{"my-rule"}, Line: 3, File: "test.yaml"},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 5, SourceFile: "test.yaml"},
+		{RuleName: "my-rule", Line: 100, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	assert.Empty(t, result, "unmatched disable should suppress to EOF")
+}
+
+func TestFilter_DisableFile(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveDisableFile, Rules: []string{"my-rule"}, Line: 1, File: "test.yaml"},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 50, SourceFile: "test.yaml"},
+		{RuleName: "other-rule", Line: 50, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "other-rule", result[0].RuleName)
+}
+
+func TestFilter_AllRules(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: nil, Line: 5, File: "test.yaml"},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "any-rule", Line: 6, SourceFile: "test.yaml"},
+		{RuleName: "another-rule", Line: 6, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	assert.Empty(t, result, "nil rules should suppress all rules")
+}
+
+func TestFilter_NoDirectives(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: nil,
+		used:       nil,
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 1},
+	}
+
+	result := ss.Filter(findings)
+	require.Len(t, result, 1)
+	assert.Equal(t, "my-rule", result[0].RuleName)
+}
+
+func TestFilter_DifferentFile(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "a.yaml"},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 6, SourceFile: "b.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	require.Len(t, result, 1, "directive for a.yaml should not suppress b.yaml findings")
+}
+
+func TestUnusedFindings_UnusedDirective(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"nonexistent-rule"}, Line: 5, File: "test.yaml"},
+		},
+		used: []bool{false},
+	}
+
+	unused := ss.UnusedFindings()
+
+	require.Len(t, unused, 1)
+	assert.Equal(t, SeverityInfo, unused[0].Severity)
+	assert.Equal(t, "unused-suppression", unused[0].RuleName)
+	assert.Equal(t, 5, unused[0].Line)
+	assert.Contains(t, unused[0].Message, "nonexistent-rule")
+}
+
+func TestUnusedFindings_UsedDirective(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "test.yaml"},
+		},
+		used: []bool{true},
+	}
+
+	unused := ss.UnusedFindings()
+	assert.Empty(t, unused)
+}
+
+func TestUnusedFindings_SkipsUsedEnableDirectives(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveDisable, Rules: []string{"my-rule"}, Line: 3, File: "test.yaml"},
+			{Type: DirectiveEnable, Rules: []string{"my-rule"}, Line: 8, File: "test.yaml"},
+		},
+		used: []bool{false, true}, // enable is used (paired with disable)
+	}
+
+	unused := ss.UnusedFindings()
+
+	// Only the disable directive should produce an unused finding.
+	require.Len(t, unused, 1)
+	assert.Equal(t, 3, unused[0].Line)
+	assert.Contains(t, unused[0].Message, "did not match")
+}
+
+func TestUnusedFindings_UnmatchedEnable(t *testing.T) {
+	t.Parallel()
+
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveEnable, Rules: []string{"my-rule"}, Line: 10, File: "test.yaml"},
+		},
+		used: []bool{false},
+	}
+
+	unused := ss.UnusedFindings()
+
+	require.Len(t, unused, 1)
+	assert.Equal(t, "unused-suppression", unused[0].RuleName)
+	assert.Equal(t, 10, unused[0].Line)
+	assert.Contains(t, unused[0].Message, "no matching disable")
+}
+
+func TestParseRuleList_EmptyColon(t *testing.T) {
+	t.Parallel()
+
+	rules := parseRuleList(": ")
+	assert.Nil(t, rules)
+}
+
+func TestParseRuleList_WhitespaceHandling(t *testing.T) {
+	t.Parallel()
+
+	rules := parseRuleList(":  rule-a ,  rule-b , rule-c ")
+	assert.Equal(t, []string{"rule-a", "rule-b", "rule-c"}, rules)
+}
+
+func TestRulesMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		a, b  []string
+		match bool
+	}{
+		{"both empty (all rules)", nil, nil, true},
+		{"a empty b not", nil, []string{"x"}, false},
+		{"a not empty b empty", []string{"x"}, nil, false},
+		{"exact match", []string{"x", "y"}, []string{"y", "x"}, true},
+		{"different length", []string{"x"}, []string{"x", "y"}, false},
+		{"no match", []string{"x"}, []string{"y"}, false},
+		{"same length different rules", []string{"a", "b"}, []string{"a", "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.match, rulesMatch(tt.a, tt.b))
+		})
+	}
+}
+
+func TestRulesOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    []string
+		overlap bool
+	}{
+		{"both empty (all rules)", nil, nil, true},
+		{"a empty", nil, []string{"x"}, true},
+		{"b empty", []string{"x"}, nil, true},
+		{"matching", []string{"x", "y"}, []string{"y", "z"}, true},
+		{"no overlap", []string{"x"}, []string{"y"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.overlap, rulesOverlap(tt.a, tt.b))
+		})
+	}
+}
+
+func TestFindInlineComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want int
+	}{
+		{"simple inline", "foo: bar # comment", 9},
+		{"no comment", "foo: bar", -1},
+		{"single-quoted hash", "foo: 'bar # baz'", -1},
+		{"double-quoted hash", `foo: "bar # baz"`, -1},
+		{"hash after quote close", "foo: 'bar' # comment", 11},
+		{"no space before hash", "foo: bar#comment", -1},
+		{"escaped double quote", `foo: "bar \" # baz"`, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, findInlineComment(tt.line))
+		})
+	}
+}
+
+func TestKnownRules_UnusedSuppression(t *testing.T) {
+	t.Parallel()
+
+	rule, ok := GetRule("unused-suppression")
+	require.True(t, ok, "unused-suppression rule should be in KnownRules")
+	assert.Equal(t, "info", rule.Severity)
+	assert.Equal(t, "suppression", rule.Category)
+}
+
+func TestParseDirectives_RejectsFalsePrefixMatch(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("# scafctl-lint-disablefoo\n# scafctl-lint-ignorex: rule-a\n# scafctl-lint-enableXYZ\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	assert.Empty(t, ss.directives, "false prefix matches must not be parsed as directives")
+}
+
+func TestParseDirectives_InlineComment(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("foo: bar  # scafctl-lint-ignore: my-rule\nbaz: qux\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1)
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+	assert.Equal(t, []string{"my-rule"}, ss.directives[0].Rules)
+	assert.Equal(t, 1, ss.directives[0].Line, "inline directive should be on the same line")
+	assert.True(t, ss.directives[0].Inline)
+}
+
+func TestFilter_InlineIgnoreSuppressesSameLine(t *testing.T) {
+	t.Parallel()
+
+	// Inline directive on line 1 should suppress a finding on line 1 only.
+	ss := &SuppressionSet{
+		directives: []Directive{
+			{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 1, File: "test.yaml", Inline: true},
+		},
+		used: make([]bool, 1),
+	}
+
+	findings := []*Finding{
+		{RuleName: "my-rule", Line: 1, SourceFile: "test.yaml"},
+	}
+
+	result := ss.Filter(findings)
+	assert.Empty(t, result, "inline ignore should suppress finding on same line")
+}
+
+func TestDirectiveMatchesFile_EmptyDirectiveFile(t *testing.T) {
+	t.Parallel()
+
+	d := &Directive{File: ""}
+	f := &Finding{SourceFile: "something.yaml"}
+
+	assert.True(t, directiveMatchesFile(d, f), "empty directive file should match any finding")
+}
+
+func TestDirectiveMatchesFile_BothEmpty(t *testing.T) {
+	t.Parallel()
+
+	d := &Directive{File: ""}
+	f := &Finding{SourceFile: ""}
+
+	assert.True(t, directiveMatchesFile(d, f), "both empty should match")
+}
+
+func TestParseDirectives_LongLine(t *testing.T) {
+	t.Parallel()
+
+	// Ensure lines up to scannerMaxLine are handled correctly.
+	long := strings.Repeat("x", 100_000)
+	yaml := []byte("key: " + long + "\n# scafctl-lint-ignore: rule-a\nfoo: bar\n")
+	ss := ParseDirectives(yaml, "test.yaml")
+
+	require.Len(t, ss.directives, 1, "directive after long line should be parsed")
+	assert.Equal(t, DirectiveIgnore, ss.directives[0].Type)
+}
+
+func BenchmarkParseDirectives(b *testing.B) {
+	yaml := []byte("# scafctl-lint-disable-file: rule-a\napiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: test\n# scafctl-lint-ignore: rule-b\nspec:\n  resolvers:\n    greeting:\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: hello\n# scafctl-lint-disable: rule-c\n  workflow:\n    actions:\n      step1:\n        provider: exec\n# scafctl-lint-enable: rule-c\n")
+
+	b.ResetTimer()
+	for b.Loop() {
+		ParseDirectives(yaml, "bench.yaml")
+	}
+}
+
+func BenchmarkFilter(b *testing.B) {
+	findings := make([]*Finding, 20)
+	for i := range findings {
+		findings[i] = &Finding{
+			RuleName:   "my-rule",
+			Line:       i*5 + 1,
+			SourceFile: "test.yaml",
+		}
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		ss := &SuppressionSet{
+			directives: []Directive{
+				{Type: DirectiveIgnore, Rules: []string{"my-rule"}, Line: 5, File: "test.yaml"},
+				{Type: DirectiveDisable, Rules: []string{"my-rule"}, Line: 20, File: "test.yaml"},
+				{Type: DirectiveEnable, Rules: []string{"my-rule"}, Line: 40, File: "test.yaml"},
+				{Type: DirectiveDisableFile, Rules: []string{"other-rule"}, Line: 1, File: "test.yaml"},
+			},
+			used: make([]bool, 4),
+		}
+		ss.Filter(findings)
+	}
+}


### PR DESCRIPTION
- add ParseDirectives to scan raw YAML for scafctl-lint-* comment directives (ignore, disable/enable, disable-file)
- support both standalone comment lines and inline comments (e.g. "foo: bar  # scafctl-lint-ignore: rule")
- validate directive prefix boundaries to reject false positives like "scafctl-lint-disablefoo"
- wire suppression into Solution() lint pipeline with unused-suppression info findings for stale directives
- register unused-suppression rule in KnownRules

Closes #362
Closes #296