### PR TITLE
feat(auth): forward host auth config to auth handler plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.5.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/oakwood-commons/kvx v0.12.0 h1:vGSUe/4WP0HXc4Hixh8nSVeNl9blTF0K+6/djG
 github.com/oakwood-commons/kvx v0.12.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0 h1:NNFtY/dCNHO0ZwEQmW3kskA1a5u3ZtcHqBQpRG32HJg=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.5.0/go.mod h1:nu15ohRNWoy6/XtQJW4wMxkdB9fhDQTQrT/GxBEwF9o=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.5.1 h1:xO2bNOTmCBC7IUe6e6Vhlq235MBz6lkfzJKcnfHPZLY=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.5.1/go.mod h1:+Qo2BXZ7Dhj8RoOwvueYFvhJsllyy1wPEJV71W1PoF0=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -54,6 +54,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	solprepare "github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/telemetry"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/input"
@@ -586,6 +587,45 @@ func Root(opts *RootOptions) *cobra.Command {
 
 			ctx = auth.WithRegistry(ctx, authRegistry)
 
+			// Wire plugin signature policy unconditionally so all downstream
+			// plugin operations (auth handlers, providers, solution prepare)
+			// respect the embedder's policy regardless of feature flags.
+			if opts.PluginSignaturePolicy != nil {
+				ctx = plugin.WithSignaturePolicy(ctx, opts.PluginSignaturePolicy)
+			}
+
+			// ── Auto-resolve official auth handlers for direct CLI commands ──
+			// The prepare pipeline handles solution-level auto-resolution, but
+			// direct CLI commands (auth login, auth status, auth token) bypass
+			// the prepare pipeline. This fetches any missing official auth
+			// handlers so they are available for all CLI commands.
+			if !cfg.Settings.DisableOfficialAuthHandlers {
+				var cooldownDuration time.Duration
+				if cfg.Plugins.FetchCooldown != "" {
+					if d, parseErr := time.ParseDuration(cfg.Plugins.FetchCooldown); parseErr == nil {
+						cooldownDuration = d
+					} else {
+						lgr.V(1).Info("invalid plugins.fetchCooldown duration, using default", "value", cfg.Plugins.FetchCooldown, "error", parseErr)
+					}
+				}
+				cooldown := plugin.NewFetchCooldown(settings.PluginCacheDirFor(binaryName), cooldownDuration)
+				pluginCfg := &plugin.ProviderConfig{
+					Quiet:      cliParams.IsQuiet,
+					NoColor:    cliParams.NoColor,
+					BinaryName: binaryName,
+				}
+				hostDeps := plugin.HostDepsFromAuthRegistry(authRegistry)
+				if hostDeps != nil && secretErr == nil {
+					hostDeps.SecretStore = sharedSecretStore
+				}
+				clientOpts := []plugin.ClientOption{plugin.WithHostDeps(hostDeps)}
+				officialAuthClients, resolveErr := solprepare.ResolveOfficialAuthHandlers(ctx, authRegistry, cooldown, pluginCfg, clientOpts...)
+				if resolveErr != nil {
+					lgr.V(1).Info("auto-resolve official auth handlers failed", "error", resolveErr)
+				}
+				authPluginClients = append(authPluginClients, officialAuthClients...)
+			}
+
 			// ── Wire official provider registry for auto-resolution ──
 			// When the embedder provides a custom registry, use it.
 			// Otherwise, use the default registry unless disabled in config.
@@ -602,11 +642,6 @@ func Root(opts *RootOptions) *cobra.Command {
 				ctx = official.WithRegistry(ctx, officialReg)
 			} else {
 				lgr.V(1).Info("official provider registry disabled via config")
-			}
-
-			// ── Wire plugin signature policy override ──
-			if opts.PluginSignaturePolicy != nil {
-				ctx = plugin.WithSignaturePolicy(ctx, opts.PluginSignaturePolicy)
 			}
 
 			cCmd.SetContext(ctx)

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -1044,6 +1044,34 @@ func TestConfigureAndRegisterAuthHandlers_DuplicateSkipped(t *testing.T) {
 	assert.Equal(t, "Pre", h.DisplayName())
 }
 
+func TestConfigureAndRegisterAuthHandlers_DuplicateSkipsConfig(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockAuthHandlerPlugin{}
+	ahClient := &AuthHandlerClient{
+		plugin: mock,
+		name:   "test-plugin",
+	}
+	registry := auth.NewRegistry()
+
+	// Pre-register a handler
+	preWrapper := NewAuthHandlerWrapper(ahClient, AuthHandlerInfo{Name: "handler-a", DisplayName: "Pre"})
+	require.NoError(t, registry.Register(preWrapper))
+
+	// Try to register duplicate with config containing settings (simulates secrets)
+	handlers := []AuthHandlerInfo{
+		{Name: "handler-a", DisplayName: "Dup"},
+	}
+	cfg := &ProviderConfig{
+		BinaryName: "mycli",
+		Settings:   map[string]json.RawMessage{"client_secret": json.RawMessage(`"super-secret"`)},
+	}
+	configureAndRegisterAuthHandlers(context.Background(), registry, ahClient, handlers, cfg)
+
+	// ConfigureAuthHandler must NOT have been called — no secrets leaked
+	assert.Nil(t, mock.lastConfig, "ConfigureAuthHandler should not be called for duplicate handler")
+}
+
 func TestConfigureAndRegisterAuthHandlers_ConfigureError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -5,7 +5,9 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"sync"
 
@@ -227,14 +229,12 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 	}
 
 	for _, info := range handlers {
-		if cfg != nil {
-			hostCfg := *cfg
-			hostCfg.HostServiceID = client.HostServiceID()
-			if cfgErr := client.ConfigureAuthHandler(ctx, info.Name, hostCfg); cfgErr != nil {
-				lgr.Info("failed to configure auth handler plugin",
-					"handler", info.Name,
-					"error", cfgErr)
-			}
+		// Pre-check registration before sending config to the plugin.
+		// This avoids leaking secrets (via ConfigureAuthHandler) to a
+		// plugin whose handler name collides with an existing entry.
+		if registry.Has(info.Name) {
+			lgr.V(1).Info("skipping auth handler: name already registered", "handler", info.Name)
+			continue
 		}
 
 		wrapper := NewAuthHandlerWrapper(client, info)
@@ -248,6 +248,20 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 		if err := registry.Register(wrapper); err != nil {
 			lgr.V(1).Info("failed to register auth handler", "handler", info.Name, "error", err)
 			continue
+		}
+
+		// Configure only after successful registration so secrets are
+		// never sent to a plugin that won't actually be used.
+		if cfg != nil {
+			hostCfg := *cfg
+			hostCfg.Settings = maps.Clone(cfg.Settings)
+			hostCfg.HostServiceID = client.HostServiceID()
+			injectAuthHandlerSettings(ctx, info.Name, &hostCfg)
+			if cfgErr := client.ConfigureAuthHandler(ctx, info.Name, hostCfg); cfgErr != nil {
+				lgr.Info("failed to configure auth handler plugin",
+					"handler", info.Name,
+					"error", cfgErr)
+			}
 		}
 	}
 }
@@ -264,6 +278,48 @@ func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry,
 
 	domains = append(domains, cfgDomains...)
 	return domains
+}
+
+// injectAuthHandlerSettings reads per-handler auth configuration from the app
+// config and serializes it into cfg.Settings[handlerName] so the plugin can
+// apply host-side overrides (clientId, hostname, scopes, etc.).
+func injectAuthHandlerSettings(ctx context.Context, handlerName string, cfg *ProviderConfig) {
+	appCfg := config.FromContext(ctx)
+	if appCfg == nil {
+		return
+	}
+
+	var raw json.RawMessage
+	var err error
+
+	switch handlerName {
+	case "github":
+		if appCfg.Auth.GitHub == nil {
+			return
+		}
+		raw, err = json.Marshal(appCfg.Auth.GitHub) //nolint:gosec // G117: intentionally forwarding host config (including clientSecret) to plugin over local gRPC
+	case "entra":
+		if appCfg.Auth.Entra == nil {
+			return
+		}
+		raw, err = json.Marshal(appCfg.Auth.Entra)
+	case "gcp":
+		if appCfg.Auth.GCP == nil {
+			return
+		}
+		raw, err = json.Marshal(appCfg.Auth.GCP) //nolint:gosec // G117: intentionally forwarding host config (including clientSecret) to plugin over local gRPC
+	default:
+		return
+	}
+
+	if err != nil || len(raw) == 0 || string(raw) == "{}" {
+		return
+	}
+
+	if cfg.Settings == nil {
+		cfg.Settings = make(map[string]json.RawMessage)
+	}
+	cfg.Settings[handlerName] = raw
 }
 
 // RegisterAuthHandlerPlugins discovers auth handler plugins and registers them

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectAuthHandlerSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerName string
+		appCfg      *config.Config
+		wantKey     string
+		wantField   string
+		wantValue   string
+	}{
+		{
+			name:        "github config forwarded",
+			handlerName: "github",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					GitHub: &config.GitHubAuthConfig{
+						ClientID:      "test-client-id",
+						Hostname:      "github.example.com",
+						DefaultScopes: []string{"read:org"},
+					},
+				},
+			},
+			wantKey:   "github",
+			wantField: "clientId",
+			wantValue: "test-client-id",
+		},
+		{
+			name:        "entra config forwarded",
+			handlerName: "entra",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					Entra: &config.EntraAuthConfig{
+						ClientID: "entra-client-id",
+						TenantID: "tenant-123",
+					},
+				},
+			},
+			wantKey:   "entra",
+			wantField: "clientId",
+			wantValue: "entra-client-id",
+		},
+		{
+			name:        "gcp config forwarded",
+			handlerName: "gcp",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					GCP: &config.GCPAuthConfig{
+						ClientID: "gcp-client-id",
+						Project:  "my-project",
+					},
+				},
+			},
+			wantKey:   "gcp",
+			wantField: "clientId",
+			wantValue: "gcp-client-id",
+		},
+		{
+			name:        "nil github config skipped",
+			handlerName: "github",
+			appCfg:      &config.Config{},
+		},
+		{
+			name:        "unknown handler skipped",
+			handlerName: "unknown",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					GitHub: &config.GitHubAuthConfig{ClientID: "test"},
+				},
+			},
+		},
+		{
+			name:        "nil app config skipped",
+			handlerName: "github",
+			appCfg:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.appCfg != nil {
+				ctx = config.WithConfig(ctx, tt.appCfg)
+			}
+
+			cfg := &ProviderConfig{}
+			injectAuthHandlerSettings(ctx, tt.handlerName, cfg)
+
+			if tt.wantKey == "" {
+				assert.Nil(t, cfg.Settings)
+				return
+			}
+
+			require.NotNil(t, cfg.Settings)
+			raw, ok := cfg.Settings[tt.wantKey]
+			require.True(t, ok, "expected settings key %q", tt.wantKey)
+
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(raw, &m))
+			assert.Equal(t, tt.wantValue, m[tt.wantField])
+		})
+	}
+}


### PR DESCRIPTION
- inject per-handler auth settings (github, entra, gcp) from app config into plugin ProviderConfig.Settings during registration
- clone Settings map before mutation to avoid shared-state bugs
- auto-resolve official auth handlers in root command for direct CLI commands that bypass the solution prepare pipeline
- bump scafctl-plugin-sdk to v0.5.1
- add tests for injectAuthHandlerSettings covering all handlers and nil/unknown edge cases
