### PR TITLE
Add migrate command for pre-installing auth handler plugins

### DIFF
--- a/pkg/api/endpoints/providers_test.go
+++ b/pkg/api/endpoints/providers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
 
 // testProvider is a minimal provider for endpoint test registration.
@@ -274,6 +275,29 @@ func TestEnsureAPIProvider_NoFetcher(t *testing.T) {
 	assert.Contains(t, err.Error(), "exec")
 }
 
+func TestEnsureAPIProvider_RegistryMiss(t *testing.T) {
+	// EnsureAndAcquire succeeds (provider is already known in pool's registry)
+	// but the handler context uses a different registry for lookup.
+	poolReg := provider.NewRegistry()
+	handlerReg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+
+	// Mark the name as known in the pool's registry so Ensure passes
+	poolReg.MarkKnown("exec")
+
+	pool := plugin.NewPool(nil, poolReg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	hctx := &api.HandlerContext{
+		ProviderRegistry:  handlerReg, // different registry — lookup misses
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	_, _, err := ensureAPIProvider(context.Background(), hctx, "exec")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestGetProvider_AutoResolve_Fallback(t *testing.T) {
 	// When pool has no fetcher, get-provider returns the pool error (502)
 	_, testAPI := humatest.New(t)
@@ -335,5 +359,89 @@ func TestGetProvider_NoPool_Returns404(t *testing.T) {
 	RegisterProviderEndpoints(testAPI, hctx, "/v1")
 
 	resp := testAPI.Get("/v1/providers/exec")
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestEnsureAPIProvider_Success(t *testing.T) {
+	// When pool has an adopted entry and the provider is registered in the
+	// handler's registry, ensureAPIProvider should return the provider.
+	reg := newRegistryWithProvider(t, "exec")
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	// Adopt a mock client so EnsureAndAcquire succeeds
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", new(plugin.Client), dep, nil)
+
+	hctx := &api.HandlerContext{
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	p, release, err := ensureAPIProvider(context.Background(), hctx, "exec")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NotNil(t, release)
+	assert.Equal(t, "exec", p.Descriptor().Name)
+	release()
+}
+
+func TestGetProvider_AutoResolve_Adopted(t *testing.T) {
+	// When pool has an adopted entry but the provider is NOT registered,
+	// the detail endpoint should return 404 because EnsureAndAcquire
+	// succeeds (entry exists) but the registry lookup in the handler fails.
+	_, testAPI := humatest.New(t)
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	// Adopt entry but do NOT register provider — simulates post-spawn
+	// where pool entry exists but registry lookup in handler fails.
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", new(plugin.Client), dep, nil)
+
+	var shutting int32
+	hctx := &api.HandlerContext{
+		Config:            &config.Config{},
+		IsShuttingDown:    &shutting,
+		StartTime:         time.Now(),
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	RegisterProviderEndpoints(testAPI, hctx, "/v1")
+
+	// Provider is not in registry, pool entry is adopted but no provider
+	// registered — ensureAPIProvider succeeds (EnsureAndAcquire) but then
+	// ProviderRegistry.Get fails, returning 404.
+	resp := testAPI.Get("/v1/providers/exec")
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestGetProviderSchema_AutoResolve_Adopted(t *testing.T) {
+	// Same as above but for the schema endpoint.
+	_, testAPI := humatest.New(t)
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", new(plugin.Client), dep, nil)
+
+	var shutting int32
+	hctx := &api.HandlerContext{
+		Config:            &config.Config{},
+		IsShuttingDown:    &shutting,
+		StartTime:         time.Now(),
+		ProviderRegistry:  reg,
+		PluginPool:        pool,
+		OfficialProviders: officialReg,
+	}
+	RegisterProviderEndpoints(testAPI, hctx, "/v1")
+
+	resp := testAPI.Get("/v1/providers/exec/schema")
 	assert.Equal(t, http.StatusNotFound, resp.Code)
 }

--- a/pkg/auth/migrate/migrate.go
+++ b/pkg/auth/migrate/migrate.go
@@ -1,0 +1,157 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package migrate provides domain logic for migrating built-in auth handlers
+// to plugin-based handlers.
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// Status represents the migration status of a single handler.
+type Status string
+
+const (
+	// StatusReady indicates the handler is fully migrated and ready.
+	StatusReady Status = "READY"
+
+	// StatusFailed indicates the handler migration failed.
+	StatusFailed Status = "FAILED"
+)
+
+// Result holds the migration result for a single handler.
+type Result struct {
+	Name         string `json:"name"         yaml:"name"`
+	PluginSource string `json:"pluginSource" yaml:"pluginSource"`
+	TokenMessage string `json:"tokenMessage" yaml:"tokenMessage"`
+	Status       Status `json:"status"       yaml:"status"`
+	ErrorMessage string `json:"errorMessage,omitempty" yaml:"errorMessage,omitempty"`
+}
+
+// FetchFunc is the signature for the function that fetches plugins.
+type FetchFunc func(ctx context.Context, deps []solution.PluginDependency) ([]plugin.FetchResult, error)
+
+// Handlers performs the migration for all official auth handlers.
+// It fetches plugin binaries via fetchFn and validates cached token
+// accessibility for each handler.
+func Handlers(ctx context.Context, officialReg *authofficial.Registry, authReg *auth.Registry, fetchFn FetchFunc) []Result {
+	names := officialReg.Names()
+	results := make([]Result, 0, len(names))
+
+	// Build plugin dependencies for all official handlers.
+	deps := make([]solution.PluginDependency, 0, len(names))
+	for _, name := range names {
+		handler := officialReg.MustGet(name)
+		deps = append(deps, handler.ToPluginDependency())
+	}
+
+	// Fetch all plugins.
+	fetchResults, fetchErr := fetchFn(ctx, deps)
+
+	// Build a map of fetch results by name for lookup.
+	fetchMap := make(map[string]*plugin.FetchResult, len(fetchResults))
+	for i := range fetchResults {
+		fetchMap[fetchResults[i].Name] = &fetchResults[i]
+	}
+
+	for _, name := range names {
+		handler := officialReg.MustGet(name)
+		result := Result{Name: name}
+
+		fr, fetched := fetchMap[handler.CatalogRef]
+		if fetchErr != nil && !fetched {
+			result.PluginSource = fmt.Sprintf("FAILED (%v)", fetchErr)
+			result.Status = StatusFailed
+			result.ErrorMessage = fetchErr.Error()
+			result.TokenMessage = "skipped (plugin not available)"
+			results = append(results, result)
+			continue
+		}
+
+		if fetched {
+			if fr.FromCache {
+				result.PluginSource = fmt.Sprintf("cached (%s)", fr.Version)
+			} else {
+				result.PluginSource = fmt.Sprintf("installed (%s)", fr.Version)
+			}
+		} else {
+			result.PluginSource = "FAILED (not found in catalog)"
+			result.Status = StatusFailed
+			result.ErrorMessage = fmt.Sprintf("handler %q not found in catalog", name)
+			result.TokenMessage = "skipped (plugin not available)"
+			results = append(results, result)
+			continue
+		}
+
+		// Validate token migration by checking cached tokens.
+		tokenMsg, tokenOK := validateTokenMigration(ctx, authReg, name)
+		result.TokenMessage = tokenMsg
+		if tokenOK {
+			result.Status = StatusReady
+		} else {
+			result.Status = StatusFailed
+			result.ErrorMessage = tokenMsg
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// validateTokenMigration checks if cached tokens are accessible for a handler.
+// It returns a human-readable message describing the token state and a boolean
+// indicating whether the check passed (true) or encountered an error (false).
+func validateTokenMigration(ctx context.Context, authReg *auth.Registry, name string) (string, bool) {
+	if authReg == nil || !authReg.Has(name) {
+		return "no cached tokens (login required after migration)", true
+	}
+
+	handler, err := authReg.Get(name)
+	if err != nil {
+		return "no cached tokens (login required after migration)", true
+	}
+
+	lister, ok := handler.(auth.TokenLister)
+	if !ok {
+		return "no cached tokens (login required after migration)", true
+	}
+
+	tokens, err := lister.ListCachedTokens(ctx)
+	if err != nil {
+		return fmt.Sprintf("could not read cached tokens: %v", err), false
+	}
+
+	if len(tokens) == 0 {
+		return "no cached tokens (login required after migration)", true
+	}
+
+	valid := 0
+	for _, t := range tokens {
+		if !t.IsExpired {
+			valid++
+		}
+	}
+
+	if valid == len(tokens) {
+		return fmt.Sprintf("%d cached token(s) validated successfully", len(tokens)), true
+	}
+
+	return fmt.Sprintf("%d cached token(s), %d expired", len(tokens), len(tokens)-valid), true
+}
+
+// IsReady returns true if the result indicates a successful migration.
+func (r *Result) IsReady() bool {
+	return r.Status == StatusReady
+}
+
+// StatusString returns the status as a string for display.
+func (r *Result) StatusString() string {
+	return string(r.Status)
+}

--- a/pkg/auth/migrate/migrate_test.go
+++ b/pkg/auth/migrate/migrate_test.go
@@ -1,0 +1,338 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package migrate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		officialNames  []authofficial.AuthHandler
+		authHandlers   map[string]*auth.MockHandler
+		fetchResults   []plugin.FetchResult
+		fetchErr       error
+		expectStatuses map[string]Status
+		expectTokenMsg map[string]string
+		expectSource   map[string]string
+	}{
+		{
+			name: "all handlers fetched successfully with cached tokens",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+				{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{
+				"github": func() *auth.MockHandler {
+					m := auth.NewMockHandler("github")
+					m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+						{IsExpired: false},
+						{IsExpired: false},
+					}
+					return m
+				}(),
+				"entra": func() *auth.MockHandler {
+					m := auth.NewMockHandler("entra")
+					m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+						{IsExpired: false},
+					}
+					return m
+				}(),
+			},
+			fetchResults: []plugin.FetchResult{
+				{Name: "github", Version: "0.1.2", FromCache: true},
+				{Name: "entra", Version: "0.1.0", FromCache: false},
+			},
+			expectStatuses: map[string]Status{
+				"github": StatusReady,
+				"entra":  StatusReady,
+			},
+			expectTokenMsg: map[string]string{
+				"github": "2 cached token(s) validated successfully",
+				"entra":  "1 cached token(s) validated successfully",
+			},
+			expectSource: map[string]string{
+				"github": "cached (0.1.2)",
+				"entra":  "installed (0.1.0)",
+			},
+		},
+		{
+			name: "handler not in auth registry - no cached tokens",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "gcp", CatalogRef: "gcp", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{},
+			fetchResults: []plugin.FetchResult{
+				{Name: "gcp", Version: "0.1.1", FromCache: false},
+			},
+			expectStatuses: map[string]Status{
+				"gcp": StatusReady,
+			},
+			expectTokenMsg: map[string]string{
+				"gcp": "no cached tokens (login required after migration)",
+			},
+			expectSource: map[string]string{
+				"gcp": "installed (0.1.1)",
+			},
+		},
+		{
+			name: "fetch error - all handlers fail",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{},
+			fetchResults: nil,
+			fetchErr:     errors.New("network timeout"),
+			expectStatuses: map[string]Status{
+				"github": StatusFailed,
+			},
+			expectTokenMsg: map[string]string{
+				"github": "skipped (plugin not available)",
+			},
+		},
+		{
+			name: "handler with expired tokens",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{
+				"entra": func() *auth.MockHandler {
+					m := auth.NewMockHandler("entra")
+					m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+						{IsExpired: false},
+						{IsExpired: true},
+					}
+					return m
+				}(),
+			},
+			fetchResults: []plugin.FetchResult{
+				{Name: "entra", Version: "0.1.0", FromCache: true},
+			},
+			expectStatuses: map[string]Status{
+				"entra": StatusReady,
+			},
+			expectTokenMsg: map[string]string{
+				"entra": "2 cached token(s), 1 expired",
+			},
+		},
+		{
+			name: "handler with token list error",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{
+				"github": func() *auth.MockHandler {
+					m := auth.NewMockHandler("github")
+					m.ListCachedTokensErr = errors.New("keyring unavailable")
+					return m
+				}(),
+			},
+			fetchResults: []plugin.FetchResult{
+				{Name: "github", Version: "0.1.2", FromCache: true},
+			},
+			expectStatuses: map[string]Status{
+				"github": StatusFailed,
+			},
+			expectTokenMsg: map[string]string{
+				"github": "could not read cached tokens: keyring unavailable",
+			},
+		},
+		{
+			name: "handler not found in catalog",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{},
+			fetchResults: []plugin.FetchResult{},
+			expectStatuses: map[string]Status{
+				"github": StatusFailed,
+			},
+			expectTokenMsg: map[string]string{
+				"github": "skipped (plugin not available)",
+			},
+		},
+		{
+			name: "embedder handler where Name differs from CatalogRef",
+			officialNames: []authofficial.AuthHandler{
+				{Name: "my-auth", CatalogRef: "my-auth-oci-ref", DefaultVersion: "latest"},
+			},
+			authHandlers: map[string]*auth.MockHandler{
+				"my-auth": func() *auth.MockHandler {
+					m := auth.NewMockHandler("my-auth")
+					m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+						{IsExpired: false},
+					}
+					return m
+				}(),
+			},
+			fetchResults: []plugin.FetchResult{
+				{Name: "my-auth-oci-ref", Version: "1.0.0", FromCache: false},
+			},
+			expectStatuses: map[string]Status{
+				"my-auth": StatusReady,
+			},
+			expectTokenMsg: map[string]string{
+				"my-auth": "1 cached token(s) validated successfully",
+			},
+			expectSource: map[string]string{
+				"my-auth": "installed (1.0.0)",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			officialReg := authofficial.NewRegistryFrom(tc.officialNames)
+
+			authReg := auth.NewRegistry()
+			for _, mock := range tc.authHandlers {
+				require.NoError(t, authReg.Register(mock))
+			}
+
+			fetchFn := func(_ context.Context, _ []solution.PluginDependency) ([]plugin.FetchResult, error) {
+				return tc.fetchResults, tc.fetchErr
+			}
+
+			results := Handlers(context.Background(), officialReg, authReg, fetchFn)
+
+			for _, r := range results {
+				if expectedStatus, ok := tc.expectStatuses[r.Name]; ok {
+					assert.Equal(t, expectedStatus, r.Status, "handler %s status mismatch", r.Name)
+				}
+				if expectedMsg, ok := tc.expectTokenMsg[r.Name]; ok {
+					assert.Equal(t, expectedMsg, r.TokenMessage, "handler %s token message mismatch", r.Name)
+				}
+				if expectedSrc, ok := tc.expectSource[r.Name]; ok {
+					assert.Equal(t, expectedSrc, r.PluginSource, "handler %s source mismatch", r.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateTokenMigration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		handler   *auth.MockHandler
+		queryName string
+		expectMsg string
+		expectOK  bool
+	}{
+		{
+			name:      "nil registry",
+			handler:   nil,
+			queryName: "github",
+			expectMsg: "no cached tokens (login required after migration)",
+			expectOK:  true,
+		},
+		{
+			name:      "handler not registered",
+			handler:   auth.NewMockHandler("entra"),
+			queryName: "github",
+			expectMsg: "no cached tokens (login required after migration)",
+			expectOK:  true,
+		},
+		{
+			name: "handler with valid tokens",
+			handler: func() *auth.MockHandler {
+				m := auth.NewMockHandler("github")
+				m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+					{IsExpired: false},
+					{IsExpired: false},
+				}
+				return m
+			}(),
+			queryName: "github",
+			expectMsg: "2 cached token(s) validated successfully",
+			expectOK:  true,
+		},
+		{
+			name: "handler with mixed tokens",
+			handler: func() *auth.MockHandler {
+				m := auth.NewMockHandler("gcp")
+				m.ListCachedTokensResult = []*auth.CachedTokenInfo{
+					{IsExpired: false},
+					{IsExpired: true},
+					{IsExpired: true},
+				}
+				return m
+			}(),
+			queryName: "gcp",
+			expectMsg: "3 cached token(s), 2 expired",
+			expectOK:  true,
+		},
+		{
+			name: "handler with no tokens",
+			handler: func() *auth.MockHandler {
+				m := auth.NewMockHandler("github")
+				m.ListCachedTokensResult = []*auth.CachedTokenInfo{}
+				return m
+			}(),
+			queryName: "github",
+			expectMsg: "no cached tokens (login required after migration)",
+			expectOK:  true,
+		},
+		{
+			name: "handler with token list error",
+			handler: func() *auth.MockHandler {
+				m := auth.NewMockHandler("github")
+				m.ListCachedTokensErr = errors.New("keyring unavailable")
+				return m
+			}(),
+			queryName: "github",
+			expectMsg: "could not read cached tokens: keyring unavailable",
+			expectOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var authReg *auth.Registry
+			if tc.handler != nil {
+				authReg = auth.NewRegistry()
+				require.NoError(t, authReg.Register(tc.handler))
+			}
+
+			msg, ok := validateTokenMigration(context.Background(), authReg, tc.queryName)
+			assert.Equal(t, tc.expectMsg, msg)
+			assert.Equal(t, tc.expectOK, ok)
+		})
+	}
+}
+
+func TestResult_Methods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ready result", func(t *testing.T) {
+		t.Parallel()
+		r := &Result{Status: StatusReady}
+		assert.True(t, r.IsReady())
+		assert.Equal(t, "READY", r.StatusString())
+	})
+
+	t.Run("failed result", func(t *testing.T) {
+		t.Parallel()
+		r := &Result{Status: StatusFailed}
+		assert.False(t, r.IsReady())
+		assert.Equal(t, "FAILED", r.StatusString())
+	})
+}

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -45,6 +45,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandMigrate(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandStatus(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandToken(cliParams, ioStreams, cmdPath))
 

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -25,7 +25,7 @@ func TestCommandAuth(t *testing.T) {
 
 	// Verify subcommands are added
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 6)
+	require.Len(t, subCmds, 7)
 
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
@@ -35,6 +35,7 @@ func TestCommandAuth(t *testing.T) {
 	assert.Contains(t, cmdNames, "list [handler]")
 	assert.Contains(t, cmdNames, "login <handler>")
 	assert.Contains(t, cmdNames, "logout [handler]")
+	assert.Contains(t, cmdNames, "migrate")
 	assert.Contains(t, cmdNames, "status [handler]")
 	assert.Contains(t, cmdNames, "token <handler>")
 }

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -11,10 +11,12 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
@@ -114,6 +116,25 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 					Status:   diagnose.StatusOK,
 					Message:  fmt.Sprintf("registered handlers: %v", handlerNames),
 				})
+			}
+
+			// ── 1.5. Handler source ──────────────────────────────────────────
+			officialReg := authofficial.RegistryFromContext(ctx)
+			authReg := authpkg.RegistryFromContext(ctx)
+			if officialReg != nil {
+				for _, name := range officialReg.Names() {
+					source := handlerSource(authReg, name)
+					status := diagnose.StatusOK
+					if source == "not found" {
+						status = diagnose.StatusWarn
+					}
+					addCheck(diagnose.Check{
+						Category: "source",
+						Name:     fmt.Sprintf("%s: handler source", name),
+						Status:   status,
+						Message:  fmt.Sprintf("Handler source: %s", source),
+					})
+				}
 			}
 
 			// ── 2. Config file ────────────────────────────────────────────────
@@ -361,4 +382,22 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 	cmd.Flags().BoolVar(&liveToken, "live-token", false, "Attempt a live token fetch for each authenticated handler to confirm end-to-end health")
 
 	return cmd
+}
+
+// handlerSource determines the source of an auth handler:
+//   - "built-in" if the handler is registered but not a plugin wrapper
+//   - "plugin" if the handler is a plugin wrapper
+//   - "not found" if the handler is not registered
+func handlerSource(authReg *authpkg.Registry, name string) string {
+	if authReg == nil || !authReg.Has(name) {
+		return "not found"
+	}
+	handler, err := authReg.Get(name)
+	if err != nil {
+		return "not found"
+	}
+	if _, ok := handler.(*plugin.AuthHandlerWrapper); ok {
+		return "plugin"
+	}
+	return "built-in"
 }

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -472,5 +473,64 @@ func BenchmarkDiagnose_Authenticated(b *testing.B) {
 		cmd.SetContext(ctx)
 		cmd.SetArgs([]string{})
 		_ = cmd.Execute()
+	}
+}
+
+func TestHandlerSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setup    func() *auth.Registry
+		query    string
+		expected string
+	}{
+		{
+			name:     "nil registry",
+			setup:    func() *auth.Registry { return nil },
+			query:    "github",
+			expected: "not found",
+		},
+		{
+			name: "handler not registered",
+			setup: func() *auth.Registry {
+				r := auth.NewRegistry()
+				_ = r.Register(auth.NewMockHandler("entra"))
+				return r
+			},
+			query:    "github",
+			expected: "not found",
+		},
+		{
+			name: "built-in handler",
+			setup: func() *auth.Registry {
+				r := auth.NewRegistry()
+				_ = r.Register(auth.NewMockHandler("github"))
+				return r
+			},
+			query:    "github",
+			expected: "built-in",
+		},
+		{
+			name: "plugin handler",
+			setup: func() *auth.Registry {
+				r := auth.NewRegistry()
+				wrapper := plugin.NewAuthHandlerWrapper(nil, plugin.AuthHandlerInfo{
+					Name: "github",
+				})
+				_ = r.Register(wrapper)
+				return r
+			},
+			query:    "github",
+			expected: "plugin",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reg := tc.setup()
+			assert.Equal(t, tc.expected, handlerSource(reg, tc.query))
+		})
 	}
 }

--- a/pkg/cmd/scafctl/auth/migrate.go
+++ b/pkg/cmd/scafctl/auth/migrate.go
@@ -1,0 +1,139 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authmigrate "github.com/oakwood-commons/scafctl/pkg/auth/migrate"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// buildPluginFetchFunc creates a FetchFunc that builds a catalog chain and
+// fetches plugins. This is the production wiring; tests can supply their own.
+func buildPluginFetchFunc(binaryName string) authmigrate.FetchFunc {
+	return func(ctx context.Context, deps []solution.PluginDependency) ([]plugin.FetchResult, error) {
+		appCfg := config.FromContext(ctx)
+		var chainLogger logr.Logger
+		lgr := logger.FromContext(ctx)
+		if lgr != nil {
+			chainLogger = *lgr
+		} else {
+			chainLogger = logr.Discard()
+		}
+
+		chain, err := catalog.BuildCatalogChain(appCfg, auth.RegistryFromContext(ctx), chainLogger)
+		if err != nil {
+			return nil, fmt.Errorf("building catalog chain: %w", err)
+		}
+
+		fetcher := plugin.NewFetcher(plugin.FetcherConfig{
+			Catalog:    chain,
+			BinaryName: binaryName,
+			Logger:     chainLogger,
+		})
+
+		return fetcher.FetchPlugins(ctx, deps, nil)
+	}
+}
+
+// CommandMigrate creates the 'auth migrate' command for proactive pre-Stage-B migration.
+func CommandMigrate(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Pre-install official auth handler plugins from catalog",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Pre-install all official auth handler plugins from the catalog
+			and validate token migration readiness.
+
+			This command:
+			  1. Pre-installs all official auth handler plugins from the catalog
+			  2. Validates token migration (checks cached tokens are accessible)
+			  3. Reports pass/fail per handler with actionable guidance
+
+			Run this before upgrading to a release that removes built-in
+			auth handlers. It is safe to run multiple times.
+
+			Examples:
+			  # Migrate all official auth handlers to plugins
+			  scafctl auth migrate
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMigrate(cmd.Context(), buildPluginFetchFunc(cliParams.BinaryName))
+		},
+	}
+
+	return cmd
+}
+
+// runMigrate is the testable core of the migrate command. It accepts a
+// FetchFunc so tests can inject a mock without hitting the catalog.
+func runMigrate(ctx context.Context, fetchFn authmigrate.FetchFunc) error {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	officialReg := authofficial.RegistryFromContext(ctx)
+	if officialReg == nil {
+		w.Errorf("Official auth handler registry not available")
+		return exitcode.WithCode(
+			fmt.Errorf("official auth handler registry not in context"),
+			exitcode.GeneralError,
+		)
+	}
+
+	authReg := auth.RegistryFromContext(ctx)
+
+	w.Infof("Migrating auth handlers to plugins...")
+	w.Plainln("")
+
+	results := authmigrate.Handlers(ctx, officialReg, authReg, fetchFn)
+
+	// Print results.
+	failCount := 0
+	for _, r := range results {
+		w.Infof("  %s:", r.Name)
+		w.Infof("    Plugin: %s", r.PluginSource)
+		w.Infof("    Tokens: %s", r.TokenMessage)
+		if r.IsReady() {
+			w.Successf("    Status: %s", r.StatusString())
+		} else {
+			w.Errorf("    Status: %s", r.StatusString())
+			if r.ErrorMessage != "" {
+				w.Errorf("    Error: %s", r.ErrorMessage)
+			}
+			failCount++
+		}
+		w.Plainln("")
+	}
+
+	if failCount > 0 {
+		w.Errorf("Migration incomplete. %d handler(s) failed.", failCount)
+		return exitcode.WithCode(
+			fmt.Errorf("migration incomplete: %d handler(s) failed", failCount),
+			exitcode.GeneralError,
+		)
+	}
+
+	w.Successf("Migration complete. All handlers ready for plugin mode.")
+	return nil
+}

--- a/pkg/cmd/scafctl/auth/migrate_test.go
+++ b/pkg/cmd/scafctl/auth/migrate_test.go
@@ -1,0 +1,270 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandMigrate_Structure(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandMigrate(cliParams, ioStreams, "scafctl/auth")
+
+	assert.Equal(t, "migrate", cmd.Use)
+	assert.Contains(t, cmd.Short, "Pre-install")
+}
+
+func TestCommandMigrate_NoArgs(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandMigrate(cliParams, ioStreams, "scafctl/auth")
+	ctx, _ := newTestContext(t)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"extra-arg"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestCommandMigrate_NoWriterInContext(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandMigrate(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestCommandMigrate_NoOfficialRegistry(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+
+	cmd := CommandMigrate(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "Official auth handler registry not available")
+}
+
+func TestCommandMigrate_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandMigrate(cliParams, ioStreams, "mycli/auth")
+
+	assert.Contains(t, cmd.Long, "mycli auth migrate")
+	assert.NotContains(t, cmd.Long, "scafctl")
+}
+
+// migrateTestContext builds a context with writer, logger, and official+auth
+// registries wired for runMigrate tests.
+func migrateTestContext(t *testing.T, officialHandlers []authofficial.AuthHandler, authMocks []*auth.MockHandler) (context.Context, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+
+	officialReg := authofficial.NewRegistryFrom(officialHandlers)
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	if len(authMocks) > 0 {
+		authReg := auth.NewRegistry()
+		for _, m := range authMocks {
+			require.NoError(t, authReg.Register(m))
+		}
+		ctx = auth.WithRegistry(ctx, authReg)
+	}
+
+	return ctx, &buf
+}
+
+func TestRunMigrate_AllReady(t *testing.T) {
+	t.Parallel()
+
+	handlers := []authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	}
+
+	mock := auth.NewMockHandler("github")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{{IsExpired: false}}
+
+	ctx, buf := migrateTestContext(t, handlers, []*auth.MockHandler{mock})
+
+	fetchFn := func(_ context.Context, _ []solution.PluginDependency) ([]plugin.FetchResult, error) {
+		return []plugin.FetchResult{
+			{Name: "github", Version: "0.1.0", FromCache: true},
+			{Name: "entra", Version: "0.2.0", FromCache: false},
+		}, nil
+	}
+
+	err := runMigrate(ctx, fetchFn)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "entra")
+	assert.Contains(t, output, "READY")
+	assert.Contains(t, output, "Migration complete")
+}
+
+func TestRunMigrate_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	handlers := []authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	}
+
+	ctx, buf := migrateTestContext(t, handlers, nil)
+
+	fetchFn := func(_ context.Context, _ []solution.PluginDependency) ([]plugin.FetchResult, error) {
+		// Only github succeeds; entra missing from results
+		return []plugin.FetchResult{
+			{Name: "github", Version: "0.1.0", FromCache: true},
+		}, nil
+	}
+
+	err := runMigrate(ctx, fetchFn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 handler(s) failed")
+
+	output := buf.String()
+	assert.Contains(t, output, "READY")
+	assert.Contains(t, output, "FAILED")
+	assert.Contains(t, output, "Migration incomplete")
+}
+
+func TestRunMigrate_FetchError(t *testing.T) {
+	t.Parallel()
+
+	handlers := []authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	}
+
+	ctx, buf := migrateTestContext(t, handlers, nil)
+
+	fetchFn := func(_ context.Context, _ []solution.PluginDependency) ([]plugin.FetchResult, error) {
+		return nil, errors.New("network timeout")
+	}
+
+	err := runMigrate(ctx, fetchFn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 handler(s) failed")
+
+	output := buf.String()
+	assert.Contains(t, output, "FAILED")
+	assert.Contains(t, output, "network timeout")
+}
+
+func TestRunMigrate_NoWriter(t *testing.T) {
+	t.Parallel()
+
+	err := runMigrate(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestRunMigrate_NoOfficialRegistry(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	err := runMigrate(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "Official auth handler registry not available")
+}
+
+func TestBuildPluginFetchFunc_ReturnsNonNil(t *testing.T) {
+	t.Parallel()
+
+	fn := buildPluginFetchFunc("testcli")
+	assert.NotNil(t, fn)
+}
+
+func TestBuildPluginFetchFunc_NilLoggerFallback(t *testing.T) {
+	t.Parallel()
+
+	fn := buildPluginFetchFunc("testcli")
+	// Call with bare context (no logger, no config) — should not panic,
+	// but will fail on catalog build (no config). We verify it doesn't
+	// panic and returns a reasonable result or error.
+	results, err := fn(context.Background(), []solution.PluginDependency{
+		{Name: "test", Kind: solution.PluginKindProvider},
+	})
+	// May fail (no catalog configured) or succeed (plugin cached) —
+	// the important thing is it does not panic.
+	if err == nil {
+		assert.NotEmpty(t, results)
+	}
+}
+
+func BenchmarkRunMigrate(b *testing.B) {
+	b.ReportAllocs()
+
+	handlers := []authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	}
+	officialReg := authofficial.NewRegistryFrom(handlers)
+	fetchFn := func(_ context.Context, _ []solution.PluginDependency) ([]plugin.FetchResult, error) {
+		return []plugin.FetchResult{{Name: "github", Version: "0.1.0", FromCache: true}}, nil
+	}
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+
+	b.ResetTimer()
+	for b.Loop() {
+		buf.Reset()
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+		ctx = authofficial.WithRegistry(ctx, officialReg)
+		_ = runMigrate(ctx, fetchFn)
+	}
+}

--- a/pkg/cmd/scafctl/mcp/serve_test.go
+++ b/pkg/cmd/scafctl/mcp/serve_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -137,5 +139,33 @@ func TestBuildMCPPluginPool(t *testing.T) {
 
 		// MCP pools should not sanitize env so host credentials are available
 		assert.False(t, pool.SanitizeEnv(), "MCP pool should not sanitize env")
+	})
+
+	t.Run("wires auth client opts when auth registry in context", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		authReg := auth.NewRegistry()
+		ctx := auth.WithRegistry(context.Background(), authReg)
+
+		pool, resultCtx := buildMCPPluginPool(ctx, nil, reg, &lgr)
+		defer pool.Shutdown()
+
+		// Auth opts should be wired into the pool via WithClientOptions
+		opts := plugin.AuthClientOptsFromContext(resultCtx)
+		assert.NotNil(t, opts, "auth client opts should be available from context")
+		assert.False(t, pool.SanitizeEnv())
+		// Verify client opts were actually wired into the pool configuration
+		assert.Greater(t, pool.ClientOptsLen(), 0, "pool should have client opts configured from auth registry")
+	})
+
+	t.Run("no auth client opts when no auth registry", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		pool, resultCtx := buildMCPPluginPool(context.Background(), nil, reg, &lgr)
+		defer pool.Shutdown()
+
+		opts := plugin.AuthClientOptsFromContext(resultCtx)
+		assert.Nil(t, opts, "no auth client opts when no auth registry")
+		assert.Equal(t, 0, pool.ClientOptsLen(), "pool should have no client opts without auth registry")
 	})
 }

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -888,3 +888,277 @@ func TestProviderSource(t *testing.T) {
 		assert.Equal(t, "builtin", srv.providerSource("custom-provider"))
 	})
 }
+
+func TestEnsureProvider(t *testing.T) {
+	t.Run("returns error when pool is nil", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "plugin pool not configured")
+	})
+
+	t.Run("returns error when official registry not in context", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "official registry not available")
+	})
+
+	t.Run("returns error for unknown provider", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		officialReg := official.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "nonexistent-provider")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "not a known official provider")
+	})
+
+	t.Run("returns error when pool has no fetcher", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		officialReg := official.NewRegistry()
+		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		defer pool.Shutdown()
+
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerRegistry(reg),
+			WithServerPluginPool(pool),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		release, err := srv.ensureProvider(context.Background(), "exec")
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "loading plugin")
+	})
+}
+
+func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "run_provider"
+	request.Params.Arguments = map[string]any{
+		"provider": "nonexistent",
+		"inputs":   map[string]any{},
+	}
+
+	result, err := srv.handleRunProvider(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderSchema_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_schema"
+	request.Params.Arguments = map[string]any{
+		"name": "nonexistent",
+	}
+
+	result, err := srv.handleGetProviderSchema(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_AutoResolve_NoPool(t *testing.T) {
+	// When no pool is configured, unknown providers should still return NOT_FOUND
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name": "nonexistent",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_AllCapabilities(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name": "cel",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var output map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &output))
+	assert.Equal(t, "cel", output["provider"])
+	assert.NotNil(t, output["outputSchemas"], "expected outputSchemas for all capabilities")
+}
+
+func TestHandleGetProviderOutputShape_SingleCapability(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name":       "cel",
+		"capability": "transform",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var output map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &output))
+	assert.Equal(t, "cel", output["provider"])
+	assert.Equal(t, "transform", output["capability"])
+	assert.NotNil(t, output["outputSchema"])
+}
+
+func TestHandleGetProviderOutputShape_InvalidCapability(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{
+		"name":       "cel",
+		"capability": "authentication",
+	}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderOutputShape_MissingName(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_output_shape"
+	request.Params.Arguments = map[string]any{}
+
+	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "INVALID_INPUT")
+}
+
+func TestProviderSource(t *testing.T) {
+	t.Run("returns builtin when no official registry", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		assert.Equal(t, "builtin", srv.providerSource("exec"))
+	})
+
+	t.Run("returns official for known official provider", func(t *testing.T) {
+		officialReg := official.NewRegistry()
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		// "exec" is a known official provider
+		assert.Equal(t, "official", srv.providerSource("exec"))
+	})
+
+	t.Run("returns builtin for unknown provider", func(t *testing.T) {
+		officialReg := official.NewRegistry()
+		ctx := official.WithRegistry(context.Background(), officialReg)
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, "builtin", srv.providerSource("custom-provider"))
+	})
+}

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -964,7 +964,7 @@ func TestEnsureProvider(t *testing.T) {
 }
 
 func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should still return NOT_FOUND
+	// When no pool is configured, unknown providers should return LOAD_FAILED
 	reg, err := builtin.DefaultRegistry(context.Background())
 	require.NoError(t, err)
 	srv, err := NewServer(
@@ -984,7 +984,8 @@ func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	text := result.Content[0].(mcp.TextContent).Text
-	assert.Contains(t, text, "NOT_FOUND")
+	assert.Contains(t, text, "LOAD_FAILED")
+	assert.Contains(t, text, "plugin pool not configured")
 }
 
 func TestHandleGetProviderSchema_AutoResolve_NoPool(t *testing.T) {

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -856,127 +857,27 @@ func TestHandleGetProviderOutputShape_MissingName(t *testing.T) {
 	assert.Contains(t, text, "INVALID_INPUT")
 }
 
-func TestProviderSource(t *testing.T) {
-	t.Run("returns builtin when no official registry", func(t *testing.T) {
-		srv, err := NewServer(WithServerVersion("test"))
-		require.NoError(t, err)
-		assert.Equal(t, "builtin", srv.providerSource("exec"))
-	})
+func TestHandleRunProvider_AutoResolve_PoolError(t *testing.T) {
+	// When pool exists with official registry but EnsureAndAcquire fails (no fetcher),
+	// handleRunProvider should return LOAD_FAILED with the pool error.
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	ctx := official.WithRegistry(context.Background(), officialReg)
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
 
-	t.Run("returns official for known official provider", func(t *testing.T) {
-		officialReg := official.NewRegistry()
-		ctx := official.WithRegistry(context.Background(), officialReg)
-		srv, err := NewServer(
-			WithServerVersion("test"),
-			WithServerContext(ctx),
-		)
-		require.NoError(t, err)
-
-		// "exec" is a known official provider
-		assert.Equal(t, "official", srv.providerSource("exec"))
-	})
-
-	t.Run("returns builtin for unknown provider", func(t *testing.T) {
-		officialReg := official.NewRegistry()
-		ctx := official.WithRegistry(context.Background(), officialReg)
-		srv, err := NewServer(
-			WithServerVersion("test"),
-			WithServerContext(ctx),
-		)
-		require.NoError(t, err)
-
-		assert.Equal(t, "builtin", srv.providerSource("custom-provider"))
-	})
-}
-
-func TestEnsureProvider(t *testing.T) {
-	t.Run("returns error when pool is nil", func(t *testing.T) {
-		srv, err := NewServer(
-			WithServerVersion("test"),
-		)
-		require.NoError(t, err)
-
-		release, err := srv.ensureProvider(context.Background(), "exec")
-		assert.Error(t, err)
-		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "plugin pool not configured")
-	})
-
-	t.Run("returns error when official registry not in context", func(t *testing.T) {
-		reg := provider.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
-		defer pool.Shutdown()
-
-		srv, err := NewServer(
-			WithServerVersion("test"),
-			WithServerRegistry(reg),
-			WithServerPluginPool(pool),
-		)
-		require.NoError(t, err)
-
-		release, err := srv.ensureProvider(context.Background(), "exec")
-		assert.Error(t, err)
-		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "official registry not available")
-	})
-
-	t.Run("returns error for unknown provider", func(t *testing.T) {
-		reg := provider.NewRegistry()
-		officialReg := official.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
-		defer pool.Shutdown()
-
-		ctx := official.WithRegistry(context.Background(), officialReg)
-		srv, err := NewServer(
-			WithServerVersion("test"),
-			WithServerRegistry(reg),
-			WithServerPluginPool(pool),
-			WithServerContext(ctx),
-		)
-		require.NoError(t, err)
-
-		release, err := srv.ensureProvider(context.Background(), "nonexistent-provider")
-		assert.Error(t, err)
-		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "not a known official provider")
-	})
-
-	t.Run("returns error when pool has no fetcher", func(t *testing.T) {
-		reg := provider.NewRegistry()
-		officialReg := official.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
-		defer pool.Shutdown()
-
-		ctx := official.WithRegistry(context.Background(), officialReg)
-		srv, err := NewServer(
-			WithServerVersion("test"),
-			WithServerRegistry(reg),
-			WithServerPluginPool(pool),
-			WithServerContext(ctx),
-		)
-		require.NoError(t, err)
-
-		release, err := srv.ensureProvider(context.Background(), "exec")
-		assert.Error(t, err)
-		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "loading plugin")
-	})
-}
-
-func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should return LOAD_FAILED
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
 	srv, err := NewServer(
 		WithServerRegistry(reg),
 		WithServerVersion("test"),
+		WithServerContext(ctx),
+		WithServerPluginPool(pool),
 	)
 	require.NoError(t, err)
 
 	request := mcp.CallToolRequest{}
 	request.Params.Name = "run_provider"
 	request.Params.Arguments = map[string]any{
-		"provider": "nonexistent",
+		"provider": "exec",
 		"inputs":   map[string]any{},
 	}
 
@@ -985,123 +886,107 @@ func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
 	assert.True(t, result.IsError)
 	text := result.Content[0].(mcp.TextContent).Text
 	assert.Contains(t, text, "LOAD_FAILED")
-	assert.Contains(t, text, "plugin pool not configured")
+	assert.Contains(t, text, "exec")
 }
 
-func TestHandleGetProviderSchema_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should still return NOT_FOUND
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
+func TestHandleRunProvider_AutoResolve_RegistryMiss(t *testing.T) {
+	// When auto-resolve succeeds (adopted entry) but provider is still not in
+	// the registry, handleRunProvider should fall through to NOT_FOUND.
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	ctx := official.WithRegistry(context.Background(), officialReg)
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	// Adopt a mock client so EnsureAndAcquire succeeds
+	mockClient := &plugin.Client{}
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", mockClient, dep, nil)
+
 	srv, err := NewServer(
 		WithServerRegistry(reg),
 		WithServerVersion("test"),
+		WithServerContext(ctx),
+		WithServerPluginPool(pool),
+	)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "run_provider"
+	request.Params.Arguments = map[string]any{
+		"provider": "exec",
+		"inputs":   map[string]any{},
+	}
+
+	result, err := srv.handleRunProvider(context.Background(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "NOT_FOUND")
+}
+
+func TestHandleGetProviderSchema_AutoResolve_RegistryMiss(t *testing.T) {
+	// When auto-resolve succeeds but provider is still not in the registry,
+	// handleGetProviderSchema should fall back to official registry info.
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	ctx := official.WithRegistry(context.Background(), officialReg)
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	// Adopt so EnsureAndAcquire succeeds
+	mockClient := &plugin.Client{}
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", mockClient, dep, nil)
+
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+		WithServerContext(ctx),
+		WithServerPluginPool(pool),
 	)
 	require.NoError(t, err)
 
 	request := mcp.CallToolRequest{}
 	request.Params.Name = "get_provider_schema"
 	request.Params.Arguments = map[string]any{
-		"name": "nonexistent",
+		"name": "exec",
 	}
 
 	result, err := srv.handleGetProviderSchema(context.Background(), request)
 	require.NoError(t, err)
-	assert.True(t, result.IsError)
-	text := result.Content[0].(mcp.TextContent).Text
-	assert.Contains(t, text, "NOT_FOUND")
-}
-
-func TestHandleGetProviderOutputShape_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should still return NOT_FOUND
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
-	srv, err := NewServer(
-		WithServerRegistry(reg),
-		WithServerVersion("test"),
-	)
-	require.NoError(t, err)
-
-	request := mcp.CallToolRequest{}
-	request.Params.Name = "get_provider_output_shape"
-	request.Params.Arguments = map[string]any{
-		"name": "nonexistent",
-	}
-
-	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
-	require.NoError(t, err)
-	assert.True(t, result.IsError)
-	text := result.Content[0].(mcp.TextContent).Text
-	assert.Contains(t, text, "NOT_FOUND")
-}
-
-func TestHandleGetProviderOutputShape_AllCapabilities(t *testing.T) {
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
-	srv, err := NewServer(
-		WithServerRegistry(reg),
-		WithServerVersion("test"),
-	)
-	require.NoError(t, err)
-
-	request := mcp.CallToolRequest{}
-	request.Params.Name = "get_provider_output_shape"
-	request.Params.Arguments = map[string]any{
-		"name": "cel",
-	}
-
-	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
-	require.NoError(t, err)
+	// Falls through to official registry fallback
 	assert.False(t, result.IsError)
-
 	text := result.Content[0].(mcp.TextContent).Text
-	var output map[string]any
-	require.NoError(t, json.Unmarshal([]byte(text), &output))
-	assert.Equal(t, "cel", output["provider"])
-	assert.NotNil(t, output["outputSchemas"], "expected outputSchemas for all capabilities")
+	assert.Contains(t, text, "exec")
 }
 
-func TestHandleGetProviderOutputShape_SingleCapability(t *testing.T) {
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
+func TestHandleGetProviderOutputShape_AutoResolve_RegistryMiss(t *testing.T) {
+	// When auto-resolve succeeds but provider is still not in the registry,
+	// handleGetProviderOutputShape should return NOT_FOUND.
+	reg := provider.NewRegistry()
+	officialReg := official.NewRegistry()
+	ctx := official.WithRegistry(context.Background(), officialReg)
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	defer pool.Shutdown()
+
+	// Adopt so EnsureAndAcquire succeeds
+	mockClient := &plugin.Client{}
+	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}
+	pool.Adopt("exec", mockClient, dep, nil)
+
 	srv, err := NewServer(
 		WithServerRegistry(reg),
 		WithServerVersion("test"),
+		WithServerContext(ctx),
+		WithServerPluginPool(pool),
 	)
 	require.NoError(t, err)
 
 	request := mcp.CallToolRequest{}
 	request.Params.Name = "get_provider_output_shape"
 	request.Params.Arguments = map[string]any{
-		"name":       "cel",
-		"capability": "transform",
-	}
-
-	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
-	require.NoError(t, err)
-	assert.False(t, result.IsError)
-
-	text := result.Content[0].(mcp.TextContent).Text
-	var output map[string]any
-	require.NoError(t, json.Unmarshal([]byte(text), &output))
-	assert.Equal(t, "cel", output["provider"])
-	assert.Equal(t, "transform", output["capability"])
-	assert.NotNil(t, output["outputSchema"])
-}
-
-func TestHandleGetProviderOutputShape_InvalidCapability(t *testing.T) {
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
-	srv, err := NewServer(
-		WithServerRegistry(reg),
-		WithServerVersion("test"),
-	)
-	require.NoError(t, err)
-
-	request := mcp.CallToolRequest{}
-	request.Params.Name = "get_provider_output_shape"
-	request.Params.Arguments = map[string]any{
-		"name":       "cel",
-		"capability": "authentication",
+		"name": "exec",
 	}
 
 	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
@@ -1109,26 +994,6 @@ func TestHandleGetProviderOutputShape_InvalidCapability(t *testing.T) {
 	assert.True(t, result.IsError)
 	text := result.Content[0].(mcp.TextContent).Text
 	assert.Contains(t, text, "NOT_FOUND")
-}
-
-func TestHandleGetProviderOutputShape_MissingName(t *testing.T) {
-	reg, err := builtin.DefaultRegistry(context.Background())
-	require.NoError(t, err)
-	srv, err := NewServer(
-		WithServerRegistry(reg),
-		WithServerVersion("test"),
-	)
-	require.NoError(t, err)
-
-	request := mcp.CallToolRequest{}
-	request.Params.Name = "get_provider_output_shape"
-	request.Params.Arguments = map[string]any{}
-
-	result, err := srv.handleGetProviderOutputShape(context.Background(), request)
-	require.NoError(t, err)
-	assert.True(t, result.IsError)
-	text := result.Content[0].(mcp.TextContent).Text
-	assert.Contains(t, text, "INVALID_INPUT")
 }
 
 func TestProviderSource(t *testing.T) {

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -366,6 +366,23 @@ func (p *Pool) waitAndValidate(ctx context.Context, entry *poolEntry) error {
 	return nil
 }
 
+// buildSpawnClientOpts builds the ClientOption slice used when spawning a
+// plugin process. When sanitize is true, WithSanitizedEnv() is prepended.
+func buildSpawnClientOpts(sanitize bool, extraOpts []ClientOption) []ClientOption {
+	if sanitize {
+		opts := make([]ClientOption, 1, 1+len(extraOpts))
+		opts[0] = WithSanitizedEnv()
+		opts = append(opts, extraOpts...)
+		return opts
+	}
+	if len(extraOpts) == 0 {
+		return nil
+	}
+	opts := make([]ClientOption, len(extraOpts))
+	copy(opts, extraOpts)
+	return opts
+}
+
 // spawn fetches and starts a plugin, updating the entry state.
 func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 	defer close(entry.ready)
@@ -390,15 +407,7 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 	result := results[0]
 
 	// Spawn client, optionally sanitizing the environment.
-	var clientOpts []ClientOption
-	if p.opts.sanitizeEnv {
-		clientOpts = make([]ClientOption, 1, 1+len(p.opts.clientOpts))
-		clientOpts[0] = WithSanitizedEnv()
-		clientOpts = append(clientOpts, p.opts.clientOpts...)
-	} else {
-		clientOpts = make([]ClientOption, 0, len(p.opts.clientOpts))
-		clientOpts = append(clientOpts, p.opts.clientOpts...)
-	}
+	clientOpts := buildSpawnClientOpts(p.opts.sanitizeEnv, p.opts.clientOpts)
 	client, err := NewClient(result.Path, clientOpts...)
 	if err != nil {
 		entry.failWith(fmt.Errorf("starting process: %w", err))
@@ -639,6 +648,12 @@ func (p *Pool) Stats() PoolStats {
 // plugin clients. See [WithSanitizeEnv].
 func (p *Pool) SanitizeEnv() bool {
 	return p.opts.sanitizeEnv
+}
+
+// ClientOptsLen returns the number of extra client options configured on the pool.
+// This is primarily useful for testing that WithClientOptions was wired correctly.
+func (p *Pool) ClientOptsLen() int {
+	return len(p.opts.clientOpts)
 }
 
 // Shutdown kills all managed plugin processes. Called once on server stop.

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -90,6 +90,64 @@ func TestNewPool_WithSanitizeEnv(t *testing.T) {
 	})
 }
 
+func TestBuildSpawnClientOpts(t *testing.T) {
+	// applyOpts applies a slice of ClientOption to a fresh clientOptions struct
+	// and returns the result for assertion.
+	applyOpts := func(opts []ClientOption) clientOptions {
+		var co clientOptions
+		for _, o := range opts {
+			o(&co)
+		}
+		return co
+	}
+
+	t.Run("sanitize true prepends WithSanitizedEnv", func(t *testing.T) {
+		extra := []ClientOption{WithDebugLogging()} // dummy extra opt
+		opts := buildSpawnClientOpts(true, extra)
+		assert.Len(t, opts, 2)
+		// First option should set sanitizeEnv.
+		var first clientOptions
+		opts[0](&first)
+		assert.True(t, first.sanitizeEnv, "first option must set sanitizeEnv")
+		// All opts applied should have both flags.
+		co := applyOpts(opts)
+		assert.True(t, co.sanitizeEnv)
+		assert.True(t, co.debugLog)
+	})
+
+	t.Run("sanitize false does not prepend", func(t *testing.T) {
+		extra := []ClientOption{WithDebugLogging()}
+		opts := buildSpawnClientOpts(false, extra)
+		assert.Len(t, opts, 1)
+		co := applyOpts(opts)
+		assert.False(t, co.sanitizeEnv, "sanitizeEnv must not be set")
+		assert.True(t, co.debugLog)
+	})
+
+	t.Run("sanitize true with no extras", func(t *testing.T) {
+		opts := buildSpawnClientOpts(true, nil)
+		assert.Len(t, opts, 1)
+		co := applyOpts(opts)
+		assert.True(t, co.sanitizeEnv)
+	})
+
+	t.Run("sanitize false with no extras", func(t *testing.T) {
+		opts := buildSpawnClientOpts(false, nil)
+		assert.Empty(t, opts)
+	})
+
+	t.Run("sanitize true with multiple extras", func(t *testing.T) {
+		extra := []ClientOption{WithDebugLogging(), WithDebugLogging()}
+		opts := buildSpawnClientOpts(true, extra)
+		assert.Len(t, opts, 3)
+		// First must be the sanitize option.
+		var first clientOptions
+		opts[0](&first)
+		assert.True(t, first.sanitizeEnv)
+		assert.False(t, first.debugLog, "first option must only set sanitizeEnv")
+	})
+}
+
 func TestPool_Adopt(t *testing.T) {
 	reg := provider.NewRegistry()
 	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1982,6 +1982,14 @@ func TestIntegration_AuthTokenHelp(t *testing.T) {
 	assert.Contains(t, stdout, "--force-refresh")
 }
 
+func TestIntegration_AuthMigrateHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "migrate", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "migrate")
+}
+
 func TestIntegration_AuthLoginGCPHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "auth", "login", "gcp", "--help")


### PR DESCRIPTION
- add `auth migrate` command to pre-install official auth handler
  plugins from the catalog and validate token readiness
- add `pkg/auth/migrate` domain package with migration logic,
  token validation, and per-handler status reporting
- enhance `auth diagnose` with handler source checks (built-in,
  plugin, or not found)
- extract `buildSpawnClientOpts` from plugin pool spawn for
  testability
- refactor MCP and API provider tests to use pool-adopted entries
  and registry-miss scenarios instead of no-pool stubs
- add MCP serve tests for auth client opts wiring