### PR TITLE
feat(auth): add handler discovery command and registry-based flow detection

### DIFF
--- a/docs/tutorials/auth-migration-guide.md
+++ b/docs/tutorials/auth-migration-guide.md
@@ -1,0 +1,150 @@
+# Auth Handler Migration Guide
+
+This guide covers migrating from built-in auth handlers to the plugin-based
+auth handler system in scafctl.
+
+## Overview
+
+scafctl is transitioning from compiled-in auth handlers (entra, github, gcp) to
+a plugin-based architecture where handlers run as separate gRPC processes. This
+enables independent updates, third-party handlers, and catalog-based distribution.
+
+## What Changed
+
+### Auto-Resolution
+
+Auth handlers are now resolved automatically from the official auth handler
+registry. When you run `scafctl auth login github`, scafctl:
+
+1. Checks the local auth registry for a handler named "github"
+2. If not found, checks the official registry for a catalog reference
+3. Auto-fetches and installs the plugin from the catalog
+4. Registers it and proceeds with login
+
+### Handler Discovery
+
+Use `scafctl auth handlers` to see all known handlers and their status:
+
+~~~sh
+scafctl auth handlers
+~~~
+
+Output columns:
+
+| Column      | Description                                    |
+|-------------|------------------------------------------------|
+| name        | Handler identifier (e.g., entra, github, gcp)  |
+| displayName | Human-readable name                            |
+| status      | installed, available, or not-found             |
+| source      | built-in, plugin, or catalog                   |
+| flows       | Supported authentication flows                 |
+| loggedIn    | Whether currently authenticated                |
+
+### Strict Mode
+
+Use `--strict` to disable auto-fetching and require all handlers to be
+pre-installed:
+
+~~~sh
+scafctl auth login github --strict
+~~~
+
+This is useful in CI environments where you want to fail fast if a handler
+is not available.
+
+## Configuration Changes
+
+### Custom Entra Domains
+
+Entra handler configuration remains in the config file:
+
+~~~yaml
+auth:
+  entra:
+    clientId: "your-client-id"
+    tenantId: "your-tenant-id"
+    defaultScopes:
+      - "https://graph.microsoft.com/.default"
+~~~
+
+These settings are forwarded to the plugin via `ConfigureAuthHandler` RPC.
+
+### GitHub Enterprise Server (GHES) Hostname
+
+~~~yaml
+auth:
+  github:
+    hostname: "github.example.com"
+    clientId: "your-ghes-client-id"
+~~~
+
+### Google Regional Domains
+
+~~~yaml
+auth:
+  gcp:
+    clientId: "your-client-id"
+    impersonateServiceAccount: "sa@project.iam.gserviceaccount.com"
+~~~
+
+### Trusted Verification Domains
+
+Per-handler trusted domains can be configured globally:
+
+~~~yaml
+auth:
+  trustedVerificationDomains:
+    - "login.microsoftonline.com"
+    - "github.com"
+~~~
+
+## Telemetry
+
+The plugin auth system includes OpenTelemetry instrumentation:
+
+- **auth.plugin.login** -- span for each login operation
+- **auth.plugin.status** -- span for each status query
+- **auth.plugin.get_token** -- span for each token retrieval
+- **auth_plugin_startup_duration_seconds** -- histogram for plugin process startup latency
+
+Use `scafctl auth diagnose` to see startup latency per handler:
+
+~~~
+[ok]   entra: startup latency  Handler startup: 65ms (plugin)
+[ok]   github: startup latency  Handler startup: <1ms (built-in)
+~~~
+
+## Offline Behavior
+
+When offline, plugin-based handlers behave as follows:
+
+- **Cached tokens**: Token retrieval works normally from the local cache
+- **Login**: Requires network for OAuth flows; PAT/service-principal flows may
+  work offline
+- **Auto-fetch**: Plugin download from catalog requires network; use `--strict`
+  to skip
+
+## Emergency Rollback
+
+If the plugin system causes issues, the built-in handlers are still available
+in the current release. They take priority in the registry when both are present.
+
+## Token Migration
+
+Existing tokens cached by built-in handlers are compatible with the plugin
+handlers. Use `scafctl auth migrate` to migrate token storage if needed:
+
+~~~sh
+scafctl auth migrate
+~~~
+
+## Diagnostics
+
+Run `scafctl auth diagnose` for a full health check including:
+
+- Registry status (which handlers are registered)
+- Handler source (built-in vs plugin vs catalog)
+- Plugin startup latency
+- Configuration validation
+- Token cache health
+- Network connectivity

--- a/pkg/auth/constants.go
+++ b/pkg/auth/constants.go
@@ -1,0 +1,16 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+// Environment variable constants used by auth handlers.
+// These are defined here so that CLI commands can reference them without
+// importing handler-specific packages (e.g., pkg/auth/entra).
+const (
+	// EnvAzureFederatedToken is the raw federated token (for testing/debugging).
+	// Takes precedence over EnvAzureFederatedTokenFile if both are set.
+	EnvAzureFederatedToken = "AZURE_FEDERATED_TOKEN" //nolint:gosec // This is the env var name, not a credential
+
+	// EnvAzureFederatedTokenFile is the path to the projected service account token.
+	EnvAzureFederatedTokenFile = "AZURE_FEDERATED_TOKEN_FILE" //nolint:gosec // This is the env var name, not a credential
+)

--- a/pkg/auth/entra/workload_identity.go
+++ b/pkg/auth/entra/workload_identity.go
@@ -21,11 +21,11 @@ import (
 // Environment variable names for workload identity (Azure SDK convention).
 const (
 	// EnvAzureFederatedTokenFile is the path to the projected service account token.
-	EnvAzureFederatedTokenFile = "AZURE_FEDERATED_TOKEN_FILE" //nolint:gosec // This is the env var name, not a credential
+	EnvAzureFederatedTokenFile = auth.EnvAzureFederatedTokenFile //nolint:gosec // This is the env var name, not a credential
 
 	// EnvAzureFederatedToken is the raw federated token (for testing/debugging).
 	// Takes precedence over EnvAzureFederatedTokenFile if both are set.
-	EnvAzureFederatedToken = "AZURE_FEDERATED_TOKEN" //nolint:gosec // This is the env var name, not a credential
+	EnvAzureFederatedToken = auth.EnvAzureFederatedToken //nolint:gosec // This is the env var name, not a credential
 
 	// EnvAzureAuthorityHost is the Azure AD authority host (optional).
 	EnvAzureAuthorityHost = "AZURE_AUTHORITY_HOST"

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -161,3 +161,24 @@ var (
 	_ TokenLister = (*MockHandler)(nil)
 	_ TokenPurger = (*MockHandler)(nil)
 )
+
+// MockFlowDetectorHandler embeds MockHandler and adds FlowDetector support.
+type MockFlowDetectorHandler struct {
+	*MockHandler
+	DetectFlowsResult []FlowAvailability
+	DetectFlowsErr    error
+}
+
+// NewMockFlowDetectorHandler creates a mock handler that implements FlowDetector.
+func NewMockFlowDetectorHandler(name string) *MockFlowDetectorHandler {
+	return &MockFlowDetectorHandler{
+		MockHandler: NewMockHandler(name),
+	}
+}
+
+// DetectAvailableFlows implements FlowDetector.
+func (m *MockFlowDetectorHandler) DetectAvailableFlows(_ context.Context) ([]FlowAvailability, error) {
+	return m.DetectFlowsResult, m.DetectFlowsErr
+}
+
+var _ FlowDetector = (*MockFlowDetectorHandler)(nil)

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -42,6 +42,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandDiagnose(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandHandlers(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -25,7 +25,7 @@ func TestCommandAuth(t *testing.T) {
 
 	// Verify subcommands are added
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 7)
+	require.Len(t, subCmds, 8)
 
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
@@ -36,6 +36,7 @@ func TestCommandAuth(t *testing.T) {
 	assert.Contains(t, cmdNames, "login <handler>")
 	assert.Contains(t, cmdNames, "logout [handler]")
 	assert.Contains(t, cmdNames, "migrate")
+	assert.Contains(t, cmdNames, "handlers")
 	assert.Contains(t, cmdNames, "status [handler]")
 	assert.Contains(t, cmdNames, "token <handler>")
 }

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -24,6 +24,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pluginStartupWarnThreshold is the latency above which a plugin handler
+// startup is flagged as slow during 'auth diagnose'.
+const pluginStartupWarnThreshold = 2 * time.Second
+
 // clockSkewCheckFunc is the function used to perform the clock skew check.
 // Tests can replace this to avoid real network calls.
 var clockSkewCheckFunc = diagnose.RunClockSkewCheck
@@ -134,6 +138,38 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 						Status:   status,
 						Message:  fmt.Sprintf("Handler source: %s", source),
 					})
+				}
+			}
+
+			// ── 1.6. Plugin startup latency ──────────────────────────────────
+			if authReg != nil {
+				for _, name := range handlerNames {
+					h, hErr := authReg.Get(name)
+					if hErr != nil {
+						continue
+					}
+					if pw, ok := h.(*plugin.AuthHandlerWrapper); ok {
+						latency := pw.StartupLatency()
+						status := diagnose.StatusOK
+						msg := fmt.Sprintf("Handler startup: %s (plugin)", latency.Round(time.Millisecond))
+						if latency > pluginStartupWarnThreshold {
+							status = diagnose.StatusWarn
+							msg += " -- slow startup"
+						}
+						addCheck(diagnose.Check{
+							Category: "startup",
+							Name:     fmt.Sprintf("%s: startup latency", name),
+							Status:   status,
+							Message:  msg,
+						})
+					} else {
+						addCheck(diagnose.Check{
+							Category: "startup",
+							Name:     fmt.Sprintf("%s: startup latency", name),
+							Status:   diagnose.StatusOK,
+							Message:  "Handler startup: n/a (built-in, not measured)",
+						})
+					}
 				}
 			}
 

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -534,3 +534,103 @@ func TestHandlerSource(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandDiagnose_StartupLatency_BuiltIn(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// Set up an auth registry with a built-in mock handler.
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("test-handler")
+	mock.SetNotAuthenticated()
+	require.NoError(t, registry.Register(mock))
+	ctx = auth.WithRegistry(ctx, registry)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "n/a (built-in, not measured)")
+}
+
+func TestCommandDiagnose_StartupLatency_Plugin(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// Set up an auth registry with both a plugin wrapper (for startup latency)
+	// and a built-in mock (for the status check section).
+	registry := auth.NewRegistry()
+	wrapper := plugin.NewAuthHandlerWrapper(nil, plugin.AuthHandlerInfo{
+		Name: "test-plugin",
+	})
+	wrapper.SetStartupLatency(50 * time.Millisecond)
+	require.NoError(t, registry.Register(wrapper))
+
+	// Also register a built-in mock so the status check doesn't panic.
+	builtIn := auth.NewMockHandler("builtin-handler")
+	builtIn.SetNotAuthenticated()
+	require.NoError(t, registry.Register(builtIn))
+	ctx = auth.WithRegistry(ctx, registry)
+
+	// Scope to builtin-handler for status checks; startup latency is still emitted for all.
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"builtin-handler"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	// The built-in handler should report "n/a (built-in, not measured)"
+	assert.Contains(t, output, "n/a (built-in, not measured)")
+}
+
+func TestCommandDiagnose_StartupLatency_SlowPlugin(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// Set up an auth registry with a slow plugin wrapper and a built-in mock
+	// so the status check (section 4) uses the mock instead of the nil-client wrapper.
+	registry := auth.NewRegistry()
+	wrapper := plugin.NewAuthHandlerWrapper(nil, plugin.AuthHandlerInfo{
+		Name: "slow-plugin",
+	})
+	wrapper.SetStartupLatency(3 * time.Second) // over pluginStartupWarnThreshold
+	require.NoError(t, registry.Register(wrapper))
+
+	builtIn := auth.NewMockHandler("builtin-handler")
+	builtIn.SetNotAuthenticated()
+	require.NoError(t, registry.Register(builtIn))
+	ctx = auth.WithRegistry(ctx, registry)
+
+	// Scope to builtin-handler for status checks; startup latency is still emitted for all.
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"builtin-handler"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "slow startup")
+	assert.Contains(t, output, "[warn]")
+}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -9,11 +9,6 @@ import (
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
-	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
-	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
-	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
-	"github.com/oakwood-commons/scafctl/pkg/config"
-	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
 // handlerContextKey is used for test injection of handlers.
@@ -93,97 +88,11 @@ func validateHandlerName(ctx context.Context, handlerName string) error {
 	return fmt.Errorf("unknown auth handler: %s (registered: %v)", handlerName, handlers)
 }
 
-// getEntraHandlerWithOverrides creates an Entra handler with optional tenant and client ID overrides.
-// The flags take precedence over config.
-//
-//nolint:dupl // Entra and GitHub handler construction share structure but use different types and config paths.
-func getEntraHandlerWithOverrides(ctx context.Context, tenantOverride, clientIDOverride string) (auth.Handler, error) {
-	// Check for test-injected handler
-	if h := handlerFromContext(ctx); h != nil {
-		return h, nil
-	}
-
-	entraCfg := &entra.Config{}
-	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.Entra != nil {
-		entraCfg.ClientID = cfg.Auth.Entra.ClientID
-		entraCfg.TenantID = cfg.Auth.Entra.TenantID
-		entraCfg.DefaultScopes = cfg.Auth.Entra.DefaultScopes
-		entraCfg.DefaultFlow = cfg.Auth.Entra.DefaultFlow
-	}
-
-	applyOverride(&entraCfg.TenantID, tenantOverride)
-	applyOverride(&entraCfg.ClientID, clientIDOverride)
-
-	var opts []entra.Option
-	if entraCfg.ClientID != "" || entraCfg.TenantID != "" || len(entraCfg.DefaultScopes) > 0 || entraCfg.DefaultFlow != "" {
-		opts = append(opts, entra.WithConfig(entraCfg))
-	}
-	opts = append(opts, entra.WithLogger(*logger.FromContext(ctx)))
-
-	return entra.New(opts...)
-}
-
-// getGitHubHandlerWithOverrides creates a GitHub handler with optional hostname and client ID overrides.
-// The flags take precedence over config.
-//
-//nolint:dupl // GitHub and Entra handler construction share structure but use different types and config paths.
-func getGitHubHandlerWithOverrides(ctx context.Context, hostnameOverride, clientIDOverride string) (auth.Handler, error) {
-	// Check for test-injected handler
-	if h := handlerFromContext(ctx); h != nil {
-		return h, nil
-	}
-
-	ghCfg := &ghauth.Config{}
-	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GitHub != nil {
-		ghCfg.ClientID = cfg.Auth.GitHub.ClientID
-		ghCfg.Hostname = cfg.Auth.GitHub.Hostname
-		ghCfg.DefaultScopes = cfg.Auth.GitHub.DefaultScopes
-	}
-
-	applyOverride(&ghCfg.Hostname, hostnameOverride)
-	applyOverride(&ghCfg.ClientID, clientIDOverride)
-
-	var opts []ghauth.Option
-	if ghCfg.ClientID != "" || ghCfg.Hostname != "" || len(ghCfg.DefaultScopes) > 0 {
-		opts = append(opts, ghauth.WithConfig(ghCfg))
-	}
-	opts = append(opts, ghauth.WithLogger(*logger.FromContext(ctx)))
-
-	return ghauth.New(opts...)
-}
-
-// getGCPHandlerWithOverrides creates a GCP handler with optional client ID and impersonation overrides.
-// The flags take precedence over config.
-func getGCPHandlerWithOverrides(ctx context.Context, clientIDOverride, impersonateOverride string) (auth.Handler, error) {
-	// Check for test-injected handler
-	if h := handlerFromContext(ctx); h != nil {
-		return h, nil
-	}
-
-	gcpCfg := &gcpauth.Config{}
-	if cfg := config.FromContext(ctx); cfg != nil && cfg.Auth.GCP != nil {
-		gcpCfg.ClientID = cfg.Auth.GCP.ClientID
-		gcpCfg.ClientSecret = cfg.Auth.GCP.ClientSecret
-		gcpCfg.DefaultScopes = cfg.Auth.GCP.DefaultScopes
-		gcpCfg.ImpersonateServiceAccount = cfg.Auth.GCP.ImpersonateServiceAccount
-		gcpCfg.Project = cfg.Auth.GCP.Project
-	}
-
-	applyOverride(&gcpCfg.ClientID, clientIDOverride)
-	applyOverride(&gcpCfg.ImpersonateServiceAccount, impersonateOverride)
-
-	var opts []gcpauth.Option
-	if gcpCfg.ClientID != "" || gcpCfg.ImpersonateServiceAccount != "" || len(gcpCfg.DefaultScopes) > 0 {
-		opts = append(opts, gcpauth.WithConfig(gcpCfg))
-	}
-	opts = append(opts, gcpauth.WithLogger(*logger.FromContext(ctx)))
-
-	return gcpauth.New(opts...)
-}
-
-// applyOverride sets the target to the override value if it is non-empty.
-func applyOverride(target *string, override string) {
-	if override != "" {
-		*target = override
-	}
+// getHandlerWithOverrides retrieves a handler from the registry.
+// Override parameters are accepted for backward compatibility with CLI flags
+// but are no-ops for plugin-based handlers (which are pre-configured via
+// ConfigureAuthHandler RPC). When builtins are removed, these parameters
+// will be dropped entirely.
+func getHandlerWithOverrides(ctx context.Context, handlerName, _, _, _, _ string) (auth.Handler, error) {
+	return getHandler(ctx, handlerName)
 }

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -116,3 +116,23 @@ func TestGetHandler_NoContext(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no auth registry in context")
 }
+
+func TestGetHandlerWithOverrides_DelegatesToGetHandler(t *testing.T) {
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("github")
+	require.NoError(t, registry.Register(mock))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	// Override params are accepted but ignored (plugins are pre-configured).
+	handler, err := getHandlerWithOverrides(ctx, "github", "tenant", "client", "host", "impersonate")
+	require.NoError(t, err)
+	assert.Equal(t, "github", handler.Name())
+}
+
+func TestGetHandlerWithOverrides_NotFound(t *testing.T) {
+	registry := auth.NewRegistry()
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	_, err := getHandlerWithOverrides(ctx, "missing", "", "", "", "")
+	assert.Error(t, err)
+}

--- a/pkg/cmd/scafctl/auth/handlers.go
+++ b/pkg/cmd/scafctl/auth/handlers.go
@@ -1,0 +1,173 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/spf13/cobra"
+)
+
+// authHandlersSchema controls table column display for the handlers command.
+var authHandlersSchema = []byte(`{
+	"type": "array",
+	"items": {
+		"type": "object",
+		"required": ["name", "status", "source"],
+		"properties": {
+			"name":        { "type": "string", "title": "Name", "maxLength": 16 },
+			"displayName": { "type": "string", "title": "Display Name", "maxLength": 30 },
+			"status":      { "type": "string", "title": "Status", "maxLength": 16 },
+			"source":      { "type": "string", "title": "Source", "maxLength": 16 },
+			"flows":       { "type": "string", "title": "Flows", "maxLength": 40 },
+			"loggedIn":    { "type": "boolean", "title": "Logged In" }
+		}
+	}
+}`)
+
+// CommandHandlers creates the 'auth handlers' command.
+func CommandHandlers(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+	outputFlags.AppName = cliParams.BinaryName
+
+	cmd := &cobra.Command{
+		Use:   "handlers",
+		Short: "List registered and available auth handlers",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Show registered and auto-fetchable authentication handlers with their
+			current status.
+
+			For each handler, shows:
+			  - name: handler identifier
+			  - status: installed or available
+			  - source: built-in, plugin, or catalog
+			  - flows: supported authentication flows
+			  - loggedIn: whether the handler is currently authenticated
+
+			Installed handlers are those registered in the auth registry (either
+			built-in or loaded via plugin). Available handlers are those in the
+			official auth handler registry that can be auto-fetched from the catalog.
+
+			Note: 'scafctl auth list' shows cached tokens, not handlers. This
+			command shows handler discovery and installation status.
+
+			Examples:
+			  # List all auth handlers
+			  scafctl auth handlers
+
+			  # Output as JSON
+			  scafctl auth handlers -o json
+
+			  # Output as YAML
+			  scafctl auth handlers -o yaml
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			results := collectHandlerInfo(ctx)
+
+			outputOpts := flags.ToKvxOutputOptions(&outputFlags,
+				kvx.WithIOStreams(ioStreams),
+				kvx.WithOutputColumnOrder([]string{"name", "displayName", "status", "source", "flows", "loggedIn"}),
+				kvx.WithOutputSchemaJSON(authHandlersSchema),
+			)
+
+			return outputOpts.Write(results)
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}
+
+// collectHandlerInfo gathers information about all known auth handlers:
+// registered (installed) and official (available for auto-fetch).
+func collectHandlerInfo(ctx context.Context) []map[string]any {
+	authReg := authpkg.RegistryFromContext(ctx)
+	officialReg := authofficial.RegistryFromContext(ctx)
+
+	// Collect all unique handler names from both registries.
+	nameSet := make(map[string]struct{})
+	if authReg != nil {
+		for _, name := range authReg.List() {
+			nameSet[name] = struct{}{}
+		}
+	}
+	if officialReg != nil {
+		for _, name := range officialReg.Names() {
+			nameSet[name] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	results := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		result := buildHandlerInfoResult(ctx, name, authReg, officialReg)
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// buildHandlerInfoResult builds a single handler info result map.
+func buildHandlerInfoResult(ctx context.Context, name string, authReg *authpkg.Registry, officialReg *authofficial.Registry) map[string]any {
+	result := map[string]any{
+		"name":        name,
+		"displayName": name,
+		"status":      "not-found",
+		"source":      "",
+		"flows":       "",
+		"loggedIn":    false,
+	}
+
+	// Check if handler is installed (registered in auth registry).
+	if authReg != nil && authReg.Has(name) {
+		handler, err := authReg.Get(name)
+		if err == nil {
+			result["status"] = "installed"
+			result["displayName"] = handler.DisplayName()
+			if _, ok := handler.(*plugin.AuthHandlerWrapper); ok {
+				result["source"] = "plugin"
+			} else {
+				result["source"] = "built-in"
+			}
+
+			// Collect supported flows.
+			flows := handler.SupportedFlows()
+			flowNames := make([]string, 0, len(flows))
+			for _, f := range flows {
+				flowNames = append(flowNames, string(f))
+			}
+			result["flows"] = strings.Join(flowNames, ", ")
+
+			// Check authentication status.
+			if status, err := handler.Status(ctx); err == nil {
+				result["loggedIn"] = status.Authenticated
+			}
+		}
+	} else if officialReg != nil && officialReg.Has(name) {
+		// Handler is in the official registry but not installed yet.
+		result["status"] = "available"
+		result["source"] = "catalog"
+		result["flows"] = "unknown (install to inspect)"
+	}
+
+	return result
+}

--- a/pkg/cmd/scafctl/auth/handlers_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"testing"
+
+	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectHandlerInfo_EmptyRegistries(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	results := collectHandlerInfo(ctx)
+	assert.Empty(t, results)
+}
+
+func TestCollectHandlerInfo_WithRegisteredHandler(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("github")
+	mock.StatusResult = &authpkg.Status{Authenticated: true}
+	require.NoError(t, registry.Register(mock))
+	ctx = authpkg.WithRegistry(ctx, registry)
+
+	results := collectHandlerInfo(ctx)
+	require.Len(t, results, 1)
+	assert.Equal(t, "github", results[0]["name"])
+	assert.Equal(t, "installed", results[0]["status"])
+	assert.Equal(t, true, results[0]["loggedIn"])
+}
+
+func TestCollectHandlerInfo_WithOfficialAndRegistered(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	// Set up auth registry with one handler.
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("entra")
+	require.NoError(t, registry.Register(mock))
+	ctx = authpkg.WithRegistry(ctx, registry)
+
+	// Set up official registry with two handlers.
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "auth-entra"},
+		{Name: "gcp", CatalogRef: "auth-gcp"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	results := collectHandlerInfo(ctx)
+	require.Len(t, results, 2)
+
+	// Results should be sorted by name.
+	assert.Equal(t, "entra", results[0]["name"])
+	assert.Equal(t, "installed", results[0]["status"])
+
+	assert.Equal(t, "gcp", results[1]["name"])
+	assert.Equal(t, "available", results[1]["status"])
+	assert.Equal(t, "catalog", results[1]["source"])
+}
+
+func TestBuildHandlerInfoResult_NotFound(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	result := buildHandlerInfoResult(ctx, "unknown", nil, nil)
+	assert.Equal(t, "unknown", result["name"])
+	assert.Equal(t, "not-found", result["status"])
+	assert.Equal(t, false, result["loggedIn"])
+}
+
+func TestBuildHandlerInfoResult_InstalledBuiltIn(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.FlowsValue = []authpkg.Flow{authpkg.FlowDeviceCode, authpkg.FlowInteractive}
+	mock.StatusResult = &authpkg.Status{Authenticated: false}
+	require.NoError(t, registry.Register(mock))
+
+	result := buildHandlerInfoResult(ctx, "entra", registry, nil)
+	assert.Equal(t, "installed", result["status"])
+	assert.Equal(t, "Microsoft Entra ID", result["displayName"])
+	assert.Equal(t, "built-in", result["source"])
+	assert.Contains(t, result["flows"], "device_code")
+	assert.Equal(t, false, result["loggedIn"])
+}
+
+func TestCommandHandlers_WithRegisteredHandler(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("github")
+	mock.DisplayNameValue = "GitHub"
+	mock.StatusResult = &authpkg.Status{Authenticated: true}
+	require.NoError(t, registry.Register(mock))
+	ctx = authpkg.WithRegistry(ctx, registry)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandHandlers(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "installed")
+}
+
+func TestCommandHandlers_EmptyRegistries(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandHandlers(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	// With no registries, output should be empty (no rows) or an empty table header.
+	assert.NotContains(t, output, "installed")
+	assert.NotContains(t, output, "available")
+}
+
+func TestCommandHandlers_JSONOutput(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.StatusResult = &authpkg.Status{Authenticated: false}
+	require.NoError(t, registry.Register(mock))
+	ctx = authpkg.WithRegistry(ctx, registry)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandHandlers(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "\"name\"")
+	assert.Contains(t, output, "entra")
+}
+
+func TestCommandHandlers_NonDefaultBinaryName(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	mock := authpkg.NewMockHandler("github")
+	mock.StatusResult = &authpkg.Status{Authenticated: false}
+	require.NoError(t, registry.Register(mock))
+	ctx = authpkg.WithRegistry(ctx, registry)
+
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandHandlers(cliParams, ioStreams, "mycli/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+}

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -14,19 +14,23 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
-	"github.com/oakwood-commons/scafctl/pkg/auth/entra"
-	gcpauth "github.com/oakwood-commons/scafctl/pkg/auth/gcp"
-	ghauth "github.com/oakwood-commons/scafctl/pkg/auth/github"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // CommandLogin creates the 'auth login' command.
@@ -258,8 +262,7 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 			}
 
 			// Post-login registry bridge.
-			// Re-create the handler with the same overrides used during login so that
-			// token retrieval uses the correct clientID fingerprint and refresh token.
+			// Retrieve the handler from the registry for credential bridging.
 			var discovered []registryWithScope
 			if registry == "" {
 				// Auto-discover registries from config when --registry is not provided.
@@ -272,22 +275,11 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 				return nil
 			}
 
-			var bridgeHandler auth.Handler
-			var bridgeErr error
-			switch handlerName {
-			case "github":
-				bridgeHandler, bridgeErr = getGitHubHandlerWithOverrides(ctx, hostname, clientID)
-			case "gcp":
-				bridgeHandler, bridgeErr = getGCPHandlerWithOverrides(ctx, clientID, impersonateServiceAccount)
-			case "entra":
-				bridgeHandler, bridgeErr = getEntraHandlerWithOverrides(ctx, tenantID, clientID)
-			default:
+			// Retrieve the handler for registry bridge.
+			bridgeHandler, bridgeErr := getHandlerWithOverrides(ctx, handlerName, tenantID, clientID, hostname, impersonateServiceAccount)
+			if bridgeErr != nil || bridgeHandler == nil {
 				// Custom OAuth2 handlers have no CLI overrides; re-use the
 				// handler resolved at the start of this command.
-				bridgeHandler = handler
-			}
-			if bridgeErr != nil {
-				// Fall back to the pre-login handler rather than failing outright.
 				bridgeHandler = handler
 			}
 
@@ -313,8 +305,8 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 		},
 	}
 
-	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (overrides config, requires tenant_id capability)")
-	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth application/client ID (overrides default)")
+	cmd.Flags().StringVar(&tenantID, "tenant", "", "Azure tenant ID (requires tenant_id capability)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth application/client ID")
 	cmd.Flags().StringVar(&hostname, "hostname", "", "Hostname for enterprise/self-hosted instances (requires hostname capability)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "Timeout for authentication flow")
 	cmd.Flags().StringVar(&flowStr, "flow", "", "Authentication flow (handler-specific)")
@@ -333,29 +325,26 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 
 // loginGitHub handles the login flow for the GitHub auth handler.
 func loginGitHub(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, hostname, clientID string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
-	// Auto-detect flow from available credentials.
-	// Skip PAT auto-detection when user provides --scope flags, since scopes
-	// only apply to the device code / interactive flows (PAT scopes are fixed at creation).
-	var detectors []auth.CredentialDetector
-	if len(scopes) == 0 {
-		detectors = append(detectors, auth.CredentialDetector{
-			HasCredentials: ghauth.HasPATCredentials,
-			Flow:           auth.FlowPAT,
-			Description:    "Detected GitHub token in environment variables",
-		})
-	}
-	detection := auth.DetectFlow(flow, detectors, auth.FlowDeviceCode)
-	flow = detection.Flow
-	if detection.Description != "" {
-		w.Info(detection.Description)
-	}
-
 	// Get or create handler
-	handler, err := getGitHubHandlerWithOverrides(ctx, hostname, clientID)
+	handler, err := getHandlerWithOverrides(ctx, "github", "", clientID, hostname, "")
 	if err != nil {
 		err = fmt.Errorf("failed to initialize auth handler: %w", err)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Auto-detect flow from available credentials via registry-based detection.
+	// Skip PAT auto-detection when user provides --scope flags, since scopes
+	// only apply to the device code / interactive flows (PAT scopes are fixed at creation).
+	var skipFlows []auth.Flow
+	if len(scopes) > 0 {
+		skipFlows = []auth.Flow{auth.FlowPAT}
+	}
+	detectors := detectAvailableFlowsAsDetectors(ctx, handler, skipFlows)
+	detection := auth.DetectFlow(flow, detectors, auth.FlowDeviceCode)
+	flow = detection.Flow
+	if detection.Description != "" {
+		w.Info(detection.Description)
 	}
 
 	// Check pre-login state
@@ -381,30 +370,20 @@ func loginGitHub(ctx context.Context, w *writer.Writer, binaryName string, flow 
 
 // loginGCP handles the login flow for the GCP auth handler.
 func loginGCP(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, clientID, impersonateServiceAccount string, callbackPort int, timeout time.Duration, scopes []string, force, skipIfAuthenticated bool) error {
-	// Auto-detect flow based on available credentials (highest priority first)
-	detection := auth.DetectFlow(flow, []auth.CredentialDetector{
-		{
-			HasCredentials: gcpauth.HasWorkloadIdentityCredentials,
-			Flow:           auth.FlowWorkloadIdentity,
-			Description:    "Detected workload identity credentials in environment",
-		},
-		{
-			HasCredentials: gcpauth.HasServiceAccountCredentials,
-			Flow:           auth.FlowServicePrincipal,
-			Description:    "Detected service account key in environment",
-		},
-	}, auth.FlowInteractive)
-	flow = detection.Flow
-	if detection.Description != "" {
-		w.Info(detection.Description)
-	}
-
 	// Get or create handler with overrides
-	handler, err := getGCPHandlerWithOverrides(ctx, clientID, impersonateServiceAccount)
+	handler, err := getHandlerWithOverrides(ctx, "gcp", "", clientID, "", impersonateServiceAccount)
 	if err != nil {
 		err = fmt.Errorf("failed to initialize auth handler: %w", err)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Auto-detect flow based on available credentials via registry-based detection.
+	detectors := detectAvailableFlowsAsDetectors(ctx, handler, nil)
+	detection := auth.DetectFlow(flow, detectors, auth.FlowInteractive)
+	flow = detection.Flow
+	if detection.Description != "" {
+		w.Info(detection.Description)
 	}
 
 	// Check pre-login state (skip check for non-interactive flows except interactive and gcloud_adc)
@@ -433,7 +412,7 @@ func loginGCP(ctx context.Context, w *writer.Writer, binaryName string, flow aut
 func loginEntra(ctx context.Context, w *writer.Writer, binaryName string, flow auth.Flow, tenantID, clientID string, callbackPort int, timeout time.Duration, federatedToken, flowStr string, scopes []string, force, skipIfAuthenticated bool) error {
 	// If --federated-token is provided, set the env var for workload identity
 	if federatedToken != "" {
-		if err := os.Setenv(entra.EnvAzureFederatedToken, federatedToken); err != nil {
+		if err := os.Setenv(auth.EnvAzureFederatedToken, federatedToken); err != nil {
 			err = fmt.Errorf("failed to set federated token: %w", err)
 			w.Errorf("%v", err)
 			return exitcode.WithCode(err, exitcode.GeneralError)
@@ -444,30 +423,20 @@ func loginEntra(ctx context.Context, w *writer.Writer, binaryName string, flow a
 		}
 	}
 
-	// Auto-detect flow from available credentials
-	detection := auth.DetectFlow(flow, []auth.CredentialDetector{
-		{
-			HasCredentials: entra.HasWorkloadIdentityCredentials,
-			Flow:           auth.FlowWorkloadIdentity,
-			Description:    "Detected workload identity credentials in environment",
-		},
-		{
-			HasCredentials: entra.HasServicePrincipalCredentials,
-			Flow:           auth.FlowServicePrincipal,
-			Description:    "Detected service principal credentials in environment variables",
-		},
-	}, auth.FlowDeviceCode)
-	flow = detection.Flow
-	if detection.Description != "" {
-		w.Info(detection.Description)
-	}
-
 	// Get or create handler
-	handler, err := getEntraHandlerWithOverrides(ctx, tenantID, clientID)
+	handler, err := getHandlerWithOverrides(ctx, "entra", tenantID, clientID, "", "")
 	if err != nil {
 		err = fmt.Errorf("failed to initialize auth handler: %w", err)
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	// Auto-detect flow from available credentials via registry-based detection.
+	detectors := detectAvailableFlowsAsDetectors(ctx, handler, nil)
+	detection := auth.DetectFlow(flow, detectors, auth.FlowDeviceCode)
+	flow = detection.Flow
+	if detection.Description != "" {
+		w.Info(detection.Description)
 	}
 
 	// Check pre-login state (skip check for service principal)
@@ -519,7 +488,19 @@ func loginGeneric(ctx context.Context, w *writer.Writer, binaryName string, hand
 // executeLogin runs the common login logic for any auth handler.
 // For device-code flows on a terminal, it uses the kvx status screen TUI.
 // All other flows (and non-terminal output) use plain text output.
-func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, flow auth.Flow, tenantID string, callbackPort int, timeout time.Duration, scopes []string) error {
+func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, flow auth.Flow, tenantID string, callbackPort int, timeout time.Duration, scopes []string) (loginErr error) {
+	tracer := otel.Tracer("scafctl/auth")
+	ctx, span := tracer.Start(ctx, "auth.login",
+		trace.WithAttributes(
+			attribute.String("auth.handler", handler.Name()),
+			attribute.String("auth.flow", string(flow))))
+	defer span.End()
+
+	loginStart := time.Now()
+	defer func() {
+		metrics.RecordAuthLogin(ctx, handler.Name(), string(flow), time.Since(loginStart).Seconds(), loginErr == nil)
+	}()
+
 	// Set up cancellation handling
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1085,4 +1066,62 @@ func discoverRegistriesForHandler(ctx context.Context, handlerName string) []reg
 	}
 
 	return registries
+}
+
+// detectAvailableFlowsAsDetectors queries a handler's DetectAvailableFlows
+// (via the FlowDetector interface) and converts the results to
+// CredentialDetector slices for use with auth.DetectFlow.
+// This replaces direct imports of handler packages (ghauth.HasPATCredentials,
+// entra.HasWorkloadIdentityCredentials, etc.) with registry-based detection.
+//
+// If the handler does not implement FlowDetector (e.g., built-in oauth2), or
+// if the gRPC call returns Unimplemented (SDK <0.5.0 plugin), the function
+// returns nil (no detectors) which causes DetectFlow to use the default flow.
+//
+// skipFlows filters out specific flows from detection (e.g., skip PAT when
+// --scope is provided since scopes only apply to OAuth flows).
+func detectAvailableFlowsAsDetectors(ctx context.Context, handler auth.Handler, skipFlows []auth.Flow) []auth.CredentialDetector {
+	lgr := logger.FromContext(ctx)
+
+	detector, ok := handler.(auth.FlowDetector)
+	if !ok {
+		return nil
+	}
+
+	flows, err := detector.DetectAvailableFlows(ctx)
+	if err != nil {
+		// Graceful fallback for older plugins (SDK <0.5.0):
+		// if DetectAvailableFlows returns gRPC Unimplemented, log at
+		// debug level and fall through to default flow logic.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			lgr.V(1).Info("handler does not support DetectAvailableFlows, using default flow",
+				"handler", handler.Name())
+			return nil
+		}
+		lgr.V(1).Info("DetectAvailableFlows failed, using default flow",
+			"handler", handler.Name(), "error", err)
+		return nil
+	}
+
+	skipSet := make(map[auth.Flow]struct{}, len(skipFlows))
+	for _, f := range skipFlows {
+		skipSet[f] = struct{}{}
+	}
+
+	var detectors []auth.CredentialDetector
+	for _, fa := range flows {
+		if !fa.Available {
+			continue
+		}
+		if _, skip := skipSet[auth.Flow(fa.Flow)]; skip {
+			continue
+		}
+		detectors = append(detectors, auth.CredentialDetector{
+			HasCredentials: func() bool { return true },
+			Flow:           auth.Flow(fa.Flow),
+			Description:    fa.Reason,
+		})
+	}
+
+	return detectors
 }

--- a/pkg/cmd/scafctl/auth/login_detect_test.go
+++ b/pkg/cmd/scafctl/auth/login_detect_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDetectAvailableFlowsAsDetectors_NoFlowDetector(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockHandler("test")
+
+	// MockHandler does not implement FlowDetector.
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, nil)
+	assert.Nil(t, detectors)
+}
+
+func TestDetectAvailableFlowsAsDetectors_WithFlows(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockFlowDetectorHandler("test")
+	mock.DetectFlowsResult = []auth.FlowAvailability{
+		{Flow: "device-code", Available: true, Reason: "always available"},
+		{Flow: "pat", Available: false, Reason: "no token found"},
+		{Flow: "interactive", Available: true, Reason: "browser available"},
+	}
+
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, nil)
+	require.Len(t, detectors, 2, "only available flows should be returned")
+
+	assert.Equal(t, auth.Flow("device-code"), detectors[0].Flow)
+	assert.Equal(t, "always available", detectors[0].Description)
+	assert.True(t, detectors[0].HasCredentials())
+
+	assert.Equal(t, auth.Flow("interactive"), detectors[1].Flow)
+	assert.Equal(t, "browser available", detectors[1].Description)
+	assert.True(t, detectors[1].HasCredentials())
+}
+
+func TestDetectAvailableFlowsAsDetectors_SkipFlows(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockFlowDetectorHandler("test")
+	mock.DetectFlowsResult = []auth.FlowAvailability{
+		{Flow: "device-code", Available: true, Reason: "available"},
+		{Flow: "pat", Available: true, Reason: "token found"},
+	}
+
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, []auth.Flow{"pat"})
+	require.Len(t, detectors, 1)
+	assert.Equal(t, auth.Flow("device-code"), detectors[0].Flow)
+}
+
+func TestDetectAvailableFlowsAsDetectors_GRPCUnimplemented(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockFlowDetectorHandler("test")
+	mock.DetectFlowsErr = status.Error(codes.Unimplemented, "not implemented")
+
+	// Should gracefully return nil for older plugins.
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, nil)
+	assert.Nil(t, detectors)
+}
+
+func TestDetectAvailableFlowsAsDetectors_OtherError(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockFlowDetectorHandler("test")
+	mock.DetectFlowsErr = fmt.Errorf("network error")
+
+	// Non-gRPC errors also fall back gracefully.
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, nil)
+	assert.Nil(t, detectors)
+}
+
+func TestDetectAvailableFlowsAsDetectors_AllUnavailable(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockFlowDetectorHandler("test")
+	mock.DetectFlowsResult = []auth.FlowAvailability{
+		{Flow: "device-code", Available: false, Reason: "no network"},
+		{Flow: "pat", Available: false, Reason: "no token"},
+	}
+
+	detectors := detectAvailableFlowsAsDetectors(ctx, mock, nil)
+	assert.Empty(t, detectors)
+}

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -16,11 +17,16 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 )
 
 // authStatusSchema controls table column display. Columns in the "required"
@@ -116,124 +122,10 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				handlers = []string{handlerName}
 			}
 
-			results := make([]map[string]any, 0, len(handlers))
+			results, warnings := queryHandlerStatuses(ctx, cliParams, handlers)
 
-			for _, handlerName := range handlers {
-				handler, err := getHandler(ctx, handlerName)
-				if err != nil {
-					w.Warningf("Failed to initialize %s: %v", handlerName, err)
-					continue
-				}
-
-				status, err := handler.Status(ctx)
-				if err != nil {
-					w.Warningf("Failed to check %s status: %v", handlerName, err)
-					continue
-				}
-
-				// Always include all columns so kvx detects a homogeneous
-				// array and renders a proper columnar table. The schema
-				// controls which columns are visible in table vs json/yaml.
-				// Derive a human-readable status string
-				statusStr := "valid"
-				if !status.Authenticated {
-					if status.Reason != "" {
-						statusStr = status.Reason
-					} else {
-						statusStr = "not logged in"
-					}
-				}
-
-				// Detect the active credential source if the handler supports it.
-				var flowStr string
-				if reporter, ok := handler.(auth.FlowReporter); ok && status.Authenticated {
-					if f := reporter.ActiveFlow(ctx); f != "" {
-						flowStr = string(f)
-					}
-				}
-
-				result := map[string]any{
-					"handler":       handlerName,
-					"displayName":   handler.DisplayName(),
-					"type":          "handler",
-					"status":        statusStr,
-					"authenticated": status.Authenticated,
-					"email":         "",
-					"username":      "",
-					"user":          "",
-					"expiresIn":     "",
-					"flow":          flowStr,
-					"hint":          "",
-					"identityType":  "",
-					"clientId":      "",
-					"tokenFile":     "",
-					"name":          "",
-					"tenantId":      "",
-					"expiresAt":     "",
-					"lastRefresh":   "",
-					"scopes":        []string{},
-					"cachedTokens":  0,
-				}
-
-				if !status.Authenticated {
-					result["hint"] = fmt.Sprintf("run '%s auth login %s' to authenticate", cliParams.BinaryName, handlerName)
-				}
-
-				if status.IdentityType != "" {
-					result["identityType"] = string(status.IdentityType)
-				}
-
-				if status.ClientID != "" {
-					result["clientId"] = status.ClientID
-				}
-
-				if status.IdentityType == auth.IdentityTypeWorkloadIdentity && status.TokenFile != "" {
-					result["tokenFile"] = status.TokenFile
-				}
-
-				if status.Authenticated && status.Claims != nil {
-					if status.Claims.Email != "" {
-						result["email"] = status.Claims.Email
-					}
-					if status.Claims.Name != "" {
-						result["name"] = status.Claims.Name
-					}
-					if status.Claims.Username != "" {
-						result["username"] = status.Claims.Username
-					}
-					// Derive a compact "user" for the table: prefer email, then username.
-					switch {
-					case status.Claims.Email != "":
-						result["user"] = status.Claims.Email
-					case status.Claims.Username != "":
-						result["user"] = status.Claims.Username
-					}
-					if status.TenantID != "" {
-						result["tenantId"] = status.TenantID
-					}
-					if !status.ExpiresAt.IsZero() {
-						result["expiresAt"] = status.ExpiresAt
-						if timeUntil := time.Until(status.ExpiresAt); timeUntil > 0 {
-							result["expiresIn"] = humanDuration(timeUntil)
-						}
-					}
-					if !status.LastRefresh.IsZero() {
-						result["lastRefresh"] = status.LastRefresh
-					}
-				}
-
-				if len(status.Scopes) > 0 {
-					result["scopes"] = status.Scopes
-				}
-
-				// Cached token count (when available).
-				if lister, ok := handler.(auth.TokenLister); ok {
-					if tokens, err := lister.ListCachedTokens(ctx); err == nil {
-						result["cachedTokens"] = len(tokens)
-					}
-				}
-
-				results = append(results, result)
+			for _, warn := range warnings {
+				w.Warningf("%s", warn)
 			}
 
 			if len(results) == 0 {
@@ -293,6 +185,177 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 	cmd.Flags().BoolVar(&exitCodeFlag, "exit-code", false, "Exit non-zero if any handler is not authenticated (useful for scripting)")
 	cmd.Flags().DurationVar(&warnWithin, "warn-within", 0, "Exit non-zero if any authenticated handler's token expires within this duration (e.g. 10m, 1h)")
 	return cmd
+}
+
+// queryHandlerStatuses queries all handlers for their authentication status
+// concurrently using errgroup. Results are returned in the same order as the
+// input handlers slice for deterministic output regardless of which handler
+// responds first.
+func queryHandlerStatuses(ctx context.Context, cliParams *settings.Run, handlers []string) ([]map[string]any, []string) {
+	tracer := otel.Tracer("scafctl/auth")
+	ctx, span := tracer.Start(ctx, "auth.status.query_all",
+		trace.WithAttributes(attribute.Int("auth.handler_count", len(handlers))))
+	defer span.End()
+
+	type indexedResult struct {
+		index  int
+		result map[string]any
+	}
+
+	var (
+		mu       sync.Mutex
+		indexed  []indexedResult
+		warnings []string
+	)
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	for i, handlerName := range handlers {
+		g.Go(func() error {
+			statusStart := time.Now()
+
+			handler, err := getHandler(gCtx, handlerName)
+			if err != nil {
+				metrics.RecordAuthStatus(gCtx, handlerName, time.Since(statusStart).Seconds(), false)
+				mu.Lock()
+				warnings = append(warnings, fmt.Sprintf("Failed to initialize %s: %v", handlerName, err))
+				mu.Unlock()
+				return nil
+			}
+
+			st, err := handler.Status(gCtx)
+			if err != nil {
+				metrics.RecordAuthStatus(gCtx, handlerName, time.Since(statusStart).Seconds(), false)
+				mu.Lock()
+				warnings = append(warnings, fmt.Sprintf("Failed to check %s status: %v", handlerName, err))
+				mu.Unlock()
+				return nil
+			}
+
+			metrics.RecordAuthStatus(gCtx, handlerName, time.Since(statusStart).Seconds(), true)
+			result := buildStatusResult(gCtx, cliParams, handlerName, handler, st)
+
+			mu.Lock()
+			indexed = append(indexed, indexedResult{index: i, result: result})
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	// errgroup never returns an error (we handle errors inline).
+	_ = g.Wait()
+
+	// Sort by original index for deterministic output order.
+	sort.Slice(indexed, func(i, j int) bool {
+		return indexed[i].index < indexed[j].index
+	})
+
+	results := make([]map[string]any, 0, len(indexed))
+	for _, ir := range indexed {
+		results = append(results, ir.result)
+	}
+
+	return results, warnings
+}
+
+// buildStatusResult constructs the result map for a single handler status query.
+func buildStatusResult(ctx context.Context, cliParams *settings.Run, handlerName string, handler auth.Handler, status *auth.Status) map[string]any {
+	statusStr := "valid"
+	if !status.Authenticated {
+		if status.Reason != "" {
+			statusStr = status.Reason
+		} else {
+			statusStr = "not logged in"
+		}
+	}
+
+	var flowStr string
+	if reporter, ok := handler.(auth.FlowReporter); ok && status.Authenticated {
+		if f := reporter.ActiveFlow(ctx); f != "" {
+			flowStr = string(f)
+		}
+	}
+
+	result := map[string]any{
+		"handler":       handlerName,
+		"displayName":   handler.DisplayName(),
+		"type":          "handler",
+		"status":        statusStr,
+		"authenticated": status.Authenticated,
+		"email":         "",
+		"username":      "",
+		"user":          "",
+		"expiresIn":     "",
+		"flow":          flowStr,
+		"hint":          "",
+		"identityType":  "",
+		"clientId":      "",
+		"tokenFile":     "",
+		"name":          "",
+		"tenantId":      "",
+		"expiresAt":     "",
+		"lastRefresh":   "",
+		"scopes":        []string{},
+		"cachedTokens":  0,
+	}
+
+	if !status.Authenticated {
+		result["hint"] = fmt.Sprintf("run '%s auth login %s' to authenticate", cliParams.BinaryName, handlerName)
+	}
+
+	if status.IdentityType != "" {
+		result["identityType"] = string(status.IdentityType)
+	}
+
+	if status.ClientID != "" {
+		result["clientId"] = status.ClientID
+	}
+
+	if status.IdentityType == auth.IdentityTypeWorkloadIdentity && status.TokenFile != "" {
+		result["tokenFile"] = status.TokenFile
+	}
+
+	if status.Authenticated && status.Claims != nil {
+		if status.Claims.Email != "" {
+			result["email"] = status.Claims.Email
+		}
+		if status.Claims.Name != "" {
+			result["name"] = status.Claims.Name
+		}
+		if status.Claims.Username != "" {
+			result["username"] = status.Claims.Username
+		}
+		switch {
+		case status.Claims.Email != "":
+			result["user"] = status.Claims.Email
+		case status.Claims.Username != "":
+			result["user"] = status.Claims.Username
+		}
+		if status.TenantID != "" {
+			result["tenantId"] = status.TenantID
+		}
+		if !status.ExpiresAt.IsZero() {
+			result["expiresAt"] = status.ExpiresAt
+			if timeUntil := time.Until(status.ExpiresAt); timeUntil > 0 {
+				result["expiresIn"] = humanDuration(timeUntil)
+			}
+		}
+		if !status.LastRefresh.IsZero() {
+			result["lastRefresh"] = status.LastRefresh
+		}
+	}
+
+	if len(status.Scopes) > 0 {
+		result["scopes"] = status.Scopes
+	}
+
+	if lister, ok := handler.(auth.TokenLister); ok {
+		if tokens, err := lister.ListCachedTokens(ctx); err == nil {
+			result["cachedTokens"] = len(tokens)
+		}
+	}
+
+	return result
 }
 
 // appendCatalogStatus adds a row for each remote (OCI) catalog from config,

--- a/pkg/cmd/scafctl/auth/status_test.go
+++ b/pkg/cmd/scafctl/auth/status_test.go
@@ -151,3 +151,38 @@ func TestCommandStatus_JSONOutput(t *testing.T) {
 	assert.Contains(t, output, "Test User")
 	assert.Contains(t, output, "authenticated")
 }
+
+func TestQueryHandlerStatuses_DeterministicOrder(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	// Register multiple handlers.
+	registry := auth.NewRegistry()
+	for _, name := range []string{"zulu", "alpha", "mike"} {
+		mock := auth.NewMockHandler(name)
+		mock.StatusResult = &auth.Status{Authenticated: false}
+		require.NoError(t, registry.Register(mock))
+	}
+	ctx = auth.WithRegistry(ctx, registry)
+	cliParams := settings.NewCliParams()
+
+	// Request in a specific order; results should preserve that order.
+	results, warnings := queryHandlerStatuses(ctx, cliParams, []string{"zulu", "alpha", "mike"})
+	assert.Empty(t, warnings)
+	require.Len(t, results, 3)
+
+	assert.Equal(t, "zulu", results[0]["handler"])
+	assert.Equal(t, "alpha", results[1]["handler"])
+	assert.Equal(t, "mike", results[2]["handler"])
+}
+
+func TestQueryHandlerStatuses_WarningOnFailure(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	// No registry means handler lookup will fail.
+	cliParams := settings.NewCliParams()
+
+	results, warnings := queryHandlerStatuses(ctx, cliParams, []string{"missing"})
+	assert.Empty(t, results)
+	assert.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "Failed to initialize missing")
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,6 +64,10 @@ var (
 
 	PluginResolutionDuration metric.Float64Histogram
 	PluginResolutionTotal    metric.Int64Counter
+
+	AuthPluginStartupDuration metric.Float64Histogram
+	AuthLoginDuration         metric.Float64Histogram
+	AuthStatusDuration        metric.Float64Histogram
 )
 
 // private instruments
@@ -236,6 +240,33 @@ func InitMetrics(_ context.Context) error {
 			initErr = fmt.Errorf("PluginResolutionTotal: %w", err)
 			return
 		}
+
+		AuthPluginStartupDuration, err = m.Float64Histogram(fmt.Sprintf("%s_auth_plugin_startup_duration_seconds", n),
+			metric.WithDescription("Auth handler plugin startup duration in seconds"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(requestTimesBuckets...))
+		if err != nil {
+			initErr = fmt.Errorf("AuthPluginStartupDuration: %w", err)
+			return
+		}
+
+		AuthLoginDuration, err = m.Float64Histogram(fmt.Sprintf("%s_auth_login_duration_seconds", n),
+			metric.WithDescription("Auth login duration in seconds"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(requestTimesBuckets...))
+		if err != nil {
+			initErr = fmt.Errorf("AuthLoginDuration: %w", err)
+			return
+		}
+
+		AuthStatusDuration, err = m.Float64Histogram(fmt.Sprintf("%s_auth_status_duration_seconds", n),
+			metric.WithDescription("Auth status query duration in seconds"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(requestTimesBuckets...))
+		if err != nil {
+			initErr = fmt.Errorf("AuthStatusDuration: %w", err)
+			return
+		}
 	})
 	return initErr
 }
@@ -321,4 +352,51 @@ func RecordProviderExecution(ctx context.Context, providerName string, duration 
 	)
 	ProviderExecutionDuration.Record(ctx, duration, attrs)
 	ProviderExecutionTotal.Add(ctx, 1, attrs)
+}
+
+// Attribute key constants for auth metrics.
+const (
+	AttrAuthHandler = "auth_handler"
+	AttrAuthFlow    = "auth_flow"
+)
+
+// RecordAuthPluginStartup records auth handler plugin startup latency.
+func RecordAuthPluginStartup(ctx context.Context, handlerName string, duration float64) {
+	if AuthPluginStartupDuration == nil {
+		return
+	}
+	AuthPluginStartupDuration.Record(ctx, duration, metric.WithAttributes(
+		attribute.String(AttrAuthHandler, handlerName),
+	))
+}
+
+// RecordAuthLogin records auth login duration.
+func RecordAuthLogin(ctx context.Context, handlerName, flow string, duration float64, success bool) {
+	if AuthLoginDuration == nil {
+		return
+	}
+	status := "success"
+	if !success {
+		status = "failure"
+	}
+	AuthLoginDuration.Record(ctx, duration, metric.WithAttributes(
+		attribute.String(AttrAuthHandler, handlerName),
+		attribute.String(AttrAuthFlow, flow),
+		attribute.String(AttrStatus, status),
+	))
+}
+
+// RecordAuthStatus records auth status query duration.
+func RecordAuthStatus(ctx context.Context, handlerName string, duration float64, success bool) {
+	if AuthStatusDuration == nil {
+		return
+	}
+	status := "success"
+	if !success {
+		status = "failure"
+	}
+	AuthStatusDuration.Record(ctx, duration, metric.WithAttributes(
+		attribute.String(AttrAuthHandler, handlerName),
+		attribute.String(AttrStatus, status),
+	))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -32,6 +32,9 @@ func TestInitMetrics(t *testing.T) {
 	assert.NotNil(t, GetSolutionTimeHistogram)
 	assert.NotNil(t, ProviderExecutionDuration)
 	assert.NotNil(t, ProviderExecutionTotal)
+	assert.NotNil(t, AuthPluginStartupDuration)
+	assert.NotNil(t, AuthLoginDuration)
+	assert.NotNil(t, AuthStatusDuration)
 }
 
 // Not parallel: calls InitMetrics which mutates package-level globals.
@@ -214,6 +217,8 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "status", AttrStatus)
 	assert.Equal(t, "plugin_name", AttrPluginName)
 	assert.Equal(t, "source", AttrPluginSource)
+	assert.Equal(t, "auth_handler", AttrAuthHandler)
+	assert.Equal(t, "auth_flow", AttrAuthFlow)
 }
 
 // ── Benchmark tests ───────────────────────────────────────────────────────────
@@ -255,5 +260,104 @@ func BenchmarkSetCircuitBreakerState(b *testing.B) {
 	for b.Loop() {
 		SetCircuitBreakerState("bench-host", float64(i%3))
 		i++
+	}
+}
+
+// ── RecordAuthPluginStartup tests ────────────────────────────────────────────
+
+// Not parallel: calls InitMetrics which mutates package-level globals.
+func TestRecordAuthPluginStartup_Success(t *testing.T) {
+	_ = InitMetrics(context.Background())
+	assert.NotPanics(t, func() {
+		RecordAuthPluginStartup(context.Background(), "entra", 0.35)
+	})
+}
+
+// This test mutates package globals; do NOT add t.Parallel().
+func TestRecordAuthPluginStartup_NilInstrument(t *testing.T) {
+	saved := AuthPluginStartupDuration
+	AuthPluginStartupDuration = nil
+	defer func() { AuthPluginStartupDuration = saved }()
+
+	assert.NotPanics(t, func() {
+		RecordAuthPluginStartup(context.Background(), "test", 0.5)
+	})
+}
+
+// ── RecordAuthLogin tests ────────────────────────────────────────────────────
+
+// Not parallel: calls InitMetrics which mutates package-level globals.
+func TestRecordAuthLogin_Success(t *testing.T) {
+	_ = InitMetrics(context.Background())
+	assert.NotPanics(t, func() {
+		RecordAuthLogin(context.Background(), "github", "device_code", 2.5, true)
+	})
+}
+
+// Not parallel: calls InitMetrics which mutates package-level globals.
+func TestRecordAuthLogin_Failure(t *testing.T) {
+	_ = InitMetrics(context.Background())
+	assert.NotPanics(t, func() {
+		RecordAuthLogin(context.Background(), "entra", "interactive", 5.0, false)
+	})
+}
+
+// This test mutates package globals; do NOT add t.Parallel().
+func TestRecordAuthLogin_NilInstrument(t *testing.T) {
+	saved := AuthLoginDuration
+	AuthLoginDuration = nil
+	defer func() { AuthLoginDuration = saved }()
+
+	assert.NotPanics(t, func() {
+		RecordAuthLogin(context.Background(), "test", "device_code", 1.0, true)
+	})
+}
+
+// ── RecordAuthStatus tests ───────────────────────────────────────────────────
+
+// Not parallel: calls InitMetrics which mutates package-level globals.
+func TestRecordAuthStatus_Success(t *testing.T) {
+	_ = InitMetrics(context.Background())
+	assert.NotPanics(t, func() {
+		RecordAuthStatus(context.Background(), "gcp", 0.1, true)
+	})
+}
+
+// Not parallel: calls InitMetrics which mutates package-level globals.
+func TestRecordAuthStatus_Failure(t *testing.T) {
+	_ = InitMetrics(context.Background())
+	assert.NotPanics(t, func() {
+		RecordAuthStatus(context.Background(), "entra", 0.3, false)
+	})
+}
+
+// This test mutates package globals; do NOT add t.Parallel().
+func TestRecordAuthStatus_NilInstrument(t *testing.T) {
+	saved := AuthStatusDuration
+	AuthStatusDuration = nil
+	defer func() { AuthStatusDuration = saved }()
+
+	assert.NotPanics(t, func() {
+		RecordAuthStatus(context.Background(), "test", 0.1, true)
+	})
+}
+
+func BenchmarkRecordAuthLogin(b *testing.B) {
+	_ = InitMetrics(context.Background())
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		RecordAuthLogin(ctx, "bench-handler", "device_code", 1.5, true)
+	}
+}
+
+func BenchmarkRecordAuthStatus(b *testing.B) {
+	_ = InitMetrics(context.Background())
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		RecordAuthStatus(ctx, "bench-handler", 0.05, true)
 	}
 }

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -440,10 +440,11 @@ func Discover(pluginDirs []string, opts ...ClientOption) ([]*Client, error) {
 
 // AuthHandlerClient wraps a plugin client for auth handler plugins.
 type AuthHandlerClient struct {
-	pluginClient *plugin.Client
-	plugin       AuthHandlerPlugin
-	path         string
-	name         string
+	pluginClient    *plugin.Client
+	plugin          AuthHandlerPlugin
+	path            string
+	name            string
+	startupDuration time.Duration
 }
 
 // newAuthHandlerClientWithConnector creates an auth handler plugin client
@@ -455,6 +456,7 @@ func newAuthHandlerClientWithConnector(
 	connectFn func(string, pluginConfig) (any, *plugin.Client, error),
 	opts ...ClientOption,
 ) (*AuthHandlerClient, error) {
+	startupStart := time.Now()
 	authPlugin, client, err := buildPluginClient(
 		pluginPath,
 		opts,
@@ -482,10 +484,11 @@ func newAuthHandlerClientWithConnector(
 	}
 
 	return &AuthHandlerClient{
-		pluginClient: client,
-		plugin:       authPlugin,
-		path:         pluginPath,
-		name:         pluginNameFromPath(pluginPath),
+		pluginClient:    client,
+		plugin:          authPlugin,
+		path:            pluginPath,
+		name:            pluginNameFromPath(pluginPath),
+		startupDuration: time.Since(startupStart),
 	}, nil
 }
 
@@ -553,6 +556,11 @@ func (c *AuthHandlerClient) Name() string {
 // Path returns the plugin path.
 func (c *AuthHandlerClient) Path() string {
 	return c.path
+}
+
+// StartupDuration returns the time taken to start and handshake with the plugin process.
+func (c *AuthHandlerClient) StartupDuration() time.Duration {
+	return c.startupDuration
 }
 
 // DiscoverAuthHandlers discovers auth handler plugins from the given directories.

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -547,7 +547,8 @@ func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Regis
 			return nil, fmt.Errorf("getting auth handlers from plugin %s: %w", r.Name, err)
 		}
 
-		configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		registered := configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		propagateStartupLatency(ctx, registry, client, registered)
 
 		clients = append(clients, client)
 	}

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -10,12 +10,20 @@ import (
 	"maps"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/metrics"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// authTracer is the OpenTelemetry tracer for auth handler plugin operations.
+var authTracer = otel.Tracer("scafctl/plugin/auth")
 
 // Compile-time interface checks.
 var (
@@ -32,6 +40,7 @@ type AuthHandlerWrapper struct {
 	handlerName    string
 	info           AuthHandlerInfo
 	trustedDomains []string
+	startupLatency time.Duration
 	mu             sync.RWMutex
 }
 
@@ -88,6 +97,10 @@ func (w *AuthHandlerWrapper) Capabilities() []auth.Capability {
 
 // Login implements auth.Handler.
 func (w *AuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	ctx, span := authTracer.Start(ctx, "auth.plugin.login",
+		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
+	defer span.End()
+
 	lgr := logger.FromContext(ctx)
 	lgr.V(1).Info("login via plugin auth handler", "handler", w.handlerName)
 
@@ -150,11 +163,19 @@ func (w *AuthHandlerWrapper) Logout(ctx context.Context) error {
 
 // Status implements auth.Handler.
 func (w *AuthHandlerWrapper) Status(ctx context.Context) (*auth.Status, error) {
+	ctx, span := authTracer.Start(ctx, "auth.plugin.status",
+		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
+	defer span.End()
+
 	return w.client.plugin.GetStatus(ctx, w.handlerName)
 }
 
 // GetToken implements auth.Handler.
 func (w *AuthHandlerWrapper) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	ctx, span := authTracer.Start(ctx, "auth.plugin.get_token",
+		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
+	defer span.End()
+
 	req := TokenRequest{
 		Scope:        opts.Scope,
 		MinValidFor:  opts.MinValidFor,
@@ -214,11 +235,26 @@ func (w *AuthHandlerWrapper) Client() *AuthHandlerClient {
 	return w.client
 }
 
+// StartupLatency returns the plugin process startup latency.
+func (w *AuthHandlerWrapper) StartupLatency() time.Duration {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.startupLatency
+}
+
+// SetStartupLatency records the plugin process startup latency.
+func (w *AuthHandlerWrapper) SetStartupLatency(d time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.startupLatency = d
+}
+
 // configureAndRegisterAuthHandlers configures each handler with host-side
 // settings (when cfg is non-nil) and registers it in the auth registry.
 // It also sets trusted verification domains on each wrapper from the official
 // auth handler registry (per-handler) plus config.Auth.TrustedVerificationDomains.
-func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Registry, client *AuthHandlerClient, handlers []AuthHandlerInfo, cfg *ProviderConfig) {
+// Returns the names of successfully registered handlers.
+func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Registry, client *AuthHandlerClient, handlers []AuthHandlerInfo, cfg *ProviderConfig) []string {
 	lgr := logger.FromContext(ctx)
 
 	// Resolve trusted verification domains from context sources.
@@ -227,6 +263,8 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 	if appCfg := config.FromContext(ctx); appCfg != nil {
 		cfgDomains = appCfg.Auth.TrustedVerificationDomains
 	}
+
+	var registered []string
 
 	for _, info := range handlers {
 		// Pre-check registration before sending config to the plugin.
@@ -250,6 +288,8 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 			continue
 		}
 
+		registered = append(registered, info.Name)
+
 		// Configure only after successful registration so secrets are
 		// never sent to a plugin that won't actually be used.
 		if cfg != nil {
@@ -263,6 +303,27 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 					"error", cfgErr)
 			}
 		}
+	}
+
+	return registered
+}
+
+// propagateStartupLatency sets startup latency on each wrapper registered by a
+// specific client and records the associated metric. It iterates only the given
+// handler names instead of scanning the full registry.
+func propagateStartupLatency(ctx context.Context, registry *auth.Registry, client *AuthHandlerClient, names []string) {
+	startupDuration := client.StartupDuration()
+	for _, name := range names {
+		h, err := registry.Get(name)
+		if err != nil {
+			continue
+		}
+		w, ok := h.(*AuthHandlerWrapper)
+		if !ok {
+			continue
+		}
+		w.SetStartupLatency(startupDuration)
+		metrics.RecordAuthPluginStartup(ctx, name, startupDuration.Seconds())
 	}
 }
 
@@ -340,7 +401,9 @@ func RegisterAuthHandlerPlugins(ctx context.Context, registry *auth.Registry, pl
 			continue
 		}
 
-		configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		registered := configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		propagateStartupLatency(ctx, registry, client, registered)
+
 		allClients = append(allClients, client)
 	}
 

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,4 +115,95 @@ func TestInjectAuthHandlerSettings(t *testing.T) {
 			assert.Equal(t, tt.wantValue, m[tt.wantField])
 		})
 	}
+}
+
+func TestPropagateStartupLatency(t *testing.T) {
+	tests := []struct {
+		name           string
+		registerNames  []string
+		propagateNames []string
+		wantLatency    map[string]time.Duration
+	}{
+		{
+			name:           "sets latency on all registered wrappers",
+			registerNames:  []string{"handler-a", "handler-b"},
+			propagateNames: []string{"handler-a", "handler-b"},
+			wantLatency:    map[string]time.Duration{"handler-a": 42 * time.Millisecond, "handler-b": 42 * time.Millisecond},
+		},
+		{
+			name:           "only propagates to specified names",
+			registerNames:  []string{"handler-a", "handler-b"},
+			propagateNames: []string{"handler-a"},
+			wantLatency:    map[string]time.Duration{"handler-a": 42 * time.Millisecond, "handler-b": 0},
+		},
+		{
+			name:           "unknown names are skipped",
+			registerNames:  []string{"handler-a"},
+			propagateNames: []string{"handler-a", "nonexistent"},
+			wantLatency:    map[string]time.Duration{"handler-a": 42 * time.Millisecond},
+		},
+		{
+			name:           "empty names slice is no-op",
+			registerNames:  []string{"handler-a"},
+			propagateNames: []string{},
+			wantLatency:    map[string]time.Duration{"handler-a": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			reg := auth.NewRegistry()
+			client := &AuthHandlerClient{startupDuration: 42 * time.Millisecond}
+
+			for _, name := range tt.registerNames {
+				w := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: name})
+				require.NoError(t, reg.Register(w))
+			}
+
+			propagateStartupLatency(ctx, reg, client, tt.propagateNames)
+
+			for name, want := range tt.wantLatency {
+				h, err := reg.Get(name)
+				require.NoError(t, err)
+				w, ok := h.(*AuthHandlerWrapper)
+				require.True(t, ok)
+				assert.Equal(t, want, w.startupLatency, "latency mismatch for %s", name)
+			}
+		})
+	}
+}
+
+func TestConfigureAndRegisterAuthHandlers_ReturnsRegisteredNames(t *testing.T) {
+	ctx := context.Background()
+	reg := auth.NewRegistry()
+	client := &AuthHandlerClient{startupDuration: 10 * time.Millisecond}
+
+	handlers := []AuthHandlerInfo{
+		{Name: "handler-a", DisplayName: "Handler A"},
+		{Name: "handler-b", DisplayName: "Handler B"},
+	}
+
+	registered := configureAndRegisterAuthHandlers(ctx, reg, client, handlers, nil)
+	assert.Equal(t, []string{"handler-a", "handler-b"}, registered)
+	assert.True(t, reg.Has("handler-a"))
+	assert.True(t, reg.Has("handler-b"))
+}
+
+func TestConfigureAndRegisterAuthHandlers_SkipsDuplicates(t *testing.T) {
+	ctx := context.Background()
+	reg := auth.NewRegistry()
+	client := &AuthHandlerClient{startupDuration: 10 * time.Millisecond}
+
+	// Pre-register handler-a.
+	existing := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "handler-a"})
+	require.NoError(t, reg.Register(existing))
+
+	handlers := []AuthHandlerInfo{
+		{Name: "handler-a", DisplayName: "Handler A"},
+		{Name: "handler-b", DisplayName: "Handler B"},
+	}
+
+	registered := configureAndRegisterAuthHandlers(ctx, reg, client, handlers, nil)
+	assert.Equal(t, []string{"handler-b"}, registered)
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1932,6 +1932,35 @@ func TestIntegration_AuthHelp(t *testing.T) {
 	assert.Contains(t, stdout, "login")
 	assert.Contains(t, stdout, "logout")
 	assert.Contains(t, stdout, "status")
+	assert.Contains(t, stdout, "handlers")
+}
+
+func TestIntegration_AuthHandlers(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "handlers")
+
+	assert.Equal(t, 0, exitCode)
+	// The command should produce output listing available handlers.
+	assert.NotEmpty(t, stdout)
+}
+
+func TestIntegration_AuthHandlersJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "handlers", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	// JSON output must be valid and parseable.
+	var parsed []map[string]any
+	err := json.Unmarshal([]byte(stdout), &parsed)
+	assert.NoError(t, err, "output should be valid JSON")
+}
+
+func TestIntegration_AuthHandlersHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "handlers", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "handlers")
 }
 
 func TestIntegration_AuthList(t *testing.T) {


### PR DESCRIPTION
- add 'auth handlers' command listing installed, available, and catalog-fetchable auth handlers with status and flows
- replace handler-specific factory functions (getEntraHandlerWithOverrides, getGitHubHandlerWithOverrides, getGCPHandlerWithOverrides) with unified getHandlerWithOverrides that delegates to the auth registry
- replace direct credential detection imports with FlowDetector interface via detectAvailableFlowsAsDetectors, enabling plugin-based flow detection
- query handler statuses concurrently using errgroup in auth status command
- add OpenTelemetry spans for plugin login, status, and get_token operations
- add auth metrics: plugin startup duration, login duration, status duration
- track and report plugin startup latency in auth diagnose command
- extract Azure federated token env var constants to pkg/auth/constants.go
- add MockFlowDetectorHandler to auth mock for testing FlowDetector
- add auth handler migration guide documentation