### PR TITLE
feat(action): add `explicit` flag to exclude actions and resolvers from bare invocations

### DIFF
--- a/pkg/action/filter.go
+++ b/pkg/action/filter.go
@@ -10,14 +10,63 @@ import (
 
 // FilterWorkflowActions returns a new Workflow containing only the specified
 // actions and their transitive dependsOn dependencies. Finally actions are
-// always included regardless of the filter. When targetNames is empty the
-// original workflow is returned unchanged.
+// always included regardless of the filter. When targetNames is empty,
+// explicit actions (and their exclusive dependents) are excluded; any
+// non-explicit action whose transitive deps include an explicit action will
+// still pull that explicit action into the result.
 //
 // An error is returned if any target name does not match an action in the
 // workflow's actions section.
 func FilterWorkflowActions(w *Workflow, targetNames []string) (*Workflow, error) {
-	if len(targetNames) == 0 || w == nil {
+	if w == nil {
 		return w, nil
+	}
+
+	if len(targetNames) == 0 {
+		// Exclude explicit actions from bare invocations, but preserve
+		// dependency closure: start from all non-explicit actions, then
+		// collect their transitive deps (which may include explicit ones).
+		hasExplicit := false
+		for _, act := range w.Actions {
+			if act.Explicit {
+				hasExplicit = true
+				break
+			}
+		}
+		if !hasExplicit {
+			return w, nil
+		}
+
+		needed := make(map[string]bool)
+		var collectDeps func(name string)
+		collectDeps = func(name string) {
+			if needed[name] {
+				return
+			}
+			a, exists := w.Actions[name]
+			if !exists || a == nil {
+				return
+			}
+			needed[name] = true
+			for _, dep := range a.DependsOn {
+				collectDeps(dep)
+			}
+		}
+		for name, act := range w.Actions {
+			if !act.Explicit {
+				collectDeps(name)
+			}
+		}
+
+		filtered := &Workflow{
+			Actions:          make(map[string]*Action, len(needed)),
+			Finally:          w.Finally,
+			ResultSchemaMode: w.ResultSchemaMode,
+		}
+		for name := range needed {
+			filtered.Actions[name] = w.Actions[name]
+		}
+		return filtered, nil
 	}
 
 	// Build alias → name map for resolving alias references

--- a/pkg/action/filter_test.go
+++ b/pkg/action/filter_test.go
@@ -136,3 +136,102 @@ func TestFilterWorkflowActions_MissingDependency(t *testing.T) {
 	assert.NotNil(t, result.Actions["build"])
 	assert.Nil(t, result.Actions["missing"], "missing dep should not appear in filtered actions")
 }
+
+func TestFilterWorkflowActions_ExplicitExcluded(t *testing.T) {
+	t.Parallel()
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"build": {Name: "build"},
+			"test":  {Name: "test", DependsOn: []string{"build"}},
+			"info":  {Name: "info", Explicit: true},
+		},
+		Finally: map[string]*Action{
+			"cleanup": {Name: "cleanup"},
+		},
+	}
+
+	// Bare invocation excludes explicit
+	result, err := FilterWorkflowActions(w, nil)
+	require.NoError(t, err)
+	assert.Len(t, result.Actions, 2)
+	assert.NotNil(t, result.Actions["build"])
+	assert.NotNil(t, result.Actions["test"])
+	assert.Nil(t, result.Actions["info"])
+	assert.Len(t, result.Finally, 1)
+
+	// Explicit naming includes explicit
+	result, err = FilterWorkflowActions(w, []string{"info"})
+	require.NoError(t, err)
+	assert.Len(t, result.Actions, 1)
+	assert.NotNil(t, result.Actions["info"])
+}
+
+func TestFilterWorkflowActions_ExplicitAsDepIncluded(t *testing.T) {
+	t.Parallel()
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"setup":  {Name: "setup", Explicit: true},
+			"deploy": {Name: "deploy", DependsOn: []string{"setup"}},
+		},
+	}
+
+	// Naming "deploy" pulls in explicit "setup" via deps
+	result, err := FilterWorkflowActions(w, []string{"deploy"})
+	require.NoError(t, err)
+	assert.Len(t, result.Actions, 2)
+	assert.NotNil(t, result.Actions["setup"])
+	assert.NotNil(t, result.Actions["deploy"])
+}
+
+func TestFilterWorkflowActions_AllExplicit(t *testing.T) {
+	t.Parallel()
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"info":  {Name: "info", Explicit: true},
+			"debug": {Name: "debug", Explicit: true},
+		},
+	}
+
+	// Bare invocation with all explicit results in empty actions
+	result, err := FilterWorkflowActions(w, nil)
+	require.NoError(t, err)
+	assert.Len(t, result.Actions, 0)
+}
+
+func TestFilterWorkflowActions_ExplicitDepPreserved(t *testing.T) {
+	t.Parallel()
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"setup":  {Name: "setup", Explicit: true},
+			"deploy": {Name: "deploy", DependsOn: []string{"setup"}},
+		},
+	}
+
+	// Bare invocation: "deploy" is non-explicit and depends on "setup" (explicit).
+	// The dependency closure must pull "setup" in so the graph is valid.
+	result, err := FilterWorkflowActions(w, nil)
+	require.NoError(t, err)
+	assert.Len(t, result.Actions, 2)
+	assert.NotNil(t, result.Actions["setup"], "explicit dep should be preserved")
+	assert.NotNil(t, result.Actions["deploy"])
+}
+
+func TestFilterWorkflowActions_NoExplicitUnchanged(t *testing.T) {
+	t.Parallel()
+
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"build": {Name: "build"},
+			"test":  {Name: "test"},
+		},
+	}
+
+	// No explicit actions — returns original workflow
+	result, err := FilterWorkflowActions(w, nil)
+	require.NoError(t, err)
+	assert.Equal(t, w, result, "should return original workflow when no explicit actions exist")
+}

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -56,6 +56,11 @@ type Action struct {
 	// Sensitive indicates the action handles sensitive data (masks in logs).
 	Sensitive bool `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"If true, inputs and outputs are masked in logs"`
 
+	// Explicit marks this action as opt-in only. When true, the action is excluded
+	// from bare "run action" invocations and only runs when explicitly named on the CLI.
+	// Default is false (action runs normally). Not meaningful on finally actions.
+	Explicit bool `json:"explicit,omitempty" yaml:"explicit,omitempty" doc:"If true, action only runs when explicitly named on the CLI"`
+
 	// Provider specifies which action provider to use for execution.
 	// The provider must have CapabilityAction.
 	Provider string `json:"provider" yaml:"provider" doc:"Action provider name" maxLength:"100" example:"shell"`

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -59,13 +59,12 @@ var listColumnHints = map[string]tui.ColumnHint{
 	"kind":        {MaxWidth: 12, Priority: 10},
 	"displayName": {MaxWidth: 25, Priority: 6, DisplayName: "display name"},
 	"category":    {MaxWidth: 15, Priority: 4},
-	"digest":      {MaxWidth: 40, Priority: 2},
 	"catalog":     {MaxWidth: 25, Priority: 8},
 }
 
 // artifactListSchema controls table column display. Columns in the "required" array
-// (name, tag, kind, catalog) resist truncation; digest is visible but lower priority.
-// version and createdAt are hidden in table view but included in json/yaml output.
+// (name, tag, kind, catalog) resist truncation.
+// version, createdAt, and digest are hidden in table view but included in json/yaml output.
 var artifactListSchema = []byte(`{
 	"type": "array",
 	"items": {
@@ -79,7 +78,7 @@ var artifactListSchema = []byte(`{
 			"category":    { "type": "string", "title": "Category" },
 			"catalog":     { "type": "string", "title": "Catalog" },
 			"version":     { "type": "string", "deprecated": true },
-			"digest":      { "type": "string", "title": "Digest" },
+			"digest":      { "type": "string", "deprecated": true },
 			"createdAt":   { "type": "string", "deprecated": true }
 		}
 	}

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -227,7 +227,7 @@ func TestArtifactListSchema_RequiredFields(t *testing.T) {
 	assert.NotContains(t, requiredNames, "digest")
 }
 
-func TestArtifactListSchema_DigestVisible(t *testing.T) {
+func TestArtifactListSchema_DigestHiddenInTable(t *testing.T) {
 	t.Parallel()
 
 	var schema map[string]any
@@ -238,10 +238,10 @@ func TestArtifactListSchema_DigestVisible(t *testing.T) {
 	props := items["properties"].(map[string]any)
 	digest := props["digest"].(map[string]any)
 
-	// Digest should be visible (no deprecated flag)
-	_, hasDeprecated := digest["deprecated"]
-	assert.False(t, hasDeprecated, "digest column should not be deprecated (must be visible)")
-	assert.Equal(t, "Digest", digest["title"])
+	// Digest should be hidden from table view (deprecated flag set)
+	deprecated, ok := digest["deprecated"]
+	assert.True(t, ok, "digest column should have deprecated flag")
+	assert.Equal(t, true, deprecated, "digest column should be deprecated (hidden from table view)")
 }
 
 func TestArtifactListSchema_HiddenFields(t *testing.T) {
@@ -254,8 +254,8 @@ func TestArtifactListSchema_HiddenFields(t *testing.T) {
 	items := schema["items"].(map[string]any)
 	props := items["properties"].(map[string]any)
 
-	// version and createdAt should be hidden
-	for _, field := range []string{"version", "createdAt"} {
+	// version, createdAt, and digest should be hidden
+	for _, field := range []string{"version", "createdAt", "digest"} {
 		fieldMap := props[field].(map[string]any)
 		deprecated, ok := fieldMap["deprecated"]
 		assert.True(t, ok, "field %q should have deprecated", field)

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -314,13 +314,15 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 
 	// Apply action filter
 	workflow := sol.Spec.Workflow
-	if len(o.Names) > 0 {
+	{
 		filtered, filterErr := action.FilterWorkflowActions(workflow, o.Names)
 		if filterErr != nil {
 			return o.exitWithCode(ctx, filterErr, exitcode.InvalidInput)
 		}
 		workflow = filtered
-		lgr.V(1).Info("action filter applied", "targets", o.Names, "remaining", len(workflow.Actions))
+		if len(o.Names) > 0 {
+			lgr.V(1).Info("action filter applied", "targets", o.Names, "remaining", len(workflow.Actions))
+		}
 	}
 
 	// Parse resolver parameters

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -6,6 +6,7 @@ package run
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -336,7 +337,18 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// Prepare solution: load, set up registry, handle bundles
 	sol, reg, solutionDir, cleanup, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
-		return o.exitWithCode(ctx, err, exitcode.FileNotFound)
+		// When no -f/--file was provided, auto-discovery failed to find a
+		// solution file, and the first positional arg looks like a catalog
+		// reference, retry using that arg as the solution source.
+		if o.File == "" && errors.Is(err, get.ErrNoSolutionFound) && len(o.Names) > 0 && get.IsCatalogReference(o.Names[0]) {
+			o.File = o.Names[0]
+			o.Names = o.Names[1:]
+			lgr.V(1).Info("retrying with first positional arg as catalog reference", "file", o.File)
+			sol, reg, solutionDir, cleanup, err = o.prepareSolutionForExecution(ctx)
+		}
+		if err != nil {
+			return o.exitWithCode(ctx, err, exitcode.FileNotFound)
+		}
 	}
 	defer cleanup()
 

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -2275,3 +2275,40 @@ func TestParseResolverArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestResolverOptions_Run_CatalogFallback(t *testing.T) {
+	t.Parallel()
+
+	// When File is empty and the first positional arg is a catalog-style name,
+	// Run() should retry using that arg as the solution source after
+	// auto-discovery fails. The retry will also fail (no catalog configured),
+	// but we verify the fallback path is taken by checking that File is set
+	// and the arg is removed from Names.
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams: streams,
+			CliParams: cliParams,
+			File:      "",
+		},
+		Names: []string{"my-solution"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	// Run will fail because no catalog is configured, but the fallback
+	// should move Names[0] to File.
+	err := opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, "my-solution", opts.File, "fallback should set File to the first positional arg")
+	assert.Empty(t, opts.Names, "fallback should remove the arg from Names")
+}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -422,13 +422,15 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Finally actions are always preserved. Filtering happens on the original workflow
 	// before graph building so that pruned actions never enter the DAG.
 	workflow := sol.Spec.Workflow
-	if len(o.ActionNames) > 0 {
+	{
 		filtered, filterErr := action.FilterWorkflowActions(workflow, o.ActionNames)
 		if filterErr != nil {
 			return o.exitWithCode(ctx, filterErr, exitcode.InvalidInput)
 		}
 		workflow = filtered
-		lgr.V(1).Info("action filter applied", "targets", o.ActionNames, "remaining", len(workflow.Actions))
+		if len(o.ActionNames) > 0 {
+			lgr.V(1).Info("action filter applied", "targets", o.ActionNames, "remaining", len(workflow.Actions))
+		}
 	}
 
 	// Parse resolver parameters (pass stdin for @- support)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -392,6 +392,13 @@ func lintWorkflow(sol *solution.Solution, result *Result, registry *provider.Reg
 				"Move the action to workflow.actions or remove forEach",
 				"finally-with-foreach")
 		}
+
+		if act.Explicit {
+			result.addFinding(SeverityWarning, "workflow", location,
+				"explicit: true has no effect on finally actions",
+				"Remove explicit: true or move the action to workflow.actions",
+				"explicit-on-finally")
+		}
 	}
 
 	// Validate workflow structure (circular deps, etc.)

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1057,6 +1057,36 @@ func TestLintWorkflow_FinallyWithForEach(t *testing.T) {
 	assert.Contains(t, findings[0].Location, "cleanup")
 }
 
+func TestLintWorkflow_ExplicitOnFinally(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Workflow: &action.Workflow{
+				Actions: map[string]*action.Action{
+					"main": {
+						Name:        "main",
+						Description: "main action",
+					},
+				},
+				Finally: map[string]*action.Action{
+					"cleanup": {
+						Name:        "cleanup",
+						Description: "cleanup action",
+						Explicit:    true,
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "explicit-on-finally")
+	require.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Location, "cleanup")
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+}
+
 func TestLintAction_MissingProviderAndLongTimeout(t *testing.T) {
 	reg := provider.NewRegistry()
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -349,6 +349,14 @@ var KnownRules = map[string]RuleMeta{
 			"# Line suppression:\n# scafctl-lint-ignore: exec-command-injection\n\n# Block suppression:\n# scafctl-lint-disable: exec-command-injection\n...\n# scafctl-lint-enable: exec-command-injection\n\n# File-level suppression:\n# scafctl-lint-disable-file: exec-command-injection",
 		},
 	},
+	"explicit-on-finally": {
+		Rule:        "explicit-on-finally",
+		Severity:    string(SeverityWarning),
+		Category:    "workflow",
+		Description: "A finally action has explicit: true, which has no effect because finally actions always run.",
+		Why:         "Finally actions execute unconditionally after all regular actions complete. Setting explicit: true is misleading because the action cannot be excluded from execution.",
+		Fix:         "Remove explicit: true from the finally action, or move the action to workflow.actions if it should be opt-in.",
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 35 rules — update this when new rules are added
-	assert.Equal(t, 35, len(KnownRules), "expected 35 known lint rules")
+	// We expect exactly 36 rules — update this when new rules are added
+	assert.Equal(t, 36, len(KnownRules), "expected 36 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -155,6 +155,7 @@ type Resolver struct {
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"Display name for UI" maxLength:"80" example:"Environment"`
 	Sensitive   bool   `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether value should be redacted in table output and logs (JSON/YAML output reveals values for machine consumption)" example:"false"`
 	Internal    bool   `json:"internal,omitempty" yaml:"internal,omitempty" doc:"Whether this resolver is internal (excluded from default output, included in structured output)"`
+	Explicit    bool   `json:"explicit,omitempty" yaml:"explicit,omitempty" doc:"If true, resolver only runs when explicitly named on the CLI"`
 	Example     any    `json:"example,omitempty" yaml:"example,omitempty" doc:"Example value for documentation"`
 
 	// Type declaration

--- a/pkg/solution/execute/results.go
+++ b/pkg/solution/execute/results.go
@@ -54,12 +54,60 @@ func ResolverProviderName(r *resolver.Resolver) string {
 }
 
 // FilterResolversWithDependencies returns the specified resolvers and all their dependencies.
-// When targetNames is empty, all resolvers are returned.
+// When targetNames is empty, explicit resolvers are excluded unless they are
+// transitively required by a non-explicit resolver.
 // Uses resolver.ExtractDependencies to detect dependencies from CEL expressions,
 // Go templates, explicit rslvr: references, and provider-specific extraction.
 func FilterResolversWithDependencies(resolvers []*resolver.Resolver, targetNames []string, lookup resolver.DescriptorLookup) []*resolver.Resolver {
 	if len(targetNames) == 0 {
-		return resolvers
+		// Exclude explicit resolvers from bare invocations, but preserve
+		// dependency closure: start from all non-explicit resolvers, then
+		// collect their transitive deps (which may include explicit ones).
+		hasExplicit := false
+		for _, r := range resolvers {
+			if r.Explicit {
+				hasExplicit = true
+				break
+			}
+		}
+		if !hasExplicit {
+			return resolvers
+		}
+
+		resolverMap := make(map[string]*resolver.Resolver, len(resolvers))
+		for _, r := range resolvers {
+			resolverMap[r.Name] = r
+		}
+
+		needed := make(map[string]bool)
+		var collectDeps func(name string)
+		collectDeps = func(name string) {
+			if needed[name] {
+				return
+			}
+			r, exists := resolverMap[name]
+			if !exists {
+				return
+			}
+			needed[name] = true
+			deps := resolver.ExtractDependencies(r, lookup)
+			for _, dep := range deps {
+				collectDeps(dep)
+			}
+		}
+		for _, r := range resolvers {
+			if !r.Explicit {
+				collectDeps(r.Name)
+			}
+		}
+
+		var result []*resolver.Resolver
+		for _, r := range resolvers {
+			if needed[r.Name] {
+				result = append(result, r)
+			}
+		}
+		return result
 	}
 
 	// Build a map of resolvers by name

--- a/pkg/solution/execute/results_test.go
+++ b/pkg/solution/execute/results_test.go
@@ -88,6 +88,71 @@ func TestFilterResolversWithDependencies_TargetOnly(t *testing.T) {
 	assert.Equal(t, "b", result[0].Name)
 }
 
+func TestFilterResolversWithDependencies_ExplicitExcluded(t *testing.T) {
+	t.Parallel()
+
+	resolvers := []*resolver.Resolver{
+		{Name: "a"},
+		{Name: "b"},
+		{Name: "debug", Explicit: true},
+	}
+
+	// Bare invocation excludes explicit
+	result := FilterResolversWithDependencies(resolvers, nil, nil)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "a", result[0].Name)
+	assert.Equal(t, "b", result[1].Name)
+}
+
+func TestFilterResolversWithDependencies_ExplicitIncludedWhenNamed(t *testing.T) {
+	t.Parallel()
+
+	resolvers := []*resolver.Resolver{
+		{Name: "a"},
+		{Name: "debug", Explicit: true, Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{{Provider: "static"}},
+		}},
+	}
+
+	result := FilterResolversWithDependencies(resolvers, []string{"debug"}, nil)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "debug", result[0].Name)
+}
+
+func TestFilterResolversWithDependencies_NoExplicitUnchanged(t *testing.T) {
+	t.Parallel()
+
+	resolvers := []*resolver.Resolver{
+		{Name: "a"},
+		{Name: "b"},
+	}
+
+	// No explicit resolvers — returns original slice
+	result := FilterResolversWithDependencies(resolvers, nil, nil)
+	assert.Len(t, result, 2)
+	assert.Equal(t, resolvers, result, "should return original slice when no explicit resolvers exist")
+}
+
+func TestFilterResolversWithDependencies_ExplicitDepPreserved(t *testing.T) {
+	t.Parallel()
+
+	resolvers := []*resolver.Resolver{
+		{Name: "config", Explicit: true, Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{{Provider: "static"}},
+		}},
+		{Name: "app", DependsOn: []string{"config"}, Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{{Provider: "static"}},
+		}},
+	}
+
+	// Bare invocation: "app" is non-explicit and depends on "config" (explicit).
+	// The dependency closure must preserve "config".
+	result := FilterResolversWithDependencies(resolvers, nil, nil)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "config", result[0].Name, "explicit dep should be preserved")
+	assert.Equal(t, "app", result[1].Name)
+}
+
 func TestBuildExecutionData(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -5,6 +5,7 @@ package get
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +29,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ErrNoSolutionFound is returned when no solution path was provided and
+// auto-discovery did not find a solution file in any default location.
+var ErrNoSolutionFound = errors.New("no solution path provided and no solution file found in default locations")
 
 // CatalogResolver is an interface for fetching solutions from a catalog.
 // This avoids a circular dependency with the catalog package.
@@ -278,7 +283,7 @@ func (o *Getter) Get(ctx context.Context, path string) (*solution.Solution, erro
 	}()
 
 	if path == "" {
-		return nil, fmt.Errorf("no solution path provided and no solution file found in default locations")
+		return nil, ErrNoSolutionFound
 	}
 
 	// Check if this is a bare name that should be resolved from catalog.
@@ -340,7 +345,7 @@ func (o *Getter) GetWithBundle(ctx context.Context, path string) (*solution.Solu
 	}()
 
 	if path == "" {
-		return nil, nil, fmt.Errorf("no solution path provided and no solution file found in default locations")
+		return nil, nil, ErrNoSolutionFound
 	}
 
 	// Check if this is a bare name that should be resolved from catalog


### PR DESCRIPTION
- add Explicit bool field to Action and Resolver structs
- update FilterWorkflowActions to exclude explicit actions when no target names are specified
- update FilterResolversWithDependencies to exclude explicit resolvers when no target names are specified
- always call FilterWorkflowActions in run solution and run action commands so explicit filtering applies on bare runs
- add explicit-on-finally lint rule warning when explicit: true is set on finally actions (has no effect)
- add resolver catalog fallback so `run resolver my-app` auto- resolves catalog references like `run solution` does
- hide digest column from catalog list table output

Closes #288
Closes #369