### PR TITLE
feat: add version bumping, solution listing, and API path validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ permissions:
   packages: write
   id-token: write  # Required for cosign keyless signing via OIDC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: Lint

--- a/pkg/api/endpoints/solutions.go
+++ b/pkg/api/endpoints/solutions.go
@@ -109,16 +109,65 @@ type SolutionTestResponse struct {
 	}
 }
 
-// requireURLPath returns a 400 Huma error if path is not an HTTP or HTTPS URL.
-// API-supplied solution paths must be URLs — local file system access is not
-// permitted via the API, as the server cannot safely access arbitrary local
-// paths supplied by remote callers.
-func requireURLPath(path, opName string) error {
-	lower := strings.ToLower(path)
-	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+// requireRemotePath returns a 400 Huma error if path looks like a local
+// filesystem reference. The API server accepts HTTP/HTTPS URLs and catalog
+// names. Local file paths are blocked because the server cannot safely
+// access arbitrary paths supplied by remote callers.
+func requireRemotePath(path, opName string) error {
+	if path == "" {
 		return huma.NewError(http.StatusBadRequest,
-			fmt.Sprintf("%s: path must be an HTTP or HTTPS URL", opName))
+			fmt.Sprintf("%s: path is required", opName))
 	}
+
+	// Reject path-traversal segments regardless of surrounding context.
+	for _, seg := range strings.Split(path, "/") {
+		if seg == ".." {
+			return huma.NewError(http.StatusBadRequest,
+				fmt.Sprintf("%s: path must not contain '..' segments", opName))
+		}
+	}
+
+	lower := strings.ToLower(path)
+
+	// Explicitly allowed schemes.
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return nil
+	}
+
+	// Block all other URL schemes (file://, ftp://, data://, oci://, etc.).
+	if strings.Contains(lower, "://") {
+		return huma.NewError(http.StatusBadRequest,
+			fmt.Sprintf("%s: unsupported URL scheme; only http:// and https:// are allowed", opName))
+	}
+
+	// Block obvious local-path indicators.
+	if strings.HasPrefix(path, "/") || strings.HasPrefix(path, ".") ||
+		strings.HasPrefix(path, "~") || strings.Contains(path, "\\") ||
+		scafpath.HasWindowsDrivePrefix(path) {
+		return huma.NewError(http.StatusBadRequest,
+			fmt.Sprintf("%s: path must be a URL or catalog reference, not a local file path", opName))
+	}
+
+	// Bare filenames ending in .yaml/.yml/.json are almost certainly local files.
+	if strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".json") {
+		return huma.NewError(http.StatusBadRequest,
+			fmt.Sprintf("%s: path must be a URL or catalog reference, not a local file path", opName))
+	}
+
+	// Paths containing "/" are either registry refs (ghcr.io/org/sol) or
+	// relative local paths (configs/secret, dir/../../etc/passwd). Registry
+	// hostnames always contain "." or ":" in the first segment; plain
+	// directory names do not. Block the latter to prevent path traversal.
+	if strings.Contains(path, "/") {
+		firstSegment := strings.SplitN(path, "/", 2)[0]
+		if !strings.Contains(firstSegment, ".") && !strings.Contains(firstSegment, ":") {
+			return huma.NewError(http.StatusBadRequest,
+				fmt.Sprintf("%s: path must be a URL or catalog reference, not a local file path", opName))
+		}
+	}
+
+	// Anything else is treated as a catalog reference (e.g. "my-app",
+	// "my-app@1.0.0", "ghcr.io/org/solution").
 	return nil
 }
 
@@ -145,7 +194,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Validates a solution file and returns findings (errors, warnings, info).",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionLintRequest) (*SolutionLintResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-lint"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-lint"); err != nil {
 			return nil, err
 		}
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
@@ -166,7 +215,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Loads a solution and returns its full structural explanation.",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionInspectRequest) (*SolutionInspectResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-inspect"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-inspect"); err != nil {
 			return nil, err
 		}
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
@@ -187,7 +236,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Performs a dry run of the solution, showing what actions would be taken without executing them.",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionDryRunRequest) (*SolutionDryRunResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-dryrun"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-dryrun"); err != nil {
 			return nil, err
 		}
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
@@ -226,7 +275,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Executes a solution: resolves all inputs and runs the action workflow.",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionRunRequest) (*SolutionRunResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-run"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-run"); err != nil {
 			return nil, err
 		}
 		if input.Body.OutputDir != "" {
@@ -290,7 +339,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Resolves all inputs in a solution without executing actions. Returns the resolved values.",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionRenderRequest) (*SolutionRenderResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-render"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-render"); err != nil {
 			return nil, err
 		}
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
@@ -330,7 +379,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		Description: "Validates a solution's structure and workflow against the provider registry.",
 		Tags:        []string{"Solutions"},
 	}, hctx, http.StatusOK), func(ctx context.Context, input *SolutionTestRequest) (*SolutionTestResponse, error) {
-		if err := requireURLPath(input.Body.Path, "solution-test"); err != nil {
+		if err := requireRemotePath(input.Body.Path, "solution-test"); err != nil {
 			return nil, err
 		}
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)

--- a/pkg/api/endpoints/solutions_test.go
+++ b/pkg/api/endpoints/solutions_test.go
@@ -250,7 +250,7 @@ func TestRejectUnsafePath_Direct(t *testing.T) {
 }
 
 // TestSolutionRun_UnsafeOutputDir_ViaURL passes a valid HTTP URL for path so that
-// requireURLPath succeeds, then verifies rejectUnsafePath blocks the unsafe outputDir.
+// requireRemotePath succeeds, then verifies rejectUnsafePath blocks the unsafe outputDir.
 func TestSolutionRun_UnsafeOutputDir_ViaURL(t *testing.T) {
 	unsafe := []string{"/etc/passwd", "../secret", "~/evil"}
 	for _, tc := range unsafe {
@@ -263,5 +263,79 @@ func TestSolutionRun_UnsafeOutputDir_ViaURL(t *testing.T) {
 			resp := testAPI.Post("/v1/solutions/run", body, "Content-Type: application/json")
 			assert.Equal(t, http.StatusBadRequest, resp.Code, "expected 400 for unsafe outputDir %q", tc)
 		})
+	}
+}
+
+// ── requireRemotePath tests ──
+
+func TestRequireRemotePath_AllowedPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "https URL", path: "https://example.com/solution.yaml"},
+		{name: "http URL", path: "http://example.com/solution.yaml"},
+		{name: "catalog name", path: "my-solution"},
+		{name: "versioned catalog ref", path: "my-solution@1.0.0"},
+		{name: "registry ref", path: "ghcr.io/org/solution"},
+		{name: "registry ref with port", path: "localhost:5000/solution"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireRemotePath(tt.path, "test-op")
+			assert.NoError(t, err, "path %q should be allowed", tt.path)
+		})
+	}
+}
+
+func TestRequireRemotePath_BlockedPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "absolute unix path", path: "/etc/solution.yaml"},
+		{name: "relative dot path", path: "./solution.yaml"},
+		{name: "parent dir path", path: "../solution.yaml"},
+		{name: "home tilde", path: "~/solutions/my-app.yaml"},
+		{name: "windows backslash", path: "dir\\solution.yaml"},
+		{name: "windows drive", path: "C:\\solutions\\app.yaml"},
+		{name: "bare yaml file", path: "solution.yaml"},
+		{name: "bare yml file", path: "solution.yml"},
+		{name: "bare json file", path: "config.json"},
+		{name: "empty string", path: ""},
+		{name: "file scheme", path: "file:///etc/passwd"},
+		{name: "file scheme uppercase", path: "FILE:///etc/passwd"},
+		{name: "oci scheme", path: "oci://ghcr.io/org/solution:1.0.0"},
+		{name: "relative dir path", path: "configs/secret"},
+		{name: "path traversal", path: "dir/../../etc/passwd"},
+		{name: "path traversal via hostname", path: "ghcr.io/../../etc/passwd"},
+		{name: "path traversal in https URL", path: "https://example.com/../etc/passwd"},
+		{name: "nested relative", path: "a/b/c/solution"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireRemotePath(tt.path, "test-op")
+			assert.Error(t, err, "path %q should be blocked", tt.path)
+		})
+	}
+}
+
+func TestRequireRemotePath_CatalogNameViaRunEndpoint(t *testing.T) {
+	_, testAPI := humatest.New(t)
+	hctx := newTestHandlerContext(t)
+	RegisterSolutionEndpoints(testAPI, hctx, "/v1")
+
+	// Catalog name should pass validation (will fail later at resolution, not here)
+	resp := testAPI.Post("/v1/solutions/run", `{"path": "entra-user-groups"}`)
+	// Should NOT be 400 "path must be a URL" — any non-400 or a different 400 is acceptable
+	if resp.Code == http.StatusBadRequest {
+		assert.NotContains(t, resp.Body.String(), "not a local file path",
+			"catalog name should not be rejected as a local file path")
 	}
 }

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -5,6 +5,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -52,6 +53,7 @@ type SolutionOptions struct {
 	AllowDirty      bool
 	NoGitMetadata   bool
 	BaseDir         string
+	Bump            string
 	CliParams       *settings.Run
 	IOStreams       *terminal.IOStreams
 
@@ -123,6 +125,16 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate --bump value early
+			if options.Bump != "" {
+				if _, err := solution.ParseBumpLevel(options.Bump); err != nil {
+					if w := writer.FromContext(cmd.Context()); w != nil {
+						w.Errorf("%v", err)
+					}
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+			}
+
 			// Parse -t/--tag if provided: supports both "name@version" and
 			// full remote refs like "registry/repo/solutions/name@version".
 			if options.Tag != "" {
@@ -180,6 +192,15 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 				}
 			}
 
+			// --bump conflicts with --version (explicit or derived from --tag)
+			if options.Bump != "" && options.Version != "" {
+				err := fmt.Errorf("--bump cannot be used together with --version or a versioned --tag")
+				if w := writer.FromContext(cmd.Context()); w != nil {
+					w.Errorf("%v", err)
+				}
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
 			if options.File == "" {
 				getter := get.NewGetterFromContext(cmd.Context())
 				options.File = getter.FindSolution()
@@ -223,6 +244,7 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 	cmd.Flags().BoolVar(&options.AllowDirty, "allow-dirty", false, "Suppress warning when building from a dirty working tree")
 	cmd.Flags().BoolVar(&options.NoGitMetadata, "no-git-metadata", false, "Skip git commit and dirty-state annotations on the built artifact")
 	cmd.Flags().StringVar(&options.BaseDir, "base-dir", "", "Override base directory for resolving relative paths in the solution (default: solution file's directory)")
+	cmd.Flags().StringVar(&options.Bump, "bump", "", "Auto-increment version based on last published version (patch, minor, major)")
 
 	return cmd
 }
@@ -297,24 +319,48 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	// Determine version (priority: --version flag > metadata.version > auto-increment)
-	version, versionOverride, err := solution.ResolveArtifactVersion(opts.Version, sol.Metadata.Version)
-	if err != nil {
-		// No explicit version and no metadata version — try auto-increment
-		if opts.Version == "" && sol.Metadata.Version == nil {
-			localCat, catErr := catalog.NewLocalCatalog(*lgr)
-			if catErr == nil {
-				nextVer, nextErr := solution.NextPatchVersion(ctx, localCat, catalog.ArtifactKindSolution, name)
-				if nextErr == nil {
-					version = nextVer
-					w.Infof("Auto-incremented version to %s", version.String())
-					err = nil
+	// Determine version (priority: --bump > --version flag > metadata.version > auto-increment)
+	var version *semver.Version
+	var versionOverride bool
+	if opts.Bump != "" {
+		bumpLevel, _ := solution.ParseBumpLevel(opts.Bump) // already validated
+		localCat, catErr := catalog.NewLocalCatalog(*lgr)
+		if catErr != nil {
+			w.Errorf("--bump requires a local catalog: %v", catErr)
+			return exitcode.WithCode(catErr, exitcode.CatalogError)
+		}
+		bumpVer, bumpErr := solution.BumpVersion(ctx, localCat, catalog.ArtifactKindSolution, name, bumpLevel)
+		if bumpErr != nil {
+			w.Errorf("--bump: %v", bumpErr)
+			code := exitcode.CatalogError
+			var noVersions *solution.ErrNoVersions
+			if errors.As(bumpErr, &noVersions) {
+				code = exitcode.InvalidInput
+			}
+			return exitcode.WithCode(bumpErr, code)
+		}
+		version = bumpVer
+		w.Infof("Bumped version to %s (%s)", version.String(), opts.Bump)
+	} else {
+		var err error
+		version, versionOverride, err = solution.ResolveArtifactVersion(opts.Version, sol.Metadata.Version)
+		if err != nil {
+			// No explicit version and no metadata version — try auto-increment
+			if opts.Version == "" && sol.Metadata.Version == nil {
+				localCat, catErr := catalog.NewLocalCatalog(*lgr)
+				if catErr == nil {
+					nextVer, nextErr := solution.NextPatchVersion(ctx, localCat, catalog.ArtifactKindSolution, name)
+					if nextErr == nil {
+						version = nextVer
+						w.Infof("Auto-incremented version to %s", version.String())
+						err = nil
+					}
 				}
 			}
-		}
-		if err != nil {
-			w.Errorf("%v", err)
-			return exitcode.WithCode(err, exitcode.InvalidInput)
+			if err != nil {
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
 		}
 	}
 	if versionOverride {
@@ -348,9 +394,15 @@ func runBuildSolution(ctx context.Context, opts *SolutionOptions) error {
 			sol.Metadata.Annotations[catalog.AnnotationBuildCommit] = repoStatus.Commit
 			if repoStatus.IsDirty {
 				sol.Metadata.Annotations[catalog.AnnotationBuildDirty] = "true"
+			} else {
+				delete(sol.Metadata.Annotations, catalog.AnnotationBuildDirty)
 			}
 			w.Verbosef("Git metadata: commit=%s dirty=%v", repoStatus.Commit, repoStatus.IsDirty)
 		}
+	} else {
+		// --no-git-metadata: strip any pre-existing build annotations.
+		delete(sol.Metadata.Annotations, catalog.AnnotationBuildCommit)
+		delete(sol.Metadata.Annotations, catalog.AnnotationBuildDirty)
 	}
 
 	// Stamp resolved name and version into the solution so the stored

--- a/pkg/cmd/scafctl/build/solution_test.go
+++ b/pkg/cmd/scafctl/build/solution_test.go
@@ -4,11 +4,19 @@
 package build
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/format"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -171,4 +179,159 @@ func TestTagFlagRemoteRefParsing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommandBuildSolution_BumpFlag(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+
+	f := cmd.Flags().Lookup("bump")
+	require.NotNil(t, f, "--bump flag should exist")
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestCommandBuildSolution_BumpConflictsWithVersion(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetArgs([]string{"--bump", "patch", "--version", "1.0.0", "-f", "test.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error()+errBuf.String(), "--bump cannot be used together with --version or a versioned --tag")
+}
+
+func TestCommandBuildSolution_BumpInvalidLevel(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetArgs([]string{"--bump", "invalid", "-f", "test.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error()+errBuf.String(), "invalid bump level")
+}
+
+func TestCommandBuildSolution_BumpConflictsWithVersionedTag(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetArgs([]string{"--bump", "patch", "-t", "my-solution@1.0.0", "-f", "test.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error()+errBuf.String(), "--bump cannot be used together with --version or a versioned --tag")
+}
+
+func TestCommandBuildSolution_TagLatestRejected(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, cliParams)
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetContext(writer.WithWriter(context.Background(), w))
+	cmd.SetArgs([]string{"-t", "my-solution@latest", "-f", "test.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'latest' is not a valid build version")
+}
+
+func TestCommandBuildSolution_TagRemoteRefWrongKind(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, cliParams)
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetContext(writer.WithWriter(context.Background(), w))
+	cmd.SetArgs([]string{"-t", "ghcr.io/myorg/providers/my-provider@1.0.0", "-f", "test.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "references kind")
+}
+
+func TestCommandBuildSolution_TagRemoteRefSetsNameAndVersion(t *testing.T) {
+	t.Parallel()
+
+	// A valid remote --tag should parse without tag errors.
+	// The command will fail later (no solution file), but tag parsing succeeds.
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, cliParams)
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetContext(writer.WithWriter(context.Background(), w))
+	cmd.SetArgs([]string{"-t", "ghcr.io/myorg/solutions/my-solution@2.0.0", "-f", "/nonexistent/solution.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid tag")
+	assert.NotContains(t, err.Error(), "references kind")
+}
+
+func TestCommandBuildSolution_BumpWithUnversionedTag(t *testing.T) {
+	t.Parallel()
+
+	// --bump with a name-only tag (no version) should NOT conflict.
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, cliParams)
+	cmd := CommandBuildSolution(cliParams, ioStreams, "build")
+	cmd.SetContext(writer.WithWriter(context.Background(), w))
+	cmd.SetArgs([]string{"--bump", "patch", "-t", "my-solution", "-f", "/nonexistent/solution.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "--bump cannot be used together with --version")
+}
+
+func TestRunBuildSolution_NoGitMetadata(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Write solution file with pre-existing git annotations.
+	solFile := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: git-test
+  version: 1.0.0
+  annotations:
+    io.scafctl.build.commit: "abc123"
+    io.scafctl.build.dirty: "true"
+spec: {}
+`), 0o644))
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, &settings.Run{NoColor: true, BinaryName: "testcli"})
+	ctx := writer.WithWriter(context.Background(), w)
+	nlgr := logr.Discard()
+	ctx = logger.WithLogger(ctx, &nlgr)
+
+	opts := &SolutionOptions{
+		File:          solFile,
+		Version:       "1.0.0",
+		DryRun:        true,
+		NoBundle:      true,
+		SkipLint:      true,
+		SkipTests:     true,
+		NoGitMetadata: true,
+		CliParams:     &settings.Run{NoColor: true, BinaryName: "testcli"},
+		IOStreams:     ioStreams,
+	}
+	err := runBuildSolution(ctx, opts)
+	require.NoError(t, err)
+	assert.Contains(t, outBuf.String(), "Dry run: would build git-test@1.0.0")
 }

--- a/pkg/cmd/scafctl/catalog/push.go
+++ b/pkg/cmd/scafctl/catalog/push.go
@@ -35,6 +35,7 @@ type PushOptions struct {
 	DryRun     bool   // Show what would be pushed without pushing (--dry-run)
 	Insecure   bool   // Allow HTTP (--insecure)
 	SBOM       bool   // Auto-generate and attach SBOM (--sbom)
+	Latest     bool   // Tag the pushed version as "latest" (--latest)
 	CliParams  *settings.Run
 	IOStreams  *terminal.IOStreams
 }
@@ -103,6 +104,7 @@ func CommandPush(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Show what would be pushed without actually pushing")
 	cmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Allow insecure HTTP connections")
 	cmd.Flags().BoolVar(&options.SBOM, "sbom", false, "Auto-generate and attach an SPDX SBOM after pushing")
+	cmd.Flags().BoolVar(&options.Latest, "latest", false, "Tag the pushed version as 'latest' in the remote registry")
 
 	return cmd
 }
@@ -253,6 +255,9 @@ func runPush(ctx context.Context, opts *PushOptions) error {
 		if opts.Force {
 			w.Infof("  --force: would overwrite if exists")
 		}
+		if opts.Latest {
+			w.Infof("  --latest: would tag as \"latest\"")
+		}
 		return nil
 	}
 
@@ -328,6 +333,24 @@ func runPush(ctx context.Context, opts *PushOptions) error {
 		if err := attachSBOM(ctx, opts, localCatalog, remoteCatalog, ref); err != nil {
 			w.Warningf("SBOM attachment failed: %v", err)
 			// Non-fatal: the push itself succeeded
+		}
+	}
+
+	// Tag as "latest" in the remote registry if requested.
+	// This intentionally bypasses catalog.ValidateAlias (which rejects "latest")
+	// because push --latest is a publish-time concern, not a manual alias operation.
+	if opts.Latest {
+		tagRef := ref
+		if opts.TargetName != "" {
+			tagRef.Name = opts.TargetName
+		}
+		w.Infof("Tagging %s@%s as \"latest\"...", displayName, tagRef.Version.String())
+		_, tagErr := remoteCatalog.Tag(ctx, tagRef, "latest")
+		if tagErr != nil {
+			w.Warningf("failed to tag as latest: %v", tagErr)
+			// Non-fatal: the push itself succeeded
+		} else {
+			w.Successf("Tagged %s@%s as \"latest\"", displayName, ref.Version.String())
 		}
 	}
 

--- a/pkg/cmd/scafctl/catalog/push_test.go
+++ b/pkg/cmd/scafctl/catalog/push_test.go
@@ -131,6 +131,18 @@ func TestCommandPush_LocalRefNoCatalog(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCommandPush_LatestFlag(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandPush(cliParams, ioStreams, "scafctl/catalog")
+
+	f := cmd.Flags().Lookup("latest")
+	require.NotNil(t, f, "latest flag should exist")
+	assert.Equal(t, "false", f.DefValue)
+}
+
 func BenchmarkCommandPush(b *testing.B) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()

--- a/pkg/cmd/scafctl/get/solution/solution.go
+++ b/pkg/cmd/scafctl/get/solution/solution.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/cache"
@@ -35,6 +36,7 @@ type CmdOptionsVersion struct {
 	Output    string
 	File      string
 	NoCache   bool
+	Local     bool
 }
 
 func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
@@ -42,8 +44,33 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 	cCmd := &cobra.Command{
 		Use:     "solution [name[@version]]",
 		Aliases: []string{"sol", "SOL", "Solution", "solutions"},
-		Short:   fmt.Sprintf("Gets %s solutions", strings.SplitN(path, "/", 2)[0]),
-		Args:    cobra.MaximumNArgs(1),
+		Short:   fmt.Sprintf("List or get %s solutions", strings.SplitN(path, "/", 2)[0]),
+		Long: strings.ReplaceAll(`List solutions from the catalog or get details about a specific solution.
+
+Without arguments, lists solutions from the configured catalog (and local catalog).
+With a name argument or --file flag, shows details for a specific solution.
+Use --local to auto-discover and display a solution from the current directory.
+
+Examples:
+  # List all solutions in the catalog
+  scafctl get solutions
+
+  # Get a specific solution from the catalog
+  scafctl get solution my-solution
+
+  # Get a specific version
+  scafctl get solution my-solution@1.0.0
+
+  # Auto-discover and display a local solution
+  scafctl get solution --local
+
+  # Get a solution from a file
+  scafctl get solution -f ./solution.yaml
+
+  # Output as JSON
+  scafctl get solution my-solution -o json
+`, settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Name())
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
@@ -79,13 +106,20 @@ func CommandSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
+
+			// No args, no --file, and not --local: list solutions from catalog
+			if len(args) == 0 && options.File == "" && !options.Local {
+				return options.ListSolutions(ctx)
+			}
+
 			return options.GetSolution(ctx)
 		},
 		SilenceUsage: true,
 	}
 	cCmd.PersistentFlags().StringVarP(&options.Output, "output", "o", "", fmt.Sprintf("Output format. One of: (%s)", strings.Join(ValidOutputTypes, ", ")))
-	cCmd.PersistentFlags().StringVarP(&options.File, "file", "f", "", "Path to the solution. This can be a local file path or a URL. If not provided, the command will attempt to locate a solution file in default locations.")
+	cCmd.PersistentFlags().StringVarP(&options.File, "file", "f", "", "Path to the solution. This can be a local file path or a URL. If not provided and no arguments given, lists catalog solutions.")
 	cCmd.PersistentFlags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
+	cCmd.PersistentFlags().BoolVar(&options.Local, "local", false, "Auto-discover and display a solution from the current directory")
 	return cCmd
 }
 
@@ -175,6 +209,103 @@ func (o *CmdOptionsVersion) GetSolutionWithGetter(ctx context.Context, getter ge
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
 	return nil
+}
+
+// ListSolutions lists solutions from the local and configured catalogs.
+func (o *CmdOptionsVersion) ListSolutions(ctx context.Context) error {
+	lgr := logger.FromContext(ctx)
+	w := writer.FromContext(ctx)
+
+	var artifacts []catalog.ArtifactInfo
+
+	// List from local catalog
+	localCatalog, err := catalog.NewLocalCatalog(*lgr)
+	if err == nil {
+		localArtifacts, listErr := localCatalog.List(ctx, catalog.ArtifactKindSolution, "")
+		if listErr != nil {
+			lgr.V(1).Info("failed to list local solutions", "error", listErr)
+		} else {
+			artifacts = append(artifacts, localArtifacts...)
+		}
+	} else {
+		lgr.V(1).Info("local catalog not available", "error", err)
+	}
+
+	// List from remote catalogs
+	remoteCatalogs := catalog.RemoteCatalogsFromContext(ctx, *lgr)
+	for _, rc := range remoteCatalogs {
+		remoteArtifacts, listErr := rc.List(ctx, catalog.ArtifactKindSolution, "")
+		if listErr != nil {
+			lgr.V(1).Info("failed to list remote solutions", "catalog", rc.Name(), "error", listErr)
+			continue
+		}
+		artifacts = append(artifacts, remoteArtifacts...)
+	}
+
+	if len(artifacts) == 0 {
+		if w != nil {
+			w.Infof("No solutions found. Use '%s get solution --local' to auto-discover a local solution.", o.CliParams.BinaryName)
+		}
+		return nil
+	}
+
+	items := deduplicateAndFormatSolutions(artifacts)
+
+	format := o.Output
+	if format == "" {
+		format = "auto"
+	}
+	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
+		format,
+		false,
+		"",
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.CliParams.BinaryName+" get solution"),
+	)
+	kvxOpts.IOStreams = o.IOStreams
+	return kvxOpts.Write(items)
+}
+
+// deduplicateAndFormatSolutions deduplicates artifacts by name (keeping the
+// highest version) and returns sorted display items.
+func deduplicateAndFormatSolutions(artifacts []catalog.ArtifactInfo) []solutionListItem {
+	latestByName := make(map[string]catalog.ArtifactInfo)
+	for _, a := range artifacts {
+		existing, ok := latestByName[a.Reference.Name]
+		if !ok {
+			latestByName[a.Reference.Name] = a
+			continue
+		}
+		if a.Reference.Version != nil && (existing.Reference.Version == nil || a.Reference.Version.GreaterThan(existing.Reference.Version)) {
+			latestByName[a.Reference.Name] = a
+		}
+	}
+
+	items := make([]solutionListItem, 0, len(latestByName))
+	for _, a := range latestByName {
+		version := ""
+		if a.Reference.Version != nil {
+			version = a.Reference.Version.String()
+		}
+		items = append(items, solutionListItem{
+			Name:    a.Reference.Name,
+			Version: version,
+			Kind:    string(a.Reference.Kind),
+			Catalog: a.Catalog,
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return items
+}
+
+// solutionListItem is a display-friendly representation for solution listing.
+type solutionListItem struct {
+	Name    string `json:"name" yaml:"name"`
+	Version string `json:"version" yaml:"version"`
+	Kind    string `json:"kind" yaml:"kind"`
+	Catalog string `json:"catalog" yaml:"catalog"`
 }
 
 // solutionSummary is a display-friendly representation of a solution.

--- a/pkg/cmd/scafctl/get/solution/solution_test.go
+++ b/pkg/cmd/scafctl/get/solution/solution_test.go
@@ -7,8 +7,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/adrg/xdg"
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	solutionpkg "github.com/oakwood-commons/scafctl/pkg/solution"
@@ -19,6 +25,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// xdgMu serialises tests that mutate the global xdg.DataHome variable.
+var xdgMu sync.Mutex
 
 func TestCmdOptionsVersion_GetSolutionWithGetter(t *testing.T) {
 	t.Run("successful get from local file with json output", func(t *testing.T) {
@@ -449,4 +458,258 @@ func BenchmarkCommandSolution_Structure(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandSolution(cliParams, ioStreams, "get")
 	}
+}
+
+func TestCommandSolution_LocalFlag(t *testing.T) {
+	t.Run("--local flag is registered", func(t *testing.T) {
+		cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		cmd := CommandSolution(cliParams, ioStreams, "get")
+
+		localFlag := cmd.PersistentFlags().Lookup("local")
+		require.NotNil(t, localFlag, "--local flag should be registered")
+		assert.Equal(t, "false", localFlag.DefValue)
+	})
+}
+
+func TestCommandSolution_HelpText(t *testing.T) {
+	t.Run("short description mentions listing", func(t *testing.T) {
+		cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		cmd := CommandSolution(cliParams, ioStreams, "get")
+
+		assert.Contains(t, cmd.Short, "List or get")
+	})
+
+	t.Run("long description mentions --local", func(t *testing.T) {
+		cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		cmd := CommandSolution(cliParams, ioStreams, "get")
+
+		assert.Contains(t, cmd.Long, "--local")
+	})
+
+	t.Run("embedder binary name in long description", func(t *testing.T) {
+		cliParams := &settings.Run{NoColor: true, BinaryName: "mycli"}
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		cmd := CommandSolution(cliParams, ioStreams, "get")
+
+		assert.Contains(t, cmd.Long, "mycli")
+	})
+}
+
+func TestListSolutions_OutputFormat(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: outBuf, ErrOut: errBuf}
+
+	options := &CmdOptionsVersion{
+		IOStreams: ioStreams,
+		CliParams: &settings.Run{
+			NoColor:    true,
+			BinaryName: "testcli",
+		},
+		Output: "json",
+	}
+
+	w := writer.New(ioStreams, options.CliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	err := options.ListSolutions(ctx)
+	require.NoError(t, err)
+	// Should produce JSON output (either empty hint or list of solutions)
+	output := outBuf.String()
+	assert.NotEmpty(t, output)
+}
+
+func TestListSolutions_WithLocalArtifacts(t *testing.T) {
+	// Cannot be parallel: temporarily redirects xdg.DataHome.
+	xdgMu.Lock()
+	tmpDir := t.TempDir()
+	origDataHome := xdg.DataHome
+	xdg.DataHome = tmpDir
+	t.Cleanup(func() {
+		xdg.DataHome = origDataHome
+		xdgMu.Unlock()
+	})
+
+	// Pre-populate a local catalog with a solution.
+	lgr := logr.Discard()
+	localCat, err := catalog.NewLocalCatalogAt(
+		filepath.Join(tmpDir, "scafctl", "catalog"), lgr)
+	require.NoError(t, err)
+
+	solYAML := []byte("apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: list-test\n  version: 1.0.0\nspec: {}\n")
+	ref := catalog.Reference{
+		Kind:    catalog.ArtifactKindSolution,
+		Name:    "list-test",
+		Version: semver.MustParse("1.0.0"),
+	}
+	_, err = localCat.Store(context.Background(), ref, solYAML, nil, nil, false)
+	require.NoError(t, err)
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: outBuf, ErrOut: errBuf}
+
+	options := &CmdOptionsVersion{
+		IOStreams: ioStreams,
+		CliParams: &settings.Run{
+			NoColor:    true,
+			BinaryName: "testcli",
+		},
+		Output: "json",
+	}
+
+	w := writer.New(ioStreams, options.CliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	err = options.ListSolutions(ctx)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "list-test")
+	assert.Contains(t, output, "1.0.0")
+}
+
+func TestListSolutions_WithMultipleArtifacts(t *testing.T) {
+	xdgMu.Lock()
+	tmpDir := t.TempDir()
+	origDataHome := xdg.DataHome
+	xdg.DataHome = tmpDir
+	t.Cleanup(func() {
+		xdg.DataHome = origDataHome
+		xdgMu.Unlock()
+	})
+
+	lgr := logr.Discard()
+	localCat, err := catalog.NewLocalCatalogAt(
+		filepath.Join(tmpDir, "scafctl", "catalog"), lgr)
+	require.NoError(t, err)
+
+	for _, item := range []struct{ name, ver string }{
+		{"alpha-sol", "1.0.0"},
+		{"alpha-sol", "2.0.0"},
+		{"beta-sol", "0.5.0"},
+	} {
+		ref := catalog.Reference{
+			Kind:    catalog.ArtifactKindSolution,
+			Name:    item.name,
+			Version: semver.MustParse(item.ver),
+		}
+		_, storeErr := localCat.Store(context.Background(), ref,
+			[]byte("apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: "+item.name+"\n  version: "+item.ver+"\nspec: {}\n"),
+			nil, nil, false)
+		require.NoError(t, storeErr)
+	}
+
+	outBuf := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: outBuf, ErrOut: &bytes.Buffer{}}
+
+	options := &CmdOptionsVersion{
+		IOStreams: ioStreams,
+		CliParams: &settings.Run{
+			NoColor:    true,
+			BinaryName: "testcli",
+		},
+		Output: "json",
+	}
+
+	w := writer.New(ioStreams, options.CliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	err = options.ListSolutions(ctx)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	// Deduplication: alpha-sol should show 2.0.0 (highest), not 1.0.0.
+	assert.Contains(t, output, "alpha-sol")
+	assert.Contains(t, output, "2.0.0")
+	assert.Contains(t, output, "beta-sol")
+	assert.Contains(t, output, "0.5.0")
+}
+
+func TestDeduplicateAndFormatSolutions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deduplicates by name keeping highest version", func(t *testing.T) {
+		t.Parallel()
+		artifacts := []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Name: "app-a", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("1.0.0")}, Catalog: "local"},
+			{Reference: catalog.Reference{Name: "app-a", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("2.0.0")}, Catalog: "local"},
+			{Reference: catalog.Reference{Name: "app-b", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("0.1.0")}, Catalog: "remote"},
+		}
+		items := deduplicateAndFormatSolutions(artifacts)
+		require.Len(t, items, 2)
+		assert.Equal(t, "app-a", items[0].Name)
+		assert.Equal(t, "2.0.0", items[0].Version)
+		assert.Equal(t, "app-b", items[1].Name)
+		assert.Equal(t, "0.1.0", items[1].Version)
+	})
+
+	t.Run("sorted alphabetically by name", func(t *testing.T) {
+		t.Parallel()
+		artifacts := []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Name: "zebra", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("1.0.0")}, Catalog: "local"},
+			{Reference: catalog.Reference{Name: "alpha", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("1.0.0")}, Catalog: "local"},
+			{Reference: catalog.Reference{Name: "mid", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("1.0.0")}, Catalog: "remote"},
+		}
+		items := deduplicateAndFormatSolutions(artifacts)
+		require.Len(t, items, 3)
+		assert.Equal(t, "alpha", items[0].Name)
+		assert.Equal(t, "mid", items[1].Name)
+		assert.Equal(t, "zebra", items[2].Name)
+	})
+
+	t.Run("nil version kept when no versioned duplicate", func(t *testing.T) {
+		t.Parallel()
+		artifacts := []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Name: "app-c", Kind: catalog.ArtifactKindSolution}, Catalog: "local"},
+		}
+		items := deduplicateAndFormatSolutions(artifacts)
+		require.Len(t, items, 1)
+		assert.Equal(t, "app-c", items[0].Name)
+		assert.Equal(t, "", items[0].Version)
+	})
+
+	t.Run("versioned beats nil version", func(t *testing.T) {
+		t.Parallel()
+		artifacts := []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Name: "app-d", Kind: catalog.ArtifactKindSolution}, Catalog: "local"},
+			{Reference: catalog.Reference{Name: "app-d", Kind: catalog.ArtifactKindSolution, Version: semver.MustParse("1.0.0")}, Catalog: "remote"},
+		}
+		items := deduplicateAndFormatSolutions(artifacts)
+		require.Len(t, items, 1)
+		assert.Equal(t, "1.0.0", items[0].Version)
+		assert.Equal(t, "remote", items[0].Catalog)
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		t.Parallel()
+		items := deduplicateAndFormatSolutions(nil)
+		assert.Empty(t, items)
+	})
+}
+
+func TestCommandSolution_NoArgsCallsListSolutions(t *testing.T) {
+	t.Parallel()
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: outBuf, ErrOut: errBuf}
+	cliParams := &settings.Run{NoColor: true, BinaryName: "testcli"}
+
+	w := writer.New(ioStreams, cliParams)
+	cmd := CommandSolution(cliParams, ioStreams, "get")
+	cmd.SetArgs([]string{}) // no args
+	ctx := writer.WithWriter(context.Background(), w)
+	cmd.SetContext(ctx)
+
+	// No args, no --file, no --local: should call ListSolutions.
+	// Without a real catalog this produces "No solutions found" info message.
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	combined := outBuf.String() + errBuf.String()
+	assert.Contains(t, combined, "No solutions found")
 }

--- a/pkg/solution/build.go
+++ b/pkg/solution/build.go
@@ -5,6 +5,7 @@ package solution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -67,9 +68,58 @@ func ResolveArtifactVersion(explicitVersion string, metadataVersion *semver.Vers
 	return nil, false, fmt.Errorf("no version: solution has no version in metadata; provide --version or set metadata.version")
 }
 
+// ErrNoVersions is returned by BumpVersion when no published versions exist.
+type ErrNoVersions struct {
+	Name string
+}
+
+func (e *ErrNoVersions) Error() string {
+	return fmt.Sprintf("no existing versions for %q: use --version for first publish", e.Name)
+}
+
+// BumpLevel represents a semver increment level.
+type BumpLevel string
+
+const (
+	BumpPatch BumpLevel = "patch"
+	BumpMinor BumpLevel = "minor"
+	BumpMajor BumpLevel = "major"
+)
+
+// ParseBumpLevel validates and returns a BumpLevel from a string.
+func ParseBumpLevel(s string) (BumpLevel, error) {
+	switch strings.ToLower(s) {
+	case "patch":
+		return BumpPatch, nil
+	case "minor":
+		return BumpMinor, nil
+	case "major":
+		return BumpMajor, nil
+	default:
+		return "", fmt.Errorf("invalid bump level %q: must be patch, minor, or major", s)
+	}
+}
+
 // NextPatchVersion queries the catalog for existing versions of the named artifact
 // and returns the next patch version. If no versions exist, it returns 0.1.0.
 func NextPatchVersion(ctx context.Context, cat catalog.Catalog, kind catalog.ArtifactKind, name string) (*semver.Version, error) {
+	v, err := BumpVersion(ctx, cat, kind, name, BumpPatch)
+	if err != nil {
+		// BumpVersion returns ErrNoVersions when no published versions exist;
+		// NextPatchVersion falls back to 0.1.0 for backward compatibility.
+		var noVersions *ErrNoVersions
+		if errors.As(err, &noVersions) {
+			return semver.MustParse("0.1.0"), nil
+		}
+		return nil, err
+	}
+	return v, nil
+}
+
+// BumpVersion queries the catalog for existing versions of the named artifact
+// and returns the next version incremented by the given level.
+// If no versions exist, it returns an error (use --version for first publish).
+func BumpVersion(ctx context.Context, cat catalog.Catalog, kind catalog.ArtifactKind, name string, level BumpLevel) (*semver.Version, error) {
 	artifacts, err := cat.List(ctx, kind, name)
 	if err != nil {
 		return nil, fmt.Errorf("listing catalog versions for %q: %w", name, err)
@@ -83,7 +133,7 @@ func NextPatchVersion(ctx context.Context, cat catalog.Catalog, kind catalog.Art
 	}
 
 	if len(versions) == 0 {
-		return semver.MustParse("0.1.0"), nil
+		return nil, &ErrNoVersions{Name: name}
 	}
 
 	sort.Slice(versions, func(i, j int) bool {
@@ -91,6 +141,18 @@ func NextPatchVersion(ctx context.Context, cat catalog.Catalog, kind catalog.Art
 	})
 
 	highest := versions[len(versions)-1]
-	next := semver.New(highest.Major(), highest.Minor(), highest.Patch()+1, "", "")
+
+	var next *semver.Version
+	switch level {
+	case BumpMajor:
+		next = semver.New(highest.Major()+1, 0, 0, "", "")
+	case BumpMinor:
+		next = semver.New(highest.Major(), highest.Minor()+1, 0, "", "")
+	case BumpPatch:
+		next = semver.New(highest.Major(), highest.Minor(), highest.Patch()+1, "", "")
+	default:
+		return nil, fmt.Errorf("invalid bump level %q", level)
+	}
+
 	return next, nil
 }

--- a/pkg/solution/build_test.go
+++ b/pkg/solution/build_test.go
@@ -212,3 +212,115 @@ func BenchmarkNextPatchVersion(b *testing.B) {
 		_, _ = NextPatchVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app")
 	}
 }
+
+func TestParseBumpLevel(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    BumpLevel
+		wantErr bool
+	}{
+		{"patch", BumpPatch, false},
+		{"minor", BumpMinor, false},
+		{"major", BumpMajor, false},
+		{"PATCH", BumpPatch, false},
+		{"Minor", BumpMinor, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseBumpLevel(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid bump level")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBumpVersion(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("patch bump", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}},
+			},
+		}
+		v, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpPatch)
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.4", v.String())
+	})
+
+	t.Run("minor bump", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}},
+			},
+		}
+		v, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpMinor)
+		require.NoError(t, err)
+		assert.Equal(t, "1.3.0", v.String())
+	})
+
+	t.Run("major bump", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}},
+			},
+		}
+		v, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpMajor)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.0", v.String())
+	})
+
+	t.Run("no existing versions returns ErrNoVersions", func(t *testing.T) {
+		cat := &mockCatalog{}
+		_, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpPatch)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no existing versions")
+		var noVersions *ErrNoVersions
+		assert.ErrorAs(t, err, &noVersions)
+		assert.Equal(t, "my-app", noVersions.Name)
+	})
+
+	t.Run("catalog list error", func(t *testing.T) {
+		cat := &mockCatalog{listErr: assert.AnError}
+		_, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpPatch)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "listing catalog versions")
+	})
+
+	t.Run("picks highest version from multiple", func(t *testing.T) {
+		cat := &mockCatalog{
+			artifacts: []catalog.ArtifactInfo{
+				{Reference: catalog.Reference{Version: semver.MustParse("1.0.0")}},
+				{Reference: catalog.Reference{Version: semver.MustParse("3.1.0")}},
+				{Reference: catalog.Reference{Version: semver.MustParse("2.5.0")}},
+			},
+		}
+		v, err := BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpMinor)
+		require.NoError(t, err)
+		assert.Equal(t, "3.2.0", v.String())
+	})
+}
+
+func BenchmarkBumpVersion(b *testing.B) {
+	ctx := context.Background()
+	cat := &mockCatalog{
+		artifacts: []catalog.ArtifactInfo{
+			{Reference: catalog.Reference{Version: semver.MustParse("1.0.0")}},
+			{Reference: catalog.Reference{Version: semver.MustParse("1.2.3")}},
+			{Reference: catalog.Reference{Version: semver.MustParse("1.1.0")}},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = BumpVersion(ctx, cat, catalog.ArtifactKindSolution, "my-app", BumpMinor)
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2841,10 +2841,14 @@ func TestIntegration_CatalogListHelp(t *testing.T) {
 func TestIntegration_CatalogList_Empty(t *testing.T) {
 	t.Parallel()
 	// Create a temp directory for the catalog — no local artifacts.
+	// XDG_CONFIG_HOME is also isolated to prevent the binary from reading
+	// the real config, which may reference remote catalogs that require
+	// auth or are unreachable in CI.
 	tmpDir := t.TempDir()
 	env := map[string]string{
-		"XDG_DATA_HOME":  tmpDir,
-		"XDG_CACHE_HOME": tmpDir,
+		"XDG_DATA_HOME":   tmpDir,
+		"XDG_CACHE_HOME":  tmpDir,
+		"XDG_CONFIG_HOME": tmpDir,
 	}
 
 	stdout, _, exitCode := runScafctlWithEnv(t, env, "catalog", "list", "-o", "json")


### PR DESCRIPTION
- add --bump flag (patch/minor/major) to build solution for auto-incrementing version based on last published version
- add --latest flag to catalog push for tagging remote artifacts
- change get solution default to list catalog solutions; add --local flag for previous auto-discovery behavior
- replace requireURLPath with requireRemotePath to accept OCI URLs and catalog names while blocking local paths and file://
- add ErrNoVersions sentinel to eliminate double catalog listing in NextPatchVersion
- detect --bump conflict with versioned --tag after tag parsing
- sort solution list output for deterministic ordering
- strip stale git annotations when repo is clean or --no-git-metadata is used

BREAKING CHANGE: get solution without arguments now lists catalog solutions instead of auto-discovering a local file. Use --local for the previous behavior.

Closes #375
Closes #346
Closes #321