### PR TITLE
fix(ci): use correct certificate identity in cosign verify

### DIFF
--- a/.github/workflows/sign-plugin.yml
+++ b/.github/workflows/sign-plugin.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Verify signature
         env:
           IMAGE_REF: ${{ inputs.image-ref }}
-          REPO: ${{ github.repository }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
           cosign verify \
-            --certificate-identity-regexp="https://github.com/${REPO}/.*" \
+            --certificate-identity="https://github.com/${WORKFLOW_REF}" \
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
             "$IMAGE_REF"


### PR DESCRIPTION
## Problem

The cosign verify step in `sign-plugin.yml` used `github.repository` for the `--certificate-identity-regexp`, which resolves to the **calling** repo (e.g. `oakwood-commons/scafctl-plugin-sleep`).

However, when using reusable workflows with OIDC, the certificate identity is the **reusable workflow's path** in the source repo:
```
https://github.com/oakwood-commons/scafctl/.github/workflows/sign-plugin.yml@refs/tags/sign-plugin/v1
```

This caused verification to fail with:
> no matching signatures: none of the expected identities matched what was in the certificate

## Fix

Replace `--certificate-identity-regexp` (using `github.repository`) with `--certificate-identity` using the exact workflow identity path.

## After merge

Update the `sign-plugin/v1` tag:
```bash
git checkout main && git pull
git tag -f sign-plugin/v1 HEAD
git push --force-with-lease origin refs/tags/sign-plugin/v1
```

Then re-run the failed sleep release or tag `v0.1.2`.