### PR TITLE
fix(ci): use certificate-identity-regexp for cosign verify

### DIFF
--- a/.github/workflows/sign-plugin.yml
+++ b/.github/workflows/sign-plugin.yml
@@ -66,9 +66,8 @@ jobs:
       - name: Verify signature
         env:
           IMAGE_REF: ${{ inputs.image-ref }}
-          WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
           cosign verify \
-            --certificate-identity="https://github.com/${WORKFLOW_REF}" \
+            --certificate-identity-regexp="^https://github\.com/oakwood-commons/scafctl/\.github/workflows/sign-plugin\.yml@refs/tags/sign-plugin/v[0-9]+$" \
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
             "$IMAGE_REF"


### PR DESCRIPTION
## Problem

PR #381 used `github.workflow_ref` to derive the certificate identity, but in a reusable workflow **all** `github.*` context variables reflect the **caller**, not the reusable workflow itself.

So `github.workflow_ref` resolved to:
```
oakwood-commons/scafctl-plugin-sleep/.github/workflows/release.yaml@refs/tags/v0.1.2
```

But the OIDC certificate identity is always the reusable workflow's own path:
```
https://github.com/oakwood-commons/scafctl/.github/workflows/sign-plugin.yml@refs/tags/sign-plugin/v1
```

## Fix

Use `--certificate-identity-regexp` with a regex matching the exact workflow file path (escaped dots) but flexible on the ref/tag suffix. No GitHub context variable exposes the reusable workflow's own path, so a static regexp scoped to this file is the correct approach.

## After merge

```bash
git checkout main && git pull
git tag -f sign-plugin/v1 HEAD
git push --force origin refs/tags/sign-plugin/v1
```

Then tag `v0.1.3` on sleep to validate.