### PR TITLE
feat(provider): register solution provider in default registry

### DIFF
--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -21,7 +21,6 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
-	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
@@ -299,16 +298,6 @@ func getRegistry(ctx context.Context) *provider.Registry {
 	reg, err := builtin.DefaultRegistry(ctx)
 	if err != nil {
 		reg = provider.GetGlobalRegistry()
-	}
-	// The solution provider is not part of DefaultRegistry because it has a
-	// circular dependency on the registry itself and requires a loader. For
-	// lint purposes we only need the provider to be *registered* (so the
-	// missing-provider rule doesn't false-positive); it will never be executed.
-	if !reg.Has(solutionprovider.ProviderName) {
-		solProvider := solutionprovider.New(
-			solutionprovider.WithRegistry(reg),
-		)
-		_ = reg.Register(solProvider)
 	}
 	return reg
 }

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -268,11 +268,14 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, fmt.Errorf("failed to get working directory: %w", err), exitcode.GeneralError)
 	}
 
-	sol, reg, solutionDir, cleanup, err := o.prepareSolutionForExecution(ctx)
+	sol, reg, solutionDir, cleanup, providerCtx, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
 		return o.exitWithCode(ctx, err, exitcode.FileNotFound)
 	}
 	defer cleanup()
+	if providerCtx != nil {
+		ctx = providerCtx(ctx)
+	}
 
 	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -578,7 +578,7 @@ func (o *sharedResolverOptions) executeResolvers(
 //
 // This method delegates to the standalone prepare.PrepareSolution function,
 // passing CLI-specific options (getter, registry, stdin, metrics).
-func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context) (*solution.Solution, *provider.Registry, string, func(), error) {
+func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context) (*solution.Solution, *provider.Registry, string, func(), func(context.Context) context.Context, error) {
 	w := writer.FromContext(ctx)
 
 	var opts []prepare.Option
@@ -667,7 +667,7 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 
 	result, err := prepare.Solution(ctx, o.File, opts...)
 	if err != nil {
-		return nil, nil, "", func() {}, err
+		return nil, nil, "", func() {}, nil, err
 	}
 
 	if w != nil {
@@ -709,7 +709,7 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 		}
 	}
 
-	return result.Solution, result.Registry, result.SolutionDir, result.Cleanup, nil
+	return result.Solution, result.Registry, result.SolutionDir, result.Cleanup, result.ProviderCtx, nil
 }
 
 func (o *sharedResolverOptions) appendClientPluginOptions(opts []prepare.Option) []prepare.Option {

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -335,7 +335,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	}
 
 	// Prepare solution: load, set up registry, handle bundles
-	sol, reg, solutionDir, cleanup, err := o.prepareSolutionForExecution(ctx)
+	sol, reg, solutionDir, cleanup, providerCtx, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
 		// When no -f/--file was provided, auto-discovery failed to find a
 		// solution file, and the first positional arg looks like a catalog
@@ -344,13 +344,16 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 			o.File = o.Names[0]
 			o.Names = o.Names[1:]
 			lgr.V(1).Info("retrying with first positional arg as catalog reference", "file", o.File)
-			sol, reg, solutionDir, cleanup, err = o.prepareSolutionForExecution(ctx)
+			sol, reg, solutionDir, cleanup, providerCtx, err = o.prepareSolutionForExecution(ctx)
 		}
 		if err != nil {
 			return o.exitWithCode(ctx, err, exitcode.FileNotFound)
 		}
 	}
 	defer cleanup()
+	if providerCtx != nil {
+		ctx = providerCtx(ctx)
+	}
 
 	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -369,11 +369,14 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	}
 
 	// Prepare solution: load, set up registry, handle bundles
-	sol, reg, solutionDir, cleanup, err := o.prepareSolutionForExecution(ctx)
+	sol, reg, solutionDir, cleanup, providerCtx, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
 		return o.exitWithCode(ctx, err, exitcode.FileNotFound)
 	}
 	defer cleanup()
+	if providerCtx != nil {
+		ctx = providerCtx(ctx)
+	}
 
 	// Set the solution directory for resolver-phase path resolution.
 	// --base-dir takes precedence; otherwise use the solution file's directory.

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -100,6 +100,9 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+	if prepResult.ProviderCtx != nil {
+		ctx = prepResult.ProviderCtx(ctx)
+	}
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -136,6 +136,9 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+	if prepResult.ProviderCtx != nil {
+		ctx = prepResult.ProviderCtx(ctx)
+	}
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,

--- a/pkg/mcp/tools_run.go
+++ b/pkg/mcp/tools_run.go
@@ -133,6 +133,9 @@ func (s *Server) handleRunSolution(_ context.Context, request mcp.CallToolReques
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+	if prepResult.ProviderCtx != nil {
+		ctx = prepResult.ProviderCtx(ctx)
+	}
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle.

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -466,6 +466,9 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
 	}
+	if prepResult.ProviderCtx != nil {
+		ctx = prepResult.ProviderCtx(ctx)
+	}
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,
@@ -722,6 +725,9 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 	if prepResult.Cleanup != nil {
 		defer prepResult.Cleanup()
+	}
+	if prepResult.ProviderCtx != nil {
+		ctx = prepResult.ProviderCtx(ctx)
 	}
 
 	sol := prepResult.Solution

--- a/pkg/provider/builtin/builtin.go
+++ b/pkg/provider/builtin/builtin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/httpprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/messageprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/parameterprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/validationprovider"
 )
@@ -52,6 +53,11 @@ func registerAllToRegistry(ctx context.Context, reg *provider.Registry) error {
 		messageprovider.NewMessageProvider(),
 		staticprovider.New(),
 		parameterprovider.NewParameterProvider(),
+		// solution provider is registered bare (no runtime deps). At execution
+		// time, callers inject a loader and registry via context (preferred) or
+		// via Configure() (legacy fallback). See prepare.Solution() which builds
+		// a ProviderCtx function to inject these deps per execution.
+		solutionprovider.New(),
 	}
 
 	lgr.V(2).Info("registering built-in providers", "count", len(providers))
@@ -87,5 +93,6 @@ func ProviderNames() []string {
 		"message",
 		"static",
 		"parameter",
+		"solution",
 	}
 }

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -70,7 +70,7 @@ func TestProviderNames(t *testing.T) {
 	names := ProviderNames()
 
 	// Should have all built-in providers
-	expectedCount := 9 // http, cel, file, validation, debug, go-template, message, static, parameter
+	expectedCount := 10 // http, cel, file, validation, debug, go-template, message, static, parameter, solution
 	assert.Len(t, names, expectedCount, "should have %d built-in providers", expectedCount)
 
 	// Verify expected names are present
@@ -84,6 +84,7 @@ func TestProviderNames(t *testing.T) {
 		"message",
 		"static",
 		"parameter",
+		"solution",
 	}
 
 	for _, expected := range expectedNames {
@@ -143,6 +144,7 @@ func TestAllProvidersRegistered(t *testing.T) {
 		{"message", "message"},
 		{"static", "static"},
 		{"parameter", "parameter"},
+		{"solution", "solution"},
 	}
 
 	for _, expected := range expectedProviders {

--- a/pkg/provider/builtin/solutionprovider/context.go
+++ b/pkg/provider/builtin/solutionprovider/context.go
@@ -8,11 +8,137 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 )
 
 type ancestorStackKey struct{}
+
+type loaderKey struct{}
+
+type registryKey struct{}
+
+type officialProvidersKey struct{}
+
+type pluginFetcherKey struct{}
+
+type pluginConfigKey struct{}
+
+type clientOptsKey struct{}
+
+// WithLoaderCtx returns a context carrying a Loader for the solution provider.
+func WithLoaderCtx(ctx context.Context, l Loader) context.Context {
+	return context.WithValue(ctx, loaderKey{}, l)
+}
+
+// LoaderFromContext retrieves the Loader from the context.
+func LoaderFromContext(ctx context.Context) Loader {
+	l, _ := ctx.Value(loaderKey{}).(Loader)
+	return l
+}
+
+// WithProviderRegistry returns a context carrying a provider Registry for
+// the solution provider to use when executing sub-solutions.
+func WithProviderRegistry(ctx context.Context, r *provider.Registry) context.Context {
+	return context.WithValue(ctx, registryKey{}, r)
+}
+
+// ProviderRegistryFromContext retrieves the provider Registry from context.
+func ProviderRegistryFromContext(ctx context.Context) *provider.Registry {
+	r, _ := ctx.Value(registryKey{}).(*provider.Registry)
+	return r
+}
+
+// WithOfficialProvidersCtx returns a context carrying an official provider Registry.
+func WithOfficialProvidersCtx(ctx context.Context, r *official.Registry) context.Context {
+	return context.WithValue(ctx, officialProvidersKey{}, r)
+}
+
+// OfficialProvidersFromContext retrieves the official provider Registry from context.
+func OfficialProvidersFromContext(ctx context.Context) *official.Registry {
+	r, _ := ctx.Value(officialProvidersKey{}).(*official.Registry)
+	return r
+}
+
+// WithPluginFetcherCtx returns a context carrying a plugin Fetcher.
+func WithPluginFetcherCtx(ctx context.Context, f *plugin.Fetcher) context.Context {
+	return context.WithValue(ctx, pluginFetcherKey{}, f)
+}
+
+// PluginFetcherFromContext retrieves the plugin Fetcher from context.
+func PluginFetcherFromContext(ctx context.Context) *plugin.Fetcher {
+	f, _ := ctx.Value(pluginFetcherKey{}).(*plugin.Fetcher)
+	return f
+}
+
+// WithPluginConfigCtx returns a context carrying plugin configuration.
+func WithPluginConfigCtx(ctx context.Context, cfg *plugin.ProviderConfig) context.Context {
+	return context.WithValue(ctx, pluginConfigKey{}, cfg)
+}
+
+// PluginConfigFromContext retrieves the plugin configuration from context.
+func PluginConfigFromContext(ctx context.Context) *plugin.ProviderConfig {
+	cfg, _ := ctx.Value(pluginConfigKey{}).(*plugin.ProviderConfig)
+	return cfg
+}
+
+// WithClientOptionsCtx returns a context carrying plugin client options.
+func WithClientOptionsCtx(ctx context.Context, opts []plugin.ClientOption) context.Context {
+	return context.WithValue(ctx, clientOptsKey{}, opts)
+}
+
+// ClientOptionsFromContext retrieves the plugin client options from context.
+func ClientOptionsFromContext(ctx context.Context) []plugin.ClientOption {
+	opts, _ := ctx.Value(clientOptsKey{}).([]plugin.ClientOption)
+	return opts
+}
+
+// ChildClientTracker tracks plugin clients started during a single execution
+// so they can be cleaned up without affecting other concurrent executions
+// sharing the same SolutionProvider singleton.
+type ChildClientTracker struct {
+	mu      sync.Mutex
+	clients []*plugin.Client
+}
+
+// NewChildClientTracker creates a new per-execution client tracker.
+func NewChildClientTracker() *ChildClientTracker {
+	return &ChildClientTracker{}
+}
+
+// Add appends plugin clients to the tracker for deferred cleanup.
+func (t *ChildClientTracker) Add(clients ...*plugin.Client) {
+	t.mu.Lock()
+	t.clients = append(t.clients, clients...)
+	t.mu.Unlock()
+}
+
+// Close kills all tracked plugin clients and clears the list.
+func (t *ChildClientTracker) Close() {
+	t.mu.Lock()
+	clients := t.clients
+	t.clients = nil
+	t.mu.Unlock()
+	for _, c := range clients {
+		c.Kill()
+	}
+}
+
+type childClientTrackerKey struct{}
+
+// WithChildClientTracker returns a context carrying a per-execution client tracker.
+func WithChildClientTracker(ctx context.Context, t *ChildClientTracker) context.Context {
+	return context.WithValue(ctx, childClientTrackerKey{}, t)
+}
+
+// ChildClientTrackerFromContext retrieves the per-execution client tracker from context.
+func ChildClientTrackerFromContext(ctx context.Context) *ChildClientTracker {
+	t, _ := ctx.Value(childClientTrackerKey{}).(*ChildClientTracker)
+	return t
+}
 
 // WithAncestorStack returns a new context with the given ancestor stack.
 // This is used to track the chain of solution invocations for circular reference detection.

--- a/pkg/provider/builtin/solutionprovider/solution.go
+++ b/pkg/provider/builtin/solutionprovider/solution.go
@@ -52,7 +52,7 @@ type SolutionProvider struct {
 	pluginConfig      *plugin.ProviderConfig
 	clientOpts        []plugin.ClientOption
 
-	// mu protects childClients from concurrent Execute calls.
+	// mu protects mutable state from concurrent Configure/Execute/Close calls.
 	mu           sync.Mutex
 	childClients []*plugin.Client
 }
@@ -100,6 +100,17 @@ func New(opts ...Option) *SolutionProvider {
 	return p
 }
 
+// Configure applies functional options to an existing SolutionProvider.
+// This is used to inject runtime dependencies (loader, registry, etc.)
+// into a provider that was registered in DefaultRegistry without them.
+func (p *SolutionProvider) Configure(opts ...Option) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, opt := range opts {
+		opt(p)
+	}
+}
+
 // Close kills all plugin clients started by child auto-resolution.
 // Must be called when the solution provider is no longer needed.
 func (p *SolutionProvider) Close() {
@@ -115,6 +126,75 @@ func (p *SolutionProvider) Close() {
 // Descriptor returns the provider's metadata and schema.
 func (p *SolutionProvider) Descriptor() *provider.Descriptor {
 	return p.descriptor
+}
+
+// resolveRuntime resolves the provider's runtime dependencies from context
+// first (per-execution override), then falls back to struct fields. This
+// allows the singleton in DefaultRegistry to remain stateless while callers
+// inject deps via context for each execution.
+func (p *SolutionProvider) resolveRuntime(ctx context.Context) (loader Loader, reg *provider.Registry, err error) {
+	// Context takes priority — enables per-execution override without
+	// mutating the shared singleton.
+	loader = LoaderFromContext(ctx)
+	reg = ProviderRegistryFromContext(ctx)
+
+	// Fall back to struct fields for anything not provided via context.
+	if loader == nil || reg == nil {
+		p.mu.Lock()
+		if loader == nil {
+			loader = p.loader
+		}
+		if reg == nil {
+			reg = p.registry
+		}
+		p.mu.Unlock()
+	}
+
+	if loader == nil {
+		return nil, nil, fmt.Errorf("%s: no solution loader configured; "+
+			"inject a loader via context (WithLoaderCtx) or call Configure(WithLoader(...))", ProviderName)
+	}
+	if reg == nil {
+		return nil, nil, fmt.Errorf("%s: no provider registry configured; "+
+			"inject a registry via context (WithProviderRegistry) or call Configure(WithRegistry(...))", ProviderName)
+	}
+
+	return loader, reg, nil
+}
+
+// resolvePluginRuntime resolves optional plugin-related dependencies from
+// context first (per-execution override), then falls back to struct fields.
+func (p *SolutionProvider) resolvePluginRuntime(ctx context.Context) (
+	officialProviders *official.Registry,
+	pluginFetcher *plugin.Fetcher,
+	pluginConfig *plugin.ProviderConfig,
+	clientOpts []plugin.ClientOption,
+) {
+	// Context takes priority.
+	officialProviders = OfficialProvidersFromContext(ctx)
+	pluginFetcher = PluginFetcherFromContext(ctx)
+	pluginConfig = PluginConfigFromContext(ctx)
+	clientOpts = ClientOptionsFromContext(ctx)
+
+	// Fall back to struct fields for anything not provided via context.
+	if officialProviders == nil || pluginFetcher == nil || pluginConfig == nil || len(clientOpts) == 0 {
+		p.mu.Lock()
+		if officialProviders == nil {
+			officialProviders = p.officialProviders
+		}
+		if pluginFetcher == nil {
+			pluginFetcher = p.pluginFetcher
+		}
+		if pluginConfig == nil {
+			pluginConfig = p.pluginConfig
+		}
+		if len(clientOpts) == 0 {
+			clientOpts = p.clientOpts
+		}
+		p.mu.Unlock()
+	}
+
+	return officialProviders, pluginFetcher, pluginConfig, clientOpts
 }
 
 // Execute runs the sub-solution and returns its results as a structured envelope.
@@ -139,13 +219,19 @@ func (p *SolutionProvider) Execute(ctx context.Context, input any) (*provider.Ou
 		return nil, fmt.Errorf("%s: expected *Input or map[string]any, got %T", ProviderName, input)
 	}
 
+	// Resolve runtime dependencies (struct fields → context fallback).
+	loader, reg, err := p.resolveRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	lgr := logger.FromContext(ctx)
 
 	// Resolve canonical name for ancestor tracking.
 	canonicalName := Canonicalize(ctx, in.Source)
 
 	// Check circular references — always a hard error regardless of propagateErrors.
-	ctx, err := PushAncestor(ctx, canonicalName)
+	ctx, err = PushAncestor(ctx, canonicalName)
 	if err != nil {
 		return nil, err
 	}
@@ -166,15 +252,15 @@ func (p *SolutionProvider) Execute(ctx context.Context, input any) (*provider.Ou
 	}
 	lgr.V(1).Info("loading sub-solution", "source", source)
 
-	sol, err := p.loader.Get(ctx, source)
-	if err != nil {
-		return nil, fmt.Errorf("solution %q: failed to load: %w", in.Source, err)
+	sol, loadErr := loader.Get(ctx, source)
+	if loadErr != nil {
+		return nil, fmt.Errorf("solution %q: failed to load: %w", in.Source, loadErr)
 	}
 
 	// Auto-resolve official providers needed by the child solution.
 	// Clients are tracked at the struct level and cleaned up via Close()
 	// to avoid killing shared plugins while parallel Execute calls are in flight.
-	if err := p.autoResolveChildProviders(ctx, sol); err != nil {
+	if err := p.autoResolveChildProviders(ctx, sol, reg); err != nil {
 		return nil, fmt.Errorf("solution %q: %w", in.Source, err)
 	}
 
@@ -192,14 +278,14 @@ func (p *SolutionProvider) Execute(ctx context.Context, input any) (*provider.Ou
 	// Determine execution mode and run.
 	mode, _ := provider.ExecutionModeFromContext(ctx)
 	if mode == provider.CapabilityAction && sol.Spec.HasWorkflow() {
-		return p.executeWithWorkflow(subCtx, sol, in)
+		return p.executeWithWorkflow(subCtx, sol, in, reg)
 	}
 
-	return p.executeResolversOnly(subCtx, sol, in)
+	return p.executeResolversOnly(subCtx, sol, in, reg)
 }
 
 // executeResolversOnly executes only the resolver phase (from capability).
-func (p *SolutionProvider) executeResolversOnly(ctx context.Context, sol *solution.Solution, in *Input) (*provider.Output, error) {
+func (p *SolutionProvider) executeResolversOnly(ctx context.Context, sol *solution.Solution, in *Input, reg *provider.Registry) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
 	// Apply timeout if specified.
@@ -226,7 +312,7 @@ func (p *SolutionProvider) executeResolversOnly(ctx context.Context, sol *soluti
 
 		lgr.V(1).Info("executing sub-solution resolvers", "count", len(resolvers), "selected", len(in.Resolvers))
 
-		adapter := &resolverRegistryAdapter{registry: p.registry}
+		adapter := &resolverRegistryAdapter{registry: reg}
 
 		// Derive child executor timeout from the context deadline so the child
 		// respects the parent's timeout budget instead of using the default 30s.
@@ -271,7 +357,7 @@ func (p *SolutionProvider) executeResolversOnly(ctx context.Context, sol *soluti
 }
 
 // executeWithWorkflow executes resolvers and then the workflow (action capability).
-func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solution.Solution, in *Input) (*provider.Output, error) {
+func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solution.Solution, in *Input, reg *provider.Registry) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
 	// Apply timeout if specified.
@@ -299,7 +385,7 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 
 		lgr.V(1).Info("executing sub-solution resolvers", "count", len(resolvers), "selected", len(in.Resolvers))
 
-		adapter := &resolverRegistryAdapter{registry: p.registry}
+		adapter := &resolverRegistryAdapter{registry: reg}
 
 		// Derive child executor timeout from the context deadline so the child
 		// respects the parent's timeout budget instead of using the default 30s.
@@ -341,7 +427,7 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 	// Phase 2: Execute workflow.
 	lgr.V(1).Info("executing sub-solution workflow")
 
-	actionAdapter := &actionRegistryAdapter{registry: p.registry}
+	actionAdapter := &actionRegistryAdapter{registry: reg}
 	actionExec := action.NewExecutor(
 		action.WithRegistry(actionAdapter),
 		action.WithResolverData(resolverData),
@@ -846,8 +932,10 @@ func (r *actionRegistryAdapter) Has(name string) bool {
 // solution that are not yet in the parent registry.
 // Clients are appended to p.childClients for deferred cleanup via Close().
 // Returns an error if fetching or registering plugins fails.
-func (p *SolutionProvider) autoResolveChildProviders(ctx context.Context, sol *solution.Solution) error {
-	if p.officialProviders == nil || p.officialProviders.Len() == 0 || p.pluginFetcher == nil {
+func (p *SolutionProvider) autoResolveChildProviders(ctx context.Context, sol *solution.Solution, reg *provider.Registry) error {
+	officialProviders, pluginFetcher, pluginCfg, clientOpts := p.resolvePluginRuntime(ctx)
+
+	if officialProviders == nil || officialProviders.Len() == 0 || pluginFetcher == nil {
 		return nil
 	}
 
@@ -855,10 +943,10 @@ func (p *SolutionProvider) autoResolveChildProviders(ctx context.Context, sol *s
 	// then filter to those that are missing and official.
 	var missing []official.Provider
 	for _, name := range sol.Spec.ReferencedProviderNames() {
-		if p.registry.Has(name) {
+		if reg.Has(name) {
 			continue
 		}
-		if op, ok := p.officialProviders.Get(name); ok {
+		if op, ok := officialProviders.Get(name); ok {
 			missing = append(missing, op)
 		}
 	}
@@ -881,25 +969,31 @@ func (p *SolutionProvider) autoResolveChildProviders(ctx context.Context, sol *s
 		deps[i] = m.ToPluginDependency()
 	}
 
-	results, err := p.pluginFetcher.FetchPlugins(ctx, deps, nil)
+	results, err := pluginFetcher.FetchPlugins(ctx, deps, nil)
 	if err != nil {
 		return fmt.Errorf("auto-fetching child solution providers: %w", err)
 	}
 
-	cfg := p.pluginConfig
+	cfg := pluginCfg
 	if cfg == nil {
 		cfg = &plugin.ProviderConfig{}
 	}
 
-	pClients, err := plugin.RegisterFetchedPlugins(ctx, p.registry, results, cfg, p.clientOpts...)
+	pClients, err := plugin.RegisterFetchedPlugins(ctx, reg, results, cfg, clientOpts...)
 	if err != nil {
 		return fmt.Errorf("registering child solution providers: %w", err)
 	}
 
 	if len(pClients) > 0 {
-		p.mu.Lock()
-		p.childClients = append(p.childClients, pClients...)
-		p.mu.Unlock()
+		// Prefer per-execution tracker from context so concurrent runs
+		// sharing the singleton don't interfere with each other's clients.
+		if tracker := ChildClientTrackerFromContext(ctx); tracker != nil {
+			tracker.Add(pClients...)
+		} else {
+			p.mu.Lock()
+			p.childClients = append(p.childClients, pClients...)
+			p.mu.Unlock()
+		}
 	}
 	return nil
 }

--- a/pkg/provider/builtin/solutionprovider/solution_test.go
+++ b/pkg/provider/builtin/solutionprovider/solution_test.go
@@ -500,6 +500,163 @@ func TestBuildWorkflowResult(t *testing.T) {
 
 // --- Execute Tests ---
 
+func TestExecute_NilLoader(t *testing.T) {
+	// A bare provider (no loader, no registry) should return a clear error.
+	p := New()
+	_, err := p.Execute(context.Background(), map[string]any{
+		"source": "child-solution",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no solution loader configured")
+}
+
+func TestExecute_NilLoaderWithRegistryOnly(t *testing.T) {
+	// Provider with registry but no loader should still error about loader.
+	p := New(WithRegistry(provider.NewRegistry()))
+	_, err := p.Execute(context.Background(), map[string]any{
+		"source": "child-solution",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no solution loader configured")
+}
+
+func TestExecute_LoaderFromContext(t *testing.T) {
+	// A bare provider should resolve loader and registry from context.
+	loader := &mockLoader{
+		solutions: map[string]*solution.Solution{
+			"ctx-child": {
+				APIVersion: "scafctl.io/v1",
+				Kind:       "Solution",
+				Metadata:   solution.Metadata{Name: "ctx-child"},
+				Spec:       solution.Spec{},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	ctx := WithLoaderCtx(context.Background(), loader)
+	ctx = WithProviderRegistry(ctx, reg)
+
+	p := New() // bare — no struct-level deps
+	out, err := p.Execute(ctx, map[string]any{
+		"source": "ctx-child",
+	})
+	require.NoError(t, err)
+	data, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "success", data["status"])
+}
+
+func TestConfigure(t *testing.T) {
+	p := New()
+	assert.Nil(t, p.loader)
+	assert.Nil(t, p.registry)
+
+	loader := &mockLoader{}
+	reg := provider.NewRegistry()
+	p.Configure(WithLoader(loader), WithRegistry(reg))
+
+	assert.NotNil(t, p.loader)
+	assert.NotNil(t, p.registry)
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("OfficialProviders", func(t *testing.T) {
+		reg := official.NewRegistry()
+		ctx := WithOfficialProvidersCtx(ctx, reg)
+		assert.Equal(t, reg, OfficialProvidersFromContext(ctx))
+	})
+
+	t.Run("PluginFetcher", func(t *testing.T) {
+		f := &plugin.Fetcher{}
+		ctx := WithPluginFetcherCtx(ctx, f)
+		assert.Equal(t, f, PluginFetcherFromContext(ctx))
+	})
+
+	t.Run("PluginConfig", func(t *testing.T) {
+		cfg := &plugin.ProviderConfig{}
+		ctx := WithPluginConfigCtx(ctx, cfg)
+		assert.Equal(t, cfg, PluginConfigFromContext(ctx))
+	})
+
+	t.Run("ClientOptions", func(t *testing.T) {
+		opts := []plugin.ClientOption{}
+		ctx := WithClientOptionsCtx(ctx, opts)
+		assert.Equal(t, opts, ClientOptionsFromContext(ctx))
+	})
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		assert.Nil(t, OfficialProvidersFromContext(ctx))
+		assert.Nil(t, PluginFetcherFromContext(ctx))
+		assert.Nil(t, PluginConfigFromContext(ctx))
+		assert.Nil(t, ClientOptionsFromContext(ctx))
+	})
+
+	t.Run("ChildClientTracker", func(t *testing.T) {
+		tracker := NewChildClientTracker()
+		ctx := WithChildClientTracker(ctx, tracker)
+		assert.Equal(t, tracker, ChildClientTrackerFromContext(ctx))
+	})
+
+	t.Run("ChildClientTracker nil", func(t *testing.T) {
+		assert.Nil(t, ChildClientTrackerFromContext(ctx))
+	})
+}
+
+func TestChildClientTracker(t *testing.T) {
+	t.Run("Add and Close", func(t *testing.T) {
+		tracker := NewChildClientTracker()
+		// Close on empty tracker should not panic.
+		tracker.Close()
+
+		tracker.Add()                    // no-op, zero clients
+		assert.Empty(t, tracker.clients) //nolint:govet // test accesses unexported field
+	})
+
+	t.Run("Close clears list", func(t *testing.T) {
+		tracker := NewChildClientTracker()
+		tracker.Close()
+		// After Close, clients should be nil.
+		assert.Nil(t, tracker.clients)
+	})
+}
+
+func TestContextOverridesStructFields(t *testing.T) {
+	// When both struct fields and context are set, context should win.
+	structLoader := &mockLoader{solutions: map[string]*solution.Solution{
+		"struct-child": newTestSolution(nil, nil),
+	}}
+	ctxLoader := &mockLoader{solutions: map[string]*solution.Solution{
+		"ctx-child": newTestSolution(nil, nil),
+	}}
+	structReg := provider.NewRegistry()
+	ctxReg := provider.NewRegistry()
+
+	p := New(WithLoader(structLoader), WithRegistry(structReg))
+
+	// Put different deps in context.
+	ctx := WithLoaderCtx(context.Background(), ctxLoader)
+	ctx = WithProviderRegistry(ctx, ctxReg)
+
+	// Execute with a source that only the context loader knows about.
+	out, err := p.Execute(ctx, map[string]any{
+		"source": "ctx-child",
+	})
+	require.NoError(t, err)
+	data, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "success", data["status"])
+
+	// Verify the struct loader's solution is NOT loaded (context won).
+	_, err = p.Execute(ctx, map[string]any{
+		"source": "struct-child",
+	})
+	// struct-child is not in ctxLoader, so this should fail with a load error.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load")
+}
+
 func TestExecute_CircularDetection(t *testing.T) {
 	loader := &mockLoader{
 		solutions: map[string]*solution.Solution{
@@ -1042,7 +1199,8 @@ func TestClose_KillsClients(t *testing.T) {
 }
 
 func TestAutoResolveChildProviders_NilOfficialProviders(t *testing.T) {
-	p := New(WithRegistry(provider.NewRegistry()))
+	reg := provider.NewRegistry()
+	p := New(WithRegistry(reg))
 	sol := &solution.Solution{
 		Spec: solution.Spec{
 			Resolvers: map[string]*resolver.Resolver{
@@ -1051,15 +1209,16 @@ func TestAutoResolveChildProviders_NilOfficialProviders(t *testing.T) {
 		},
 	}
 	// Should return immediately — no panic, no error, nothing fetched.
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.NoError(t, err)
 	assert.Empty(t, p.childClients)
 }
 
 func TestAutoResolveChildProviders_NilPluginFetcher(t *testing.T) {
 	officialReg := official.NewRegistry()
+	reg := provider.NewRegistry()
 	p := New(
-		WithRegistry(provider.NewRegistry()),
+		WithRegistry(reg),
 		WithOfficialProviders(officialReg),
 		// No WithPluginFetcher — simulates missing fetcher.
 	)
@@ -1070,7 +1229,7 @@ func TestAutoResolveChildProviders_NilPluginFetcher(t *testing.T) {
 			},
 		},
 	}
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.NoError(t, err)
 	assert.Empty(t, p.childClients)
 }
@@ -1093,7 +1252,7 @@ func TestAutoResolveChildProviders_AllRegistered(t *testing.T) {
 			},
 		},
 	}
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.NoError(t, err)
 	assert.Empty(t, p.childClients)
 }
@@ -1115,7 +1274,7 @@ func TestAutoResolveChildProviders_NoMissing(t *testing.T) {
 		},
 	}
 	// "cel" is not in the official registry so nothing to resolve.
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.NoError(t, err)
 	assert.Empty(t, p.childClients)
 }
@@ -1138,7 +1297,7 @@ func TestAutoResolveChildProviders_DeduplicatesProviders(t *testing.T) {
 			},
 		},
 	}
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.NoError(t, err)
 	assert.Empty(t, p.childClients)
 }
@@ -1172,7 +1331,7 @@ func TestAutoResolveChildProviders_FetchFails(t *testing.T) {
 			},
 		},
 	}
-	err = p.autoResolveChildProviders(context.Background(), sol)
+	err = p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auto-fetching child solution providers")
 }
@@ -1213,7 +1372,7 @@ func TestAutoResolveChildProviders_WorkflowActions(t *testing.T) {
 	}
 
 	// "git" is official but not registered and not in any catalog — errors on fetch.
-	err := p.autoResolveChildProviders(context.Background(), sol)
+	err := p.autoResolveChildProviders(context.Background(), sol, reg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auto-fetching child solution providers")
 }

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -194,6 +194,12 @@ type Result struct {
 	// DiscoveredFrom holds metadata about how the solution file was discovered.
 	// Only populated when auto-discovery is used (path was empty).
 	DiscoveredFrom get.DiscoveryResult `json:"-" yaml:"-"`
+	// ProviderCtx enriches a context with solution provider dependencies
+	// (loader, registry, plugin deps, client tracker). Callers must apply
+	// this to the execution context before running resolvers or actions so
+	// the solution provider can resolve sub-solutions. May be nil when no
+	// solution provider is registered.
+	ProviderCtx func(ctx context.Context) context.Context `json:"-" yaml:"-"`
 }
 
 // Solution loads a solution from the given path, extracts any bundle,
@@ -431,33 +437,36 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 		}
 	}
 
-	// Register the solution provider
-	if !reg.Has(solutionprovider.ProviderName) {
-		solOpts := []solutionprovider.Option{
-			solutionprovider.WithLoader(getter),
-			solutionprovider.WithRegistry(reg),
+	// Build a context enrichment function that injects solution provider
+	// dependencies via context. This avoids mutating the shared singleton
+	// in DefaultRegistry and keeps per-execution state isolated.
+	var providerCtx func(ctx context.Context) context.Context
+	if reg.Has(solutionprovider.ProviderName) {
+		tracker := solutionprovider.NewChildClientTracker()
+
+		providerCtx = func(ctx context.Context) context.Context {
+			ctx = solutionprovider.WithLoaderCtx(ctx, getter)
+			ctx = solutionprovider.WithProviderRegistry(ctx, reg)
+			ctx = solutionprovider.WithChildClientTracker(ctx, tracker)
+			if cfg.officialProviders != nil {
+				ctx = solutionprovider.WithOfficialProvidersCtx(ctx, cfg.officialProviders)
+			}
+			if cfg.pluginFetcher != nil {
+				ctx = solutionprovider.WithPluginFetcherCtx(ctx, cfg.pluginFetcher)
+			}
+			if cfg.pluginCfg != nil {
+				ctx = solutionprovider.WithPluginConfigCtx(ctx, cfg.pluginCfg)
+			}
+			if len(cfg.clientOpts) > 0 {
+				ctx = solutionprovider.WithClientOptionsCtx(ctx, cfg.clientOpts)
+			}
+			return ctx
 		}
-		if cfg.officialProviders != nil {
-			solOpts = append(solOpts, solutionprovider.WithOfficialProviders(cfg.officialProviders))
-		}
-		if cfg.pluginFetcher != nil {
-			solOpts = append(solOpts, solutionprovider.WithPluginFetcher(cfg.pluginFetcher))
-		}
-		if cfg.pluginCfg != nil {
-			solOpts = append(solOpts, solutionprovider.WithPluginConfig(cfg.pluginCfg))
-		}
-		if len(cfg.clientOpts) > 0 {
-			solOpts = append(solOpts, solutionprovider.WithClientOptions(cfg.clientOpts...))
-		}
-		solProvider := solutionprovider.New(solOpts...)
-		if err := reg.Register(solProvider); err != nil {
-			cleanup()
-			return nil, fmt.Errorf("registering solution provider: %w", err)
-		}
-		// Add solution provider cleanup to kill child plugin clients.
+
+		// Add tracker cleanup to kill child plugin clients for this run only.
 		origCleanup := cleanup
 		cleanup = func() {
-			solProvider.Close()
+			tracker.Close()
 			origCleanup()
 		}
 	}
@@ -468,6 +477,7 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 		SolutionDir:    solutionDir,
 		Cleanup:        cleanup,
 		DiscoveredFrom: discoveredFrom,
+		ProviderCtx:    providerCtx,
 	}, nil
 }
 

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/solutionprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -81,7 +82,71 @@ func TestSolution(t *testing.T) {
 		assert.Equal(t, "test-solution", result.Solution.Metadata.Name)
 		assert.NotNil(t, result.Registry)
 		assert.NotNil(t, result.Cleanup)
+		assert.NotNil(t, result.ProviderCtx, "ProviderCtx should be set when solution provider is in registry")
 
+		// Verify ProviderCtx enriches context with loader and registry.
+		enrichedCtx := result.ProviderCtx(context.Background())
+		assert.NotNil(t, solutionprovider.LoaderFromContext(enrichedCtx))
+		assert.NotNil(t, solutionprovider.ProviderRegistryFromContext(enrichedCtx))
+		assert.NotNil(t, solutionprovider.ChildClientTrackerFromContext(enrichedCtx))
+
+		result.Cleanup()
+	})
+
+	t.Run("ProviderCtx injects optional plugin deps", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+		offProviders := official.NewRegistry()
+		pluginFetcher := &plugin.Fetcher{}
+		pluginCfg := &plugin.ProviderConfig{}
+		clientOpt := plugin.WithDebugLogging()
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+			WithOfficialProviders(offProviders),
+			WithPluginFetcher(pluginFetcher),
+			WithPluginConfig(pluginCfg),
+			WithClientOptions(clientOpt),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result.ProviderCtx)
+
+		enrichedCtx := result.ProviderCtx(context.Background())
+		assert.NotNil(t, solutionprovider.OfficialProvidersFromContext(enrichedCtx))
+		assert.NotNil(t, solutionprovider.PluginFetcherFromContext(enrichedCtx))
+		assert.NotNil(t, solutionprovider.PluginConfigFromContext(enrichedCtx))
+		assert.NotNil(t, solutionprovider.ClientOptionsFromContext(enrichedCtx))
+
+		result.Cleanup()
+	})
+
+	t.Run("ProviderCtx nil when no solution provider in registry", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+		// Empty registry with no solution provider registered.
+		emptyReg := provider.NewRegistry()
+
+		result, err := Solution(context.Background(), "test.yaml",
+			WithGetter(getter),
+			WithRegistry(emptyReg),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, result.ProviderCtx, "ProviderCtx should be nil when solution provider is not in registry")
+		result.Cleanup()
+	})
+
+	t.Run("loads with logger context", func(t *testing.T) {
+		sol := minimalSolution()
+		getter := &mockGetter{sol: sol}
+
+		lgr := logr.Discard()
+		ctx := logger.WithLogger(context.Background(), &lgr)
+		result, err := Solution(ctx, "test.yaml",
+			WithGetter(getter),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "test-solution", result.Solution.Metadata.Name)
 		result.Cleanup()
 	})
 


### PR DESCRIPTION
- register bare solution provider in DefaultRegistry so it appears in `get provider` output and lint does not need special-case registration
- add Configure() method to inject runtime dependencies (loader, registry) after registration
- resolve loader and registry from struct fields first, then fall back to context, enabling both Configure() and context-based dependency injection
- protect Configure/resolve* with mutex for thread safety when the singleton provider is shared across goroutines
- simplify lint.go by removing manual solution provider registration (now handled by DefaultRegistry)
- update prepare.go to type-assert and Configure() the existing provider instead of creating a new one
- add context key pairs for all optional plugin dependencies (official providers, plugin fetcher, plugin config, client options) with round-trip tests