### PR TITLE
fix(cli)!: return cleanup func from Root to prevent auth handler leaks

### DIFF
--- a/cmd/scafctl/scafctl.go
+++ b/cmd/scafctl/scafctl.go
@@ -48,7 +48,8 @@ func run() error {
 	// Register all default factories (CEL env/cache, Go template extensions).
 	scafctl.RegisterDefaults()
 
-	cli := scafctl.Root(nil)
+	cli, cleanup := scafctl.Root(nil)
+	defer cleanup()
 	defer func() {
 		// Profiler shutdown errors are logged but not treated as fatal,
 		// as they do not affect the main application flow.

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -199,7 +200,12 @@ func NewRootOptions() *RootOptions {
 // opts may be nil, in which case production defaults are used.
 // Each invocation creates its own isolated state so multiple Root()
 // calls can execute concurrently without data races.
-func Root(opts *RootOptions) *cobra.Command {
+//
+// The returned cleanup function releases auth handler plugins and telemetry
+// resources. Callers must defer it after Execute() returns so that resources
+// are released even when RunE returns an error (cobra skips PersistentPostRun
+// in that case). The function is idempotent and safe to call multiple times.
+func Root(opts *RootOptions) (*cobra.Command, func()) {
 	if opts == nil {
 		opts = NewRootOptions()
 	}
@@ -249,6 +255,12 @@ func Root(opts *RootOptions) *cobra.Command {
 	if opts.ExitFunc != nil {
 		writerOpts = append(writerOpts, writer.WithExitFunc(opts.ExitFunc))
 	}
+
+	// cleanup is assigned after cCmd to capture per-invocation state.
+	// PersistentPostRun calls it on success; the caller defers it for the error path.
+	// Initialised to a noop so early-exit paths can call it safely before the
+	// real implementation is wired up at the end of Root().
+	cleanup := func() {}
 
 	cCmd := &cobra.Command{
 		Use:   binaryName,
@@ -576,7 +588,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			if cCmd.Use == binaryName {
 				err := output.ValidateCommands(args)
 				if err != nil {
-					plugin.KillAllAuthHandlers(authPluginClients)
+					cleanup()
 					w.ErrorWithExit(err.Error())
 					return
 				}
@@ -592,7 +604,7 @@ func Root(opts *RootOptions) *cobra.Command {
 			// Call embedder's pre-run hook after all standard setup is complete.
 			if opts.PreRunHook != nil {
 				if hookErr := opts.PreRunHook(cCmd, args); hookErr != nil {
-					plugin.KillAllAuthHandlers(authPluginClients)
+					cleanup()
 					w.ErrorWithExit(hookErr.Error())
 					return
 				}
@@ -603,7 +615,7 @@ func Root(opts *RootOptions) *cobra.Command {
 				profilePath, _ := cCmd.Flags().GetString("pprof-output-dir")
 				p, err := profiler.GetProfiler(profileType, profilePath, lgr)
 				if err != nil {
-					plugin.KillAllAuthHandlers(authPluginClients)
+					cleanup()
 					w.ErrorWithExitf("Error starting profiler: %v", err)
 					return
 				}
@@ -619,12 +631,10 @@ func Root(opts *RootOptions) *cobra.Command {
 			}
 		},
 		PersistentPostRun: func(_ *cobra.Command, _ []string) {
-			plugin.KillAllAuthHandlers(authPluginClients)
-			if telShutdown != nil {
-				shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_ = telShutdown(shutCtx)
-			}
+			// Happy path: cleanup runs here when RunE succeeds.
+			// Error path: caller must defer the returned cleanup func
+			// because cobra skips PersistentPostRun when RunE fails.
+			cleanup()
 		},
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -659,10 +669,10 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.PersistentFlags().BoolVar(&otelInsecure, "otel-insecure", false, "Disable TLS for OTLP gRPC connection (development only)")
 
 	if err := cCmd.PersistentFlags().MarkHidden("pprof"); err != nil {
-		return nil
+		return nil, func() {}
 	}
 	if err := cCmd.PersistentFlags().MarkHidden("pprof-output-dir"); err != nil {
-		return nil
+		return nil, func() {}
 	}
 	// Core Commands — primary workflows
 	cCmd.AddCommand(withGroup(groupCore, run.CommandRun(cliParams, ioStreams, binaryName)))
@@ -703,7 +713,23 @@ func Root(opts *RootOptions) *cobra.Command {
 	cCmd.AddCommand(version.CommandVersion(cliParams, ioStreams, binaryName, opts.VersionExtra))
 	cCmd.AddCommand(examplescmd.CommandExamples(cliParams, ioStreams, binaryName))
 	cCmd.AddCommand(options.CommandOptions(cliParams, ioStreams, binaryName))
-	return cCmd
+	// cleanup releases auth handler plugins and telemetry. It is safe to call
+	// multiple times (idempotent via sync.Once). PersistentPostRun calls it on
+	// success; callers must defer it to cover the error path where cobra skips
+	// PersistentPostRun.
+	var cleanupOnce sync.Once
+	cleanup = func() {
+		cleanupOnce.Do(func() {
+			plugin.KillAllAuthHandlers(authPluginClients)
+			if telShutdown != nil {
+				shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = telShutdown(shutCtx)
+			}
+		})
+	}
+
+	return cCmd, cleanup
 }
 
 // withGroup sets the GroupID on a command and returns it for chaining.

--- a/pkg/cmd/scafctl/root_coverage_test.go
+++ b/pkg/cmd/scafctl/root_coverage_test.go
@@ -30,7 +30,7 @@ func TestNewRootOptions(t *testing.T) {
 // TestRoot_NilOpts verifies that Root(nil) succeeds and uses production defaults.
 func TestRoot_NilOpts(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "scafctl", cmd.Use)
 }
@@ -40,7 +40,7 @@ func TestRoot_EnvVar_LogLevel(t *testing.T) {
 	t.Setenv("SCAFCTL_LOG_LEVEL", "debug")
 
 	ioStreams, out, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -56,7 +56,7 @@ func TestRoot_EnvVar_Debug(t *testing.T) {
 	t.Setenv("SCAFCTL_LOG_LEVEL", "") // ensure log level env is clear
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -68,7 +68,7 @@ func TestRoot_EnvVar_Debug_Zero(t *testing.T) {
 	t.Setenv("SCAFCTL_DEBUG", "0")
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -80,7 +80,7 @@ func TestRoot_EnvVar_LogFormat(t *testing.T) {
 	t.Setenv("SCAFCTL_LOG_FORMAT", "json")
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -93,7 +93,7 @@ func TestRoot_EnvVar_LogPath(t *testing.T) {
 	t.Setenv("SCAFCTL_LOG_PATH", logFile)
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -106,7 +106,7 @@ func TestRoot_WithConfigPath(t *testing.T) {
 	t.Parallel()
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:  ioStreams,
 		ConfigPath: "/nonexistent/path/config.yaml",
 	})
@@ -121,7 +121,7 @@ func TestRoot_VersionSubcommand_Output(t *testing.T) {
 	t.Parallel()
 
 	ioStreams, out, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -136,7 +136,7 @@ func TestRoot_FlagDebugOverridesEnv(t *testing.T) {
 	t.Setenv("SCAFCTL_LOG_LEVEL", "none") // env says none
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"--debug", "version"})
 
 	err := cmd.Execute()
@@ -146,14 +146,14 @@ func TestRoot_FlagDebugOverridesEnv(t *testing.T) {
 // TestRoot_SilenceErrors verifies that SilenceErrors is set on root command.
 func TestRoot_SilenceErrors(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	assert.True(t, cmd.SilenceErrors)
 }
 
 // TestRoot_HasAnnotations verifies root command has expected annotations.
 func TestRoot_HasAnnotations(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	require.NotNil(t, cmd.Annotations)
 	assert.Equal(t, "main", cmd.Annotations["commandType"])
 }
@@ -161,7 +161,7 @@ func TestRoot_HasAnnotations(t *testing.T) {
 // TestRoot_SubcommandCount verifies an expected minimum number of subcommands.
 func TestRoot_SubcommandCount(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	// Should have at least the core subcommands
 	expectedMinSubcmds := 5
 	if len(cmd.Commands()) < expectedMinSubcmds {
@@ -172,7 +172,7 @@ func TestRoot_SubcommandCount(t *testing.T) {
 // TestRoot_QuietFlagDefault verifies that the --quiet flag defaults to false.
 func TestRoot_QuietFlagDefault(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	flag := cmd.PersistentFlags().Lookup("quiet")
 	require.NotNil(t, flag)
@@ -182,7 +182,7 @@ func TestRoot_QuietFlagDefault(t *testing.T) {
 // TestRoot_LogLevelFlagDefault verifies the --log-level flag has a default.
 func TestRoot_LogLevelFlagDefault(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	flag := cmd.PersistentFlags().Lookup("log-level")
 	require.NotNil(t, flag)
@@ -192,7 +192,7 @@ func TestRoot_LogLevelFlagDefault(t *testing.T) {
 // TestRoot_OtelFlags verifies that OTel-related flags exist.
 func TestRoot_OtelFlags(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	flags := []string{"otel-endpoint", "otel-insecure"}
 	for _, name := range flags {
@@ -210,14 +210,14 @@ func BenchmarkRootConstruction(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		Root(&RootOptions{IOStreams: ioStreams})
+		_, _ = Root(&RootOptions{IOStreams: ioStreams})
 	}
 }
 
 // TestRoot_LogLevelFlagExpectedValue ensures the log-level flag's usage is set.
 func TestRoot_LogLevelFlagUsage(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	flag := cmd.PersistentFlags().Lookup("log-level")
 	require.NotNil(t, flag)
@@ -228,7 +228,7 @@ func TestRoot_LogLevelFlagUsage(t *testing.T) {
 // have a non-empty Short description for clear CLI help and UX.
 func TestRoot_SubcommandsHaveShortDesc(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	for _, sub := range cmd.Commands() {
 		if sub.Name() == "help" {
@@ -245,7 +245,7 @@ func TestRoot_EnvVar_Debug_False(t *testing.T) {
 	t.Setenv("SCAFCTL_DEBUG", "false")
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -255,7 +255,7 @@ func TestRoot_EnvVar_Debug_False(t *testing.T) {
 // TestRoot_CwdFlag verifies the --cwd flag exists.
 func TestRoot_CwdFlagExists(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	flag := cmd.PersistentFlags().Lookup("cwd")
 	require.NotNil(t, flag)
@@ -266,14 +266,14 @@ func TestRoot_CwdFlagExists(t *testing.T) {
 // TestRoot_BinaryName_Default verifies that omitting BinaryName defaults to "scafctl".
 func TestRoot_BinaryName_Default(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	assert.Equal(t, "scafctl", cmd.Use)
 }
 
 // TestRoot_BinaryName_Custom verifies that BinaryName overrides the root command Use.
 func TestRoot_BinaryName_Custom(t *testing.T) {
 	t.Parallel()
-	cmd := Root(&RootOptions{BinaryName: "mycli"})
+	cmd, _ := Root(&RootOptions{BinaryName: "mycli"})
 	assert.Equal(t, "mycli", cmd.Use)
 }
 
@@ -281,7 +281,7 @@ func TestRoot_BinaryName_Custom(t *testing.T) {
 // reflect the custom binary name instead of "scafctl".
 func TestRoot_BinaryName_SubcommandShorts(t *testing.T) {
 	t.Parallel()
-	cmd := Root(&RootOptions{BinaryName: "mycli"})
+	cmd, _ := Root(&RootOptions{BinaryName: "mycli"})
 
 	for _, sub := range cmd.Commands() {
 		if sub.Name() == "help" || sub.Short == "" {
@@ -297,7 +297,7 @@ func TestRoot_BinaryName_EnvPrefix(t *testing.T) {
 	t.Setenv("MYCLI_LOG_LEVEL", "debug")
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams, BinaryName: "mycli"})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams, BinaryName: "mycli"})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -310,7 +310,7 @@ func TestRoot_BinaryName_EnvPrefix_Hyphen(t *testing.T) {
 	t.Setenv("MY_CLI_LOG_LEVEL", "debug")
 
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams, BinaryName: "my-cli"})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams, BinaryName: "my-cli"})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -322,7 +322,7 @@ func TestRoot_PreRunHook_Called(t *testing.T) {
 	t.Parallel()
 	hookCalled := false
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams: ioStreams,
 		PreRunHook: func(cmd *cobra.Command, args []string) error {
 			hookCalled = true
@@ -340,7 +340,7 @@ func TestRoot_PreRunHook_Called(t *testing.T) {
 func TestRoot_PreRunHook_Nil(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams, PreRunHook: nil})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams, PreRunHook: nil})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -351,7 +351,7 @@ func TestRoot_PreRunHook_Nil(t *testing.T) {
 func TestRoot_VersionExtra(t *testing.T) {
 	t.Parallel()
 	ioStreams, out, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:  ioStreams,
 		BinaryName: "mycli",
 		VersionExtra: &settings.VersionInfo{
@@ -383,7 +383,7 @@ func TestRoot_PreRunHook_Error(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	exitCalled := false
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams: ioStreams,
 		ExitFunc:  func(code int) { exitCalled = true },
 		PreRunHook: func(cmd *cobra.Command, args []string) error {
@@ -399,14 +399,14 @@ func TestRoot_PreRunHook_Error(t *testing.T) {
 // TestRoot_BinaryName_Sanitized verifies that BinaryName with path/extension is sanitized.
 func TestRoot_BinaryName_Sanitized(t *testing.T) {
 	t.Parallel()
-	cmd := Root(&RootOptions{BinaryName: "/usr/bin/my-tool.exe"})
+	cmd, _ := Root(&RootOptions{BinaryName: "/usr/bin/my-tool.exe"})
 	assert.Equal(t, "my-tool", cmd.Use)
 }
 
 // TestRoot_BinaryName_Empty verifies that empty BinaryName falls back to default.
 func TestRoot_BinaryName_Empty(t *testing.T) {
 	t.Parallel()
-	cmd := Root(&RootOptions{BinaryName: ""})
+	cmd, _ := Root(&RootOptions{BinaryName: ""})
 	assert.Equal(t, "scafctl", cmd.Use)
 }
 
@@ -417,7 +417,7 @@ func TestRoot_OfficialAuthHandlerRegistry_Enabled(t *testing.T) {
 
 	var registryFromCtx *authofficial.Registry
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams: ioStreams,
 		PreRunHook: func(cmd *cobra.Command, _ []string) error {
 			registryFromCtx = authofficial.RegistryFromContext(cmd.Context())
@@ -443,7 +443,7 @@ func TestRoot_OfficialAuthHandlerRegistry_CustomEmbedder(t *testing.T) {
 
 	var registryFromCtx *authofficial.Registry
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:            ioStreams,
 		OfficialAuthHandlers: customRegistry,
 		PreRunHook: func(cmd *cobra.Command, _ []string) error {
@@ -471,7 +471,7 @@ func TestRoot_OfficialAuthHandlerRegistry_Disabled(t *testing.T) {
 	var registryFromCtx *authofficial.Registry
 	hookCalled := false
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:      ioStreams,
 		ConfigDefaults: disabledCfg,
 		PreRunHook: func(cmd *cobra.Command, _ []string) error {
@@ -495,7 +495,7 @@ func TestRoot_OfficialAuthHandlerRegistry_Enabled_NonDefaultBinary(t *testing.T)
 
 	var registryFromCtx *authofficial.Registry
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:  ioStreams,
 		BinaryName: "mycli",
 		PreRunHook: func(cmd *cobra.Command, _ []string) error {
@@ -532,7 +532,7 @@ func TestRoot_PluginSignaturePolicy_Wired(t *testing.T) {
 		},
 	}
 
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		IOStreams:             ioStreams,
 		PluginSignaturePolicy: policy,
 	})
@@ -562,7 +562,7 @@ func TestRoot_PluginSignaturePolicy_NilByDefault(t *testing.T) {
 		},
 	}
 
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.AddCommand(probe)
 	cmd.SetArgs([]string{"probe"})
 
@@ -577,7 +577,7 @@ func TestRoot_NoBuiltInHandlerWarnings(t *testing.T) {
 	t.Parallel()
 
 	ioStreams, out, errOut := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	cmd.SetArgs([]string{"version"})
 
 	err := cmd.Execute()
@@ -639,4 +639,45 @@ func TestCommandNeedsAuthHandlers(t *testing.T) {
 			assert.Equal(t, tc.want, commandNeedsAuthHandlers(tc.cmd))
 		})
 	}
+}
+
+// TestRoot_Cleanup_Idempotent verifies that the returned cleanup function
+// can be called multiple times without panicking (sync.Once idempotency).
+func TestRoot_Cleanup_Idempotent(t *testing.T) {
+	t.Parallel()
+	_, cleanup := Root(nil)
+	require.NotNil(t, cleanup, "cleanup function must not be nil")
+	// Call twice — must not panic.
+	cleanup()
+	cleanup()
+}
+
+// TestRoot_Cleanup_AfterExecute verifies that the returned cleanup function
+// releases resources even when RunE returns an error (cobra skips
+// PersistentPostRun in that case). A probe subcommand is injected so that
+// PersistentPreRun initialises the context before RunE fails.
+func TestRoot_Cleanup_AfterExecute(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	preRunCalled := false
+	probe := &cobra.Command{
+		Use: "probe",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			preRunCalled = true
+			return fmt.Errorf("simulated RunE failure")
+		},
+	}
+
+	cmd, cleanup := Root(&RootOptions{IOStreams: ioStreams})
+	defer cleanup() // mirrors production pattern in cmd/scafctl/scafctl.go
+	cmd.AddCommand(probe)
+	cmd.SetArgs([]string{"probe"})
+
+	err := cmd.Execute()
+	assert.Error(t, err, "Execute should propagate RunE error")
+	assert.True(t, preRunCalled, "PersistentPreRun should have run before RunE")
+	// cleanup runs via defer after Execute returns the error — must not panic
+	// and must be safe to call again (idempotent via sync.Once).
+	cleanup()
 }

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRoot_CommandProperties(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	require.NotNil(t, cmd)
 	if cmd.Use != "scafctl" {
 		t.Errorf("Root().Use = %q, want %q", cmd.Use, "scafctl")
@@ -31,7 +31,7 @@ func TestRoot_CommandProperties(t *testing.T) {
 
 func TestRoot_PersistentFlags(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	flags := cmd.PersistentFlags()
 	if flags.Lookup("log-level") == nil {
 		t.Error("Expected 'log-level' persistent flag to be defined")
@@ -55,7 +55,7 @@ func TestRoot_PersistentFlags(t *testing.T) {
 
 func TestRoot_HiddenFlags(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	pprofFlag := cmd.PersistentFlags().Lookup("pprof")
 	require.NotNil(t, pprofFlag, "Expected 'pprof' flag to exist")
 	if !pprofFlag.Hidden {
@@ -70,7 +70,7 @@ func TestRoot_HiddenFlags(t *testing.T) {
 
 func TestRoot_HasVersionSubcommand(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	found := false
 	for _, sub := range cmd.Commands() {
 		if sub.Name() == "version" {
@@ -85,7 +85,7 @@ func TestRoot_HasVersionSubcommand(t *testing.T) {
 
 func TestRoot_HasOptionsSubcommand(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 	found := false
 	for _, sub := range cmd.Commands() {
 		if sub.Name() == "options" {
@@ -100,7 +100,7 @@ func TestRoot_HasOptionsSubcommand(t *testing.T) {
 
 func TestRoot_CommandGroups(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	groups := cmd.Groups()
 	if len(groups) == 0 {
@@ -144,7 +144,7 @@ func TestRoot_CommandGroups(t *testing.T) {
 
 func TestRoot_UsageTemplateHidesGlobalFlags(t *testing.T) {
 	t.Parallel()
-	cmd := Root(nil)
+	cmd, _ := Root(nil)
 
 	// Verify the rendered root help omits flags and references "options".
 	var buf strings.Builder
@@ -173,7 +173,7 @@ func TestRoot_ParallelConstruction(t *testing.T) {
 	for i := range n {
 		go func(idx int) {
 			defer wg.Done()
-			cmds[idx] = Root(nil)
+			cmds[idx], _ = Root(nil)
 		}(i)
 	}
 	wg.Wait()
@@ -187,7 +187,7 @@ func TestRoot_ParallelConstruction(t *testing.T) {
 func TestRoot_WithCustomIOStreams(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := Root(&RootOptions{IOStreams: ioStreams})
+	cmd, _ := Root(&RootOptions{IOStreams: ioStreams})
 	if cmd == nil {
 		t.Fatal("Root() with custom IOStreams returned nil")
 	}
@@ -202,7 +202,7 @@ func TestRoot_WithExitFunc(t *testing.T) {
 	t.Parallel()
 	var captured int
 	exitCalled := false
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		ExitFunc: func(code int) {
 			exitCalled = true
 			captured = code
@@ -224,7 +224,7 @@ func TestRoot_CustomBinaryNameUpdatesSolutionDiscovery(t *testing.T) {
 		settings.SolutionFileNames = settings.SolutionFileNamesFor(settings.CliBinaryName)
 	})
 
-	cmd := Root(&RootOptions{
+	cmd, _ := Root(&RootOptions{
 		BinaryName: "cldctl",
 	})
 	require.NotNil(t, cmd)


### PR DESCRIPTION
- Change Root() signature to return (*cobra.Command, func()) so callers can defer cleanup after Execute() returns
- Cobra skips PersistentPostRun when RunE returns an error, which previously left auth handler plugins and telemetry running
- Wrap cleanup in sync.Once for idempotent multi-call safety
- Replace bare KillAllAuthHandlers calls in ErrorWithExit paths with cleanup() to also shut down telemetry on early exits
- Initialize cleanup to noop so it is safe to call before the real implementation is wired at end of Root()
- Add TestRoot_Cleanup_Idempotent and TestRoot_Cleanup_AfterExecute

BREAKING CHANGE: Root() now returns (*cobra.Command, func()) instead of *cobra.Command. Embedders must update call sites to capture and defer the cleanup function.
