### PR TITLE
docs: use --force instead of --force-with-lease for tag push

### DIFF
--- a/.github/workflows/sign-plugin.yml
+++ b/.github/workflows/sign-plugin.yml
@@ -10,7 +10,7 @@ name: Sign Plugin OCI Artifact
 #   After merging changes, update the tag to the current HEAD of main:
 #     git checkout main && git pull
 #     git tag -f sign-plugin/v1 HEAD
-#     git push --force-with-lease origin refs/tags/sign-plugin/v1
+#     git push --force origin refs/tags/sign-plugin/v1
 #   This propagates the change to all plugin repos on their next workflow run.
 #
 # Usage in plugin repos:

--- a/docs/design/artifact-signing.md
+++ b/docs/design/artifact-signing.md
@@ -122,7 +122,7 @@ After updating `sign-plugin.yml` on `main`, maintainers update the tag:
 ~~~bash
 git checkout main && git pull
 git tag -f sign-plugin/v1 HEAD
-git push --force-with-lease origin refs/tags/sign-plugin/v1
+git push --force origin refs/tags/sign-plugin/v1
 ~~~
 
 All plugin and solution repos referencing `@sign-plugin/v1` automatically use the updated workflow on their next release.


### PR DESCRIPTION
- --force-with-lease always fails for tags because git does not maintain remote-tracking refs for them
- update workflow comment in sign-plugin.yml
- update versioning instructions in artifact-signing.md
