### PR TITLE
fix(auth): resolve oauth2 and plugin handler secret storage incompatibility

### DIFF
--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,12 +42,13 @@ const (
 
 // Handler implements auth.Handler for generic configurable OAuth2 services.
 type Handler struct {
-	cfg         config.CustomOAuth2Config
-	secretStore secrets.Store
-	secretErr   error
-	tokenCache  *auth.TokenCache
-	httpClient  *http.Client
-	logger      logr.Logger
+	cfg             config.CustomOAuth2Config
+	secretStore     secrets.Store
+	secretErr       error
+	tokenCache      *auth.TokenCache
+	httpClient      *http.Client
+	logger          logr.Logger
+	secretKeyPrefix string
 }
 
 // Option configures the Handler.
@@ -67,6 +69,14 @@ func WithLogger(lgr logr.Logger) Option {
 	return func(h *Handler) { h.logger = lgr }
 }
 
+// WithSecretKeyPrefix overrides the default secret key prefix used for
+// storing secrets in the keychain. This allows the generic oauth2.Handler
+// to share tokens written by plugin auth handlers that use a different
+// prefix convention.
+func WithSecretKeyPrefix(prefix string) Option {
+	return func(h *Handler) { h.secretKeyPrefix = prefix }
+}
+
 // New creates a new generic OAuth2 auth handler from a CustomOAuth2Config.
 func New(cfg config.CustomOAuth2Config, opts ...Option) (*Handler, error) {
 	// Implicit grant flow does not use PKCE.
@@ -75,8 +85,9 @@ func New(cfg config.CustomOAuth2Config, opts ...Option) (*Handler, error) {
 	}
 
 	h := &Handler{
-		cfg:    cfg,
-		logger: logr.Discard(),
+		cfg:             cfg,
+		logger:          logr.Discard(),
+		secretKeyPrefix: secretKeyPrefix,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -94,7 +105,7 @@ func New(cfg config.CustomOAuth2Config, opts ...Option) (*Handler, error) {
 		h.httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 	if h.secretStore != nil {
-		prefix := secretKeyPrefix + h.cfg.Name + "." + tokenCacheSuffix
+		prefix := h.secretKeyPrefix + h.cfg.Name + "." + tokenCacheSuffix
 		h.tokenCache = auth.NewTokenCache(h.secretStore, prefix)
 	}
 	return h, nil
@@ -245,12 +256,15 @@ func (h *Handler) Logout(ctx context.Context) error {
 // Status returns the current authentication state.
 func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
 	if err := h.ensureSecrets(); err != nil {
-		return &auth.Status{Authenticated: false}, nil //nolint:nilerr // graceful degradation
+		return &auth.Status{Authenticated: false, Reason: "secrets store unavailable"}, nil //nolint:nilerr // graceful degradation
 	}
 
 	meta, err := h.loadMetadata(ctx)
-	if err != nil || meta == nil {
-		return &auth.Status{Authenticated: false}, nil //nolint:nilerr // metadata absence is not an error for status
+	if err != nil {
+		if errors.Is(err, secrets.ErrNotFound) {
+			return &auth.Status{Authenticated: false, Reason: "not logged in"}, nil
+		}
+		return &auth.Status{Authenticated: false, Reason: "metadata corrupt or unreadable"}, nil //nolint:nilerr // metadata error is not a caller error
 	}
 	if meta.ExpiresAt.Before(time.Now()) {
 		return &auth.Status{Authenticated: false, Reason: "session expired", Claims: meta.Claims}, nil
@@ -350,6 +364,34 @@ type handlerMetadata struct {
 	ExpiresAt     time.Time    `json:"expiresAt"`
 	Scopes        []string     `json:"scopes"`
 	LastLoginFlow auth.Flow    `json:"lastLoginFlow,omitempty"`
+}
+
+// unmarshalMetadata deserializes metadata JSON, handling field name differences
+// between the generic oauth2 handler and plugin auth handlers.
+// Plugin handlers use "refreshTokenExpiresAt" (vs "expiresAt") and
+// "loginFlow" (vs "lastLoginFlow").
+func unmarshalMetadata(data []byte) (*handlerMetadata, error) {
+	var meta handlerMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	// If ExpiresAt is zero, try the plugin handler's field name.
+	if meta.ExpiresAt.IsZero() {
+		var compat struct {
+			RefreshTokenExpiresAt time.Time `json:"refreshTokenExpiresAt"`
+			LoginFlow             auth.Flow `json:"loginFlow"`
+		}
+		if err := json.Unmarshal(data, &compat); err == nil {
+			if !compat.RefreshTokenExpiresAt.IsZero() {
+				meta.ExpiresAt = compat.RefreshTokenExpiresAt
+			}
+			if meta.LastLoginFlow == "" && compat.LoginFlow != "" {
+				meta.LastLoginFlow = compat.LoginFlow
+			}
+		}
+	}
+	return &meta, nil
 }
 
 type exchangeResult struct {
@@ -838,11 +880,7 @@ func (h *Handler) loadMetadata(ctx context.Context) (*handlerMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	var meta handlerMetadata
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-	return &meta, nil
+	return unmarshalMetadata(data)
 }
 
 // ---------- refresh ----------
@@ -901,7 +939,7 @@ func (h *Handler) postTokenEndpoint(ctx context.Context, data url.Values) (*toke
 // ---------- utilities ----------
 
 func (h *Handler) secretKey(suffix string) string {
-	return secretKeyPrefix + h.cfg.Name + "." + suffix
+	return h.secretKeyPrefix + h.cfg.Name + "." + suffix
 }
 
 func (h *Handler) ensureSecrets() error {

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -852,3 +852,118 @@ func TestHandler_CallbackOpts(t *testing.T) {
 		})
 	}
 }
+
+func TestWithSecretKeyPrefix(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	store := secrets.NewMockStore()
+
+	// Write metadata under the plugin-style prefix
+	pluginPrefix := "scafctl.auth."
+	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(1 * time.Hour), Scopes: []string{"read"}}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(context.Background(), pluginPrefix+"test-provider.metadata", metaBytes))
+
+	// Default prefix should NOT find the metadata
+	cfg := config.CustomOAuth2Config{Name: "test-provider", TokenURL: srv.URL + "/token", ClientID: "cid"}
+	hDefault, err := New(cfg, WithSecretStore(store))
+	require.NoError(t, err)
+	status, err := hDefault.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+
+	// Custom prefix should find it
+	hCustom, err := New(cfg, WithSecretStore(store), WithSecretKeyPrefix(pluginPrefix))
+	require.NoError(t, err)
+	status, err = hCustom.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, "testuser", status.Claims.Username)
+}
+
+func TestUnmarshalMetadata_PluginFormat(t *testing.T) {
+	// Plugin handler metadata uses different field names
+	pluginJSON := `{
+		"refreshTokenExpiresAt": "2026-08-13T01:13:46Z",
+		"loginFlow": "interactive",
+		"sessionId": "abc123",
+		"tenantId": "tenant1",
+		"clientId": "client1"
+	}`
+	meta, err := unmarshalMetadata([]byte(pluginJSON))
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 8, 13, 1, 13, 46, 0, time.UTC), meta.ExpiresAt)
+	assert.Equal(t, auth.FlowInteractive, meta.LastLoginFlow)
+}
+
+func TestUnmarshalMetadata_NativeFormat(t *testing.T) {
+	meta := handlerMetadata{
+		Claims:        &auth.Claims{Username: "testuser"},
+		ExpiresAt:     time.Date(2026, 8, 13, 1, 13, 46, 0, time.UTC),
+		Scopes:        []string{"read"},
+		LastLoginFlow: auth.FlowDeviceCode,
+	}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	result, err := unmarshalMetadata(data)
+	require.NoError(t, err)
+	assert.Equal(t, meta.ExpiresAt, result.ExpiresAt)
+	assert.Equal(t, auth.FlowDeviceCode, result.LastLoginFlow)
+	assert.Equal(t, "testuser", result.Claims.Username)
+}
+
+func TestUnmarshalMetadata_EmptyJSON(t *testing.T) {
+	meta, err := unmarshalMetadata([]byte("{}"))
+	require.NoError(t, err)
+	assert.True(t, meta.ExpiresAt.IsZero())
+}
+
+func TestUnmarshalMetadata_InvalidJSON(t *testing.T) {
+	_, err := unmarshalMetadata([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestHandler_Status_Reason_NoSecretStore(t *testing.T) {
+	cfg := config.CustomOAuth2Config{Name: "test-provider", TokenURL: "http://example.com/token", ClientID: "cid"}
+	h := &Handler{cfg: cfg, secretKeyPrefix: secretKeyPrefix}
+	status, err := h.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+	assert.Equal(t, "secrets store unavailable", status.Reason)
+}
+
+func TestHandler_Status_Reason_NotLoggedIn(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, nil)
+	status, err := h.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+	assert.Equal(t, "not logged in", status.Reason)
+}
+
+func TestHandler_Status_Reason_CorruptMetadata(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, store := newTestHandler(t, srv, nil)
+	require.NoError(t, store.Set(context.Background(), secretKeyPrefix+"test-provider.metadata", []byte("not json")))
+	status, err := h.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+	assert.Equal(t, "metadata corrupt or unreadable", status.Reason)
+}
+
+func TestHandler_Status_Reason_Expired(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, store := newTestHandler(t, srv, nil)
+	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(-1 * time.Hour)}
+	metaBytes, _ := json.Marshal(meta)
+	_ = store.Set(context.Background(), secretKeyPrefix+"test-provider.metadata", metaBytes)
+	status, err := h.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+	assert.Equal(t, "session expired", status.Reason)
+}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -7,8 +7,10 @@ package auth
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 )
 
 // handlerContextKey is used for test injection of handlers.
@@ -46,8 +48,9 @@ func getHandler(ctx context.Context, handlerName string) (auth.Handler, error) {
 	return registry.Get(handlerName)
 }
 
-// listHandlers returns the names of all registered handlers.
-// Falls back to the registry in context, or returns nil.
+// listHandlers returns the names of all registered and officially-known handlers.
+// It merges eagerly-registered handlers with the official handler registry so
+// that lazy-resolvable handlers are visible to the user.
 func listHandlers(ctx context.Context) []string {
 	// If a test handler is injected, we can't enumerate all handlers.
 	// Return the known built-in names for the test context.
@@ -55,25 +58,49 @@ func listHandlers(ctx context.Context) []string {
 		return []string{h.Name()}
 	}
 
-	registry := auth.RegistryFromContext(ctx)
-	if registry == nil {
+	seen := make(map[string]struct{})
+
+	if registry := auth.RegistryFromContext(ctx); registry != nil {
+		for _, name := range registry.List() {
+			seen[name] = struct{}{}
+		}
+	}
+
+	if official := authofficial.RegistryFromContext(ctx); official != nil {
+		for _, name := range official.Names() {
+			seen[name] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
 		return nil
 	}
-	return registry.List()
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
-// isHandlerRegistered checks if a handler name is registered.
+// isHandlerRegistered checks if a handler name is registered or known to the
+// official auth handler registry (i.e., resolvable via the lazy fallback).
 func isHandlerRegistered(ctx context.Context, name string) bool {
 	// Test-injected handlers match any name (since tests inject a single mock)
 	if h := handlerFromContext(ctx); h != nil {
 		return true // Let the test handler respond regardless of name
 	}
 
-	registry := auth.RegistryFromContext(ctx)
-	if registry == nil {
-		return false
+	if registry := auth.RegistryFromContext(ctx); registry != nil && registry.Has(name) {
+		return true
 	}
-	return registry.Has(name)
+
+	if official := authofficial.RegistryFromContext(ctx); official != nil && official.Has(name) {
+		return true
+	}
+
+	return false
 }
 
 // validateHandlerName checks if a handler name is valid and returns a formatted error if not.

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -48,12 +48,27 @@ func getHandler(ctx context.Context, handlerName string) (auth.Handler, error) {
 	return registry.Get(handlerName)
 }
 
-// listHandlers returns the names of all registered and officially-known handlers.
-// It merges eagerly-registered handlers with the official handler registry so
-// that lazy-resolvable handlers are visible to the user.
+// listHandlers returns the names of eagerly-registered (installed) handlers.
+// Use this for bulk operations (status, list, logout --all, diagnose) that
+// call getHandler on each name — it avoids triggering lazy plugin resolution.
 func listHandlers(ctx context.Context) []string {
-	// If a test handler is injected, we can't enumerate all handlers.
-	// Return the known built-in names for the test context.
+	if h := handlerFromContext(ctx); h != nil {
+		return []string{h.Name()}
+	}
+
+	registry := auth.RegistryFromContext(ctx)
+	if registry == nil {
+		return nil
+	}
+	return registry.List()
+}
+
+// listKnownHandlers returns the names of all registered and officially-known
+// handlers. It merges eagerly-registered handlers with the official handler
+// registry so that lazy-resolvable handlers appear in validation error messages
+// and shell completions. Do NOT iterate this set with getHandler — official
+// names that are not yet installed would trigger network I/O.
+func listKnownHandlers(ctx context.Context) []string {
 	if h := handlerFromContext(ctx); h != nil {
 		return []string{h.Name()}
 	}
@@ -108,7 +123,7 @@ func validateHandlerName(ctx context.Context, handlerName string) error {
 	if isHandlerRegistered(ctx, handlerName) {
 		return nil
 	}
-	handlers := listHandlers(ctx)
+	handlers := listKnownHandlers(ctx)
 	if len(handlers) == 0 {
 		return fmt.Errorf("unknown auth handler: %s (no handlers registered)", handlerName)
 	}

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -146,6 +146,7 @@ func TestIsHandlerRegistered_BothRegistries(t *testing.T) {
 }
 
 func TestListHandlers_WithOfficialRegistry(t *testing.T) {
+	// listHandlers should NOT include official-only handlers (not installed).
 	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
 		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
 		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
@@ -153,12 +154,11 @@ func TestListHandlers_WithOfficialRegistry(t *testing.T) {
 	ctx := authofficial.WithRegistry(context.Background(), official)
 
 	handlers := listHandlers(ctx)
-	assert.Contains(t, handlers, "entra")
-	assert.Contains(t, handlers, "github")
-	assert.Len(t, handlers, 2)
+	assert.Nil(t, handlers) // no eager registry → nil
 }
 
-func TestListHandlers_MergesBothRegistries(t *testing.T) {
+func TestListHandlers_OnlyEagerRegistry(t *testing.T) {
+	// listHandlers returns only eagerly-registered handlers, ignoring official.
 	registry := auth.NewRegistry()
 	require.NoError(t, registry.Register(auth.NewMockHandler("custom")))
 	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
@@ -168,13 +168,38 @@ func TestListHandlers_MergesBothRegistries(t *testing.T) {
 	ctx = authofficial.WithRegistry(ctx, official)
 
 	handlers := listHandlers(ctx)
+	assert.Equal(t, []string{"custom"}, handlers)
+}
+
+func TestListKnownHandlers_WithOfficialRegistry(t *testing.T) {
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	})
+	ctx := authofficial.WithRegistry(context.Background(), official)
+
+	handlers := listKnownHandlers(ctx)
+	assert.Contains(t, handlers, "entra")
+	assert.Contains(t, handlers, "github")
+	assert.Len(t, handlers, 2)
+}
+
+func TestListKnownHandlers_MergesBothRegistries(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("custom")))
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	})
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = authofficial.WithRegistry(ctx, official)
+
+	handlers := listKnownHandlers(ctx)
 	assert.Contains(t, handlers, "custom")
 	assert.Contains(t, handlers, "entra")
 	assert.Len(t, handlers, 2)
 }
 
-func TestListHandlers_DeduplicatesOverlap(t *testing.T) {
-	// "entra" is in both registries — should appear only once
+func TestListKnownHandlers_DeduplicatesOverlap(t *testing.T) {
 	registry := auth.NewRegistry()
 	require.NoError(t, registry.Register(auth.NewMockHandler("entra")))
 	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
@@ -184,8 +209,21 @@ func TestListHandlers_DeduplicatesOverlap(t *testing.T) {
 	ctx := auth.WithRegistry(context.Background(), registry)
 	ctx = authofficial.WithRegistry(ctx, official)
 
-	handlers := listHandlers(ctx)
+	handlers := listKnownHandlers(ctx)
 	assert.ElementsMatch(t, []string{"entra", "github"}, handlers)
+}
+
+func TestListKnownHandlers_WithTestHandler(t *testing.T) {
+	mock := auth.NewMockHandler("test")
+	ctx := withTestHandler(context.Background(), mock)
+
+	handlers := listKnownHandlers(ctx)
+	assert.Equal(t, []string{"test"}, handlers)
+}
+
+func TestListKnownHandlers_NoContext(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, listKnownHandlers(ctx))
 }
 
 func TestValidateHandlerName_OfficialHandler(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,4 +116,89 @@ func TestGetHandler_NoContext(t *testing.T) {
 	_, err := getHandler(ctx, "entra")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no auth registry in context")
+}
+
+func TestIsHandlerRegistered_WithOfficialRegistry(t *testing.T) {
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	})
+	ctx := authofficial.WithRegistry(context.Background(), official)
+
+	assert.True(t, isHandlerRegistered(ctx, "entra"))
+	assert.True(t, isHandlerRegistered(ctx, "github"))
+	assert.False(t, isHandlerRegistered(ctx, "unknown"))
+}
+
+func TestIsHandlerRegistered_BothRegistries(t *testing.T) {
+	// Auth registry has "custom", official has "entra"
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("custom")))
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	})
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = authofficial.WithRegistry(ctx, official)
+
+	assert.True(t, isHandlerRegistered(ctx, "custom"))
+	assert.True(t, isHandlerRegistered(ctx, "entra"))
+	assert.False(t, isHandlerRegistered(ctx, "unknown"))
+}
+
+func TestListHandlers_WithOfficialRegistry(t *testing.T) {
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	})
+	ctx := authofficial.WithRegistry(context.Background(), official)
+
+	handlers := listHandlers(ctx)
+	assert.Contains(t, handlers, "entra")
+	assert.Contains(t, handlers, "github")
+	assert.Len(t, handlers, 2)
+}
+
+func TestListHandlers_MergesBothRegistries(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("custom")))
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	})
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = authofficial.WithRegistry(ctx, official)
+
+	handlers := listHandlers(ctx)
+	assert.Contains(t, handlers, "custom")
+	assert.Contains(t, handlers, "entra")
+	assert.Len(t, handlers, 2)
+}
+
+func TestListHandlers_DeduplicatesOverlap(t *testing.T) {
+	// "entra" is in both registries — should appear only once
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("entra")))
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+		{Name: "github", CatalogRef: "github", DefaultVersion: "latest"},
+	})
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = authofficial.WithRegistry(ctx, official)
+
+	handlers := listHandlers(ctx)
+	assert.ElementsMatch(t, []string{"entra", "github"}, handlers)
+}
+
+func TestValidateHandlerName_OfficialHandler(t *testing.T) {
+	// No auth registry, but official registry has "entra"
+	official := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "entra", CatalogRef: "entra", DefaultVersion: "latest"},
+	})
+	ctx := authofficial.WithRegistry(context.Background(), official)
+
+	assert.NoError(t, validateHandlerName(ctx, "entra"))
+
+	err := validateHandlerName(ctx, "unknown")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown auth handler")
+	assert.Contains(t, err.Error(), "entra")
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -454,6 +454,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 			sharedSecretStore, secretErr := secrets.New(
 				secrets.WithRequireSecureKeyring(cfg.Settings.RequireSecureKeyring),
 				secrets.WithLogger(*lgr),
+				secrets.WithOrphanCleanup(true),
 			)
 			if secretErr != nil {
 				lgr.V(1).Info("shared secrets store unavailable; auth handlers will create their own", "error", secretErr)

--- a/pkg/secrets/errors.go
+++ b/pkg/secrets/errors.go
@@ -21,6 +21,10 @@ var (
 
 	// ErrKeyringAccess is returned when the OS keyring cannot be accessed.
 	ErrKeyringAccess = errors.New("cannot access keyring")
+
+	// ErrOrphanedSecrets is returned when orphaned secrets are detected and
+	// automatic cleanup is not enabled (see WithOrphanCleanup).
+	ErrOrphanedSecrets = errors.New("orphaned secrets detected")
 )
 
 // KeyringError wraps a keyring access error with additional context.

--- a/pkg/secrets/options.go
+++ b/pkg/secrets/options.go
@@ -16,6 +16,7 @@ type config struct {
 	keyring              Keyring
 	logger               logr.Logger
 	requireSecureKeyring bool
+	cleanOrphans         bool
 }
 
 // defaultConfig returns a config with default values.
@@ -25,6 +26,7 @@ func defaultConfig() *config {
 		keyring:              nil,
 		logger:               logr.Discard(),
 		requireSecureKeyring: strings.EqualFold(os.Getenv("SCAFCTL_REQUIRE_SECURE_KEYRING"), "true"),
+		cleanOrphans:         false,
 	}
 }
 
@@ -68,6 +70,16 @@ func WithLogger(logger logr.Logger) Option {
 func WithRequireSecureKeyring(require bool) Option {
 	return func(c *config) {
 		c.requireSecureKeyring = require
+	}
+}
+
+// WithOrphanCleanup controls whether orphaned secrets (encrypted with a lost
+// master key) are automatically deleted during store initialization. When false
+// (the default), initialization returns an error if orphaned secrets are detected,
+// allowing the caller to decide how to proceed.
+func WithOrphanCleanup(clean bool) Option {
+	return func(c *config) {
+		c.cleanOrphans = clean
 	}
 }
 

--- a/pkg/secrets/options_test.go
+++ b/pkg/secrets/options_test.go
@@ -104,6 +104,20 @@ func TestOptionChaining(t *testing.T) {
 	})
 }
 
+func TestDefaultConfig_CleanOrphans(t *testing.T) {
+	cfg := defaultConfig()
+	assert.False(t, cfg.cleanOrphans, "cleanOrphans should default to false")
+}
+
+func TestWithOrphanCleanup(t *testing.T) {
+	cfg := defaultConfig()
+	WithOrphanCleanup(false)(cfg)
+	assert.False(t, cfg.cleanOrphans)
+
+	WithOrphanCleanup(true)(cfg)
+	assert.True(t, cfg.cleanOrphans)
+}
+
 // mockKeyring is a simple mock implementation of the Keyring interface for testing.
 type mockKeyring struct {
 	data map[string]string

--- a/pkg/secrets/store.go
+++ b/pkg/secrets/store.go
@@ -19,6 +19,7 @@ type store struct {
 	masterKey      []byte
 	logger         logr.Logger
 	keyringBackend string
+	cleanOrphans   bool
 	mu             sync.RWMutex
 }
 
@@ -51,9 +52,10 @@ func newStore(opts ...Option) (*store, error) {
 	}
 
 	s := &store{
-		secretsDir: secretsDir,
-		keyring:    keyring,
-		logger:     cfg.logger,
+		secretsDir:   secretsDir,
+		keyring:      keyring,
+		logger:       cfg.logger,
+		cleanOrphans: cfg.cleanOrphans,
 	}
 
 	// Initialize master key
@@ -115,6 +117,11 @@ func (s *store) initMasterKey() error {
 	}
 
 	if len(existingSecrets) > 0 {
+		if !s.cleanOrphans {
+			return fmt.Errorf("%w: %d secret(s) encrypted with a lost master key in %s; "+
+				"use WithOrphanCleanup(true) to auto-delete or manually remove the directory",
+				ErrOrphanedSecrets, len(existingSecrets), s.secretsDir)
+		}
 		s.logger.Info("WARNING: found orphaned secrets due to missing master key — these secrets "+
 			"are no longer decryptable and will be deleted. This typically happens after an OS "+
 			"keychain reset or reinstall. Use 'scafctl secrets export' before clearing the keychain "+

--- a/pkg/secrets/store_test.go
+++ b/pkg/secrets/store_test.go
@@ -108,6 +108,7 @@ func TestNew(t *testing.T) {
 		store, err := New(
 			WithSecretsDir(tmpDir),
 			WithKeyring(keyring),
+			WithOrphanCleanup(true),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, store)
@@ -116,6 +117,27 @@ func TestNew(t *testing.T) {
 		secrets, err = listSecrets(tmpDir)
 		require.NoError(t, err)
 		assert.Empty(t, secrets)
+	})
+
+	t.Run("returns error for orphaned secrets by default", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		keyring := newTestKeyring()
+
+		fakeEncrypted := make([]byte, 50)
+		err := writeSecret(tmpDir, "orphaned-secret", fakeEncrypted)
+		require.NoError(t, err)
+
+		_, err = New(
+			WithSecretsDir(tmpDir),
+			WithKeyring(keyring),
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrOrphanedSecrets)
+
+		// Verify secrets were NOT deleted
+		remaining, listErr := listSecrets(tmpDir)
+		require.NoError(t, listErr)
+		assert.Len(t, remaining, 1)
 	})
 
 	t.Run("returns error if keyring access fails", func(t *testing.T) {


### PR DESCRIPTION
- add WithSecretKeyPrefix option to oauth2.Handler so embedders can
  share tokens written by plugin handlers
- add unmarshalMetadata compat shim that falls back to plugin field
  names (refreshTokenExpiresAt, loginFlow)
- populate Status().Reason with distinct strings per failure mode
  (secrets store unavailable, not logged in, metadata corrupt, expired)
- add WithOrphanCleanup option to secrets.Store; default to false so
  orphaned secrets cause an error instead of silent deletion
- opt in to orphan cleanup in the interactive CLI (root.go)
- add ErrOrphanedSecrets sentinel error

Closes #398