### PR TITLE
feat(auth): add lazy handler loading and install/remove lifecycle commands

### DIFF
--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -136,3 +136,13 @@ type FlowDetector interface {
 	// based on the current environment (env vars, config files, metadata endpoints).
 	DetectAvailableFlows(ctx context.Context) ([]FlowAvailability, error)
 }
+
+// Configurer is an optional interface for auth handlers that accept runtime
+// setting overrides. The auth login command uses this to apply --client-id
+// and --tenant flags before initiating the login flow.
+type Configurer interface {
+	// ApplyOverrides sends updated key-value settings to the handler.
+	// Keys use the handler's config field names (e.g., "clientId", "tenantId").
+	// Only non-empty values are applied; empty strings are ignored.
+	ApplyOverrides(ctx context.Context, overrides map[string]string) error
+}

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -182,3 +182,31 @@ func (m *MockFlowDetectorHandler) DetectAvailableFlows(_ context.Context) ([]Flo
 }
 
 var _ FlowDetector = (*MockFlowDetectorHandler)(nil)
+
+// MockConfigurerHandler embeds MockHandler and adds Configurer support.
+type MockConfigurerHandler struct {
+	*MockHandler
+	ApplyOverridesErr   error
+	ApplyOverridesCalls []map[string]string
+}
+
+// NewMockConfigurerHandler creates a mock handler that implements Configurer.
+func NewMockConfigurerHandler(name string) *MockConfigurerHandler {
+	return &MockConfigurerHandler{
+		MockHandler: NewMockHandler(name),
+	}
+}
+
+// ApplyOverrides implements Configurer.
+func (m *MockConfigurerHandler) ApplyOverrides(_ context.Context, overrides map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make(map[string]string, len(overrides))
+	for k, v := range overrides {
+		cp[k] = v
+	}
+	m.ApplyOverridesCalls = append(m.ApplyOverridesCalls, cp)
+	return m.ApplyOverridesErr
+}
+
+var _ Configurer = (*MockConfigurerHandler)(nil)

--- a/pkg/auth/mock_test.go
+++ b/pkg/auth/mock_test.go
@@ -142,3 +142,27 @@ func TestMockHandler_SupportedFlows_WithValue(t *testing.T) {
 	mock.FlowsValue = customFlows
 	assert.Equal(t, customFlows, mock.SupportedFlows())
 }
+
+func TestMockConfigurerHandler_ApplyOverrides(t *testing.T) {
+	mock := NewMockConfigurerHandler("entra")
+	assert.Equal(t, "entra", mock.Name())
+
+	overrides := map[string]string{"clientId": "abc", "tenantId": "xyz"}
+	err := mock.ApplyOverrides(context.Background(), overrides)
+	require.NoError(t, err)
+	require.Len(t, mock.ApplyOverridesCalls, 1)
+	assert.Equal(t, "abc", mock.ApplyOverridesCalls[0]["clientId"])
+	assert.Equal(t, "xyz", mock.ApplyOverridesCalls[0]["tenantId"])
+
+	// Mutating the original map should not affect recorded calls.
+	overrides["clientId"] = "mutated"
+	assert.Equal(t, "abc", mock.ApplyOverridesCalls[0]["clientId"])
+}
+
+func TestMockConfigurerHandler_ApplyOverrides_Error(t *testing.T) {
+	mock := NewMockConfigurerHandler("entra")
+	mock.ApplyOverridesErr = assert.AnError
+
+	err := mock.ApplyOverrides(context.Background(), map[string]string{"key": "val"})
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -107,12 +107,22 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 			// ── 1. Auth registry ──────────────────────────────────────────────
 			handlerNames := listHandlers(ctx)
 			if len(handlerNames) == 0 {
-				addCheck(diagnose.Check{
-					Category: "registry",
-					Name:     "auth registry",
-					Status:   diagnose.StatusFail,
-					Message:  "no auth handlers registered — registry may not be initialised",
-				})
+				unconfigured := listUnconfiguredOfficialHandlers(ctx)
+				if len(unconfigured) > 0 {
+					addCheck(diagnose.Check{
+						Category: "registry",
+						Name:     "auth registry",
+						Status:   diagnose.StatusInfo,
+						Message:  fmt.Sprintf("no handlers installed yet — available: %v", unconfigured),
+					})
+				} else {
+					addCheck(diagnose.Check{
+						Category: "registry",
+						Name:     "auth registry",
+						Status:   diagnose.StatusFail,
+						Message:  "no auth handlers registered — registry may not be initialised",
+					})
+				}
 			} else {
 				addCheck(diagnose.Check{
 					Category: "registry",

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -633,4 +634,34 @@ func TestCommandDiagnose_StartupLatency_SlowPlugin(t *testing.T) {
 	output := buf.String()
 	assert.Contains(t, output, "slow startup")
 	assert.Contains(t, output, "[warn]")
+}
+
+func TestCommandDiagnose_NoHandlers_ShowsOfficialAvailable(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// No auth registry → listHandlers returns nil.
+	// But add official registry so listUnconfiguredOfficialHandlers returns names.
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+		{Name: "entra", CatalogRef: "entra"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cmd := CommandDiagnose(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "no handlers installed yet")
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "entra")
 }

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -99,6 +99,33 @@ func listKnownHandlers(ctx context.Context) []string {
 	return names
 }
 
+// listUnconfiguredOfficialHandlers returns official handler names that are NOT
+// eagerly registered. These are available via lazy resolution but the user has
+// not yet used them. Use this for hint messages in CLI output.
+func listUnconfiguredOfficialHandlers(ctx context.Context) []string {
+	official := authofficial.RegistryFromContext(ctx)
+	if official == nil {
+		return nil
+	}
+
+	var eager map[string]struct{}
+	if registry := auth.RegistryFromContext(ctx); registry != nil {
+		names := registry.List()
+		eager = make(map[string]struct{}, len(names))
+		for _, n := range names {
+			eager[n] = struct{}{}
+		}
+	}
+
+	var unconfigured []string
+	for _, name := range official.Names() {
+		if _, ok := eager[name]; !ok {
+			unconfigured = append(unconfigured, name)
+		}
+	}
+	return unconfigured
+}
+
 // isHandlerRegistered checks if a handler name is registered or known to the
 // official auth handler registry (i.e., resolvable via the lazy fallback).
 func isHandlerRegistered(ctx context.Context, name string) bool {

--- a/pkg/cmd/scafctl/auth/handlers.go
+++ b/pkg/cmd/scafctl/auth/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
 
@@ -59,12 +60,21 @@ func CommandHandlers(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 			built-in or loaded via plugin). Available handlers are those in the
 			official auth handler registry that can be auto-fetched from the catalog.
 
+			Use 'scafctl auth handlers install <name>' to pre-fetch a handler.
+			Use 'scafctl auth handlers remove <name>' to delete a cached handler.
+
 			Note: 'scafctl auth list' shows cached tokens, not handlers. This
 			command shows handler discovery and installation status.
 
 			Examples:
 			  # List all auth handlers
 			  scafctl auth handlers
+
+			  # Install a handler from the catalog
+			  scafctl auth handlers install github
+
+			  # Remove a cached handler
+			  scafctl auth handlers remove github
 
 			  # Output as JSON
 			  scafctl auth handlers -o json
@@ -84,11 +94,31 @@ func CommandHandlers(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 				kvx.WithOutputSchemaJSON(authHandlersSchema),
 			)
 
-			return outputOpts.Write(results)
+			if err := outputOpts.Write(results); err != nil {
+				return err
+			}
+
+			// Show hint about catalog discovery when output is human-readable (not json/yaml/csv/toml/quiet).
+			switch outputFlags.Output {
+			case "json", "yaml", "csv", "toml", "quiet":
+				// skip hint for structured/quiet output
+			default:
+				w := writer.FromContext(ctx)
+				if w != nil {
+					w.Infof("")
+					w.Infof("Tip: run '%s catalog list --kind auth-handler' to discover additional handlers from configured catalogs.", cliParams.BinaryName)
+				}
+			}
+
+			return nil
 		},
 	}
 
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+
+	cmd.AddCommand(commandHandlersInstall(cliParams, ioStreams))
+	cmd.AddCommand(commandHandlersRemove(cliParams, ioStreams))
+
 	return cmd
 }
 
@@ -143,9 +173,10 @@ func buildHandlerInfoResult(ctx context.Context, name string, authReg *authpkg.R
 		if err == nil {
 			result["status"] = "installed"
 			result["displayName"] = handler.DisplayName()
-			if _, ok := handler.(*plugin.AuthHandlerWrapper); ok {
+			switch handler.(type) {
+			case *plugin.AuthHandlerWrapper, *plugin.LazyAuthHandlerWrapper:
 				result["source"] = "plugin"
-			} else {
+			default:
 				result["source"] = "built-in"
 			}
 
@@ -166,7 +197,8 @@ func buildHandlerInfoResult(ctx context.Context, name string, authReg *authpkg.R
 		// Handler is in the official registry but not installed yet.
 		result["status"] = "available"
 		result["source"] = "catalog"
-		result["flows"] = "unknown (install to inspect)"
+		binName := settings.BinaryNameFromContext(ctx)
+		result["flows"] = "run '" + binName + " auth handlers install " + name + "' to inspect"
 	}
 
 	return result

--- a/pkg/cmd/scafctl/auth/handlers_install.go
+++ b/pkg/cmd/scafctl/auth/handlers_install.go
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	solprepare "github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// commandHandlersInstall creates the 'auth handlers install' command.
+func commandHandlersInstall(cliParams *settings.Run, ioStreams *terminal.IOStreams) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "install <handler>",
+		Short: "Download and cache an auth handler plugin",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Download an official auth handler plugin from the catalog and cache it
+			locally. This pre-fetches the handler without requiring authentication,
+			allowing you to inspect its capabilities (flows, display name) via
+			'scafctl auth handlers'.
+
+			Official auth handlers are normally auto-fetched on first use (e.g.,
+			during 'scafctl auth login <handler>'). This command lets you fetch
+			them ahead of time.
+
+			Use --force to bypass the local cache and pull the latest version from
+			the catalog, even if a version is already cached.
+
+			Examples:
+			  # Install the GitHub auth handler
+			  scafctl auth handlers install github
+
+			  # Install the Entra ID (Azure AD) auth handler
+			  scafctl auth handlers install entra
+
+			  # Upgrade to the latest version
+			  scafctl auth handlers install entra --force
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			reg := authofficial.RegistryFromContext(cmd.Context())
+			if reg == nil {
+				reg = authofficial.NewRegistry()
+			}
+			return reg.Names(), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			officialReg := authofficial.RegistryFromContext(ctx)
+			if officialReg == nil {
+				return fmt.Errorf("official auth handler registry not available")
+			}
+
+			entry, ok := officialReg.Get(name)
+			if !ok {
+				return fmt.Errorf("unknown auth handler %q; available: %s", name, strings.Join(officialReg.Names(), ", "))
+			}
+
+			// Check if already cached on disk (skip with --force).
+			cacheKey := plugin.PluginCacheKey(name, solution.PluginKindAuthHandler)
+			cache := plugin.NewCache(settings.PluginCacheDirFor(cliParams.BinaryName))
+			if !force {
+				if _, _, found := cache.GetLatestCached(cacheKey, plugin.CurrentPlatform()); found {
+					w := writer.FromContext(ctx)
+					if w != nil {
+						w.Successf("Auth handler %q is already cached. Use --force to re-download.", name)
+					}
+					return nil
+				}
+			}
+
+			w := writer.FromContext(ctx)
+			if w != nil {
+				if force {
+					w.Infof("Fetching latest auth handler %q from catalog...", name)
+				} else {
+					w.Infof("Downloading auth handler %q from catalog...", name)
+				}
+			}
+
+			dep := entry.ToPluginDependency()
+
+			fetcher, err := solprepare.BuildPluginFetcherWithConfig(ctx, solprepare.PluginFetcherOverrides{
+				NoCache: force,
+			})
+			if err != nil {
+				return fmt.Errorf("building plugin fetcher: %w", err)
+			}
+
+			results, err := fetcher.FetchPlugins(ctx, []solution.PluginDependency{dep}, nil)
+			if err != nil {
+				return fmt.Errorf("downloading auth handler %q: %w", name, err)
+			}
+
+			if len(results) == 0 {
+				return fmt.Errorf("no results returned for auth handler %q", name)
+			}
+
+			result := results[0]
+
+			// Register the handler so we can report its capabilities.
+			authReg := authpkg.RegistryFromContext(ctx)
+			if authReg != nil {
+				clients, regErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, authReg, results, nil)
+				// Kill plugin processes — we only needed to inspect capabilities.
+				for _, c := range clients {
+					c.Kill()
+				}
+				if regErr != nil {
+					// Non-fatal: the handler is cached, just can't inspect capabilities now.
+					if w != nil {
+						w.Warningf("Handler cached but could not load for inspection: %v", regErr)
+					}
+				}
+			}
+
+			if w != nil {
+				if result.FromCache {
+					w.Successf("Auth handler %q already cached (version %s). Use --force to upgrade.", name, result.Version)
+				} else {
+					w.Successf("Auth handler %q installed (version %s).", name, result.Version)
+				}
+			}
+
+			_ = ioStreams
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Bypass cache and fetch the latest version from catalog")
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/auth/handlers_install_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_install_test.go
@@ -1,0 +1,286 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandHandlersInstall_NoOfficialRegistry(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "official auth handler registry not available")
+}
+
+func TestCommandHandlersInstall_UnknownHandler(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"nonexistent"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown auth handler")
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestCommandHandlersInstall_AlreadyCached(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	// Override xdg.CacheHome directly (t.Setenv doesn't work because
+	// the xdg package reads the env var at init-time).
+	xdgCache := t.TempDir()
+	origCacheHome := xdg.CacheHome
+	xdg.CacheHome = xdgCache
+	t.Cleanup(func() { xdg.CacheHome = origCacheHome })
+
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "testcli"
+
+	// Create the binary at the exact path the cache will look for:
+	// $XDG_CACHE_HOME/testcli/plugins/<cacheKey>/<version>/<platformCacheKey>/<cacheKey>
+	cacheKey := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
+	platform := plugin.CurrentPlatform()
+	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheKey, "1.0.0", plugin.PlatformCacheKey(platform))
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheKey), []byte("fake"), 0o755))
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "already cached")
+}
+
+func TestCommandHandlersInstall_RequiresExactlyOneArg(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCommandHandlersInstall_ForceBypassesCache(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	// Set up a cached binary.
+	xdgCache := t.TempDir()
+	origCacheHome := xdg.CacheHome
+	xdg.CacheHome = xdgCache
+	t.Cleanup(func() { xdg.CacheHome = origCacheHome })
+
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "testcli"
+
+	cacheKey := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
+	platform := plugin.CurrentPlatform()
+	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheKey, "1.0.0", plugin.PlatformCacheKey(platform))
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheKey), []byte("fake"), 0o755))
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github", "--force"})
+
+	// --force bypasses cache and attempts to download, which fails without
+	// a real catalog, but we verify it doesn't short-circuit at cache check.
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downloading auth handler")
+	assert.Contains(t, buf.String(), "Fetching latest")
+}
+
+func TestCommandHandlersInstall_ValidArgsFunction(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+		{Name: "entra", CatalogRef: "entra"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersInstall(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+
+	// ValidArgsFunction should return available handler names.
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	assert.Contains(t, completions, "github")
+	assert.Contains(t, completions, "entra")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	// After arg is provided, no further completions should be offered.
+	completions, directive = cmd.ValidArgsFunction(cmd, []string{"github"}, "")
+	assert.Nil(t, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestRemoveAuthHandler_NotCached(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	cache := plugin.NewCache(t.TempDir())
+
+	err := removeAuthHandler(ctx, "github", cliParams, cache)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not installed")
+}
+
+func TestRemoveAuthHandler_RemovesCachedHandler(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cacheDir := t.TempDir()
+	cache := plugin.NewCache(cacheDir)
+
+	// Create the expected directory structure for an auth handler.
+	handlerDir := filepath.Join(cacheDir, "auth-handler-github", "1.0.0", "darwin-arm64")
+	require.NoError(t, os.MkdirAll(handlerDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(handlerDir, "auth-handler-github"), []byte("fake-binary"), 0o755))
+
+	cliParams := settings.NewCliParams()
+
+	err := removeAuthHandler(ctx, "github", cliParams, cache)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "removed from cache")
+
+	// Verify the directory was actually removed.
+	_, err = os.Stat(filepath.Join(cacheDir, "auth-handler-github"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRemoveAuthHandler_RequiresExactlyOneArg(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersRemove(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestRemoveAuthHandler_ValidArgsFunction(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := commandHandlersRemove(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+
+	// No args yet — should offer completions.
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	assert.Contains(t, completions, "github")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	// After arg provided — no further completions.
+	completions, directive = cmd.ValidArgsFunction(cmd, []string{"github"}, "")
+	assert.Nil(t, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestRemoveAuthHandler_ShowsLogoutHint(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	cacheDir := t.TempDir()
+	cache := plugin.NewCache(cacheDir)
+
+	handlerDir := filepath.Join(cacheDir, "auth-handler-entra", "2.0.0", "darwin-arm64")
+	require.NoError(t, os.MkdirAll(handlerDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(handlerDir, "auth-handler-entra"), []byte("fake"), 0o755))
+
+	cliParams := settings.NewCliParams()
+
+	err := removeAuthHandler(ctx, "entra", cliParams, cache)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "removed from cache")
+	assert.Contains(t, output, "auth logout entra")
+}
+
+func TestRemoveAuthHandler_PathTraversal(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	cliParams := settings.NewCliParams()
+	cache := plugin.NewCache(t.TempDir())
+
+	tests := []struct {
+		name    string
+		handler string
+	}{
+		{name: "dot-dot", handler: "../../../etc"},
+		{name: "slash", handler: "foo/bar"},
+		{name: "backslash", handler: `foo\bar`},
+		{name: "single-dot", handler: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := removeAuthHandler(ctx, tt.handler, cliParams, cache)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid auth handler name")
+		})
+	}
+}

--- a/pkg/cmd/scafctl/auth/handlers_remove.go
+++ b/pkg/cmd/scafctl/auth/handlers_remove.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// commandHandlersRemove creates the 'auth handlers remove' command.
+func commandHandlersRemove(cliParams *settings.Run, ioStreams *terminal.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove <handler>",
+		Aliases: []string{"uninstall", "delete"},
+		Short:   "Remove a cached auth handler plugin",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Remove a cached auth handler plugin from the local plugin cache.
+			This deletes all cached versions of the handler.
+
+			The handler can be re-downloaded at any time using
+			'scafctl auth handlers install <handler>' or automatically on next use.
+
+			Note: this does not remove any stored credentials. Use
+			'scafctl auth logout <handler>' to clear tokens first if needed.
+
+			Examples:
+			  # Remove the GitHub auth handler
+			  scafctl auth handlers remove github
+
+			  # Remove the Entra ID auth handler
+			  scafctl auth handlers remove entra
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			reg := authofficial.RegistryFromContext(cmd.Context())
+			if reg == nil {
+				reg = authofficial.NewRegistry()
+			}
+			return reg.Names(), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			return removeAuthHandler(ctx, name, cliParams, plugin.NewCache(settings.PluginCacheDirFor(cliParams.BinaryName)))
+		},
+	}
+
+	_ = ioStreams
+
+	return cmd
+}
+
+// removeAuthHandler removes a cached auth handler plugin by name.
+func removeAuthHandler(ctx context.Context, name string, cliParams *settings.Run, cache *plugin.Cache) error {
+	// Validate the handler name to prevent path traversal.
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") || name == "." {
+		return fmt.Errorf("invalid auth handler name %q: must not contain path separators or '..'", name)
+	}
+
+	cacheKey := plugin.PluginCacheKey(name, solution.PluginKindAuthHandler)
+
+	// Check if the handler has any cached binaries.
+	handlerDir := filepath.Join(cache.Dir(), cacheKey)
+	if _, err := os.Stat(handlerDir); os.IsNotExist(err) {
+		return fmt.Errorf("auth handler %q is not installed (no cached binaries found)", name)
+	}
+
+	// Remove the entire handler directory (all versions, all platforms).
+	if err := os.RemoveAll(handlerDir); err != nil {
+		return fmt.Errorf("removing cached auth handler %q: %w", name, err)
+	}
+
+	w := writer.FromContext(ctx)
+	if w != nil {
+		w.Successf("Auth handler %q removed from cache.", name)
+		w.Infof("Stored credentials are not affected. Use '%s auth logout %s' to clear tokens.", cliParams.BinaryName, name)
+	}
+
+	return nil
+}

--- a/pkg/cmd/scafctl/auth/handlers_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,21 @@ func TestBuildHandlerInfoResult_InstalledBuiltIn(t *testing.T) {
 	assert.Equal(t, "built-in", result["source"])
 	assert.Contains(t, result["flows"], "device_code")
 	assert.Equal(t, false, result["loggedIn"])
+}
+
+func TestBuildHandlerInfoResult_LazyPluginClassifiedAsPlugin(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	registry := authpkg.NewRegistry()
+	lazy := plugin.NewLazyAuthHandlerWrapper(plugin.LazyAuthHandlerConfig{
+		Name:    "github",
+		BinPath: "/fake/path",
+	})
+	require.NoError(t, registry.Register(lazy))
+
+	result := buildHandlerInfoResult(ctx, "github", registry, nil)
+	assert.Equal(t, "installed", result["status"])
+	assert.Equal(t, "plugin", result["source"], "lazy wrappers should be classified as plugin, not built-in")
 }
 
 func TestCommandHandlers_WithRegisteredHandler(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -48,6 +48,12 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			values are never displayed here — use 'scafctl auth token <handler>'
 			to retrieve a token value.
 
+			Official auth handlers are downloaded automatically on first use via
+			'scafctl auth login <handler>'. To discover additional auth handlers
+			from a catalog, run:
+
+			  scafctl catalog list --kind auth-handler
+
 			Examples:
 			  # Show tokens for all handlers
 			  scafctl auth list
@@ -83,6 +89,12 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 		Aliases:      []string{"ls"},
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return listKnownHandlers(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)
@@ -103,13 +115,10 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			}
 
 			handlerNames := listHandlers(ctx)
-			if len(handlerNames) == 0 {
-				err := fmt.Errorf("no auth handlers registered")
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
 
-			// Filter to a single handler if specified
+			// When a specific handler is provided, allow lazy resolution (user
+			// explicitly asked for it). Otherwise only iterate eagerly-registered
+			// handlers to avoid surprise network I/O.
 			if len(args) > 0 {
 				handlerName := args[0]
 				if err := validateHandlerName(ctx, handlerName); err != nil {
@@ -117,6 +126,19 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}
 				handlerNames = []string{handlerName}
+			} else if len(handlerNames) == 0 {
+				// No eagerly-registered handlers. Check if official ones exist.
+				unconfigured := listUnconfiguredOfficialHandlers(ctx)
+				if len(unconfigured) == 0 {
+					err := fmt.Errorf("no auth handlers registered")
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.GeneralError)
+				}
+				w.Infof("No active authentication sessions.")
+				w.Infof("")
+				w.Infof("Official auth handlers: %s", strings.Join(unconfigured, ", "))
+				w.Infof("Run '%s auth login <handler>' to authenticate (downloads automatically on first use).", cliParams.BinaryName)
+				return nil
 			}
 
 			// --purge-expired: remove expired access tokens and return a summary.
@@ -183,6 +205,11 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			if len(results) == 0 {
 				w.Infof("No cached tokens found.")
+				if unconfigured := listUnconfiguredOfficialHandlers(ctx); len(unconfigured) > 0 {
+					w.Infof("")
+					w.Infof("Hint: additional official auth handlers: %s", strings.Join(unconfigured, ", "))
+					w.Infof("      Run '%s auth login <handler>' to authenticate.", cliParams.BinaryName)
+				}
 				return nil
 			}
 

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -222,4 +224,109 @@ func TestHumanDuration(t *testing.T) {
 			assert.Equal(t, tc.expected, humanDuration(tc.d))
 		})
 	}
+}
+
+func TestCommandList_NoEagerHandlers_ShowsOfficialHint(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	// Add official registry to context (no eager handlers registered)
+	officialReg := authofficial.NewRegistry()
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	// Also add an empty auth registry so the code path doesn't hit nil
+	authReg := auth.NewRegistry()
+	ctx = auth.WithRegistry(ctx, authReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "No active authentication sessions")
+	assert.Contains(t, output, "Official auth handlers")
+	assert.Contains(t, output, "entra")
+	assert.Contains(t, output, "gcp")
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "auth login <handler>")
+	assert.Contains(t, output, "downloads automatically")
+}
+
+func TestCommandList_NoOfficialRegistry_StillErrors(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	// No official registry, no eager handlers — should still error
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth handlers registered")
+}
+
+func TestCommandList_WithTokens_ShowsRemainingHint(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	// Set up a handler with tokens
+	now := time.Now()
+	mock := auth.NewMockHandler("github")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "github",
+			TokenKind: "access",
+			Scope:     "repo",
+			TokenType: "Bearer",
+			Flow:      auth.FlowDeviceCode,
+			ExpiresAt: now.Add(1 * time.Hour),
+			CachedAt:  now.Add(-5 * time.Minute),
+			IsExpired: false,
+		},
+	}
+	ctx = withTestHandler(ctx, mock)
+
+	// Add official registry so hint about remaining handlers can appear
+	officialReg := authofficial.NewRegistry()
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	// Token results are shown (this test verifies no crash with official registry present)
+	output := buf.String()
+	assert.Contains(t, output, "github")
+}
+
+func TestCommandList_ValidArgsFunction(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	assert.Contains(t, completions, "entra")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	completions, directive = cmd.ValidArgsFunction(cmd, []string{"entra"}, "")
+	assert.Empty(t, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -169,6 +169,12 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 		Args:         flags.RequireArg("handler", cliParams.BinaryName+" auth login gcp"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return listKnownHandlers(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)
@@ -232,6 +238,34 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 				err := fmt.Errorf("--impersonate-service-account is only supported by the 'gcp' auth handler")
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Apply CLI flag overrides (--client-id, --tenant) to the handler's
+			// plugin configuration before login so the plugin uses the correct
+			// OAuth application and tenant for token requests.
+			if clientID != "" || tenantID != "" {
+				if cfgr, ok := handler.(auth.Configurer); ok {
+					overrides := make(map[string]string)
+					if clientID != "" {
+						overrides["clientId"] = clientID
+					}
+					if tenantID != "" {
+						overrides["tenantId"] = tenantID
+					}
+					if err := cfgr.ApplyOverrides(ctx, overrides); err != nil {
+						return exitcode.WithCode(
+							fmt.Errorf("applying config overrides (--client-id/--tenant): %w", err),
+							exitcode.InvalidInput,
+						)
+					}
+				} else if clientID != "" {
+					// --client-id requires Configurer support; --tenant is passed via
+					// LoginOptions so it works without Configurer.
+					return exitcode.WithCode(
+						fmt.Errorf("--client-id is not supported by the %q auth handler", handlerName),
+						exitcode.InvalidInput,
+					)
+				}
 			}
 
 			// Route to handler-specific login logic
@@ -361,7 +395,7 @@ func loginWithFlowDetection(ctx context.Context, w *writer.Writer, binaryName st
 	case auth.PreLoginAlreadyAuthenticated:
 		w.Warningf("Already authenticated as %s.", preLogin.Identity)
 		w.Warningf("Use '%s auth logout %s' to sign out first, or use --force to re-authenticate.", binaryName, handlerName)
-		w.Info("")
+		return nil
 	}
 
 	return executeLogin(ctx, w, binaryName, handler, flow, tenantID, callbackPort, timeout, scopes)

--- a/pkg/cmd/scafctl/auth/login_coverage_test.go
+++ b/pkg/cmd/scafctl/auth/login_coverage_test.go
@@ -406,7 +406,7 @@ func TestCommandLogin_CustomHandler_Success(t *testing.T) {
 }
 
 func TestCommandLogin_CustomHandler_AlreadyAuthenticated(t *testing.T) {
-	// loginGeneric should print a warning when already authenticated
+	// loginGeneric should print a warning and return early when already authenticated
 	ctx, buf := newTestContext(t)
 
 	mock := auth.NewMockHandler("quay")
@@ -423,8 +423,8 @@ func TestCommandLogin_CustomHandler_AlreadyAuthenticated(t *testing.T) {
 
 	err := cmd.Execute()
 	require.NoError(t, err)
-	// Should still call Login (PreLoginAlreadyAuthenticated just warns)
-	require.Len(t, mock.LoginCalls, 1)
+	// Should NOT call Login (returns early with warning)
+	assert.Empty(t, mock.LoginCalls)
 	out := buf.String()
 	assert.Contains(t, out, "Already authenticated")
 }

--- a/pkg/cmd/scafctl/auth/login_test.go
+++ b/pkg/cmd/scafctl/auth/login_test.go
@@ -137,6 +137,9 @@ func TestCommandLogin_AlreadyAuthenticated(t *testing.T) {
 	// Verify warning about already authenticated
 	output := buf.String()
 	assert.Contains(t, output, "Already authenticated")
+
+	// Verify Login was NOT called (returns early without proceeding)
+	assert.Empty(t, mock.LoginCalls, "Login should not be called when already authenticated without --force")
 }
 
 func TestCommandLogin_WithTenant(t *testing.T) {
@@ -246,4 +249,105 @@ func TestCommandLogin_DeviceCodeCallback(t *testing.T) {
 
 	// Re-execute to test callback behavior (it was captured above)
 	capturedCallback("ABC123", "https://microsoft.com/devicelogin", "Test message")
+}
+
+func TestCommandLogin_ClientIDFlag_AppliesOverrides(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockConfigurerHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+	}
+	mock.SetNotAuthenticated()
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{
+			Name:     "Test User",
+			Email:    "test@example.com",
+			TenantID: "custom-tenant",
+		},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--client-id", "custom-client-id", "--tenant", "custom-tenant"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify ApplyOverrides was called with the right values
+	require.Len(t, mock.ApplyOverridesCalls, 1)
+	assert.Equal(t, "custom-client-id", mock.ApplyOverridesCalls[0]["clientId"])
+	assert.Equal(t, "custom-tenant", mock.ApplyOverridesCalls[0]["tenantId"])
+
+	// Verify login was still called
+	require.Len(t, mock.LoginCalls, 1)
+}
+
+func TestCommandLogin_ClientIDFlag_NoOverridesWhenEmpty(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockConfigurerHandler("entra")
+	mock.DisplayNameValue = "Microsoft Entra ID"
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapScopesOnTokenRequest,
+		auth.CapTenantID,
+	}
+	mock.SetNotAuthenticated()
+	mock.LoginResult = &auth.Result{
+		Claims: &auth.Claims{
+			Name:  "Test User",
+			Email: "test@example.com",
+		},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// No overrides when flags are empty
+	assert.Empty(t, mock.ApplyOverridesCalls)
+}
+
+func TestCommandLogin_ClientIDFlag_ErrorWhenNotConfigurer(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	// NewMockHandler does NOT implement auth.Configurer.
+	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{
+		auth.CapScopesOnLogin,
+		auth.CapTenantID,
+	}
+	mock.SetNotAuthenticated()
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--client-id", "custom-client-id"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-id is not supported")
 }

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -72,8 +72,12 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				return fmt.Errorf("accepts 1 arg(s) (handler name), received %d — or use --all to log out from all handlers", len(args))
 			}
 			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		}, ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return listKnownHandlers(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		}, RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)
 			if w == nil {
@@ -84,6 +88,14 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			if all {
 				handlerNames = listHandlers(ctx)
 				if len(handlerNames) == 0 {
+					unconfigured := listUnconfiguredOfficialHandlers(ctx)
+					if len(unconfigured) > 0 {
+						w.Infof("No active authentication sessions.")
+						w.Infof("")
+						w.Infof("Official auth handlers: %s", strings.Join(unconfigured, ", "))
+						w.Infof("Run '%s auth login <handler>' to authenticate (downloads automatically on first use).", cliParams.BinaryName)
+						return nil
+					}
 					err := fmt.Errorf("no auth handlers registered")
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.GeneralError)

--- a/pkg/cmd/scafctl/auth/logout_test.go
+++ b/pkg/cmd/scafctl/auth/logout_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,4 +121,53 @@ func TestCommandLogout_Failure(t *testing.T) {
 	assert.Contains(t, err.Error(), "one or more logout operations failed")
 	// The specific underlying error is printed to output, not wrapped in the returned error
 	assert.Contains(t, buf.String(), "failed to clear credentials")
+}
+
+func TestCommandLogout_AllNoHandlers_ShowsOfficialAvailable(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	// No auth registry / no test handler, but official registry is present.
+	officialReg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github"},
+		{Name: "entra", CatalogRef: "entra"},
+	})
+	ctx = authofficial.WithRegistry(ctx, officialReg)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogout(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--all"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "No active authentication sessions")
+	assert.Contains(t, output, "github")
+	assert.Contains(t, output, "entra")
+}
+
+func TestCommandLogout_ValidArgsFunction(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	mock := auth.NewMockHandler("github")
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandLogout(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+
+	// ValidArgsFunction with no args should return handler names.
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	assert.Contains(t, completions, "github")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	// With one arg already, should return no completions.
+	completions, directive = cmd.ValidArgsFunction(cmd, []string{"github"}, "")
+	assert.Empty(t, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -222,6 +222,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 		otelInsecure      bool
 		telShutdown       func(context.Context) error
 		authPluginClients []*plugin.AuthHandlerClient
+		authLazyHandlers  []*plugin.LazyAuthHandlerWrapper
 		authClientsMu     sync.Mutex // guards authPluginClients from concurrent fallback resolvers
 	)
 
@@ -614,6 +615,49 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 				})
 			}
 
+			// ── Register lazy wrappers for cached official auth handler plugins ──
+			// If an official auth handler has a cached binary (previously
+			// downloaded via install or login), register a lazy wrapper now.
+			// This makes it visible in registry.List() without spawning any
+			// subprocesses. The plugin is started on first actual use.
+			if officialReg := authofficial.RegistryFromContext(ctx); officialReg != nil {
+				pluginCfg := &plugin.ProviderConfig{
+					Quiet:      cliParams.IsQuiet,
+					NoColor:    cliParams.NoColor,
+					BinaryName: binaryName,
+				}
+				hostDeps := plugin.HostDepsFromAuthRegistry(authRegistry)
+				if hostDeps != nil && secretErr == nil {
+					hostDeps.SecretStore = sharedSecretStore
+				}
+				clientOpts := []plugin.ClientOption{plugin.WithHostDeps(hostDeps)}
+				cache := plugin.NewCache(settings.PluginCacheDirFor(binaryName))
+
+				for _, name := range officialReg.Names() {
+					if authRegistry.Has(name) {
+						continue // already registered (e.g., via config or plugin dir)
+					}
+					cacheKey := plugin.PluginCacheKey(name, solution.PluginKindAuthHandler)
+					binPath, _, ok := cache.GetLatestBinary(cacheKey)
+					if !ok {
+						continue // not cached, skip (will use fallback on demand)
+					}
+					lazy := plugin.NewLazyAuthHandlerWrapper(plugin.LazyAuthHandlerConfig{
+						Name:             name,
+						BinPath:          binPath,
+						PluginCfg:        pluginCfg,
+						ClientOpts:       clientOpts,
+						OfficialRegistry: officialReg,
+					})
+					lazy.SetContext(ctx)
+					if err := authRegistry.Register(lazy); err != nil {
+						lgr.V(1).Info("failed to register lazy auth handler", "handler", name, "error", err)
+						continue
+					}
+					authLazyHandlers = append(authLazyHandlers, lazy)
+				}
+			}
+
 			// ── Wire official provider registry for auto-resolution ──
 			// When the embedder provides a custom registry, use it.
 			// Otherwise, use the default registry unless disabled in config.
@@ -772,6 +816,11 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cleanup = func() {
 		cleanupOnce.Do(func() {
 			plugin.KillAllAuthHandlers(authPluginClients)
+			for _, lazy := range authLazyHandlers {
+				if c := lazy.Client(); c != nil {
+					c.Kill()
+				}
+			}
 			if telShutdown != nil {
 				shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -577,32 +577,42 @@ func cachedTokenInfoToProto(t *auth.CachedTokenInfo) *proto.CachedTokenInfo {
 	if t == nil {
 		return &proto.CachedTokenInfo{}
 	}
-	return &proto.CachedTokenInfo{
-		Handler:       t.Handler,
-		TokenKind:     t.TokenKind,
-		Scope:         t.Scope,
-		TokenType:     t.TokenType,
-		Flow:          string(t.Flow),
-		ExpiresAtUnix: t.ExpiresAt.Unix(),
-		CachedAtUnix:  t.CachedAt.Unix(),
-		IsExpired:     t.IsExpired,
-		SessionId:     t.SessionID,
+	p := &proto.CachedTokenInfo{
+		Handler:   t.Handler,
+		TokenKind: t.TokenKind,
+		Scope:     t.Scope,
+		TokenType: t.TokenType,
+		Flow:      string(t.Flow),
+		IsExpired: t.IsExpired,
+		SessionId: t.SessionID,
 	}
+	if !t.ExpiresAt.IsZero() {
+		p.ExpiresAtUnix = t.ExpiresAt.Unix()
+	}
+	if !t.CachedAt.IsZero() {
+		p.CachedAtUnix = t.CachedAt.Unix()
+	}
+	return p
 }
 
 func protoToCachedTokenInfo(t *proto.CachedTokenInfo) *auth.CachedTokenInfo {
 	if t == nil {
 		return &auth.CachedTokenInfo{}
 	}
-	return &auth.CachedTokenInfo{
+	info := &auth.CachedTokenInfo{
 		Handler:   t.Handler,
 		TokenKind: t.TokenKind,
 		Scope:     t.Scope,
 		TokenType: t.TokenType,
 		Flow:      auth.Flow(t.Flow),
-		ExpiresAt: time.Unix(t.ExpiresAtUnix, 0),
-		CachedAt:  time.Unix(t.CachedAtUnix, 0),
 		IsExpired: t.IsExpired,
 		SessionID: t.SessionId,
 	}
+	if t.ExpiresAtUnix != 0 {
+		info.ExpiresAt = time.Unix(t.ExpiresAtUnix, 0)
+	}
+	if t.CachedAtUnix != 0 {
+		info.CachedAt = time.Unix(t.CachedAtUnix, 0)
+	}
+	return info
 }

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -31,6 +31,7 @@ var (
 	_ auth.TokenLister  = (*AuthHandlerWrapper)(nil)
 	_ auth.TokenPurger  = (*AuthHandlerWrapper)(nil)
 	_ auth.FlowDetector = (*AuthHandlerWrapper)(nil)
+	_ auth.Configurer   = (*AuthHandlerWrapper)(nil)
 )
 
 // AuthHandlerWrapper wraps a plugin auth handler to implement the auth.Handler
@@ -41,7 +42,16 @@ type AuthHandlerWrapper struct {
 	info           AuthHandlerInfo
 	trustedDomains []string
 	startupLatency time.Duration
+	hostCfg        hostConfig // host-level config (Quiet, NoColor, BinaryName)
 	mu             sync.RWMutex
+}
+
+// hostConfig stores host-level ProviderConfig fields so ApplyOverrides
+// can reconstruct a full config without zeroing them.
+type hostConfig struct {
+	Quiet      bool
+	NoColor    bool
+	BinaryName string
 }
 
 // NewAuthHandlerWrapper creates a new wrapper for a plugin auth handler.
@@ -230,6 +240,66 @@ func (w *AuthHandlerWrapper) DetectAvailableFlows(ctx context.Context) ([]auth.F
 	return w.client.plugin.DetectAvailableFlows(ctx, w.handlerName)
 }
 
+// ApplyOverrides implements auth.Configurer.
+// It merges the provided key-value overrides into the handler's current
+// plugin configuration and re-sends ConfigureAuthHandler to the plugin process.
+// This allows CLI flags (e.g., --client-id, --tenant) to override config-file
+// and default settings at runtime before login.
+func (w *AuthHandlerWrapper) ApplyOverrides(ctx context.Context, overrides map[string]string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	// Filter out empty values before marshaling — empty strings mean "not set"
+	// and should not be forwarded to the plugin.
+	filtered := make(map[string]string, len(overrides))
+	for k, v := range overrides {
+		if v != "" {
+			filtered[k] = v
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	// Build a settings map with just the overrides for this handler.
+	settingsJSON, err := json.Marshal(filtered)
+	if err != nil {
+		return fmt.Errorf("marshaling overrides: %w", err)
+	}
+
+	// Reconstruct the ProviderConfig with the override settings merged.
+	// Preserve host-level fields (Quiet, NoColor, BinaryName) from initial config.
+	cfg := ProviderConfig{
+		Quiet:         w.hostCfg.Quiet,
+		NoColor:       w.hostCfg.NoColor,
+		BinaryName:    w.hostCfg.BinaryName,
+		Settings:      map[string]json.RawMessage{w.handlerName: settingsJSON},
+		HostServiceID: w.client.HostServiceID(),
+	}
+
+	// Inject base settings from app config first, then overlay overrides.
+	injectAuthHandlerSettings(ctx, w.handlerName, &cfg)
+
+	// Merge overrides on top of base settings.
+	if base, ok := cfg.Settings[w.handlerName]; ok {
+		var baseMap map[string]interface{}
+		if jsonErr := json.Unmarshal(base, &baseMap); jsonErr != nil {
+			return fmt.Errorf("unmarshaling base settings for handler %s: %w", w.handlerName, jsonErr)
+		}
+		for k, v := range filtered {
+			baseMap[k] = v
+		}
+		merged, mergeErr := json.Marshal(baseMap)
+		if mergeErr != nil {
+			return fmt.Errorf("marshaling merged settings for handler %s: %w", w.handlerName, mergeErr)
+		}
+		cfg.Settings[w.handlerName] = merged
+	}
+
+	return w.client.ConfigureAuthHandler(ctx, w.handlerName, cfg)
+}
+
 // Client returns the underlying plugin client.
 func (w *AuthHandlerWrapper) Client() *AuthHandlerClient {
 	return w.client
@@ -301,6 +371,11 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 				lgr.Info("failed to configure auth handler plugin",
 					"handler", info.Name,
 					"error", cfgErr)
+			}
+			wrapper.hostCfg = hostConfig{
+				Quiet:      cfg.Quiet,
+				NoColor:    cfg.NoColor,
+				BinaryName: cfg.BinaryName,
 			}
 		}
 	}

--- a/pkg/plugin/wrapper_auth_lazy.go
+++ b/pkg/plugin/wrapper_auth_lazy.go
@@ -1,0 +1,333 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// Compile-time interface checks.
+var (
+	_ auth.Handler      = (*LazyAuthHandlerWrapper)(nil)
+	_ auth.TokenLister  = (*LazyAuthHandlerWrapper)(nil)
+	_ auth.TokenPurger  = (*LazyAuthHandlerWrapper)(nil)
+	_ auth.FlowDetector = (*LazyAuthHandlerWrapper)(nil)
+	_ auth.Configurer   = (*LazyAuthHandlerWrapper)(nil)
+)
+
+// lazyInitTimeout is the maximum time allowed for plugin initialization
+// when triggered by metadata queries (SupportedFlows, Capabilities).
+const lazyInitTimeout = 30 * time.Second
+
+// LazyAuthHandlerWrapper implements auth.Handler by deferring plugin subprocess
+// startup until the first method that requires it. Name() and DisplayName() are
+// served from static metadata, so registry.List() and registry.Has() work
+// without any I/O.
+type LazyAuthHandlerWrapper struct {
+	name        string
+	displayName string
+
+	// initFn starts the plugin subprocess and returns the real wrapper.
+	// It is called at most once via sync.Once.
+	initFn func(ctx context.Context) (*AuthHandlerWrapper, error)
+
+	once    sync.Once
+	wrapper atomic.Pointer[AuthHandlerWrapper]
+	initErr error
+
+	// baseCtx holds the wired application context captured from the first
+	// context-bearing call (Login, ApplyOverrides, etc.). It is used as a
+	// fallback by SupportedFlows/Capabilities instead of context.Background()
+	// to ensure initialization has access to config, logger, and secret-store.
+	baseCtxMu  sync.Mutex
+	baseCtx    context.Context
+	baseCtxSet bool
+}
+
+// LazyAuthHandlerConfig holds parameters needed to construct a lazy wrapper.
+type LazyAuthHandlerConfig struct {
+	// Name is the handler name (e.g., "entra").
+	Name string
+
+	// BinPath is the absolute path to the cached plugin binary.
+	BinPath string
+
+	// PluginCfg is passed to ConfigureAuthHandler after startup.
+	PluginCfg *ProviderConfig
+
+	// ClientOpts are options for the plugin client (e.g., host deps).
+	ClientOpts []ClientOption
+
+	// OfficialRegistry provides trusted domains for the handler.
+	OfficialRegistry *authofficial.Registry
+}
+
+// NewLazyAuthHandlerWrapper creates a lazy auth handler that defers plugin
+// startup until a method requiring the plugin is called.
+func NewLazyAuthHandlerWrapper(cfg LazyAuthHandlerConfig) *LazyAuthHandlerWrapper {
+	return &LazyAuthHandlerWrapper{
+		name:        cfg.Name,
+		displayName: cfg.Name, // best we can do without starting the plugin
+		initFn: func(ctx context.Context) (*AuthHandlerWrapper, error) {
+			lgr := logger.FromContext(ctx)
+			lgr.V(1).Info("lazy-starting auth handler plugin", "handler", cfg.Name, "path", cfg.BinPath)
+
+			client, err := NewAuthHandlerClient(cfg.BinPath, cfg.ClientOpts...)
+			if err != nil {
+				return nil, fmt.Errorf("starting auth handler plugin %s: %w", cfg.Name, err)
+			}
+
+			handlers, err := client.GetAuthHandlers(ctx)
+			if err != nil {
+				client.Kill()
+				return nil, fmt.Errorf("getting handlers from plugin %s: %w", cfg.Name, err)
+			}
+
+			// Find the handler matching our name.
+			for _, info := range handlers {
+				if info.Name == cfg.Name {
+					wrapper := NewAuthHandlerWrapper(client, info)
+
+					// Set trusted domains from official registry + config.
+					if cfg.OfficialRegistry != nil {
+						if official, ok := cfg.OfficialRegistry.Get(cfg.Name); ok {
+							wrapper.SetTrustedDomains(official.TrustedVerificationDomains)
+						}
+					}
+
+					// Configure the handler.
+					if cfg.PluginCfg != nil {
+						hostCfg := *cfg.PluginCfg
+						hostCfg.HostServiceID = client.HostServiceID()
+						injectAuthHandlerSettings(ctx, info.Name, &hostCfg)
+						if cfgErr := client.ConfigureAuthHandler(ctx, info.Name, hostCfg); cfgErr != nil {
+							lgr.Info("failed to configure lazy auth handler",
+								"handler", info.Name, "error", cfgErr)
+						}
+						wrapper.hostCfg = hostConfig{
+							Quiet:      cfg.PluginCfg.Quiet,
+							NoColor:    cfg.PluginCfg.NoColor,
+							BinaryName: cfg.PluginCfg.BinaryName,
+						}
+					}
+
+					return wrapper, nil
+				}
+			}
+
+			client.Kill()
+			return nil, fmt.Errorf("plugin %s does not expose handler %q", cfg.BinPath, cfg.Name)
+		},
+	}
+}
+
+// init starts the plugin if not already started. The provided context is used
+// for the initialization call only.
+func (l *LazyAuthHandlerWrapper) init(ctx context.Context) (*AuthHandlerWrapper, error) {
+	l.storeBaseCtx(ctx)
+	l.once.Do(func() {
+		w, err := l.initFn(ctx)
+		l.initErr = err
+		if w != nil {
+			l.wrapper.Store(w)
+		}
+	})
+	return l.wrapper.Load(), l.initErr
+}
+
+// storeBaseCtx captures the first non-background context for use by metadata
+// methods that lack a context parameter.
+func (l *LazyAuthHandlerWrapper) storeBaseCtx(ctx context.Context) {
+	if ctx != nil && ctx != context.Background() && ctx != context.TODO() {
+		l.baseCtxMu.Lock()
+		defer l.baseCtxMu.Unlock()
+		if !l.baseCtxSet {
+			l.baseCtx = ctx
+			l.baseCtxSet = true
+		}
+	}
+}
+
+// getBaseCtx returns the stored base context, falling back to context.Background().
+func (l *LazyAuthHandlerWrapper) getBaseCtx() context.Context {
+	l.baseCtxMu.Lock()
+	defer l.baseCtxMu.Unlock()
+	if l.baseCtx != nil {
+		return l.baseCtx
+	}
+	return context.Background()
+}
+
+// Client returns the underlying AuthHandlerClient, or nil if not yet initialized.
+func (l *LazyAuthHandlerWrapper) Client() *AuthHandlerClient {
+	if w := l.wrapper.Load(); w != nil {
+		return w.Client()
+	}
+	return nil
+}
+
+// SetContext stores a wired application context for later use by metadata
+// methods (SupportedFlows, Capabilities) that don't receive a context parameter.
+// Only the first call takes effect.
+func (l *LazyAuthHandlerWrapper) SetContext(ctx context.Context) {
+	l.storeBaseCtx(ctx)
+}
+
+// IsInitialized reports whether the plugin subprocess has been started.
+func (l *LazyAuthHandlerWrapper) IsInitialized() bool {
+	return l.wrapper.Load() != nil
+}
+
+// --- auth.Handler (static, no plugin needed) ---
+
+// Name implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) Name() string {
+	return l.name
+}
+
+// DisplayName implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) DisplayName() string {
+	// After initialization, use the real display name from the plugin.
+	if w := l.wrapper.Load(); w != nil {
+		return w.DisplayName()
+	}
+	return l.displayName
+}
+
+// SupportedFlows implements auth.Handler.
+// This triggers plugin initialization because flow information is needed
+// for command validation (e.g., determining which login flags to show).
+func (l *LazyAuthHandlerWrapper) SupportedFlows() []auth.Flow {
+	if w := l.wrapper.Load(); w != nil {
+		return w.SupportedFlows()
+	}
+	ctx, cancel := context.WithTimeout(l.getBaseCtx(), lazyInitTimeout)
+	defer cancel()
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil
+	}
+	return w.SupportedFlows()
+}
+
+// Capabilities implements auth.Handler.
+// This triggers plugin initialization because capabilities determine which
+// flags and validation rules apply (e.g., CapScopesOnTokenRequest controls
+// whether --scope is accepted by 'auth token').
+func (l *LazyAuthHandlerWrapper) Capabilities() []auth.Capability {
+	if w := l.wrapper.Load(); w != nil {
+		return w.Capabilities()
+	}
+	ctx, cancel := context.WithTimeout(l.getBaseCtx(), lazyInitTimeout)
+	defer cancel()
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil
+	}
+	return w.Capabilities()
+}
+
+// --- auth.Configurer ---
+
+// ApplyOverrides implements auth.Configurer.
+// Triggers plugin initialization if needed, then delegates to the wrapper.
+func (l *LazyAuthHandlerWrapper) ApplyOverrides(ctx context.Context, overrides map[string]string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+	w, err := l.init(ctx)
+	if err != nil {
+		return err
+	}
+	return w.ApplyOverrides(ctx, overrides)
+}
+
+// --- auth.Handler (requires plugin) ---
+
+// Login implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.Login(ctx, opts)
+}
+
+// Logout implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) Logout(ctx context.Context) error {
+	w, err := l.init(ctx)
+	if err != nil {
+		return err
+	}
+	return w.Logout(ctx)
+}
+
+// Status implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) Status(ctx context.Context) (*auth.Status, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.Status(ctx)
+}
+
+// GetToken implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.GetToken(ctx, opts)
+}
+
+// InjectAuth implements auth.Handler.
+func (l *LazyAuthHandlerWrapper) InjectAuth(ctx context.Context, req *http.Request, opts auth.TokenOptions) error {
+	w, err := l.init(ctx)
+	if err != nil {
+		return err
+	}
+	return w.InjectAuth(ctx, req, opts)
+}
+
+// --- auth.TokenLister ---
+
+// ListCachedTokens implements auth.TokenLister.
+func (l *LazyAuthHandlerWrapper) ListCachedTokens(ctx context.Context) ([]*auth.CachedTokenInfo, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.ListCachedTokens(ctx)
+}
+
+// --- auth.TokenPurger ---
+
+// PurgeExpiredTokens implements auth.TokenPurger.
+func (l *LazyAuthHandlerWrapper) PurgeExpiredTokens(ctx context.Context) (int, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return w.PurgeExpiredTokens(ctx)
+}
+
+// --- auth.FlowDetector ---
+
+// DetectAvailableFlows implements auth.FlowDetector.
+func (l *LazyAuthHandlerWrapper) DetectAvailableFlows(ctx context.Context) ([]auth.FlowAvailability, error) {
+	w, err := l.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.DetectAvailableFlows(ctx)
+}

--- a/pkg/plugin/wrapper_auth_lazy_test.go
+++ b/pkg/plugin/wrapper_auth_lazy_test.go
@@ -1,0 +1,366 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyAuthHandlerWrapper_Name(t *testing.T) {
+	lazy := NewLazyAuthHandlerWrapper(LazyAuthHandlerConfig{
+		Name:    "github",
+		BinPath: "/fake/path",
+	})
+
+	assert.Equal(t, "github", lazy.Name())
+	assert.False(t, lazy.IsInitialized())
+}
+
+func TestLazyAuthHandlerWrapper_DisplayName_BeforeInit(t *testing.T) {
+	lazy := NewLazyAuthHandlerWrapper(LazyAuthHandlerConfig{
+		Name:    "entra",
+		BinPath: "/fake/path",
+	})
+
+	// Before initialization, display name falls back to handler name.
+	assert.Equal(t, "entra", lazy.DisplayName())
+}
+
+func TestLazyAuthHandlerWrapper_SupportedFlows_InvalidBinary_ReturnsNil(t *testing.T) {
+	lazy := NewLazyAuthHandlerWrapper(LazyAuthHandlerConfig{
+		Name:    "gcp",
+		BinPath: "/fake/path",
+	})
+
+	// Plugin binary doesn't exist — init fails, returns nil.
+	assert.Nil(t, lazy.SupportedFlows())
+}
+
+func TestLazyAuthHandlerWrapper_Capabilities_InvalidBinary_ReturnsNil(t *testing.T) {
+	lazy := NewLazyAuthHandlerWrapper(LazyAuthHandlerConfig{
+		Name:    "gcp",
+		BinPath: "/fake/path",
+	})
+
+	assert.Nil(t, lazy.Capabilities())
+}
+
+func TestLazyAuthHandlerWrapper_Client_BeforeInit(t *testing.T) {
+	lazy := NewLazyAuthHandlerWrapper(LazyAuthHandlerConfig{
+		Name:    "github",
+		BinPath: "/fake/path",
+	})
+
+	assert.Nil(t, lazy.Client())
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnLogin(t *testing.T) {
+	initErr := errors.New("binary not found")
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, initErr
+		},
+	}
+
+	_, err := lazy.Login(context.Background(), auth.LoginOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binary not found")
+	assert.True(t, lazy.IsInitialized() == false || lazy.wrapper.Load() == nil)
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnStatus(t *testing.T) {
+	initErr := errors.New("plugin crashed")
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, initErr
+		},
+	}
+
+	_, err := lazy.Status(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin crashed")
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnGetToken(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("timeout")
+		},
+	}
+
+	_, err := lazy.GetToken(context.Background(), auth.TokenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnLogout(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("not available")
+		},
+	}
+
+	err := lazy.Logout(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not available")
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnListCachedTokens(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("startup failed")
+		},
+	}
+
+	_, err := lazy.ListCachedTokens(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "startup failed")
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnPurge(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("gone")
+		},
+	}
+
+	_, err := lazy.PurgeExpiredTokens(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone")
+}
+
+func TestLazyAuthHandlerWrapper_InitError_PropagatesOnDetectFlows(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("no exec permission")
+		},
+	}
+
+	_, err := lazy.DetectAvailableFlows(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no exec permission")
+}
+
+func TestLazyAuthHandlerWrapper_InitCalledOnce(t *testing.T) {
+	callCount := 0
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "counter",
+		displayName: "counter",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			callCount++
+			return nil, errors.New("fail")
+		},
+	}
+
+	// Call multiple methods — initFn should only be invoked once.
+	_, _ = lazy.Login(context.Background(), auth.LoginOptions{})
+	_, _ = lazy.Status(context.Background())
+	_ = lazy.Logout(context.Background())
+
+	assert.Equal(t, 1, callCount)
+}
+
+func TestLazyAuthHandlerWrapper_InjectAuth_PropagatesError(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("cannot start")
+		},
+	}
+
+	err := lazy.InjectAuth(context.Background(), nil, auth.TokenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start")
+}
+
+func TestLazyAuthHandlerWrapper_Capabilities_TriggersInit(t *testing.T) {
+	wrapper := NewAuthHandlerWrapper(nil, AuthHandlerInfo{
+		Name:         "entra",
+		DisplayName:  "Microsoft Entra ID",
+		Capabilities: []auth.Capability{auth.CapScopesOnLogin, auth.CapScopesOnTokenRequest},
+	})
+
+	initCalled := false
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "entra",
+		displayName: "entra",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			initCalled = true
+			return wrapper, nil
+		},
+	}
+
+	caps := lazy.Capabilities()
+	assert.True(t, initCalled, "Capabilities() should trigger plugin initialization")
+	assert.Contains(t, caps, auth.CapScopesOnTokenRequest)
+	assert.Contains(t, caps, auth.CapScopesOnLogin)
+	assert.True(t, lazy.IsInitialized())
+}
+
+func TestLazyAuthHandlerWrapper_Capabilities_InitError_ReturnsNil(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("plugin binary missing")
+		},
+	}
+
+	caps := lazy.Capabilities()
+	assert.Nil(t, caps)
+}
+
+func TestLazyAuthHandlerWrapper_SupportedFlows_TriggersInit(t *testing.T) {
+	wrapper := NewAuthHandlerWrapper(nil, AuthHandlerInfo{
+		Name:        "entra",
+		DisplayName: "Microsoft Entra ID",
+		Flows:       []auth.Flow{auth.FlowDeviceCode, auth.FlowInteractive},
+	})
+
+	initCalled := false
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "entra",
+		displayName: "entra",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			initCalled = true
+			return wrapper, nil
+		},
+	}
+
+	flows := lazy.SupportedFlows()
+	assert.True(t, initCalled, "SupportedFlows() should trigger plugin initialization")
+	assert.Contains(t, flows, auth.FlowDeviceCode)
+	assert.Contains(t, flows, auth.FlowInteractive)
+	assert.True(t, lazy.IsInitialized())
+}
+
+func TestLazyAuthHandlerWrapper_SupportedFlows_InitError_ReturnsNil(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "broken",
+		displayName: "broken",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("not installed")
+		},
+	}
+
+	flows := lazy.SupportedFlows()
+	assert.Nil(t, flows)
+}
+
+func TestLazyAuthHandlerWrapper_ApplyOverrides_TriggersInit(t *testing.T) {
+	initCalled := false
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "entra",
+		displayName: "entra",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			initCalled = true
+			return nil, errors.New("no plugin for test")
+		},
+	}
+
+	err := lazy.ApplyOverrides(context.Background(), map[string]string{"clientId": "custom-id"})
+	assert.True(t, initCalled, "ApplyOverrides should trigger init")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no plugin for test")
+}
+
+func TestLazyAuthHandlerWrapper_ApplyOverrides_EmptyMapSkipsInit(t *testing.T) {
+	initCalled := false
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "entra",
+		displayName: "entra",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			initCalled = true
+			return nil, errors.New("should not reach here")
+		},
+	}
+
+	err := lazy.ApplyOverrides(context.Background(), map[string]string{})
+	assert.False(t, initCalled, "ApplyOverrides with empty map should not trigger init")
+	assert.NoError(t, err)
+
+	err = lazy.ApplyOverrides(context.Background(), nil)
+	assert.False(t, initCalled, "ApplyOverrides with nil map should not trigger init")
+	assert.NoError(t, err)
+}
+
+func TestLazyAuthHandlerWrapper_SetContext_UsedByMetadataMethods(t *testing.T) {
+	type ctxKey struct{}
+	wiredCtx := context.WithValue(context.Background(), ctxKey{}, "wired")
+
+	var receivedCtx context.Context
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "github",
+		displayName: "github",
+		initFn: func(ctx context.Context) (*AuthHandlerWrapper, error) {
+			receivedCtx = ctx
+			return nil, errors.New("init fails for test")
+		},
+	}
+
+	lazy.SetContext(wiredCtx)
+
+	// SupportedFlows uses getBaseCtx — should receive the wired context (with timeout).
+	_ = lazy.SupportedFlows()
+	require.NotNil(t, receivedCtx)
+	assert.Equal(t, "wired", receivedCtx.Value(ctxKey{}))
+}
+
+func TestLazyAuthHandlerWrapper_SetContext_OnlyFirstCallTakesEffect(t *testing.T) {
+	type ctxKey struct{}
+	first := context.WithValue(context.Background(), ctxKey{}, "first")
+	second := context.WithValue(context.Background(), ctxKey{}, "second")
+
+	var receivedCtx context.Context
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "github",
+		displayName: "github",
+		initFn: func(ctx context.Context) (*AuthHandlerWrapper, error) {
+			receivedCtx = ctx
+			return nil, errors.New("init fails for test")
+		},
+	}
+
+	lazy.SetContext(first)
+	lazy.SetContext(second) // should be ignored
+
+	_ = lazy.Capabilities()
+	require.NotNil(t, receivedCtx)
+	assert.Equal(t, "first", receivedCtx.Value(ctxKey{}))
+}
+
+func TestLazyAuthHandlerWrapper_SetContext_IgnoresBackgroundContext(t *testing.T) {
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "github",
+		displayName: "github",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("init fails for test")
+		},
+	}
+
+	// SetContext with context.Background() should be a no-op.
+	lazy.SetContext(context.Background())
+	assert.Nil(t, lazy.baseCtx)
+}

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -207,3 +207,85 @@ func TestConfigureAndRegisterAuthHandlers_SkipsDuplicates(t *testing.T) {
 	registered := configureAndRegisterAuthHandlers(ctx, reg, client, handlers, nil)
 	assert.Equal(t, []string{"handler-b"}, registered)
 }
+
+func TestAuthHandlerWrapper_ApplyOverrides_Empty(t *testing.T) {
+	t.Parallel()
+	mock := &MockAuthHandlerPlugin{}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "entra"})
+
+	err := wrapper.ApplyOverrides(context.Background(), map[string]string{})
+	require.NoError(t, err)
+	// No call to ConfigureAuthHandler when overrides are empty.
+	assert.Nil(t, mock.lastConfig)
+}
+
+func TestAuthHandlerWrapper_ApplyOverrides_MergesOntoBase(t *testing.T) {
+	t.Parallel()
+	mock := &MockAuthHandlerPlugin{}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "entra"})
+
+	overrides := map[string]string{
+		"clientId": "my-client",
+		"tenantId": "my-tenant",
+	}
+	err := wrapper.ApplyOverrides(context.Background(), overrides)
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfig)
+
+	// The settings should contain the handler name key with the merged JSON.
+	raw, ok := mock.lastConfig.Settings["entra"]
+	require.True(t, ok)
+
+	var settings map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &settings))
+	assert.Equal(t, "my-client", settings["clientId"])
+	assert.Equal(t, "my-tenant", settings["tenantId"])
+}
+
+func TestAuthHandlerWrapper_ApplyOverrides_SkipsEmptyValues(t *testing.T) {
+	t.Parallel()
+	mock := &MockAuthHandlerPlugin{}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "gcp"})
+
+	// Empty values are filtered out before marshaling — they should not
+	// appear in the settings sent to the plugin.
+	overrides := map[string]string{
+		"projectId": "proj-123",
+		"region":    "",
+	}
+	err := wrapper.ApplyOverrides(context.Background(), overrides)
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfig)
+
+	raw := mock.lastConfig.Settings["gcp"]
+	var settings map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &settings))
+	assert.Equal(t, "proj-123", settings["projectId"])
+	// Empty string is filtered out — key should not be present.
+	assert.NotContains(t, settings, "region")
+}
+
+func TestAuthHandlerWrapper_ApplyOverrides_PreservesHostConfig(t *testing.T) {
+	t.Parallel()
+	mock := &MockAuthHandlerPlugin{}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "entra"})
+	wrapper.hostCfg = hostConfig{
+		Quiet:      true,
+		NoColor:    true,
+		BinaryName: "mycli",
+	}
+
+	overrides := map[string]string{"clientId": "abc"}
+	err := wrapper.ApplyOverrides(context.Background(), overrides)
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfig)
+
+	// Host-level fields must be preserved from initial config.
+	assert.True(t, mock.lastConfig.Quiet, "Quiet should be preserved")
+	assert.True(t, mock.lastConfig.NoColor, "NoColor should be preserved")
+	assert.Equal(t, "mycli", mock.lastConfig.BinaryName, "BinaryName should be preserved")
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1026,10 +1026,20 @@ tasks:
   test:e2e:
     deps: [info, git-unshallow-clone, lint]
     desc: "Run end-to-end tests (lint + coverage + solutions + integration)"
+    vars:
+      START_TIME:
+        sh: date +%s
     cmds:
       - task: test-cover
       - task: lint:solutions
       - task: integration
+      - |
+        END_TIME=$(date +%s)
+        ELAPSED=$((END_TIME - {{.START_TIME}}))
+        MINS=$((ELAPSED / 60))
+        SECS=$((ELAPSED % 60))
+        echo ""
+        echo "✅ test:e2e completed in ${MINS}m${SECS}s"
 
   # ──────────────────────────────────────────────────────────────────────────────
   # Load Testing (k6)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2143,15 +2143,23 @@ func TestIntegration_AuthLoginGitHubInvalidFlow(t *testing.T) {
 
 func TestIntegration_AuthLoginGitHubAppFlow(t *testing.T) {
 	t.Parallel()
-	// github-app flow without required config should fail.
-	_, stderr, exitCode := runScafctl(t, "auth", "login", "github", "--flow", "github-app")
+	// github-app flow without required config should fail, unless already authenticated.
+	stdout, stderr, exitCode := runScafctl(t, "auth", "login", "github", "--flow", "github-app")
 
-	assert.NotEqual(t, 0, exitCode)
-	// Either config error (plugin installed) or handler not found (plugin not installed)
-	assert.True(t,
-		strings.Contains(stderr, "app ID is required") || strings.Contains(stderr, "unknown auth handler"),
-		"expected config or handler error, got: %s", stderr,
-	)
+	combined := stdout + stderr
+	if exitCode == 0 {
+		// Already authenticated — handler short-circuits with a warning.
+		assert.True(t,
+			strings.Contains(combined, "Already authenticated") || strings.Contains(combined, "already authenticated"),
+			"expected already-authenticated warning on success, got stdout=%s stderr=%s", stdout, stderr,
+		)
+	} else {
+		// Either config error (plugin installed) or handler not found (plugin not installed)
+		assert.True(t,
+			strings.Contains(stderr, "app ID is required") || strings.Contains(stderr, "unknown auth handler"),
+			"expected config or handler error, got: %s", stderr,
+		)
+	}
 }
 
 func TestIntegration_AuthStatusEntra(t *testing.T) {
@@ -2183,6 +2191,38 @@ func TestIntegration_AuthLogoutEntra(t *testing.T) {
 			"expected handler/plugin error, got: %s", stderr,
 		)
 	}
+}
+
+func TestIntegration_AuthHandlersInstallHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "handlers", "install", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Download an official auth handler plugin")
+}
+
+func TestIntegration_AuthHandlersRemoveHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "handlers", "remove", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Remove a cached auth handler plugin")
+}
+
+func TestIntegration_AuthHandlersInstallUnknown(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "auth", "handlers", "install", "nonexistent-handler-xyz")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "unknown auth handler")
+}
+
+func TestIntegration_AuthHandlersRemoveNotInstalled(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "auth", "handlers", "remove", "nonexistent-handler-xyz")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "is not installed")
 }
 
 // ============================================================================


### PR DESCRIPTION
- introduce LazyAuthHandlerWrapper that defers plugin subprocess startup until first method requiring I/O (Name/DisplayName served statically)
- register lazy wrappers at startup for cached official auth handler binaries, making them visible in registry without spawning processes
- add auth-handlers-install command to pre-fetch plugins from catalog
- add auth-handlers-remove command to delete cached handler binaries
- add shell completion for handler names on login/logout commands
- improve empty-state UX: show available official handlers with usage hints instead of opaque error when no handlers are registered
- fix protoToCachedTokenInfo to skip zero-value timestamps
- display elapsed time at end of test:e2e task