### PR TITLE
feat(auth): add token listing and purging with MCP tools and lifecycle docs

### DIFF
--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -2808,6 +2808,72 @@ verification, see [examples/auth/custom-oauth2-config.md](https://github.com/oak
 
 ---
 
+## Handler Lifecycle Management
+
+Official auth handlers (github, gcp, entra) are delivered as plugin binaries and
+downloaded automatically on first use (e.g., during `scafctl auth login github`).
+You can also manage them explicitly.
+
+### Listing Available Handlers
+
+```bash
+# Show all registered handlers with flows and capabilities
+scafctl auth handlers
+scafctl auth handlers -o json
+```
+
+### Pre-installing a Handler
+
+Download a handler plugin before first use (e.g., for air-gapped environments or
+to inspect capabilities):
+
+```bash
+# Install a specific handler
+scafctl auth handlers install github
+scafctl auth handlers install entra
+
+# Force re-download (replaces cached binary)
+scafctl auth handlers install entra --force
+```
+
+### Removing a Handler
+
+Remove cached handler plugin binaries to free disk space or force a fresh
+download on next use:
+
+```bash
+# Remove a handler's cached binary
+scafctl auth handlers remove github
+scafctl auth handlers remove entra
+```
+
+After removal, the handler will be re-downloaded automatically on next
+`scafctl auth login <handler>`.
+
+### Lazy Loading Behavior
+
+Auth handlers are loaded lazily -- plugin subprocesses are started only when an
+operation requires I/O (login, token refresh, listing cached tokens). This
+means:
+
+- `scafctl auth handlers` lists registered handler names without network I/O
+- `scafctl auth list` queries all eagerly-registered handlers (initializing
+  them as needed) but does not trigger auto-download of unconfigured handlers
+- Running `scafctl auth login <handler>` triggers auto-download if the handler
+  is not yet cached locally
+
+This design avoids surprise network I/O and plugin downloads until explicitly
+requested.
+
+### Shell Completion
+
+The `login` and `logout` commands support shell completion for handler names.
+If you have shell completions enabled for scafctl, pressing `<Tab>` after
+`scafctl auth login` or `scafctl auth logout` will suggest available handler
+names (e.g., `entra`, `github`, `gcp`, and any custom OAuth2 handlers).
+
+---
+
 ## Next Steps
 
 - [CEL Expressions Tutorial](cel-tutorial.md) -- Master CEL expressions and extension functions

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -71,6 +71,8 @@ You should see JSON output listing all available tools:
     { "name": "inspect_solution", "description": "Get full solution metadata..." },
     { "name": "lint_solution", "description": "Validate a solution file..." },
     { "name": "list_auth_handlers", "description": "List all registered auth handlers..." },
+    { "name": "auth_list_tokens", "description": "List all cached access tokens across auth handlers..." },
+    { "name": "auth_purge_expired", "description": "Remove expired access tokens from the cache..." },
     { "name": "list_cel_functions", "description": "List all available CEL functions..." },
     { "name": "list_go_template_functions", "description": "List all available Go template extension functions..." },
     { "name": "list_examples", "description": "List available scafctl example files..." },
@@ -733,6 +735,8 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `show_snapshot` | Display the contents of a resolver execution snapshot file — resolver values, timing, status, and errors |
 | `diff_snapshots` | Compare two resolver snapshots and return structured diffs — added, removed, modified, and unchanged resolvers |
 | `list_auth_handlers` | List all registered authentication handlers with their configuration status and token expiry |
+| `auth_list_tokens` | List all cached access tokens across registered auth handlers -- shows metadata (handler, scope, flow, expiry) without revealing token values |
+| `auth_purge_expired` | Remove expired access tokens from the cache across all (or a specific) auth handler. Keeps valid tokens and refresh tokens |
 | `get_config_paths` | List all XDG-compliant paths used by scafctl — config, data, cache, state, secrets, plugins, and runtime directories |
 | `validate_expressions` | Batch-validate multiple CEL expressions or Go templates — returns validity, errors, and referenced fields for each |
 | `get_version` | Return scafctl version, commit SHA, and build timestamp |

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -238,6 +238,30 @@ scafctl auth logout entra --force
 
 ---
 
+## Handler Lifecycle Management
+
+Official auth handler plugins are downloaded automatically on first use.
+You can also manage them explicitly:
+
+```bash
+# List registered handlers with flows and capabilities
+scafctl auth handlers
+scafctl auth handlers -o json
+
+# Pre-install a handler (useful for air-gapped environments)
+scafctl auth handlers install github
+scafctl auth handlers install entra
+
+# Force re-download
+scafctl auth handlers install entra --force
+
+# Remove cached handler binary (will be re-downloaded on next login)
+scafctl auth handlers remove github
+scafctl auth handlers remove entra
+```
+
+---
+
 ## Related
 
 - [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) — full walkthrough

--- a/examples/auth/diagnose-workflow.md
+++ b/examples/auth/diagnose-workflow.md
@@ -1,0 +1,84 @@
+# Auth Diagnose Workflow
+
+The `scafctl auth diagnose` command (alias: `auth doctor`) runs diagnostic
+checks on your authentication configuration and reports any issues.
+
+## Basic Usage
+
+~~~bash
+# Run diagnostics for all handlers
+scafctl auth diagnose
+
+# Run diagnostics for a specific handler
+scafctl auth diagnose entra
+
+# Output as JSON (for scripting or MCP consumption)
+scafctl auth diagnose -o json
+~~~
+
+## Live Token Check
+
+By default, diagnose only inspects cached state. Use `--live-token` to also
+attempt a live token fetch, confirming end-to-end token acquisition works:
+
+~~~bash
+scafctl auth diagnose --live-token
+scafctl auth diagnose entra --live-token
+~~~
+
+## What It Checks
+
+| Check | Description |
+|-------|-------------|
+| Auth registry | Are any handlers registered? |
+| Config file | Does your config file exist and contain auth sections? |
+| Environment variables | Are handler-specific env vars set correctly? |
+| Clock skew | Is local time within tolerance of an HTTPS server? |
+| Auth status | Are you logged in to each handler? |
+| Cached token health | Are there expired or missing tokens? |
+| Plugin binary | Is the handler plugin binary present and executable? |
+
+## Example Output
+
+~~~text
+Auth Diagnostics
+================
+
+[PASS] auth registry: 2 handlers registered (entra, github)
+[PASS] config file: /Users/you/.config/scafctl/config.yaml exists
+[PASS] clock skew: local time within 2s of remote
+[PASS] entra: logged in, token valid (expires in 47m)
+[WARN] github: token expired 3h ago -- run 'scafctl auth login github'
+
+1 warning found. Run with --live-token to verify token refresh.
+~~~
+
+## JSON Output
+
+~~~json
+{
+  "checks": [
+    {"name": "auth_registry", "status": "pass", "message": "2 handlers registered"},
+    {"name": "clock_skew", "status": "pass", "message": "within 2s"},
+    {"name": "handler_entra", "status": "pass", "message": "token valid"},
+    {"name": "handler_github", "status": "warn", "message": "token expired"}
+  ],
+  "summary": {"pass": 3, "warn": 1, "fail": 0}
+}
+~~~
+
+## CI/CD Usage
+
+Use diagnose in pipelines to verify auth is configured before running
+solutions that require credentials:
+
+~~~bash
+# Fail the pipeline if auth is not healthy
+scafctl auth diagnose -o json | jq -e '.summary.fail == 0'
+~~~
+
+## Related
+
+- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) -- full auth walkthrough
+- [Handler Lifecycle](handler-lifecycle.md) -- install/remove handler plugins
+- [Custom OAuth2 Config](custom-oauth2-config.md) -- adding custom handlers

--- a/examples/auth/handler-lifecycle.md
+++ b/examples/auth/handler-lifecycle.md
@@ -1,0 +1,108 @@
+# Auth Handler Lifecycle Management
+
+Official auth handlers (github, gcp, entra) are delivered as plugin binaries.
+They are downloaded automatically on first use, but you can manage them
+explicitly for air-gapped environments, debugging, or disk cleanup.
+
+## Listing Handlers
+
+~~~bash
+# Show all registered handlers with status, flows, and source
+scafctl auth handlers
+
+# Machine-readable output
+scafctl auth handlers -o json
+scafctl auth handlers -o yaml
+~~~
+
+Example table output:
+
+~~~text
+NAME     DISPLAY NAME   STATUS      SOURCE    FLOWS                 LOGGED IN
+entra    Microsoft      installed   official  interactive,device    true
+github   GitHub         installed   official  interactive,device    true
+gcp      Google Cloud   available   official  interactive           false
+gitlab   GitLab         installed   custom    interactive           true
+~~~
+
+## Pre-Installing a Handler
+
+Download a handler plugin before first use. Useful for:
+- Air-gapped environments (download once, deploy everywhere)
+- Inspecting handler capabilities before logging in
+- Ensuring a specific handler version is cached
+
+~~~bash
+# Install a handler
+scafctl auth handlers install github
+scafctl auth handlers install entra
+
+# Force re-download (replaces cached binary)
+scafctl auth handlers install entra --force
+~~~
+
+## Removing a Handler
+
+Remove cached handler plugin binaries to free disk space or force a fresh
+download on next use:
+
+~~~bash
+# Remove a handler's cached binary
+scafctl auth handlers remove github
+scafctl auth handlers remove entra
+~~~
+
+After removal, the handler will be re-downloaded automatically on next
+`scafctl auth login <handler>`.
+
+## Lazy Loading
+
+Auth handlers use lazy loading -- plugin subprocesses are started only when an
+operation requires I/O (login, token refresh, listing cached tokens). This
+means:
+
+- `scafctl auth handlers` lists registered handler names without network I/O
+- `scafctl auth list` queries all eagerly-registered handlers (initializing
+  them as needed) but does not trigger auto-download of unconfigured handlers
+- `scafctl auth login <handler>` triggers auto-download if not cached
+
+The optimization avoids surprise network I/O and plugin downloads unless the
+user explicitly requests a handler by name.
+
+## Shell Completion
+
+The `login` and `logout` commands support shell completion for handler names:
+
+~~~bash
+# Bash
+scafctl auth login <Tab>
+# Suggests: entra  gcp  github  gitlab
+
+scafctl auth logout <Tab>
+# Suggests: entra  github  gitlab
+~~~
+
+## Workflow: Air-Gapped Setup
+
+~~~bash
+# On a machine with internet access:
+scafctl auth handlers install github
+scafctl auth handlers install entra
+
+# Copy the plugin cache directory to the air-gapped machine:
+# Default location: ~/.cache/scafctl/plugins/
+tar czf auth-plugins.tar.gz ~/.cache/scafctl/plugins/
+
+# On the air-gapped machine:
+tar xzf auth-plugins.tar.gz -C ~/
+
+# Verify handlers are available:
+scafctl auth handlers
+scafctl auth diagnose
+~~~
+
+## Related
+
+- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) -- full auth walkthrough
+- [Diagnose Workflow](diagnose-workflow.md) -- troubleshooting auth issues
+- [Auth README](README.md) -- overview of auth examples

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -99,6 +99,9 @@ Enable file logging for troubleshooting:
 | `list_cel_functions` | List CEL functions |
 | `list_providers` | List providers with filtering |
 | `list_solutions` | List catalog solutions |
+| `list_auth_handlers` | List registered auth handlers with config status |
+| `auth_list_tokens` | List cached access tokens (metadata only, no secrets) |
+| `auth_purge_expired` | Remove expired tokens from the cache |
 | `render_solution` | Render action/resolver graphs |
 | `get_openapi_spec` | Generate full OpenAPI specification for the REST API |
 | `list_api_endpoints` | List all REST API endpoints with method, path, and summary |

--- a/examples/providers/http-custom-oauth2.yaml
+++ b/examples/providers/http-custom-oauth2.yaml
@@ -1,0 +1,57 @@
+# Custom OAuth2 Authentication Example (GitLab)
+#
+# This example demonstrates using a custom OAuth2 handler configured in your
+# scafctl config to call an external API with auto-injected tokens.
+#
+# Prerequisites:
+#   1. Add to ~/.config/scafctl/config.yaml:
+#
+#      auth:
+#        customOAuth2:
+#          - name: gitlab
+#            displayName: "GitLab"
+#            authorizeURL: "https://gitlab.com/oauth/authorize"
+#            tokenURL: "https://gitlab.com/oauth/token"
+#            clientID: "<YOUR_GITLAB_APP_ID>"
+#            scopes:
+#              - read_user
+#              - read_api
+#            callbackPort: 8080
+#            verifyURL: "https://gitlab.com/api/v4/user"
+#            identityFields:
+#              username: "username"
+#              displayName: "name"
+#
+#   2. Login: scafctl auth login gitlab
+#
+# Run: scafctl run resolver -f examples/providers/http-custom-oauth2.yaml -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: http-custom-oauth2-example
+  displayName: HTTP Custom OAuth2 Example
+  category: providers
+  tags:
+    - oauth2
+    - http
+    - custom-auth
+    - provider-example
+  description: API call using a custom OAuth2 handler (GitLab)
+
+spec:
+  resolvers:
+    whoami:
+      description: Fetch the authenticated user's profile via custom OAuth2 handler
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://gitlab.com/api/v4/user"
+              method: GET
+              authProvider: gitlab
+              scope: "read_user"
+              autoParseJson: true
+              timeout: 30

--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -51,6 +51,12 @@ type Handler struct {
 	secretKeyPrefix string
 }
 
+// Compile-time interface assertions.
+var (
+	_ auth.TokenLister = (*Handler)(nil)
+	_ auth.TokenPurger = (*Handler)(nil)
+)
+
 // Option configures the Handler.
 type Option func(*Handler)
 
@@ -251,6 +257,61 @@ func (h *Handler) Logout(ctx context.Context) error {
 		return fmt.Errorf("logout %s: %w", h.cfg.Name, errs[0])
 	}
 	return nil
+}
+
+// ListCachedTokens returns all cached tokens for this handler.
+func (h *Handler) ListCachedTokens(ctx context.Context) ([]*auth.CachedTokenInfo, error) {
+	if h.tokenCache == nil {
+		return nil, nil
+	}
+
+	entries, err := h.tokenCache.ListCachedEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list cached tokens for %s: %w", h.cfg.Name, err)
+	}
+
+	var result []*auth.CachedTokenInfo
+	var getErrors []string
+	for _, entry := range entries {
+		token, err := h.tokenCache.Get(ctx, entry.Flow, entry.Fingerprint, entry.Scope)
+		if err != nil {
+			getErrors = append(getErrors, fmt.Sprintf("flow=%s scope=%s: %v", entry.Flow, entry.Scope, err))
+			continue
+		}
+		if token == nil {
+			continue
+		}
+		result = append(result, &auth.CachedTokenInfo{
+			Handler:     h.cfg.Name,
+			TokenKind:   "access",
+			Scope:       entry.Scope,
+			TokenType:   token.TokenType,
+			Flow:        entry.Flow,
+			Fingerprint: entry.Fingerprint,
+			ExpiresAt:   token.ExpiresAt,
+			CachedAt:    token.CachedAt,
+			IsExpired:   token.IsExpired(),
+			SessionID:   token.SessionID,
+		})
+	}
+
+	var retErr error
+	if len(getErrors) > 0 {
+		retErr = fmt.Errorf("partial read failures for %s: %s", h.cfg.Name, strings.Join(getErrors, "; "))
+	}
+	return result, retErr
+}
+
+// PurgeExpiredTokens removes all expired access tokens from the cache.
+func (h *Handler) PurgeExpiredTokens(ctx context.Context) (int, error) {
+	if h.tokenCache == nil {
+		return 0, nil
+	}
+	n, err := h.tokenCache.PurgeExpired(ctx)
+	if err != nil {
+		return n, fmt.Errorf("purge expired tokens for %s: %w", h.cfg.Name, err)
+	}
+	return n, nil
 }
 
 // Status returns the current authentication state.

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -967,3 +967,108 @@ func TestHandler_Status_Reason_Expired(t *testing.T) {
 	assert.False(t, status.Authenticated)
 	assert.Equal(t, "session expired", status.Reason)
 }
+
+func TestHandler_ListCachedTokens_Empty(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, nil)
+
+	tokens, err := h.ListCachedTokens(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+}
+
+func TestHandler_ListCachedTokens_WithTokens(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, nil)
+
+	// Store a token in the cache
+	token := &auth.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "read",
+		Flow:        auth.FlowInteractive,
+		SessionID:   "sess-123",
+		CachedAt:    time.Now(),
+	}
+	err := h.tokenCache.Set(context.Background(), auth.FlowInteractive, "fp1", "read", token)
+	require.NoError(t, err)
+
+	tokens, err := h.ListCachedTokens(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, "test-provider", tokens[0].Handler)
+	assert.Equal(t, "access", tokens[0].TokenKind)
+	assert.Equal(t, "read", tokens[0].Scope)
+	assert.Equal(t, "Bearer", tokens[0].TokenType)
+	assert.Equal(t, auth.FlowInteractive, tokens[0].Flow)
+	assert.False(t, tokens[0].IsExpired)
+}
+
+func TestHandler_ListCachedTokens_NilCache(t *testing.T) {
+	h := &Handler{cfg: config.CustomOAuth2Config{Name: "no-cache"}, secretErr: fmt.Errorf("no keyring"), logger: logr.Discard()}
+
+	tokens, err := h.ListCachedTokens(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, tokens)
+}
+
+func TestHandler_PurgeExpiredTokens_Empty(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, nil)
+
+	n, err := h.PurgeExpiredTokens(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestHandler_PurgeExpiredTokens_RemovesExpired(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+	h, _ := newTestHandler(t, srv, nil)
+
+	// Store an expired token
+	expired := &auth.Token{
+		AccessToken: "expired-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(-time.Hour),
+		Scope:       "read",
+		Flow:        auth.FlowInteractive,
+		CachedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	err := h.tokenCache.Set(context.Background(), auth.FlowInteractive, "fp1", "read", expired)
+	require.NoError(t, err)
+
+	// Store a valid token
+	valid := &auth.Token{
+		AccessToken: "valid-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "write",
+		Flow:        auth.FlowInteractive,
+		CachedAt:    time.Now(),
+	}
+	err = h.tokenCache.Set(context.Background(), auth.FlowInteractive, "fp2", "write", valid)
+	require.NoError(t, err)
+
+	n, err := h.PurgeExpiredTokens(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	// Verify valid token is still there
+	tokens, err := h.ListCachedTokens(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, "write", tokens[0].Scope)
+}
+
+func TestHandler_PurgeExpiredTokens_NilCache(t *testing.T) {
+	h := &Handler{cfg: config.CustomOAuth2Config{Name: "no-cache"}, secretErr: fmt.Errorf("no keyring"), logger: logr.Discard()}
+
+	n, err := h.PurgeExpiredTokens(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -134,6 +134,18 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.GeneralError)
 				}
+				if outputFlags.Output == "json" || outputFlags.Output == "yaml" || outputFlags.Output == "quiet" {
+					opts := flags.NewKvxOutputOptionsFromFlags(
+						outputFlags.Output,
+						outputFlags.Interactive,
+						outputFlags.Expression,
+						kvx.WithOutputContext(ctx),
+						kvx.WithOutputNoColor(cliParams.NoColor),
+						kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
+					)
+					opts.IOStreams = ioStreams
+					return opts.Write([]map[string]any{})
+				}
 				w.Infof("No active authentication sessions.")
 				w.Infof("")
 				w.Infof("Official auth handlers: %s", strings.Join(unconfigured, ", "))
@@ -147,17 +159,17 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				for _, name := range handlerNames {
 					handler, err := getHandler(ctx, name)
 					if err != nil {
-						w.Warningf("Failed to initialize %s: %v", name, err)
+						w.WarnStderrf("Failed to initialize %s: %v", name, err)
 						continue
 					}
 					purger, ok := handler.(auth.TokenPurger)
 					if !ok {
-						w.Warningf("%s does not support token purging", name)
+						w.WarnStderrf("%s does not support token purging", name)
 						continue
 					}
 					n, err := purger.PurgeExpiredTokens(ctx)
 					if err != nil {
-						w.Warningf("Failed to purge expired tokens for %s: %v", name, err)
+						w.WarnStderrf("Failed to purge expired tokens for %s: %v", name, err)
 						continue
 					}
 					if n > 0 {
@@ -179,22 +191,32 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			results := make([]map[string]any, 0)
 
+			outputOpts := flags.NewKvxOutputOptionsFromFlags(
+				outputFlags.Output,
+				outputFlags.Interactive,
+				outputFlags.Expression,
+				kvx.WithOutputContext(ctx),
+				kvx.WithOutputNoColor(cliParams.NoColor),
+				kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
+			)
+			outputOpts.IOStreams = ioStreams
+
 			for _, name := range handlerNames {
 				handler, err := getHandler(ctx, name)
 				if err != nil {
-					w.Warningf("Failed to initialize %s: %v", name, err)
+					w.WarnStderrf("Failed to initialize %s: %v", name, err)
 					continue
 				}
 
 				lister, ok := handler.(auth.TokenLister)
 				if !ok {
-					w.Warningf("%s does not support token listing", name)
+					w.WarnStderrf("%s does not support token listing", name)
 					continue
 				}
 
 				tokens, err := lister.ListCachedTokens(ctx)
 				if err != nil {
-					w.Warningf("Failed to list tokens for %s: %v", name, err)
+					w.WarnStderrf("Failed to list tokens for %s: %v", name, err)
 					continue
 				}
 
@@ -204,6 +226,9 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			}
 
 			if len(results) == 0 {
+				if outputFlags.Output == "json" || outputFlags.Output == "yaml" || outputFlags.Output == "quiet" {
+					return outputOpts.Write(results)
+				}
 				w.Infof("No cached tokens found.")
 				if unconfigured := listUnconfiguredOfficialHandlers(ctx); len(unconfigured) > 0 {
 					w.Infof("")
@@ -228,6 +253,9 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			}
 
 			if len(results) == 0 {
+				if outputFlags.Output == "json" || outputFlags.Output == "yaml" || outputFlags.Output == "quiet" {
+					return outputOpts.Write(results)
+				}
 				w.Infof("No cached tokens matched the filter.")
 				return nil
 			}
@@ -239,16 +267,6 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}
 			}
-
-			outputOpts := flags.NewKvxOutputOptionsFromFlags(
-				outputFlags.Output,
-				outputFlags.Interactive,
-				outputFlags.Expression,
-				kvx.WithOutputContext(ctx),
-				kvx.WithOutputNoColor(cliParams.NoColor),
-				kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
-			)
-			outputOpts.IOStreams = ioStreams
 
 			return outputOpts.Write(results)
 		},

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -4,13 +4,18 @@
 package auth
 
 import (
+	"bytes"
+	"context"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -329,4 +334,55 @@ func TestCommandList_ValidArgsFunction(t *testing.T) {
 	completions, directive = cmd.ValidArgsFunction(cmd, []string{"entra"}, "")
 	assert.Empty(t, completions)
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestCommandList_WarningsGoToStderr(t *testing.T) {
+	// Verify that when a handler doesn't support token listing,
+	// the warning goes to stderr (not stdout) so it doesn't corrupt JSON output.
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+
+	// Register a handler that does NOT implement TokenLister.
+	// Use a minimal mock that only implements auth.Handler (not TokenLister).
+	reg := auth.NewRegistry()
+	minimalMock := &minimalHandler{name: "minimal"}
+	require.NoError(t, reg.Register(minimalMock))
+	ctx = auth.WithRegistry(ctx, reg)
+
+	cliParams := settings.NewCliParams()
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	// Warning should be in stderr, not stdout
+	assert.Contains(t, stderr.String(), "does not support token listing")
+	assert.NotContains(t, stdout.String(), "does not support token listing")
+}
+
+// minimalHandler implements only auth.Handler (not TokenLister or TokenPurger).
+type minimalHandler struct {
+	name string
+}
+
+func (m *minimalHandler) Name() string                    { return m.name }
+func (m *minimalHandler) DisplayName() string             { return m.name }
+func (m *minimalHandler) SupportedFlows() []auth.Flow     { return nil }
+func (m *minimalHandler) Capabilities() []auth.Capability { return nil }
+func (m *minimalHandler) Login(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+	return nil, nil
+}
+func (m *minimalHandler) Logout(_ context.Context) error                 { return nil }
+func (m *minimalHandler) Status(_ context.Context) (*auth.Status, error) { return &auth.Status{}, nil }
+func (m *minimalHandler) GetToken(_ context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+	return nil, nil
+}
+
+func (m *minimalHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
+	return nil
 }

--- a/pkg/mcp/tools_auth.go
+++ b/pkg/mcp/tools_auth.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 )
 
 // registerAuthTools registers all auth-related MCP tools.
@@ -35,6 +37,34 @@ func (s *Server) registerAuthTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 	)
 	s.addTool(listAuthHandlersTool, s.handleListAuthHandlers)
+
+	listCachedTokensTool := mcp.NewTool("auth_list_tokens",
+		mcp.WithDescription("List all cached tokens across registered auth handlers. Shows token metadata including handler, scope, flow, expiry, and whether expired. Use to inspect cached credentials without revealing actual token values."),
+		mcp.WithTitleAnnotation("List Cached Auth Tokens"),
+		mcp.WithToolIcons(toolIcons["auth"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("handler",
+			mcp.Description("Optional handler name to filter tokens (e.g., 'entra', 'github'). If omitted, tokens from all handlers are returned."),
+		),
+	)
+	s.addTool(listCachedTokensTool, s.handleListCachedTokens)
+
+	purgeExpiredTool := mcp.NewTool("auth_purge_expired",
+		mcp.WithDescription("Remove expired access tokens from the cache across all registered auth handlers (or a specific one). Keeps valid tokens and refresh tokens. Returns the count of purged tokens."),
+		mcp.WithTitleAnnotation("Purge Expired Auth Tokens"),
+		mcp.WithToolIcons(toolIcons["auth"]),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("handler",
+			mcp.Description("Optional handler name to scope the purge (e.g., 'entra', 'github'). If omitted, all handlers are purged."),
+		),
+	)
+	s.addTool(purgeExpiredTool, s.handlePurgeExpiredTokens)
 }
 
 // authHandlerStatus represents the status of a single auth handler.
@@ -171,5 +201,168 @@ func (s *Server) handleListAuthHandlers(_ context.Context, _ mcp.CallToolRequest
 	return mcp.NewToolResultJSON(map[string]any{
 		"handlers": handlers,
 		"count":    len(handlers),
+	})
+}
+
+// handleListCachedTokens lists all cached tokens across auth handlers.
+func (s *Server) handleListCachedTokens(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.authReg == nil {
+		return mcp.NewToolResultJSON(map[string]any{
+			"tokens":  []any{},
+			"count":   0,
+			"message": "No auth registry configured",
+		})
+	}
+
+	args := req.GetArguments()
+	handlerFilter, _ := args["handler"].(string)
+
+	names := s.authReg.List()
+	if len(names) == 0 {
+		return mcp.NewToolResultJSON(map[string]any{
+			"tokens":  []any{},
+			"count":   0,
+			"message": "No auth handlers registered",
+		})
+	}
+
+	type tokenInfo struct {
+		Handler     string `json:"handler"`
+		TokenKind   string `json:"tokenKind"`
+		Scope       string `json:"scope,omitempty"`
+		TokenType   string `json:"tokenType,omitempty"`
+		Flow        string `json:"flow,omitempty"`
+		ExpiresAt   string `json:"expiresAt,omitempty"`
+		CachedAt    string `json:"cachedAt,omitempty"`
+		IsExpired   bool   `json:"isExpired"`
+		Fingerprint string `json:"fingerprint,omitempty"`
+		SessionID   string `json:"sessionId,omitempty"`
+	}
+
+	var tokens []tokenInfo
+	var warnings []string
+	for _, name := range names {
+		if handlerFilter != "" && name != handlerFilter {
+			continue
+		}
+
+		h, err := s.authReg.Get(name)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("handler %q: failed to get: %v", name, err))
+			continue
+		}
+
+		lister, ok := h.(auth.TokenLister)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("handler %q: does not support token listing", name))
+			continue
+		}
+
+		cached, err := lister.ListCachedTokens(ctx)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("handler %q: %v", name, err))
+		}
+
+		for _, t := range cached {
+			info := tokenInfo{
+				Handler:     t.Handler,
+				TokenKind:   t.TokenKind,
+				Scope:       t.Scope,
+				TokenType:   t.TokenType,
+				Flow:        string(t.Flow),
+				IsExpired:   t.IsExpired,
+				Fingerprint: t.Fingerprint,
+				SessionID:   t.SessionID,
+			}
+			if !t.ExpiresAt.IsZero() {
+				info.ExpiresAt = t.ExpiresAt.Format(time.RFC3339)
+			}
+			if !t.CachedAt.IsZero() {
+				info.CachedAt = t.CachedAt.Format(time.RFC3339)
+			}
+			tokens = append(tokens, info)
+		}
+	}
+
+	if tokens == nil {
+		tokens = []tokenInfo{}
+	}
+
+	result := map[string]any{
+		"tokens": tokens,
+		"count":  len(tokens),
+	}
+	if len(warnings) > 0 {
+		result["warnings"] = warnings
+	}
+
+	return mcp.NewToolResultJSON(result)
+}
+
+// handlePurgeExpiredTokens removes expired access tokens from the cache.
+func (s *Server) handlePurgeExpiredTokens(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.authReg == nil {
+		return mcp.NewToolResultJSON(map[string]any{
+			"handlers":    []any{},
+			"totalPurged": 0,
+			"message":     "No auth registry configured",
+		})
+	}
+
+	args := req.GetArguments()
+	handlerFilter, _ := args["handler"].(string)
+
+	names := s.authReg.List()
+	if len(names) == 0 {
+		return mcp.NewToolResultJSON(map[string]any{
+			"handlers":    []any{},
+			"totalPurged": 0,
+			"message":     "No auth handlers registered",
+		})
+	}
+
+	type purgeResult struct {
+		Handler string `json:"handler"`
+		Purged  int    `json:"purged"`
+		Error   string `json:"error,omitempty"`
+		Status  string `json:"status,omitempty"`
+	}
+
+	var results []purgeResult
+	total := 0
+	for _, name := range names {
+		if handlerFilter != "" && name != handlerFilter {
+			continue
+		}
+
+		h, err := s.authReg.Get(name)
+		if err != nil {
+			results = append(results, purgeResult{Handler: name, Error: fmt.Sprintf("failed to get handler: %v", err)})
+			continue
+		}
+
+		purger, ok := h.(auth.TokenPurger)
+		if !ok {
+			results = append(results, purgeResult{Handler: name, Status: "skipped: does not support token purging"})
+			continue
+		}
+
+		n, err := purger.PurgeExpiredTokens(ctx)
+		if err != nil {
+			results = append(results, purgeResult{Handler: name, Error: fmt.Sprintf("purge failed: %v", err)})
+			continue
+		}
+
+		results = append(results, purgeResult{Handler: name, Purged: n})
+		total += n
+	}
+
+	if results == nil {
+		results = []purgeResult{}
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"handlers":    results,
+		"totalPurged": total,
 	})
 }

--- a/pkg/mcp/tools_auth_test.go
+++ b/pkg/mcp/tools_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -261,3 +262,330 @@ func TestHandleAuthStatus(t *testing.T) {
 		assert.NotEmpty(t, parsed.Handlers[0].Capabilities)
 	})
 }
+
+func TestHandleListCachedTokens(t *testing.T) {
+	t.Run("no auth registry", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		srv.authReg = nil
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No auth registry configured")
+	})
+
+	t.Run("empty registry", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No auth handlers registered")
+	})
+
+	t.Run("with cached tokens", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		mock := auth.NewMockHandler("gitlab")
+		mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+			{
+				Handler:   "gitlab",
+				TokenKind: "access",
+				Scope:     "read_user",
+				TokenType: "Bearer",
+				Flow:      auth.FlowInteractive,
+				ExpiresAt: time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC),
+				CachedAt:  time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC),
+				IsExpired: false,
+			},
+		}
+		require.NoError(t, reg.Register(mock))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Tokens []map[string]any `json:"tokens"`
+			Count  int              `json:"count"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 1, parsed.Count)
+		assert.Equal(t, "gitlab", parsed.Tokens[0]["handler"])
+		assert.Equal(t, "read_user", parsed.Tokens[0]["scope"])
+		assert.Equal(t, false, parsed.Tokens[0]["isExpired"])
+	})
+
+	t.Run("filter by handler", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		mock1 := auth.NewMockHandler("gitlab")
+		mock1.ListCachedTokensResult = []*auth.CachedTokenInfo{
+			{Handler: "gitlab", TokenKind: "access", Scope: "read_user"},
+		}
+		mock2 := auth.NewMockHandler("entra")
+		mock2.ListCachedTokensResult = []*auth.CachedTokenInfo{
+			{Handler: "entra", TokenKind: "access", Scope: "api://example/.default"},
+		}
+		require.NoError(t, reg.Register(mock1))
+		require.NoError(t, reg.Register(mock2))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{"handler": "gitlab"}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Tokens []map[string]any `json:"tokens"`
+			Count  int              `json:"count"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 1, parsed.Count)
+		assert.Equal(t, "gitlab", parsed.Tokens[0]["handler"])
+	})
+}
+
+func TestHandlePurgeExpiredTokens(t *testing.T) {
+	t.Run("no auth registry", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		srv.authReg = nil
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_purge_expired"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handlePurgeExpiredTokens(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No auth registry configured")
+	})
+
+	t.Run("purges expired tokens", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		mock := auth.NewMockHandler("entra")
+		mock.PurgeExpiredResult = 3
+		require.NoError(t, reg.Register(mock))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_purge_expired"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handlePurgeExpiredTokens(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Handlers    []map[string]any `json:"handlers"`
+			TotalPurged int              `json:"totalPurged"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 3, parsed.TotalPurged)
+		assert.Equal(t, "entra", parsed.Handlers[0]["handler"])
+	})
+
+	t.Run("filter by handler", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		mock1 := auth.NewMockHandler("entra")
+		mock1.PurgeExpiredResult = 2
+		mock2 := auth.NewMockHandler("github")
+		mock2.PurgeExpiredResult = 5
+		require.NoError(t, reg.Register(mock1))
+		require.NoError(t, reg.Register(mock2))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_purge_expired"
+		request.Params.Arguments = map[string]any{"handler": "entra"}
+
+		result, err := srv.handlePurgeExpiredTokens(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Handlers    []map[string]any `json:"handlers"`
+			TotalPurged int              `json:"totalPurged"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 2, parsed.TotalPurged)
+		assert.Len(t, parsed.Handlers, 1)
+		assert.Equal(t, "entra", parsed.Handlers[0]["handler"])
+	})
+
+	t.Run("skipped handler without TokenPurger", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		minimal := &mcpMinimalHandler{name: "basic"}
+		require.NoError(t, reg.Register(minimal))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_purge_expired"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handlePurgeExpiredTokens(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Handlers    []map[string]any `json:"handlers"`
+			TotalPurged int              `json:"totalPurged"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 0, parsed.TotalPurged)
+		assert.Len(t, parsed.Handlers, 1)
+		assert.Equal(t, "basic", parsed.Handlers[0]["handler"])
+		assert.Contains(t, parsed.Handlers[0]["status"], "does not support token purging")
+	})
+}
+
+func TestHandleListCachedTokens_Warnings(t *testing.T) {
+	t.Run("handler without TokenLister", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		minimal := &mcpMinimalHandler{name: "basic"}
+		require.NoError(t, reg.Register(minimal))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Tokens   []map[string]any `json:"tokens"`
+			Count    int              `json:"count"`
+			Warnings []string         `json:"warnings"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 0, parsed.Count)
+		require.Len(t, parsed.Warnings, 1)
+		assert.Contains(t, parsed.Warnings[0], "does not support token listing")
+	})
+
+	t.Run("handler with ListCachedTokens error", func(t *testing.T) {
+		reg := auth.NewRegistry()
+		mock := auth.NewMockHandler("gitlab")
+		mock.ListCachedTokensErr = fmt.Errorf("cache corrupted")
+		require.NoError(t, reg.Register(mock))
+
+		srv, err := NewServer(
+			WithServerVersion("test"),
+			WithServerAuthRegistry(reg),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_list_tokens"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListCachedTokens(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed struct {
+			Tokens   []map[string]any `json:"tokens"`
+			Count    int              `json:"count"`
+			Warnings []string         `json:"warnings"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Equal(t, 0, parsed.Count)
+		require.Len(t, parsed.Warnings, 1)
+		assert.Contains(t, parsed.Warnings[0], "cache corrupted")
+	})
+}
+
+// mcpMinimalHandler implements only auth.Handler (not TokenLister or TokenPurger).
+type mcpMinimalHandler struct {
+	name string
+}
+
+func (m *mcpMinimalHandler) Name() string        { return m.name }
+func (m *mcpMinimalHandler) DisplayName() string { return m.name }
+
+func (m *mcpMinimalHandler) SupportedFlows() []auth.Flow {
+	return []auth.Flow{auth.FlowDeviceCode}
+}
+
+func (m *mcpMinimalHandler) Capabilities() []auth.Capability { return nil }
+
+func (m *mcpMinimalHandler) Login(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+	return nil, nil
+}
+
+func (m *mcpMinimalHandler) Logout(_ context.Context) error { return nil }
+
+func (m *mcpMinimalHandler) Status(_ context.Context) (*auth.Status, error) {
+	return &auth.Status{}, nil
+}
+
+func (m *mcpMinimalHandler) GetToken(_ context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+	return nil, nil
+}
+
+func (m *mcpMinimalHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
+	return nil
+}
+
+var _ auth.Handler = (*mcpMinimalHandler)(nil)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2225,6 +2225,85 @@ func TestIntegration_AuthHandlersRemoveNotInstalled(t *testing.T) {
 	assert.Contains(t, stderr, "is not installed")
 }
 
+func TestIntegration_AuthListJSONNoStdoutWarnings(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "list", "-o", "json")
+
+	// When exit code is 0 and there is stdout output, it must be valid JSON
+	// (no warnings mixed into stdout). Warnings should go to stderr.
+	if exitCode == 0 && strings.TrimSpace(stdout) != "" {
+		// Stdout must not contain warning emoji characters
+		assert.NotContains(t, stdout, "\u26a0", "warnings must not appear in stdout when using -o json")
+		assert.NotContains(t, stdout, "⚠", "warnings must not appear in stdout when using -o json")
+
+		// In -o json mode, non-empty stdout must be valid JSON.
+		// If it doesn't start with [ or {, that itself is a corruption issue.
+		trimmed := strings.TrimSpace(stdout)
+		if assert.True(t, strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{"),
+			"stdout in -o json mode must be valid JSON, got: %s", trimmed[:min(len(trimmed), 80)]) {
+			var parsed json.RawMessage
+			assert.NoError(t, json.Unmarshal([]byte(trimmed), &parsed), "stdout must be valid JSON when using -o json")
+		}
+	}
+}
+
+func TestIntegration_AuthListPurgeHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "list", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "purge-expired")
+}
+
+func TestIntegration_AuthDiagnoseHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "diagnose", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Run auth diagnostics")
+	assert.Contains(t, stdout, "--live-token")
+}
+
+func TestIntegration_AuthDiagnoseRuns(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t, "auth", "diagnose")
+
+	// diagnose should complete (exit 0 or non-zero based on handler state)
+	// but must not panic or produce empty output
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	combined := stdout + stderr
+	assert.True(t, exitCode == 0 || exitCode == 1, "expected exit code 0 or 1, got %d", exitCode)
+	assert.Contains(t, combined, "auth registry", "expected auth registry check in output")
+}
+
+func TestIntegration_AuthDiagnoseJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "diagnose", "-o", "json")
+
+	// JSON output mode should produce valid JSON
+	if exitCode == 0 && strings.TrimSpace(stdout) != "" {
+		var result interface{}
+		assert.NoError(t, json.Unmarshal([]byte(stdout), &result), "diagnose -o json must produce valid JSON")
+	}
+}
+
+func TestIntegration_AuthDiagnoseAlias(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "doctor", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Run auth diagnostics")
+}
+
+func TestIntegration_AuthDiagnoseUnknownHandler(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "auth", "diagnose", "nonexistent-xyz")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "nonexistent-xyz")
+}
+
 // ============================================================================
 // Error Handling Tests
 // ============================================================================
@@ -2809,11 +2888,14 @@ func TestIntegration_CustomOAuth2Handler_AuthList(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
 
-	stdout, _, exitCode := runScafctl(t, "--config", configPath, "auth", "list")
-
+	// auth list should succeed (no tokens for custom handler, but no error)
+	_, _, exitCode := runScafctl(t, "--config", configPath, "auth", "list")
 	assert.Equal(t, 0, exitCode)
-	// The custom handler should be registered and appear in the list.
-	assert.Contains(t, stdout, "test-quay", "expected custom handler to appear in output, got: %q", stdout)
+
+	// Verify the custom handler is registered via auth handlers
+	stdout, _, exitCode := runScafctl(t, "--config", configPath, "auth", "handlers")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "test-quay", "expected custom handler to appear in handlers output, got: %q", stdout)
 }
 
 func TestIntegration_CustomOAuth2Handler_AuthStatus(t *testing.T) {
@@ -4405,6 +4487,19 @@ spec:
 	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d", exitCode)
 	assert.Contains(t, stdout, "hello from child")
 	assert.Contains(t, stdout, "with timeout")
+}
+
+func TestIntegration_SolutionResolver_AuthProviderUnavailable(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "tests/integration/solutions/resolvers/auth-provider/solution.yaml",
+		"-o", "json",
+	)
+	t.Logf("stderr: %s", stderr)
+	// Should fail because the auth handler doesn't exist
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "nonexistent-handler-xyz", "error should reference the missing handler name")
 }
 
 // ============================================================================
@@ -7025,6 +7120,27 @@ func TestIntegration_MCPServeInfo_ExplainConcepts(t *testing.T) {
 		toolNames[tool.Name] = true
 	}
 	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool to be registered")
+}
+
+func TestIntegration_MCPServeInfo_AuthTokenTools(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "serve", "--info")
+	assert.Equal(t, 0, exitCode)
+
+	var info struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &info))
+
+	toolNames := make(map[string]bool)
+	for _, tool := range info.Tools {
+		toolNames[tool.Name] = true
+	}
+	assert.True(t, toolNames["auth_list_tokens"], "expected auth_list_tokens tool to be registered")
+	assert.True(t, toolNames["auth_purge_expired"], "expected auth_purge_expired tool to be registered")
 }
 
 func TestIntegration_MCPListHelp(t *testing.T) {

--- a/tests/integration/solutions/resolvers/auth-provider/solution.yaml
+++ b/tests/integration/solutions/resolvers/auth-provider/solution.yaml
@@ -1,0 +1,21 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: auth-provider-error-test
+  version: 1.0.0
+  description: Tests that authProvider produces a clear error when the handler is unavailable
+
+spec:
+  resolvers:
+    data:
+      description: Attempt HTTP call with unavailable auth handler
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://httpbin.org/get"
+              method: GET
+              authProvider: nonexistent-handler-xyz
+              scope: "read"


### PR DESCRIPTION
- implement TokenLister and TokenPurger interfaces on oauth2.Handler
- add auth_list_tokens and auth_purge_expired MCP tools
- fix auth list warnings to go to stderr instead of corrupting structured output
- add handler lifecycle management documentation (install/remove/ lazy-loading)
- add auth diagnose workflow example
- add HTTP custom OAuth2 provider example (GitLab)
- update MCP server tutorial with new auth tool references