### PR TITLE
feat: implement token delegation for API mode with Entra OBO/client-credentials flows, pass-through provider auth, LRU+TTL token caching, singleflight deduplication, and flow allow-list security boundary

### DIFF
--- a/docs/design/api-token-delegation.md
+++ b/docs/design/api-token-delegation.md
@@ -1,0 +1,413 @@
+---
+title: "Token Delegation"
+weight: 6
+---
+
+# Token Delegation
+
+## Implementation Status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| OBO flow (user -> downstream) | [done] Implemented | `pkg/authdelegation/flows.go` |
+| Client credentials flow (machine -> downstream) | [done] Implemented | `pkg/authdelegation/flows.go` |
+| WIF server credential | [done] Implemented | Projected federated token file |
+| Secret server credential | [done] Implemented | Static client secret via `SecretRef` |
+| LRU + TTL token cache | [done] Implemented | `pkg/authdelegation/tokencache.go` |
+| Singleflight deduplication (go-flight Manager) | [done] Implemented | Prevents thundering herd |
+| Flow registry (allow-list) | [done] Implemented | Only explicitly permitted flows execute |
+| Cache key generation (SHA-256 hashing) | [done] Implemented | `pkg/authdelegation/keygen.go` |
+| Delegator registry (multi-provider) | [done] Implemented | `pkg/authdelegation/registry.go` |
+| OpenTelemetry tracing | [done] Implemented | Spans + events for cache hits/misses |
+| TokenPassthrough middleware | [done] Implemented | Extracts configured `X-Authorization-*` headers into request context |
+| PassThroughDelegator | [done] Implemented | Returns request-scoped provider tokens without exchange |
+| HTTP provider delegator resolution | [done] Implemented | Exact `authProvider` lookup first, then `passThrough:<provider>` fallback |
+| Passing delegated tokens downstream to providers | [done] Implemented | HTTP provider injects `Authorization: Bearer <token>` |
+| Google / other IdP support | [planned] Future | Currently Entra-only |
+
+---
+
+## Problem Statement
+
+When scafctl runs in **API mode**, incoming requests carry a caller's bearer token. Providers that execute on behalf of that caller often need a *different* token scoped to a downstream Azure resource (e.g., Azure Key Vault, Microsoft Graph).
+
+Naively acquiring a new token on every provider invocation is:
+
+1. **Slow** -- each token endpoint round-trip adds 100-500 ms of latency.
+2. **Wasteful** -- identical scopes requested within the same token lifetime produce duplicate network calls.
+3. **Fragile** -- concurrent requests for the same token can trigger rate limits at the identity provider.
+
+Token delegation solves this by centralising the exchange logic, caching results, and deduplicating in-flight requests.
+
+---
+
+## Architecture
+
+~~~
++------------------------------------------------------------------+
+|                        API Server                                 |
+|                                                                  |
+|  +----------+     +-----------------+     +------------------+  |
+|  | Auth     |---->| DelegatorRegistry|---->| EntraDelegator   |  |
+|  | Middleware|     | (per-provider)  |     |                  |  |
+|  |          |     +-----------------+     |  +------------+  |  |
+|  | Extracts |                             |  |FlowRegistry|  |  |
+|  | token +  |                             |  | obo        |  |  |
+|  | claims   |                             |  | client_cred|  |  |
+|  +----------+                             |  +------------+  |  |
+|                                           |                  |  |
+|                                           |  +------------+  |  |
+|                                           |  | go-flight  |  |  |
+|                                           |  | Manager    |  |  |
+|                                           |  | (cache +   |  |  |
+|                                           |  | singleflight)| |  |
+|                                           |  +------------+  |  |
+|                                           |                  |  |
+|                                           |  +------------+  |  |
+|                                           |  |ServerCred  |  |  |
+|                                           |  |(WIF|Secret)|  |  |
+|                                           |  +------------+  |  |
+|                                           +------------------+  |
++------------------------------------------------------------------+
+~~~
+
+Pass-through delegation is intentionally separate from Entra token exchange. Entra delegation exchanges an incoming caller token for a new downstream token through OBO or client credentials. Pass-through delegation accepts a provider-specific token supplied on the API request and makes that same request-scoped token available to providers; it does not exchange, cache, or refresh it.
+
+### Key Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| `TokenDelegator` (interface) | Top-level facade -- one method: `DelegateToken(ctx, scope)` |
+| `EntraDelegator` | Concrete implementation for Azure Entra ID |
+| `TokenPassthrough` middleware | Extracts allowed `X-Authorization-*` headers and stores tokens in request context by suffix |
+| `PassThroughDelegator` | Implements `TokenDelegator` by returning a matching request-scoped pass-through token |
+| `FlowRegistry` | Write-at-init map of permitted flow names -> `FlowFn` |
+| `FlowFn` | Executes a single token endpoint request (OBO or client_credentials) |
+| `ServerCredential` | Variability point for server proof-of-identity (WIF vs secret) |
+| `DelegatorRegistry` | Maps provider names -> `TokenDelegator` instances (concurrent-safe), including non-passthrough delegators and internal `passThrough:<provider>` entries |
+| `TokenCache` | LRU + TTL local cache wrapping `pkg/cache.LRUWithTTL` |
+| `go-flight Manager` | Singleflight + cache orchestrator (dedup + stale-while-revalidate) |
+| `KeyGenerator` | Deterministic cache key from `FlowParams` |
+
+---
+
+## Flow Diagrams
+
+### On-Behalf-Of (User Caller)
+
+~~~
+User --bearer--> API Server
+                    |
+                    v
+          Auth Middleware
+          (extracts token + callerType="user")
+                    |
+                    v
+          EntraDelegator.DelegateToken(ctx, scope)
+                    |
+                    +- key = "obo|{clientID}|{scope}|sha256({callerToken})"
+                    v
+          go-flight Manager.Do(key, ...)
+                    |
+          +--------+--------+
+          | Cache hit?       |
+          | Yes -> return     |
+          | No / expired --> |
+          +--------+--------+
+                   v
+          oboFlow(ctx, FlowParams)
+                   |
+                   v
+          POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+            grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+            assertion={callerToken}
+            scope={scope}
+            requested_token_use=on_behalf_of
+            + server credential (client_assertion or client_secret)
+                   |
+                   v
+          TokenResult{AccessToken, ExpiresIn}
+~~~
+
+### Client Credentials (Machine Caller)
+
+~~~
+Service Principal --bearer--> API Server
+                                |
+                                v
+                      Auth Middleware
+                      (callerType="app")
+                                |
+                                v
+                      EntraDelegator.DelegateToken(ctx, scope)
+                                |
+                                +- key = "cc|{clientID}|{scope}"
+                                v
+                      go-flight Manager.Do(key, ...)
+                                |
+                      +---------+---------+
+                      | Cache hit? ...     |
+                      +---------+---------+
+                                v
+                      clientCredentialFlow(ctx, FlowParams)
+                                |
+                                v
+                      POST .../token
+                        grant_type=client_credentials
+                        scope={scope}
+                        + server credential
+~~~
+
+### Pass-Through Token Flow
+
+~~~
+Client request
+  Header: X-Authorization-Github: ghp_...
+                    |
+                    v
+          TokenPassthrough middleware
+          stores token in request context as "Github"
+                    |
+                    v
+          DelegatorRegistry
+          contains internal entry "passThrough:Github"
+                    |
+                    v
+          HTTP provider input
+          authProvider: Github
+                    |
+                    v
+          resolveDelegator(...)
+            1. registry lookup: "Github"
+            2. fallback lookup: "passThrough:Github"
+                    |
+                    v
+          PassThroughDelegator.DelegateToken(ctx, scope)
+          returns request-scoped token from context
+                    |
+                    v
+          Downstream request
+          Authorization: Bearer ghp_...
+~~~
+
+Users configure provider inputs with the plain provider suffix, for example `authProvider: Github`. The `passThrough:` prefix is an internal registry namespace and should not be used in provider input.
+
+---
+
+## Caching Strategy (Detailed)
+
+### Three Layers
+
+1. **Key Generation** -- deterministic key per unique token exchange scenario.
+2. **LRU + TTL local cache** (`TokenCache`) -- bounded by `cacheSize` (default 1024), entries expire per the token's `expires_in` minus an `expiryBuffer` (default 10 min).
+3. **Singleflight deduplication** (`go-flight Manager`) -- concurrent requests for the same key block on a single in-flight fetch rather than issuing duplicate token endpoint calls.
+
+### Key Generation
+
+| Caller Type | Key Format | Hash Function |
+|-------------|-----------|---------------|
+| `user` (OBO) | `obo\|{clientID}\|{scope}\|sha256({callerToken})` | SHA-256 hex of JWT |
+| `app` (client_credentials) | `cc\|{clientID}\|{scope}` | N/A -- no caller token |
+| Unknown | No caching (NoOpKeyGenerator) | -- |
+
+OBO keys include the token hash because the same scope requested by different users must produce different downstream tokens.
+
+### go-flight Manager Behaviour
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `expiryThreshold` | 30 min | Tokens expiring within this window trigger background refresh |
+| `slowThreshold` | 500 ms | Fetch exceeding this logs a warning |
+| `retryOnFollowerError` | true | If the leader fetch fails, blocked followers retry independently |
+| `cleanupInterval` | 5 min | How often the LRU evicts expired entries |
+| `expiryBuffer` | 10 min | Subtracted from `expires_in` to avoid serving nearly-expired tokens |
+
+### Cache Miss Lifecycle
+
+~~~
+Request arrives -> GenerateKey(callerType, params)
+  +- key="" -> bypass cache, call flow directly
+  +- key="obo|..." -> Manager.Do(key, fetchFn, hooks)
+       +- Cached + fresh -> return immediately (OnCacheHit event)
+       +- Cached + stale (within expiryThreshold) -> serve stale, refresh in background
+       +- Not cached -> single leader executes fetchFn
+            +- Success -> store with TTL = expires_in seconds, unblock followers
+            +- Failure -> if retryOnFollowerError, followers retry independently
+~~~
+
+---
+
+## Security Considerations
+
+### Token Handling
+
+- **Caller tokens are never stored in plaintext in cache keys.** OBO keys hash the JWT with SHA-256 before inclusion.
+- **Token cache is in-memory only.** No persistence to disk -- tokens are lost on process restart.
+- **Bounded cache size** prevents memory exhaustion from token accumulation.
+- **TTL enforcement** ensures tokens are not served past their lifetime.
+- **Pass-through tokens are request-scoped.** The middleware extracts only explicitly allowed headers and stores the resulting token map on the request context.
+- **Pass-through tokens are not exchanged, cached, refreshed, or logged.** They are copied only into the downstream `Authorization: Bearer <token>` header when the matching provider is used.
+- **Non-passthrough delegators take precedence over pass-through fallback.** If a registry entry exists for `Github`, it wins over the internal `passThrough:Github` entry.
+
+### Server Credentials
+
+| Type | Storage | Rotation |
+|------|---------|----------|
+| WIF (`WIFCredential`) | Projected token file on disk (Kubernetes) | Re-read on every request -- automatic rotation |
+| Secret (`SecretCredential`) | Resolved once at startup from `SecretRef` URI (env var or file) | Requires restart to rotate |
+
+- WIF is preferred in production -- short-lived, auto-rotated by the platform.
+- Secrets must never be hardcoded; they are resolved via `config.SecretRef` which reads from environment variables or files at startup.
+
+### Flow Allow-List
+
+The `FlowRegistry` acts as a security boundary: only flows explicitly registered during startup can execute. If an admin configures `allowedFlows: [obo]`, a machine caller requesting `client_credentials` will receive an error rather than silently falling back.
+
+### Response Validation
+
+- Token endpoint responses are read with `io.LimitReader(resp.Body, 1<<20)` (1 MB cap) to prevent response-body DoS.
+- Error responses are truncated to 512 bytes before inclusion in error messages to prevent log injection.
+
+---
+
+## Configuration
+
+### YAML Reference
+
+~~~yaml
+apiServer:
+  identity:
+    entra:
+      tenantId: "00000000-0000-0000-0000-000000000000"
+      clientId: "00000000-0000-0000-0000-000000000000"
+      credential:
+        type: secret                                             # "wif" or "secret"
+        clientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"  or file://<filepath>  # SecretRef URI (required when type=secret)
+        wifTokenPath: "/var/run/secrets/azure/tokens/fed-token"  # required when type=wif
+      allowedFlows:                  # optional -- see nil semantics below
+        flows: [obo, client_credentials]
+      tokenManager:                  # optional -- see nil semantics below
+        cacheSize: 1024
+        expiryBuffer: "10m"
+        cleanupInterval: "5m"
+        expiryThreshold: "30m"
+        slowThreshold: "500ms"
+        retryFollowerOnError: true
+  tokenPassThrough:                  # optional -- see nil semantics below
+    allowedHeaders:                  # suffixes only, without X-Authorization-
+      - Github
+      - Entra
+~~~
+
+### SecretRef Semantics
+
+`SecretRef` is a **scalar URI string** (`type SecretRef string`), not a nested object. Two schemes are supported:
+
+| Scheme | YAML Value | Resolution |
+|--------|-----------|------------|
+| `env://` | `"env://MY_CLIENT_SECRET"` | Reads `os.Getenv("MY_CLIENT_SECRET")` at startup; errors if empty or unset |
+| `file://` | `"file:///etc/secrets/client-secret"` | Reads and trims the file contents; errors if empty or missing |
+
+Any other scheme is rejected at validation time. The secret is resolved **once** during `NewEntraDelegatorFromConfig` and held in the `SecretCredential` struct in memory for the server lifetime.
+
+### Nil-Pointer Semantics
+
+The configuration uses nil-pointer semantics for key fields to distinguish "not configured" from "configured with defaults" from "configured with explicit values":
+
+| Field | nil / omitted | Present but empty | Present with values |
+|-------|---------------|-------------------|---------------------|
+| `tokenManager` | **No caching, no singleflight dedup.** Every `DelegateToken` call hits the token endpoint directly. Suitable for low-traffic deployments or testing. | Uses all defaults: cache size 1024, expiry buffer 10m, cleanup 5m, expiry threshold 30m, slow threshold 500ms, retry on error = true. | Each field overrides its corresponding default; zero-value numbers fall back to defaults. |
+| `allowedFlows` | **Only OBO is permitted** (the safe default). Machine callers (`callerType="app"`) receive error: `"delegation flow \"client_credentials\" is not permitted"`. | **All flows denied.** `flows: []` means nothing is in the allow-list -- both OBO and client_credentials are rejected. This is a deny-all posture. | Only the explicitly listed flows are registered in the `FlowRegistry`. Unrecognized flow names fail validation at startup. |
+| `tokenPassThrough` | **Default pass-through header enabled.** Omitted config allows `X-Authorization-Github` and registers `passThrough:Github`. | **Pass-through disabled.** `allowedHeaders: []` registers no internal pass-through delegators and extracts no X-Authorization headers. | Each suffix registers one internal pass-through delegator named `passThrough:<suffix>` and allows request header `X-Authorization-<suffix>`. |
+
+### Token Pass-Through Semantics
+
+`apiServer.tokenPassThrough.allowedHeaders` contains header suffixes only. Values must not include the `X-Authorization-` prefix.
+
+~~~yaml
+apiServer:
+  tokenPassThrough:
+    allowedHeaders:
+      - Github
+      - Entra
+~~~
+
+For the `Github` suffix:
+
+~~~
+X-Authorization-Github: ghp_...
+authProvider: Github
+
+authProvider "Github"
+  -> normal registry lookup: Github
+  -> fallback registry lookup: passThrough:Github
+  -> PassThroughDelegator returns token
+Authorization: Bearer ghp_...
+~~~
+
+The configured suffix is also the key used in request context. Header validation rejects empty suffixes, suffixes that already include `X-Authorization-`, and values that would produce an invalid HTTP header name.
+
+### Decision Table: `allowedFlows` Behaviour
+
+~~~
+allowedFlows field                          | User (OBO) | Machine (client_credentials)
+--------------------------------------------+------------+-----------------------------
+omitted (nil)                               | [done] allowed  | [no] denied
+present, flows: []                          | [no] denied   | [no] denied
+present, flows: [obo]                       | [done] allowed  | [no] denied
+present, flows: [client_credentials]        | [no] denied   | [done] allowed
+present, flows: [obo, client_credentials]   | [done] allowed  | [done] allowed
+~~~
+
+### Decision Table: `tokenManager` Behaviour
+
+~~~
+tokenManager field         | Caching          | Singleflight dedup | Background refresh
+---------------------------+------------------+--------------------+--------------------
+omitted (nil)              | [no] off            | [no] off              | [no] off
+present (zero values)      | [done] on (defaults)  | [done] on               | [done] on
+present (custom values)    | [done] on (custom)    | [done] on               | [done] on
+~~~
+
+### Credential Validation at Startup
+
+`ServerCredentialConfig.Validate()` enforces:
+
+- `type` is required -- must be `"wif"` or `"secret"`
+- When `type: secret` -> `clientSecret` must be a non-empty, valid `SecretRef` (validated scheme + non-empty value)
+- When `type: wif` -> `wifTokenPath` must be non-empty (file existence is checked at first use, not startup)
+
+`DelegationFlowsConfig.Validate()` enforces:
+
+- Every entry in `flows` must be one of: `"obo"`, `"client_credentials"`
+- Unrecognized flow names fail with: `invalid flow "X", must be one of: obo, client_credentials`
+
+---
+
+## Future Work
+
+| Item | Notes |
+|------|-------|
+| **Google Cloud delegation** | Same `TokenDelegator` interface, different flow implementation (STS token exchange or impersonation) |
+| **Configurable delegator priority/fallback policy** | Allow admins to choose whether pass-through can override normal delegators, remain fallback-only, or be disabled per provider |
+| **Certificate-based credential** | `ServerCredential` implementation using X.509 client cert assertion |
+| **Multi-tenant delegation** | Per-tenant `EntraDelegator` instances selected by incoming token's `tid` claim |
+| **Metrics** | Prometheus counters for cache hit/miss ratio, flow latency percentiles, error rates |
+| **Token exchange (RFC 8693)** | Generic token exchange flow for cross-IdP scenarios |
+
+---
+
+## Package Layout
+
+~~~
+pkg/authdelegation/
++-- context.go          # Registry stored/retrieved from context
++-- credentials.go      # ServerCredential interface + WIF/Secret impls
++-- delegator.go        # EntraDelegator + functional options + DelegateToken
++-- errors.go           # Sentinel errors
++-- flows.go            # FlowFn, OBO/client_credentials flows, FlowRegistry
++-- keygen.go           # Key generators + SHA256Hash
++-- passthrough.go      # PassThroughDelegator + internal passThrough:<provider> naming
++-- registry.go         # DelegatorRegistry (concurrent-safe name->delegator map)
++-- tokencache.go       # TokenCache[K,V] wrapping pkg/cache.LRUWithTTL
+~~~

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mark3labs/mcp-go v0.54.0
+	github.com/oakwood-commons/go-flight v1.0.0
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b
 	github.com/oakwood-commons/oauth-helpers v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/oakwood-commons/go-flight v1.0.0 h1:OCtDeGW0sh5do7qP1QbB7kLPIzyfecsaxOLtuRmY9p0=
+github.com/oakwood-commons/go-flight v1.0.0/go.mod h1:91490vC4QgOP+3T7ZFtjbNOJF9o8K5pxDnfNhptvE5g=
 github.com/oakwood-commons/httpc v0.1.0 h1:syQbjqerxGEVngGWOtyGhkwFFUnJekm+amnuKTO4vJQ=
 github.com/oakwood-commons/httpc v0.1.0/go.mod h1:vQ7KZ7NK7tF9Inqzikuo1HKozTw2Y0tHMp316PqwkEA=
 github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b h1:0hECYesHiHOqp+TBLHziM1xMgr9F1SiKaRIZSRY2aBQ=

--- a/pkg/api/endpoints/solutions.go
+++ b/pkg/api/endpoints/solutions.go
@@ -239,6 +239,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		if err := requireRemotePath(input.Body.Path, "solution-dryrun"); err != nil {
 			return nil, err
 		}
+
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
 		if err != nil {
 			return nil, api.HandleError(ctx, err, "solution-dryrun", http.StatusBadRequest, "failed to load solution")
@@ -283,6 +284,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 				return nil, err
 			}
 		}
+
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
 		if err != nil {
 			return nil, api.HandleError(ctx, err, "solution-run", http.StatusBadRequest, "failed to load solution")
@@ -342,6 +344,7 @@ func RegisterSolutionEndpoints(humaAPI huma.API, hctx *api.HandlerContext, prefi
 		if err := requireRemotePath(input.Body.Path, "solution-render"); err != nil {
 			return nil, err
 		}
+
 		sol, err := inspect.LoadSolution(ctx, input.Body.Path)
 		if err != nil {
 			return nil, api.HandleError(ctx, err, "solution-render", http.StatusBadRequest, "failed to load solution")

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+	"github.com/oakwood-commons/scafctl/pkg/authdelegation"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
@@ -37,6 +38,12 @@ func SetupMiddleware(ctx context.Context, router *chi.Mux, cfg *config.APIServer
 	if cfg.Auth.AzureOIDC.Enabled {
 		if cfg.Auth.AzureOIDC.TenantID == "" || cfg.Auth.AzureOIDC.ClientID == "" {
 			return nil, fmt.Errorf("entra OIDC is enabled but tenantId or clientId is empty")
+		}
+	}
+	if cfg.TokenPassThrough != nil {
+		err := cfg.TokenPassThrough.Validate()
+		if err != nil {
+			return nil, fmt.Errorf("invalid token pass-through configuration: %w", err)
 		}
 	}
 
@@ -66,8 +73,17 @@ func SetupMiddleware(ctx context.Context, router *chi.Mux, cfg *config.APIServer
 	// ── Global middleware (all routes including health probes) ──
 	router.Use(chimiddleware.Recoverer)
 	router.Use(chimiddleware.RequestID)
+	router.Use(middleware.FlightID)
 	router.Use(chimiddleware.StripSlashes)
 	router.Use(middleware.RequestLogging(lgr))
+	router.Use(middleware.TokenPassthrough(cfg.TokenPassThroughAllowedHeaders()))
+
+	delegationReg, err := authdelegation.BuildDelegationRegistry(ctx, cfg, &lgr)
+	if err != nil {
+		return nil, fmt.Errorf("building delegation registry: %w", err)
+	}
+
+	router.Use(authdelegation.Middleware(delegationReg))
 
 	// ── API middleware (versioned paths only) ──
 

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -22,7 +22,10 @@ import (
 // contextKey type for storing auth claims in context.
 type contextKey string
 
-const claimsContextKey contextKey = "auth_claims"
+const (
+	claimsContextKey      contextKey = "auth_claims"
+	accessTokenContextKey contextKey = "access_token"
+)
 
 // AuthClaims holds the validated JWT claims extracted from an Entra OIDC token.
 type AuthClaims struct {
@@ -31,6 +34,7 @@ type AuthClaims struct {
 	Email     string   `json:"email"`
 	TenantID  string   `json:"tid"`
 	ObjectID  string   `json:"oid"`
+	IDType    string   `json:"idtyp"`
 	Groups    []string `json:"groups"`
 	Roles     []string `json:"roles"`
 	Audience  string   `json:"aud"`
@@ -38,10 +42,36 @@ type AuthClaims struct {
 	ExpiresAt int64    `json:"exp"`
 }
 
+// CallerType returns "app" for service principal tokens (idtyp=app) and
+// "user" for all other callers. Per Entra spec, the idtyp claim is absent
+// for user tokens and set to "app" for application/service principal tokens.
+func (c *AuthClaims) CallerType() string {
+	if c.IDType == "app" {
+		return "app"
+	}
+	return "user"
+}
+
 // ClaimsFromContext extracts auth claims from the request context.
 func ClaimsFromContext(ctx context.Context) *AuthClaims {
 	claims, _ := ctx.Value(claimsContextKey).(*AuthClaims)
 	return claims
+}
+
+// AccessTokenFromContext extracts the raw bearer token from the request context.
+func AccessTokenFromContext(ctx context.Context) string {
+	token, _ := ctx.Value(accessTokenContextKey).(string)
+	return token
+}
+
+// WithAuthClaims stores AuthClaims in the context.
+func WithAuthClaims(ctx context.Context, claims *AuthClaims) context.Context {
+	return context.WithValue(ctx, claimsContextKey, claims)
+}
+
+// WithAccessToken stores the raw bearer token in the context.
+func WithAccessToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, accessTokenContextKey, token)
 }
 
 // jwksCache caches the JWKS endpoint response.
@@ -100,6 +130,12 @@ func NewAzureOIDCAuth(tenantID, clientID string, lgr logr.Logger) (func(http.Han
 	jwksURL := fmt.Sprintf("https://login.microsoftonline.com/%s/discovery/v2.0/keys", tenantID)
 	issuer := fmt.Sprintf("https://login.microsoftonline.com/%s/v2.0", tenantID)
 
+	return newOIDCAuthMiddleware(jwksURL, issuer, clientID, lgr), nil
+}
+
+// newOIDCAuthMiddleware builds the OIDC middleware with explicit JWKS URL,
+// issuer, and audience. Factored out of NewAzureOIDCAuth for testability.
+func newOIDCAuthMiddleware(jwksURL, issuer, clientID string, lgr logr.Logger) func(http.Handler) http.Handler {
 	cache := &jwksCache{
 		jwksURL: jwksURL,
 		client: &http.Client{
@@ -172,6 +208,7 @@ func NewAzureOIDCAuth(tenantID, clientID string, lgr logr.Logger) (func(http.Han
 				Email:    claimString(mapClaims, "email"),
 				TenantID: claimString(mapClaims, "tid"),
 				ObjectID: claimString(mapClaims, "oid"),
+				IDType:   claimString(mapClaims, "idtyp"),
 				Audience: claimString(mapClaims, "aud"),
 				Issuer:   claimString(mapClaims, "iss"),
 				Groups:   claimStringSlice(mapClaims, "groups"),
@@ -182,9 +219,10 @@ func NewAzureOIDCAuth(tenantID, clientID string, lgr logr.Logger) (func(http.Han
 			}
 
 			ctx := context.WithValue(r.Context(), claimsContextKey, claims)
+			ctx = context.WithValue(ctx, accessTokenContextKey, tokenStr)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
-	}, nil
+	}
 }
 
 // getKey fetches the RSA public key for the given kid from JWKS.

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -117,6 +117,32 @@ func TestClaimsFromContext_Present(t *testing.T) {
 	assert.Equal(t, "tenant-abc", claims.TenantID)
 }
 
+func TestAccessTokenFromContext_Nil(t *testing.T) {
+	token := AccessTokenFromContext(context.Background())
+	assert.Empty(t, token)
+}
+
+func TestAccessTokenFromContext_Present(t *testing.T) {
+	ctx := context.WithValue(context.Background(), accessTokenContextKey, "eyJ0eXAi.test.token")
+	token := AccessTokenFromContext(ctx)
+	assert.Equal(t, "eyJ0eXAi.test.token", token)
+}
+
+func TestAuthClaims_CallerType_User(t *testing.T) {
+	claims := &AuthClaims{IDType: ""}
+	assert.Equal(t, "user", claims.CallerType())
+}
+
+func TestAuthClaims_CallerType_App(t *testing.T) {
+	claims := &AuthClaims{IDType: "app"}
+	assert.Equal(t, "app", claims.CallerType())
+}
+
+func TestAuthClaims_CallerType_UnknownDefaultsToUser(t *testing.T) {
+	claims := &AuthClaims{IDType: "something"}
+	assert.Equal(t, "user", claims.CallerType())
+}
+
 func BenchmarkAzureOIDCAuth_MissingHeader(b *testing.B) {
 	mw, err := NewAzureOIDCAuth("tenant-id", "client-id", logr.Discard())
 	require.NoError(b, err)
@@ -371,4 +397,75 @@ func TestJWKSCache_Refresh_NetworkError(t *testing.T) {
 func encodeJSON(w http.ResponseWriter, v any) error {
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(v)
+}
+
+func TestAzureOIDCAuth_StoresClaimsAndTokenInContext(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const (
+		kid      = "e2e-kid"
+		tenant   = "test-tenant"
+		clientID = "test-client"
+	)
+
+	// Spin up a JWKS endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = encodeJSON(w, jwksFromKey(privKey, kid))
+	}))
+	defer srv.Close()
+
+	// Create a valid signed JWT.
+	now := time.Now()
+	issuer := "https://login.microsoftonline.com/" + tenant + "/v2.0"
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub":   "user-456",
+		"name":  "Jane Doe",
+		"email": "jane@example.com",
+		"tid":   tenant,
+		"oid":   "obj-789",
+		"idtyp": "app",
+		"aud":   clientID,
+		"iss":   issuer,
+		"exp":   float64(now.Add(time.Hour).Unix()),
+		"iat":   float64(now.Unix()),
+		"roles": []string{"admin", "reader"},
+	})
+	token.Header["kid"] = kid
+	tokenStr, err := token.SignedString(privKey)
+	require.NoError(t, err)
+
+	// Build middleware pointing at our test JWKS server.
+	mw := newOIDCAuthMiddleware(srv.URL, issuer, clientID, logr.Discard())
+
+	var capturedClaims *AuthClaims
+	var capturedToken string
+
+	handler := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedClaims = ClaimsFromContext(r.Context())
+		capturedToken = AccessTokenFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Verify middleware passed the request through (200, not 401).
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify claims stored correctly.
+	require.NotNil(t, capturedClaims)
+	assert.Equal(t, "user-456", capturedClaims.Subject)
+	assert.Equal(t, "Jane Doe", capturedClaims.Name)
+	assert.Equal(t, "jane@example.com", capturedClaims.Email)
+	assert.Equal(t, tenant, capturedClaims.TenantID)
+	assert.Equal(t, "obj-789", capturedClaims.ObjectID)
+	assert.Equal(t, "app", capturedClaims.IDType)
+	assert.Equal(t, "app", capturedClaims.CallerType())
+	assert.Equal(t, []string{"admin", "reader"}, capturedClaims.Roles)
+
+	// Verify access token stored correctly.
+	assert.Equal(t, tokenStr, capturedToken)
 }

--- a/pkg/api/middleware/flightid.go
+++ b/pkg/api/middleware/flightid.go
@@ -1,0 +1,37 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+)
+
+var flightCounter atomic.Uint64
+
+const flightIDContextKey contextKey = "flightID"
+
+// FlightID is a middleware that assigns a unique monotonic uint64 to each request
+// and stores it in the request context for go-flight singleflight tagging.
+func FlightID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := flightCounter.Add(1)
+		ctx := context.WithValue(r.Context(), flightIDContextKey, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// FlightIDFromContext extracts the flight ID from context.
+// Returns 0 if no ID was set.
+func FlightIDFromContext(ctx context.Context) uint64 {
+	id, _ := ctx.Value(flightIDContextKey).(uint64)
+	return id
+}
+
+// FlightIDExtractor returns a function compatible with go-flight's
+// cache.RequestIDExtractor type for singleflight tagging.
+func FlightIDExtractor() func(ctx context.Context) uint64 {
+	return FlightIDFromContext
+}

--- a/pkg/api/middleware/flighttid_test.go
+++ b/pkg/api/middleware/flighttid_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlightID_AssignsUniqueIDs(t *testing.T) {
+	t.Parallel()
+
+	var id1, id2 uint64
+	handler := FlightID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		id1 = FlightIDFromContext(r.Context())
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+
+	handler2 := FlightID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		id2 = FlightIDFromContext(r.Context())
+	}))
+	handler2.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+
+	assert.NotZero(t, id1)
+	assert.NotZero(t, id2)
+	assert.NotEqual(t, id1, id2, "each request must get a unique ID")
+}
+
+func TestFlightID_Monotonic(t *testing.T) {
+	t.Parallel()
+
+	ids := make([]uint64, 100)
+
+	for i := range ids {
+		var id uint64
+		h := FlightID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			id = FlightIDFromContext(r.Context())
+		}))
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+		ids[i] = id
+	}
+
+	for i := 1; i < len(ids); i++ {
+		assert.Greater(t, ids[i], ids[i-1], "IDs must be strictly increasing")
+	}
+}
+
+func TestFlightID_ConcurrentUniqueness(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 50
+	ids := make([]uint64, goroutines)
+	var wg sync.WaitGroup
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			h := FlightID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				ids[idx] = FlightIDFromContext(r.Context())
+			}))
+			h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[uint64]bool, goroutines)
+	for _, id := range ids {
+		assert.NotZero(t, id)
+		assert.False(t, seen[id], "duplicate ID detected: %d", id)
+		seen[id] = true
+	}
+}
+
+func TestFlightIDFromContext_NoID_ReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	id := FlightIDFromContext(context.Background())
+	assert.Equal(t, uint64(0), id)
+}
+
+func TestFlightIDExtractor_ReturnsFromContext(t *testing.T) {
+	t.Parallel()
+
+	var captured uint64
+	extractor := FlightIDExtractor()
+
+	h := FlightID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = extractor(r.Context())
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+
+	require.NotZero(t, captured)
+}

--- a/pkg/api/middleware/tokenpassthrough.go
+++ b/pkg/api/middleware/tokenpassthrough.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+const (
+	TokenHeaderPrefix            = "X-Authorization-"
+	tokenContextKey   contextKey = "headerTokens"
+)
+
+func TokenPassthrough(allowedTokenHeaderSuffixes []string) func(http.Handler) http.Handler {
+	allowedTokenHeaders := allowedProviderTokenHeaders(allowedTokenHeaderSuffixes)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := make(map[string]string)
+			for _, key := range allowedTokenHeaders {
+				if token := r.Header.Get(key); token != "" {
+					tokens[strings.TrimPrefix(key, TokenHeaderPrefix)] = token
+				}
+			}
+			ctx := withContextTokens(r.Context(), tokens)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func allowedProviderTokenHeaders(suffixes []string) []string {
+	headers := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		suffix = strings.TrimSpace(suffix)
+		if suffix == "" {
+			continue
+		}
+
+		header := http.CanonicalHeaderKey(TokenHeaderPrefix + suffix)
+		if !strings.HasPrefix(header, TokenHeaderPrefix) {
+			continue
+		}
+		if !validHeaderFieldName(header) {
+			continue
+		}
+
+		headers = append(headers, header)
+	}
+	return headers
+}
+
+func validHeaderFieldName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		c := name[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func withContextTokens(ctx context.Context, tokens map[string]string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, tokenContextKey, tokens)
+}
+
+func TokensFromContext(ctx context.Context) map[string]string {
+	tokens, _ := ctx.Value(tokenContextKey).(map[string]string)
+	return tokens
+}

--- a/pkg/api/middleware/tokenpassthrough_test.go
+++ b/pkg/api/middleware/tokenpassthrough_test.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenPassthrough(t *testing.T) {
+	t.Run("passes through token headers, no tokens", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Github"})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			assert.Empty(t, tokens, "expected no tokens in context when no headers are set")
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("passes through token headers, with tokens", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Github"})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			expected := map[string]string{
+				"Github": "ghp_123456",
+			}
+
+			assert.Equal(t, expected, tokens, "expected tokens in context to match headers")
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%sGithub", TokenHeaderPrefix), "ghp_123456")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("ignores if not in allowed headers", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Github"})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			assert.Empty(t, tokens, "expected unconfigured token header to be ignored")
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%sAzure-Ad", TokenHeaderPrefix), "value")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("canonicalizes configured header suffixes", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Github"})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			assert.Equal(t, map[string]string{
+				"Github": "ghp_123456",
+			}, tokens)
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%sgithub", TokenHeaderPrefix), "ghp_123456")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("ignores invalid configured header suffixes", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Bad Header", ""})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			assert.Empty(t, tokens, "expected invalid configured token headers to be ignored")
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%sBad-Header", TokenHeaderPrefix), "value")
+		req.Header.Set(TokenHeaderPrefix, "value")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("keeps token values unchanged", func(t *testing.T) {
+		mw := TokenPassthrough([]string{"Github"})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokens := TokensFromContext(r.Context())
+			assert.Equal(t, "  token with spaces  ", tokens["Github"])
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%sGithub", TokenHeaderPrefix), "  token with spaces  ")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+}

--- a/pkg/api/middleware_test.go
+++ b/pkg/api/middleware_test.go
@@ -4,6 +4,9 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -11,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apimiddleware "github.com/oakwood-commons/scafctl/pkg/api/middleware"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 )
 
@@ -75,6 +79,58 @@ func TestSetupMiddleware_WithRateLimit(t *testing.T) {
 	apiRouter, err := SetupMiddleware(t.Context(), router, cfg, lgr)
 	require.NoError(t, err)
 	assert.NotNil(t, apiRouter)
+}
+
+func TestSetupMiddleware_TokenPassThroughWiring(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.APIServerConfig
+		expected map[string]string
+	}{
+		{
+			name: "nil config allows default GitHub header",
+			cfg:  &config.APIServerConfig{},
+			expected: map[string]string{
+				"Github": "ghp_123456",
+			},
+		},
+		{
+			name: "configured headers override default",
+			cfg: &config.APIServerConfig{
+				TokenPassThrough: &config.TokenPassThroughConfig{
+					AllowedHeaders: []string{"Azure-Ad"},
+				},
+			},
+			expected: map[string]string{
+				"Azure-Ad": "azure-token",
+			},
+		},
+		{
+			name: "explicit empty list allows none",
+			cfg: &config.APIServerConfig{
+				TokenPassThrough: &config.TokenPassThroughConfig{
+					AllowedHeaders: []string{},
+				},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := chi.NewRouter()
+			apiRouter, err := SetupMiddleware(t.Context(), router, tt.cfg, logr.Discard())
+			require.NoError(t, err)
+			apiRouter.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.expected, apimiddleware.TokensFromContext(r.Context()))
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "/test", nil)
+			req.Header.Set(fmt.Sprintf("%sGithub", apimiddleware.TokenHeaderPrefix), "ghp_123456")
+			req.Header.Set(fmt.Sprintf("%sAzure-Ad", apimiddleware.TokenHeaderPrefix), "azure-token")
+			apiRouter.ServeHTTP(httptest.NewRecorder(), req)
+		})
+	}
 }
 
 func BenchmarkSetupMiddleware(b *testing.B) {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -186,7 +186,6 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		cancel:            cancel,
 		startTime:         time.Now(),
 	}
-
 	return s, nil
 }
 

--- a/pkg/authdelegation/context.go
+++ b/pkg/authdelegation/context.go
@@ -1,0 +1,20 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import "context"
+
+type registryKey struct{}
+
+// WithRegistry returns a context that carries the given DelegatorRegistry.
+func WithRegistry(ctx context.Context, reg *DelegatorRegistry) context.Context {
+	return context.WithValue(ctx, registryKey{}, reg)
+}
+
+// RegistryFromContext retrieves the DelegatorRegistry from ctx.
+// Returns nil if no registry has been stored.
+func RegistryFromContext(ctx context.Context) *DelegatorRegistry {
+	reg, _ := ctx.Value(registryKey{}).(*DelegatorRegistry)
+	return reg
+}

--- a/pkg/authdelegation/context_test.go
+++ b/pkg/authdelegation/context_test.go
@@ -1,0 +1,26 @@
+package authdelegation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRegistry_RoundTrip(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	reg.Register("entra", &mockDelegator{name: "entra"})
+
+	ctx := WithRegistry(context.Background(), reg)
+	got := RegistryFromContext(ctx)
+	require.NotNil(t, got)
+	assert.Same(t, reg, got)
+}
+
+func TestRegistryFromContext_EmptyContext(t *testing.T) {
+	t.Parallel()
+	got := RegistryFromContext(context.Background())
+	assert.Nil(t, got)
+}

--- a/pkg/authdelegation/credentials.go
+++ b/pkg/authdelegation/credentials.go
@@ -1,0 +1,50 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// ServerCredential provides the server's proof-of-identity for the token endpoint.
+// This is the variability point for WIF vs. secret vs. cert.
+type ServerCredential interface {
+	Apply(params url.Values) error
+}
+
+// WIFCredential implements ServerCredential by reading a projected token file.
+type WIFCredential struct {
+	TokenFile           string // path to federated token (re-read per request)
+	ClientAssertionType string // "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+}
+
+// SecretCredential implements ServerCredential using a static client secret.
+type SecretCredential struct {
+	Secret string
+}
+
+// Apply sets the client_secret on the token request params.
+func (c *SecretCredential) Apply(params url.Values) error {
+	params.Set("client_secret", c.Secret)
+	return nil
+}
+
+// Apply reads the projected federated token file and sets the WIF client assertion params.
+// The file is re-read on every call because projected service account tokens rotate.
+func (c *WIFCredential) Apply(params url.Values) error {
+	raw, err := os.ReadFile(c.TokenFile)
+	if err != nil {
+		return fmt.Errorf("reading federated token file %q: %w", c.TokenFile, err)
+	}
+	assertion := strings.TrimSpace(string(raw))
+	if assertion == "" {
+		return fmt.Errorf("federated token file %q is empty", c.TokenFile)
+	}
+	params.Set("client_assertion_type", c.ClientAssertionType)
+	params.Set("client_assertion", assertion)
+	return nil
+}

--- a/pkg/authdelegation/credentials_test.go
+++ b/pkg/authdelegation/credentials_test.go
@@ -1,0 +1,69 @@
+package authdelegation
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretCredential_Apply(t *testing.T) {
+	t.Parallel()
+	v := url.Values{}
+	c := &SecretCredential{Secret: "s3cr3t"}
+	require.NoError(t, c.Apply(v))
+	assert.Equal(t, "s3cr3t", v.Get("client_secret"))
+}
+
+func TestWIFCredential_Apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads file and sets assertion params", func(t *testing.T) {
+		t.Parallel()
+		f := writeTempToken(t, "my-wif-token")
+		v := url.Values{}
+		c := &WIFCredential{
+			TokenFile:           f,
+			ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+		}
+		require.NoError(t, c.Apply(v))
+		assert.Equal(t, "my-wif-token", v.Get("client_assertion"))
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", v.Get("client_assertion_type"))
+	})
+
+	t.Run("trims whitespace from token", func(t *testing.T) {
+		t.Parallel()
+		f := writeTempToken(t, "  trimmed-token\n")
+		v := url.Values{}
+		c := &WIFCredential{TokenFile: f, ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"}
+		require.NoError(t, c.Apply(v))
+		assert.Equal(t, "trimmed-token", v.Get("client_assertion"))
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		t.Parallel()
+		c := &WIFCredential{TokenFile: "/nonexistent/token", ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"}
+		err := c.Apply(url.Values{})
+		assert.ErrorContains(t, err, "reading federated token file")
+	})
+
+	t.Run("empty file returns error", func(t *testing.T) {
+		t.Parallel()
+		f := writeTempToken(t, "   ")
+		c := &WIFCredential{TokenFile: f, ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"}
+		err := c.Apply(url.Values{})
+		assert.ErrorContains(t, err, "is empty")
+	})
+}
+
+func writeTempToken(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "wif-token-*")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}

--- a/pkg/authdelegation/delegator.go
+++ b/pkg/authdelegation/delegator.go
@@ -1,0 +1,426 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	manager "github.com/oakwood-commons/go-flight/cache"
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	httpc "github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	defaultCacheSize             = 1024
+	defaultExpiryBuffer          = 10 * time.Minute
+	defaultCleanupInterval       = 5 * time.Minute
+	defaultExpiryThreshold       = 30 * time.Minute
+	defaultSlowThreshold         = 500 * time.Millisecond
+	defaultRetryOnFollowerErrors = true
+
+	CredentialTypeWIF    CredentialType = "wif"
+	CredentialTypeSecret CredentialType = "secret"
+)
+
+var (
+	defaultHTTPClientOnce sync.Once
+	defaultHTTPClientVal  *httpc.Client
+)
+
+// TokenDelegator is the top-level facade. One per server.
+type TokenDelegator interface {
+	Name() string
+	DelegateToken(ctx context.Context, scope string) (TokenResult, error)
+}
+
+// TokenResult is the normalized output of any delegation strategy.
+type TokenResult struct {
+	AccessToken string
+	ExpiresIn   int64
+}
+
+// CredentialType specifies which server authentication method to use.
+type CredentialType string
+
+// EntraDelegatorConfig holds the static configuration for the Entra delegator.
+type EntraDelegatorConfig struct {
+	TenantID           string
+	ClientID           string
+	CredentialType     CredentialType // required: "wif" or "secret"
+	FederatedTokenFile string         // required when CredentialType is "wif"
+	ClientSecret       string         // required when CredentialType is "secret"
+}
+
+// EntraDelegator implements TokenDelegator for Azure/Entra.
+// Constructed once at server startup.
+type EntraDelegator struct {
+	tokenURL     string                                // pre-built: https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+	clientID     string                                // pre-set from config
+	credential   ServerCredential                      // WIF or secret
+	flowRegistry *FlowRegistry                         // permitted flows keyed by name
+	manager      *manager.Manager[string, TokenResult] // optional; nil disables caching
+	httpClient   *httpc.Client                         // HTTP client for token endpoint requests
+	logger       logr.Logger                           // structured logger for delegation operations
+}
+
+// EntraDelegatorOption configures optional behaviour on an EntraDelegator.
+type EntraDelegatorOption func(*EntraDelegator)
+
+// WithManager injects a cache manager for token deduplication and caching.
+// If not provided, DelegateToken calls the flow function directly without caching.
+func WithManager(mgr *manager.Manager[string, TokenResult]) EntraDelegatorOption {
+	return func(d *EntraDelegator) { d.manager = mgr }
+}
+
+// WithHTTPClient overrides the default HTTP client used for token endpoint requests.
+func WithHTTPClient(client *httpc.Client) EntraDelegatorOption {
+	return func(d *EntraDelegator) { d.httpClient = client }
+}
+
+// WithFlowRegistry overrides the default flow registry.
+func WithFlowRegistry(fr *FlowRegistry) EntraDelegatorOption {
+	return func(d *EntraDelegator) { d.flowRegistry = fr }
+}
+
+// WithLogger overrides the logger used for delegation operations.
+func WithLogger(log logr.Logger) EntraDelegatorOption {
+	return func(d *EntraDelegator) { d.logger = log }
+}
+
+func defaultHTTPClient() *httpc.Client {
+	defaultHTTPClientOnce.Do(func() {
+		defaultHTTPClientVal = httpc.NewClient(
+			&httpc.ClientConfig{
+				Timeout:     5 * time.Second,
+				EnableCache: false,
+				RetryMax:    2,
+			},
+		)
+	})
+	return defaultHTTPClientVal
+}
+
+// NewEntraDelegator constructs an EntraDelegator from the given config.
+// It validates all required fields and pre-wires the flow strategy selector.
+func NewEntraDelegator(cfg EntraDelegatorConfig, opts ...EntraDelegatorOption) (*EntraDelegator, error) {
+	if cfg.TenantID == "" {
+		return nil, ErrEntraNoTenantID
+	}
+	if cfg.ClientID == "" {
+		return nil, ErrEntraNoClientID
+	}
+
+	var cred ServerCredential
+	switch cfg.CredentialType {
+	case CredentialTypeWIF:
+		if cfg.FederatedTokenFile == "" {
+			return nil, ErrEntraWIFMissingTokenFile
+		}
+		cred = &WIFCredential{
+			TokenFile:           cfg.FederatedTokenFile,
+			ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+		}
+	case CredentialTypeSecret:
+		if cfg.ClientSecret == "" {
+			return nil, ErrEntraSecretMissing
+		}
+		cred = &SecretCredential{Secret: cfg.ClientSecret}
+	default:
+		return nil, ErrEntraInvalidCredentialType
+	}
+
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", cfg.TenantID)
+
+	d := &EntraDelegator{
+		tokenURL:   tokenURL,
+		clientID:   cfg.ClientID,
+		credential: cred,
+		httpClient: defaultHTTPClient(),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.logger.GetSink() == nil {
+		d.logger = logr.Discard()
+	}
+	if d.flowRegistry == nil {
+		d.flowRegistry = NewFlowRegistry()
+		d.flowRegistry.Register("obo", oboFlow(tokenURL, cred, d.httpClient))
+		d.flowRegistry.Register("client_credentials", clientCredentialFlow(tokenURL, cred, d.httpClient))
+	}
+	return d, nil
+}
+
+func (d *EntraDelegator) Name() string {
+	return "entra"
+}
+
+// DelegateToken exchanges the caller's inbound token for a downstream-scoped token.
+// It reads the caller token and type from context (set by the auth middleware).
+// User callers get OBO delegation, machine callers get client credentials.
+// If no Manager was injected, the flow is called directly without caching.
+func (d *EntraDelegator) DelegateToken(ctx context.Context, scope string) (TokenResult, error) {
+	log := logger.FromContext(ctx)
+
+	ctx, span := telemetry.Tracer(telemetry.TracerAuthDelegation).Start(ctx, "authdelegation.DelegateToken",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attribute.String("delegation.scope", scope)),
+	)
+	defer span.End()
+
+	callerToken := middleware.AccessTokenFromContext(ctx)
+	if callerToken == "" {
+		return TokenResult{}, ErrNoCallerToken
+	}
+
+	if scope == "" {
+		return TokenResult{}, ErrNoScope
+	}
+
+	var callerType string
+	if claims := middleware.ClaimsFromContext(ctx); claims != nil {
+		callerType = claims.CallerType()
+	}
+
+	flowName := FlowNameForCaller(callerType)
+	span.SetAttributes(
+		attribute.String("delegation.callerType", callerType),
+		attribute.String("delegation.flow", flowName),
+	)
+	if log.V(1).Enabled() {
+		log.V(1).Info("delegating token", "callerType", callerType, "flow", flowName, "scope", scope)
+	}
+
+	params := FlowParams{
+		CallerToken: callerToken,
+		Scope:       scope,
+		ClientID:    d.clientID,
+	}
+	flow, err := d.flowRegistry.Select(callerType)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		log.Info("flow selection failed", "callerType", callerType, "error", err)
+		return TokenResult{}, err
+	}
+
+	if d.manager == nil {
+		if log.V(2).Enabled() {
+			log.V(2).Info("executing flow directly", "flow", flowName)
+		}
+		return flow(ctx, params)
+	}
+
+	cacheKey, ok := GenerateKey(callerType, params)
+	if !ok {
+		if log.V(2).Enabled() {
+			log.V(2).Info("cache key generation failed, bypassing cache", "flow", flowName)
+		}
+		return flow(ctx, params)
+	}
+	hooks := &manager.Hooks{
+		OnCacheHit: func(source string) {
+			span.AddEvent("cache.hit", trace.WithAttributes(attribute.String("cache.source", source)))
+			if log.V(2).Enabled() {
+				log.V(2).Info("cache hit", "source", source, "flow", flowName)
+			}
+		},
+		OnSuccess: func() {
+			span.SetAttributes(attribute.Bool("delegation.cacheHit", false))
+			if log.V(2).Enabled() {
+				log.V(2).Info("flow execution succeeded", "flow", flowName)
+			}
+		},
+		OnFetchError: func(err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			log.Info("flow execution failed", "flow", flowName, "error", err)
+		},
+	}
+	return d.manager.Do(ctx, cacheKey, func(ctx context.Context) (manager.FetchResult[TokenResult], error) {
+		if log.V(2).Enabled() {
+			log.V(2).Info("cache miss, executing flow", "flow", flowName, "cacheKey", cacheKey)
+		}
+		token, err := flow(ctx, params)
+		if err != nil {
+			return manager.FetchResult[TokenResult]{}, err
+		}
+		return manager.FetchResult[TokenResult]{
+			Value:  token,
+			TTL:    time.Duration(token.ExpiresIn) * time.Second, //nolint:gosec // ExpiresIn is a positive int from OAuth response
+			Policy: manager.CacheWithTTL,
+		}, nil
+	}, hooks)
+}
+
+// NewEntraDelegatorFromConfig constructs an EntraDelegator from application config.
+// It resolves secrets, validates flows, wires a cache manager with defaults, and
+// registers only permitted flows in the FlowRegistry.
+// The ctx controls the lifetime of the cache cleanup goroutine.
+func NewEntraDelegatorFromConfig(ctx context.Context, cfg *config.APIEntraIdentityConfig, opts ...EntraDelegatorOption) (*EntraDelegator, error) {
+	log := logger.FromContext(ctx)
+
+	if cfg == nil {
+		return nil, fmt.Errorf("APIEntraIdentityConfig is required")
+	}
+
+	if err := cfg.Credential.Validate(); err != nil {
+		return nil, fmt.Errorf("credential: %w", err)
+	}
+
+	if err := cfg.AllowedFlows.Validate(); err != nil {
+		return nil, fmt.Errorf("allowedFlows: %w", err)
+	}
+
+	delegatorCfg := EntraDelegatorConfig{
+		TenantID: cfg.TenantID,
+		ClientID: cfg.ClientID,
+	}
+
+	switch cfg.Credential.Type {
+	case "secret":
+		secret, err := cfg.Credential.ClientSecret.Resolve()
+		if err != nil {
+			return nil, fmt.Errorf("resolving client secret: %w", err)
+		}
+		delegatorCfg.CredentialType = CredentialTypeSecret
+		delegatorCfg.ClientSecret = secret
+		log.V(1).Info("credential resolved", "type", "secret")
+	case "wif":
+		delegatorCfg.CredentialType = CredentialTypeWIF
+		delegatorCfg.FederatedTokenFile = cfg.Credential.WIFTokenPath
+		log.V(1).Info("credential resolved", "type", "wif", "tokenFile", cfg.Credential.WIFTokenPath)
+	}
+
+	// Conditionally wire cache manager when TokenManager is configured.
+	var managerOpts []EntraDelegatorOption
+	if cfg.TokenManager != nil {
+		s, err := resolveTokenManagerDefaults(cfg.TokenManager)
+		if err != nil {
+			return nil, fmt.Errorf("token manager config: %w", err)
+		}
+		log.V(1).Info("token manager configured",
+			"cacheSize", s.CacheSize,
+			"expiryBuffer", s.ExpiryBuffer,
+			"cleanupInterval", s.CleanupInterval,
+			"expiryThreshold", s.ExpiryThreshold,
+			"slowThreshold", s.SlowThreshold,
+			"retryOnError", s.RetryOnError,
+		)
+		tokenCache := NewTokenCache[string, TokenResult](ctx, s.CacheSize, s.ExpiryBuffer, s.CleanupInterval)
+		mgr := manager.NewManager(
+			manager.WithStore("tokens", tokenCache),
+			manager.WithExpiryThreshold[string, TokenResult](s.ExpiryThreshold),
+			manager.WithSlowThreshold[string, TokenResult](s.SlowThreshold),
+			manager.WithRetryFollowerOnError[string, TokenResult](s.RetryOnError),
+			manager.WithRequestIDExtractor[string, TokenResult](middleware.FlightIDExtractor()),
+		)
+		managerOpts = append(managerOpts, WithManager(mgr))
+	}
+
+	// Build delegator with an empty registry to suppress default flow registration.
+	// We set the filtered registry below using the delegator's canonical credential.
+	baseOpts := make([]EntraDelegatorOption, 0, 1+len(managerOpts)+len(opts))
+	baseOpts = append(baseOpts, WithFlowRegistry(NewFlowRegistry()))
+	baseOpts = append(baseOpts, managerOpts...)
+	baseOpts = append(baseOpts, opts...)
+
+	delegator, err := NewEntraDelegator(delegatorCfg, baseOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build filtered FlowRegistry using the delegator's canonical credential.
+	registry := NewFlowRegistry()
+	if cfg.AllowedFlows.IsFlowPermitted(config.DelegationFlowOBO) {
+		registry.Register(config.DelegationFlowOBO, oboFlow(delegator.tokenURL, delegator.credential, delegator.httpClient))
+	}
+	if cfg.AllowedFlows.IsFlowPermitted(config.DelegationFlowClientCredentials) {
+		registry.Register(config.DelegationFlowClientCredentials, clientCredentialFlow(delegator.tokenURL, delegator.credential, delegator.httpClient))
+	}
+	delegator.flowRegistry = registry
+
+	var permittedFlows []string
+	if cfg.AllowedFlows != nil {
+		permittedFlows = cfg.AllowedFlows.Flows
+	}
+	log.V(1).Info("entra delegator initialized",
+		"tenantID", cfg.TenantID,
+		"clientID", cfg.ClientID,
+		"permittedFlows", permittedFlows,
+	)
+
+	return delegator, nil
+}
+
+// tokenManagerSettings holds resolved token manager configuration values.
+type tokenManagerSettings struct {
+	CacheSize       int
+	ExpiryBuffer    time.Duration
+	CleanupInterval time.Duration
+	ExpiryThreshold time.Duration
+	SlowThreshold   time.Duration
+	RetryOnError    bool
+}
+
+// resolveTokenManagerDefaults applies defaults to a TokenManagerConfig.
+// All zero values fall back to package-level constants.
+// Returns an error if any duration string is non-empty but unparseable.
+func resolveTokenManagerDefaults(tm *config.TokenManagerConfig) (tokenManagerSettings, error) {
+	s := tokenManagerSettings{
+		CacheSize:       defaultCacheSize,
+		ExpiryBuffer:    defaultExpiryBuffer,
+		CleanupInterval: defaultCleanupInterval,
+		ExpiryThreshold: defaultExpiryThreshold,
+		SlowThreshold:   defaultSlowThreshold,
+		RetryOnError:    defaultRetryOnFollowerErrors,
+	}
+
+	if tm.CacheSize != 0 {
+		s.CacheSize = tm.CacheSize
+	}
+	if tm.ExpiryBuffer != "" {
+		d, err := time.ParseDuration(tm.ExpiryBuffer)
+		if err != nil {
+			return tokenManagerSettings{}, fmt.Errorf("parsing expiryBuffer %q: %w", tm.ExpiryBuffer, err)
+		}
+		s.ExpiryBuffer = d
+	}
+	if tm.CleanupInterval != "" {
+		d, err := time.ParseDuration(tm.CleanupInterval)
+		if err != nil {
+			return tokenManagerSettings{}, fmt.Errorf("parsing cleanupInterval %q: %w", tm.CleanupInterval, err)
+		}
+		s.CleanupInterval = d
+	}
+	if tm.ExpiryThreshold != "" {
+		d, err := time.ParseDuration(tm.ExpiryThreshold)
+		if err != nil {
+			return tokenManagerSettings{}, fmt.Errorf("parsing expiryThreshold %q: %w", tm.ExpiryThreshold, err)
+		}
+		s.ExpiryThreshold = d
+	}
+	if tm.SlowThreshold != "" {
+		d, err := time.ParseDuration(tm.SlowThreshold)
+		if err != nil {
+			return tokenManagerSettings{}, fmt.Errorf("parsing slowThreshold %q: %w", tm.SlowThreshold, err)
+		}
+		s.SlowThreshold = d
+	}
+	if tm.RetryFollowerOnError != nil {
+		s.RetryOnError = *tm.RetryFollowerOnError
+	}
+
+	return s, nil
+}

--- a/pkg/authdelegation/delegator_bench_test.go
+++ b/pkg/authdelegation/delegator_bench_test.go
@@ -1,0 +1,86 @@
+package authdelegation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	manager "github.com/oakwood-commons/go-flight/cache"
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+)
+
+func BenchmarkDelegateToken_CacheHit(b *testing.B) {
+	b.ReportAllocs()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "bench-token", "expires_in": 3600,
+		})
+	}))
+	defer srv.Close()
+
+	tokenCache := NewTokenCache[string, TokenResult](context.Background(), 1024, 0, time.Hour)
+	mgr := manager.NewManager(
+		manager.WithStore("bench", tokenCache),
+	)
+
+	client := httpc.NewClient(nil)
+	registry := NewFlowRegistry()
+	registry.Register("obo", oboFlow(srv.URL, &SecretCredential{Secret: "s"}, client))
+	registry.Register("client_credentials", clientCredentialFlow(srv.URL, &SecretCredential{Secret: "s"}, client))
+
+	cfg := EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s"}
+	d, err := NewEntraDelegator(cfg, WithHTTPClient(client), WithFlowRegistry(registry), WithManager(mgr))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := middleware.WithAccessToken(context.Background(), "caller-jwt-token")
+	ctx = middleware.WithAuthClaims(ctx, &middleware.AuthClaims{IDType: "user"})
+
+	// Warm the cache
+	if _, err := d.DelegateToken(ctx, "api/.default"); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = d.DelegateToken(ctx, "api/.default")
+	}
+}
+
+func BenchmarkDelegateToken_FlowSelection(b *testing.B) {
+	b.ReportAllocs()
+
+	// Measure overhead of flow selection + key generation without network calls.
+	// Uses a no-op flow that returns immediately.
+	noopFlow := func(_ context.Context, _ FlowParams) (TokenResult, error) {
+		return TokenResult{AccessToken: "x", ExpiresIn: 60}, nil
+	}
+
+	registry := NewFlowRegistry()
+	registry.Register("obo", noopFlow)
+	registry.Register("client_credentials", noopFlow)
+
+	cfg := EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s"}
+	d, err := NewEntraDelegator(cfg, WithFlowRegistry(registry))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Realistic ~1KB JWT token
+	token := strings.Repeat("eyJhbGciOiJSUzI1NiJ9.", 40)
+	ctx := middleware.WithAccessToken(context.Background(), token)
+	ctx = middleware.WithAuthClaims(ctx, &middleware.AuthClaims{IDType: "user"})
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = d.DelegateToken(ctx, "api/.default")
+	}
+}

--- a/pkg/authdelegation/delegator_test.go
+++ b/pkg/authdelegation/delegator_test.go
@@ -1,0 +1,791 @@
+package authdelegation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	manager "github.com/oakwood-commons/go-flight/cache"
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── Constructor tests ──
+
+func TestNewEntraDelegator(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  EntraDelegatorConfig
+		err  error
+	}{
+		{"no tenant", EntraDelegatorConfig{ClientID: "c", CredentialType: CredentialTypeWIF, FederatedTokenFile: "f"}, ErrEntraNoTenantID},
+		{"no client", EntraDelegatorConfig{TenantID: "t", CredentialType: CredentialTypeWIF, FederatedTokenFile: "f"}, ErrEntraNoClientID},
+		{"invalid cred type", EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: "bad"}, ErrEntraInvalidCredentialType},
+		{"empty cred type", EntraDelegatorConfig{TenantID: "t", ClientID: "c"}, ErrEntraInvalidCredentialType},
+		{"wif no file", EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: CredentialTypeWIF}, ErrEntraWIFMissingTokenFile},
+		{"secret no value", EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret}, ErrEntraSecretMissing},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewEntraDelegator(tc.cfg)
+			assert.ErrorIs(t, err, tc.err)
+		})
+	}
+
+	t.Run("valid wif", func(t *testing.T) {
+		t.Parallel()
+		d, err := NewEntraDelegator(EntraDelegatorConfig{
+			TenantID: "t", ClientID: "c", CredentialType: CredentialTypeWIF, FederatedTokenFile: "/tok",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, d)
+		assert.NotNil(t, d.flowRegistry)
+	})
+
+	t.Run("valid secret", func(t *testing.T) {
+		t.Parallel()
+		d, err := NewEntraDelegator(EntraDelegatorConfig{
+			TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, d)
+	})
+
+	t.Run("with manager option sets manager", func(t *testing.T) {
+		t.Parallel()
+		mgr := manager.NewManager[string, TokenResult]()
+		d, err := NewEntraDelegator(EntraDelegatorConfig{
+			TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s",
+		}, WithManager(mgr))
+		require.NoError(t, err)
+		assert.NotNil(t, d.manager)
+	})
+
+	t.Run("without manager option leaves manager nil", func(t *testing.T) {
+		t.Parallel()
+		d, err := NewEntraDelegator(EntraDelegatorConfig{
+			TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, d.manager)
+	})
+}
+
+// ── DelegateToken tests ──
+
+func TestDelegateToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing token in context returns error", func(t *testing.T) {
+		t.Parallel()
+		d := mustDelegator(t, CredentialTypeSecret, "secret-val")
+		_, err := d.DelegateToken(context.Background(), "scope/.default")
+		assert.ErrorContains(t, err, "no caller token in context")
+	})
+
+	t.Run("empty scope returns error", func(t *testing.T) {
+		t.Parallel()
+		d := mustDelegator(t, CredentialTypeSecret, "secret-val")
+		ctx := middleware.WithAccessToken(context.Background(), "some-jwt")
+		ctx = middleware.WithAuthClaims(ctx, &middleware.AuthClaims{IDType: "user"})
+		_, err := d.DelegateToken(ctx, "")
+		assert.ErrorIs(t, err, ErrNoScope)
+	})
+
+	t.Run("OBO success for user caller", func(t *testing.T) {
+		t.Parallel()
+		srv := fakeTokenEndpoint(t, http.StatusOK, map[string]any{
+			"access_token": "delegated-token", "token_type": "Bearer", "expires_in": 3600, "scope": "api/.default",
+		})
+
+		d := mustDelegatorWithURL(t, "secret-val", srv.URL)
+		ctx := authContext("caller-jwt", "user")
+
+		tok, err := d.DelegateToken(ctx, "api/.default")
+		require.NoError(t, err)
+		assert.Equal(t, "delegated-token", tok.AccessToken)
+		assert.Equal(t, int64(3600), tok.ExpiresIn)
+	})
+
+	t.Run("app caller uses client credentials", func(t *testing.T) {
+		t.Parallel()
+		srv := fakeTokenEndpoint(t, http.StatusOK, map[string]any{
+			"access_token": "cc-token", "token_type": "Bearer", "expires_in": 3600, "scope": "api/.default",
+		})
+
+		d := mustDelegatorWithURL(t, "s", srv.URL)
+		ctx := authContext("app-jwt", "app")
+
+		tok, err := d.DelegateToken(ctx, "api/.default")
+		require.NoError(t, err)
+		assert.Equal(t, "cc-token", tok.AccessToken)
+		assert.Equal(t, int64(3600), tok.ExpiresIn)
+	})
+
+	t.Run("token endpoint error propagates", func(t *testing.T) {
+		t.Parallel()
+		srv := fakeTokenEndpoint(t, http.StatusBadRequest, map[string]string{"error": "invalid_grant"})
+
+		d := mustDelegatorWithURL(t, "s", srv.URL)
+		ctx := authContext("bad-jwt", "user")
+
+		_, err := d.DelegateToken(ctx, "scope/.default")
+		assert.ErrorContains(t, err, "token endpoint returned 400")
+	})
+
+	t.Run("nil claims defaults callerType to empty", func(t *testing.T) {
+		t.Parallel()
+		srv := fakeTokenEndpoint(t, http.StatusOK, map[string]any{
+			"access_token": "tok", "token_type": "Bearer", "expires_in": 60, "scope": "s",
+		})
+
+		d := mustDelegatorWithURL(t, "s", srv.URL)
+		ctx := middleware.WithAccessToken(context.Background(), "some-jwt")
+
+		tok, err := d.DelegateToken(ctx, "s")
+		require.NoError(t, err)
+		assert.Equal(t, "tok", tok.AccessToken)
+	})
+}
+
+// ── DelegateToken with Manager tests ──
+
+func TestDelegateToken_WithManager_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	var hitCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "cached-token", "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	tokenCache := NewTokenCache[string, TokenResult](context.Background(), 100, 0, 5*time.Minute)
+	mgr := manager.NewManager(
+		manager.WithStore("test", tokenCache),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+
+	// First call — should hit the server
+	tok1, err := d.DelegateToken(ctx, "api/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-token", tok1.AccessToken)
+	assert.Equal(t, int64(3600), tok1.ExpiresIn)
+	assert.Equal(t, int32(1), hitCount.Load())
+
+	// Second call — same params, should come from cache
+	tok2, err := d.DelegateToken(ctx, "api/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-token", tok2.AccessToken)
+	assert.Equal(t, int32(1), hitCount.Load(), "expected flow to be called only once")
+}
+
+func TestDelegateToken_WithManager_CacheMiss(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-token", "expires_in": 1800,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	store := &spyStore[string, TokenResult]{}
+	mgr := manager.NewManager(
+		manager.WithStore("spy", store),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+
+	tok, err := d.DelegateToken(ctx, "api/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-token", tok.AccessToken)
+	assert.Equal(t, int64(1800), tok.ExpiresIn)
+
+	// Store was empty → miss on Get, then Set was called after fetch
+	assert.Equal(t, int32(1), store.gets.Load(), "expected one cache lookup")
+	assert.Equal(t, int32(1), store.sets.Load(), "expected result to be stored after miss")
+	assert.Equal(t, int32(1), fetchCount.Load(), "expected one fetch from token endpoint")
+}
+
+func TestDelegateToken_WithManager_KeyGenFails_BypassesCache(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "direct-token", "expires_in": 900,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	store := &spyStore[string, TokenResult]{}
+	mgr := manager.NewManager(
+		manager.WithStore("spy", store),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	// Use a context with token but no claims → callerType="" → NoOpKeyGenerator → returns false
+	ctx := middleware.WithAccessToken(context.Background(), "some-jwt")
+
+	tok, err := d.DelegateToken(ctx, "api/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "direct-token", tok.AccessToken)
+	assert.Equal(t, int64(900), tok.ExpiresIn)
+
+	// Cache was never consulted — flow called directly
+	assert.Equal(t, int32(0), store.gets.Load(), "expected no cache lookup when key gen fails")
+	assert.Equal(t, int32(0), store.sets.Load(), "expected no cache write when key gen fails")
+	assert.Equal(t, int32(1), fetchCount.Load())
+}
+
+func TestDelegateToken_WithManager_FlowError_NotCached(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeTokenEndpoint(t, http.StatusBadRequest, map[string]string{"error": "invalid_grant"})
+
+	store := &spyStore[string, TokenResult]{}
+	mgr := manager.NewManager(
+		manager.WithStore("spy", store),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+
+	_, err := d.DelegateToken(ctx, "api/.default")
+	assert.ErrorContains(t, err, "token endpoint returned 400")
+
+	// Error result must not be cached
+	assert.Equal(t, int32(1), store.gets.Load(), "expected one cache lookup")
+	assert.Equal(t, int32(0), store.sets.Load(), "expected no cache write on flow error")
+}
+
+func TestDelegateToken_WithManager_TTLDerivedFromExpiresIn(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "ttl-token", "expires_in": 7200,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	store := &spyStore[string, TokenResult]{}
+	mgr := manager.NewManager(
+		manager.WithStore("spy", store),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+
+	_, err := d.DelegateToken(ctx, "api/.default")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), store.sets.Load())
+	assert.Equal(t, 7200*time.Second, store.lastTTL, "TTL should be derived from expires_in seconds")
+}
+
+func TestDelegateToken_WithManager_DifferentScopes_DifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		_ = r.ParseForm()
+		scope := r.PostForm.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "token-for-" + scope, "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	tokenCache := NewTokenCache[string, TokenResult](context.Background(), 100, 0, 5*time.Minute)
+	mgr := manager.NewManager(
+		manager.WithStore("test", tokenCache),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+
+	tok1, err := d.DelegateToken(ctx, "scope-a/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "token-for-scope-a/.default", tok1.AccessToken)
+
+	tok2, err := d.DelegateToken(ctx, "scope-b/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "token-for-scope-b/.default", tok2.AccessToken)
+
+	// Both scopes triggered separate fetches
+	assert.Equal(t, int32(2), fetchCount.Load(), "different scopes must produce different cache keys")
+
+	// Re-requesting scope-a should hit cache, not fetch again
+	tok3, err := d.DelegateToken(ctx, "scope-a/.default")
+	require.NoError(t, err)
+	assert.Equal(t, "token-for-scope-a/.default", tok3.AccessToken)
+	assert.Equal(t, int32(2), fetchCount.Load(), "repeated scope should be served from cache")
+}
+
+func TestDelegateToken_WithManager_Deduplication(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		// Simulate slow token endpoint to ensure concurrent calls overlap
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "deduped-token", "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	tokenCache := NewTokenCache[string, TokenResult](context.Background(), 100, 0, 5*time.Minute)
+	mgr := manager.NewManager(
+		manager.WithStore("test", tokenCache),
+	)
+
+	d := mustDelegatorWithURL(t, "s", srv.URL)
+	d.manager = mgr
+
+	ctx := authContext("caller-jwt", "user")
+	const concurrency = 10
+
+	var wg sync.WaitGroup
+	results := make([]TokenResult, concurrency)
+	errs := make([]error, concurrency)
+
+	for i := range concurrency {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = d.DelegateToken(ctx, "api/.default")
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range concurrency {
+		require.NoError(t, errs[i], "goroutine %d failed", i)
+		assert.Equal(t, "deduped-token", results[i].AccessToken)
+	}
+
+	// Singleflight: only one fetch despite 10 concurrent callers
+	assert.Equal(t, int32(1), fetchCount.Load(), "expected single fetch due to singleflight deduplication")
+}
+
+// ── FlowRegistry tests ──
+
+func TestFlowRegistry(t *testing.T) {
+	t.Parallel()
+	d, err := NewEntraDelegator(EntraDelegatorConfig{
+		TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret, ClientSecret: "s",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, d.flowRegistry.Has("obo"))
+	assert.True(t, d.flowRegistry.Has("client_credentials"))
+
+	fn, err := d.flowRegistry.Select("user")
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
+
+	fn, err = d.flowRegistry.Select("app")
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
+
+	fn, err = d.flowRegistry.Select("")
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
+}
+
+// ── Shared test helpers ──
+
+func authContext(token, idType string) context.Context {
+	ctx := middleware.WithAccessToken(context.Background(), token)
+	claims := &middleware.AuthClaims{IDType: idType}
+	return middleware.WithAuthClaims(ctx, claims)
+}
+
+func mustDelegator(t *testing.T, credType CredentialType, credVal string) *EntraDelegator {
+	t.Helper()
+	cfg := EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: credType}
+	if credType == CredentialTypeSecret {
+		cfg.ClientSecret = credVal
+	} else {
+		cfg.FederatedTokenFile = credVal
+	}
+	d, err := NewEntraDelegator(cfg)
+	require.NoError(t, err)
+	return d
+}
+
+func mustDelegatorWithURL(t *testing.T, credVal, tokenURL string) *EntraDelegator {
+	t.Helper()
+	cfg := EntraDelegatorConfig{TenantID: "t", ClientID: "c", CredentialType: CredentialTypeSecret}
+	cfg.ClientSecret = credVal
+	client := httpc.NewClient(nil)
+	registry := NewFlowRegistry()
+	registry.Register("obo", oboFlow(tokenURL, &SecretCredential{Secret: credVal}, client))
+	registry.Register("client_credentials", clientCredentialFlow(tokenURL, &SecretCredential{Secret: credVal}, client))
+	d, err := NewEntraDelegator(cfg, WithHTTPClient(client), WithFlowRegistry(registry))
+	require.NoError(t, err)
+	return d
+}
+
+func fakeTokenEndpoint(t *testing.T, status int, body any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+type failingCredential struct{}
+
+func (f *failingCredential) Apply(_ url.Values) error {
+	return fmt.Errorf("credential failure")
+}
+
+// spyStore is a test Store that tracks Get/Set calls via atomic counters.
+type spyStore[K comparable, V any] struct {
+	gets    atomic.Int32
+	sets    atomic.Int32
+	lastTTL time.Duration
+	data    map[K]V
+}
+
+func (s *spyStore[K, V]) Get(_ context.Context, key K) (V, bool) {
+	s.gets.Add(1)
+	if s.data != nil {
+		if v, ok := s.data[key]; ok {
+			return v, true
+		}
+	}
+	var zero V
+	return zero, false
+}
+
+func (s *spyStore[K, V]) Set(_ context.Context, key K, value V, ttl time.Duration) {
+	s.sets.Add(1)
+	s.lastTTL = ttl
+	if s.data == nil {
+		s.data = make(map[K]V)
+	}
+	s.data[key] = value
+}
+
+func TestNewEntraDelegatorFromConfig(t *testing.T) {
+	t.Run("nil config returns error", func(t *testing.T) {
+		_, err := NewEntraDelegatorFromConfig(context.Background(), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "APIEntraIdentityConfig is required")
+	})
+
+	t.Run("invalid credential type returns error", func(t *testing.T) {
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type: "invalid",
+			},
+		}
+		_, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential:")
+	})
+
+	t.Run("invalid allowed flows returns error", func(t *testing.T) {
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_SECRET",
+			},
+			AllowedFlows: &config.DelegationFlowsConfig{
+				Flows: []string{"invalid_flow"},
+			},
+		}
+		_, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allowedFlows:")
+	})
+
+	t.Run("secret credential resolves from env", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET", "my-secret-value")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET",
+			},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, delegator)
+	})
+
+	t.Run("secret credential resolve failure returns error", func(t *testing.T) {
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://NONEXISTENT_VAR_FOR_TEST_XYZ",
+			},
+		}
+		_, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolving client secret:")
+	})
+
+	t.Run("wif credential wires token path", func(t *testing.T) {
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "wif",
+				WIFTokenPath: "/var/run/secrets/token",
+			},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, delegator)
+		assert.Nil(t, delegator.manager) // nil TokenManager = no caching
+	})
+
+	t.Run("nil TokenManager disables caching", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_MGR", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_MGR",
+			},
+			TokenManager: nil,
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.Nil(t, delegator.manager)
+	})
+
+	t.Run("non-nil TokenManager enables caching with defaults", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_MGR2", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_MGR2",
+			},
+			TokenManager: &config.TokenManagerConfig{},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, delegator.manager)
+	})
+
+	t.Run("TokenManager custom values are respected", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_MGR3", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_MGR3",
+			},
+			TokenManager: &config.TokenManagerConfig{
+				CacheSize:       2048,
+				ExpiryBuffer:    "1m",
+				CleanupInterval: "10m",
+				ExpiryThreshold: "15m",
+			},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, delegator.manager)
+	})
+
+	t.Run("nil AllowedFlows registers only obo", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_NIL_FLOWS", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_NIL_FLOWS",
+			},
+			AllowedFlows: nil, // default: OBO only
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.True(t, delegator.flowRegistry.Has("obo"))
+		assert.False(t, delegator.flowRegistry.Has("client_credentials"))
+	})
+
+	t.Run("explicit flows registers only listed", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_EXPLICIT", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_EXPLICIT",
+			},
+			AllowedFlows: &config.DelegationFlowsConfig{
+				Flows: []string{"obo", "client_credentials"},
+			},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.True(t, delegator.flowRegistry.Has("obo"))
+		assert.True(t, delegator.flowRegistry.Has("client_credentials"))
+	})
+
+	t.Run("empty flows denies all", func(t *testing.T) {
+		t.Setenv("TEST_DELEGATOR_SECRET_EMPTY", "s")
+
+		cfg := &config.APIEntraIdentityConfig{
+			TenantID: "tenant-id",
+			ClientID: "client-id",
+			Credential: config.ServerCredentialConfig{
+				Type:         "secret",
+				ClientSecret: "env://TEST_DELEGATOR_SECRET_EMPTY",
+			},
+			AllowedFlows: &config.DelegationFlowsConfig{
+				Flows: []string{},
+			},
+		}
+		delegator, err := NewEntraDelegatorFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.False(t, delegator.flowRegistry.Has("obo"))
+		assert.False(t, delegator.flowRegistry.Has("client_credentials"))
+
+		// DelegateToken should fail for any caller type
+		_, selectErr := delegator.flowRegistry.Select("user")
+		assert.Error(t, selectErr)
+		assert.Contains(t, selectErr.Error(), "not permitted")
+	})
+}
+
+func TestResolveTokenManagerDefaults(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("all zeros use defaults", func(t *testing.T) {
+		t.Parallel()
+		tm := &config.TokenManagerConfig{}
+		s, err := resolveTokenManagerDefaults(tm)
+		require.NoError(t, err)
+		assert.Equal(t, 1024, s.CacheSize)
+		assert.Equal(t, 10*time.Minute, s.ExpiryBuffer)
+		assert.Equal(t, 5*time.Minute, s.CleanupInterval)
+		assert.Equal(t, 30*time.Minute, s.ExpiryThreshold)
+		assert.Equal(t, 500*time.Millisecond, s.SlowThreshold)
+		assert.True(t, s.RetryOnError)
+	})
+
+	t.Run("custom values override defaults", func(t *testing.T) {
+		t.Parallel()
+		tm := &config.TokenManagerConfig{
+			CacheSize:            512,
+			ExpiryBuffer:         "2m",
+			CleanupInterval:      "10m",
+			ExpiryThreshold:      "15m",
+			SlowThreshold:        "5s",
+			RetryFollowerOnError: boolPtr(false),
+		}
+		s, err := resolveTokenManagerDefaults(tm)
+		require.NoError(t, err)
+		assert.Equal(t, 512, s.CacheSize)
+		assert.Equal(t, 2*time.Minute, s.ExpiryBuffer)
+		assert.Equal(t, 10*time.Minute, s.CleanupInterval)
+		assert.Equal(t, 15*time.Minute, s.ExpiryThreshold)
+		assert.Equal(t, 5*time.Second, s.SlowThreshold)
+		assert.False(t, s.RetryOnError)
+	})
+
+	t.Run("invalid durations return error", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name    string
+			cfg     *config.TokenManagerConfig
+			wantMsg string
+		}{
+			{"bad expiryBuffer", &config.TokenManagerConfig{ExpiryBuffer: "not-a-duration"}, "expiryBuffer"},
+			{"bad cleanupInterval", &config.TokenManagerConfig{CleanupInterval: "also-bad"}, "cleanupInterval"},
+			{"bad expiryThreshold", &config.TokenManagerConfig{ExpiryThreshold: "nope"}, "expiryThreshold"},
+			{"bad slowThreshold", &config.TokenManagerConfig{SlowThreshold: "bad"}, "slowThreshold"},
+		}
+		for _, tc := range cases {
+			_, err := resolveTokenManagerDefaults(tc.cfg)
+			require.Error(t, err, tc.name)
+			assert.Contains(t, err.Error(), tc.wantMsg, tc.name)
+		}
+	})
+
+	t.Run("partial override keeps other defaults", func(t *testing.T) {
+		t.Parallel()
+		tm := &config.TokenManagerConfig{
+			ExpiryThreshold:      "45m",
+			RetryFollowerOnError: boolPtr(true),
+		}
+		s, err := resolveTokenManagerDefaults(tm)
+		require.NoError(t, err)
+		assert.Equal(t, 1024, s.CacheSize)
+		assert.Equal(t, 10*time.Minute, s.ExpiryBuffer)
+		assert.Equal(t, 5*time.Minute, s.CleanupInterval)
+		assert.Equal(t, 45*time.Minute, s.ExpiryThreshold)
+		assert.Equal(t, 500*time.Millisecond, s.SlowThreshold)
+		assert.True(t, s.RetryOnError)
+	})
+}

--- a/pkg/authdelegation/errors.go
+++ b/pkg/authdelegation/errors.go
@@ -1,0 +1,17 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import "fmt"
+
+var (
+	ErrEntraNoTenantID            = fmt.Errorf("tenant ID is required")
+	ErrEntraNoClientID            = fmt.Errorf("client ID is required")
+	ErrEntraNoCredential          = fmt.Errorf("at least one credential is required (federatedTokenFile or clientSecret)")
+	ErrEntraInvalidCredentialType = fmt.Errorf("credentialType must be %q or %q", CredentialTypeWIF, CredentialTypeSecret)
+	ErrEntraWIFMissingTokenFile   = fmt.Errorf("federatedTokenFile is required when credentialType is %q", CredentialTypeWIF)
+	ErrEntraSecretMissing         = fmt.Errorf("clientSecret is required when credentialType is %q", CredentialTypeSecret)
+	ErrNoCallerToken              = fmt.Errorf("no caller token in context")
+	ErrNoScope                    = fmt.Errorf("scope is required for token delegation")
+)

--- a/pkg/authdelegation/flows.go
+++ b/pkg/authdelegation/flows.go
@@ -1,0 +1,169 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	httpc "github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	grantTypeJWTBearer   = "urn:ietf:params:oauth:grant-type:jwt-bearer" //nolint:gosec // G101 -- OAuth grant_type parameter value, not a credential
+	grantTypeClientCreds = "client_credentials"
+	requestedTokenUseOBO = "on_behalf_of"
+	contentTypeForm      = "application/x-www-form-urlencoded"
+)
+
+// FlowFn executes a token delegation flow.
+type FlowFn func(ctx context.Context, params FlowParams) (TokenResult, error)
+
+// FlowParams holds the per-request inputs a flow needs to build its request.
+type FlowParams struct {
+	CallerToken string // the inbound bearer token (assertion for OBO)
+	Scope       string // desired downstream scope
+	ClientID    string // optional client ID override (for multi-tenant delegation)
+}
+
+// oboFlow returns a FlowFn that performs the On-Behalf-Of flow.
+func oboFlow(tokenURL string, cred ServerCredential, client *httpc.Client) FlowFn {
+	return func(ctx context.Context, params FlowParams) (TokenResult, error) {
+		v := url.Values{
+			"grant_type":          {grantTypeJWTBearer},
+			"client_id":           {params.ClientID},
+			"assertion":           {params.CallerToken},
+			"scope":               {params.Scope},
+			"requested_token_use": {requestedTokenUseOBO},
+		}
+		if err := cred.Apply(v); err != nil {
+			return TokenResult{}, fmt.Errorf("applying server credential: %w", err)
+		}
+		return executeTokenRequest(ctx, client, tokenURL, v)
+	}
+}
+
+func clientCredentialFlow(tokenURL string, cred ServerCredential, client *httpc.Client) FlowFn {
+	return func(ctx context.Context, params FlowParams) (TokenResult, error) {
+		v := url.Values{
+			"grant_type": {grantTypeClientCreds},
+			"client_id":  {params.ClientID},
+			"scope":      {params.Scope},
+		}
+		if err := cred.Apply(v); err != nil {
+			return TokenResult{}, fmt.Errorf("applying server credential: %w", err)
+		}
+		return executeTokenRequest(ctx, client, tokenURL, v)
+	}
+}
+
+func executeTokenRequest(ctx context.Context, client *httpc.Client, tokenURL string, params url.Values) (TokenResult, error) {
+	log := logger.FromContext(ctx)
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("building token request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentTypeForm)
+
+	log.V(2).Info("token endpoint request", "url", tokenURL, "grantType", params.Get("grant_type"), "scope", params.Get("scope"))
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("token endpoint request failed: %w", err)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("reading token response: %w", err)
+	}
+
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		log.Info("token endpoint error", "status", resp.StatusCode, "elapsed", elapsed)
+		detail := string(body)
+		if len(detail) > 512 {
+			detail = detail[:512] + "...(truncated)"
+		}
+		return TokenResult{}, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, detail)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return TokenResult{}, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	accessToken, _ := response["access_token"].(string)
+	if accessToken == "" {
+		return TokenResult{}, fmt.Errorf("token response missing access_token")
+	}
+
+	var expiresIn int64
+	if exp, ok := response["expires_in"].(float64); ok {
+		expiresIn = int64(exp)
+	}
+
+	log.V(1).Info("token endpoint success", "elapsed", elapsed, "expiresIn", expiresIn)
+
+	return TokenResult{
+		AccessToken: accessToken,
+		ExpiresIn:   expiresIn,
+	}, nil
+}
+
+// FlowRegistry holds the permitted delegation flows by name.
+// Only flows explicitly registered can be executed.
+//
+// FlowRegistry is NOT safe for concurrent use. All Register calls must
+// complete before any Select or Has calls (write-at-init, read-at-request).
+type FlowRegistry struct {
+	flows map[string]FlowFn
+}
+
+// NewFlowRegistry creates an empty FlowRegistry.
+func NewFlowRegistry() *FlowRegistry {
+	return &FlowRegistry{flows: make(map[string]FlowFn)}
+}
+
+// Register adds a flow function under the given name.
+func (r *FlowRegistry) Register(name string, fn FlowFn) {
+	r.flows[name] = fn
+}
+
+// Select returns the flow function for the given caller type.
+// Returns an error if the resolved flow is not registered.
+func (r *FlowRegistry) Select(callerType string) (FlowFn, error) {
+	name := FlowNameForCaller(callerType)
+	fn, ok := r.flows[name]
+	if !ok {
+		return nil, fmt.Errorf("delegation flow %q is not permitted", name)
+	}
+	return fn, nil
+}
+
+// Has reports whether the named flow is registered.
+func (r *FlowRegistry) Has(name string) bool {
+	_, ok := r.flows[name]
+	return ok
+}
+
+// FlowNameForCaller maps a caller type to its delegation flow name.
+func FlowNameForCaller(callerType string) string {
+	if callerType == "user" {
+		return "obo"
+	}
+	return "client_credentials"
+}

--- a/pkg/authdelegation/flows_test.go
+++ b/pkg/authdelegation/flows_test.go
@@ -1,0 +1,85 @@
+package authdelegation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOBOFlow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends correct form params", func(t *testing.T) {
+		t.Parallel()
+		var captured url.Values
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			captured = r.PostForm
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "tok", "token_type": "Bearer", "expires_in": 60, "scope": "s",
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		flow := oboFlow(srv.URL, &SecretCredential{Secret: "my-secret"}, httpc.NewClient(nil))
+		_, err := flow(context.Background(), FlowParams{CallerToken: "jwt123", Scope: "api/.default", ClientID: "my-client"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", captured.Get("grant_type"))
+		assert.Equal(t, "my-client", captured.Get("client_id"))
+		assert.Equal(t, "jwt123", captured.Get("assertion"))
+		assert.Equal(t, "api/.default", captured.Get("scope"))
+		assert.Equal(t, "on_behalf_of", captured.Get("requested_token_use"))
+		assert.Equal(t, "my-secret", captured.Get("client_secret"))
+	})
+
+	t.Run("credential apply error", func(t *testing.T) {
+		t.Parallel()
+		flow := oboFlow("http://unused", &failingCredential{}, httpc.NewClient(nil))
+		_, err := flow(context.Background(), FlowParams{CallerToken: "t", Scope: "s"})
+		assert.ErrorContains(t, err, "applying server credential")
+	})
+}
+
+func TestClientCredentialFlow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends correct form params", func(t *testing.T) {
+		t.Parallel()
+		var captured url.Values
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			captured = r.PostForm
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "cc-tok", "token_type": "Bearer", "expires_in": 3600, "scope": "api/.default",
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		flow := clientCredentialFlow(srv.URL, &SecretCredential{Secret: "my-secret"}, httpc.NewClient(nil))
+		_, err := flow(context.Background(), FlowParams{CallerToken: "ignored", Scope: "api/.default", ClientID: "my-client"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "client_credentials", captured.Get("grant_type"))
+		assert.Equal(t, "my-client", captured.Get("client_id"))
+		assert.Equal(t, "api/.default", captured.Get("scope"))
+		assert.Equal(t, "my-secret", captured.Get("client_secret"))
+		assert.Empty(t, captured.Get("assertion"))
+	})
+
+	t.Run("credential apply error", func(t *testing.T) {
+		t.Parallel()
+		flow := clientCredentialFlow("http://unused", &failingCredential{}, httpc.NewClient(nil))
+		_, err := flow(context.Background(), FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"})
+		assert.ErrorContains(t, err, "applying server credential")
+	})
+}

--- a/pkg/authdelegation/keygen.go
+++ b/pkg/authdelegation/keygen.go
@@ -1,0 +1,81 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// KeyGenerator produces a cache key from flow parameters.
+// Returns the key and true on success, or the zero value and false if inputs are insufficient.
+type KeyGenerator[K comparable] func(params FlowParams, hashFunc func(string) (string, bool)) (K, bool)
+
+// OBOKeyGenerator produces a cache key for OBO flows: "obo|clientID|scope|hash(callerToken)".
+func OBOKeyGenerator(params FlowParams, hashFunc func(string) (string, bool)) (string, bool) {
+	if hashFunc == nil {
+		hashFunc = SHA256Hash
+	}
+	if params.CallerToken == "" || params.Scope == "" || params.ClientID == "" {
+		return "", false
+	}
+	hashedToken, ok := hashFunc(params.CallerToken)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString("obo|")
+	b.WriteString(params.ClientID)
+	b.WriteString("|")
+	b.WriteString(params.Scope)
+	b.WriteString("|")
+	b.WriteString(hashedToken)
+	return b.String(), true
+}
+
+// ClientCredKeyGenerator produces a cache key for client_credentials flows: "cc|clientID|scope".
+func ClientCredKeyGenerator(params FlowParams, _ func(string) (string, bool)) (string, bool) {
+	if params.ClientID == "" || params.Scope == "" {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString("cc|")
+	b.WriteString(params.ClientID)
+	b.WriteString("|")
+	b.WriteString(params.Scope)
+	return b.String(), true
+}
+
+// NoOpKeyGenerator always returns ("", false), disabling caching.
+func NoOpKeyGenerator(_ FlowParams, _ func(string) (string, bool)) (string, bool) {
+	return "", false
+}
+
+// GetKeyGenerator selects the appropriate key generator based on the caller type.
+func GetKeyGenerator(callerType string) KeyGenerator[string] {
+	switch callerType {
+	case "user":
+		return OBOKeyGenerator
+	case "app":
+		return ClientCredKeyGenerator
+	default:
+		return NoOpKeyGenerator
+	}
+}
+
+// GenerateKey is a convenience wrapper that selects and invokes the key generator.
+func GenerateKey(callerType string, params FlowParams) (string, bool) {
+	keyGen := GetKeyGenerator(callerType)
+	return keyGen(params, nil)
+}
+
+// SHA256Hash returns the hex-encoded SHA-256 hash of the input.
+func SHA256Hash(input string) (string, bool) {
+	if input == "" {
+		return "", false
+	}
+	h := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%x", h[:]), true
+}

--- a/pkg/authdelegation/keygen_bench_test.go
+++ b/pkg/authdelegation/keygen_bench_test.go
@@ -1,0 +1,49 @@
+package authdelegation
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkOBOKeyGenerator(b *testing.B) {
+	b.ReportAllocs()
+
+	// Simulate a realistic ~1KB JWT token
+	token := strings.Repeat("eyJhbGciOiJSUzI1NiJ9.", 40)
+	params := FlowParams{
+		CallerToken: token,
+		Scope:       "api://my-app/.default",
+		ClientID:    "550e8400-e29b-41d4-a716-446655440000",
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = OBOKeyGenerator(params, nil)
+	}
+}
+
+func BenchmarkClientCredKeyGenerator(b *testing.B) {
+	b.ReportAllocs()
+
+	params := FlowParams{
+		Scope:    "api://my-app/.default",
+		ClientID: "550e8400-e29b-41d4-a716-446655440000",
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = ClientCredKeyGenerator(params, nil)
+	}
+}
+
+func BenchmarkSHA256Hash(b *testing.B) {
+	b.ReportAllocs()
+
+	// Realistic JWT size (~1KB)
+	token := strings.Repeat("eyJhbGciOiJSUzI1NiJ9.", 40)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = SHA256Hash(token)
+	}
+}

--- a/pkg/authdelegation/keygen_test.go
+++ b/pkg/authdelegation/keygen_test.go
@@ -1,0 +1,158 @@
+package authdelegation
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOBOKeyGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces correct key format", func(t *testing.T) {
+		t.Parallel()
+		params := FlowParams{CallerToken: "my-jwt", Scope: "api/.default", ClientID: "client-1"}
+		key, ok := OBOKeyGenerator(params, nil)
+		assert.True(t, ok)
+
+		expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte("my-jwt")))
+		assert.Equal(t, "obo|client-1|api/.default|"+expectedHash, key)
+	})
+
+	t.Run("uses custom hash func", func(t *testing.T) {
+		t.Parallel()
+		fakeHash := func(s string) (string, bool) { return "hashed-" + s, true }
+		params := FlowParams{CallerToken: "tok", Scope: "s", ClientID: "c"}
+		key, ok := OBOKeyGenerator(params, fakeHash)
+		assert.True(t, ok)
+		assert.Equal(t, "obo|c|s|hashed-tok", key)
+	})
+
+	t.Run("empty caller token returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := OBOKeyGenerator(FlowParams{Scope: "s", ClientID: "c"}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty scope returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := OBOKeyGenerator(FlowParams{CallerToken: "t", ClientID: "c"}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty client ID returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := OBOKeyGenerator(FlowParams{CallerToken: "t", Scope: "s"}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("hash failure returns false", func(t *testing.T) {
+		t.Parallel()
+		failHash := func(_ string) (string, bool) { return "", false }
+		params := FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"}
+		_, ok := OBOKeyGenerator(params, failHash)
+		assert.False(t, ok)
+	})
+}
+
+func TestClientCredKeyGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces correct key format", func(t *testing.T) {
+		t.Parallel()
+		params := FlowParams{ClientID: "client-1", Scope: "api/.default"}
+		key, ok := ClientCredKeyGenerator(params, nil)
+		assert.True(t, ok)
+		assert.Equal(t, "cc|client-1|api/.default", key)
+	})
+
+	t.Run("empty client ID returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ClientCredKeyGenerator(FlowParams{Scope: "s"}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty scope returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ClientCredKeyGenerator(FlowParams{ClientID: "c"}, nil)
+		assert.False(t, ok)
+	})
+}
+
+func TestNoOpKeyGenerator(t *testing.T) {
+	t.Parallel()
+	_, ok := NoOpKeyGenerator(FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"}, nil)
+	assert.False(t, ok)
+}
+
+func TestGetKeyGenerator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callerType string
+		params     FlowParams
+		wantOK     bool
+		wantPrefix string
+	}{
+		{"user routes to OBO", "user", FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"}, true, "obo|"},
+		{"app routes to CC", "app", FlowParams{ClientID: "c", Scope: "s"}, true, "cc|"},
+		{"unknown routes to NoOp", "unknown", FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"}, false, ""},
+		{"empty routes to NoOp", "", FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"}, false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			keyGen := GetKeyGenerator(tc.callerType)
+			key, ok := keyGen(tc.params, nil)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Contains(t, key, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestGenerateKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("user caller", func(t *testing.T) {
+		t.Parallel()
+		key, ok := GenerateKey("user", FlowParams{CallerToken: "jwt", Scope: "s", ClientID: "c"})
+		assert.True(t, ok)
+		assert.Contains(t, key, "obo|c|s|")
+	})
+
+	t.Run("app caller", func(t *testing.T) {
+		t.Parallel()
+		key, ok := GenerateKey("app", FlowParams{ClientID: "c", Scope: "s"})
+		assert.True(t, ok)
+		assert.Equal(t, "cc|c|s", key)
+	})
+
+	t.Run("unknown caller", func(t *testing.T) {
+		t.Parallel()
+		_, ok := GenerateKey("unknown", FlowParams{CallerToken: "t", Scope: "s", ClientID: "c"})
+		assert.False(t, ok)
+	})
+}
+
+func TestSHA256Hash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hashes non-empty input", func(t *testing.T) {
+		t.Parallel()
+		h, ok := SHA256Hash("hello")
+		assert.True(t, ok)
+		expected := fmt.Sprintf("%x", sha256.Sum256([]byte("hello")))
+		assert.Equal(t, expected, h)
+	})
+
+	t.Run("empty input returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := SHA256Hash("")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/authdelegation/middleware.go
+++ b/pkg/authdelegation/middleware.go
@@ -1,0 +1,21 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import "net/http"
+
+// Middleware returns an HTTP middleware that injects the given
+// DelegatorRegistry into every request's context. If reg is nil the
+// middleware is a no-op passthrough.
+func Middleware(reg *DelegatorRegistry) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if reg == nil {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := WithRegistry(r.Context(), reg)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/pkg/authdelegation/middleware_test.go
+++ b/pkg/authdelegation/middleware_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware_InjectsRegistry(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	reg.Register("entra", &mockDelegator{name: "entra"})
+
+	var got *DelegatorRegistry
+	handler := Middleware(reg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = RegistryFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.NotNil(t, got)
+	assert.Same(t, reg, got)
+}
+
+func TestMiddleware_NilRegistry_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		got := RegistryFromContext(r.Context())
+		assert.Nil(t, got)
+	})
+
+	handler := Middleware(nil)(inner)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.True(t, called)
+}

--- a/pkg/authdelegation/passthrough.go
+++ b/pkg/authdelegation/passthrough.go
@@ -1,0 +1,45 @@
+package authdelegation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+)
+
+const PassThroughDelegatorPrefix = "passThrough:"
+
+var _ TokenDelegator = (*PassThroughDelegator)(nil)
+
+type PassThroughDelegator struct {
+	provider string
+}
+
+func (d *PassThroughDelegator) Name() string {
+	return "passThrough:" + d.provider
+}
+
+func NewPassThroughDelegator(provider string) (*PassThroughDelegator, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("provider is required")
+	}
+	return &PassThroughDelegator{provider: provider}, nil
+}
+
+func (d *PassThroughDelegator) DelegateToken(ctx context.Context, _ string) (TokenResult, error) {
+	if ctx == nil {
+		return TokenResult{}, fmt.Errorf("context is required for token passthrough")
+	}
+
+	token := middleware.TokensFromContext(ctx)[d.provider]
+	if token == "" {
+		return TokenResult{}, fmt.Errorf("token for provider %q not found in context", d.provider)
+	}
+
+	return TokenResult{AccessToken: token}, nil
+}
+
+func PassThroughDelegatorName(provider string) string {
+	return PassThroughDelegatorPrefix + http.CanonicalHeaderKey(provider)
+}

--- a/pkg/authdelegation/passthrough_test.go
+++ b/pkg/authdelegation/passthrough_test.go
@@ -1,0 +1,77 @@
+package authdelegation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPassThroughDelegator(t *testing.T) {
+	t.Parallel()
+	t.Run("returns token for configured provider", func(t *testing.T) {
+		t.Parallel()
+		delegator, err := NewPassThroughDelegator("Github")
+		require.NoError(t, err)
+
+		handler := middleware.TokenPassthrough([]string{"Github"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			result, err := delegator.DelegateToken(r.Context(), "ignored-scope")
+
+			require.NoError(t, err)
+			assert.Equal(t, TokenResult{AccessToken: "ghp_123456"}, result)
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%s%s", middleware.TokenHeaderPrefix, "Github"), "ghp_123456")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("constructor rejects empty provider", func(t *testing.T) {
+		t.Parallel()
+		delegator, err := NewPassThroughDelegator("")
+
+		require.Error(t, err)
+		assert.Nil(t, delegator)
+		assert.Contains(t, err.Error(), "provider is required")
+	})
+
+	t.Run("returns error when token is missing from context", func(t *testing.T) {
+		t.Parallel()
+		delegator, err := NewPassThroughDelegator("Github")
+		require.NoError(t, err)
+
+		handler := middleware.TokenPassthrough([]string{"Github"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			result, err := delegator.DelegateToken(r.Context(), "")
+
+			require.Error(t, err)
+			assert.Empty(t, result.AccessToken)
+			assert.Contains(t, err.Error(), `token for provider "Github" not found`)
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("does not return a different provider token", func(t *testing.T) {
+		t.Parallel()
+		delegator, err := NewPassThroughDelegator("Azure-Ad")
+		require.NoError(t, err)
+
+		handler := middleware.TokenPassthrough([]string{"Github", "Azure-Ad"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			result, err := delegator.DelegateToken(r.Context(), "")
+
+			require.Error(t, err)
+			assert.Empty(t, result.AccessToken)
+			assert.Contains(t, err.Error(), `token for provider "Azure-Ad" not found`)
+		}))
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+		req.Header.Set(fmt.Sprintf("%s%s", middleware.TokenHeaderPrefix, "Github"), "ghp_123456")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+}

--- a/pkg/authdelegation/registry.go
+++ b/pkg/authdelegation/registry.go
@@ -1,0 +1,123 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// DelegatorRegistry maps auth provider names to TokenDelegator implementations.
+// Registration happens at server startup; lookups happen per-request concurrently.
+type DelegatorRegistry struct {
+	mu         sync.RWMutex
+	delegators map[string]TokenDelegator
+}
+
+// NewDelegatorRegistry creates an empty registry.
+func NewDelegatorRegistry() *DelegatorRegistry {
+	return &DelegatorRegistry{delegators: make(map[string]TokenDelegator)}
+}
+
+// Register adds a delegator under the given name.
+// Panics if name is empty (startup-time programming error).
+func (r *DelegatorRegistry) Register(name string, d TokenDelegator) {
+	if name == "" {
+		panic("authdelegation: Register called with empty name")
+	}
+	r.mu.Lock()
+	r.delegators[name] = d
+	r.mu.Unlock()
+}
+
+// Get returns the delegator registered under name.
+// Returns nil, false if no delegator is registered for that name.
+func (r *DelegatorRegistry) Get(name string) (TokenDelegator, bool) {
+	r.mu.RLock()
+	d, ok := r.delegators[name]
+	r.mu.RUnlock()
+	return d, ok
+}
+
+// Has reports whether a delegator is registered under name.
+func (r *DelegatorRegistry) Has(name string) bool {
+	r.mu.RLock()
+	_, ok := r.delegators[name]
+	r.mu.RUnlock()
+	return ok
+}
+
+// Names returns a sorted list of all registered delegator names.
+func (r *DelegatorRegistry) Names() []string {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.delegators))
+	for name := range r.delegators {
+		names = append(names, name)
+	}
+	r.mu.RUnlock()
+	sort.Strings(names)
+	return names
+}
+
+func BuildDelegationRegistry(ctx context.Context, cfg *config.APIServerConfig, lgr *logr.Logger) (*DelegatorRegistry, error) {
+	reg := NewDelegatorRegistry()
+
+	err := registerEntraDelegator(ctx, cfg, lgr, reg)
+	if err != nil {
+		return nil, fmt.Errorf("building Entra delegator: %w", err)
+	}
+	err = registerPassThroughDelegators(cfg, lgr, reg)
+	if err != nil {
+		return nil, fmt.Errorf("building pass-through delegators: %w", err)
+	}
+	if len(reg.Names()) == 0 {
+		return nil, nil
+	}
+	return reg, nil
+}
+
+func registerEntraDelegator(ctx context.Context, cfg *config.APIServerConfig, lgr *logr.Logger, reg *DelegatorRegistry) error {
+	if cfg.Identity.Entra == nil {
+		return nil
+	}
+	if err := cfg.Identity.Entra.Validate(); err != nil {
+		return fmt.Errorf("invalid Entra identity configuration: %w", err)
+	}
+
+	lgr.V(0).Info("building token delegation registry", "provider", "entra")
+
+	delegator, err := NewEntraDelegatorFromConfig(ctx, cfg.Identity.Entra)
+	if err != nil {
+		return fmt.Errorf("entra delegator: %w", err)
+	}
+
+	reg.Register("entra", delegator)
+	return nil
+}
+
+func registerPassThroughDelegators(cfg *config.APIServerConfig, lgr *logr.Logger, reg *DelegatorRegistry) error {
+	allowedHeaders := cfg.TokenPassThroughAllowedHeaders()
+
+	if cfg.TokenPassThrough != nil {
+		if err := cfg.TokenPassThrough.Validate(); err != nil {
+			return fmt.Errorf("invalid token pass-through configuration: %w", err)
+		}
+	}
+
+	for _, header := range allowedHeaders {
+		delegator, err := NewPassThroughDelegator(header)
+		if err != nil {
+			return fmt.Errorf("creating pass-through delegator for header %q: %w", header, err)
+		}
+		name := PassThroughDelegatorName(header)
+		reg.Register(name, delegator)
+		lgr.V(0).Info("registered token pass-through delegator", "provider", name, "header", header)
+	}
+	return nil
+}

--- a/pkg/authdelegation/registry_test.go
+++ b/pkg/authdelegation/registry_test.go
@@ -1,0 +1,184 @@
+package authdelegation
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDelegator implements TokenDelegator for testing.
+type mockDelegator struct {
+	name string
+}
+
+func (m *mockDelegator) Name() string {
+	return m.name
+}
+
+func (m *mockDelegator) DelegateToken(_ context.Context, _ string) (TokenResult, error) {
+	return TokenResult{AccessToken: m.name + "-token", ExpiresIn: 3600}, nil
+}
+
+func TestNewDelegatorRegistry(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	require.NotNil(t, reg)
+	assert.False(t, reg.Has("anything"))
+	assert.Empty(t, reg.Names())
+}
+
+func TestDelegatorRegistry_RegisterAndGet(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	mock := &mockDelegator{name: "entra"}
+	reg.Register("entra", mock)
+
+	got, ok := reg.Get("entra")
+	require.True(t, ok)
+	assert.Same(t, mock, got)
+}
+
+func TestDelegatorRegistry_GetUnknown(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	got, ok := reg.Get("nonexistent")
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestDelegatorRegistry_Has(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	reg.Register("gcp", &mockDelegator{name: "gcp"})
+
+	assert.True(t, reg.Has("gcp"))
+	assert.False(t, reg.Has("entra"))
+}
+
+func TestDelegatorRegistry_Names(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	reg.Register("gcp", &mockDelegator{name: "gcp"})
+	reg.Register("entra", &mockDelegator{name: "entra"})
+	reg.Register("github", &mockDelegator{name: "github"})
+
+	names := reg.Names()
+	assert.Equal(t, []string{"entra", "gcp", "github"}, names)
+}
+
+func TestDelegatorRegistry_RegisterOverwrites(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	first := &mockDelegator{name: "first"}
+	second := &mockDelegator{name: "second"}
+
+	reg.Register("entra", first)
+	reg.Register("entra", second)
+
+	got, ok := reg.Get("entra")
+	require.True(t, ok)
+	assert.Same(t, second, got)
+}
+
+func TestDelegatorRegistry_RegisterEmptyNamePanics(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	assert.Panics(t, func() {
+		reg.Register("", &mockDelegator{name: "x"})
+	})
+}
+
+func TestDelegatorRegistry_ConcurrentGet(t *testing.T) {
+	t.Parallel()
+	reg := NewDelegatorRegistry()
+	reg.Register("entra", &mockDelegator{name: "entra"})
+	reg.Register("gcp", &mockDelegator{name: "gcp"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = reg.Get("entra")
+			_ = reg.Has("gcp")
+			_ = reg.Names()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRegisterPassThroughDelegators_Default(t *testing.T) {
+	reg := NewDelegatorRegistry()
+	lgr := logr.Discard()
+
+	err := registerPassThroughDelegators(&config.APIServerConfig{}, &lgr, reg)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"passThrough:Github"}, reg.Names())
+}
+
+func TestRegisterPassThroughDelegators_ConfiguredHeaders(t *testing.T) {
+	reg := NewDelegatorRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			TokenPassThrough: &config.TokenPassThroughConfig{
+				AllowedHeaders: []string{"Github", "Azure-Ad"},
+			},
+		},
+	}
+
+	err := registerPassThroughDelegators(&cfg.APIServer, &lgr, reg)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"passThrough:Azure-Ad", "passThrough:Github"}, reg.Names())
+}
+
+func TestRegisterPassThroughDelegators_ExplicitEmpty(t *testing.T) {
+	reg := NewDelegatorRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			TokenPassThrough: &config.TokenPassThroughConfig{
+				AllowedHeaders: []string{},
+			},
+		},
+	}
+
+	err := registerPassThroughDelegators(&cfg.APIServer, &lgr, reg)
+
+	require.NoError(t, err)
+	assert.Empty(t, reg.Names())
+}
+
+func TestBuildDelegationRegistry_NoDelegators(t *testing.T) {
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			TokenPassThrough: &config.TokenPassThroughConfig{
+				AllowedHeaders: []string{},
+			},
+		},
+	}
+
+	reg, err := BuildDelegationRegistry(context.Background(), &cfg.APIServer, &lgr)
+
+	require.NoError(t, err)
+	assert.Nil(t, reg)
+}
+
+func TestBuildDelegationRegistry_DefaultPassThrough(t *testing.T) {
+	lgr := logr.Discard()
+
+	reg, err := BuildDelegationRegistry(context.Background(), &config.APIServerConfig{}, &lgr)
+
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	assert.Equal(t, []string{"passThrough:Github"}, reg.Names())
+}

--- a/pkg/authdelegation/tokencache.go
+++ b/pkg/authdelegation/tokencache.go
@@ -1,0 +1,34 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authdelegation
+
+import (
+	"context"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cache"
+)
+
+type TokenCache[K comparable, V any] struct {
+	lrucache *cache.LRUWithTTL[K, V]
+}
+
+func (c *TokenCache[K, V]) Get(_ context.Context, key K) (V, bool) {
+	return c.lrucache.Get(key)
+}
+
+func (c *TokenCache[K, V]) Set(_ context.Context, key K, value V, ttl time.Duration) {
+	c.lrucache.Set(key, value, ttl)
+}
+
+func NewTokenCache[K comparable, V any](ctx context.Context, size int, expiryBuffer, cleanUpInterval time.Duration) *TokenCache[K, V] {
+	lruCache := cache.NewLRUWithTTL(
+		cache.WithSize[K, V](size),
+		cache.WithExpiryBuffer[K, V](expiryBuffer),
+	)
+	go lruCache.Cleanup(ctx, cleanUpInterval)
+	return &TokenCache[K, V]{
+		lrucache: lruCache,
+	}
+}

--- a/pkg/authdelegation/tokencache_bench_test.go
+++ b/pkg/authdelegation/tokencache_bench_test.go
@@ -1,0 +1,77 @@
+package authdelegation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkTokenCache_Get_Hit(b *testing.B) {
+	b.ReportAllocs()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 1024, 0, time.Hour)
+	token := TokenResult{AccessToken: "bench-token", ExpiresIn: 3600}
+	tc.Set(ctx, "bench-key", token, 10*time.Minute)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = tc.Get(ctx, "bench-key")
+	}
+}
+
+func BenchmarkTokenCache_Get_Miss(b *testing.B) {
+	b.ReportAllocs()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 1024, 0, time.Hour)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = tc.Get(ctx, "nonexistent")
+	}
+}
+
+func BenchmarkTokenCache_Set(b *testing.B) {
+	b.ReportAllocs()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 1024, 0, time.Hour)
+	token := TokenResult{AccessToken: "bench-token", ExpiresIn: 3600}
+
+	b.ResetTimer()
+	for i := range b.N {
+		tc.Set(ctx, fmt.Sprintf("key-%d", i), token, 10*time.Minute)
+	}
+}
+
+func BenchmarkTokenCache_Get_Parallel(b *testing.B) {
+	b.ReportAllocs()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 1024, 0, time.Hour)
+	token := TokenResult{AccessToken: "bench-token", ExpiresIn: 3600}
+
+	// Pre-populate with entries to simulate warm cache
+	for i := range 100 {
+		tc.Set(ctx, fmt.Sprintf("key-%d", i), token, 10*time.Minute)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = tc.Get(ctx, fmt.Sprintf("key-%d", i%100))
+			i++
+		}
+	})
+}

--- a/pkg/authdelegation/tokencache_test.go
+++ b/pkg/authdelegation/tokencache_test.go
@@ -1,0 +1,83 @@
+package authdelegation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenCache_GetSet_RoundTrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 10, 0, time.Hour)
+
+	token := TokenResult{
+		AccessToken: "abc123",
+		ExpiresIn:   3600,
+	}
+
+	tc.Set(ctx, "key1", token, 5*time.Minute)
+
+	got, ok := tc.Get(ctx, "key1")
+	assert.True(t, ok)
+	assert.Equal(t, token, got)
+}
+
+func TestTokenCache_Get_Miss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 10, 0, time.Hour)
+
+	got, ok := tc.Get(ctx, "nonexistent")
+	assert.False(t, ok)
+	assert.Equal(t, TokenResult{}, got)
+}
+
+func TestTokenCache_TTLExpiry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := NewTokenCache[string, TokenResult](ctx, 10, 0, 10*time.Millisecond)
+
+	token := TokenResult{
+		AccessToken: "expires-soon",
+		ExpiresIn:   1,
+	}
+
+	tc.Set(ctx, "ephemeral", token, 50*time.Millisecond)
+
+	got, ok := tc.Get(ctx, "ephemeral")
+	assert.True(t, ok)
+	assert.Equal(t, token, got)
+
+	// Wait for TTL + cleanup interval to pass
+	time.Sleep(100 * time.Millisecond)
+
+	got, ok = tc.Get(ctx, "ephemeral")
+	assert.False(t, ok)
+	assert.Equal(t, TokenResult{}, got)
+}
+
+func TestNewTokenCache_CleanupRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tc := NewTokenCache[string, TokenResult](ctx, 10, 0, 10*time.Millisecond)
+
+	token := TokenResult{AccessToken: "test", ExpiresIn: 1}
+	tc.Set(ctx, "k", token, time.Hour)
+
+	// Cancel context — cleanup goroutine should exit without panic or leak
+	cancel()
+
+	// Give goroutine time to exit
+	time.Sleep(50 * time.Millisecond)
+
+	// Cache still returns the value (cancellation stops cleanup, not reads)
+	got, ok := tc.Get(context.Background(), "k")
+	assert.True(t, ok)
+	assert.Equal(t, token, got)
+}

--- a/pkg/cache/ttlcache.go
+++ b/pkg/cache/ttlcache.go
@@ -1,0 +1,215 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+const defaultSize = 1024
+
+// LRUWithTTL is a concurrency-safe, size-bounded LRU cache with per-entry TTL.
+type LRUWithTTL[K comparable, V any] struct {
+	mu           sync.RWMutex
+	size         int
+	expiryBuffer time.Duration // how much earlier than actual expiry an entry is considered stale
+	store        map[K]*list.Element
+	order        *list.List
+}
+
+type entry[K comparable, V any] struct {
+	key       K
+	value     V
+	expiresAt time.Time
+}
+
+func (e *entry[K, V]) isExpired(buffer time.Duration) bool {
+	return time.Now().After(e.expiresAt.Add(-buffer))
+}
+
+// Option configures an LRUWithTTL instance.
+type Option[K comparable, V any] func(*LRUWithTTL[K, V])
+
+// WithSize sets the maximum number of entries. Values <= 0 use the default (1024).
+func WithSize[K comparable, V any](size int) Option[K, V] {
+	return func(c *LRUWithTTL[K, V]) {
+		if size > 0 {
+			c.size = size
+		}
+	}
+}
+
+// WithExpiryBuffer sets how much earlier than actual expiry an entry is considered stale.
+func WithExpiryBuffer[K comparable, V any](d time.Duration) Option[K, V] {
+	return func(c *LRUWithTTL[K, V]) {
+		c.expiryBuffer = d
+	}
+}
+
+// NewLRUWithTTL creates a new LRU cache with TTL support.
+func NewLRUWithTTL[K comparable, V any](opts ...Option[K, V]) *LRUWithTTL[K, V] {
+	c := &LRUWithTTL[K, V]{
+		size:  defaultSize,
+		store: make(map[K]*list.Element),
+		order: list.New(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Get retrieves a value by key. Returns the zero value and false if the key
+// is missing or expired.
+func (c *LRUWithTTL[K, V]) Get(key K) (V, bool) {
+	c.mu.RLock()
+	elem, exists := c.store[key]
+	if !exists {
+		c.mu.RUnlock()
+		var zero V
+		return zero, false
+	}
+	if elem == nil || elem.Value == nil {
+		c.mu.RUnlock()
+		c.removeBadEntry(key, elem)
+		var zero V
+		return zero, false
+	}
+	e, ok := elem.Value.(*entry[K, V])
+	if !ok {
+		c.mu.RUnlock()
+		c.removeBadEntry(key, elem)
+		var zero V
+		return zero, false
+	}
+	if e.isExpired(c.expiryBuffer) {
+		c.mu.RUnlock()
+		c.removeEntry(key, elem)
+		var zero V
+		return zero, false
+	}
+	value := e.value
+	c.mu.RUnlock()
+
+	c.promote(elem)
+	return value, true
+}
+
+// Set inserts or updates a key with the given value and TTL.
+func (c *LRUWithTTL[K, V]) Set(key K, value V, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, exists := c.store[key]; exists && elem != nil {
+		c.order.MoveToFront(elem)
+		if e, ok := elem.Value.(*entry[K, V]); ok {
+			e.value = value
+			e.expiresAt = time.Now().Add(ttl)
+			return
+		}
+	}
+
+	e := &entry[K, V]{
+		key:       key,
+		value:     value,
+		expiresAt: time.Now().Add(ttl),
+	}
+	elem := c.order.PushFront(e)
+	c.store[key] = elem
+
+	if c.order.Len() > c.size {
+		c.evictOldest()
+	}
+}
+
+// Delete removes a key from the cache.
+func (c *LRUWithTTL[K, V]) Delete(key K) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, exists := c.store[key]; exists {
+		if elem != nil {
+			c.order.Remove(elem)
+		}
+		delete(c.store, key)
+	}
+}
+
+// Len returns the number of entries currently in the cache (including expired but not yet cleaned).
+func (c *LRUWithTTL[K, V]) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.order.Len()
+}
+
+// Cleanup runs periodic eviction of expired entries until the context is cancelled.
+// The caller owns the goroutine lifecycle.
+func (c *LRUWithTTL[K, V]) Cleanup(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *LRUWithTTL[K, V]) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key, elem := range c.store {
+		if elem == nil || elem.Value == nil {
+			if elem != nil {
+				c.order.Remove(elem)
+			}
+			delete(c.store, key)
+			continue
+		}
+		e, ok := elem.Value.(*entry[K, V])
+		if ok && e.isExpired(c.expiryBuffer) {
+			c.order.Remove(elem)
+			delete(c.store, key)
+		}
+	}
+}
+
+func (c *LRUWithTTL[K, V]) promote(elem *list.Element) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.order.MoveToFront(elem)
+}
+
+func (c *LRUWithTTL[K, V]) removeBadEntry(key K, elem *list.Element) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem != nil {
+		c.order.Remove(elem)
+	}
+	delete(c.store, key)
+}
+
+func (c *LRUWithTTL[K, V]) removeEntry(key K, elem *list.Element) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.order.Remove(elem)
+	delete(c.store, key)
+}
+
+func (c *LRUWithTTL[K, V]) evictOldest() {
+	oldest := c.order.Back()
+	if oldest != nil {
+		if e, ok := oldest.Value.(*entry[K, V]); ok {
+			delete(c.store, e.key)
+		}
+		c.order.Remove(oldest)
+	}
+}

--- a/pkg/cache/ttlcache_test.go
+++ b/pkg/cache/ttlcache_test.go
@@ -1,0 +1,534 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLRUWithTTL_New(t *testing.T) {
+	t.Run("creates with default size", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string]()
+		assert.NotNil(t, c)
+		assert.Equal(t, defaultSize, c.size)
+		assert.NotNil(t, c.store)
+		assert.NotNil(t, c.order)
+	})
+
+	t.Run("creates with custom size", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		assert.NotNil(t, c)
+		assert.Equal(t, 10, c.size)
+	})
+
+	t.Run("ignores non-positive size", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](-1))
+		assert.Equal(t, defaultSize, c.size)
+	})
+
+	t.Run("creates with expiry buffer", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithExpiryBuffer[string, string](30 * time.Second))
+		assert.Equal(t, 30*time.Second, c.expiryBuffer)
+	})
+}
+
+func TestLRUWithTTL_Set(t *testing.T) {
+	t.Run("new entry", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "token1", 1*time.Hour)
+
+		assert.Contains(t, c.store, "key1")
+		e := c.store["key1"].Value.(*entry[string, string])
+		assert.Equal(t, "key1", e.key)
+		assert.Equal(t, "token1", e.value)
+		assert.WithinDuration(t, time.Now().Add(1*time.Hour), e.expiresAt, 5*time.Second)
+		assert.Equal(t, 1, c.order.Len())
+	})
+
+	t.Run("update existing entry", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "old-token", 5*time.Minute)
+		c.Set("key1", "new-token", 10*time.Minute)
+
+		e := c.store["key1"].Value.(*entry[string, string])
+		assert.Equal(t, "new-token", e.value)
+		assert.Equal(t, 1, c.order.Len(), "update should not add a second list entry")
+	})
+
+	t.Run("update moves to front", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "t1", 5*time.Minute)
+		c.Set("key2", "t2", 5*time.Minute)
+
+		c.Set("key1", "t1-updated", 5*time.Minute)
+
+		front := c.order.Front().Value.(*entry[string, string])
+		assert.Equal(t, "key1", front.key)
+	})
+
+	t.Run("multiple entries", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("a", "ta", time.Minute)
+		c.Set("b", "tb", time.Minute)
+		c.Set("c", "tc", time.Minute)
+
+		assert.Equal(t, 3, c.order.Len())
+		assert.Len(t, c.store, 3)
+	})
+}
+
+func TestLRUWithTTL_Get(t *testing.T) {
+	t.Run("returns value for existing key", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "my-token", time.Hour)
+
+		v, found := c.Get("key1")
+		assert.True(t, found)
+		assert.Equal(t, "my-token", v)
+	})
+
+	t.Run("returns false for missing key", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+
+		v, found := c.Get("nonexistent")
+		assert.False(t, found)
+		assert.Equal(t, "", v)
+	})
+
+	t.Run("returns false for expired entry", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "expired-token", time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
+
+		v, found := c.Get("key1")
+		assert.False(t, found)
+		assert.Equal(t, "", v)
+		assert.NotContains(t, c.store, "key1")
+		assert.Equal(t, 0, c.order.Len())
+	})
+
+	t.Run("expired entry with expiry buffer", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](
+			WithSize[string, string](10),
+			WithExpiryBuffer[string, string](time.Hour),
+		)
+		// Token TTL is 30min, but buffer is 1h — so it's already "expired"
+		c.Set("key1", "buffered-token", 30*time.Minute)
+
+		v, found := c.Get("key1")
+		assert.False(t, found)
+		assert.Equal(t, "", v)
+	})
+
+	t.Run("moves accessed entry to front", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("key1", "t1", time.Hour)
+		c.Set("key2", "t2", time.Hour)
+		// key2 is at front after Set
+		c.Get("key1")
+		// key1 should now be at front
+
+		front := c.order.Front().Value.(*entry[string, string])
+		assert.Equal(t, "key1", front.key)
+	})
+
+	t.Run("cleans up nil element in store", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		// Manually inject a nil element to simulate corruption
+		c.store["bad-key"] = nil
+
+		v, found := c.Get("bad-key")
+		assert.False(t, found)
+		assert.Equal(t, "", v)
+		assert.NotContains(t, c.store, "bad-key", "nil element should be cleaned up")
+	})
+}
+
+func TestLRUWithTTL_Eviction(t *testing.T) {
+	t.Run("evicts oldest when over capacity", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](2))
+		c.Set("key1", "t1", time.Minute)
+		c.Set("key2", "t2", time.Minute)
+		c.Set("key3", "t3", time.Minute) // should evict key1
+
+		assert.Equal(t, 2, c.order.Len())
+		assert.Len(t, c.store, 2)
+		assert.NotContains(t, c.store, "key1", "oldest entry should be evicted")
+		assert.Contains(t, c.store, "key2")
+		assert.Contains(t, c.store, "key3")
+	})
+
+	t.Run("recently updated not evicted", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](2))
+		c.Set("key1", "t1", time.Minute)
+		c.Set("key2", "t2", time.Minute)
+		// Update key1 — moves to front, key2 is now oldest
+		c.Set("key1", "t1-updated", time.Minute)
+		c.Set("key3", "t3", time.Minute) // should evict key2
+
+		assert.NotContains(t, c.store, "key2", "key2 should be evicted as oldest")
+		assert.Contains(t, c.store, "key1")
+		assert.Contains(t, c.store, "key3")
+	})
+
+	t.Run("no eviction when under capacity", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](5))
+		c.Set("key1", "t1", time.Minute)
+		c.Set("key2", "t2", time.Minute)
+
+		assert.Equal(t, 2, c.order.Len())
+		assert.Len(t, c.store, 2)
+	})
+
+	t.Run("evicts down to size", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](1))
+		c.Set("key1", "t1", time.Minute)
+		c.Set("key2", "t2", time.Minute) // evicts key1
+
+		assert.Equal(t, 1, c.order.Len())
+		assert.Len(t, c.store, 1)
+		assert.Contains(t, c.store, "key2")
+	})
+}
+
+func TestLRUWithTTL_Delete(t *testing.T) {
+	t.Run("removes existing key", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("k", "v", time.Minute)
+		c.Delete("k")
+
+		_, ok := c.Get("k")
+		assert.False(t, ok)
+		assert.Equal(t, 0, c.Len())
+	})
+
+	t.Run("noop for missing key", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Delete("nope") // should not panic
+	})
+}
+
+func TestLRUWithTTL_Concurrency(t *testing.T) {
+	t.Run("concurrent reads and writes", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](100))
+		const goroutines = 20
+		const ops = 500
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines * 2)
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					key := fmt.Sprintf("key-%d-%d", id, j)
+					c.Set(key, fmt.Sprintf("token-%d-%d", id, j), time.Minute)
+				}
+			}(i)
+		}
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					key := fmt.Sprintf("key-%d-%d", id, j)
+					c.Get(key)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("concurrent writes same key", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		const goroutines = 50
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg.Done()
+				c.Set("same-key", fmt.Sprintf("token-%d", id), time.Minute)
+			}(i)
+		}
+
+		wg.Wait()
+		assert.Contains(t, c.store, "same-key")
+		assert.Equal(t, 1, c.order.Len(), "should have exactly 1 entry for same key")
+	})
+
+	t.Run("concurrent get during eviction", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](5))
+		const writers = 10
+		const readers = 10
+		const ops = 200
+
+		var wg sync.WaitGroup
+		wg.Add(writers + readers)
+
+		for i := range writers {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					c.Set(fmt.Sprintf("k-%d-%d", id, j), "t", time.Minute)
+				}
+			}(i)
+		}
+
+		for i := range readers {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					c.Get(fmt.Sprintf("k-%d-%d", id, j))
+				}
+			}(i)
+		}
+
+		wg.Wait()
+		assert.LessOrEqual(t, c.order.Len(), 5, "should not exceed max size")
+	})
+
+	t.Run("no deadlock under contention", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		const goroutines = 100
+
+		done := make(chan struct{})
+		go func() {
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			for i := range goroutines {
+				go func(id int) {
+					defer wg.Done()
+					for j := range 1000 {
+						key := fmt.Sprintf("key-%d", j%20)
+						if j%2 == 0 {
+							c.Set(key, fmt.Sprintf("t-%d", id), time.Minute)
+						} else {
+							c.Get(key)
+						}
+					}
+				}(i)
+			}
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("deadlock detected: test did not complete within 10 seconds")
+		}
+	})
+
+	t.Run("concurrent get during expiry cleanup", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](100))
+		const goroutines = 20
+		const ops = 200
+
+		var wg1 sync.WaitGroup
+		var wg2 sync.WaitGroup
+		wg1.Add(goroutines)
+		wg2.Add(goroutines)
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg1.Done()
+				for j := range ops {
+					key := fmt.Sprintf("exp-%d-%d", id, j)
+					c.Set(key, "short-lived", time.Millisecond)
+				}
+			}(i)
+		}
+		wg1.Wait()
+		time.Sleep(2 * time.Millisecond)
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg2.Done()
+				for j := range ops {
+					key := fmt.Sprintf("exp-%d-%d", id, j)
+					v, found := c.Get(key)
+					assert.False(t, found, "entry should be expired")
+					assert.Equal(t, "", v)
+				}
+			}(i)
+		}
+		wg2.Wait()
+	})
+}
+
+func TestLRUWithTTL_Cleanup(t *testing.T) {
+	t.Run("removes expired keeps valid", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("expired1", "t1", time.Millisecond)
+		c.Set("expired2", "t2", time.Millisecond)
+		c.Set("valid", "t3", time.Hour)
+		time.Sleep(5 * time.Millisecond)
+
+		c.cleanup()
+
+		assertCacheState(t, c, []string{"valid"})
+	})
+
+	t.Run("noop when nothing expired", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("a", "t1", time.Hour)
+		c.Set("b", "t2", time.Hour)
+
+		c.cleanup()
+
+		assertCacheState(t, c, []string{"a", "b"})
+	})
+
+	t.Run("noop on empty cache", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.cleanup()
+		assertCacheState(t, c, []string{})
+	})
+
+	t.Run("removes nil elements", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.store["bad"] = nil
+		c.Set("good", "t1", time.Hour)
+
+		c.cleanup()
+
+		assertCacheState(t, c, []string{"good"})
+	})
+
+	t.Run("respects expiry buffer", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](
+			WithSize[string, string](10),
+			WithExpiryBuffer[string, string](time.Hour),
+		)
+		c.Set("buffered", "t1", 30*time.Minute)
+
+		c.cleanup()
+
+		assertCacheState(t, c, []string{})
+	})
+
+	t.Run("all expired empties cache", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		for i := range 5 {
+			c.Set(fmt.Sprintf("k%d", i), "t", time.Millisecond)
+		}
+		time.Sleep(5 * time.Millisecond)
+
+		c.cleanup()
+
+		assertCacheState(t, c, []string{})
+	})
+
+	t.Run("periodic removes expired entries", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		c.Set("short1", "t1", 5*time.Millisecond)
+		c.Set("short2", "t2", 5*time.Millisecond)
+		c.Set("long", "t3", time.Hour)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go c.Cleanup(ctx, 10*time.Millisecond)
+
+		time.Sleep(50 * time.Millisecond)
+		assertCacheState(t, c, []string{"long"})
+	})
+
+	t.Run("periodic stops on context cancel", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](10))
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan struct{})
+		go func() {
+			c.Cleanup(ctx, 10*time.Millisecond)
+			close(done)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Cleanup goroutine did not exit after context cancel")
+		}
+	})
+
+	t.Run("periodic concurrent with get set", func(t *testing.T) {
+		c := NewLRUWithTTL[string, string](WithSize[string, string](100))
+		const goroutines = 10
+		const ops = 200
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go c.Cleanup(ctx, time.Millisecond)
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines * 2)
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					c.Set(fmt.Sprintf("k-%d-%d", id, j), "t", time.Millisecond)
+				}
+			}(i)
+		}
+
+		for i := range goroutines {
+			go func(id int) {
+				defer wg.Done()
+				for j := range ops {
+					c.Get(fmt.Sprintf("k-%d-%d", id, j))
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestLRUWithTTL_GenericTypes(t *testing.T) {
+	t.Parallel()
+
+	type customKey struct {
+		Tenant string
+		Scope  string
+	}
+	type customVal struct {
+		Token string
+		TTL   int
+	}
+
+	c := NewLRUWithTTL[customKey, customVal](WithSize[customKey, customVal](10))
+	k := customKey{Tenant: "t1", Scope: "s1"}
+	c.Set(k, customVal{Token: "tok", TTL: 60}, time.Minute)
+
+	v, ok := c.Get(k)
+	require.True(t, ok)
+	assert.Equal(t, "tok", v.Token)
+}
+
+// ── Test helpers ──
+
+func assertCacheState(t *testing.T, c *LRUWithTTL[string, string], expectedKeys []string) {
+	t.Helper()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Equal(t, len(expectedKeys), len(c.store), "map size mismatch")
+	assert.Equal(t, len(expectedKeys), c.order.Len(), "list size mismatch")
+	for _, key := range expectedKeys {
+		assert.Contains(t, c.store, key)
+	}
+}

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -166,6 +166,11 @@ func runServe(ctx context.Context, opts *Options) error {
 	// lifecycle (shutdown) is managed consistently.
 	pluginPool := buildPluginPool(ctx, cfg, pluginFetcher, reg, lgr, pluginClients)
 
+	// // Build delegation registry for API-mode token delegation.
+	// delegationReg, err := buildDelegationRegistry(ctx, &cfg.APIServer, lgr)
+	// if err != nil {
+	// 	return fmt.Errorf("building delegation registry: %w", err)
+	// }
 	// Build server options
 	serverOpts := []api.ServerOption{
 		api.WithServerLogger(*lgr),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,10 +4,12 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +37,107 @@ func TestManager_Load_NoFile(t *testing.T) {
 	assert.Equal(t, "official", cfg.Settings.DefaultCatalog)
 	assert.False(t, cfg.Settings.NoColor)
 	assert.False(t, cfg.Settings.Quiet)
+	assert.Nil(t, cfg.APIServer.TokenPassThrough)
+	assert.Equal(t, []string{"Github"}, cfg.APIServer.TokenPassThroughAllowedHeaders())
+}
+
+func TestManager_Load_TokenPassThroughAllowedHeaders(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+apiServer:
+  tokenPassThrough:
+    allowedHeaders:
+      - " azure-ad "
+      - github-enterprise
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg.APIServer.TokenPassThrough)
+	assert.Equal(t, []string{" azure-ad ", "github-enterprise"}, cfg.APIServer.TokenPassThrough.AllowedHeaders)
+	assert.Equal(t, []string{"Azure-Ad", "Github-Enterprise"}, cfg.APIServer.TokenPassThroughAllowedHeaders())
+}
+
+func TestManager_Load_TokenPassThroughExplicitEmptyAllowedHeaders(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+apiServer:
+  tokenPassThrough:
+    allowedHeaders: []
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg.APIServer.TokenPassThrough)
+	assert.Empty(t, cfg.APIServer.TokenPassThrough.AllowedHeaders)
+	assert.Empty(t, cfg.APIServer.TokenPassThroughAllowedHeaders())
+}
+
+func TestManager_Load_TokenPassThroughInvalidAllowedHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  string
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			header:  `""`,
+			wantErr: "allowedHeaders[0]: must not be empty",
+		},
+		{
+			name:    "prefixed",
+			header:  fmt.Sprintf("%s%s", middleware.TokenHeaderPrefix, "Github"),
+			wantErr: fmt.Sprintf("allowedHeaders[0]: must not include %s prefix", middleware.TokenHeaderPrefix),
+		},
+		{
+			name:    "invalid header field name",
+			header:  `"Bad Header"`,
+			wantErr: `allowedHeaders[0]: invalid HTTP header suffix "Bad Header"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+
+			configContent := `
+apiServer:
+  tokenPassThrough:
+    allowedHeaders:
+      - ` + tt.header + `
+`
+			err := os.WriteFile(configPath, []byte(configContent), 0o600)
+			require.NoError(t, err)
+
+			mgr := NewManager(configPath)
+			_, err = mgr.Load()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid config: apiServer: tokenPassThrough")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestManager_Load_WithFile(t *testing.T) {

--- a/pkg/config/identity_test.go
+++ b/pkg/config/identity_test.go
@@ -1,0 +1,294 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIEntraIdentityConfig_Validate_ValidSecret(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type:         "secret",
+			ClientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET",
+		},
+	}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAPIEntraIdentityConfig_Validate_ValidWIF(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type:         "wif",
+			WIFTokenPath: "/var/run/secrets/azure/tokens/federated-token",
+		},
+	}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAPIEntraIdentityConfig_Validate_MissingTenantID(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type:         "secret",
+			ClientSecret: "env://SECRET",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenantId is required")
+}
+
+func TestAPIEntraIdentityConfig_Validate_MissingClientID(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		Credential: ServerCredentialConfig{
+			Type:         "secret",
+			ClientSecret: "env://SECRET",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clientId is required")
+}
+
+func TestAPIEntraIdentityConfig_Validate_MissingCredentialType(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential:")
+	assert.Contains(t, err.Error(), "type is required")
+}
+
+func TestAPIEntraIdentityConfig_Validate_InvalidCredentialType(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type: "certificate",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential:")
+	assert.Contains(t, err.Error(), "invalid value")
+	assert.Contains(t, err.Error(), "certificate")
+}
+
+func TestAPIEntraIdentityConfig_Validate_SecretMissingRef(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type: "secret",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clientSecret is required")
+}
+
+func TestAPIEntraIdentityConfig_Validate_WIFMissingPath(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type: "wif",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wifTokenPath is required")
+}
+
+func TestAPIIdentityConfig_Validate_NilEntra(t *testing.T) {
+	t.Parallel()
+	cfg := &APIIdentityConfig{}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAPIIdentityConfig_Validate_DelegatesToEntra(t *testing.T) {
+	t.Parallel()
+	cfg := &APIIdentityConfig{
+		Entra: &APIEntraIdentityConfig{
+			Credential: ServerCredentialConfig{Type: "secret"},
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entra:")
+	assert.Contains(t, err.Error(), "tenantId is required")
+}
+
+func TestDelegationFlowsConfig_IsFlowPermitted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		config   *DelegationFlowsConfig
+		flow     string
+		expected bool
+	}{
+		{
+			name:     "nil allows OBO",
+			config:   nil,
+			flow:     DelegationFlowOBO,
+			expected: true,
+		},
+		{
+			name:     "nil denies client_credentials",
+			config:   nil,
+			flow:     DelegationFlowClientCredentials,
+			expected: false,
+		},
+		{
+			name:     "empty flows denies OBO",
+			config:   &DelegationFlowsConfig{},
+			flow:     DelegationFlowOBO,
+			expected: false,
+		},
+		{
+			name:     "empty flows denies client_credentials",
+			config:   &DelegationFlowsConfig{},
+			flow:     DelegationFlowClientCredentials,
+			expected: false,
+		},
+		{
+			name:     "explicit OBO permits OBO",
+			config:   &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO}},
+			flow:     DelegationFlowOBO,
+			expected: true,
+		},
+		{
+			name:     "explicit OBO denies client_credentials",
+			config:   &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO}},
+			flow:     DelegationFlowClientCredentials,
+			expected: false,
+		},
+		{
+			name:     "both flows permits OBO",
+			config:   &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO, DelegationFlowClientCredentials}},
+			flow:     DelegationFlowOBO,
+			expected: true,
+		},
+		{
+			name:     "both flows permits client_credentials",
+			config:   &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO, DelegationFlowClientCredentials}},
+			flow:     DelegationFlowClientCredentials,
+			expected: true,
+		},
+		{
+			name:     "unknown flow denied",
+			config:   &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO}},
+			flow:     "unknown",
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.config.IsFlowPermitted(tc.flow)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDelegationFlowsConfig_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		config  *DelegationFlowsConfig
+		wantErr string
+	}{
+		{
+			name:   "nil is valid",
+			config: nil,
+		},
+		{
+			name:   "empty flows is valid",
+			config: &DelegationFlowsConfig{},
+		},
+		{
+			name:   "valid OBO",
+			config: &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO}},
+		},
+		{
+			name:   "valid client_credentials",
+			config: &DelegationFlowsConfig{Flows: []string{DelegationFlowClientCredentials}},
+		},
+		{
+			name:   "valid both",
+			config: &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO, DelegationFlowClientCredentials}},
+		},
+		{
+			name:    "invalid flow",
+			config:  &DelegationFlowsConfig{Flows: []string{"password"}},
+			wantErr: "invalid flow",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.config.Validate()
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAPIEntraIdentityConfig_Validate_AllowedFlowsInvalid(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type:         "secret",
+			ClientSecret: "env://SECRET",
+		},
+		AllowedFlows: &DelegationFlowsConfig{Flows: []string{"invalid"}},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowedFlows:")
+	assert.Contains(t, err.Error(), "invalid flow")
+}
+
+func TestAPIEntraIdentityConfig_Validate_AllowedFlowsValid(t *testing.T) {
+	t.Parallel()
+	cfg := &APIEntraIdentityConfig{
+		TenantID: "00000000-0000-0000-0000-000000000000",
+		ClientID: "11111111-1111-1111-1111-111111111111",
+		Credential: ServerCredentialConfig{
+			Type:         "secret",
+			ClientSecret: "env://SECRET",
+		},
+		AllowedFlows: &DelegationFlowsConfig{Flows: []string{DelegationFlowOBO, DelegationFlowClientCredentials}},
+	}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}

--- a/pkg/config/secretref.go
+++ b/pkg/config/secretref.go
@@ -1,0 +1,70 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	secretRefSchemeEnv  = "env://"
+	secretRefSchemeFile = "file://"
+)
+
+// Validate checks that the SecretRef has a recognized scheme and a non-empty value.
+func (s SecretRef) Validate() error {
+	str := string(s)
+	switch {
+	case strings.HasPrefix(str, secretRefSchemeEnv):
+		if strings.TrimPrefix(str, secretRefSchemeEnv) == "" {
+			return fmt.Errorf("env:// scheme requires a variable name")
+		}
+	case strings.HasPrefix(str, secretRefSchemeFile):
+		if strings.TrimPrefix(str, secretRefSchemeFile) == "" {
+			return fmt.Errorf("file:// scheme requires a path")
+		}
+	default:
+		return fmt.Errorf("unsupported secret ref scheme %q, must start with env:// or file://", str)
+	}
+	return nil
+}
+
+// Resolve reads the secret value from the referenced source.
+// For env:// it reads the environment variable; for file:// it reads and trims the file.
+func (s SecretRef) Resolve() (string, error) {
+	str := string(s)
+	switch {
+	case strings.HasPrefix(str, secretRefSchemeEnv):
+		name := strings.TrimPrefix(str, secretRefSchemeEnv)
+		val := os.Getenv(name)
+		if val == "" {
+			return "", fmt.Errorf("environment variable %q is empty or not set", name)
+		}
+		return val, nil
+	case strings.HasPrefix(str, secretRefSchemeFile):
+		path := strings.TrimPrefix(str, secretRefSchemeFile)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading secret file %q: %w", path, err)
+		}
+		val := strings.TrimSpace(string(data))
+		if val == "" {
+			return "", fmt.Errorf("secret file %q is empty", path)
+		}
+		return val, nil
+	default:
+		return "", fmt.Errorf("unsupported secret ref scheme %q", str)
+	}
+}
+
+// Scheme returns the scheme portion of the secret reference (e.g. "env", "file").
+func (s SecretRef) Scheme() string {
+	str := string(s)
+	if idx := strings.Index(str, "://"); idx >= 0 {
+		return str[:idx]
+	}
+	return ""
+}

--- a/pkg/config/secretref_test.go
+++ b/pkg/config/secretref_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretRef_Validate_ValidEnv(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("env://MY_SECRET")
+	assert.NoError(t, s.Validate())
+}
+
+func TestSecretRef_Validate_ValidFile(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("file:///run/secrets/token")
+	assert.NoError(t, s.Validate())
+}
+
+func TestSecretRef_Validate_EmptyEnvName(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("env://")
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a variable name")
+}
+
+func TestSecretRef_Validate_EmptyFilePath(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("file://")
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a path")
+}
+
+func TestSecretRef_Validate_UnknownScheme(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("vault://secret/data/foo")
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported secret ref scheme")
+}
+
+func TestSecretRef_Validate_NoScheme(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("just-a-string")
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported secret ref scheme")
+}
+
+func TestSecretRef_Resolve_Env(t *testing.T) {
+	t.Setenv("TEST_SECRET_REF_VAL", "s3cr3t")
+	s := SecretRef("env://TEST_SECRET_REF_VAL")
+	val, err := s.Resolve()
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", val)
+}
+
+func TestSecretRef_Resolve_EnvEmpty(t *testing.T) {
+	t.Setenv("TEST_SECRET_REF_EMPTY", "")
+	s := SecretRef("env://TEST_SECRET_REF_EMPTY")
+	_, err := s.Resolve()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty or not set")
+}
+
+func TestSecretRef_Resolve_FileExists(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	require.NoError(t, os.WriteFile(path, []byte("file-secret\n"), 0o600))
+	s := SecretRef("file://" + path)
+	val, err := s.Resolve()
+	require.NoError(t, err)
+	assert.Equal(t, "file-secret", val)
+}
+
+func TestSecretRef_Resolve_FileMissing(t *testing.T) {
+	t.Parallel()
+	s := SecretRef("file:///nonexistent/path/secret")
+	_, err := s.Resolve()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading secret file")
+}
+
+func TestSecretRef_Scheme(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "env", SecretRef("env://FOO").Scheme())
+	assert.Equal(t, "file", SecretRef("file:///bar").Scheme())
+	assert.Equal(t, "", SecretRef("noscheme").Scheme())
+}

--- a/pkg/config/tokenpassthrough.go
+++ b/pkg/config/tokenpassthrough.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"net/http"
+	"strings"
+)
+
+// DefaultTokenPassThroughAllowedHeaders returns the default token pass-through
+// header suffixes used when apiServer.tokenPassThrough is omitted.
+func DefaultTokenPassThroughAllowedHeaders() []string {
+	return []string{"Github"}
+}
+
+// TokenPassThroughAllowedHeaders returns the configured token pass-through
+// header suffixes. A nil TokenPassThrough config uses the default GitHub
+// suffix; a non-nil config returns its normalized list, including an empty list.
+func (c *APIServerConfig) TokenPassThroughAllowedHeaders() []string {
+	if c == nil || c.TokenPassThrough == nil {
+		return DefaultTokenPassThroughAllowedHeaders()
+	}
+	seen := make(map[string]struct{})
+	headers := make([]string, 0, len(c.TokenPassThrough.AllowedHeaders))
+	for _, header := range c.TokenPassThrough.AllowedHeaders {
+		canonicalHeader := http.CanonicalHeaderKey(strings.TrimSpace(header))
+		if canonicalHeader == "" {
+			continue
+		}
+		if _, exists := seen[canonicalHeader]; !exists {
+			seen[canonicalHeader] = struct{}{}
+			headers = append(headers, canonicalHeader)
+		}
+	}
+	return headers
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -683,24 +683,26 @@ type DiscoveryConfig struct {
 
 // APIServerConfig holds REST API server configuration.
 type APIServerConfig struct {
-	Host            string               `json:"host,omitempty" yaml:"host,omitempty" mapstructure:"host" doc:"Host to bind to (defaults to 127.0.0.1; use 0.0.0.0 to expose publicly)" example:"127.0.0.1" maxLength:"253"`
-	Port            int                  `json:"port,omitempty" yaml:"port,omitempty" mapstructure:"port" doc:"Port to listen on" example:"8080" minimum:"1" maximum:"65535"`
-	APIVersion      string               `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty" mapstructure:"apiVersion" doc:"API version prefix (e.g. v1, v2)" example:"v1" maxLength:"10" pattern:"^v[0-9]+$" patternDescription:"must be 'v' followed by one or more digits (e.g. v1, v2)"`
-	ShutdownTimeout string               `json:"shutdownTimeout,omitempty" yaml:"shutdownTimeout,omitempty" mapstructure:"shutdownTimeout" doc:"Graceful shutdown timeout" example:"30s" maxLength:"20"`
-	RequestTimeout  string               `json:"requestTimeout,omitempty" yaml:"requestTimeout,omitempty" mapstructure:"requestTimeout" doc:"Default request timeout" example:"60s" maxLength:"20"`
-	BodyReadTimeout string               `json:"bodyReadTimeout,omitempty" yaml:"bodyReadTimeout,omitempty" mapstructure:"bodyReadTimeout" doc:"Default body read timeout for Huma operations" example:"15s" maxLength:"20"`
-	MaxRequestSize  int64                `json:"maxRequestSize,omitempty" yaml:"maxRequestSize,omitempty" mapstructure:"maxRequestSize" doc:"Maximum request body size in bytes" maximum:"1073741824" example:"10485760"`
-	TLS             APITLSConfig         `json:"tls,omitempty" yaml:"tls,omitempty" mapstructure:"tls" doc:"TLS configuration"`
-	CORS            APICORSConfig        `json:"cors,omitempty" yaml:"cors,omitempty" mapstructure:"cors" doc:"CORS configuration"`
-	RateLimit       APIRateLimitConfig   `json:"rateLimit,omitempty" yaml:"rateLimit,omitempty" mapstructure:"rateLimit" doc:"Rate limiting configuration"`
-	Auth            APIAuthConfig        `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth" doc:"Authentication configuration"`
-	Compression     APICompressionConfig `json:"compression,omitempty" yaml:"compression,omitempty" mapstructure:"compression" doc:"Response compression configuration"`
-	OpenAPI         APIOpenAPIConfig     `json:"openAPI,omitempty" yaml:"openAPI,omitempty" mapstructure:"openAPI" doc:"OpenAPI specification configuration (Servers field is wired; Title, Description, and other fields are reserved for future use)"`
-	Profiler        APIProfilerConfig    `json:"profiler,omitempty" yaml:"profiler,omitempty" mapstructure:"profiler" doc:"Profiler configuration (reserved for future use — not yet wired into server setup)"`
-	Audit           APIAuditConfig       `json:"audit,omitempty" yaml:"audit,omitempty" mapstructure:"audit" doc:"Audit logging configuration"`
-	Tracing         APITracingConfig     `json:"tracing,omitempty" yaml:"tracing,omitempty" mapstructure:"tracing" doc:"OpenTelemetry tracing configuration"`
-	MaxConcurrent   int                  `json:"maxConcurrent,omitempty" yaml:"maxConcurrent,omitempty" mapstructure:"maxConcurrent" doc:"Maximum concurrent in-flight requests (chi Throttle, not TCP connections)" maximum:"100000" example:"1000"`
-	Plugins         APIPluginConfig      `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin security configuration"`
+	Host             string                  `json:"host,omitempty" yaml:"host,omitempty" mapstructure:"host" doc:"Host to bind to (defaults to 127.0.0.1; use 0.0.0.0 to expose publicly)" example:"127.0.0.1" maxLength:"253"`
+	Port             int                     `json:"port,omitempty" yaml:"port,omitempty" mapstructure:"port" doc:"Port to listen on" example:"8080" minimum:"1" maximum:"65535"`
+	APIVersion       string                  `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty" mapstructure:"apiVersion" doc:"API version prefix (e.g. v1, v2)" example:"v1" maxLength:"10" pattern:"^v[0-9]+$" patternDescription:"must be 'v' followed by one or more digits (e.g. v1, v2)"`
+	ShutdownTimeout  string                  `json:"shutdownTimeout,omitempty" yaml:"shutdownTimeout,omitempty" mapstructure:"shutdownTimeout" doc:"Graceful shutdown timeout" example:"30s" maxLength:"20"`
+	RequestTimeout   string                  `json:"requestTimeout,omitempty" yaml:"requestTimeout,omitempty" mapstructure:"requestTimeout" doc:"Default request timeout" example:"60s" maxLength:"20"`
+	BodyReadTimeout  string                  `json:"bodyReadTimeout,omitempty" yaml:"bodyReadTimeout,omitempty" mapstructure:"bodyReadTimeout" doc:"Default body read timeout for Huma operations" example:"15s" maxLength:"20"`
+	MaxRequestSize   int64                   `json:"maxRequestSize,omitempty" yaml:"maxRequestSize,omitempty" mapstructure:"maxRequestSize" doc:"Maximum request body size in bytes" maximum:"1073741824" example:"10485760"`
+	TLS              APITLSConfig            `json:"tls,omitempty" yaml:"tls,omitempty" mapstructure:"tls" doc:"TLS configuration"`
+	CORS             APICORSConfig           `json:"cors,omitempty" yaml:"cors,omitempty" mapstructure:"cors" doc:"CORS configuration"`
+	RateLimit        APIRateLimitConfig      `json:"rateLimit,omitempty" yaml:"rateLimit,omitempty" mapstructure:"rateLimit" doc:"Rate limiting configuration"`
+	Auth             APIAuthConfig           `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth" doc:"Authentication configuration"`
+	Identity         APIIdentityConfig       `json:"identity,omitempty" yaml:"identity,omitempty" mapstructure:"identity" doc:"Server identity for token delegation"`
+	Compression      APICompressionConfig    `json:"compression,omitempty" yaml:"compression,omitempty" mapstructure:"compression" doc:"Response compression configuration"`
+	OpenAPI          APIOpenAPIConfig        `json:"openAPI,omitempty" yaml:"openAPI,omitempty" mapstructure:"openAPI" doc:"OpenAPI specification configuration (Servers field is wired; Title, Description, and other fields are reserved for future use)"`
+	Profiler         APIProfilerConfig       `json:"profiler,omitempty" yaml:"profiler,omitempty" mapstructure:"profiler" doc:"Profiler configuration (reserved for future use — not yet wired into server setup)"`
+	Audit            APIAuditConfig          `json:"audit,omitempty" yaml:"audit,omitempty" mapstructure:"audit" doc:"Audit logging configuration"`
+	Tracing          APITracingConfig        `json:"tracing,omitempty" yaml:"tracing,omitempty" mapstructure:"tracing" doc:"OpenTelemetry tracing configuration"`
+	MaxConcurrent    int                     `json:"maxConcurrent,omitempty" yaml:"maxConcurrent,omitempty" mapstructure:"maxConcurrent" doc:"Maximum concurrent in-flight requests (chi Throttle, not TCP connections)" maximum:"100000" example:"1000"`
+	Plugins          APIPluginConfig         `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin security configuration"`
+	TokenPassThrough *TokenPassThroughConfig `json:"tokenPassThrough,omitempty" yaml:"tokenPassThrough,omitempty" mapstructure:"tokenPassThrough" doc:"Token pass-through configuration for delegating tokens to plugin providers"`
 }
 
 // APIPluginConfig holds security settings for plugin execution in the API server.
@@ -759,6 +761,66 @@ type APIAzureOIDCConfig struct {
 	TenantID string `json:"tenantId,omitempty" yaml:"tenantId,omitempty" mapstructure:"tenantId" doc:"Azure AD tenant ID" maxLength:"36" example:"00000000-0000-0000-0000-000000000000"`
 	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty" mapstructure:"clientId" doc:"Azure AD client ID" maxLength:"36" example:"00000000-0000-0000-0000-000000000000"`
 }
+
+// APIIdentityConfig holds server identity configuration for token delegation.
+type APIIdentityConfig struct {
+	Entra *APIEntraIdentityConfig `json:"entra,omitempty" yaml:"entra,omitempty" mapstructure:"entra" doc:"Azure Entra ID identity for token delegation"`
+}
+
+// APIEntraIdentityConfig holds Azure Entra ID credential configuration for OBO and client_credentials delegation.
+type APIEntraIdentityConfig struct {
+	TenantID     string                 `json:"tenantId" yaml:"tenantId" mapstructure:"tenantId" doc:"Azure AD tenant ID" maxLength:"36" example:"00000000-0000-0000-0000-000000000000"`
+	ClientID     string                 `json:"clientId" yaml:"clientId" mapstructure:"clientId" doc:"Azure AD client ID" maxLength:"36" example:"00000000-0000-0000-0000-000000000000"`
+	Credential   ServerCredentialConfig `json:"credential" yaml:"credential" mapstructure:"credential" doc:"Server credential configuration"`
+	TokenManager *TokenManagerConfig    `json:"tokenManager,omitempty" yaml:"tokenManager,omitempty" mapstructure:"tokenManager" doc:"Token manager configuration (nil = no caching/deduplication)"`
+	AllowedFlows *DelegationFlowsConfig `json:"allowedFlows,omitempty" yaml:"allowedFlows,omitempty" mapstructure:"allowedFlows" doc:"Permitted delegation flows (nil = OBO only, present with empty flows = deny all)"`
+}
+
+// TokenManagerConfig holds configuration for the token delegation cache manager.
+// A nil pointer on the parent disables caching entirely.
+// A non-nil struct with zero values uses sensible defaults defined in pkg/authdelegation.
+type TokenManagerConfig struct {
+	// CacheSize is the maximum number of cached tokens. Zero uses the package default.
+	CacheSize int `json:"cacheSize,omitempty" yaml:"cacheSize,omitempty" mapstructure:"cacheSize" doc:"LRU cache size (0 = package default)" maximum:"100000"`
+
+	// ExpiryBuffer is the safety margin subtracted from token TTL before caching.
+	// Prevents serving tokens that are about to expire. Use Go duration syntax.
+	ExpiryBuffer string `json:"expiryBuffer,omitempty" yaml:"expiryBuffer,omitempty" mapstructure:"expiryBuffer" doc:"Safety margin before token expiry" maxLength:"20"`
+
+	// CleanupInterval is how often the background goroutine evicts expired entries.
+	// Use Go duration syntax.
+	CleanupInterval string `json:"cleanupInterval,omitempty" yaml:"cleanupInterval,omitempty" mapstructure:"cleanupInterval" doc:"Background eviction interval" maxLength:"20"`
+
+	// ExpiryThreshold is the minimum remaining TTL a token must have to be cached.
+	// Tokens with TTL <= this value are treated as uncacheable. Use Go duration syntax.
+	ExpiryThreshold string `json:"expiryThreshold,omitempty" yaml:"expiryThreshold,omitempty" mapstructure:"expiryThreshold" doc:"Minimum TTL to cache a token" maxLength:"20"`
+
+	// SlowThreshold is how long a follower waits for the leader before retrying independently.
+	// Use Go duration syntax.
+	SlowThreshold string `json:"slowThreshold,omitempty" yaml:"slowThreshold,omitempty" mapstructure:"slowThreshold" doc:"Follower bail-out duration" maxLength:"20"`
+
+	// RetryFollowerOnError controls whether followers retry independently when the leader errors.
+	RetryFollowerOnError *bool `json:"retryFollowerOnError,omitempty" yaml:"retryFollowerOnError,omitempty" mapstructure:"retryFollowerOnError" doc:"Followers retry on leader error"`
+}
+
+// ServerCredentialConfig holds the server's authentication credential for token delegation.
+type ServerCredentialConfig struct {
+	Type         string    `json:"type" yaml:"type" mapstructure:"type" doc:"Server credential type" enum:"wif,secret" example:"secret" maxLength:"10"`
+	ClientSecret SecretRef `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty" mapstructure:"clientSecret" doc:"Secret reference URI (env://VAR_NAME or file:///path)" maxLength:"512" example:"env://SCAFCTL_API_ENTRA_CLIENT_SECRET"`
+	WIFTokenPath string    `json:"wifTokenPath,omitempty" yaml:"wifTokenPath,omitempty" mapstructure:"wifTokenPath" doc:"Path to federated token file (required when type is wif)" maxLength:"512" example:"/var/run/secrets/azure/tokens/federated-token"`
+}
+
+// DelegationFlowsConfig controls which delegation flows the server may use.
+// A nil pointer on the parent means "use defaults (OBO only)".
+// A non-nil struct with empty Flows means "deny all delegation".
+// A non-nil struct with populated Flows means "only permit listed flows".
+type DelegationFlowsConfig struct {
+	Flows []string `json:"flows,omitempty" yaml:"flows,omitempty" mapstructure:"flows" doc:"Permitted delegation flows (obo, client_credentials)" maxItems:"10"`
+}
+
+// SecretRef is a URI-style reference to a secret value.
+// Supported schemes: env:// (environment variable), file:// (file path).
+type SecretRef string
 
 // APICompressionConfig holds response compression configuration.
 type APICompressionConfig struct {
@@ -864,4 +926,8 @@ type IdentityFieldMapping struct {
 	Username string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username" doc:"JSON field for username" maxLength:"128" example:"username"`
 	Email    string `json:"email,omitempty" yaml:"email,omitempty" mapstructure:"email" doc:"JSON field for email" maxLength:"128" example:"email"`
 	Name     string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name" doc:"JSON field for display name" maxLength:"128"`
+}
+
+type TokenPassThroughConfig struct {
+	AllowedHeaders []string `json:"allowedHeaders,omitempty" yaml:"allowedHeaders,omitempty" mapstructure:"allowedHeaders" doc:"Allowed token header suffixes without the X-Authorization- prefix" maxItems:"50"`
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -5,9 +5,18 @@ package config
 
 import (
 	"fmt"
+	"net/http"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+const (
+	DelegationFlowOBO               = "obo"
+	DelegationFlowClientCredentials = "client_credentials"
 )
 
 // Validate validates the entire configuration.
@@ -46,6 +55,11 @@ func (c *Config) Validate() error {
 	// Validate build config
 	if err := c.Build.Validate(); err != nil {
 		return fmt.Errorf("build: %w", err)
+	}
+
+	// Validate API server config
+	if err := c.APIServer.Validate(); err != nil {
+		return fmt.Errorf("apiServer: %w", err)
 	}
 
 	return nil
@@ -227,5 +241,142 @@ func (c *Config) CheckVersion() string {
 func (b *BuildConfig) Validate() error {
 	// CacheDir and PluginCacheDir are validated for length by struct tags;
 	// no additional semantic validation needed at this time.
+	return nil
+}
+
+// Validate validates the API server configuration.
+func (c *APIServerConfig) Validate() error {
+	if err := c.Identity.Validate(); err != nil {
+		return fmt.Errorf("identity: %w", err)
+	}
+	if c.TokenPassThrough != nil {
+		if err := c.TokenPassThrough.Validate(); err != nil {
+			return fmt.Errorf("tokenPassThrough: %w", err)
+		}
+	}
+	return nil
+}
+
+// Validate validates token pass-through configuration.
+func (c *TokenPassThroughConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	for i, suffix := range c.AllowedHeaders {
+		suffix = strings.TrimSpace(suffix)
+		if suffix == "" {
+			return fmt.Errorf("allowedHeaders[%d]: must not be empty", i)
+		}
+		if strings.HasPrefix(http.CanonicalHeaderKey(suffix), middleware.TokenHeaderPrefix) {
+			return fmt.Errorf("allowedHeaders[%d]: must not include %s prefix", i, middleware.TokenHeaderPrefix)
+		}
+		header := http.CanonicalHeaderKey(middleware.TokenHeaderPrefix + suffix)
+		if !validHTTPHeaderFieldName(header) {
+			return fmt.Errorf("allowedHeaders[%d]: invalid HTTP header suffix %q", i, c.AllowedHeaders[i])
+		}
+	}
+	return nil
+}
+
+func validHTTPHeaderFieldName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		c := name[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// Validate validates the API identity configuration.
+func (c *APIIdentityConfig) Validate() error {
+	if c.Entra != nil {
+		if err := c.Entra.Validate(); err != nil {
+			return fmt.Errorf("entra: %w", err)
+		}
+	}
+	return nil
+}
+
+// Validate validates the Entra identity configuration.
+func (c *APIEntraIdentityConfig) Validate() error {
+	if c.TenantID == "" {
+		return fmt.Errorf("entra identity: tenantId is required")
+	}
+	if c.ClientID == "" {
+		return fmt.Errorf("entra identity: clientId is required")
+	}
+	if err := c.Credential.Validate(); err != nil {
+		return fmt.Errorf("entra identity: credential: %w", err)
+	}
+	if err := c.AllowedFlows.Validate(); err != nil {
+		return fmt.Errorf("entra identity: allowedFlows: %w", err)
+	}
+	return nil
+}
+
+// ValidDelegationFlows returns the list of valid delegation flow names.
+func ValidDelegationFlows() []string {
+	return []string{DelegationFlowOBO, DelegationFlowClientCredentials}
+}
+
+// IsFlowPermitted reports whether the given delegation flow is permitted.
+// When the receiver is nil, only OBO is permitted (the default).
+func (d *DelegationFlowsConfig) IsFlowPermitted(flow string) bool {
+	if d == nil {
+		return flow == DelegationFlowOBO
+	}
+	return slices.Contains(d.Flows, flow)
+}
+
+// Validate checks that all listed flows are recognized values.
+func (d *DelegationFlowsConfig) Validate() error {
+	if d == nil {
+		return nil
+	}
+	valid := ValidDelegationFlows()
+	for _, f := range d.Flows {
+		found := false
+		for _, v := range valid {
+			if f == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid flow %q, must be one of: %s", f, strings.Join(valid, ", "))
+		}
+	}
+	return nil
+}
+
+// Validate checks that the credential configuration is complete and consistent.
+func (c *ServerCredentialConfig) Validate() error {
+	switch c.Type {
+	case "secret":
+		if c.ClientSecret == "" {
+			return fmt.Errorf("clientSecret is required when type is %q", c.Type)
+		}
+		if err := c.ClientSecret.Validate(); err != nil {
+			return fmt.Errorf("clientSecret: %w", err)
+		}
+	case "wif":
+		if c.WIFTokenPath == "" {
+			return fmt.Errorf("wifTokenPath is required when type is %q", c.Type)
+		}
+	case "":
+		return fmt.Errorf("type is required")
+	default:
+		return fmt.Errorf("type: invalid value %q, must be one of: wif, secret", c.Type)
+	}
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -4,8 +4,10 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/api/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -229,6 +231,86 @@ func TestConfig_Validate_InvalidCatalogType(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "catalogs[0]")
 	assert.Contains(t, err.Error(), "type")
+}
+
+func TestConfig_Validate_InvalidTokenPassThrough(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIServer: APIServerConfig{
+			TokenPassThrough: &TokenPassThroughConfig{
+				AllowedHeaders: []string{"Bad Header"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apiServer")
+	assert.Contains(t, err.Error(), "tokenPassThrough")
+	assert.Contains(t, err.Error(), "invalid HTTP header suffix")
+}
+
+func TestTokenPassThroughConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *TokenPassThroughConfig
+		wantErr string
+	}{
+		{
+			name: "nil",
+			cfg:  nil,
+		},
+		{
+			name: "valid",
+			cfg: &TokenPassThroughConfig{
+				AllowedHeaders: []string{"Github", "Azure-Ad"},
+			},
+		},
+		{
+			name: "explicit empty list",
+			cfg: &TokenPassThroughConfig{
+				AllowedHeaders: []string{},
+			},
+		},
+		{
+			name: "empty suffix",
+			cfg: &TokenPassThroughConfig{
+				AllowedHeaders: []string{""},
+			},
+			wantErr: "allowedHeaders[0]: must not be empty",
+		},
+		{
+			name: "prefixed suffix",
+			cfg: &TokenPassThroughConfig{
+				AllowedHeaders: []string{fmt.Sprintf("%s%s", middleware.TokenHeaderPrefix, "Github")},
+			},
+			wantErr: fmt.Sprintf("allowedHeaders[0]: must not include %s prefix", middleware.TokenHeaderPrefix),
+		},
+		{
+			name: "invalid suffix",
+			cfg: &TokenPassThroughConfig{
+				AllowedHeaders: []string{"Bad Header"},
+			},
+			wantErr: `allowedHeaders[0]: invalid HTTP header suffix "Bad Header"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestConfig_CheckVersion_Current(t *testing.T) {

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/authdelegation"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -506,66 +507,25 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 	scope, _ := inputs["scope"].(string)
 
 	if authProvider != "" {
-		// Parse profile from handler@profile syntax and inject into context.
-		handlerName, profile := auth.ParseProfileKey(authProvider)
-		if profile != "" {
-			if err := auth.ValidateProfileName(profile); err != nil {
-				return nil, fmt.Errorf("%s: invalid profile in authProvider: %w", ProviderName, err)
+		if reg := authdelegation.RegistryFromContext(ctx); reg != nil {
+			if err := injectDelegatedToken(ctx, reg, authProvider, scope, headers); err != nil {
+				return nil, err
 			}
-			ctx = auth.WithProfile(ctx, profile)
-		} else if resolved := auth.ResolveActiveProfile(ctx, handlerName); resolved != "" {
-			// No explicit profile in authProvider, use the active profile
-			ctx = auth.WithProfile(ctx, resolved)
+		} else {
+			if err := injectCLIToken(ctx, authProvider, scope, timeoutDuration, headers); err != nil {
+				return nil, err
+			}
 		}
-
-		// Get auth handler from context
-		handler, err := auth.GetHandler(ctx, authProvider)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", ProviderName, err)
-		}
-
-		// Validate scope requirement based on handler capabilities
-		requiresScope := auth.HasCapability(handler.Capabilities(), auth.CapScopesOnTokenRequest)
-		if scope == "" && requiresScope {
-			return nil, fmt.Errorf("%s: scope is required when authProvider %q is set (handler supports per-request scopes)", ProviderName, authProvider)
-		}
-		if scope != "" && !requiresScope {
-			lgr.V(1).Info("ignoring scope for auth provider that does not support per-request scopes",
-				"authProvider", authProvider,
-				"scope", scope,
-			)
-			scope = ""
-		}
-
-		// Calculate minimum token validity: request timeout + 60 second buffer
-		minValidFor := timeoutDuration + 60*time.Second
-
-		// Get token with sufficient validity
-		token, err := handler.GetToken(ctx, auth.TokenOptions{
-			Scope:       scope,
-			MinValidFor: minValidFor,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to get auth token: %w", ProviderName, err)
-		}
-
-		// Inject authorization header
-		headers["Authorization"] = fmt.Sprintf("%s %s", token.TokenType, token.AccessToken)
-		lgr.V(1).Info("injected auth header",
-			"authProvider", authProvider,
-			"scope", scope,
-			"tokenExpiresAt", token.ExpiresAt,
-			"minValidFor", minValidFor,
-		)
 	}
 
 	// Build httpc client with timeout and user-supplied retry configuration.
 	retryCfg := parseRetryConfig(inputs)
 	httpcCfg := buildHTTPClientConfig(timeoutDuration, retryCfg)
 
-	// Wire 401 token-refresh via the httpc OnUnauthorized hook when an auth provider is configured.
-	// The initial token was already injected into headers above; this hook handles silent re-auth on 401.
-	if authProvider != "" {
+	// Wire 401 token-refresh via the httpc OnUnauthorized hook when an auth provider is configured
+	// in CLI mode. In API mode (delegation registry present), no 401 retry is attempted because
+	// token refresh is handled by the delegation registry's layer.
+	if authProvider != "" && authdelegation.RegistryFromContext(ctx) == nil {
 		capturedScope := scope
 		capturedTimeout := timeoutDuration
 		capturedHandlerName, capturedProfile := auth.ParseProfileKey(authProvider)
@@ -768,4 +728,94 @@ func isJSONContentType(contentType string) bool {
 	ct := strings.ToLower(strings.TrimSpace(contentType))
 	return strings.HasPrefix(ct, "application/json") ||
 		strings.HasSuffix(ct, "+json")
+}
+
+// injectDelegatedToken resolves a token via the delegation registry (API mode) and sets
+// the Authorization header.
+func injectDelegatedToken(ctx context.Context, reg *authdelegation.DelegatorRegistry, authProvider, scope string, headers map[string]any) error {
+	lgr := logger.FromContext(ctx)
+
+	delegator, err := resolveDelegator(reg, authProvider)
+	if err != nil {
+		return err
+	}
+
+	result, err := delegator.DelegateToken(ctx, scope)
+	if err != nil {
+		return fmt.Errorf("%s: token delegation failed for %q: %w", ProviderName, authProvider, err)
+	}
+
+	headers["Authorization"] = "Bearer " + result.AccessToken
+	lgr.V(1).Info("injected delegated auth header",
+		"authProvider", authProvider,
+		"scope", scope,
+	)
+	return nil
+}
+
+// injectCLIToken resolves a token via the auth handler registry (CLI mode) and sets
+// the Authorization header.
+func injectCLIToken(ctx context.Context, authProvider, scope string, timeoutDuration time.Duration, headers map[string]any) error {
+	lgr := logger.FromContext(ctx)
+	// Parse profile from handler@profile syntax and inject into context.
+	handlerName, profile := auth.ParseProfileKey(authProvider)
+	if profile != "" {
+		if err := auth.ValidateProfileName(profile); err != nil {
+			return fmt.Errorf("%s: invalid profile in authProvider: %w", ProviderName, err)
+		}
+		ctx = auth.WithProfile(ctx, profile)
+	} else if resolved := auth.ResolveActiveProfile(ctx, handlerName); resolved != "" {
+		// No explicit profile in authProvider, use the active profile
+		ctx = auth.WithProfile(ctx, resolved)
+	}
+	handler, err := auth.GetHandler(ctx, authProvider)
+	if err != nil {
+		return fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
+	// Validate scope requirement based on handler capabilities
+	requiresScope := auth.HasCapability(handler.Capabilities(), auth.CapScopesOnTokenRequest)
+	if scope == "" && requiresScope {
+		return fmt.Errorf("%s: scope is required when authProvider %q is set (handler supports per-request scopes)", ProviderName, authProvider)
+	}
+	if scope != "" && !requiresScope {
+		lgr.V(1).Info("ignoring scope for auth provider that does not support per-request scopes",
+			"authProvider", authProvider,
+			"scope", scope,
+		)
+		scope = ""
+	}
+
+	// Calculate minimum token validity: request timeout + 60 second buffer
+	minValidFor := timeoutDuration + 60*time.Second
+
+	token, err := handler.GetToken(ctx, auth.TokenOptions{
+		Scope:       scope,
+		MinValidFor: minValidFor,
+	})
+	if err != nil {
+		return fmt.Errorf("%s: failed to get auth token: %w", ProviderName, err)
+	}
+
+	headers["Authorization"] = fmt.Sprintf("%s %s", token.TokenType, token.AccessToken)
+	lgr.V(1).Info("injected auth header",
+		"authProvider", authProvider,
+		"scope", scope,
+		"tokenExpiresAt", token.ExpiresAt,
+		"minValidFor", minValidFor,
+	)
+	return nil
+}
+
+func resolveDelegator(reg *authdelegation.DelegatorRegistry, authProvider string) (authdelegation.TokenDelegator, error) {
+	if delegator, ok := reg.Get(authProvider); ok {
+		return delegator, nil
+	}
+	// passthrough providers are registered under a different name, so check for that as well as a fallback to allow using the auth provider name directly in the http provider's authProvider field.
+	passThroughProvider := authdelegation.PassThroughDelegatorName(authProvider)
+	if delegator, ok := reg.Get(passThroughProvider); ok {
+		return delegator, nil
+	}
+
+	return nil, fmt.Errorf("%s: auth provider %q not found in delegation registry (available: %v)", ProviderName, authProvider, reg.Names())
 }

--- a/pkg/provider/builtin/httpprovider/http_test.go
+++ b/pkg/provider/builtin/httpprovider/http_test.go
@@ -5,6 +5,7 @@ package httpprovider
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/authdelegation"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/ptrs"
@@ -1222,4 +1224,198 @@ func TestIsJSONContentType(t *testing.T) {
 			assert.Equal(t, tt.expected, isJSONContentType(tt.contentType))
 		})
 	}
+}
+
+// ── Delegation registry tests ──
+
+// testDelegator implements authdelegation.TokenDelegator for testing.
+type testDelegator struct {
+	token string
+	name  string
+	err   error
+	calls int
+}
+
+func (d *testDelegator) DelegateToken(_ context.Context, _ string) (authdelegation.TokenResult, error) {
+	d.calls++
+	if d.err != nil {
+		return authdelegation.TokenResult{}, d.err
+	}
+	return authdelegation.TokenResult{AccessToken: d.token, ExpiresIn: 3600}, nil
+}
+
+func (d *testDelegator) Name() string {
+	return d.name
+}
+
+func TestHTTPProvider_Execute_DelegationRegistry_Success(t *testing.T) {
+	t.Parallel()
+	var receivedAuthHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"delegated": true}`))
+	}))
+	defer server.Close()
+
+	delegator := &testDelegator{token: "delegated-token-abc"}
+	reg := authdelegation.NewDelegatorRegistry()
+	reg.Register("entra", delegator)
+
+	ctx := authdelegation.WithRegistry(testContext(t), reg)
+
+	p := NewHTTPProvider()
+	inputs := map[string]any{
+		"url":          server.URL,
+		"method":       "GET",
+		"authProvider": "entra",
+		"scope":        "https://graph.microsoft.com/.default",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "Bearer delegated-token-abc", receivedAuthHeader)
+	assert.Equal(t, 1, delegator.calls)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 200, data["statusCode"])
+}
+
+func TestHTTPProvider_Execute_DelegationRegistry_ProviderNotRegistered(t *testing.T) {
+	t.Parallel()
+	reg := authdelegation.NewDelegatorRegistry()
+	// Registry exists but "gcp" is not registered.
+
+	ctx := authdelegation.WithRegistry(testContext(t), reg)
+
+	p := NewHTTPProvider()
+	inputs := map[string]any{
+		"url":          "https://example.com/api",
+		"method":       "GET",
+		"authProvider": "gcp",
+		"scope":        "https://www.googleapis.com/auth/cloud-platform",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcp")
+}
+
+func TestHTTPProvider_Execute_DelegationRegistry_DelegationError(t *testing.T) {
+	t.Parallel()
+	delegator := &testDelegator{err: fmt.Errorf("token endpoint returned 400")}
+	reg := authdelegation.NewDelegatorRegistry()
+	reg.Register("entra", delegator)
+
+	ctx := authdelegation.WithRegistry(testContext(t), reg)
+
+	p := NewHTTPProvider()
+	inputs := map[string]any{
+		"url":          "https://example.com/api",
+		"method":       "GET",
+		"authProvider": "entra",
+		"scope":        "https://graph.microsoft.com/.default",
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+}
+
+func TestHTTPProvider_Execute_DelegationRegistry_No401Retry(t *testing.T) {
+	t.Parallel()
+	attemptCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	delegator := &testDelegator{token: "delegated-token"}
+	reg := authdelegation.NewDelegatorRegistry()
+	reg.Register("entra", delegator)
+
+	ctx := authdelegation.WithRegistry(testContext(t), reg)
+
+	p := NewHTTPProvider()
+	inputs := map[string]any{
+		"url":          server.URL,
+		"method":       "GET",
+		"authProvider": "entra",
+		"scope":        "https://graph.microsoft.com/.default",
+	}
+
+	output, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	// Should NOT retry on 401 in API mode — only one request made.
+	assert.Equal(t, 1, attemptCount)
+	// DelegateToken called once for the initial token, NOT again for retry.
+	assert.Equal(t, 1, delegator.calls)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, 401, data["statusCode"])
+}
+
+func TestResolveDelegator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("if delegator has a normal and pass-through variants , return the non-pass-through delegator", func(t *testing.T) {
+		t.Parallel()
+		normal := &testDelegator{token: "token", name: "entra"}
+		reg := authdelegation.NewDelegatorRegistry()
+		passThroughProvider := authdelegation.PassThroughDelegatorName("entra")
+		reg.Register("entra", normal)
+		reg.Register(passThroughProvider, &testDelegator{token: "passthrough-token", name: passThroughProvider})
+
+		resolved, err := resolveDelegator(reg, "entra")
+		require.NoError(t, err)
+		assert.Equal(t, normal, resolved)
+	})
+	t.Run("if delegator has only pass-through variant, return it", func(t *testing.T) {
+		t.Parallel()
+		reg := authdelegation.NewDelegatorRegistry()
+		passThroughProvider := authdelegation.PassThroughDelegatorName("entra")
+		reg.Register(passThroughProvider, &testDelegator{token: "passthrough-token", name: passThroughProvider})
+		resolved, err := resolveDelegator(reg, "entra")
+		require.NoError(t, err)
+		assert.Equal(t, passThroughProvider, resolved.Name())
+	})
+	t.Run("canonicalizes pass-through delegator lookup", func(t *testing.T) {
+		t.Parallel()
+		reg := authdelegation.NewDelegatorRegistry()
+		passThroughProvider := authdelegation.PassThroughDelegatorName("Github")
+		reg.Register(passThroughProvider, &testDelegator{token: "passthrough-token", name: passThroughProvider})
+
+		resolved, err := resolveDelegator(reg, "Github")
+		require.NoError(t, err)
+		assert.Equal(t, passThroughProvider, resolved.Name())
+	})
+	t.Run("preserves exact direct lookup precedence", func(t *testing.T) {
+		t.Parallel()
+		exact := &testDelegator{token: "token", name: "Github"}
+		reg := authdelegation.NewDelegatorRegistry()
+		reg.Register("Github", exact)
+		passThroughProvider := authdelegation.PassThroughDelegatorName("Github")
+		reg.Register(passThroughProvider, &testDelegator{token: "passthrough-token", name: passThroughProvider})
+
+		resolved, err := resolveDelegator(reg, "Github")
+		require.NoError(t, err)
+		assert.Equal(t, exact, resolved)
+	})
+
+	t.Run("if delegator is not found, return error", func(t *testing.T) {
+		t.Parallel()
+		reg := authdelegation.NewDelegatorRegistry()
+
+		_, err := resolveDelegator(reg, "entra")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in delegation registry")
+	})
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -220,6 +220,9 @@ const (
 	// CEL or Go-template evaluation request. Prevents CPU exhaustion from
 	// expensive user-supplied expressions.
 	DefaultAPIEvalTimeout = 30 * time.Second
+
+	// DefaultAPIIdentityCacheSize is the default LRU cache size for delegated tokens.
+	DefaultAPIIdentityCacheSize = 1024
 )
 
 // Circuit breaker defaults

--- a/pkg/telemetry/tracer.go
+++ b/pkg/telemetry/tracer.go
@@ -25,6 +25,8 @@ const (
 	TracerAction = TracerRoot + "/action"
 	// TracerMCP is the instrumentation scope for MCP server handling.
 	TracerMCP = TracerRoot + "/mcp"
+	// TracerAuthDelegation is the instrumentation scope for token delegation flows.
+	TracerAuthDelegation = TracerRoot + "/authdelegation"
 )
 
 // Tracer returns a named tracer from the global TracerProvider.


### PR DESCRIPTION


## Description

Implements API-mode token delegation for downstream provider calls.

This PR adds:

- `token extraction` Token is extracted from authorization header and deduces types from claims
- `pkg/authdelegation` with Entra OBO and client credentials delegation flows
- server credential support for WIF and `SecretRef` client secrets
- LRU + TTL token caching with singleflight deduplication
- delegation flow allow-listing as a startup-time security boundary
- API token pass-through middleware for configured `Provider-Authorization-*` headers
- pass-through delegator registry wiring for request-scoped provider tokens
- HTTP provider delegated-token injection via `authProvider` and `scope`
- fallback resolution from `authProvider` to internal `passThrough:<provider>` entries
- config validation and defaults for Entra delegation and token pass-through
- design documentation for the implemented architecture

## Configuration Behavior

This PR uses explicit nil-pointer semantics so operators can distinguish omitted config from intentionally empty config.

### `apiServer.identity.entra.tokenManager`

- Omitted / `nil`: disables caching and singleflight; each `DelegateToken` call executes the token flow directly.
- Present but empty: enables token caching and singleflight with package defaults.
- Present with values: enables token caching and singleflight with the supplied overrides.

Default token manager settings include cache size, expiry buffer, cleanup interval, stale refresh threshold, slow request threshold, and follower retry behavior.

### `apiServer.identity.entra.allowedFlows`

- Omitted / `nil`: permits only OBO delegation by default.
- Present with `flows: []`: denies all delegation flows.
- Present with values: permits only the explicitly listed flows.

Supported Entra flow names are:

- `obo`
- `client_credentials`

This makes `client_credentials` opt-in rather than silently available.

### `apiServer.tokenPassThrough`

- Omitted / `nil`: enables the default pass-through provider header suffix, currently `Github-Cloud`.
- Present with `allowedHeaders: []`: disables token pass-through completely.
- Present with values: enables pass-through only for the listed suffixes.

~~~yaml
apiServer:
  identity:
    entra:
      tenantId: "00000000-0000-0000-0000-000000000000"
      clientId: "00000000-0000-0000-0000-000000000000"
      credential:
        type: secret                                             # "wif" or "secret"
        clientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"  or file://<filepath>  # SecretRef URI (required when type=secret)
        wifTokenPath: "/var/run/secrets/azure/tokens/fed-token"  # required when type=wif
      allowedFlows:                  # optional -- see nil semantics below
        flows: [obo, client_credentials]
      tokenManager:                  # optional -- see nil semantics below
        cacheSize: 1024
        expiryBuffer: "10m"
        cleanupInterval: "5m"
        expiryThreshold: "30m"
        slowThreshold: "500ms"
        retryFollowerOnError: true
  tokenPassThrough:                  # optional -- see nil semantics below
    allowedHeaders:                  # suffixes only, without Provider-Authorization-
      - Github-Cloud
      - Azure-Ad
~~~
## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [ ] `task lint` passes
- [ ] I have signed off my commits (`git commit -s -S`)
