### PR TITLE
ci: allow CI workflows to run on fork pull requests

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,0 +1,177 @@
+name: Benchmark Report
+
+# This workflow runs after the Benchmark workflow completes.
+# It downloads benchmark artifacts and posts comparison results as a PR comment.
+# Using workflow_run allows this to have write access without exposing secrets
+# to untrusted fork code.
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  report:
+    name: Post Benchmark Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            const benchArtifact = artifacts.data.artifacts.find(a => a.name === 'benchmark-results');
+            if (!benchArtifact) {
+              console.log('No benchmark-results artifact found, skipping.');
+              return;
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: benchArtifact.id,
+              archive_format: 'zip',
+            });
+
+            fs.writeFileSync('${{ github.workspace }}/benchmark-results.zip', Buffer.from(download.data));
+
+      - name: Determine PR number from workflow_run payload
+        id: pr-info
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Derive PR number from the trusted workflow_run event payload
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              console.log('No pull_requests in workflow_run payload, skipping.');
+              core.setOutput('pr_number', '');
+              return;
+            }
+            core.setOutput('pr_number', String(prs[0].number));
+
+      - name: Extract artifacts safely
+        if: steps.pr-info.outputs.pr_number != ''
+        run: |
+          if [ ! -f benchmark-results.zip ]; then
+            echo "No artifact to process, exiting."
+            exit 0
+          fi
+          # Extract only expected files into a dedicated directory to prevent
+          # zip-slip / path-traversal attacks from untrusted artifact content.
+          mkdir -p bench-artifacts
+          unzip -j -o benchmark-results.zip \
+            benchstat-result.txt pr-number.txt bench-metadata.json \
+            -d bench-artifacts/
+
+      - name: Post benchmark comparison
+        if: steps.pr-info.outputs.pr_number != '' && hashFiles('bench-artifacts/benchstat-result.txt') != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- benchmark-comparison -->';
+
+            // Use the trusted PR number from the workflow_run payload
+            const trustedPrNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}', 10);
+
+            // Cross-check against artifact value to detect tampering
+            let artifactPrNumber;
+            try {
+              artifactPrNumber = parseInt(fs.readFileSync('bench-artifacts/pr-number.txt', 'utf8').trim(), 10);
+            } catch (e) {
+              console.log('Could not read pr-number.txt from artifact:', e.message);
+              return;
+            }
+
+            if (artifactPrNumber !== trustedPrNumber) {
+              core.setFailed(`PR number mismatch: artifact says ${artifactPrNumber}, workflow_run says ${trustedPrNumber}. Aborting to prevent comment injection.`);
+              return;
+            }
+
+            const prNumber = trustedPrNumber;
+
+            // Read benchmark results
+            let result = 'No results available';
+            try {
+              result = fs.readFileSync('bench-artifacts/benchstat-result.txt', 'utf8').trim();
+            } catch (e) {
+              console.log('Could not read benchstat-result.txt:', e.message);
+              return;
+            }
+
+            // Sanitize: compute a fence delimiter longer than any backtick run in the content.
+            // This guarantees the content cannot break out of the code block.
+            const maxRun = (result.match(/`+/g) || []).reduce((max, s) => Math.max(max, s.length), 0);
+            const fence = '`'.repeat(Math.max(maxRun + 1, 4));
+
+            // Read metadata
+            let benchCount = '6';
+            let benchTime = '1s';
+            try {
+              const meta = JSON.parse(fs.readFileSync('bench-artifacts/bench-metadata.json', 'utf8'));
+              benchCount = meta.count || benchCount;
+              benchTime = meta.time || benchTime;
+            } catch (e) {
+              console.log('Could not read bench-metadata.json, using defaults.');
+            }
+
+            const body = [
+              marker,
+              '## Benchmark Comparison',
+              '',
+              '<details>',
+              '<summary>Click to expand benchmark results</summary>',
+              '',
+              fence,
+              result,
+              fence,
+              '',
+              '</details>',
+              '',
+              '> **How to read**: `~` means no significant change, `+` means regression, `-` means improvement. `p`-value >= 0.05 means the difference is not statistically significant.',
+              '>',
+              `> Benchmarks ran with \`-count=${benchCount}\` and \`-benchtime=${benchTime}\`.`,
+            ].join('\n');
+
+            // Find and update existing comment, or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +20,6 @@ concurrency:
 jobs:
   benchmark:
     name: Benchmark Comparison
-    # Only run on PRs from the same repo (not forks)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       SCAFCTL_SECRET_KEY: ${{ secrets.SCAFCTL_SECRET_KEY || 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=' }}
@@ -116,69 +113,19 @@ jobs:
           echo "$RESULT" > benchstat-result.txt
           set -e
 
-      - name: Post benchmark comparison
+      - name: Save PR number and metadata
         if: steps.find-bench.outputs.packages != '' && steps.benchstat.outputs.empty != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo '{"count":"'"${BENCH_COUNT}"'","time":"'"${BENCH_TIME}"'"}' > bench-metadata.json
+
+      - name: Upload benchmark results
+        if: steps.find-bench.outputs.packages != '' && steps.benchstat.outputs.empty != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- benchmark-comparison -->';
-            let result = 'No results available';
-            try {
-              result = fs.readFileSync('benchstat-result.txt', 'utf8').trim();
-            } catch (e) {
-              console.log('Could not read benchstat-result.txt:', e.message);
-            }
-            const count = process.env.BENCH_COUNT || '5';
-            const benchTime = process.env.BENCH_TIME || '1s';
-            const body = [
-              marker,
-              '## Benchmark Comparison',
-              '',
-              '<details>',
-              '<summary>Click to expand benchmark results</summary>',
-              '',
-              '```',
-              result,
-              '```',
-              '',
-              '</details>',
-              '',
-              '> **How to read**: `~` means no significant change, `+` means regression, `-` means improvement. `p`-value >= 0.05 means the difference is not statistically significant.',
-              '>',
-              `> Benchmarks ran with \`-count=${count}\` and \`-benchtime=${benchTime}\`.`,
-            ].join('\n');
-
-            const prNumber = context.payload.pull_request?.number;
-            if (!prNumber) {
-              console.log('No PR number found, skipping comment.');
-              return;
-            }
-
-            // Find and update existing comment, or create new one
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-            }
-        env:
-          BENCH_COUNT: ${{ env.BENCH_COUNT }}
-          BENCH_TIME: ${{ env.BENCH_TIME }}
+          name: benchmark-results
+          path: |
+            benchstat-result.txt
+            pr-number.txt
+            bench-metadata.json
+          retention-days: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,6 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    # Only run automatically for PRs from the same repo (not forks); push and schedule always run
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ env:
 jobs:
   lint:
     name: Lint
-    # Only run on PRs from the same repo (not forks)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -59,8 +58,6 @@ jobs:
 
   test:
     name: Test
-    # Run on PRs from the same repo and on push to main
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -96,6 +93,11 @@ jobs:
       - name: Run tests with coverage
         run: task test-cover
 
+      - name: Pre-warm plugin cache
+        run: |
+          task build
+          ./dist/scafctl plugins install sleep directory env exec git hcl metadata
+
       - name: Run functional integration tests
         run: task integration
 
@@ -115,7 +117,6 @@ jobs:
 
   plugin-sdk-compat:
     name: Plugin SDK Compatibility
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,25 @@ git push origin feat/my-feature
 
 Then create a Pull Request on GitHub.
 
+### Contributing from a Fork
+
+External contributors are welcome to fork the repository and submit pull requests.
+CI runs automatically on code-affecting PRs (including those from forks) with the
+following security model. Note that docs-only changes may not trigger all workflows
+due to path filters:
+
+- **Lint, Test, and Plugin SDK Compatibility** run automatically on fork PRs in
+  an unprivileged sandbox (read-only token, no access to repository secrets).
+- **Benchmarks** run in the same unprivileged context. Results are uploaded as
+  artifacts and a separate privileged workflow posts the comparison comment on the
+  PR.
+- **First-time contributors** may require a maintainer to approve the workflow run
+  via the GitHub repository setting "Require approval for first-time contributors."
+
+This means your PR will get full CI feedback without needing maintainer
+intervention (after your first contribution is approved). No secrets are ever
+exposed to fork code.
+
 ## Coding Standards
 
 ### Error Handling

--- a/tests/integration/solutions/providers/sleep/solution.yaml
+++ b/tests/integration/solutions/providers/sleep/solution.yaml
@@ -36,7 +36,7 @@ spec:
         description: Verify sleep provider completes successfully
         extends: [_base]
         tags: [smoke]
-        timeout: "10s"
+        timeout: "30s"
         assertions:
           - contains: shortSleep
             message: "Sleep resolver should appear in output"


### PR DESCRIPTION
- Remove fork-only guards from lint, test, and plugin-sdk-compat jobs in test.yml so external contributors get CI feedback
- Remove fork guard from CodeQL workflow
- Split benchmark workflow into two phases: unprivileged benchmark run (pull_request) uploads artifacts, privileged report (workflow_run) posts PR comment without executing fork code
- Drop pull-requests: write permission from benchmark.yml
- Add benchmark-report.yml using workflow_run trigger for safe privileged PR commenting
- Document the fork contribution CI model in CONTRIBUTING.md