### PR TITLE
fix(plugin): reject cached version that does not satisfy requested co…

### DIFF
--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -223,14 +223,8 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		if !f.noCache {
 			if cachedPath, cachedVer, ok := f.cache.GetLatestCached(cacheKey, f.platform); ok {
 				// If a version constraint is specified, verify the cached version satisfies it.
-				useCached := true
-				if dep.Version != "" && !strings.EqualFold(dep.Version, "latest") {
-					satisfies, err := bundler.CheckVersionConstraint(dep.Version, cachedVer)
-					if err != nil || !satisfies {
-						useCached = false
-					}
-				}
-				if useCached {
+				satisfies, _ := cachedVersionSatisfies(dep.Version, cachedVer)
+				if satisfies {
 					// Security: reject cached plugins when an allowlist is configured
 					// but cache lacks catalog origin metadata.
 					if err := f.checkCatalogAllowed(""); err != nil {
@@ -259,9 +253,21 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 
 		info, err := f.catalogFetcher.ResolvePlugin(ctx, dep.Name, kind, dep.Version)
 		if err != nil {
-			// Fallback: if catalog resolution fails, check if a cached version exists.
+			// Fallback: if catalog resolution fails, check if a cached version
+			// satisfies the requested constraint. If the cached version does not
+			// match, fail with the original error so users are never silently
+			// given a different version than they requested.
 			if !f.noCache {
 				if cachedPath, cachedVer, ok := f.cache.GetLatestCached(cacheKey, f.platform); ok {
+					// Verify cached version satisfies the requested constraint.
+					satisfies, constraintErr := cachedVersionSatisfies(dep.Version, cachedVer)
+					if constraintErr != nil {
+						return FetchResult{}, fmt.Errorf("resolving version: %w (constraint check failed: %w)", err, constraintErr)
+					}
+					if !satisfies {
+						return FetchResult{}, fmt.Errorf("resolving version: %w (cached version %s does not satisfy %q)", err, cachedVer, dep.Version)
+					}
+
 					// Security: reject cached plugins when an allowlist is configured
 					// but cache lacks catalog origin metadata.
 					if allowErr := f.checkCatalogAllowed(""); allowErr != nil {
@@ -628,4 +634,16 @@ func findLockPlugin(plugins []bundler.LockPlugin, name, kind string) *bundler.Lo
 		}
 	}
 	return nil
+}
+
+// cachedVersionSatisfies checks whether a cached version satisfies a version
+// constraint. Returns true when no constraint is specified or the constraint is
+// "latest". Returns false with a nil error when the constraint is simply not
+// satisfied. Returns false with a non-nil error when the constraint or cached
+// version string cannot be parsed.
+func cachedVersionSatisfies(constraint, cachedVer string) (bool, error) {
+	if constraint == "" || strings.EqualFold(constraint, "latest") {
+		return true, nil
+	}
+	return bundler.CheckVersionConstraint(constraint, cachedVer)
 }

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -767,3 +767,167 @@ func TestPluginCacheKey_NamespaceIsolation(t *testing.T) {
 	authKey := PluginCacheKey("github", solution.PluginKindAuthHandler)
 	assert.NotEqual(t, providerKey, authKey)
 }
+
+func TestFetcher_FetchPlugins_CatalogFallback_RejectsConstraintMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Catalog is empty — resolution will fail.
+	cat := newMockCatalog()
+
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir)
+
+	// Pre-populate cache with version 0.5.0
+	_, err := cache.Put("my-plugin", "0.5.0", "linux/amd64", []byte("old-binary"))
+	require.NoError(t, err)
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    cache,
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	// Request version 0.6.0 — catalog fails, cache has 0.5.0 which doesn't match.
+	deps := []solution.PluginDependency{
+		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: "0.6.0"},
+	}
+
+	_, err = f.FetchPlugins(context.Background(), deps, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not satisfy")
+	assert.Contains(t, err.Error(), "0.5.0")
+	assert.Contains(t, err.Error(), "0.6.0")
+}
+
+func TestFetcher_FetchPlugins_CacheHit_RangeConstraintSatisfied(t *testing.T) {
+	t.Parallel()
+
+	// Catalog is empty — resolution will fail if attempted.
+	cat := newMockCatalog()
+
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir)
+
+	// Pre-populate cache with version 0.5.2
+	_, err := cache.Put("my-plugin", "0.5.2", "linux/amd64", []byte("cached-binary"))
+	require.NoError(t, err)
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    cache,
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	// Request ^0.5.0 — cache has 0.5.2 which satisfies ^0.5.0.
+	// The first cache check should match and return without hitting catalog.
+	deps := []solution.PluginDependency{
+		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: "^0.5.0"},
+	}
+
+	results, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "0.5.2", results[0].Version)
+	assert.True(t, results[0].FromCache)
+}
+
+func TestFetcher_FetchPlugins_CacheHit_LatestUsesAnyVersion(t *testing.T) {
+	t.Parallel()
+
+	// Catalog is empty — resolution will fail if attempted.
+	cat := newMockCatalog()
+
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir)
+
+	// Pre-populate cache with version 0.5.0
+	_, err := cache.Put("my-plugin", "0.5.0", "linux/amd64", []byte("cached-binary"))
+	require.NoError(t, err)
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    cache,
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	// Request "latest" — cache has 0.5.0 which matches any version.
+	// The first cache check should match and return without hitting catalog.
+	deps := []solution.PluginDependency{
+		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: "latest"},
+	}
+
+	results, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "0.5.0", results[0].Version)
+	assert.True(t, results[0].FromCache)
+}
+
+func TestFetcher_FetchPlugins_CatalogFallback_InvalidConstraintReportsParseError(t *testing.T) {
+	t.Parallel()
+
+	// Catalog is empty — resolution will fail.
+	cat := newMockCatalog()
+
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir)
+
+	// Pre-populate cache with a valid version
+	_, err := cache.Put("my-plugin", "1.0.0", "linux/amd64", []byte("binary"))
+	require.NoError(t, err)
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    cache,
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	// Use an unparseable constraint — the fallback should surface the parse
+	// error separately from a "does not satisfy" message.
+	deps := []solution.PluginDependency{
+		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: ">>>invalid<<<"},
+	}
+
+	_, err = f.FetchPlugins(context.Background(), deps, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "constraint check failed")
+}
+
+func TestCachedVersionSatisfies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		constraint string
+		cached     string
+		want       bool
+		wantErr    bool
+	}{
+		{"empty constraint", "", "1.0.0", true, false},
+		{"latest", "latest", "0.5.0", true, false},
+		{"LATEST case insensitive", "LATEST", "0.5.0", true, false},
+		{"exact match", "1.0.0", "1.0.0", true, false},
+		{"exact mismatch", "2.0.0", "1.0.0", false, false},
+		{"range satisfied", "^1.0.0", "1.2.3", true, false},
+		{"range not satisfied", "^2.0.0", "1.2.3", false, false},
+		{"invalid constraint", ">>>bad<<<", "1.0.0", false, true},
+		{"invalid cached version", "^1.0.0", "not-semver", false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := cachedVersionSatisfies(tc.constraint, tc.cached)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
…nstraint

- Add version constraint check in the catalog resolution fallback path so `plugins install oci@0.6.0` errors instead of silently returning a cached 0.5.0 when the catalog is unavailable
- Error message includes both the catalog resolution failure and the constraint mismatch for clear diagnostics
- Add tests covering constraint rejection, range match, and "latest" cache behavior

Closes #412