### PR TITLE
fix(config): resolve unset for nested values and propagate auth defaults

### DIFF
--- a/pkg/cmd/scafctl/config/config_test.go
+++ b/pkg/cmd/scafctl/config/config_test.go
@@ -249,3 +249,131 @@ settings:
 	require.NoError(t, err)
 	assert.Equal(t, "none", cfg.Logging.Level)
 }
+
+func TestUnsetOptions_Run_NestedArrayKey(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `auth:
+  customOAuth2:
+    - name: my-handler
+      clientId: abc123
+      scopes:
+        - repo:read
+        - repo:write
+  github:
+    clientId: test-id
+settings:
+  defaultCatalog: official
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	opts := &UnsetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Key:        "auth.customOAuth2",
+	}
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	// Verify the key was removed from file entirely.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "customOAuth2")
+	assert.NotContains(t, string(data), "my-handler")
+	// Other keys remain.
+	assert.Contains(t, string(data), "github")
+}
+
+func TestUnsetOptions_Run_KeyNotInFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Config file exists but doesn't have the key we're unsetting.
+	configContent := `settings:
+  defaultCatalog: official
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	opts := &UnsetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Key:        "logging.level",
+	}
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// Should succeed (idempotent) and report that key was not present.
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "not present")
+}
+
+func TestUnsetOptions_Run_BrokenConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Config file has valid YAML but would fail validation during Load()
+	// (e.g., invalid catalog type). Unset should still work because it
+	// operates directly on the YAML without requiring Load().
+	configContent := `catalogs:
+  - name: bad
+    type: invalid-type-that-fails-validation
+    url: something
+auth:
+  customOAuth2:
+    - name: stale-handler
+      clientId: old-value
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	opts := &UnsetOptions{
+		IOStreams:  ioStreams,
+		CliParams:  cliParams,
+		ConfigPath: configPath,
+		Key:        "auth.customOAuth2",
+	}
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+
+	// Should succeed even though the config would fail Load() validation.
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	// Verify the key was removed.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "customOAuth2")
+	assert.NotContains(t, string(data), "stale-handler")
+	// Other content remains.
+	assert.Contains(t, string(data), "bad")
+}

--- a/pkg/cmd/scafctl/config/unset.go
+++ b/pkg/cmd/scafctl/config/unset.go
@@ -87,46 +87,20 @@ func (o *UnsetOptions) Run(ctx context.Context) error {
 	}
 
 	mgr := appconfig.NewManager(o.ConfigPath)
-	_, err := mgr.Load()
+
+	// Delete operates directly on the YAML file and does not require a
+	// successful Load(). This allows unset to repair broken config files
+	// that would fail validation during Load().
+	removed, err := mgr.Delete(o.Key)
 	if err != nil {
 		w.Errorf("%v", err)
 		return exitcode.WithCode(err, exitcode.ConfigError)
 	}
 
-	// Check if key exists
-	if !mgr.IsSet(o.Key) {
-		err := fmt.Errorf("key %q is not set in configuration", o.Key)
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
-	}
-
-	// Get default value based on key
-	defaultValue := o.getDefaultValue(o.Key)
-	mgr.Set(o.Key, defaultValue)
-
-	if err := mgr.Save(); err != nil {
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.ConfigError)
-	}
-
-	w.Successf("Unset %s (reset to default: %v)", o.Key, defaultValue)
-	return nil
-}
-
-// getDefaultValue returns the default value for a configuration key.
-func (o *UnsetOptions) getDefaultValue(key string) any {
-	defaults := map[string]any{
-		"settings.defaultCatalog": "official",
-		"settings.noColor":        false,
-		"settings.quiet":          false,
-		"logging.level":           "none",
-		"logging.format":          "console",
-		"logging.timestamps":      true,
-		"logging.enableProfiling": false,
-	}
-
-	if v, ok := defaults[key]; ok {
-		return v
+	if removed {
+		w.Successf("Unset %s (removed from config file; defaults will apply)", o.Key)
+	} else {
+		w.Successf("Key %s was not present in user config (defaults already apply)", o.Key)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -538,6 +539,76 @@ func (m *Manager) Set(key string, value any) {
 	}
 }
 
+// Delete removes a configuration key from the user's config file on disk.
+// Unlike Set(key, nil), this physically removes the key from the YAML so that
+// embedded defaults or Viper defaults take effect on next Load().
+// It operates directly on the YAML file to avoid Viper's inability to truly
+// delete keys.
+//
+// Returns true if the key was found and removed, false if it was not present.
+// A missing config file is treated as a no-op (returns false, nil).
+func (m *Manager) Delete(key string) (bool, error) {
+	configPath, err := m.configPathOrError()
+	if err != nil {
+		return false, err
+	}
+
+	data, err := os.ReadFile(configPath) //nolint:gosec // config path from trusted source
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // no config file means nothing to delete
+		}
+		return false, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var rawCfg map[string]any
+	if err := yaml.Unmarshal(data, &rawCfg); err != nil {
+		return false, fmt.Errorf("parsing config file: %w", err)
+	}
+	if rawCfg == nil {
+		return false, nil // nothing to delete
+	}
+
+	if !deleteNestedKey(rawCfg, strings.Split(key, ".")) {
+		return false, nil // key not present, nothing to do
+	}
+
+	out, err := yaml.Marshal(rawCfg)
+	if err != nil {
+		return false, fmt.Errorf("marshaling config: %w", err)
+	}
+	if err := os.WriteFile(configPath, out, 0o600); err != nil { //nolint:gosec // config file permissions
+		return false, fmt.Errorf("writing config file: %w", err)
+	}
+	return true, nil
+}
+
+// deleteNestedKey removes a key from a nested map structure given a path of
+// dot-separated segments. Returns true if the key was found and removed.
+func deleteNestedKey(m map[string]any, parts []string) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	if len(parts) == 1 {
+		if _, exists := m[parts[0]]; exists {
+			delete(m, parts[0])
+			return true
+		}
+		return false
+	}
+	// Traverse into the next level.
+	next, ok := m[parts[0]].(map[string]any)
+	if !ok {
+		return false
+	}
+	deleted := deleteNestedKey(next, parts[1:])
+	// Clean up empty parent maps.
+	if deleted && len(next) == 0 {
+		delete(m, parts[0])
+	}
+	return deleted
+}
+
 // Config returns the loaded configuration.
 func (m *Manager) Config() *Config {
 	return m.config
@@ -545,21 +616,30 @@ func (m *Manager) Config() *Config {
 
 // ConfigPath returns the path to the config file.
 func (m *Manager) ConfigPath() string {
+	p, _ := m.configPathOrError()
+	return p
+}
+
+// configPathOrError resolves the config file path, returning an error with the
+// root cause when the path cannot be determined.
+func (m *Manager) configPathOrError() (string, error) {
 	used := m.v.ConfigFileUsed()
 	if used != "" {
-		return used
+		return used, nil
 	}
 	// Return the configured path if no file has been loaded yet
 	if m.configPath != "" {
-		return m.configPath
+		return m.configPath, nil
 	}
 	// Return default XDG path
 	defaultPath, err := paths.ConfigFile()
 	if err != nil {
-		// Fallback should not happen in practice
-		return ""
+		return "", fmt.Errorf("failed to determine config path: %w", err)
 	}
-	return defaultPath
+	if defaultPath == "" {
+		return "", fmt.Errorf("failed to determine config path: resolved to empty string")
+	}
+	return defaultPath, nil
 }
 
 // IsSet checks if a configuration key is set.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -829,3 +829,165 @@ func TestRestoreAuthProfileEntries_PreservesNonEmpty(t *testing.T) {
 	assert.Equal(t, "work-app", cfg.Auth.GitHub.Profiles["work"].ClientID)
 	assert.NotNil(t, cfg.Auth.GitHub.Profiles["empty"])
 }
+
+func TestManager_Delete_SimpleKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	initial := `logging:
+  level: "2"
+  format: json
+settings:
+  noColor: true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	removed, err := mgr.Delete("logging.level")
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	// Verify the key is removed from file.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "level")
+	// Other keys remain.
+	assert.Contains(t, string(data), "format")
+	assert.Contains(t, string(data), "noColor")
+}
+
+func TestManager_Delete_NestedArraySection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	initial := `auth:
+  customOAuth2:
+    - name: my-handler
+      clientId: abc123
+      scopes:
+        - read
+        - write
+  github:
+    clientId: test-id
+settings:
+  defaultCatalog: official
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	removed, err := mgr.Delete("auth.customOAuth2")
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	// Verify customOAuth2 is removed but other auth keys remain.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "customOAuth2")
+	assert.NotContains(t, string(data), "my-handler")
+	assert.Contains(t, string(data), "github")
+	assert.Contains(t, string(data), "test-id")
+}
+
+func TestManager_Delete_TopLevelKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	initial := `logging:
+  level: "2"
+settings:
+  noColor: true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	removed, err := mgr.Delete("logging")
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "logging")
+	assert.NotContains(t, string(data), "level")
+	assert.Contains(t, string(data), "settings")
+}
+
+func TestManager_Delete_NonexistentKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	initial := `logging:
+  level: "2"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	// Should not error on non-existent key.
+	removed, err := mgr.Delete("nonexistent.key")
+	require.NoError(t, err)
+	assert.False(t, removed)
+
+	// File unchanged.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "level")
+}
+
+func TestManager_Delete_CleansEmptyParents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	initial := `auth:
+  github:
+    clientId: test-id
+settings:
+  defaultCatalog: official
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	removed, err := mgr.Delete("auth.github.clientId")
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	// github section had only clientId, so it should be cleaned up.
+	assert.NotContains(t, string(data), "clientId")
+	assert.NotContains(t, string(data), "github")
+	// auth is now empty, so it should be removed too.
+	assert.NotContains(t, string(data), "auth")
+	assert.Contains(t, string(data), "settings")
+}
+
+func TestManager_Delete_MissingFileIsNoOp(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "nonexistent", "config.yaml")
+
+	mgr := NewManager(configPath)
+	// Don't call Load -- simulate fresh install with no config file.
+
+	removed, err := mgr.Delete("logging.level")
+	require.NoError(t, err)
+	assert.False(t, removed)
+}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -116,6 +116,7 @@ func mergeDefaults(configPath string, defsYAML []byte) error {
 	changed := false
 	changed = mergeCatalogDefaults(existing, defs) || changed
 	changed = mergeDefaultCatalogSetting(existing, defs) || changed
+	changed = mergeAuthDefaults(existing, defs) || changed
 
 	if !changed {
 		return nil
@@ -215,6 +216,167 @@ func mergeDefaultCatalogSetting(existing, defs map[string]any) bool {
 	}
 	existingSettings["defaultCatalog"] = defaultCatalog
 	return true
+}
+
+// mergeAuthDefaults merges auth handler defaults from the provided defaults
+// into the existing config. For each known auth handler (github, entra, gcp),
+// it backfills missing fields (of any type except defaultScopes, which is
+// merged additively) and appends new scope entries from defaults that are not
+// already present. This ensures updated embedded defaults (e.g., new OAuth
+// scopes or new configuration keys) propagate to existing user config files.
+func mergeAuthDefaults(existing, defs map[string]any) bool {
+	defaultAuth, _ := defs["auth"].(map[string]any)
+	if defaultAuth == nil {
+		return false
+	}
+
+	if existing["auth"] == nil {
+		existing["auth"] = make(map[string]any)
+	}
+	existingAuth, _ := existing["auth"].(map[string]any)
+	if existingAuth == nil {
+		return false
+	}
+
+	changed := false
+	// Merge each known auth handler section.
+	for _, handler := range []string{"github", "entra", "gcp"} {
+		defHandler, _ := defaultAuth[handler].(map[string]any)
+		if defHandler == nil {
+			continue
+		}
+
+		if existingAuth[handler] == nil {
+			// Handler not in user config — add entire section from defaults.
+			existingAuth[handler] = defHandler
+			changed = true
+			continue
+		}
+
+		existingHandler, _ := existingAuth[handler].(map[string]any)
+		if existingHandler == nil {
+			continue
+		}
+
+		// Backfill missing scalar fields.
+		for k, v := range defHandler {
+			if k == "defaultScopes" {
+				continue // handled separately below
+			}
+			if _, has := existingHandler[k]; !has {
+				existingHandler[k] = v
+				changed = true
+			}
+		}
+
+		// Additively merge defaultScopes.
+		if mergeDefaultScopes(existingHandler, defHandler) {
+			changed = true
+		}
+	}
+
+	// Merge customOAuth2 entries by name (backfill missing entries only).
+	if mergeCustomOAuth2Defaults(existingAuth, defaultAuth) {
+		changed = true
+	}
+
+	return changed
+}
+
+// mergeDefaultScopes additively merges defaultScopes from defHandler into
+// existingHandler. New scope entries from defaults that are not already
+// present in the existing list are appended.
+func mergeDefaultScopes(existingHandler, defHandler map[string]any) bool {
+	defScopes := toStringSlice(defHandler["defaultScopes"])
+	if len(defScopes) == 0 {
+		return false
+	}
+
+	existingScopes := toStringSlice(existingHandler["defaultScopes"])
+	scopeSet := make(map[string]struct{}, len(existingScopes))
+	for _, s := range existingScopes {
+		scopeSet[s] = struct{}{}
+	}
+
+	changed := false
+	for _, s := range defScopes {
+		if _, has := scopeSet[s]; !has {
+			existingScopes = append(existingScopes, s)
+			scopeSet[s] = struct{}{}
+			changed = true
+		}
+	}
+
+	if changed {
+		// Store as []any to match YAML unmarshal format.
+		result := make([]any, len(existingScopes))
+		for i, s := range existingScopes {
+			result[i] = s
+		}
+		existingHandler["defaultScopes"] = result
+	}
+	return changed
+}
+
+// mergeCustomOAuth2Defaults adds any customOAuth2 entries from defaults that
+// are not already present (matched by name) in the existing auth config.
+// Existing entries are intentionally never modified -- customOAuth2 handlers
+// are user-defined configurations and their fields should not be overwritten
+// by defaults. Only entirely new entries (by name) are appended.
+func mergeCustomOAuth2Defaults(existingAuth, defaultAuth map[string]any) bool {
+	defaultCustom := toSlice(defaultAuth["customOAuth2"])
+	if len(defaultCustom) == 0 {
+		return false
+	}
+
+	existingCustom := toSlice(existingAuth["customOAuth2"])
+	nameSet := make(map[string]struct{}, len(existingCustom))
+	for _, c := range existingCustom {
+		if m, ok := c.(map[string]any); ok {
+			if name, ok := m["name"].(string); ok {
+				nameSet[name] = struct{}{}
+			}
+		}
+	}
+
+	changed := false
+	for _, c := range defaultCustom {
+		dm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := dm["name"].(string)
+		if name == "" {
+			continue
+		}
+		if _, exists := nameSet[name]; !exists {
+			existingCustom = append(existingCustom, c)
+			changed = true
+		}
+	}
+
+	if changed {
+		existingAuth["customOAuth2"] = existingCustom
+	}
+	return changed
+}
+
+// toStringSlice converts an any that is expected to be []any of strings (from
+// YAML unmarshalling) into a []string. Returns nil if the underlying value is
+// not a slice (via toSlice). Non-string items within the slice are silently
+// skipped, so the result may be shorter than the input.
+func toStringSlice(v any) []string {
+	items := toSlice(v)
+	if items == nil {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 // toSlice converts an any that is expected to be []any (from YAML

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -462,3 +462,250 @@ func TestMergeDefaultCatalogEntries_ReservedOverwrite(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeAuthDefaults_AddsNewScopes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Existing config with old scopes (missing "read:packages").
+	existing := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    hostname: github.com
+    defaultScopes:
+      - repo
+      - read:org
+catalogs:
+  - name: local
+    type: filesystem
+  - name: official
+    type: oci
+    url: oci://ghcr.io/oakwood-commons
+    authProvider: github
+settings:
+  defaultCatalog: official
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	// Defaults with new scope "read:packages".
+	defaults := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    hostname: github.com
+    defaultScopes:
+      - repo
+      - read:org
+      - read:packages
+catalogs:
+  - name: local
+    type: filesystem
+settings:
+  defaultCatalog: official
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	require.NotNil(t, auth)
+	github, _ := auth["github"].(map[string]any)
+	require.NotNil(t, github)
+
+	scopes := toStringSlice(github["defaultScopes"])
+	assert.Contains(t, scopes, "repo")
+	assert.Contains(t, scopes, "read:org")
+	assert.Contains(t, scopes, "read:packages")
+}
+
+func TestMergeAuthDefaults_DoesNotDuplicateExistingScopes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	existing := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    defaultScopes:
+      - repo
+      - read:org
+      - read:packages
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	defaults := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    defaultScopes:
+      - repo
+      - read:org
+      - read:packages
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	github, _ := auth["github"].(map[string]any)
+	scopes := toStringSlice(github["defaultScopes"])
+	assert.Len(t, scopes, 3, "should not duplicate existing scopes")
+}
+
+func TestMergeAuthDefaults_BackfillsMissingHandler(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Existing config has no auth section at all.
+	existing := `settings:
+  defaultCatalog: official
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	defaults := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    hostname: github.com
+    defaultScopes:
+      - repo
+settings:
+  defaultCatalog: official
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	require.NotNil(t, auth)
+	github, _ := auth["github"].(map[string]any)
+	require.NotNil(t, github)
+	assert.Equal(t, "Ov23li6xn492GhPmt4YG", github["clientId"])
+	assert.Equal(t, "github.com", github["hostname"])
+}
+
+func TestMergeAuthDefaults_BackfillsNewField(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Existing has github but no hostname field.
+	existing := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    defaultScopes:
+      - repo
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	defaults := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    hostname: github.com
+    defaultScopes:
+      - repo
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	github, _ := auth["github"].(map[string]any)
+	assert.Equal(t, "github.com", github["hostname"])
+	// clientId must not be overwritten.
+	assert.Equal(t, "Ov23li6xn492GhPmt4YG", github["clientId"])
+}
+
+func TestMergeAuthDefaults_PreservesUserClientID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// User has a custom clientId.
+	existing := `auth:
+  github:
+    clientId: user-custom-id
+    defaultScopes:
+      - repo
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	defaults := `auth:
+  github:
+    clientId: Ov23li6xn492GhPmt4YG
+    defaultScopes:
+      - repo
+      - read:org
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	github, _ := auth["github"].(map[string]any)
+	// User's custom clientId must not be overwritten.
+	assert.Equal(t, "user-custom-id", github["clientId"])
+	// But new scope should be added.
+	scopes := toStringSlice(github["defaultScopes"])
+	assert.Contains(t, scopes, "read:org")
+}
+
+func TestMergeAuthDefaults_CustomOAuth2_AddsNew(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	existing := `auth:
+  customOAuth2:
+    - name: existing-handler
+      clientId: abc
+`
+	require.NoError(t, os.WriteFile(path, []byte(existing), 0o600))
+
+	defaults := `auth:
+  customOAuth2:
+    - name: existing-handler
+      clientId: xyz
+    - name: new-handler
+      clientId: def
+`
+	err := EnsureDefaultsWith(path, []byte(defaults))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	auth, _ := cfg["auth"].(map[string]any)
+	customOAuth2 := toSlice(auth["customOAuth2"])
+	assert.Len(t, customOAuth2, 2)
+
+	// Existing handler should not be modified.
+	first, _ := customOAuth2[0].(map[string]any)
+	assert.Equal(t, "existing-handler", first["name"])
+	assert.Equal(t, "abc", first["clientId"], "existing entry must not be modified")
+
+	// New handler should be added.
+	second, _ := customOAuth2[1].(map[string]any)
+	assert.Equal(t, "new-handler", second["name"])
+}


### PR DESCRIPTION
- Add Manager.Delete() method that removes keys from the YAML file directly, fixing nested array values (e.g., auth.customOAuth2) that Set(nil) could not remove via Viper
- Rewrite config unset command to use Delete() instead of the broken Set-to-hardcoded-default approach
- Add mergeAuthDefaults() to EnsureDefaultsWith so updated embedded defaults (new OAuth scopes, new handler fields) propagate to existing user config files additively
- Add mergeCustomOAuth2Defaults() for name-matched custom handler merging
- Clean up empty parent maps after key deletion

Closes #399