### PR TITLE
feat(cli)!: unified solution auto-discovery and resolution chain

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,3 +61,17 @@ gosec ./...
 ## Additional Conventions
 
 Go coding conventions (struct tags, error handling, design patterns), testing rules, integration test scoping, and documentation requirements are in `.github/instructions/*.instructions.md` files -- they load automatically when editing relevant files.
+
+## Auto-Discovery and Resolution
+
+When no `-f` flag is provided, all CLI commands use the unified `Resolve()` function from `pkg/solution/get` which:
+
+1. Returns the explicit `-f` path if provided.
+2. Returns the positional argument if provided (catalog reference).
+3. Auto-discovers solution files by searching folder prefixes (`scafctl/`, `.scafctl/`, `.`) combined with file names (`solution.yaml`, `solution.yml`, `scafctl.yaml`, `scafctl.yml`, `solution.json`, `scafctl.json`, `taskfile.yaml`, `taskfile.yml`, `actions.yaml`, `actions.yml`).
+
+**Multi-match ambiguity handling** uses risk levels:
+- **Low-risk** (`DiscoveryRiskLow`): uses first match, emits a warning about other matches. Used by `run`, `lint`, `test`.
+- **High-risk** (`DiscoveryRiskHigh`): returns an error requiring `-f`. Used by `build`.
+
+The MCP server's `list_solutions` tool also uses `FindAllSolutions()` and returns all discovered paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(cli)* [**breaking**] Unified solution auto-discovery and resolution chain across all commands (#260)
+  - Add `taskfile.yaml` and `taskfile.yml` to default discovery search order (after solution/binary files, before actions)
+  - All commands now use the same resolution chain: `-f` flag → positional catalog ref → auto-discovery
+  - Multi-match ambiguity handling: low-risk commands (run, lint, test) warn and use first match; high-risk commands (build) error and require `-f`
+  - Auto-discovery now prints "Using {path}" when a solution is found
+  - Fix lint auto-discovery bug where discovered path was not passed to the linter
+  - Fix test functional error message to include searched paths
+  - `taskfile.yaml` is NOT searched in action discovery mode
 - *(dryrun)* [**breaking**] Replace static `MockBehavior` string with dynamic `WhatIf` function on provider `Descriptor` for context-aware dry-run messages
 - *(dryrun)* [**breaking**] Remove resolver-level dry-run (`run resolver --dry-run` removed); use `run solution --dry-run` or `run resolver --graph` instead
 - *(dryrun)* [**breaking**] Resolvers now execute normally during dry-run (side-effect-free) instead of being mocked, providing real data for WhatIf messages

--- a/docs/design/auto-discovery-resolution.md
+++ b/docs/design/auto-discovery-resolution.md
@@ -1,0 +1,152 @@
+---
+title: "Auto-Discovery Resolution Chain"
+weight: 10
+---
+
+# Auto-Discovery Resolution Chain
+
+## Overview
+
+When no `-f` flag is provided, scafctl automatically searches for solution files
+using a unified resolution chain. This design introduces risk-based ambiguity
+handling and adds `taskfile.yaml`/`taskfile.yml` as discoverable file names.
+
+## Problem Statement
+
+1. **Inconsistent discovery** -- Each CLI command implemented its own discovery
+   logic with slightly different behavior, making it hard to predict which file
+   would be used.
+2. **Silent ambiguity** -- When multiple solution files existed in a project
+   (e.g., `solution.yaml` and `actions.yaml`), the first match was used with
+   no feedback to the user.
+3. **Destructive command risk** -- Commands like `build` that publish artifacts
+   should not silently pick an ambiguous file -- the consequences of choosing
+   wrong are harder to reverse.
+4. **Missing taskfile support** -- Projects using `taskfile.yaml` as their
+   solution filename had to always specify `-f`.
+
+## Design
+
+### Unified Resolution Chain
+
+All commands use a single `Resolve()` function from `pkg/solution/get` that
+implements a three-step chain:
+
+1. **Explicit flag** -- If `-f` is provided, use it directly (no discovery).
+2. **Positional argument** -- If a positional arg is given (catalog reference),
+   use it as-is.
+3. **Auto-discovery** -- Search configured folders and file names in priority
+   order, returning all matches.
+
+~~~go
+resolved, err := get.Resolve(ctx, getter, file, positionalArg, get.ResolveOptions{
+    Risk: get.DiscoveryRiskLow,
+})
+~~~
+
+### Discovery Risk Levels
+
+The `DiscoveryRisk` type controls how multi-match ambiguity is handled:
+
+| Risk Level | Behavior | Commands |
+|------------|----------|----------|
+| `DiscoveryRiskLow` | Use first match, emit warning about others to stderr | `run`, `lint`, `test`, `render` |
+| `DiscoveryRiskHigh` | Return an error listing all matches, require `-f` | `build` |
+
+This ensures read-only or easily-reversible commands remain convenient while
+destructive operations require explicit intent.
+
+### File Name Search Order
+
+The search combines folder prefixes with file names in this order:
+
+**Folder prefixes** (checked in order):
+1. `scafctl/` -- conventional project subfolder
+2. `.scafctl/` -- hidden project subfolder
+3. *(current directory)* -- root
+
+**File names** (checked in order per folder):
+1. `solution.yaml`
+2. `solution.yml`
+3. `scafctl.yaml`
+4. `scafctl.yml`
+5. `solution.json`
+6. `scafctl.json`
+7. `taskfile.yaml`
+8. `taskfile.yml`
+9. `actions.yaml`
+10. `actions.yml`
+
+This produces 30 candidate paths checked in priority order (3 folders x 10 names).
+
+### FindAllSolutions vs FindSolution
+
+| Function | Behavior |
+|----------|----------|
+| `FindSolution()` | Returns the first match (backward compatible) |
+| `FindAllSolutions()` | Returns all matches in priority order with deduplication |
+
+`FindAllSolutions` uses canonical path resolution to deduplicate entries when
+different relative paths resolve to the same absolute file.
+
+### MCP Server Integration
+
+The MCP server's `discoverSolutionFiles()` uses `FindAllSolutions()` to report
+all discoverable solutions to AI clients, enabling them to present the full set
+of available solutions in a workspace.
+
+## Behavior Examples
+
+### Single match (common case)
+
+~~~
+$ scafctl lint
+Using solution.yaml
+...
+~~~
+
+### Multiple matches, low-risk command
+
+~~~
+$ scafctl lint
+Using solution.yaml
+WARNING: Multiple solution files found (also: actions.yaml); using first match
+...
+~~~
+
+### Multiple matches, high-risk command
+
+~~~
+$ scafctl build solution
+Error: multiple solution files found: solution.yaml, actions.yaml; use -f/--file to specify which one
+~~~
+
+## API
+
+~~~go
+package get
+
+type DiscoveryRisk int
+
+const (
+    DiscoveryRiskLow  DiscoveryRisk = iota  // warn on ambiguity
+    DiscoveryRiskHigh                       // error on ambiguity
+)
+
+type ResolveOptions struct {
+    Risk          DiscoveryRisk
+    DiscoveryMode settings.DiscoveryMode
+}
+
+func Resolve(ctx context.Context, getter *Getter, file, positionalArg string, opts ResolveOptions) (string, error)
+
+func (o *Getter) FindAllSolutions() []DiscoveryResult
+func (o *Getter) SearchedPaths() []string
+~~~
+
+## Testing
+
+- Unit tests in `pkg/solution/get/resolve_test.go` cover the resolution chain,
+  risk levels, and edge cases (no files, single match, multi-match).
+- Integration tests in `tests/integration/cli_test.go` verify end-to-end
+  discovery of `taskfile.yaml` and multi-match warning output.

--- a/docs/tutorials/auto-discovery-tutorial.md
+++ b/docs/tutorials/auto-discovery-tutorial.md
@@ -55,16 +55,16 @@ scafctl run solution
 
 ## How Auto-Discovery Works
 
-When no `-f` flag is provided, scafctl calls `FindSolution()`, which iterates over a set of **folder prefixes** and **file names** in order, returning the first match.
+When no `-f` flag is provided, scafctl searches for solution files using the unified resolution chain, which iterates over a set of **folder prefixes** and **file names** in order, returning the first match.
 
 ### Search Order
 
 The search combines these folder prefixes with these file names:
 
 **Folder prefixes** (checked in order):
-1. `scafctl/` — conventional project subfolder
-2. `.scafctl/` — hidden project subfolder
-3. *(current directory)* — no subfolder prefix
+1. `scafctl/` -- conventional project subfolder
+2. `.scafctl/` -- hidden project subfolder
+3. *(current directory)* -- no subfolder prefix
 
 **File names** (checked in order for each folder):
 1. `solution.yaml`
@@ -73,8 +73,12 @@ The search combines these folder prefixes with these file names:
 4. `scafctl.yml`
 5. `solution.json`
 6. `scafctl.json`
+7. `taskfile.yaml`
+8. `taskfile.yml`
+9. `actions.yaml`
+10. `actions.yml`
 
-This produces 18 candidate paths checked in this exact order:
+This produces 30 candidate paths checked in this exact order:
 
 | Priority | Path |
 |----------|------|
@@ -84,20 +88,62 @@ This produces 18 candidate paths checked in this exact order:
 | 4 | `scafctl/scafctl.yml` |
 | 5 | `scafctl/solution.json` |
 | 6 | `scafctl/scafctl.json` |
-| 7 | `.scafctl/solution.yaml` |
-| 8 | `.scafctl/solution.yml` |
-| 9 | `.scafctl/scafctl.yaml` |
-| 10 | `.scafctl/scafctl.yml` |
-| 11 | `.scafctl/solution.json` |
-| 12 | `.scafctl/scafctl.json` |
-| 13 | `solution.yaml` |
-| 14 | `solution.yml` |
-| 15 | `scafctl.yaml` |
-| 16 | `scafctl.yml` |
-| 17 | `solution.json` |
-| 18 | `scafctl.json` |
+| 7 | `scafctl/taskfile.yaml` |
+| 8 | `scafctl/taskfile.yml` |
+| 9 | `scafctl/actions.yaml` |
+| 10 | `scafctl/actions.yml` |
+| 11 | `.scafctl/solution.yaml` |
+| 12 | `.scafctl/solution.yml` |
+| 13 | `.scafctl/scafctl.yaml` |
+| 14 | `.scafctl/scafctl.yml` |
+| 15 | `.scafctl/solution.json` |
+| 16 | `.scafctl/scafctl.json` |
+| 17 | `.scafctl/taskfile.yaml` |
+| 18 | `.scafctl/taskfile.yml` |
+| 19 | `.scafctl/actions.yaml` |
+| 20 | `.scafctl/actions.yml` |
+| 21 | `solution.yaml` |
+| 22 | `solution.yml` |
+| 23 | `scafctl.yaml` |
+| 24 | `scafctl.yml` |
+| 25 | `solution.json` |
+| 26 | `scafctl.json` |
+| 27 | `taskfile.yaml` |
+| 28 | `taskfile.yml` |
+| 29 | `actions.yaml` |
+| 30 | `actions.yml` |
 
 The first file that exists on disk is used.
+
+> **Note:** `taskfile.yaml` is NOT searched in action discovery mode (`scafctl run action`). It is only searched in default and solution discovery modes.
+
+### Multi-Match Ambiguity Handling
+
+When multiple solution files exist in a project, scafctl handles them based on command risk level:
+
+| Risk Level | Commands | Behavior |
+|------------|----------|----------|
+| Low | `run solution`, `run resolver`, `lint`, `test`, `render` | Uses first match, prints a warning about other files found |
+| High | `build solution`, `catalog push` | Returns an error, requires `-f` to disambiguate |
+
+When auto-discovery succeeds, scafctl always prints which file was selected:
+
+```
+Using scafctl/solution.yaml
+```
+
+When multiple files are found with a low-risk command:
+
+```
+Using scafctl/solution.yaml
+WARNING: Multiple solution files found (also: solution.yaml); using first match
+```
+
+When multiple files are found with a high-risk command:
+
+```
+Error: multiple solution files found: scafctl/solution.yaml, solution.yaml; use -f/--file to specify which one
+```
 
 ## Supported Commands
 
@@ -271,7 +317,7 @@ cd /path/to/project; scafctl run solution
 {{% /tab %}}
 {{< /tabs >}}
 
-All 18 candidate paths are resolved against the `--cwd` target.
+All 30 candidate paths are resolved against the `--cwd` target.
 
 ## When Auto-Discovery Fails
 
@@ -303,12 +349,16 @@ scafctl config paths
 
 ## Best Practices
 
-1. **Use `solution.yaml` at the project root** — this is the most common convention and is discovered without any subfolder prefix.
+1. **Use `solution.yaml` at the project root** -- this is the most common convention and is discovered without any subfolder prefix.
 
-2. **Use `scafctl/` subfolder for multi-tool repos** — keeps scafctl configuration separate from other tools.
+2. **Use `scafctl/` subfolder for multi-tool repos** -- keeps scafctl configuration separate from other tools.
 
-3. **Use `.scafctl/` for hidden configuration** — useful when the solution is infrastructure that shouldn't be front-and-center.
+3. **Use `.scafctl/` for hidden configuration** -- useful when the solution is infrastructure that shouldn't be front-and-center.
 
-4. **Always use `-f` in CI/CD** — explicit paths prevent surprises when the working directory changes.
+4. **Use `taskfile.yaml` for task runner workflows** -- similar to how `make` uses `Makefile` or `task` uses `Taskfile.yaml`, scafctl discovers `taskfile.yaml` for task-oriented solutions.
 
-5. **Combine with `--cwd` for monorepos** — target a specific project without changing directories.
+5. **Always use `-f` in CI/CD** -- explicit paths prevent surprises when the working directory changes.
+
+6. **Combine with `--cwd` for monorepos** -- target a specific project without changing directories.
+
+7. **Avoid multiple solution files** -- if you must have them (e.g., both `solution.yaml` and `taskfile.yaml`), use `-f` with high-risk commands like `build solution` to avoid errors.

--- a/examples/README.md
+++ b/examples/README.md
@@ -166,6 +166,7 @@ Complete solutions demonstrating real-world use cases.
 | [scaffold-demo/](solutions/scaffold-demo/) | Test scaffolding with `scafctl test init` -- generates starter test suites |
 | [github-auth/](solutions/github-auth/) | GitHub authentication -- identity, API calls, and status checks |
 | [message-demo/](solutions/message-demo/) | Message provider -- styled terminal output with templates |
+| [taskfile-discovery.yaml](solutions/taskfile-discovery.yaml) | Auto-discovery of `taskfile.yaml` named solutions without `-f` |
 
 ---
 

--- a/examples/solutions/taskfile-discovery.yaml
+++ b/examples/solutions/taskfile-discovery.yaml
@@ -1,0 +1,51 @@
+# Auto-Discovery: taskfile.yaml
+#
+# scafctl auto-discovers solution files by name. When a file is named
+# "taskfile.yaml" or "taskfile.yml", it can be found without -f:
+#
+#   cp examples/solutions/taskfile-discovery.yaml ./taskfile.yaml
+#   scafctl run resolver          # auto-discovers taskfile.yaml
+#   scafctl lint                  # auto-discovers taskfile.yaml
+#
+# Discovery priority (per folder): solution.yaml > solution.yml >
+# scafctl.yaml > scafctl.yml > solution.json > scafctl.json >
+# taskfile.yaml > taskfile.yml > actions.yaml > actions.yml
+#
+# Multi-match behavior:
+#   - Low-risk commands (run, lint, test): use first match, warn about others
+#   - High-risk commands (build): error when ambiguous, require -f
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: taskfile-discovery
+  version: "1.0.0"
+  displayName: Taskfile Auto-Discovery Example
+  category: examples
+  tags:
+    - example
+    - discovery
+    - taskfile
+  description: |
+    Demonstrates that solutions named taskfile.yaml are auto-discovered
+    by scafctl without needing the -f flag.
+
+spec:
+  resolvers:
+    greeting:
+      description: A greeting resolved from a taskfile-named solution
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Hello from taskfile.yaml!"
+
+    discovery_note:
+      description: Explains how this file was discovered
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "This solution was auto-discovered because it is named taskfile.yaml"

--- a/pkg/cmd/scafctl/build/solution.go
+++ b/pkg/cmd/scafctl/build/solution.go
@@ -203,14 +203,16 @@ func CommandBuildSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams
 
 			if options.File == "" {
 				getter := get.NewGetterFromContext(cmd.Context())
-				options.File = getter.FindSolution()
-				if options.File == "" {
-					err := fmt.Errorf("no -f/--file specified and no solution file found in default locations")
+				resolvedPath, resolveErr := get.Resolve(cmd.Context(), getter, "", "", get.ResolveOptions{
+					Risk: get.DiscoveryRiskHigh,
+				})
+				if resolveErr != nil {
 					if w := writer.FromContext(cmd.Context()); w != nil {
-						w.Errorf("%v", err)
+						w.Errorf("%v", resolveErr)
 					}
-					return exitcode.WithCode(err, exitcode.InvalidInput)
+					return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
 				}
+				options.File = resolvedPath
 			}
 
 			// Stdin requires --no-bundle: there is no local directory to discover files from.

--- a/pkg/cmd/scafctl/build/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/build/solution_coverage_test.go
@@ -86,7 +86,7 @@ func TestCommandBuildSolution_RequiresArgs(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no -f/--file specified")
+	assert.Contains(t, err.Error(), "no solution path provided")
 }
 
 func TestCommandBuildSolution_TagConflictsWithName(t *testing.T) {

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -188,17 +188,20 @@ func runLint(ctx context.Context, opts *Options) error {
 
 	getter := get.NewGetterFromContext(ctx, getterOpts...)
 
+	// Unified resolution chain: -f > positional arg > auto-discover
+	resolvedPath, resolveErr := get.Resolve(ctx, getter, opts.File, "", get.ResolveOptions{
+		Risk: get.DiscoveryRiskLow,
+	})
+	if resolveErr != nil {
+		writeError(opts, fmt.Sprintf("failed to load solution: %v", resolveErr))
+		return exitcode.WithCode(resolveErr, exitcode.FileNotFound)
+	}
+	// Update opts.File so downstream linting reports the correct path.
+	opts.File = resolvedPath
+
 	// Emit verbose discovery information
 	if w := writer.FromContext(ctx); w != nil && w.VerboseEnabled() {
 		switch opts.File {
-		case "":
-			binaryName := settings.CliBinaryName
-			if opts.CliParams != nil && opts.CliParams.BinaryName != "" {
-				binaryName = opts.CliParams.BinaryName
-			}
-			w.Verbosef("Auto-discovering solution (binary=%s)", binaryName)
-			w.Verbosef("  Search folders: %v", settings.SolutionFoldersFor(binaryName))
-			w.Verbosef("  Search filenames: %v", settings.SolutionFileNamesFor(binaryName))
 		case "-":
 			w.Verbose("Loading solution from stdin")
 		default:

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -563,20 +563,24 @@ func (o *SolutionOptions) loadSolution(ctx context.Context) (*solution.Solution,
 			lgr.V(1).Info("catalog not available for solution resolution", "error", err)
 		}
 
-		getter = get.NewGetterFromContext(ctx, getterOpts...)
+		concreteGetter := get.NewGetterFromContext(ctx, getterOpts...)
+		getter = concreteGetter
+
+		// Unified resolution chain: -f > positional arg > auto-discover
+		if o.File != "-" {
+			resolvedPath, resolveErr := get.Resolve(ctx, concreteGetter, o.File, "", get.ResolveOptions{
+				Risk: get.DiscoveryRiskLow,
+			})
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			o.File = resolvedPath
+		}
 	}
 
 	// Emit verbose discovery information
 	if w := writer.FromContext(ctx); w != nil && w.VerboseEnabled() {
 		switch o.File {
-		case "":
-			binaryName := settings.CliBinaryName
-			if o.CliParams != nil && o.CliParams.BinaryName != "" {
-				binaryName = o.CliParams.BinaryName
-			}
-			w.Verbosef("Auto-discovering solution (binary=%s)", binaryName)
-			w.Verbosef("  Search folders: %v", settings.SolutionFoldersFor(binaryName))
-			w.Verbosef("  Search filenames: %v", settings.SolutionFileNamesFor(binaryName))
 		case "-":
 			// stdin handled below
 		default:

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -645,19 +645,25 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 		binaryName = o.CliParams.BinaryName
 	}
 
+	// Unified resolution chain for auto-discovery with ambiguity handling.
+	// Only applies when -f is not specified and no positional arg was given.
+	if o.File == "" {
+		getter := get.NewGetterFromContext(ctx)
+		if o.discoveryMode != settings.DiscoveryModeDefault {
+			getter.SetDiscoveryMode(o.discoveryMode)
+		}
+		resolvedPath, resolveErr := get.Resolve(ctx, getter, "", "", get.ResolveOptions{
+			Risk: get.DiscoveryRiskLow,
+		})
+		if resolveErr != nil {
+			return nil, nil, "", func() {}, nil, resolveErr
+		}
+		o.File = resolvedPath
+	}
+
 	// Emit verbose discovery information before loading
 	if w != nil && w.VerboseEnabled() {
 		switch o.File {
-		case "":
-			var customActionFiles []string
-			if o.CliParams != nil {
-				customActionFiles = o.CliParams.ActionDiscoveryFileNames
-			}
-			folders := settings.SolutionFoldersFor(binaryName)
-			fileNames := settings.FileNamesForMode(o.discoveryMode, binaryName, customActionFiles)
-			w.Verbosef("Auto-discovering solution (binary=%s, mode=%s)", binaryName, o.discoveryMode)
-			w.Verbosef("  Search folders: %v", folders)
-			w.Verbosef("  Search filenames: %v", fileNames)
 		case "-":
 			w.Verbose("Loading solution from stdin")
 		default:

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -170,14 +171,19 @@ func runFunctional(ctx context.Context, opts *FunctionalOptions) error {
 		testsPath = opts.File
 	}
 	if testsPath == "" {
-		testsPath = get.NewGetterFromContext(ctx).FindSolution()
-	}
-	if testsPath == "" {
-		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f) or --tests-path")
-		if w != nil {
-			w.Errorf("%s", err)
+		getter := get.NewGetterFromContext(ctx)
+		resolvedPath, resolveErr := get.Resolve(ctx, getter, "", "", get.ResolveOptions{
+			Risk: get.DiscoveryRiskLow,
+		})
+		if resolveErr != nil {
+			searchedPaths := getter.SearchedPaths()
+			err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f) or --tests-path\n  searched: %s", strings.Join(searchedPaths, ", "))
+			if w != nil {
+				w.Errorf("%s", err)
+			}
+			return exitcode.WithCode(err, exitcode.InvalidInput)
 		}
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+		testsPath = resolvedPath
 	}
 
 	// If the path is a catalog/remote reference (and not a local file/directory),

--- a/pkg/cmd/scafctl/test/init.go
+++ b/pkg/cmd/scafctl/test/init.go
@@ -92,12 +92,15 @@ func runInit(ctx context.Context, opts *InitOptions) error {
 	// Auto-discover solution file if not provided
 	filePath := opts.File
 	if filePath == "" {
-		filePath = get.NewGetterFromContext(ctx).FindSolution()
-	}
-	if filePath == "" {
-		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f)")
-		w.Errorf("%s", err)
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+		getter := get.NewGetterFromContext(ctx)
+		resolvedPath, resolveErr := get.Resolve(ctx, getter, "", "", get.ResolveOptions{
+			Risk: get.DiscoveryRiskLow,
+		})
+		if resolveErr != nil {
+			w.Errorf("%s", resolveErr)
+			return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
+		}
+		filePath = resolvedPath
 	}
 
 	// Read and parse the solution

--- a/pkg/cmd/scafctl/test/list.go
+++ b/pkg/cmd/scafctl/test/list.go
@@ -117,14 +117,17 @@ func runList(ctx context.Context, opts *ListOptions) error {
 		testsPath = opts.File
 	}
 	if testsPath == "" {
-		testsPath = get.NewGetterFromContext(ctx).FindSolution()
-	}
-	if testsPath == "" {
-		err := fmt.Errorf("no solution path provided and no solution file found in default locations; use --file (-f) or --tests-path")
-		if w != nil {
-			w.Errorf("%s", err)
+		getter := get.NewGetterFromContext(ctx)
+		resolvedPath, resolveErr := get.Resolve(ctx, getter, "", "", get.ResolveOptions{
+			Risk: get.DiscoveryRiskLow,
+		})
+		if resolveErr != nil {
+			if w != nil {
+				w.Errorf("%s", resolveErr)
+			}
+			return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
 		}
-		return exitcode.WithCode(err, exitcode.InvalidInput)
+		testsPath = resolvedPath
 	}
 
 	solutions, err := soltesting.DiscoverSolutions(testsPath)

--- a/pkg/mcp/capabilities.go
+++ b/pkg/mcp/capabilities.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	pathlib "path/filepath"
 	"sort"
 	"strings"
 
@@ -37,22 +38,22 @@ func (s *Server) discoverWorkspaceRoots(ctx context.Context) []string {
 	return paths
 }
 
-// discoverSolutionFiles searches for solution files using the same conventions
-// as the CLI (settings.RootSolutionFolders + settings.SolutionFileNames). It also
-// searches MCP workspace roots if provided by the client. Returns all discovered
-// file paths, or nil if none found.
+// discoverSolutionFiles searches for solution files using the unified resolution
+// chain (FindAllSolutions) which respects taskfile.yaml/yml and returns matches
+// in priority order. It also searches MCP workspace roots if provided by the
+// client. Returns all discovered file paths, or nil if none found.
 func (s *Server) discoverSolutionFiles(ctx context.Context) []string {
 	var files []string
 
-	// 1. Use the canonical CLI discovery logic (searches CWD-relative paths)
+	// 1. Use the unified discovery logic (searches CWD-relative paths)
 	solutionFolders := settings.SolutionFoldersFor(s.name)
 	solutionFileNames := settings.SolutionFileNamesFor(s.name)
 	getter := solutionget.NewGetter(
 		solutionget.WithLogger(s.logger),
 		solutionget.WithSolutionDiscovery(solutionFolders, solutionFileNames),
 	)
-	if found := getter.FindSolution(); found != "" {
-		files = append(files, found)
+	for _, result := range getter.FindAllSolutions() {
+		files = append(files, result.Path)
 	}
 
 	// 2. Also search MCP workspace roots using the same file name patterns
@@ -77,10 +78,20 @@ func (s *Server) discoverSolutionFiles(ctx context.Context) []string {
 	return files
 }
 
-// containsPath checks if a path is already in the slice.
+// containsPath checks if a path is already in the slice using absolute path
+// comparison to handle cases where CWD-relative and workspace-root-relative
+// paths resolve to the same file.
 func containsPath(paths []string, target string) bool {
+	absTarget := target
+	if abs, err := pathlib.Abs(target); err == nil {
+		absTarget = abs
+	}
 	for _, p := range paths {
-		if p == target {
+		absP := p
+		if abs, err := pathlib.Abs(p); err == nil {
+			absP = abs
+		}
+		if absP == absTarget {
 			return true
 		}
 	}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -313,6 +313,8 @@ func SolutionFileNamesFor(binaryName string) []string {
 		fmt.Sprintf("%s.yml", binaryName),
 		"solution.json",
 		fmt.Sprintf("%s.json", binaryName),
+		"taskfile.yaml",
+		"taskfile.yml",
 		"actions.yaml",
 		"actions.yml",
 	}
@@ -342,6 +344,8 @@ func SolutionOnlyFileNamesFor(binaryName string) []string {
 		fmt.Sprintf("%s.yml", binaryName),
 		"solution.json",
 		fmt.Sprintf("%s.json", binaryName),
+		"taskfile.yaml",
+		"taskfile.yml",
 	}
 }
 
@@ -369,6 +373,12 @@ func FileNamesForMode(mode DiscoveryMode, binaryName string, customActionFiles [
 // (actions.yaml or actions.yml).
 func IsActionFile(name string) bool {
 	return name == "actions.yaml" || name == "actions.yml"
+}
+
+// IsTaskFile returns true when the given filename is a task file
+// (taskfile.yaml or taskfile.yml).
+func IsTaskFile(name string) bool {
+	return name == "taskfile.yaml" || name == "taskfile.yml"
 }
 
 // HTTPCacheKeyPrefixFor returns the HTTP cache key prefix for the given binary name.

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -96,14 +96,14 @@ func TestSolutionFileNamesFor(t *testing.T) {
 		{
 			name:        "default binary name",
 			binaryName:  "scafctl",
-			wantLen:     8,
-			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json", "actions.yaml", "actions.yml"},
+			wantLen:     10,
+			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json", "taskfile.yaml", "taskfile.yml", "actions.yaml", "actions.yml"},
 		},
 		{
 			name:        "custom binary name",
 			binaryName:  "mycli",
-			wantLen:     8,
-			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json", "actions.yaml", "actions.yml"},
+			wantLen:     10,
+			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json", "taskfile.yaml", "taskfile.yml", "actions.yaml", "actions.yml"},
 		},
 	}
 	for _, tt := range tests {
@@ -188,6 +188,50 @@ func TestSanitizeBinaryName(t *testing.T) {
 			assert.Equal(t, tt.want, SanitizeBinaryName(tt.raw))
 		})
 	}
+}
+
+func TestIsTaskFile(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsTaskFile("taskfile.yaml"))
+	assert.True(t, IsTaskFile("taskfile.yml"))
+	assert.False(t, IsTaskFile("solution.yaml"))
+	assert.False(t, IsTaskFile("actions.yaml"))
+	assert.False(t, IsTaskFile("taskfile.json"))
+}
+
+func TestTaskfileNotInActionMode(t *testing.T) {
+	t.Parallel()
+	actionFiles := ActionFileNamesFor("scafctl")
+	assert.NotContains(t, actionFiles, "taskfile.yaml")
+	assert.NotContains(t, actionFiles, "taskfile.yml")
+}
+
+func TestTaskfileInSolutionOnlyMode(t *testing.T) {
+	t.Parallel()
+	solFiles := SolutionOnlyFileNamesFor("scafctl")
+	assert.Contains(t, solFiles, "taskfile.yaml")
+	assert.Contains(t, solFiles, "taskfile.yml")
+}
+
+func TestTaskfilePriority(t *testing.T) {
+	t.Parallel()
+	files := SolutionFileNamesFor("scafctl")
+	taskIdx := -1
+	actionIdx := -1
+	solutionIdx := -1
+	for i, f := range files {
+		switch f {
+		case "taskfile.yaml":
+			taskIdx = i
+		case "actions.yaml":
+			actionIdx = i
+		case "solution.yaml":
+			solutionIdx = i
+		}
+	}
+	// taskfile.yaml should come after solution.yaml but before actions.yaml
+	assert.Greater(t, taskIdx, solutionIdx, "taskfile.yaml should come after solution.yaml")
+	assert.Less(t, taskIdx, actionIdx, "taskfile.yaml should come before actions.yaml")
 }
 
 func TestSafeEnvPrefix(t *testing.T) {

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -591,8 +591,8 @@ func TestGetPossibleSolutionPaths(t *testing.T) {
 	t.Run("returns all possible paths", func(t *testing.T) {
 		paths := PossibleSolutionPaths()
 
-		// Should have 3 folders * 8 filenames = 24 paths
-		assert.Len(t, paths, 24)
+		// Should have 3 folders * 10 filenames = 30 paths
+		assert.Len(t, paths, 30)
 	})
 
 	t.Run("contains expected paths", func(t *testing.T) {

--- a/pkg/solution/get/resolve.go
+++ b/pkg/solution/get/resolve.go
@@ -1,0 +1,199 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package get
+
+import (
+	"context"
+	"fmt"
+	pathlib "path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/filepath"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// DiscoveryRisk controls how multi-match ambiguity is handled during
+// solution auto-discovery.
+type DiscoveryRisk int
+
+const (
+	// DiscoveryRiskLow uses the first match and emits a warning when multiple
+	// solution files are found. Suitable for read-only or low-consequence
+	// commands like run, lint, and test.
+	DiscoveryRiskLow DiscoveryRisk = iota
+
+	// DiscoveryRiskHigh returns an error when multiple solution files are
+	// found, requiring the user to specify -f explicitly. Suitable for
+	// destructive or publishing commands like build and catalog push.
+	DiscoveryRiskHigh
+)
+
+// ResolveOptions configures the unified resolution chain.
+type ResolveOptions struct {
+	// Risk controls ambiguity handling when multiple files are discovered.
+	Risk DiscoveryRisk
+	// DiscoveryMode controls which file names auto-discovery searches for.
+	DiscoveryMode settings.DiscoveryMode
+}
+
+// Resolve implements the unified solution resolution chain:
+//  1. If file is non-empty, return it (explicit -f flag takes precedence).
+//  2. If positionalArg is non-empty, return it as-is (catalog/registry reference).
+//  3. Otherwise, auto-discover with ambiguity handling based on risk level.
+//
+// When auto-discovery finds a solution, the resolved path is printed to stderr
+// via the writer in context. When multiple matches exist, behavior depends on Risk.
+func Resolve(ctx context.Context, getter *Getter, file, positionalArg string, opts ResolveOptions) (string, error) {
+	// Step 1: explicit -f flag (takes precedence over positional arg)
+	if file != "" {
+		return file, nil
+	}
+
+	// Step 2: positional catalog/registry reference (returned as-is for
+	// downstream resolution by the catalog client)
+	if positionalArg != "" {
+		return positionalArg, nil
+	}
+
+	// Step 3: auto-discovery with ambiguity handling
+	if opts.DiscoveryMode != settings.DiscoveryModeDefault {
+		getter.SetDiscoveryMode(opts.DiscoveryMode)
+	}
+
+	matches := getter.FindAllSolutions()
+	if len(matches) == 0 {
+		return "", ErrNoSolutionFound
+	}
+
+	resolved := matches[0].Path
+
+	// Handle multi-match ambiguity before emitting any messages.
+	// DiscoveryRiskHigh returns an error, so we must not print "Using" in that case.
+	if len(matches) > 1 {
+		others := make([]string, 0, len(matches)-1)
+		for _, m := range matches[1:] {
+			others = append(others, m.Path)
+		}
+
+		switch opts.Risk {
+		case DiscoveryRiskLow:
+			if w := writer.FromContext(ctx); w != nil {
+				w.WarnStderrf("Multiple solution files found (also: %s); using first match", strings.Join(others, ", "))
+			}
+		case DiscoveryRiskHigh:
+			return "", fmt.Errorf(
+				"multiple solution files found: %s; use -f/--file to specify which one",
+				strings.Join(allPaths(matches), ", "),
+			)
+		}
+	}
+
+	// Emit "Using <path>" to stderr after confirming we will return it.
+	// Written to stderr so it doesn't corrupt structured stdout (-o json).
+	if w := writer.FromContext(ctx); w != nil {
+		w.PlainStderrf("Using %s", resolved)
+	}
+
+	return resolved, nil
+}
+
+// FindAllSolutions searches for all solution files across configured discovery
+// paths and returns all matches in priority order. Unlike FindSolution which
+// stops at the first match, this returns every discoverable solution file.
+func (o *Getter) FindAllSolutions() []DiscoveryResult {
+	fileNames := o.solutionFileNames
+	if o.discoveryMode != settings.DiscoveryModeDefault {
+		binaryName := settings.CliBinaryName
+		for _, fn := range o.solutionFileNames {
+			if fn != "solution.yaml" && fn != "solution.yml" &&
+				fn != "solution.json" && fn != "actions.yaml" && fn != "actions.yml" &&
+				fn != "taskfile.yaml" && fn != "taskfile.yml" {
+				binaryName = strings.TrimSuffix(strings.TrimSuffix(fn, ".yaml"), ".yml")
+				binaryName = strings.TrimSuffix(binaryName, ".json")
+				break
+			}
+		}
+		fileNames = settings.FileNamesForMode(o.discoveryMode, binaryName, o.customActionFiles)
+	}
+
+	o.logger.V(1).Info("searching for all solution files",
+		"folders", o.solutionFolders,
+		"fileNames", fileNames,
+		"mode", o.discoveryMode)
+
+	var results []DiscoveryResult
+
+	// Track which canonical paths we've already added to avoid duplicates.
+	seen := make(map[string]bool)
+
+	for _, folder := range o.solutionFolders {
+		for _, filename := range fileNames {
+			fullPath := filepath.NormalizeFilePath(pathlib.Join(folder, filename))
+			if filepath.PathExists(fullPath, o.statFunc) {
+				// Resolve to absolute path to detect duplicates from different
+				// relative paths pointing to the same file.
+				canonical := fullPath
+				if abs, err := pathlib.Abs(fullPath); err == nil {
+					canonical = abs
+				}
+				if seen[canonical] {
+					continue
+				}
+				seen[canonical] = true
+
+				results = append(results, DiscoveryResult{
+					Path:         fullPath,
+					IsActionFile: settings.IsActionFile(filename),
+					Mode:         o.discoveryMode,
+				})
+			}
+		}
+	}
+
+	// Update lastDiscovery with first result for backward compatibility.
+	if len(results) > 0 {
+		o.lastDiscovery = results[0]
+	} else {
+		o.lastDiscovery = DiscoveryResult{Mode: o.discoveryMode}
+	}
+
+	return results
+}
+
+// SearchedPaths returns a human-readable list of all paths that would be
+// checked during auto-discovery. Useful for error messages.
+func (o *Getter) SearchedPaths() []string {
+	fileNames := o.solutionFileNames
+	if o.discoveryMode != settings.DiscoveryModeDefault {
+		binaryName := settings.CliBinaryName
+		for _, fn := range o.solutionFileNames {
+			if fn != "solution.yaml" && fn != "solution.yml" &&
+				fn != "solution.json" && fn != "actions.yaml" && fn != "actions.yml" &&
+				fn != "taskfile.yaml" && fn != "taskfile.yml" {
+				binaryName = strings.TrimSuffix(strings.TrimSuffix(fn, ".yaml"), ".yml")
+				binaryName = strings.TrimSuffix(binaryName, ".json")
+				break
+			}
+		}
+		fileNames = settings.FileNamesForMode(o.discoveryMode, binaryName, o.customActionFiles)
+	}
+
+	paths := make([]string, 0, len(o.solutionFolders)*len(fileNames))
+	for _, folder := range o.solutionFolders {
+		for _, filename := range fileNames {
+			paths = append(paths, filepath.NormalizeFilePath(pathlib.Join(folder, filename)))
+		}
+	}
+	return paths
+}
+
+// allPaths extracts the Path field from a slice of DiscoveryResults.
+func allPaths(results []DiscoveryResult) []string {
+	paths := make([]string, len(results))
+	for i, r := range results {
+		paths[i] = r.Path
+	}
+	return paths
+}

--- a/pkg/solution/get/resolve_test.go
+++ b/pkg/solution/get/resolve_test.go
@@ -1,0 +1,307 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package get
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindAllSolutions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns all matching files", func(t *testing.T) {
+		t.Parallel()
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"solution.yaml":         true,
+			"taskfile.yaml":         true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+		results := getter.FindAllSolutions()
+
+		assert.Len(t, results, 3)
+		assert.Equal(t, "scafctl/solution.yaml", results[0].Path)
+		assert.Equal(t, "solution.yaml", results[1].Path)
+		assert.Equal(t, "taskfile.yaml", results[2].Path)
+	})
+
+	t.Run("returns empty slice when no files found", func(t *testing.T) {
+		t.Parallel()
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+		results := getter.FindAllSolutions()
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("deduplicates same file from different paths", func(t *testing.T) {
+		t.Parallel()
+		// When the current folder ("") finds "solution.yaml" which is the
+		// same physical file as "./solution.yaml", we should deduplicate.
+		existingFiles := map[string]bool{
+			"solution.yaml": true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+		results := getter.FindAllSolutions()
+
+		// Should not have duplicates
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("excludes taskfile in action mode", func(t *testing.T) {
+		t.Parallel()
+		existingFiles := map[string]bool{
+			"actions.yaml":  true,
+			"taskfile.yaml": true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+		)
+		results := getter.FindAllSolutions()
+
+		// taskfile.yaml should NOT appear in action mode
+		for _, r := range results {
+			assert.NotEqual(t, "taskfile.yaml", r.Path)
+		}
+		// But actions.yaml should be found
+		require.NotEmpty(t, results)
+		assert.Equal(t, "actions.yaml", results[0].Path)
+		assert.True(t, results[0].IsActionFile)
+	})
+
+	t.Run("includes taskfile in solution mode", func(t *testing.T) {
+		t.Parallel()
+		existingFiles := map[string]bool{
+			"taskfile.yaml": true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeSolution),
+		)
+		results := getter.FindAllSolutions()
+
+		require.Len(t, results, 1)
+		assert.Equal(t, "taskfile.yaml", results[0].Path)
+	})
+
+	t.Run("updates lastDiscovery with first result", func(t *testing.T) {
+		t.Parallel()
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"solution.yaml":         true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+		results := getter.FindAllSolutions()
+
+		require.NotEmpty(t, results)
+		disc := getter.LastDiscoveryResult()
+		assert.Equal(t, results[0].Path, disc.Path)
+	})
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	newCtx := func() context.Context {
+		ios := &terminal.IOStreams{
+			Out:    &discardWriter{},
+			ErrOut: &discardWriter{},
+			In:     os.Stdin,
+		}
+		cliParams := settings.NewCliParams()
+		w := writer.New(ios, cliParams)
+		return writer.WithWriter(context.Background(), w)
+	}
+
+	t.Run("returns file flag when provided", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		getter := NewGetter()
+
+		path, err := Resolve(ctx, getter, "./my-solution.yaml", "", ResolveOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "./my-solution.yaml", path)
+	})
+
+	t.Run("returns positional arg when provided", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		getter := NewGetter()
+
+		path, err := Resolve(ctx, getter, "", "my-catalog-ref@1.0.0", ResolveOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "my-catalog-ref@1.0.0", path)
+	})
+
+	t.Run("file flag takes priority over positional", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		getter := NewGetter()
+
+		path, err := Resolve(ctx, getter, "./explicit.yaml", "ignored-ref", ResolveOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "./explicit.yaml", path)
+	})
+
+	t.Run("auto-discovers when no file or positional", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		existingFiles := map[string]bool{
+			"solution.yaml": true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+
+		path, err := Resolve(ctx, getter, "", "", ResolveOptions{Risk: DiscoveryRiskLow})
+		require.NoError(t, err)
+		assert.Equal(t, "solution.yaml", path)
+	})
+
+	t.Run("returns error when nothing found", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+
+		_, err := Resolve(ctx, getter, "", "", ResolveOptions{Risk: DiscoveryRiskLow})
+		assert.ErrorIs(t, err, ErrNoSolutionFound)
+	})
+
+	t.Run("low risk warns on multiple matches", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"solution.yaml":         true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+
+		path, err := Resolve(ctx, getter, "", "", ResolveOptions{Risk: DiscoveryRiskLow})
+		require.NoError(t, err)
+		// Returns first match
+		assert.Equal(t, "scafctl/solution.yaml", path)
+	})
+
+	t.Run("high risk errors on multiple matches", func(t *testing.T) {
+		t.Parallel()
+		ctx := newCtx()
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"solution.yaml":         true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(WithStatFunc(customStatFunc))
+
+		_, err := Resolve(ctx, getter, "", "", ResolveOptions{Risk: DiscoveryRiskHigh})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple solution files found")
+		assert.Contains(t, err.Error(), "use -f/--file")
+	})
+}
+
+func TestSearchedPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns expected search paths", func(t *testing.T) {
+		t.Parallel()
+		getter := NewGetter()
+		paths := getter.SearchedPaths()
+
+		assert.Contains(t, paths, "scafctl/solution.yaml")
+		assert.Contains(t, paths, "solution.yaml")
+		assert.Contains(t, paths, "taskfile.yaml")
+		assert.Contains(t, paths, "scafctl/taskfile.yaml")
+	})
+
+	t.Run("custom binary name", func(t *testing.T) {
+		t.Parallel()
+		getter := NewGetter(WithSolutionDiscovery(
+			settings.SolutionFoldersFor("mycli"),
+			settings.SolutionFileNamesFor("mycli"),
+		))
+		paths := getter.SearchedPaths()
+
+		assert.Contains(t, paths, "mycli/solution.yaml")
+		assert.Contains(t, paths, "mycli/mycli.yaml")
+		assert.Contains(t, paths, "taskfile.yaml")
+		assert.NotContains(t, paths, "scafctl/solution.yaml")
+	})
+}
+
+// discardWriter implements io.Writer and discards all writes.
+type discardWriter struct{}
+
+func (d *discardWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8573,3 +8573,181 @@ func TestIntegration_InspectSolution_Alias(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "\"name\"")
 }
+
+// ============================================================================
+// Auto-Discovery: Taskfile and Multi-Match Tests
+// ============================================================================
+
+func TestIntegration_Lint_AutoDiscovery_TaskfileYaml(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Only a taskfile.yaml exists — should be auto-discovered
+	taskfile := filepath.Join(tmpDir, "taskfile.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: taskfile-discovery
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello from taskfile
+`
+	require.NoError(t, os.WriteFile(taskfile, []byte(content), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "lint", "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
+	assert.Contains(t, stdout, "findings")
+	assert.Contains(t, stderr, "Using taskfile.yaml")
+}
+
+func TestIntegration_Lint_AutoDiscovery_MultiMatch_Warning(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Place two solution files — low-risk command should warn
+	solutionYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-match
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "taskfile.yaml"), []byte(solutionYAML), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "lint", "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	// Should succeed (low risk) but warn about multiple matches
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
+	assert.Contains(t, stderr, "Multiple solution files found")
+	assert.Contains(t, stderr, "Using solution.yaml")
+}
+
+func TestIntegration_BuildSolution_AutoDiscovery_MultiMatch_Error(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Place two solution files — high-risk command should error
+	solutionYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-match-build
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "taskfile.yaml"), []byte(solutionYAML), 0o644))
+
+	_, stderr, exitCode := runScafctlInDir(t, tmpDir, "build", "solution")
+	t.Logf("stderr: %s", stderr)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "multiple solution files found")
+	assert.Contains(t, stderr, "use -f/--file")
+}
+
+func TestIntegration_RunResolver_AutoDiscovery_TaskfileYaml(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Only a taskfile.yaml exists — run resolver should auto-discover it
+	taskfile := filepath.Join(tmpDir, "taskfile.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: taskfile-run-resolver
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello from taskfile resolver
+`
+	require.NoError(t, os.WriteFile(taskfile, []byte(content), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "resolver", "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Hello from taskfile resolver")
+	assert.Contains(t, stderr, "Using taskfile.yaml")
+}
+
+func TestIntegration_RunResolver_AutoDiscovery_MultiMatch_Warning(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Place solution.yaml and taskfile.yaml — run resolver (low-risk) should
+	// use solution.yaml (higher priority) and warn about the other.
+	solutionYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-match-resolver
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: from solution.yaml
+`
+	taskfileYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-match-taskfile
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: from taskfile.yaml
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "taskfile.yaml"), []byte(taskfileYAML), 0o644))
+
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "resolver", "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "from solution.yaml")
+	assert.Contains(t, stderr, "Multiple solution files found")
+	assert.Contains(t, stderr, "Using solution.yaml")
+}


### PR DESCRIPTION
- add Resolve() function implementing 3-step resolution: -f flag, positional catalog ref, then auto-discovery with ambiguity handling
- add FindAllSolutions() returning all matches with dedup by canonical path
- add DiscoveryRisk levels: low-risk (warn) for run/lint/test, high-risk (error) for build
- add taskfile.yaml and taskfile.yml to default discovery search order (excluded from action discovery mode)
- refactor lint, test, build, render, and run commands to use Resolve()
- fix lint auto-discovery bug where discovered path was not passed to linter
- fix test functional error message to include searched paths
- MCP list_solutions now returns all discoverable files via FindAllSolutions()
- add design doc, update tutorial, add example and integration tests

BREAKING CHANGE: build command now errors when multiple solution files are found instead of silently using the first match; use -f to disambiguate

Closes #260