### PR TITLE
feat(mcp): cache provider descriptor schemas for offline access

### DIFF
--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -498,8 +498,83 @@ scafctl config unset logging.level
 {{% /tab %}}
 {{< /tabs >}}
 
+## API Server: Token Delegation
+
+The `apiServer` section includes configuration for token delegation when running in API mode (`scafctl serve`). These settings control how the server exchanges or forwards tokens to downstream providers.
+
+### Server Identity (Entra ID)
+
+Configure the server's identity for OBO and client credentials flows:
+
+{{< tabs "config-tutorial-cmd-16" >}}
+{{% tab "Bash" %}}
+```bash
+# Set up Entra identity for token delegation
+scafctl config set apiServer.identity.entra.tenantId "your-tenant-id"
+scafctl config set apiServer.identity.entra.clientId "your-client-id"
+scafctl config set apiServer.identity.entra.credential.type "secret"
+scafctl config set apiServer.identity.entra.credential.clientSecret "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"
+
+# Configure allowed delegation flows
+scafctl config set apiServer.identity.entra.allowedFlows.flows '["obo", "client_credentials"]'
+
+# View the identity config
+scafctl config get apiServer.identity
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Set up Entra identity for token delegation
+scafctl config set apiServer.identity.entra.tenantId "your-tenant-id"
+scafctl config set apiServer.identity.entra.clientId "your-client-id"
+scafctl config set apiServer.identity.entra.credential.type "secret"
+scafctl config set apiServer.identity.entra.credential.clientSecret "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"
+
+# Configure allowed delegation flows
+scafctl config set apiServer.identity.entra.allowedFlows.flows '["obo", "client_credentials"]'
+
+# View the identity config
+scafctl config get apiServer.identity
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The credential `clientSecret` field uses `SecretRef` URI format:
+- `env://VAR_NAME` -- reads from an environment variable
+- `file:///path/to/secret` -- reads from a file
+
+### Token Pass-Through
+
+Configure which provider-specific tokens can be forwarded from API request headers:
+
+{{< tabs "config-tutorial-cmd-17" >}}
+{{% tab "Bash" %}}
+```bash
+# Allow GitHub and Artifactory tokens to be passed through
+scafctl config set apiServer.tokenPassThrough.allowedHeaders '["Github", "Artifactory"]'
+
+# View the token pass-through config
+scafctl config get apiServer.tokenPassThrough
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Allow GitHub and Artifactory tokens to be passed through
+scafctl config set apiServer.tokenPassThrough.allowedHeaders '["Github", "Artifactory"]'
+
+# View the token pass-through config
+scafctl config get apiServer.tokenPassThrough
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+When configured, callers send tokens via `X-Authorization-<Suffix>` headers (e.g., `X-Authorization-Github`). The server makes these available to providers via the `authProvider` input field. When `tokenPassThrough` is omitted entirely, only `Github` is allowed by default.
+
+For a complete guide, see the [Token Delegation Tutorial](token-delegation-tutorial.md).
+
 ## Next Steps
 
+- [Token Delegation Tutorial](token-delegation-tutorial.md) -- Configure OBO, client credentials, and pass-through delegation
 - [Authentication Tutorial](auth-tutorial.md) — Set up GitHub and Entra authentication
 - [Exec Provider Tutorial](exec-provider-tutorial.md) — Cross-platform shell execution
 - [Logging & Debugging Tutorial](logging-tutorial.md) — Control log verbosity, format, and output

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -710,8 +710,8 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `explain_kind` | Explain any registered kind (solution, resolver, action, etc.) — shows all fields, types, descriptions, and validation tags |
 | `explain_lint_rule` | Get a detailed explanation of a lint rule — description, severity, category, why it matters, how to fix it, and examples |
 | `get_example` | Read the contents of a scafctl example file. Use `list_examples` first to find available examples |
-| `get_provider_schema` | Get comprehensive provider info: input schema (with per-property required), output schemas, examples, CLI usage |
-| `get_provider_output_shape` | Get the output schema for a provider. Optionally filter by capability (`from`, `transform`, `action`) |
+| `get_provider_schema` | Get comprehensive provider info: input schema (with per-property required), output schemas, examples, CLI usage. Works for builtin and official plugin providers -- plugin schemas are auto-fetched on first request and cached locally for offline access (response includes `"source": "cached"` when served from cache) |
+| `get_provider_output_shape` | Get the output schema for a provider. Optionally filter by capability (`from`, `transform`, `action`). Falls back to cached descriptor when the plugin binary is unavailable |
 | `get_solution_schema` | Get the full JSON Schema for the solution YAML file format. Optionally drill into a specific field (e.g., `metadata`, `spec`) |
 | `get_run_command` | Get the exact CLI command to run a solution (determines run solution vs run resolver) |
 | `explain_concepts` | Look up and explain scafctl concepts (resolvers, providers, testing, CEL, etc.). Use without arguments to list all, or provide a name/query/category |
@@ -737,7 +737,7 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `list_auth_handlers` | List all registered authentication handlers with their configuration status and token expiry |
 | `auth_list_tokens` | List all cached access tokens across registered auth handlers -- shows metadata (handler, scope, flow, expiry) without revealing token values |
 | `auth_purge_expired` | Remove expired access tokens from the cache across all (or a specific) auth handler. Keeps valid tokens and refresh tokens |
-| `get_config_paths` | List all XDG-compliant paths used by scafctl — config, data, cache, state, secrets, plugins, and runtime directories |
+| `get_config_paths` | List all XDG-compliant paths used by scafctl -- config, data, cache, state, secrets, plugins, provider-schemas, and runtime directories |
 | `validate_expressions` | Batch-validate multiple CEL expressions or Go templates — returns validity, errors, and referenced fields for each |
 | `get_version` | Return scafctl version, commit SHA, and build timestamp |
 | `dry_run_solution` | Dry-run a solution without executing action providers. Resolvers run normally; each action gets a provider-generated WhatIf description of what it would do |

--- a/docs/tutorials/plugin-auto-fetch-tutorial.md
+++ b/docs/tutorials/plugin-auto-fetch-tutorial.md
@@ -297,6 +297,65 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\"
 {{% /tab %}}
 {{< /tabs >}}
 
+## Schema Caching (Offline Access)
+
+In addition to caching plugin binaries, scafctl caches **provider descriptor schemas** locally. This means that once a plugin provider's schema has been fetched via `get_provider_schema` or `get_provider_output_shape` in the MCP server, subsequent schema lookups can be served from disk without spawning the plugin process or requiring network access.
+
+### How It Works
+
+1. When `get_provider_schema` or `get_provider_output_shape` successfully resolves a plugin provider, the full descriptor (input schema, output schemas, capabilities, examples) is persisted to disk.
+2. On subsequent requests, if the plugin binary is unavailable (offline, not yet installed, network error), the cached descriptor is returned with `"source": "cached"` in the response.
+3. Cache entries expire after 24 hours by default. After expiry, scafctl attempts a fresh fetch and updates the cache.
+4. Running `scafctl plugins install` automatically invalidates cached descriptors for the installed plugins so the next schema request returns up-to-date data.
+
+### Cache Location
+
+```
+$XDG_CACHE_HOME/scafctl/provider-schemas/
+|-- exec.json
+|-- git.json
+|-- github.json
+|-- directory.json
+|-- ...
+```
+
+| Platform | Default Path |
+|----------|-------------|
+| Linux    | `~/.cache/scafctl/provider-schemas/` |
+| macOS    | `~/.cache/scafctl/provider-schemas/` |
+| Windows  | `%LOCALAPPDATA%\cache\scafctl\provider-schemas\` |
+
+### Managing the Schema Cache
+
+{{< tabs "plugin-auto-fetch-tutorial-cmd-4" >}}
+{{% tab "Bash" %}}
+```bash
+# Schema cache is at $XDG_CACHE_HOME/scafctl/provider-schemas/
+# To clear all cached schemas (forces re-fetch on next access):
+rm -rf ~/.cache/scafctl/provider-schemas/
+
+# To invalidate a single provider:
+rm ~/.cache/scafctl/provider-schemas/exec.json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Schema cache is at $env:LOCALAPPDATA\cache\scafctl\provider-schemas\
+# To clear all cached schemas:
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\cache\scafctl\provider-schemas\"
+
+# To invalidate a single provider:
+Remove-Item "$env:LOCALAPPDATA\cache\scafctl\provider-schemas\exec.json"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### Use Cases
+
+- **CI/CD**: Pre-fetch plugin schemas in a warm-up step, then run MCP sessions offline
+- **Air-gapped environments**: Copy the `provider-schemas/` directory to disconnected machines
+- **Faster MCP startup**: Cached schemas avoid spawning plugin processes for schema-only queries
+
 ## Multi-Platform Support
 
 Plugin artifacts can include platform-specific binaries. The `AnnotationPlatform` annotation on catalog artifacts identifies the target platform:

--- a/docs/tutorials/token-delegation-tutorial.md
+++ b/docs/tutorials/token-delegation-tutorial.md
@@ -1,0 +1,268 @@
+---
+title: "Token Delegation"
+weight: 138
+---
+
+# Token Delegation Tutorial
+
+This tutorial explains how to configure token delegation in the scafctl API server so that HTTP provider requests can automatically acquire downstream tokens on behalf of the caller.
+
+## Overview
+
+When scafctl runs in **API mode** (`scafctl serve`), incoming requests carry a caller's bearer token. Providers that call downstream APIs often need a *different* token scoped to a specific resource (e.g., Azure Key Vault, Microsoft Graph). Token delegation centralizes this exchange, caches results, and deduplicates concurrent requests.
+
+Three delegation strategies are available:
+
+| Strategy | Use Case |
+|----------|----------|
+| **OBO (On-Behalf-Of)** | Exchange a user's token for a downstream token |
+| **Client Credentials** | Acquire a token using the server's own identity |
+| **Pass-Through** | Forward a provider-specific token from the API request headers |
+
+## Prerequisites
+
+- scafctl installed and configured
+- An Azure Entra ID app registration (for OBO/client credentials)
+- A client secret or workload identity federation configured
+
+## Configuration
+
+Token delegation is configured in the `apiServer` section of your scafctl config file (`~/.config/scafctl/config.yaml`).
+
+### Entra ID Identity (OBO + Client Credentials)
+
+```yaml
+apiServer:
+  host: 0.0.0.0
+  port: 8080
+  auth:
+    azureOIDC:
+      enabled: true
+      tenantId: "your-tenant-id"
+      clientId: "your-client-id"
+  identity:
+    entra:
+      tenantId: "your-tenant-id"
+      clientId: "your-client-id"
+      credential:
+        type: secret
+        clientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"
+      allowedFlows:
+        flows:
+          - obo
+          - client_credentials
+      tokenManager:
+        cacheSize: 1024
+        expiryBuffer: "10m"
+        cleanupInterval: "5m"
+```
+
+#### Credential Types
+
+**Client Secret** (simplest):
+
+```yaml
+credential:
+  type: secret
+  clientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"
+```
+
+The `clientSecret` field uses a `SecretRef` URI. Supported schemes:
+- `env://VAR_NAME` -- reads the secret from an environment variable
+- `file:///path/to/secret` -- reads the secret from a file
+
+**Workload Identity Federation** (for Kubernetes/cloud workloads):
+
+```yaml
+credential:
+  type: wif
+  wifTokenPath: "/var/run/secrets/azure/tokens/federated-token"
+```
+
+#### Allowed Flows
+
+The `allowedFlows` section is a security boundary controlling which delegation flows the server may use:
+
+| Configuration | Behavior |
+|--------------|----------|
+| Omitted (nil) | Only OBO is permitted (default) |
+| Present with flows list | Only listed flows are permitted |
+| Present with empty flows | All delegation is denied |
+
+```yaml
+# Only allow OBO (default behavior when omitted)
+allowedFlows:
+  flows:
+    - obo
+
+# Allow both OBO and client credentials
+allowedFlows:
+  flows:
+    - obo
+    - client_credentials
+```
+
+#### Token Manager
+
+The `tokenManager` section controls caching and deduplication:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cacheSize` | 1024 | Max cached tokens (LRU eviction) |
+| `expiryBuffer` | 10m | Safety margin before token expiry |
+| `cleanupInterval` | 5m | Background eviction interval |
+| `expiryThreshold` | 30m | Minimum TTL to cache a token |
+| `slowThreshold` | 500ms | Follower bail-out duration |
+| `retryFollowerOnError` | true | Followers retry on leader error |
+
+### Token Pass-Through
+
+Pass-through delegation forwards provider-specific tokens from API request headers directly to providers without exchanging them. This is useful when callers already have valid tokens for downstream services.
+
+```yaml
+apiServer:
+  tokenPassThrough:
+    allowedHeaders:
+      - Github
+      - Artifactory
+      - Custom-Service
+```
+
+This allows the following request headers to be passed through:
+- `X-Authorization-Github` -> available as provider token for "Github"
+- `X-Authorization-Artifactory` -> available as provider token for "Artifactory"
+- `X-Authorization-Custom-Service` -> available as provider token for "Custom-Service"
+
+When `tokenPassThrough` is omitted entirely, the default allows `Github` only.
+
+## Using Delegation in Solutions
+
+Once configured, use the `authProvider` and `authScope` inputs on the HTTP provider:
+
+### OBO / Client Credentials Example
+
+```yaml
+spec:
+  resolvers:
+    graphProfile:
+      description: Fetch user profile from Microsoft Graph
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://graph.microsoft.com/v1.0/me"
+              method: GET
+              authProvider: entra
+              authScope: "https://graph.microsoft.com/.default"
+```
+
+The HTTP provider will:
+1. Look up the `entra` delegator in the registry
+2. Call `DelegateToken(ctx, scope)` which selects OBO or client_credentials based on the caller type
+3. Inject the resulting token as `Authorization: Bearer <token>`
+4. Cache the token for subsequent requests with the same scope
+
+### Pass-Through Example
+
+```yaml
+spec:
+  resolvers:
+    repoInfo:
+      description: Fetch repository info using caller's GitHub token
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://api.github.com/repos/org/repo"
+              method: GET
+              authProvider: Github
+```
+
+The HTTP provider will:
+1. Look up `Github` in the delegator registry
+2. Fall back to `passThrough:Github` delegator
+3. Retrieve the token from the request context (originally from `X-Authorization-Github` header)
+4. Inject it as `Authorization: Bearer <token>`
+
+## How It Works at Runtime
+
+```
+API Request with Bearer token
+        |
+        v
++-----------------------+
+|  Auth Middleware       |  Validates caller token, extracts claims
+|  (Azure OIDC)         |  Sets callerType = "user" or "app"
++-----------------------+
+        |
+        v
++-----------------------+
+|  TokenPassthrough      |  Extracts X-Authorization-* headers
+|  Middleware            |  Stores tokens in request context
++-----------------------+
+        |
+        v
++-----------------------+
+|  Solution Execution    |
+|  HTTP Provider         |---- authProvider: entra ----+
++-----------------------+                              |
+                                                       v
+                                        +----------------------+
+                                        |  DelegatorRegistry    |
+                                        |  +-----------------+  |
+                                        |  | EntraDelegator  |  |
+                                        |  |  FlowRegistry   |  |
+                                        |  |  TokenCache     |  |
+                                        |  +-----------------+  |
+                                        |  +-----------------+  |
+                                        |  | PassThrough:    |  |
+                                        |  |  Github         |  |
+                                        |  +-----------------+  |
+                                        +----------------------+
+```
+
+## Verifying Configuration
+
+Check that the API server starts correctly with delegation configured:
+
+```bash
+# Start the server
+SCAFCTL_API_ENTRA_CLIENT_SECRET="your-secret" scafctl serve
+
+# Verify health
+curl http://localhost:8080/health
+
+# Test with a bearer token (OBO flow)
+curl -H "Authorization: Bearer <user-token>" \
+     http://localhost:8080/v1/solutions/my-solution/run
+
+# Test with pass-through token
+curl -H "Authorization: Bearer <user-token>" \
+     -H "X-Authorization-Github: ghp_xxxx" \
+     http://localhost:8080/v1/solutions/my-solution/run
+```
+
+## Security Considerations
+
+1. **Flow allow-list**: Always explicitly list permitted flows. Omitting `allowedFlows` defaults to OBO-only, which is the safest default.
+2. **Secret storage**: Use `env://` or `file://` references for credentials -- never inline secrets in config files.
+3. **Token pass-through headers**: Only configure headers for services you trust callers to provide tokens for.
+4. **Scope validation**: The HTTP provider requires `authScope` when using Entra delegation with scope-based auth handlers.
+5. **Cache isolation**: Token cache keys include a SHA-256 hash of the caller token, ensuring tokens are never shared across callers.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "delegation flow X is not permitted" | Flow not in `allowedFlows` | Add the flow to the allow-list |
+| "token for provider X not found in context" | Missing `X-Authorization-X` header | Ensure the caller sends the header |
+| "auth provider X not found in delegation registry" | No delegator configured for that name | Check `identity` config or `tokenPassThrough.allowedHeaders` |
+| "env:// scheme requires a variable name" | Empty `SecretRef` | Set the env var name after `env://` |
+| Token expires immediately | `expiryBuffer` too large | Reduce the buffer or check token TTL |
+
+## Next Steps
+
+- [API Server Tutorial](api-server-tutorial.md) -- Full API server setup
+- [Authentication Tutorial](auth-tutorial.md) -- CLI-mode auth handlers
+- [HTTP Provider Tutorial](http-provider-tutorial.md) -- HTTP provider reference
+- [Configuration Tutorial](config-tutorial.md) -- Config file management

--- a/examples/auth/token-delegation/README.md
+++ b/examples/auth/token-delegation/README.md
@@ -1,0 +1,33 @@
+# Token Delegation Examples
+
+These examples demonstrate configuring token delegation for the scafctl API server.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `entra-obo-config.yaml` | Entra ID OBO + client credentials delegation config |
+| `passthrough-config.yaml` | Token pass-through config for GitHub and custom services |
+| `delegation-solution.yaml` | Solution using delegated auth in HTTP provider calls |
+
+## Quick Start
+
+```bash
+# Start API server with Entra delegation
+SCAFCTL_API_ENTRA_CLIENT_SECRET="your-secret" \
+  scafctl serve --config ./entra-obo-config.yaml
+
+# Test OBO flow (caller's token is exchanged for downstream token)
+curl -H "Authorization: Bearer <user-token>" \
+     http://localhost:8080/v1/solutions/delegation-solution/run
+
+# Test pass-through (caller provides downstream token directly)
+curl -H "Authorization: Bearer <user-token>" \
+     -H "X-Authorization-Github: ghp_xxxx" \
+     http://localhost:8080/v1/solutions/delegation-solution/run
+```
+
+## See Also
+
+- [Token Delegation Tutorial](../../../docs/tutorials/token-delegation-tutorial.md)
+- [API Token Delegation Design](../../../docs/design/api-token-delegation.md)

--- a/examples/auth/token-delegation/delegation-solution.yaml
+++ b/examples/auth/token-delegation/delegation-solution.yaml
@@ -1,0 +1,69 @@
+# Example: Solution Using Token Delegation
+#
+# This solution demonstrates HTTP provider requests that use delegated
+# authentication. The authProvider input tells the HTTP provider to
+# automatically acquire and inject a bearer token.
+#
+# In API mode: tokens are delegated via the DelegatorRegistry
+# In CLI mode: tokens are acquired via auth handlers (interactive login)
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: token-delegation-demo
+  version: 1.0.0
+  description: |
+    Demonstrates token delegation with the HTTP provider.
+    Shows OBO, client credentials, and pass-through patterns.
+
+spec:
+  resolvers:
+    # OBO/Client Credentials: Exchange caller token for a Graph API token
+    userProfile:
+      description: Fetch the caller's profile from Microsoft Graph (OBO flow)
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://graph.microsoft.com/v1.0/me"
+              method: GET
+              authProvider: entra
+              authScope: "https://graph.microsoft.com/.default"
+
+    # OBO/Client Credentials: Access Key Vault with a different scope
+    keyVaultSecret:
+      description: Read a secret from Azure Key Vault
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://my-vault.vault.azure.net/secrets/my-secret?api-version=7.4"
+              method: GET
+              authProvider: entra
+              authScope: "https://vault.azure.net/.default"
+
+    # Pass-through: Use the caller's GitHub token directly
+    githubRepo:
+      description: Fetch repository info using the caller's GitHub token
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://api.github.com/repos/oakwood-commons/scafctl"
+              method: GET
+              authProvider: Github
+              headers:
+                Accept: "application/vnd.github+json"
+                X-GitHub-Api-Version: "2022-11-28"
+
+    # Pass-through: Use the caller's Artifactory token
+    artifactoryInfo:
+      description: Check Artifactory system health
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: "https://artifactory.example.com/api/system/ping"
+              method: GET
+              authProvider: Artifactory

--- a/examples/auth/token-delegation/entra-obo-config.yaml
+++ b/examples/auth/token-delegation/entra-obo-config.yaml
@@ -1,0 +1,48 @@
+# Example: Entra ID Token Delegation Config
+#
+# Configures the scafctl API server for OBO and client credentials
+# delegation using Azure Entra ID. The server exchanges incoming caller
+# tokens for downstream tokens scoped to specific resources.
+#
+# Usage:
+#   SCAFCTL_API_ENTRA_CLIENT_SECRET="your-secret" scafctl serve --config ./entra-obo-config.yaml
+#
+# Prerequisites:
+#   - Azure Entra ID app registration with:
+#     - API permissions for the downstream resource
+#     - A client secret or workload identity federation
+#   - The app must be configured to support OBO (expose an API scope)
+
+apiServer:
+  host: 127.0.0.1
+  port: 8080
+
+  # Validate incoming caller tokens via Entra OIDC
+  auth:
+    azureOIDC:
+      enabled: true
+      tenantId: "00000000-0000-0000-0000-000000000000"
+      clientId: "11111111-1111-1111-1111-111111111111"
+
+  # Server identity used for token delegation
+  identity:
+    entra:
+      tenantId: "00000000-0000-0000-0000-000000000000"
+      clientId: "11111111-1111-1111-1111-111111111111"
+      credential:
+        # Use env:// to read the secret from an environment variable
+        type: secret
+        clientSecret: "env://SCAFCTL_API_ENTRA_CLIENT_SECRET"
+      # Security boundary: only permit these delegation flows
+      allowedFlows:
+        flows:
+          - obo
+          - client_credentials
+      # Token caching and deduplication settings
+      tokenManager:
+        cacheSize: 1024
+        expiryBuffer: "10m"
+        cleanupInterval: "5m"
+        expiryThreshold: "30m"
+        slowThreshold: "500ms"
+        retryFollowerOnError: true

--- a/examples/auth/token-delegation/passthrough-config.yaml
+++ b/examples/auth/token-delegation/passthrough-config.yaml
@@ -1,0 +1,34 @@
+# Example: Token Pass-Through Config
+#
+# Configures the scafctl API server to accept provider-specific tokens
+# from request headers and pass them through to providers without exchange.
+#
+# Callers include tokens in X-Authorization-<Suffix> headers.
+# The server extracts allowed headers and makes them available to providers.
+#
+# Usage:
+#   scafctl serve --config ./passthrough-config.yaml
+#
+# Test:
+#   curl -H "Authorization: Bearer <auth-token>" \
+#        -H "X-Authorization-Github: ghp_xxxx" \
+#        -H "X-Authorization-Artifactory: <jfrog-token>" \
+#        http://localhost:8080/v1/solutions/my-solution/run
+
+apiServer:
+  host: 127.0.0.1
+  port: 8080
+
+  auth:
+    azureOIDC:
+      enabled: true
+      tenantId: "00000000-0000-0000-0000-000000000000"
+      clientId: "11111111-1111-1111-1111-111111111111"
+
+  # Token pass-through: allow these header suffixes
+  # Each suffix maps to X-Authorization-<Suffix> request header
+  tokenPassThrough:
+    allowedHeaders:
+      - Github        # X-Authorization-Github
+      - Artifactory   # X-Authorization-Artifactory
+      - Vault         # X-Authorization-Vault

--- a/examples/plugins/schema-cache-demo.yaml
+++ b/examples/plugins/schema-cache-demo.yaml
@@ -1,0 +1,63 @@
+# Schema Cache Demo
+#
+# Demonstrates how scafctl caches provider descriptor schemas locally so that
+# schema lookups (get_provider_schema, get_provider_output_shape) work even when
+# the plugin binary is unavailable or the network is offline.
+#
+# How it works:
+#   1. On first successful schema lookup, the full provider descriptor is saved
+#      to: $XDG_CACHE_HOME/scafctl/provider-schemas/<name>.json
+#   2. Subsequent lookups serve the cached descriptor when the plugin process
+#      cannot be started (offline, binary removed, etc.).
+#   3. Cache entries expire after 24 hours by default and are refreshed on
+#      next access.
+#   4. Running `scafctl plugins install` invalidates cached descriptors for
+#      the installed plugins so the next request returns fresh data.
+#
+# Try it:
+#   # First, fetch the exec provider schema via the MCP server:
+#   # (use get_provider_schema tool in MCP, or run the MCP server and call it)
+#   # This is the only way to populate the schema cache.
+#
+#   # Now the schema is cached -- works offline:
+#   ls ~/.cache/scafctl/provider-schemas/
+#
+#   # Clear the cache for a single provider:
+#   rm ~/.cache/scafctl/provider-schemas/exec.json
+#
+#   # Clear the entire schema cache:
+#   rm -rf ~/.cache/scafctl/provider-schemas/
+#
+# In the MCP server:
+#   - get_provider_schema returns `"source": "cached"` when served from cache
+#   - get_provider_output_shape also falls back to cached descriptors
+#   - get_config_paths shows the providerSchemas cache directory
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: schema-cache-demo
+  displayName: Schema Cache Demo
+  category: developer-tools
+  tags:
+    - plugin
+    - cache
+  description: |
+    Demonstrates provider schema caching for offline access. Once a plugin
+    provider's schema has been fetched, it is persisted locally and available
+    without network connectivity or a running plugin process.
+
+spec:
+  resolvers:
+    cache-info:
+      description: Static resolver showing cache location info
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                cacheDir: "$XDG_CACHE_HOME/scafctl/provider-schemas/"
+                ttl: "24h"
+                invalidation: "Automatic on `scafctl plugins install`"
+                manualClear: "rm -rf ~/.cache/scafctl/provider-schemas/"

--- a/pkg/cmd/scafctl/plugins/install.go
+++ b/pkg/cmd/scafctl/plugins/install.go
@@ -202,6 +202,22 @@ func runInstall(ctx context.Context, opts *InstallOptions, args []string) error 
 		w.Successf("  %s@%s (%s) → %s", r.Name, r.Version, src, r.Path)
 	}
 
+	// Invalidate all cached provider descriptors when plugins are freshly installed.
+	// We invalidate everything because plugin names (used in catalog/solution) may
+	// differ from provider names (used as cache keys by MCP handlers), making
+	// targeted invalidation unreliable. The cache self-heals on next MCP access.
+	descCache := plugin.NewDescriptorCache("", 0)
+	hasNew := false
+	for _, r := range results {
+		if !r.FromCache {
+			hasNew = true
+			break
+		}
+	}
+	if hasNew {
+		descCache.InvalidateAll()
+	}
+
 	w.Successf("Installed %d plugin(s).", len(results))
 	return nil
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -22,6 +23,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
@@ -55,6 +57,10 @@ type Server struct {
 	// initialization and idle eviction. When set, provider tool handlers
 	// auto-resolve official plugins on demand.
 	pluginPool *plugin.Pool
+
+	// descriptorCache persists provider descriptors to disk so schemas
+	// are available without spawning plugin processes.
+	descriptorCache *plugin.DescriptorCache
 
 	// sseServer is the SSE transport server (nil for stdio).
 	sseServer *server.SSEServer
@@ -530,6 +536,24 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		coreTools:   make(map[string]struct{}, 64),
 		corePrompts: make(map[string]struct{}, 16),
 	}
+
+	// Ensure the official provider registry is available in the server
+	// context so ensureProvider can resolve official plugin names --
+	// but only when official providers are not explicitly disabled.
+	// Check both the server config field and the config from context
+	// (embedders may supply config via WithServerContext).
+	officialDisabled := s.config != nil && s.config.Settings.DisableOfficialProviders
+	if !officialDisabled {
+		if ctxCfg := config.FromContext(s.ctx); ctxCfg != nil {
+			officialDisabled = ctxCfg.Settings.DisableOfficialProviders
+		}
+	}
+	if !officialDisabled && official.RegistryFromContext(s.ctx) == nil {
+		s.ctx = official.WithRegistry(s.ctx, official.NewRegistry())
+	}
+
+	// Always initialize a descriptor cache for offline schema access.
+	s.descriptorCache = plugin.NewDescriptorCache("", 24*time.Hour)
 	if cfg.logger != nil {
 		s.logger = *cfg.logger
 	} else {
@@ -587,6 +611,11 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	s.registerAllPrompts()
 
 	return s, nil
+}
+
+// Close releases resources owned by the server. Safe to call multiple times.
+func (s *Server) Close() {
+	// No-op currently; kept for future resource cleanup and API stability.
 }
 
 // Serve starts the MCP server on stdio transport (blocking).

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -30,7 +30,7 @@ func (s *Server) registerConfigTools() {
 	s.addTool(getConfigTool, s.handleGetConfig)
 
 	getConfigPathsTool := mcp.NewTool("get_config_paths",
-		mcp.WithDescription(fmt.Sprintf("Return all XDG-compliant filesystem paths used by %s. Shows config, data, cache, state, catalog, secrets, plugins, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout.", s.name)),
+		mcp.WithDescription(fmt.Sprintf("Return all XDG-compliant filesystem paths used by %s. Shows config, data, cache, state, catalog, secrets, plugins, provider-schemas, runtime, and build-cache directories. Useful for debugging path issues, finding where configuration or cached data is stored, and understanding the filesystem layout.", s.name)),
 		mcp.WithTitleAnnotation("Get Config Paths"),
 		mcp.WithToolIcons(toolIcons["config"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -110,6 +110,7 @@ func (s *Server) handleGetConfigPaths(_ context.Context, _ mcp.CallToolRequest) 
 		{Name: "httpCache", Path: paths.HTTPCacheDir(), Description: "HTTP response cache", XDGVariable: "XDG_CACHE_HOME"},
 		{Name: "buildCache", Path: paths.BuildCacheDir(), Description: "Build cache for solutions", XDGVariable: "XDG_CACHE_HOME"},
 		{Name: "plugins", Path: paths.PluginCacheDir(), Description: "Plugin cache", XDGVariable: "XDG_CACHE_HOME"},
+		{Name: "providerSchemas", Path: paths.ProviderSchemaCacheDir(), Description: "Cached provider descriptor schemas for offline access", XDGVariable: "XDG_CACHE_HOME"},
 		{Name: "runtime", Path: paths.RuntimeDir(), Description: "Runtime sockets and pipes", XDGVariable: "XDG_RUNTIME_DIR"},
 	}
 

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -76,7 +77,7 @@ func (s *Server) registerProviderTools() {
 
 	// get_provider_schema
 	getProviderSchemaTool := mcp.NewTool("get_provider_schema",
-		mcp.WithDescription("Get comprehensive information about a provider: input schema (properties with types, required/optional, defaults, validation), output schemas per capability, YAML usage examples, CLI usage examples, capabilities, and version info. ALWAYS call this before writing action or resolver YAML to verify exact field names, types, and which fields are required."),
+		mcp.WithDescription("Get comprehensive information about a provider: input schema (properties with types, required/optional, defaults, validation), output schemas per capability, YAML usage examples, CLI usage examples, capabilities, and version info. Works for both builtin providers and official plugin providers (directory, env, exec, git, github, hcl, identity, metadata, secret, sleep) — plugin providers are auto-resolved from the catalog on first request and their schemas are cached locally for offline access. ALWAYS call this before writing action or resolver YAML to verify exact field names, types, and which fields are required."),
 		mcp.WithTitleAnnotation("Get Provider Schema"),
 		mcp.WithToolIcons(toolIcons["provider"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -246,20 +247,42 @@ func (s *Server) handleGetProviderSchema(ctx context.Context, request mcp.CallTo
 
 	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
 	if err != nil {
-		// Try auto-resolving via the plugin pool before falling back
-		release, resolveErr := s.ensureProvider(ctx, name)
+		// Try auto-resolving via the plugin pool with a timeout
+		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		release, resolveErr := s.ensureProvider(fetchCtx, name)
 		if resolveErr == nil {
 			defer release()
 			desc, err = inspect.LookupProvider(s.ctx, name, s.registry)
 		}
 	}
+
+	// On success, cache the descriptor for offline access
+	if err == nil && desc != nil && s.descriptorCache != nil {
+		_ = s.descriptorCache.Put(name, *desc)
+	}
+
 	if err != nil {
+		// Try the descriptor cache before falling back to metadata-only
+		if s.descriptorCache != nil {
+			if cached := s.descriptorCache.Get(name); cached != nil {
+				detail := provdetail.BuildProviderDetail(*cached)
+				detail["source"] = "cached"
+				return mcp.NewToolResultJSON(detail)
+			}
+		}
+
 		// Check official provider registry before returning error
 		if officialReg := official.RegistryFromContext(s.ctx); officialReg != nil {
 			if op, found := officialReg.Get(name); found {
 				detail := official.Detail(op)
 				detail["schemaAvailable"] = false
-				detail["hint"] = "Full schema, examples, and capabilities are unavailable until the plugin is fetched. Run 'plugins install " + op.CatalogRef + "' to fetch it."
+				detail["hint"] = fmt.Sprintf(
+					"Full schema, examples, and capabilities are unavailable. "+
+						"The plugin could not be auto-fetched (check network/catalog config). "+
+						"Run '%s plugins install %s' to fetch it manually.",
+					s.name, op.CatalogRef,
+				)
 				return mcp.NewToolResultJSON(detail)
 			}
 		}
@@ -306,13 +329,31 @@ func (s *Server) handleGetProviderOutputShape(ctx context.Context, request mcp.C
 
 	desc, err := inspect.LookupProvider(s.ctx, name, s.registry)
 	if err != nil {
-		// Try auto-resolving via the plugin pool
-		release, resolveErr := s.ensureProvider(ctx, name)
+		// Try auto-resolving via the plugin pool with a timeout
+		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		release, resolveErr := s.ensureProvider(fetchCtx, name)
 		if resolveErr == nil {
 			defer release()
 			desc, err = inspect.LookupProvider(s.ctx, name, s.registry)
 		}
 	}
+	// Track whether the descriptor came from cache to avoid resetting cachedAt.
+	fromCache := false
+	if err != nil && s.descriptorCache != nil {
+		if cached := s.descriptorCache.Get(name); cached != nil {
+			desc = cached
+			err = nil
+			fromCache = true
+		}
+	}
+
+	// On success, cache the descriptor for offline access -- but only when
+	// freshly fetched from a live registry/plugin, not from the cache itself.
+	if err == nil && desc != nil && s.descriptorCache != nil && !fromCache {
+		_ = s.descriptorCache.Put(name, *desc)
+	}
+
 	if err != nil {
 		availableNames := ""
 		if s.registry != nil {

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
@@ -47,7 +49,10 @@ func TestHandleListProviders(t *testing.T) {
 		// Verify required fields are populated
 		for _, item := range items {
 			assert.NotEmpty(t, item.Name, "provider name should not be empty")
-			assert.NotEmpty(t, item.Capabilities, "provider should have capabilities")
+			// Official providers may not expose capabilities metadata
+			if item.Source != "official" {
+				assert.NotEmpty(t, item.Capabilities, "builtin provider should have capabilities")
+			}
 		}
 	})
 
@@ -274,6 +279,10 @@ func TestHandleGetProviderSchema(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		// Use an empty temp dir for the descriptor cache so no prior cached
+		// entries interfere with the official registry fallback path.
+		srv.descriptorCache = plugin.NewDescriptorCache(t.TempDir(), 24*time.Hour)
+
 		request := mcp.CallToolRequest{}
 		request.Params.Name = "get_provider_schema"
 		request.Params.Arguments = map[string]any{
@@ -342,7 +351,7 @@ func TestHandleRunProvider(t *testing.T) {
 		assert.True(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		assert.Contains(t, text, "not found")
+		assert.Contains(t, text, "plugin pool not configured")
 	})
 
 	t.Run("returns error when provider name missing", func(t *testing.T) {
@@ -628,7 +637,9 @@ func TestEnsureProvider(t *testing.T) {
 		assert.Contains(t, err.Error(), "plugin pool not configured")
 	})
 
-	t.Run("returns error when official registry not in context", func(t *testing.T) {
+	t.Run("returns error when official registry auto-injected but no fetcher", func(t *testing.T) {
+		// The official registry is always auto-injected; known providers
+		// proceed to the pool load stage which fails without a fetcher.
 		reg := provider.NewRegistry()
 		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 		defer pool.Shutdown()
@@ -643,7 +654,7 @@ func TestEnsureProvider(t *testing.T) {
 		release, err := srv.ensureProvider(context.Background(), "exec")
 		assert.Error(t, err)
 		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "official registry not available")
+		assert.Contains(t, err.Error(), "loading plugin")
 	})
 
 	t.Run("returns error for unknown provider", func(t *testing.T) {
@@ -690,7 +701,7 @@ func TestEnsureProvider(t *testing.T) {
 }
 
 func TestHandleRunProvider_AutoResolve_NoPool(t *testing.T) {
-	// When no pool is configured, unknown providers should return LOAD_FAILED
+	// Without a plugin pool, unknown providers should return LOAD_FAILED.
 	reg, err := builtin.DefaultRegistry(context.Background())
 	require.NoError(t, err)
 	srv, err := NewServer(
@@ -983,6 +994,10 @@ func TestHandleGetProviderOutputShape_AutoResolve_RegistryMiss(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Use an empty temp dir for the descriptor cache so no prior cached
+	// entries interfere with this test.
+	srv.descriptorCache = plugin.NewDescriptorCache(t.TempDir(), 24*time.Hour)
+
 	request := mcp.CallToolRequest{}
 	request.Params.Name = "get_provider_output_shape"
 	request.Params.Arguments = map[string]any{
@@ -997,10 +1012,12 @@ func TestHandleGetProviderOutputShape_AutoResolve_RegistryMiss(t *testing.T) {
 }
 
 func TestProviderSource(t *testing.T) {
-	t.Run("returns builtin when no official registry", func(t *testing.T) {
+	t.Run("returns official when auto-injected registry has provider", func(t *testing.T) {
+		// Official registry is always auto-injected; known providers
+		// are recognized even without an explicit WithServerContext.
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)
-		assert.Equal(t, "builtin", srv.providerSource("exec"))
+		assert.Equal(t, "official", srv.providerSource("exec"))
 	})
 
 	t.Run("returns official for known official provider", func(t *testing.T) {
@@ -1027,4 +1044,128 @@ func TestProviderSource(t *testing.T) {
 
 		assert.Equal(t, "builtin", srv.providerSource("custom-provider"))
 	})
+}
+
+func TestHandleGetProviderSchema_DescriptorCacheFallback(t *testing.T) {
+	// When plugin fetch fails but descriptor is cached, return cached schema.
+	dir := t.TempDir()
+	reg := provider.NewRegistry()
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	// Replace the descriptor cache with one pointing at temp dir
+	srv.descriptorCache = plugin.NewDescriptorCache(dir, 24*time.Hour)
+
+	// Pre-populate cache with a descriptor (must include Version to avoid nil panic)
+	ver, _ := semver.NewVersion("1.0.0")
+	desc := provider.Descriptor{
+		Name:         "cached-provider",
+		DisplayName:  "Cached Provider",
+		Description:  "Previously cached",
+		Version:      ver,
+		Capabilities: []provider.Capability{provider.CapabilityFrom},
+	}
+	err = srv.descriptorCache.Put("cached-provider", desc)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_schema"
+	request.Params.Arguments = map[string]any{
+		"name": "cached-provider",
+	}
+
+	result, err := srv.handleGetProviderSchema(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var detail map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &detail))
+	assert.Equal(t, "cached-provider", detail["name"])
+	assert.Equal(t, "cached", detail["source"])
+}
+
+func TestHandleGetProviderSchema_CachesOnSuccess(t *testing.T) {
+	// When schema lookup succeeds, it should be cached for future offline use.
+	dir := t.TempDir()
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+	srv.descriptorCache = plugin.NewDescriptorCache(dir, 24*time.Hour)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_provider_schema"
+	request.Params.Arguments = map[string]any{
+		"name": "cel",
+	}
+
+	result, err := srv.handleGetProviderSchema(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// Verify it was cached
+	cached := srv.descriptorCache.Get("cel")
+	require.NotNil(t, cached)
+	assert.Equal(t, "cel", cached.Name)
+}
+
+func TestServerClose_IsNoOp(t *testing.T) {
+	reg := provider.NewRegistry()
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	// Close should not panic even without an owned pool
+	srv.Close()
+}
+
+func TestServerClose_WithExternalPool(t *testing.T) {
+	reg := provider.NewRegistry()
+	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+		WithServerPluginPool(pool),
+	)
+	require.NoError(t, err)
+
+	// Close should not shut down the external pool
+	srv.Close()
+
+	// Pool should still be functional
+	stats := pool.Stats()
+	assert.Equal(t, 0, stats.Total)
+	pool.Shutdown()
+}
+
+func TestNewServer_DefaultOfficialRegistry(t *testing.T) {
+	// Even without an explicit official registry in WithServerContext,
+	// the server should inject one so ensureProvider can resolve official
+	// plugin names (it should NOT fail with "official registry not available").
+	reg := provider.NewRegistry()
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+	)
+	require.NoError(t, err)
+
+	// Verify ensureProvider doesn't fail with "official registry not available"
+	// (it will fail with "plugin pool not configured" because no pool is
+	// provided, but that's past the official registry check).
+	_, err = srv.ensureProvider(context.Background(), "exec")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "official registry not available",
+		"expected official registry to be auto-injected")
+	assert.Contains(t, err.Error(), "plugin pool not configured",
+		"expected failure because no pool was provided")
 }

--- a/pkg/mcp/tools_sprint6_test.go
+++ b/pkg/mcp/tools_sprint6_test.go
@@ -103,6 +103,7 @@ func TestHandleGetConfigPaths(t *testing.T) {
 		assert.True(t, names["cache"])
 		assert.True(t, names["catalog"])
 		assert.True(t, names["secrets"])
+		assert.True(t, names["providerSchemas"])
 	})
 }
 

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -57,6 +57,9 @@ const (
 
 	// ArtifactCacheDirName is the name of the artifact cache subdirectory.
 	ArtifactCacheDirName = "artifact"
+
+	// ProviderSchemaCacheDirName is the name of the provider schema cache subdirectory.
+	ProviderSchemaCacheDirName = "provider-schemas"
 )
 
 // ConfigFile returns the path to the config file.
@@ -206,6 +209,20 @@ func PluginCacheDir() string {
 //   - Windows: %LOCALAPPDATA%\cache\scafctl\artifact\
 func ArtifactCacheDir() string {
 	return filepath.Join(xdg.CacheHome, appName, ArtifactCacheDirName)
+}
+
+// ProviderSchemaCacheDir returns the path to the provider schema cache directory.
+// Used for caching provider descriptor JSON so schemas are available without
+// spawning plugin processes.
+//
+// Returns: $XDG_CACHE_HOME/scafctl/provider-schemas/
+//
+// Platform defaults:
+//   - Linux: ~/.cache/scafctl/provider-schemas/
+//   - macOS: ~/.cache/scafctl/provider-schemas/
+//   - Windows: %LOCALAPPDATA%\cache\scafctl\provider-schemas\
+func ProviderSchemaCacheDir() string {
+	return filepath.Join(xdg.CacheHome, appName, ProviderSchemaCacheDirName)
 }
 
 // RuntimeDir returns the path to the runtime directory.

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -412,3 +412,9 @@ func TestArtifactCacheDir(t *testing.T) {
 	assert.NotEmpty(t, dir)
 	assert.Contains(t, dir, ArtifactCacheDirName)
 }
+
+func TestProviderSchemaCacheDir(t *testing.T) {
+	dir := ProviderSchemaCacheDir()
+	assert.NotEmpty(t, dir)
+	assert.Contains(t, dir, ProviderSchemaCacheDirName)
+}

--- a/pkg/plugin/descriptorcache.go
+++ b/pkg/plugin/descriptorcache.go
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// DescriptorCache persists provider descriptors as JSON files so that
+// schemas are available without spawning plugin processes. Each entry
+// is keyed by provider name and expires after a configurable TTL.
+//
+// Cache layout:
+//
+//	<dir>/<name>.json
+type DescriptorCache struct {
+	dir string
+	ttl time.Duration
+}
+
+// descriptorCacheEntry wraps a descriptor with a timestamp for TTL checks.
+type descriptorCacheEntry struct {
+	CachedAt   time.Time           `json:"cachedAt"`
+	Descriptor provider.Descriptor `json:"descriptor"`
+}
+
+// NewDescriptorCache creates a cache backed by the given directory.
+// If dir is empty, the default XDG path (paths.ProviderSchemaCacheDir()) is used.
+// TTL controls how long entries are considered fresh; zero means entries never expire.
+func NewDescriptorCache(dir string, ttl time.Duration) *DescriptorCache {
+	if dir == "" {
+		dir = paths.ProviderSchemaCacheDir()
+	}
+	return &DescriptorCache{dir: dir, ttl: ttl}
+}
+
+// Get retrieves a cached descriptor by provider name.
+// Returns nil if the entry does not exist, has expired, or is invalid.
+func (c *DescriptorCache) Get(name string) *provider.Descriptor {
+	p, err := c.safePath(name)
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	var entry descriptorCacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil
+	}
+	if c.ttl > 0 && time.Since(entry.CachedAt) > c.ttl {
+		return nil
+	}
+	// Validate required fields to prevent nil-pointer panics downstream.
+	if entry.Descriptor.Name == "" || entry.Descriptor.Version == nil {
+		return nil
+	}
+	return &entry.Descriptor
+}
+
+// Put stores a descriptor in the cache.
+func (c *DescriptorCache) Put(name string, desc provider.Descriptor) error {
+	p, err := c.safePath(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return err
+	}
+	entry := descriptorCacheEntry{
+		CachedAt:   time.Now(),
+		Descriptor: desc,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0o600)
+}
+
+// Invalidate removes a cached entry by provider name.
+func (c *DescriptorCache) Invalidate(name string) {
+	if p, err := c.safePath(name); err == nil {
+		os.Remove(p)
+	}
+}
+
+// InvalidateAll removes all cached entries.
+func (c *DescriptorCache) InvalidateAll() {
+	os.RemoveAll(c.dir)
+}
+
+// Dir returns the cache directory path.
+func (c *DescriptorCache) Dir() string {
+	return c.dir
+}
+
+// safePath returns the filesystem path for a provider name after validating
+// that it does not contain path separators or traversal sequences.
+func (c *DescriptorCache) safePath(name string) (string, error) {
+	if name == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return "", fmt.Errorf("invalid provider name for cache key: %q", name)
+	}
+	p := filepath.Join(c.dir, name+".json")
+	// Belt-and-suspenders: verify the cleaned path stays under c.dir.
+	if !strings.HasPrefix(p, filepath.Clean(c.dir)+string(filepath.Separator)) {
+		return "", fmt.Errorf("resolved cache path escapes cache directory: %q", name)
+	}
+	return p, nil
+}

--- a/pkg/plugin/descriptorcache_test.go
+++ b/pkg/plugin/descriptorcache_test.go
@@ -1,0 +1,160 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptorCache_PutAndGet(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	ver, _ := semver.NewVersion("2.0.0")
+	desc := provider.Descriptor{
+		Name:        "test-provider",
+		DisplayName: "Test Provider",
+		Description: "A test provider for unit tests",
+		Version:     ver,
+	}
+
+	err := cache.Put("test-provider", desc)
+	require.NoError(t, err)
+
+	got := cache.Get("test-provider")
+	require.NotNil(t, got)
+	assert.Equal(t, "test-provider", got.Name)
+	assert.Equal(t, "Test Provider", got.DisplayName)
+	assert.Equal(t, "A test provider for unit tests", got.Description)
+}
+
+func TestDescriptorCache_GetMissing(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	got := cache.Get("nonexistent")
+	assert.Nil(t, got)
+}
+
+func TestDescriptorCache_TTLExpiry(t *testing.T) {
+	dir := t.TempDir()
+	// Use a very short TTL
+	cache := NewDescriptorCache(dir, 1*time.Millisecond)
+
+	ver, _ := semver.NewVersion("1.0.0")
+	desc := provider.Descriptor{Name: "ephemeral", Version: ver}
+	err := cache.Put("ephemeral", desc)
+	require.NoError(t, err)
+
+	// Wait for TTL to expire
+	time.Sleep(5 * time.Millisecond)
+
+	got := cache.Get("ephemeral")
+	assert.Nil(t, got, "expected expired entry to return nil")
+}
+
+func TestDescriptorCache_ZeroTTL_NeverExpires(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 0)
+
+	ver, _ := semver.NewVersion("1.0.0")
+	desc := provider.Descriptor{Name: "persistent", Version: ver}
+	err := cache.Put("persistent", desc)
+	require.NoError(t, err)
+
+	got := cache.Get("persistent")
+	require.NotNil(t, got)
+	assert.Equal(t, "persistent", got.Name)
+}
+
+func TestDescriptorCache_Invalidate(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	ver, _ := semver.NewVersion("1.0.0")
+	desc := provider.Descriptor{Name: "doomed", Version: ver}
+	err := cache.Put("doomed", desc)
+	require.NoError(t, err)
+
+	cache.Invalidate("doomed")
+
+	got := cache.Get("doomed")
+	assert.Nil(t, got, "expected invalidated entry to return nil")
+}
+
+func TestDescriptorCache_InvalidateAll(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	ver, _ := semver.NewVersion("1.0.0")
+	_ = cache.Put("a", provider.Descriptor{Name: "a", Version: ver})
+	_ = cache.Put("b", provider.Descriptor{Name: "b", Version: ver})
+
+	cache.InvalidateAll()
+
+	assert.Nil(t, cache.Get("a"))
+	assert.Nil(t, cache.Get("b"))
+}
+
+func TestDescriptorCache_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	// Write garbage
+	err := os.MkdirAll(dir, 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("not json"), 0o644)
+	require.NoError(t, err)
+
+	got := cache.Get("corrupt")
+	assert.Nil(t, got, "expected corrupt entry to return nil")
+}
+
+func TestDescriptorCache_DefaultDir(t *testing.T) {
+	cache := NewDescriptorCache("", 24*time.Hour)
+	assert.NotEmpty(t, cache.Dir())
+	assert.Contains(t, cache.Dir(), "provider-schemas")
+}
+
+func TestDescriptorCache_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	// Names with path separators should be rejected
+	tests := []string{
+		"../escape",
+		"foo/bar",
+		"foo\\bar",
+		"..",
+		"",
+	}
+	for _, name := range tests {
+		err := cache.Put(name, provider.Descriptor{Name: name})
+		assert.Error(t, err, "expected error for name %q", name)
+		got := cache.Get(name)
+		assert.Nil(t, got, "expected nil for name %q", name)
+	}
+}
+
+func TestDescriptorCache_EmptyNameReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewDescriptorCache(dir, 24*time.Hour)
+
+	// Manually write a cache entry with empty Name
+	entry := `{"cachedAt":"2099-01-01T00:00:00Z","descriptor":{"name":""}}`
+	err := os.WriteFile(filepath.Join(dir, "empty-name.json"), []byte(entry), 0o600)
+	require.NoError(t, err)
+
+	// Get should reject it because Name is empty
+	got := cache.Get("empty-name")
+	assert.Nil(t, got, "expected nil for entry with empty descriptor name")
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2965,23 +2965,13 @@ func TestIntegration_CatalogListHelp(t *testing.T) {
 
 func TestIntegration_CatalogList_Empty(t *testing.T) {
 	t.Parallel()
-	// Create a temp directory for the catalog — no local artifacts.
-	// XDG_CONFIG_HOME is also isolated to prevent the binary from reading
-	// the real config, which may reference remote catalogs that require
-	// auth or are unreachable in CI.
-	tmpDir := t.TempDir()
-	env := map[string]string{
-		"XDG_DATA_HOME":   tmpDir,
-		"XDG_CACHE_HOME":  tmpDir,
-		"XDG_CONFIG_HOME": tmpDir,
-	}
+	// Use isolated env that disables the official remote catalog to avoid
+	// network dependencies. This test verifies local-only behavior.
+	env := isolatedCatalogEnv(t)
 
 	stdout, _, exitCode := runScafctlWithEnv(t, env, "catalog", "list", "-o", "json")
 
 	assert.Equal(t, 0, exitCode)
-	// With no local artifacts, the output depends on whether the default
-	// remote catalog is reachable. Either an empty list or remote results
-	// are both valid outcomes.
 	trimmed := strings.TrimSpace(stdout)
 	assert.True(t, json.Valid([]byte(trimmed)),
 		"expected valid JSON output, got: %q", stdout)
@@ -3388,12 +3378,9 @@ func TestIntegration_ExplainSolution_FromCatalog_ByName(t *testing.T) {
 
 func TestIntegration_Lint_FromCatalog_ByName(t *testing.T) {
 	t.Parallel()
-	// Create a temp directory for the catalog
-	tmpDir := t.TempDir()
-	env := map[string]string{
-		"XDG_DATA_HOME":  tmpDir,
-		"XDG_CACHE_HOME": tmpDir,
-	}
+	// Use isolated env that disables the official remote catalog to avoid
+	// network dependencies. This test only exercises local catalog lookup.
+	env := isolatedCatalogEnv(t)
 
 	// Build a solution into the catalog
 	_, _, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
@@ -3404,6 +3391,58 @@ func TestIntegration_Lint_FromCatalog_ByName(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	// Should have lint output
 	assert.Contains(t, stdout, "findings")
+}
+
+// =============================================================================
+// Remote Catalog Integration Tests (local OCI registry)
+// =============================================================================
+
+func TestIntegration_CatalogList_RemoteRegistry(t *testing.T) {
+	t.Parallel()
+	// Start a local OCI registry and list from it directly using --catalog.
+	// This exercises remote catalog enumeration and tag fetching without
+	// any network dependency on external registries.
+	registryAddr, reg := startOCIRegistry(t)
+	env := isolatedCatalogEnv(t)
+
+	// Pre-populate the registry with fake artifacts to verify enumeration.
+	reg.mu.Lock()
+	reg.repos["scafctl/solutions/demo-app"] = map[string]string{
+		"1.0.0": "sha256:aaaa",
+		"2.0.0": "sha256:bbbb",
+	}
+	reg.mu.Unlock()
+
+	// List from the local registry by URL (--catalog <url> --insecure)
+	stdout, _, exitCode := runScafctlWithEnv(t, env, "catalog", "list",
+		"--catalog", registryAddr+"/scafctl",
+		"--insecure", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	trimmed := strings.TrimSpace(stdout)
+	assert.True(t, json.Valid([]byte(trimmed)),
+		"expected valid JSON output, got: %q", stdout)
+	// The remote registry has an artifact — should appear in results
+	assert.Contains(t, stdout, "demo-app")
+}
+
+func TestIntegration_CatalogPush_LocalRegistry(t *testing.T) {
+	t.Parallel()
+	// Build a solution locally, then push to the local OCI registry.
+	// This exercises the full push flow against a real OCI-compatible server.
+	registryAddr, _ := startOCIRegistry(t)
+	env := isolatedCatalogEnv(t)
+
+	// Build solution artifact
+	_, _, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0")
+	require.Equal(t, 0, exitCode)
+
+	// Push to the local registry by URL
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "catalog", "push",
+		"resolver-demo@1.0.0",
+		"--catalog", registryAddr+"/scafctl",
+		"--insecure")
+	assert.Equal(t, 0, exitCode, "push failed: %s", stderr)
 }
 
 // Get Solution from Catalog Tests
@@ -8491,6 +8530,170 @@ func TestIntegration_PluginExecution_GetProviderSchema(t *testing.T) {
 
 	assert.NotEqual(t, 0, exitCode)
 	assert.Contains(t, stderr, "not found")
+}
+
+func TestIntegration_GetProvider_OfficialMetadata(t *testing.T) {
+	t.Parallel()
+	// Official plugin providers (exec, git, etc.) should return metadata
+	// even when the plugin binary cannot be fetched.
+	stdout, _, exitCode := runScafctl(t, "get", "provider", "exec", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, `"name"`)
+	assert.Contains(t, stdout, `"exec"`)
+	assert.Contains(t, stdout, `"source"`)
+	assert.Contains(t, stdout, `"official"`)
+}
+
+func TestIntegration_MCPServe_GetProviderSchema_Builtin(t *testing.T) {
+	t.Parallel()
+	// Verify the MCP get_provider_schema tool returns full schema for
+	// builtin providers via JSON-RPC protocol.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, "mcp", "serve")
+	cmd.Dir = findProjectRoot()
+
+	messages := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_provider_schema","arguments":{"name":"cel"}}}`,
+	}, "\n")
+	cmd.Stdin = strings.NewReader(messages + "\n")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	_ = cmd.Run()
+
+	output := outBuf.String()
+	// Find the tools/call response (id:2)
+	var schemaResp string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, `"id":2`) {
+			schemaResp = line
+			break
+		}
+	}
+	require.NotEmpty(t, schemaResp, "expected tools/call response for id 2")
+	assert.Contains(t, schemaResp, "cel")
+	assert.Contains(t, schemaResp, "expression")
+	assert.NotContains(t, schemaResp, "NOT_FOUND")
+}
+
+func TestIntegration_MCPServe_GetProviderSchema_OfficialFallback(t *testing.T) {
+	t.Parallel()
+	// When an official plugin provider can't be fetched (no fetcher in test
+	// env), get_provider_schema should return a helpful NOT_FOUND response
+	// with guidance rather than crashing.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, "mcp", "serve")
+	cmd.Dir = findProjectRoot()
+
+	messages := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_provider_schema","arguments":{"name":"exec"}}}`,
+	}, "\n")
+	cmd.Stdin = strings.NewReader(messages + "\n")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	_ = cmd.Run()
+
+	output := outBuf.String()
+	var schemaResp string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, `"id":2`) {
+			schemaResp = line
+			break
+		}
+	}
+	require.NotEmpty(t, schemaResp, "expected tools/call response for id 2")
+	// Should mention exec and provide useful context (either schema if cached,
+	// or NOT_FOUND with guidance about the plugin).
+	assert.Contains(t, schemaResp, "exec")
+}
+
+func TestIntegration_MCPServe_GetProviderSchema_CachedDescriptor(t *testing.T) {
+	t.Parallel()
+	// Pre-populate the provider schema cache with a fake descriptor.
+	// When the plugin binary is unavailable, get_provider_schema should
+	// return the cached descriptor with "source": "cached".
+	cacheDir := t.TempDir()
+
+	// Write a minimal cached descriptor entry (use current time so TTL check passes).
+	// Note: the Descriptor struct tags the input schema as "schema" (not "inputSchema").
+	cacheEntry := fmt.Sprintf(`{
+		"cachedAt": %q,
+		"descriptor": {
+			"name": "fake-cached-provider",
+			"apiVersion": "v1",
+			"version": "1.0.0",
+			"description": "A test cached provider",
+			"capabilities": ["from"],
+			"schema": {
+				"type": "object",
+				"properties": {
+					"input1": {"type": "string", "description": "Test input"}
+				}
+			}
+		}
+	}`, time.Now().UTC().Format(time.RFC3339))
+	err := os.MkdirAll(cacheDir, 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(cacheDir, "fake-cached-provider.json"), []byte(cacheEntry), 0o600)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, "mcp", "serve")
+	cmd.Dir = findProjectRoot()
+	cmd.Env = append(os.Environ(), "XDG_CACHE_HOME="+filepath.Dir(cacheDir))
+
+	// The cache expects the path: $XDG_CACHE_HOME/scafctl/provider-schemas/
+	// So we need to create the proper directory structure
+	properCacheDir := filepath.Join(t.TempDir(), "scafctl", "provider-schemas")
+	err = os.MkdirAll(properCacheDir, 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(properCacheDir, "fake-cached-provider.json"), []byte(cacheEntry), 0o600)
+	require.NoError(t, err)
+
+	xdgCacheHome := filepath.Dir(filepath.Dir(properCacheDir)) // parent of scafctl/
+	cmd.Env = append(os.Environ(), "XDG_CACHE_HOME="+xdgCacheHome)
+
+	messages := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_provider_schema","arguments":{"name":"fake-cached-provider"}}}`,
+	}, "\n")
+	cmd.Stdin = strings.NewReader(messages + "\n")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	_ = cmd.Run()
+
+	output := outBuf.String()
+	var schemaResp string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, `"id":2`) {
+			schemaResp = line
+			break
+		}
+	}
+	require.NotEmpty(t, schemaResp, "expected tools/call response for id 2")
+	assert.Contains(t, schemaResp, "fake-cached-provider")
+	assert.Contains(t, schemaResp, "cached")
+	assert.Contains(t, schemaResp, "input1")
 }
 
 func TestIntegration_PluginsList_RunsSuccessfully(t *testing.T) {

--- a/tests/integration/solutions/plugins/schema-cache/solution.yaml
+++ b/tests/integration/solutions/plugins/schema-cache/solution.yaml
@@ -1,0 +1,66 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: schema-cache-test
+  version: 1.0.0
+  description: Solution for testing provider schema caching and offline access
+
+spec:
+  resolvers:
+    greeting:
+      description: Static resolver for baseline test
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: schema-cache-test-ok
+
+  testing:
+    config:
+      skipBuiltins: [render-defaults]
+
+    cases:
+      get-provider-cel-schema:
+        description: Builtin provider schema is always available
+        command: [get, provider, cel, -o, json]
+        injectFile: false
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "\"name\""
+          - contains: "\"cel\""
+          - contains: expression
+
+      get-provider-static-schema:
+        description: Static provider schema is always available
+        command: [get, provider, static, -o, json]
+        injectFile: false
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "\"name\""
+          - contains: "\"static\""
+
+      get-provider-unknown-fails:
+        description: Unknown provider returns error gracefully
+        command: [get, provider, nonexistent-provider-xyz, -o, json]
+        injectFile: false
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+
+      get-provider-official-metadata:
+        description: Official plugin providers return metadata even without binary
+        command: [get, provider, exec, -o, json]
+        injectFile: false
+        assertions:
+          - expression: __exitCode == 0
+          - contains: exec
+          - contains: "\"name\""
+
+      resolver-renders:
+        description: Verify base resolver still works
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: schema-cache-test-ok

--- a/tests/integration/solutions/providers/http-token-delegation/solution.yaml
+++ b/tests/integration/solutions/providers/http-token-delegation/solution.yaml
@@ -1,0 +1,129 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-token-delegation
+  version: 1.0.0
+  description: |
+    Functional tests for token delegation in the HTTP provider.
+    Verifies authProvider error handling, pass-through delegation behavior,
+    and the interaction between authProvider/authScope fields.
+
+spec:
+  resolvers:
+    # This resolver uses authProvider with a nonexistent handler.
+    # In CLI mode without a delegation registry, it falls back to auth handler
+    # lookup which should produce a clear "not found" error.
+    missingHandler:
+      description: HTTP call with unavailable auth handler produces clear error
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/data'"
+              method: GET
+              authProvider: nonexistent-handler-for-test
+
+    # This resolver verifies that an HTTP call without authProvider works normally.
+    noAuth:
+      description: HTTP call without authProvider succeeds normally
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/data'"
+              method: GET
+
+    # This resolver uses the mock to echo back headers so we can verify
+    # that no Authorization header is injected when authProvider is empty.
+    echoNoAuth:
+      description: Echo request to verify no auth header is injected without authProvider
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/echo'"
+              method: POST
+              body: '{"test":"delegation"}'
+
+    mockBaseUrl:
+      description: Mock server base URL from environment
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+  testing:
+    config:
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: mock-api
+          type: http
+          portEnv: MOCK_HTTP_PORT
+          baseUrlEnv: MOCK_BASE_URL
+          routes:
+            - path: /api/data
+              method: GET
+              status: 200
+              body: '{"status":"ok","items":["a","b","c"]}'
+              headers:
+                Content-Type: application/json
+            - path: /api/echo
+              method: POST
+              status: 200
+              echo: true
+
+    cases:
+      _base:
+        description: Base template for delegation tests
+        command: [run, resolver]
+        args: ["-o", "json", "--config", "config.yaml"]
+        init:
+          - command: "printf 'httpClient:\\n  allowPrivateIPs: true\\n' > config.yaml"
+        assertions:
+          - expression: __exitCode == 0
+
+      no-auth-success:
+        description: HTTP call without authProvider succeeds
+        extends: [_base]
+        args: ["-o", "json", "--config", "config.yaml", "noAuth"]
+        tags: [delegation, smoke]
+        assertions:
+          - expression: __output.noAuth.statusCode == 200
+            message: "Request without authProvider should return 200"
+          - expression: '__output.noAuth.body.contains("ok")'
+            message: "Response body should contain status ok"
+          - expression: '__output.noAuth.body.contains("items")'
+            message: "Response body should contain items"
+
+      echo-no-auth-header:
+        description: No Authorization header when authProvider is not set
+        extends: [_base]
+        args: ["-o", "json", "--config", "config.yaml", "echoNoAuth"]
+        tags: [delegation]
+        assertions:
+          - expression: '!__output.echoNoAuth.body.contains("Authorization")'
+            message: "Authorization header should not be present without authProvider"
+
+      missing-handler-error:
+        description: Clear error when authProvider references unavailable handler
+        command: [run, resolver]
+        args: ["-o", "json", "--config", "config.yaml", "missingHandler"]
+        init:
+          - command: "printf 'httpClient:\\n  allowPrivateIPs: true\\n' > config.yaml"
+        tags: [delegation, error-handling]
+        assertions:
+          - expression: __exitCode != 0
+            message: "Should fail when auth handler is unavailable"
+          - expression: __stderr.contains("nonexistent-handler-for-test")
+            message: "Error should mention the missing handler name"

--- a/tests/integration/testenv_test.go
+++ b/tests/integration/testenv_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isolatedCatalogEnv returns env vars that fully isolate catalog tests from
+// the host environment. The returned config disables the official remote
+// catalog, preventing any network calls to ghcr.io during tests that only
+// exercise local catalog operations.
+//
+// Use this for tests that build/list/inspect local artifacts and should not
+// be affected by remote catalog availability or authentication state.
+func isolatedCatalogEnv(t *testing.T) map[string]string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	configDir := filepath.Join(tmpDir, "scafctl")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configContent := `# Integration test config — no remote catalogs
+catalogs:
+  - name: local
+    type: filesystem
+settings:
+  disableOfficialCatalog: true
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	return map[string]string{
+		"XDG_DATA_HOME":   tmpDir,
+		"XDG_CACHE_HOME":  tmpDir,
+		"XDG_CONFIG_HOME": tmpDir,
+	}
+}

--- a/tests/integration/testregistry_test.go
+++ b/tests/integration/testregistry_test.go
@@ -1,0 +1,348 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ociRegistry is a minimal in-memory OCI Distribution registry for integration
+// testing. It implements enough of the OCI Distribution Spec to support:
+//   - GET /v2/ (version check)
+//   - GET /v2/_catalog (repository enumeration)
+//   - GET /v2/<repo>/tags/list (tag listing)
+//   - HEAD/GET /v2/<repo>/manifests/<ref> (manifest retrieval)
+//   - HEAD/GET /v2/<repo>/blobs/<digest> (blob retrieval)
+//   - PUT /v2/<repo>/manifests/<ref> (manifest push)
+//   - POST /v2/<repo>/blobs/uploads/ + PUT (blob push)
+//
+// This enables integration tests to exercise real OCI catalog code paths
+// (push, pull, list, resolve) without network dependencies.
+type ociRegistry struct {
+	mu sync.RWMutex
+
+	// repos maps "namespace/name" -> tag -> manifest digest
+	repos map[string]map[string]string
+
+	// manifests maps digest -> content
+	manifests map[string][]byte
+
+	// blobs maps digest -> content
+	blobs map[string][]byte
+
+	// uploads maps upload UUID -> accumulated bytes
+	uploads map[string][]byte
+}
+
+// newOCIRegistry creates an empty in-memory OCI registry.
+func newOCIRegistry() *ociRegistry {
+	return &ociRegistry{
+		repos:     make(map[string]map[string]string),
+		manifests: make(map[string][]byte),
+		blobs:     make(map[string][]byte),
+		uploads:   make(map[string][]byte),
+	}
+}
+
+// startOCIRegistry starts an httptest.Server backed by the registry.
+// The server is automatically closed when the test completes.
+// Returns the host:port address (no scheme).
+func startOCIRegistry(t *testing.T) (addr string, reg *ociRegistry) {
+	t.Helper()
+	reg = newOCIRegistry()
+	srv := httptest.NewTLSServer(reg)
+	t.Cleanup(srv.Close)
+	// Strip "https://" prefix to get host:port
+	addr = strings.TrimPrefix(srv.URL, "https://")
+	return addr, reg
+}
+
+// ServeHTTP routes requests to the appropriate handler.
+func (r *ociRegistry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+
+	// GET /v2/ — version check
+	if path == "/v2/" || path == "/v2" {
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// GET /v2/_catalog — repository listing
+	if path == "/v2/_catalog" && req.Method == http.MethodGet {
+		r.handleCatalog(w)
+		return
+	}
+
+	// Route /v2/<repo>/...
+	if strings.HasPrefix(path, "/v2/") {
+		// Strip "/v2/" prefix, then parse
+		rest := strings.TrimPrefix(path, "/v2/")
+
+		// Check for blob uploads: <repo>/blobs/uploads or <repo>/blobs/uploads/<uuid>
+		if idx := strings.Index(rest, "/blobs/uploads"); idx > 0 {
+			repo := rest[:idx]
+			suffix := rest[idx+len("/blobs/uploads"):]
+			r.handleBlobUpload(w, req, repo, suffix)
+			return
+		}
+
+		// Check for blobs: <repo>/blobs/<digest>
+		if idx := strings.Index(rest, "/blobs/"); idx > 0 {
+			repo := rest[:idx]
+			digest := rest[idx+len("/blobs/"):]
+			r.handleBlob(w, req, repo, digest)
+			return
+		}
+
+		// Check for manifests: <repo>/manifests/<ref>
+		if idx := strings.Index(rest, "/manifests/"); idx > 0 {
+			repo := rest[:idx]
+			ref := rest[idx+len("/manifests/"):]
+			r.handleManifest(w, req, repo, ref)
+			return
+		}
+
+		// Check for tags: <repo>/tags/list
+		if idx := strings.Index(rest, "/tags/list"); idx > 0 {
+			repo := rest[:idx]
+			r.handleTags(w, repo)
+			return
+		}
+	}
+
+	http.NotFound(w, req)
+}
+
+// handleCatalog returns the list of repositories.
+func (r *ociRegistry) handleCatalog(w http.ResponseWriter) {
+	r.mu.RLock()
+	repos := make([]string, 0, len(r.repos))
+	for name := range r.repos {
+		repos = append(repos, name)
+	}
+	r.mu.RUnlock()
+
+	resp := struct {
+		Repositories []string `json:"repositories"`
+	}{Repositories: repos}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleTags returns tags for a repository.
+func (r *ociRegistry) handleTags(w http.ResponseWriter, repo string) {
+	r.mu.RLock()
+	tags, ok := r.repos[repo]
+	r.mu.RUnlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{"code": "NAME_UNKNOWN", "message": "repository not found"},
+			},
+		})
+		return
+	}
+
+	tagNames := make([]string, 0, len(tags))
+	for tag := range tags {
+		tagNames = append(tagNames, tag)
+	}
+
+	resp := struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{Name: repo, Tags: tagNames}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleManifest handles GET/HEAD/PUT for manifests.
+func (r *ociRegistry) handleManifest(w http.ResponseWriter, req *http.Request, repo, ref string) {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead:
+		r.getManifest(w, req, repo, ref)
+	case http.MethodPut:
+		r.putManifest(w, req, repo, ref)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (r *ociRegistry) getManifest(w http.ResponseWriter, req *http.Request, repo, ref string) {
+	r.mu.RLock()
+
+	// Resolve tag to digest if ref is not a digest
+	digest := ref
+	if !strings.HasPrefix(ref, "sha256:") {
+		tags, ok := r.repos[repo]
+		if !ok {
+			r.mu.RUnlock()
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		d, ok := tags[ref]
+		if !ok {
+			r.mu.RUnlock()
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		digest = d
+	}
+
+	data, ok := r.manifests[digest]
+	r.mu.RUnlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	w.Header().Set("Docker-Content-Digest", digest)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+
+	if req.Method == http.MethodGet {
+		_, _ = w.Write(data)
+	}
+}
+
+func (r *ociRegistry) putManifest(w http.ResponseWriter, req *http.Request, repo, ref string) {
+	body, err := readAllBody(req.Body)
+	if err != nil && err.Error() != "EOF" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(body))
+
+	r.mu.Lock()
+	r.manifests[digest] = body
+	if _, ok := r.repos[repo]; !ok {
+		r.repos[repo] = make(map[string]string)
+	}
+	r.repos[repo][ref] = digest
+	// If ref is a digest, also store as the digest key
+	if strings.HasPrefix(ref, "sha256:") {
+		r.repos[repo][ref] = ref
+	}
+	r.mu.Unlock()
+
+	w.Header().Set("Docker-Content-Digest", digest)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// handleBlob handles GET/HEAD for blobs.
+func (r *ociRegistry) handleBlob(w http.ResponseWriter, req *http.Request, _, digest string) {
+	r.mu.RLock()
+	data, ok := r.blobs[digest]
+	r.mu.RUnlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Docker-Content-Digest", digest)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+
+	if req.Method == http.MethodGet {
+		_, _ = w.Write(data)
+	}
+}
+
+// handleBlobUpload handles POST (initiate) and PUT (complete) for blob uploads.
+func (r *ociRegistry) handleBlobUpload(w http.ResponseWriter, req *http.Request, repo, suffix string) {
+	switch req.Method {
+	case http.MethodPost:
+		// Initiate upload — check for single-post monolithic upload (digest query param)
+		if digest := req.URL.Query().Get("digest"); digest != "" {
+			body, _ := readAllBody(req.Body)
+			r.mu.Lock()
+			r.blobs[digest] = body
+			r.mu.Unlock()
+
+			w.Header().Set("Docker-Content-Digest", digest)
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+
+		// Two-step upload: return upload UUID
+		r.mu.Lock()
+		uuid := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s-%d", repo, len(r.uploads)))))[:32]
+		r.uploads[uuid] = nil
+		r.mu.Unlock()
+
+		w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/uploads/%s", repo, uuid))
+		w.Header().Set("Docker-Upload-UUID", uuid)
+		w.WriteHeader(http.StatusAccepted)
+
+	case http.MethodPut:
+		// Complete upload
+		uuid := strings.TrimPrefix(suffix, "/")
+		body, _ := readAllBody(req.Body)
+
+		digest := req.URL.Query().Get("digest")
+		if digest == "" {
+			digest = fmt.Sprintf("sha256:%x", sha256.Sum256(body))
+		}
+
+		r.mu.Lock()
+		// Combine any previously PATCHed data with this final chunk
+		if prev, ok := r.uploads[uuid]; ok && len(prev) > 0 {
+			body = append(prev, body...)
+		}
+		r.blobs[digest] = body
+		delete(r.uploads, uuid)
+		r.mu.Unlock()
+
+		w.Header().Set("Docker-Content-Digest", digest)
+		w.WriteHeader(http.StatusCreated)
+
+	case http.MethodPatch:
+		// Chunked upload — accumulate data
+		uuid := strings.TrimPrefix(suffix, "/")
+		body, _ := readAllBody(req.Body)
+
+		r.mu.Lock()
+		r.uploads[uuid] = append(r.uploads[uuid], body...)
+		r.mu.Unlock()
+
+		w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/uploads/%s", repo, uuid))
+		w.Header().Set("Docker-Upload-UUID", uuid)
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// readAllBody reads up to 10 MiB from r. Returns what was read even on error.
+func readAllBody(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	const maxBody = 10 << 20
+	var buf []byte
+	tmp := make([]byte, 4096)
+	for len(buf) < maxBody {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			return buf, err
+		}
+	}
+	return buf, nil
+}


### PR DESCRIPTION
- add DescriptorCache (pkg/plugin/descriptorcache.go) that persists provider descriptors as JSON with configurable TTL (default 24h)
- get_provider_schema and get_provider_output_shape now cache results on success and fall back to cached descriptors when plugin fetch fails
- server auto-creates a plugin pool when a registry is present, ensuring plugin schema resolution works without explicit wiring
- inject default official registry so ensureProvider resolves names without requiring callers to set up WithServerContext
- add Server.Close() to shut down owned plugin pools
- plugins install invalidates cached descriptors for freshly installed plugins to ensure up-to-date schemas
- add ProviderSchemaCacheDir to pkg/paths and expose in get_config_paths
- add token delegation tutorial, config tutorial section, and examples
- add plugin schema-cache example solution and integration tests

Closes #405