### PR TITLE
feat(auth): add builtin auth handlers, dynamic credential resolution, and profile wiring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.7.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b h1:0hECYesH
 github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.7.0 h1:irpsqXy5xB93gb2jW8/2hLfBgn5kNuaSPYK9eSd4MvQ=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.7.0/go.mod h1:+Qo2BXZ7Dhj8RoOwvueYFvhJsllyy1wPEJV71W1PoF0=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0 h1:EE4FnUT+RjyUsAYDZ8C6YKK7fPjpckTA/6otlQz5nzk=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0/go.mod h1:FiF5Nx8FqKxsfYqr93NnHVVVQLUaV6rPOY7Nu6dOIsg=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
@@ -7,6 +7,7 @@
 package credentialhelper
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,7 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -48,7 +51,7 @@ Or add manually to ~/.docker/config.json:
 	return cmd
 }
 
-func newHelper() (*credentialhelper.Helper, error) {
+func newHelper(opts ...credentialhelper.Option) (*credentialhelper.Helper, error) {
 	store, err := secrets.New()
 	if err != nil {
 		return nil, fmt.Errorf("initialize secrets store: %w", err)
@@ -56,7 +59,25 @@ func newHelper() (*credentialhelper.Helper, error) {
 	// Inject the already-initialised secrets store so the native credential store
 	// uses the same backend as the credential helper, avoiding a second keyring init.
 	nativeStore := catalog.NewNativeCredentialStoreWithSecretsStore(store)
-	return credentialhelper.New(store, credentialhelper.WithNativeStore(nativeStore)), nil
+	allOpts := make([]credentialhelper.Option, 0, 1+len(opts))
+	allOpts = append(allOpts, credentialhelper.WithNativeStore(nativeStore))
+	allOpts = append(allOpts, opts...)
+	return credentialhelper.New(store, allOpts...), nil
+}
+
+// buildTokenResolver creates a token resolver from the command context
+// if an auth registry is available. Returns nil if no registry is present
+// (e.g., when PersistentPreRun was not executed).
+func buildTokenResolver(ctx context.Context) credentialhelper.TokenResolver {
+	registry := auth.RegistryFromContext(ctx)
+	if registry == nil {
+		return nil
+	}
+	var resolverOpts []credentialhelper.ResolverOption
+	if cfg := config.FromContext(ctx); cfg != nil {
+		resolverOpts = append(resolverOpts, credentialhelper.WithCustomHandlers(cfg.Auth.CustomOAuth2))
+	}
+	return credentialhelper.NewAuthTokenResolver(registry, resolverOpts...)
 }
 
 func commandGet() *cobra.Command {
@@ -73,7 +94,11 @@ func commandGet() *cobra.Command {
 			if err != nil {
 				return writeError(os.Stdout, "failed to read input")
 			}
-			helper, err := newHelper()
+			var helperOpts []credentialhelper.Option
+			if resolver := buildTokenResolver(cmd.Context()); resolver != nil {
+				helperOpts = append(helperOpts, credentialhelper.WithTokenResolver(resolver))
+			}
+			helper, err := newHelper(helperOpts...)
 			if err != nil {
 				return writeError(os.Stdout, err.Error())
 			}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -160,6 +160,12 @@ type RootOptions struct {
 	// alongside built-in handlers during PersistentPreRunE.
 	AuthPluginDirs []string
 
+	// BuiltinAuthHandlers are pre-built auth handler instances that the
+	// embedder compiles into the binary. They are registered eagerly at
+	// startup before config-based or plugin handlers, and appear in
+	// 'auth list' immediately.
+	BuiltinAuthHandlers []auth.Handler
+
 	// ActionDiscoveryFileNames overrides the file names used by "run action"
 	// auto-discovery. When empty, the defaults from
 	// settings.ActionFileNamesFor are used.
@@ -238,8 +244,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	// Update package-level solution discovery lists so any code reading them
 	// directly (e.g., PossibleSolutionPaths, MCP capabilities) reflects the
 	// embedder's binary name rather than the hardcoded default.
-	settings.RootSolutionFolders = settings.SolutionFoldersFor(binaryName)
-	settings.SolutionFileNames = settings.SolutionFileNamesFor(binaryName)
+	settings.SetSolutionDiscovery(settings.SolutionFoldersFor(binaryName), settings.SolutionFileNamesFor(binaryName))
 
 	// Wire embedder-supplied action discovery file names into cliParams
 	// so they are available via settings.FromContext during command execution.
@@ -468,6 +473,13 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 
 			// Initialize auth registry
 			authRegistry := auth.NewRegistry()
+
+			// Register embedder-provided builtin auth handlers first
+			for _, h := range opts.BuiltinAuthHandlers {
+				if regErr := authRegistry.Register(h); regErr != nil {
+					lgr.V(1).Info("failed to register builtin auth handler", "name", h.Name(), "error", regErr)
+				}
+			}
 
 			// Register custom OAuth2 handlers from config
 			for _, customCfg := range cfg.Auth.CustomOAuth2 {

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -4,13 +4,18 @@
 package scafctl
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -220,8 +225,7 @@ func TestRoot_WithExitFunc(t *testing.T) {
 func TestRoot_CustomBinaryNameUpdatesSolutionDiscovery(t *testing.T) {
 	// Restore package-level state regardless of test outcome.
 	t.Cleanup(func() {
-		settings.RootSolutionFolders = settings.SolutionFoldersFor(settings.CliBinaryName)
-		settings.SolutionFileNames = settings.SolutionFileNamesFor(settings.CliBinaryName)
+		settings.SetSolutionDiscovery(settings.SolutionFoldersFor(settings.CliBinaryName), settings.SolutionFileNamesFor(settings.CliBinaryName))
 	})
 
 	cmd, _ := Root(&RootOptions{
@@ -233,21 +237,77 @@ func TestRoot_CustomBinaryNameUpdatesSolutionDiscovery(t *testing.T) {
 	}
 	// Verify package-level solution discovery vars were updated
 	expectedFolders := settings.SolutionFoldersFor("cldctl")
-	if len(settings.RootSolutionFolders) != len(expectedFolders) {
-		t.Errorf("RootSolutionFolders length = %d, want %d", len(settings.RootSolutionFolders), len(expectedFolders))
-	}
-	for i, f := range settings.RootSolutionFolders {
-		if f != expectedFolders[i] {
-			t.Errorf("RootSolutionFolders[%d] = %q, want %q", i, f, expectedFolders[i])
-		}
-	}
+	assert.Equal(t, expectedFolders, settings.GetRootSolutionFolders())
 	expectedNames := settings.SolutionFileNamesFor("cldctl")
-	if len(settings.SolutionFileNames) != len(expectedNames) {
-		t.Errorf("SolutionFileNames length = %d, want %d", len(settings.SolutionFileNames), len(expectedNames))
-	}
-	for i, n := range settings.SolutionFileNames {
-		if n != expectedNames[i] {
-			t.Errorf("SolutionFileNames[%d] = %q, want %q", i, n, expectedNames[i])
+	assert.Equal(t, expectedNames, settings.GetSolutionFileNames())
+}
+
+// stubAuthHandler is a minimal auth.Handler for testing BuiltinAuthHandlers.
+type stubAuthHandler struct {
+	name        string
+	displayName string
+}
+
+func (s *stubAuthHandler) Name() string                    { return s.name }
+func (s *stubAuthHandler) DisplayName() string             { return s.displayName }
+func (s *stubAuthHandler) SupportedFlows() []auth.Flow     { return []auth.Flow{auth.FlowDeviceCode} }
+func (s *stubAuthHandler) Capabilities() []auth.Capability { return nil }
+func (s *stubAuthHandler) Login(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+	return nil, nil
+}
+func (s *stubAuthHandler) Logout(_ context.Context) error                 { return nil }
+func (s *stubAuthHandler) Status(_ context.Context) (*auth.Status, error) { return &auth.Status{}, nil }
+func (s *stubAuthHandler) GetToken(_ context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+	return nil, nil
+}
+
+func (s *stubAuthHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
+	return nil
+}
+
+func TestRoot_WithBuiltinAuthHandlers(t *testing.T) {
+	t.Parallel()
+	handler := &stubAuthHandler{name: "internal-idp", displayName: "Internal IdP"}
+	cmd, cleanup := Root(&RootOptions{
+		BinaryName:          "mycli",
+		BuiltinAuthHandlers: []auth.Handler{handler},
+	})
+	defer cleanup()
+	require.NotNil(t, cmd)
+
+	// Verify the command tree was constructed with the option accepted.
+	assert.Equal(t, "mycli", cmd.Use)
+}
+
+func TestRoot_WithBuiltinAuthHandlers_Execution(t *testing.T) {
+	t.Parallel()
+	handler := &stubAuthHandler{name: "internal-idp", displayName: "Internal IdP"}
+	ioStreams, stdout, _ := terminal.NewTestIOStreams()
+
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams:           ioStreams,
+		BinaryName:          "mycli",
+		BuiltinAuthHandlers: []auth.Handler{handler},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"auth", "handlers", "-o", "json"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := stdout.String()
+
+	// Parse the JSON output and verify our builtin handler appears.
+	var handlers []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &handlers))
+
+	var found bool
+	for _, h := range handlers {
+		if h["name"] == "internal-idp" {
+			found = true
+			assert.Equal(t, "Internal IdP", h["displayName"])
+			assert.Equal(t, "built-in", h["source"])
+			break
 		}
 	}
+	assert.True(t, found, "builtin handler 'internal-idp' should appear in auth handlers output")
 }

--- a/pkg/credentialhelper/credentialhelper.go
+++ b/pkg/credentialhelper/credentialhelper.go
@@ -40,8 +40,17 @@ type ErrorResponse struct {
 
 // Helper implements the Docker credential helper protocol operations.
 type Helper struct {
-	store       secrets.Store
-	nativeStore *catalog.NativeCredentialStore
+	store         secrets.Store
+	nativeStore   *catalog.NativeCredentialStore
+	tokenResolver TokenResolver
+}
+
+// TokenResolver dynamically resolves fresh credentials for a registry
+// server URL by calling the appropriate auth handler. Implementations
+// should infer the handler, resolve the active profile, acquire a fresh
+// token, and return the registry credential.
+type TokenResolver interface {
+	Resolve(ctx context.Context, serverURL string) (*Credential, error)
 }
 
 // Option configures the Helper.
@@ -50,6 +59,13 @@ type Option func(*Helper)
 // WithNativeStore sets the native credential store for fallback lookups on Get.
 func WithNativeStore(ns *catalog.NativeCredentialStore) Option {
 	return func(h *Helper) { h.nativeStore = ns }
+}
+
+// WithTokenResolver sets a dynamic token resolver that acquires fresh
+// credentials from auth handlers. When set, Get() tries dynamic
+// resolution before falling back to stored credentials.
+func WithTokenResolver(r TokenResolver) Option {
+	return func(h *Helper) { h.tokenResolver = r }
 }
 
 // New creates a new credential helper with the given secrets store.
@@ -62,15 +78,27 @@ func New(store secrets.Store, opts ...Option) *Helper {
 }
 
 // Get retrieves credentials for a registry server URL.
-// It first checks the credhelper: namespace, then falls back to the native
-// credential store if configured.
+// Lookup precedence:
+//  1. Dynamic token resolution via auth handler (fresh token)
+//  2. Secrets store (credhelper: namespace)
+//  3. Native credential store (registries.json)
 func (h *Helper) Get(ctx context.Context, serverURL string) (*Credential, error) {
 	serverURL = strings.TrimSpace(serverURL)
 	if serverURL == "" {
 		return nil, fmt.Errorf("credentials not found")
 	}
 
-	// Check credhelper: namespace first
+	// Try dynamic resolution first — this returns a fresh token from the
+	// auth handler, avoiding stale bridged credentials.
+	if h.tokenResolver != nil {
+		cred, err := h.tokenResolver.Resolve(ctx, serverURL)
+		if err == nil && cred != nil {
+			return cred, nil
+		}
+		// Fall through to stored credentials on any error.
+	}
+
+	// Check credhelper: namespace next
 	data, err := h.store.Get(ctx, keyPrefix+serverURL)
 	if err == nil && len(data) > 0 {
 		var cred Credential

--- a/pkg/credentialhelper/resolver.go
+++ b/pkg/credentialhelper/resolver.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialhelper
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// AuthTokenResolver resolves fresh registry credentials by inferring
+// the auth handler for a registry host, resolving the active profile,
+// and acquiring a fresh token via BridgeAuthToRegistry.
+type AuthTokenResolver struct {
+	registry       *auth.Registry
+	customHandlers []config.CustomOAuth2Config
+}
+
+// ResolverOption configures the AuthTokenResolver.
+type ResolverOption func(*AuthTokenResolver)
+
+// WithCustomHandlers sets the custom OAuth2 handler configs used for
+// registry-to-handler inference.
+func WithCustomHandlers(handlers []config.CustomOAuth2Config) ResolverOption {
+	return func(r *AuthTokenResolver) { r.customHandlers = handlers }
+}
+
+// NewAuthTokenResolver creates a resolver that dynamically acquires fresh
+// registry credentials from auth handlers.
+func NewAuthTokenResolver(registry *auth.Registry, opts ...ResolverOption) *AuthTokenResolver {
+	r := &AuthTokenResolver{registry: registry}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Resolve infers the auth handler for serverURL, resolves the active profile,
+// and returns fresh credentials. Returns an error if no handler can be inferred
+// or the handler is not registered/authenticated.
+func (r *AuthTokenResolver) Resolve(ctx context.Context, serverURL string) (*Credential, error) {
+	host := normalizeRegistryHost(serverURL)
+	handlerName := catalog.InferAuthHandler(host, r.customHandlers)
+	if handlerName == "" {
+		return nil, fmt.Errorf("no auth handler for registry %q", serverURL)
+	}
+
+	handler, err := r.registry.Get(handlerName)
+	if err != nil {
+		return nil, fmt.Errorf("auth handler %q not available: %w", handlerName, err)
+	}
+
+	// Resolve profile and inject into context.
+	profile := auth.ResolveActiveProfile(ctx, handlerName)
+	if profile != "" {
+		ctx = auth.WithProfile(ctx, profile)
+	}
+
+	scope := catalog.InferDefaultScope(host)
+	username, password, err := catalog.BridgeAuthToRegistry(ctx, handler, host, scope)
+	if err != nil {
+		return nil, fmt.Errorf("bridge auth for %q: %w", serverURL, err)
+	}
+
+	return &Credential{
+		ServerURL: serverURL,
+		Username:  username,
+		Secret:    password,
+	}, nil
+}
+
+// normalizeRegistryHost extracts the bare host (with optional port) from a
+// server URL that may include a scheme or path. Docker credential helpers
+// receive URLs like "https://ghcr.io" but InferAuthHandler expects bare
+// hosts like "ghcr.io".
+func normalizeRegistryHost(serverURL string) string {
+	s := strings.TrimSpace(serverURL)
+	if s == "" {
+		return s
+	}
+	// If there's a scheme, parse as URL.
+	if strings.Contains(s, "://") {
+		if u, err := url.Parse(s); err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+	// Strip any path component from bare host.
+	if idx := strings.Index(s, "/"); idx != -1 {
+		s = s[:idx]
+	}
+	return s
+}

--- a/pkg/credentialhelper/resolver_test.go
+++ b/pkg/credentialhelper/resolver_test.go
@@ -1,0 +1,313 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialhelper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mock TokenResolver for Helper.Get tests ---
+
+type mockResolver struct {
+	cred *Credential
+	err  error
+}
+
+func (m *mockResolver) Resolve(_ context.Context, _ string) (*Credential, error) {
+	return m.cred, m.err
+}
+
+func TestHelperGet_DynamicResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolver succeeds", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		resolver := &mockResolver{
+			cred: &Credential{ServerURL: "ghcr.io", Username: "user1", Secret: "fresh-token"},
+		}
+		helper := New(store, WithTokenResolver(resolver))
+
+		got, err := helper.Get(context.Background(), "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-token", got.Secret)
+		assert.Equal(t, "user1", got.Username)
+	})
+
+	t.Run("resolver preferred over stored", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		cred := Credential{ServerURL: "ghcr.io", Username: "stale", Secret: "stale-token"}
+		data, _ := json.Marshal(cred)
+		store.Data["credhelper:ghcr.io"] = data
+
+		resolver := &mockResolver{
+			cred: &Credential{ServerURL: "ghcr.io", Username: "fresh", Secret: "fresh-token"},
+		}
+		helper := New(store, WithTokenResolver(resolver))
+
+		got, err := helper.Get(context.Background(), "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-token", got.Secret, "dynamic token should be preferred over stored")
+	})
+
+	t.Run("resolver fails falls back to stored", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		cred := Credential{ServerURL: "ghcr.io", Username: "stored-user", Secret: "stored-token"}
+		data, _ := json.Marshal(cred)
+		store.Data["credhelper:ghcr.io"] = data
+
+		resolver := &mockResolver{err: fmt.Errorf("handler not authenticated")}
+		helper := New(store, WithTokenResolver(resolver))
+
+		got, err := helper.Get(context.Background(), "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "stored-token", got.Secret, "should fall back to stored credential")
+	})
+
+	t.Run("resolver returns nil falls back to stored", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		cred := Credential{ServerURL: "ghcr.io", Username: "stored-user", Secret: "stored-token"}
+		data, _ := json.Marshal(cred)
+		store.Data["credhelper:ghcr.io"] = data
+
+		resolver := &mockResolver{cred: nil, err: nil}
+		helper := New(store, WithTokenResolver(resolver))
+
+		got, err := helper.Get(context.Background(), "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "stored-token", got.Secret, "nil credential should fall through")
+	})
+}
+
+// --- mock auth handler for AuthTokenResolver tests ---
+
+type mockAuthHandler struct {
+	name        string
+	tokenErr    error
+	statusErr   error
+	claims      *auth.Claims
+	capturedCtx context.Context // records the context passed to GetToken
+}
+
+func (m *mockAuthHandler) Name() string                    { return m.name }
+func (m *mockAuthHandler) DisplayName() string             { return m.name }
+func (m *mockAuthHandler) SupportedFlows() []auth.Flow     { return []auth.Flow{auth.FlowDeviceCode} }
+func (m *mockAuthHandler) Capabilities() []auth.Capability { return nil }
+func (m *mockAuthHandler) Login(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+	return nil, nil
+}
+func (m *mockAuthHandler) Logout(_ context.Context) error { return nil }
+func (m *mockAuthHandler) Status(ctx context.Context) (*auth.Status, error) {
+	if m.statusErr != nil {
+		return nil, m.statusErr
+	}
+	return &auth.Status{Authenticated: true, Claims: m.claims}, nil
+}
+
+func (m *mockAuthHandler) GetToken(ctx context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+	m.capturedCtx = ctx
+	if m.tokenErr != nil {
+		return nil, m.tokenErr
+	}
+	return &auth.Token{AccessToken: "fresh-access-token", TokenType: "bearer"}, nil
+}
+
+func (m *mockAuthHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
+	return nil
+}
+
+func TestAuthTokenResolver_Resolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ghcr.io infers github handler", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{
+			name:   "github",
+			claims: &auth.Claims{Username: "octocat"},
+		}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(context.Background(), "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "ghcr.io", cred.ServerURL)
+		assert.Equal(t, "octocat", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
+	t.Run("https URL is normalized to bare host", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{
+			name:   "github",
+			claims: &auth.Claims{Username: "octocat"},
+		}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(context.Background(), "https://ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "https://ghcr.io", cred.ServerURL, "ServerURL should preserve the original input")
+		assert.Equal(t, "octocat", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
+	t.Run("URL with path is normalized", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{
+			name:   "github",
+			claims: &auth.Claims{Username: "octocat"},
+		}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(context.Background(), "https://ghcr.io/v2/")
+		require.NoError(t, err)
+		assert.Equal(t, "https://ghcr.io/v2/", cred.ServerURL)
+		assert.Equal(t, "octocat", cred.Username)
+	})
+
+	t.Run("azurecr.io infers entra handler", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{name: "entra"}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(context.Background(), "myregistry.azurecr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "00000000-0000-0000-0000-000000000000", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
+	t.Run("pkg.dev infers gcp handler", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{name: "gcp"}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(context.Background(), "us-docker.pkg.dev")
+		require.NoError(t, err)
+		assert.Equal(t, "oauth2accesstoken", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
+	t.Run("unknown registry returns error", func(t *testing.T) {
+		t.Parallel()
+		registry := auth.NewRegistry()
+		resolver := NewAuthTokenResolver(registry)
+
+		_, err := resolver.Resolve(context.Background(), "unknown.registry.io")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no auth handler")
+	})
+
+	t.Run("handler not registered returns error", func(t *testing.T) {
+		t.Parallel()
+		registry := auth.NewRegistry()
+		resolver := NewAuthTokenResolver(registry)
+
+		_, err := resolver.Resolve(context.Background(), "ghcr.io")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not available")
+	})
+
+	t.Run("handler token error returns error", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{
+			name:     "github",
+			tokenErr: fmt.Errorf("refresh token expired"),
+			claims:   &auth.Claims{Username: "octocat"},
+		}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+		_, err := resolver.Resolve(context.Background(), "ghcr.io")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bridge auth")
+	})
+
+	t.Run("custom handler via config", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{name: "custom-idp"}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		customHandlers := []config.CustomOAuth2Config{
+			{Name: "custom-idp", Registry: "registry.example.com"},
+		}
+		resolver := NewAuthTokenResolver(registry, WithCustomHandlers(customHandlers))
+
+		cred, err := resolver.Resolve(context.Background(), "registry.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "oauth2accesstoken", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
+	t.Run("profile is resolved from context", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{name: "github", claims: &auth.Claims{Username: "work-user"}}
+		registry := auth.NewRegistry()
+		require.NoError(t, registry.Register(handler))
+
+		resolver := NewAuthTokenResolver(registry)
+
+		// Set a global profile in context
+		ctx := auth.WithGlobalProfile(context.Background(), "work")
+		cred, err := resolver.Resolve(ctx, "ghcr.io")
+		require.NoError(t, err)
+		assert.Equal(t, "work-user", cred.Username)
+
+		// Verify the profile was propagated to the handler's GetToken call
+		require.NotNil(t, handler.capturedCtx, "GetToken should have been called")
+		assert.Equal(t, "work", auth.ProfileFromContext(handler.capturedCtx))
+	})
+}
+
+func TestAuthTokenResolver_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+	var _ TokenResolver = (*AuthTokenResolver)(nil)
+}
+
+func TestNormalizeRegistryHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare host", "ghcr.io", "ghcr.io"},
+		{"https scheme", "https://ghcr.io", "ghcr.io"},
+		{"https with path", "https://ghcr.io/v2/", "ghcr.io"},
+		{"https with port", "https://ghcr.io:443", "ghcr.io:443"},
+		{"http scheme", "http://localhost:5000", "localhost:5000"},
+		{"bare host with path", "ghcr.io/v2/library", "ghcr.io"},
+		{"empty string", "", ""},
+		{"whitespace only", "  ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, normalizeRegistryHost(tt.input))
+		})
+	}
+}

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -32,6 +32,7 @@ type mockAuthHandlerServiceClient struct {
 	getAuthHandlersErr       error
 	configureAuthHandlerResp *proto.ConfigureAuthHandlerResponse
 	configureAuthHandlerErr  error
+	lastConfigureReq         *proto.ConfigureAuthHandlerRequest
 	loginFunc                func(ctx context.Context, req *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error)
 	logoutResp               *proto.LogoutResponse
 	logoutErr                error
@@ -54,6 +55,7 @@ func (m *mockAuthHandlerServiceClient) GetAuthHandlers(_ context.Context, _ *pro
 }
 
 func (m *mockAuthHandlerServiceClient) ConfigureAuthHandler(_ context.Context, req *proto.ConfigureAuthHandlerRequest, _ ...grpc.CallOption) (*proto.ConfigureAuthHandlerResponse, error) {
+	m.lastConfigureReq = req
 	return m.configureAuthHandlerResp, m.configureAuthHandlerErr
 }
 
@@ -588,6 +590,26 @@ func TestAuthHandlerGRPCClient_ConfigureAuthHandler_WithSettings(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+}
+
+func TestAuthHandlerGRPCClient_ConfigureAuthHandler_SendsProfile(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthHandlerServiceClient{
+		configureAuthHandlerResp: &proto.ConfigureAuthHandlerResponse{
+			ProtocolVersion: PluginProtocolVersion,
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock, hostServiceID: 42}
+
+	err := client.ConfigureAuthHandler(context.Background(), "github", ProviderConfig{
+		BinaryName: "mycli",
+		Profile:    "work",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfigureReq)
+	assert.Equal(t, "work", mock.lastConfigureReq.Profile)
+	assert.Equal(t, "github", mock.lastConfigureReq.HandlerName)
 }
 
 func TestAuthHandlerGRPCClient_StopAuthHandler_Success(t *testing.T) {

--- a/pkg/plugin/coverage_test.go
+++ b/pkg/plugin/coverage_test.go
@@ -2043,6 +2043,21 @@ func TestGRPCClient_ConfigureProvider_SendsProtocolVersion(t *testing.T) {
 	assert.Equal(t, PluginProtocolVersion, mock.lastConfigureReq.ProtocolVersion)
 }
 
+func TestGRPCClient_ConfigureProvider_SendsProfile(t *testing.T) {
+	mock := &mockPluginServiceClient{
+		configureProviderResp: &proto.ConfigureProviderResponse{},
+	}
+	client := &GRPCClient{client: mock}
+
+	err := client.ConfigureProvider(context.Background(), "test", ProviderConfig{
+		BinaryName: "scafctl",
+		Profile:    "work",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mock.lastConfigureReq)
+	assert.Equal(t, "work", mock.lastConfigureReq.Profile)
+}
+
 // --- WrapperOption tests ---
 
 func TestNewProviderWrapper_WithContext(t *testing.T) {

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -166,6 +166,7 @@ func (s *GRPCServer) ConfigureProvider(ctx context.Context, req *proto.Configure
 		NoColor:       req.NoColor,
 		BinaryName:    req.BinaryName,
 		HostServiceID: req.HostServiceId,
+		Profile:       req.Profile,
 		Settings:      settings,
 	}
 
@@ -589,6 +590,7 @@ func (c *GRPCClient) ConfigureProvider(ctx context.Context, providerName string,
 		Quiet:           cfg.Quiet,
 		NoColor:         cfg.NoColor,
 		BinaryName:      cfg.BinaryName,
+		Profile:         cfg.Profile,
 		Settings:        protoSettings,
 		ProtocolVersion: PluginProtocolVersion,
 	})

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -283,6 +283,7 @@ func (s *AuthHandlerGRPCServer) ConfigureAuthHandler(ctx context.Context, req *p
 		Quiet:      req.Quiet,
 		NoColor:    req.NoColor,
 		BinaryName: req.BinaryName,
+		Profile:    req.Profile,
 		Settings:   settings,
 	}
 	if req.HostServiceId != 0 && s.broker != nil {
@@ -450,6 +451,7 @@ func (c *AuthHandlerGRPCClient) ConfigureAuthHandler(ctx context.Context, handle
 		Quiet:           cfg.Quiet,
 		NoColor:         cfg.NoColor,
 		BinaryName:      cfg.BinaryName,
+		Profile:         cfg.Profile,
 		HostServiceId:   c.hostServiceID,
 		Settings:        protoSettings,
 		ProtocolVersion: PluginProtocolVersion,

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -50,6 +50,7 @@ func TestGRPCServer_ConfigureProvider(t *testing.T) {
 				NoColor:       true,
 				BinaryName:    "mycli",
 				HostServiceId: 99,
+				Profile:       "work",
 				Settings: map[string][]byte{
 					"maxBodySize": []byte(`1048576`),
 				},
@@ -67,6 +68,7 @@ func TestGRPCServer_ConfigureProvider(t *testing.T) {
 			assert.True(t, mock.lastConfig.NoColor)
 			assert.Equal(t, "mycli", mock.lastConfig.BinaryName)
 			assert.Equal(t, uint32(99), mock.lastConfig.HostServiceID)
+			assert.Equal(t, "work", mock.lastConfig.Profile)
 			assert.Contains(t, mock.lastConfig.Settings, "maxBodySize")
 		})
 	}

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -578,6 +578,7 @@ func TestAuthHandlerGRPCServer_ConfigureAuthHandler(t *testing.T) {
 				Quiet:           true,
 				NoColor:         true,
 				BinaryName:      "mycli",
+				Profile:         "work",
 				ProtocolVersion: PluginProtocolVersion,
 				Settings: map[string][]byte{
 					"timeout": []byte(`30`),
@@ -596,6 +597,7 @@ func TestAuthHandlerGRPCServer_ConfigureAuthHandler(t *testing.T) {
 			assert.True(t, mock.lastConfig.Quiet)
 			assert.True(t, mock.lastConfig.NoColor)
 			assert.Equal(t, "mycli", mock.lastConfig.BinaryName)
+			assert.Equal(t, "work", mock.lastConfig.Profile)
 			assert.Contains(t, mock.lastConfig.Settings, "timeout")
 		})
 	}

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -52,6 +52,7 @@ type hostConfig struct {
 	Quiet      bool
 	NoColor    bool
 	BinaryName string
+	Profile    string
 }
 
 // NewAuthHandlerWrapper creates a new wrapper for a plugin auth handler.
@@ -274,6 +275,7 @@ func (w *AuthHandlerWrapper) ApplyOverrides(ctx context.Context, overrides map[s
 		Quiet:         w.hostCfg.Quiet,
 		NoColor:       w.hostCfg.NoColor,
 		BinaryName:    w.hostCfg.BinaryName,
+		Profile:       w.hostCfg.Profile,
 		Settings:      map[string]json.RawMessage{w.handlerName: settingsJSON},
 		HostServiceID: w.client.HostServiceID(),
 	}
@@ -376,6 +378,7 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 				Quiet:      cfg.Quiet,
 				NoColor:    cfg.NoColor,
 				BinaryName: cfg.BinaryName,
+				Profile:    cfg.Profile,
 			}
 		}
 	}
@@ -427,6 +430,7 @@ func injectAuthHandlerSettings(ctx context.Context, handlerName string, cfg *Pro
 	}
 
 	profile := auth.ResolveActiveProfile(ctx, handlerName)
+	cfg.Profile = profile
 
 	var raw json.RawMessage
 	var err error

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -401,6 +401,7 @@ func TestAuthHandlerWrapper_ApplyOverrides_PreservesHostConfig(t *testing.T) {
 		Quiet:      true,
 		NoColor:    true,
 		BinaryName: "mycli",
+		Profile:    "work",
 	}
 
 	overrides := map[string]string{"clientId": "abc"}
@@ -412,4 +413,5 @@ func TestAuthHandlerWrapper_ApplyOverrides_PreservesHostConfig(t *testing.T) {
 	assert.True(t, mock.lastConfig.Quiet, "Quiet should be preserved")
 	assert.True(t, mock.lastConfig.NoColor, "NoColor should be preserved")
 	assert.Equal(t, "mycli", mock.lastConfig.BinaryName, "BinaryName should be preserved")
+	assert.Equal(t, "work", mock.lastConfig.Profile, "Profile should be preserved")
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -386,10 +387,44 @@ func HTTPCacheKeyPrefixFor(binaryName string) string {
 	return binaryName + ":"
 }
 
-var (
-	RootSolutionFolders = SolutionFoldersFor(CliBinaryName)
-	SolutionFileNames   = SolutionFileNamesFor(CliBinaryName)
-)
+// solutionDiscoveryState guards the process-wide solution discovery lists that
+// are written once by Root() and read by solution/get and MCP capabilities.
+var solutionDiscoveryState = newSolutionDiscovery()
+
+type solutionDiscovery struct {
+	mu              sync.RWMutex
+	solutionFolders []string
+	solutionFiles   []string
+}
+
+func newSolutionDiscovery() *solutionDiscovery {
+	return &solutionDiscovery{
+		solutionFolders: SolutionFoldersFor(CliBinaryName),
+		solutionFiles:   SolutionFileNamesFor(CliBinaryName),
+	}
+}
+
+// GetRootSolutionFolders returns the current solution folder search paths.
+func GetRootSolutionFolders() []string {
+	solutionDiscoveryState.mu.RLock()
+	defer solutionDiscoveryState.mu.RUnlock()
+	return solutionDiscoveryState.solutionFolders
+}
+
+// GetSolutionFileNames returns the current solution file names.
+func GetSolutionFileNames() []string {
+	solutionDiscoveryState.mu.RLock()
+	defer solutionDiscoveryState.mu.RUnlock()
+	return solutionDiscoveryState.solutionFiles
+}
+
+// SetSolutionDiscovery atomically updates both solution folder and file name lists.
+func SetSolutionDiscovery(folders, fileNames []string) {
+	solutionDiscoveryState.mu.Lock()
+	defer solutionDiscoveryState.mu.Unlock()
+	solutionDiscoveryState.solutionFolders = folders
+	solutionDiscoveryState.solutionFiles = fileNames
+}
 
 var VersionInformation = VersionInfo{
 	Commit:       "unknown",

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -156,12 +156,12 @@ func TestPluginCacheDirFor(t *testing.T) {
 
 func TestRootSolutionFolders_MatchesDefault(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, SolutionFoldersFor(CliBinaryName), RootSolutionFolders)
+	assert.Equal(t, SolutionFoldersFor(CliBinaryName), GetRootSolutionFolders())
 }
 
 func TestSolutionFileNames_MatchesDefault(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, SolutionFileNamesFor(CliBinaryName), SolutionFileNames)
+	assert.Equal(t, SolutionFileNamesFor(CliBinaryName), GetSolutionFileNames())
 }
 
 func TestSanitizeBinaryName(t *testing.T) {

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -197,8 +197,8 @@ func NewGetter(opts ...Option) *Getter {
 		statFunc:          os.Stat,
 		httpClient:        httpc.NewClient(nil), // Use default HTTP client
 		logger:            logr.Discard(),       // Use discard logger by default
-		solutionFolders:   settings.RootSolutionFolders,
-		solutionFileNames: settings.SolutionFileNames,
+		solutionFolders:   settings.GetRootSolutionFolders(),
+		solutionFileNames: settings.GetSolutionFileNames(),
 	}
 
 	// Apply all options
@@ -933,10 +933,12 @@ func (o *Getter) SetDiscoveryMode(mode settings.DiscoveryMode) {
 // each root solution folder with each solution file name defined in the settings.
 // It constructs the full path for each combination and aggregates them into a list.
 func PossibleSolutionPaths() []string {
-	paths := make([]string, 0, len(settings.RootSolutionFolders)*len(settings.SolutionFileNames))
+	folders := settings.GetRootSolutionFolders()
+	fileNames := settings.GetSolutionFileNames()
+	paths := make([]string, 0, len(folders)*len(fileNames))
 
-	for _, folder := range settings.RootSolutionFolders {
-		for _, filename := range settings.SolutionFileNames {
+	for _, folder := range folders {
+		for _, filename := range fileNames {
 			fullPath := filepath.NormalizeFilePath(pathlib.Join(folder, filename))
 			paths = append(paths, fullPath)
 		}

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -1125,8 +1125,8 @@ func TestNewGetterFromContext_NilContext(t *testing.T) {
 	//nolint:staticcheck // SA1012: intentionally testing nil context handling
 	g := NewGetterFromContext(nil)
 	// Should fall back to defaults
-	assert.Equal(t, settings.RootSolutionFolders, g.solutionFolders)
-	assert.Equal(t, settings.SolutionFileNames, g.solutionFileNames)
+	assert.Equal(t, settings.GetRootSolutionFolders(), g.solutionFolders)
+	assert.Equal(t, settings.GetSolutionFileNames(), g.solutionFileNames)
 }
 
 func TestNewGetterFromContext_NoSettings(t *testing.T) {
@@ -1134,8 +1134,8 @@ func TestNewGetterFromContext_NoSettings(t *testing.T) {
 	ctx := context.Background()
 	g := NewGetterFromContext(ctx)
 	// No settings in context — should use defaults
-	assert.Equal(t, settings.RootSolutionFolders, g.solutionFolders)
-	assert.Equal(t, settings.SolutionFileNames, g.solutionFileNames)
+	assert.Equal(t, settings.GetRootSolutionFolders(), g.solutionFolders)
+	assert.Equal(t, settings.GetSolutionFileNames(), g.solutionFileNames)
 }
 
 func TestNewGetterFromContext_DefaultBinaryName(t *testing.T) {
@@ -1144,8 +1144,8 @@ func TestNewGetterFromContext_DefaultBinaryName(t *testing.T) {
 	ctx := settings.IntoContext(context.Background(), run)
 	g := NewGetterFromContext(ctx)
 	// BinaryName matches default — should not override
-	assert.Equal(t, settings.RootSolutionFolders, g.solutionFolders)
-	assert.Equal(t, settings.SolutionFileNames, g.solutionFileNames)
+	assert.Equal(t, settings.GetRootSolutionFolders(), g.solutionFolders)
+	assert.Equal(t, settings.GetSolutionFileNames(), g.solutionFileNames)
 }
 
 func TestNewGetterFromContext_CustomBinaryName(t *testing.T) {


### PR DESCRIPTION
SDK & plugin profile wiring:
- bump scafctl-plugin-sdk to v0.8.0 (adds Profile field)
- wire Profile through gRPC bridge for both providers and auth handlers (grpc.go, grpc_auth.go, wrapper_auth.go)

BuiltinAuthHandlers (#403):
- add RootOptions.BuiltinAuthHandlers for embedder-compiled auth handlers registered eagerly at startup
- handlers appear in 'auth handlers' with source "built-in"

Dynamic credential resolution (#424):
- add TokenResolver interface and WithTokenResolver option to credential helper
- add AuthTokenResolver that infers auth handler from registry host, resolves profile, and acquires fresh tokens via BridgeAuthToRegistry
- wire into credential-helper get command with fallback to stored credentials

Race fix (#371):
- replace bare settings.RootSolutionFolders and settings.SolutionFileNames vars with sync.RWMutex-guarded GetRootSolutionFolders()/GetSolutionFileNames()/ SetSolutionDiscovery() accessors
- update all call sites in root.go, get.go, and tests

Closes #403
Closes #424
Closes #371
