### PR TITLE
feat(lint): add redundant-depends-on rule for auto-inferred dependencies

### DIFF
--- a/.github/skills/solution-spec/SKILL.md
+++ b/.github/skills/solution-spec/SKILL.md
@@ -47,7 +47,7 @@ spec:
       type: string           # string|int|float|bool|array|object|time|duration|any
       sensitive: false       # Redact from logs/output
       when: "_.some_flag"    # CEL condition -- skip if false
-      dependsOn: [other]     # Explicit deps (auto-extracted from expressions too)
+      dependsOn: [other]     # Explicit deps (rarely needed — auto-inferred from expr/rslvr/tmpl refs)
       timeout: 30s
       example: "sample"
 
@@ -127,9 +127,12 @@ transform:
 ### Dependency Resolution (DAG)
 
 Dependencies are extracted automatically from:
-- CEL expressions: `_.resolverName` references
+- CEL expressions: `_.resolverName` and `_["resolverName"]` references
+- Resolver references: `rslvr: resolverName` in ValueRef inputs
 - Go templates: `{{.resolverName}}` references
-- Explicit `dependsOn` list
+- Explicit `dependsOn` list (merged with auto-inferred deps)
+
+**Important**: `dependsOn` is usually unnecessary because dependencies are auto-inferred from value references. Only add explicit `dependsOn` when a resolver must run after another but does NOT reference its value (pure ordering dependency).
 
 The executor builds a DAG, topologically sorts into phases, then executes phases sequentially with concurrent execution within each phase.
 

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -429,7 +429,63 @@ spec:
 
 This is an **info**-level finding (not an error) because hyphenated names are valid — they just require bracket notation in CEL expressions.
 
-## 7. Using Lint with the MCP Server
+## 7. Redundant dependsOn
+
+The `redundant-depends-on` rule detects when a resolver's `dependsOn` entries are already auto-inferred from value references. scafctl automatically infers dependencies from `expr:`, `rslvr:`, and `tmpl:` references -- explicit `dependsOn` is only needed for pure ordering dependencies (where a resolver must wait for another without referencing its value).
+
+```yaml
+# ℹ️ INFO: dependsOn is redundant — all listed dependencies are already inferred
+spec:
+  resolvers:
+    registry:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: docker.io
+
+    namespace:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: myteam
+
+    imageRef:
+      dependsOn: [registry, namespace]  # Redundant! Inferred from expr below
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression:
+                expr: '_.registry + "/" + _.namespace + "/app"'
+```
+
+**Fix**: Remove the `dependsOn` field -- the dependencies are already inferred from the `expr:` reference to `_.registry` and `_.namespace`:
+
+```yaml
+    imageRef:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression:
+                expr: '_.registry + "/" + _.namespace + "/app"'
+```
+
+Only keep explicit `dependsOn` for ordering without a data dependency:
+
+```yaml
+    deploy:
+      dependsOn: [setup]  # Must wait for setup, but doesn't read its value
+      resolve:
+        with:
+          - provider: exec
+            inputs:
+              command: deploy.sh
+```
+
+## 8. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -354,9 +354,11 @@ Phase numbers in brackets show concurrent execution groups. Resolvers in the sam
 
 ### Dependency Rules
 
+- Dependencies are **auto-inferred** from value references (`expr:`, `rslvr:`, `tmpl:`) -- you do NOT need to declare `dependsOn` when a resolver references another by value
 - Resolvers in the same phase run concurrently
 - A resolver waits for all its dependencies to complete
 - Circular dependencies cause an error
+- Only add explicit `dependsOn` when a resolver must wait for another without referencing its value (pure ordering dependency)
 
 ---
 

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -285,6 +285,9 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 		// Using _.resolverName in these phases creates a circular dependency;
 		// the correct idiom is __self.
 		lintResolverSelfReferences(name, res, location, result)
+
+		// Check for redundant dependsOn entries that are already inferred.
+		lintRedundantDependsOn(res, location, result, registry)
 	}
 }
 
@@ -343,6 +346,48 @@ func lintResolverSelfReferences(name string, res *resolver.Resolver, location st
 				}
 			}
 		}
+	}
+}
+
+// lintRedundantDependsOn checks if a resolver's explicit dependsOn entries are
+// already covered by auto-inferred dependencies from value references.
+func lintRedundantDependsOn(res *resolver.Resolver, location string, result *Result, registry *provider.Registry) {
+	if len(res.DependsOn) == 0 {
+		return
+	}
+
+	var lookup resolver.DescriptorLookup
+	if registry != nil {
+		lookup = registry.DescriptorLookup()
+	}
+
+	inferred := resolver.ExtractInferredDependencies(res, lookup)
+	inferredSet := make(map[string]bool, len(inferred))
+	for _, dep := range inferred {
+		inferredSet[dep] = true
+	}
+
+	var redundant []string
+	for _, dep := range res.DependsOn {
+		if inferredSet[dep] {
+			redundant = append(redundant, dep)
+		}
+	}
+
+	if len(redundant) == 0 {
+		return
+	}
+
+	if len(redundant) == len(res.DependsOn) {
+		result.addFinding(SeverityInfo, "dependency", location+".dependsOn",
+			"dependsOn is redundant — all listed dependencies are already inferred from value references",
+			"Remove the dependsOn field; dependencies are auto-inferred from expr:, rslvr:, and tmpl: references",
+			"redundant-depends-on")
+	} else {
+		result.addFinding(SeverityInfo, "dependency", location+".dependsOn",
+			fmt.Sprintf("dependsOn contains redundant entries already inferred from value references: %s", strings.Join(redundant, ", ")),
+			"Remove the redundant entries; only keep dependsOn for ordering dependencies not referenced by value",
+			"redundant-depends-on")
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1303,3 +1303,138 @@ func TestLintResolveForEach(t *testing.T) {
 	assert.Contains(t, findings[0].Message, "forEach on resolve step")
 	assert.Equal(t, SeverityWarning, findings[0].Severity)
 }
+
+func TestLintRedundantDependsOn(t *testing.T) {
+	celProv := newFakeProvider("cel", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(celProv))
+	require.NoError(t, reg.Register(staticProv))
+
+	tests := []struct {
+		name          string
+		resolvers     map[string]*resolver.Resolver
+		expectFinding bool
+		msgContains   string
+	}{
+		{
+			name: "all dependsOn entries are redundant (inferred from expr)",
+			resolvers: map[string]*resolver.Resolver{
+				"registry":  {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "docker.io"}}}}}},
+				"namespace": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "myns"}}}}}},
+				"imageRef": {
+					Type:      "string",
+					DependsOn: []string{"registry", "namespace"},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs:   map[string]*spec.ValueRef{"expression": {Expr: exprPtr("_.registry + '/' + _.namespace")}},
+						}},
+					},
+				},
+			},
+			expectFinding: true,
+			msgContains:   "all listed dependencies are already inferred",
+		},
+		{
+			name: "partial redundancy (some dependsOn are not inferred)",
+			resolvers: map[string]*resolver.Resolver{
+				"registry":  {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "docker.io"}}}}}},
+				"namespace": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "myns"}}}}}},
+				"setup":     {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "done"}}}}}},
+				"imageRef": {
+					Type:      "string",
+					DependsOn: []string{"registry", "setup"},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs:   map[string]*spec.ValueRef{"expression": {Expr: exprPtr("_.registry + '/image'")}},
+						}},
+					},
+				},
+			},
+			expectFinding: true,
+			msgContains:   "redundant entries",
+		},
+		{
+			name: "no redundancy (dependsOn not inferred)",
+			resolvers: map[string]*resolver.Resolver{
+				"setup": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "done"}}}}}},
+				"imageRef": {
+					Type:      "string",
+					DependsOn: []string{"setup"},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "myimage"}},
+						}},
+					},
+				},
+			},
+			expectFinding: false,
+		},
+		{
+			name: "no dependsOn field at all",
+			resolvers: map[string]*resolver.Resolver{
+				"registry": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "docker.io"}}}}}},
+				"imageRef": {
+					Type: "string",
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs:   map[string]*spec.ValueRef{"expression": {Expr: exprPtr("_.registry + '/image'")}},
+						}},
+					},
+				},
+			},
+			expectFinding: false,
+		},
+		{
+			name: "dependsOn inferred from rslvr reference",
+			resolvers: map[string]*resolver.Resolver{
+				"env": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "prod"}}}}}},
+				"config": {
+					Type:      "string",
+					DependsOn: []string{"env"},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Resolver: strPtr("env")}},
+						}},
+					},
+				},
+			},
+			expectFinding: true,
+			msgContains:   "all listed dependencies are already inferred",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sol := &solution.Solution{
+				Spec: solution.Spec{
+					Resolvers: tt.resolvers,
+				},
+			}
+
+			result := Solution(sol, "test.yaml", reg)
+
+			findings := filterFindingsByRule(result, "redundant-depends-on")
+			if tt.expectFinding {
+				require.NotEmpty(t, findings, "expected redundant-depends-on finding")
+				assert.Contains(t, findings[0].Message, tt.msgContains)
+				assert.Equal(t, SeverityInfo, findings[0].Severity)
+			} else {
+				assert.Empty(t, findings, "expected no redundant-depends-on finding")
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -357,6 +357,17 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "Finally actions execute unconditionally after all regular actions complete. Setting explicit: true is misleading because the action cannot be excluded from execution.",
 		Fix:         "Remove explicit: true from the finally action, or move the action to workflow.actions if it should be opt-in.",
 	},
+	"redundant-depends-on": {
+		Rule:        "redundant-depends-on",
+		Severity:    string(SeverityInfo),
+		Category:    "dependency",
+		Description: "A resolver's dependsOn entries are already inferred from value references (expr:, rslvr:, tmpl:).",
+		Why:         "dependsOn is automatically inferred from value references in resolver inputs, when clauses, and expressions. Explicit entries that duplicate inferred dependencies add noise without changing behavior.",
+		Fix:         "Remove redundant dependsOn entries. Only use explicit dependsOn when a resolver must run after another without referencing its value.",
+		Examples: []string{
+			"# Redundant (inferred from expr):\nimageRef:\n  dependsOn: [registry, namespace]\n  resolve:\n    with:\n      - provider: cel\n        inputs:\n          expression:\n            expr: _.registry + \"/\" + _.namespace\n\n# Correct (no explicit dependsOn needed):\nimageRef:\n  resolve:\n    with:\n      - provider: cel\n        inputs:\n          expression:\n            expr: _.registry + \"/\" + _.namespace",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 36 rules — update this when new rules are added
-	assert.Equal(t, 36, len(KnownRules), "expected 36 known lint rules")
+	// We expect exactly 37 rules — update this when new rules are added
+	assert.Equal(t, 37, len(KnownRules), "expected 37 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -305,6 +305,8 @@ Follow these rules when creating the solution:
 - Use ValueRef format for inputs: literal (raw value), rslvr (resolver reference), expr (CEL expression), or tmpl (Go template)
 - Always validate user inputs using the validate phase with the validation provider
 - Use dependsOn for ordering (both resolvers and actions)
+- Resolver dependsOn is AUTO-INFERRED from value references (expr:, rslvr:, tmpl:) — only add explicit dependsOn when a resolver must run after another without referencing its value
+- Action dependsOn within the same section is auto-inferred from __actions references
 - Use when clauses (CEL expressions) for conditional execution
 - CEL context variables available in resolver when/inputs: _ (resolved values), __plan (pre-execution topology)
   - __plan["resolverName"].phase, __plan["resolverName"].dependsOn, __plan["resolverName"].dependencyCount
@@ -388,7 +390,7 @@ Check for common issues:
 - Circular dependencies in resolvers or actions
 - Invalid CEL expressions in when/expr fields
 - Type mismatches (resolver type vs actual value)
-- Missing dependsOn when referencing other resolvers (same-section action dependencies are auto-inferred from __actions references)
+- Redundant dependsOn on resolvers (resolver dependencies are auto-inferred from expr:, rslvr:, tmpl: references — only add explicit dependsOn for ordering without a data reference)
 - Using dependsOn in workflow.finally to reference a workflow.actions action — this is a validation error; use __actions.<name> in inputs or when instead (the ref appears in crossSectionRefs on the rendered graph)
 
 7. Call preview_resolvers with path %q to check if resolvers execute successfully and produce expected values

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -58,6 +58,55 @@ func ExtractDependencies(r *Resolver, lookup DescriptorLookup) []string {
 	return extractDependencies(r, lookup)
 }
 
+// ExtractInferredDependencies extracts only auto-inferred dependencies from value
+// references (expr:, rslvr:, tmpl:) and when clauses, excluding explicit DependsOn entries.
+// This is useful for detecting redundant dependsOn declarations.
+func ExtractInferredDependencies(r *Resolver, lookup DescriptorLookup) []string {
+	return extractInferredDependencies(r, lookup)
+}
+
+func extractInferredDependencies(r *Resolver, lookup DescriptorLookup) []string {
+	deps := make(map[string]bool)
+
+	// Extract from when condition
+	if r.When != nil && r.When.Expr != nil {
+		extractDepsFromExpression(string(*r.When.Expr), deps)
+	}
+
+	// Extract from resolve phase
+	if r.Resolve != nil {
+		extractDepsFromResolvePhase(r.Resolve, deps, lookup)
+	}
+
+	// Extract from transform phase (excluding self-refs)
+	if r.Transform != nil {
+		transformDeps := make(map[string]bool)
+		extractDepsFromTransformPhase(r.Transform, transformDeps, lookup)
+		for dep := range transformDeps {
+			if dep != r.Name {
+				deps[dep] = true
+			}
+		}
+	}
+
+	// Extract from validate phase (excluding self-refs)
+	if r.Validate != nil {
+		validateDeps := make(map[string]bool)
+		extractDepsFromValidatePhase(r.Validate, validateDeps, lookup)
+		for dep := range validateDeps {
+			if dep != r.Name {
+				deps[dep] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(deps))
+	for dep := range deps {
+		result = append(result, dep)
+	}
+	return result
+}
+
 func extractDependencies(r *Resolver, lookup DescriptorLookup) []string {
 	deps := make(map[string]bool) // Use map to deduplicate
 

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -555,6 +555,87 @@ func TestExtractDependencies(t *testing.T) {
 	}
 }
 
+func TestExtractInferredDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver *Resolver
+		want     []string
+	}{
+		{
+			name: "explicit dependsOn excluded from inferred",
+			resolver: &Resolver{
+				Name:      "target",
+				DependsOn: []string{"config", "credentials"},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "static",
+							Inputs: map[string]*ValueRef{
+								"value": {Literal: "test"},
+							},
+						},
+					},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "inferred from expr without explicit dependsOn",
+			resolver: &Resolver{
+				Name:      "target",
+				DependsOn: []string{"explicit"},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "cel",
+							Inputs: map[string]*ValueRef{
+								"expression": {Expr: celExpPtr("_.registry + '/' + _.namespace")},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"registry", "namespace"},
+		},
+		{
+			name: "inferred from rslvr reference",
+			resolver: &Resolver{
+				Name:      "target",
+				DependsOn: []string{"other"},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider: "static",
+							Inputs: map[string]*ValueRef{
+								"value": {Resolver: stringPtr("env")},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"env"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractInferredDependencies(tt.resolver, nil)
+
+			gotMap := make(map[string]bool)
+			for _, dep := range got {
+				gotMap[dep] = true
+			}
+
+			wantMap := make(map[string]bool)
+			for _, dep := range tt.want {
+				wantMap[dep] = true
+			}
+
+			assert.Equal(t, wantMap, gotMap, "inferred dependencies should match")
+		})
+	}
+}
+
 func TestExtractDepsFromExpression(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
- Add `redundant-depends-on` info-level lint rule that warns when dependsOn entries are already inferred from value references
- Add `ExtractInferredDependencies()` to pkg/resolver for extracting only auto-inferred deps (excluding explicit dependsOn)
- Update MCP prompts to document resolver dependsOn auto-inference and remove misleading "missing dependsOn" checklist item
- Update solution-spec skill with clearer DAG resolution guidance
- Add tutorial section for the new lint rule in linting-tutorial.md
- Document auto-inference in resolver-tutorial.md dependency rules

Closes #411