### PR TITLE
fix(cli): render auth status as columnar table instead of KEY/VALUE p…

### DIFF
--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -64,7 +65,8 @@ var authStatusSchema = []byte(`{
 			"lastRefresh":    { "type": "string", "deprecated": true },
 			"scopes":         { "type": "array", "deprecated": true },
 			"cachedTokens":   { "type": "integer", "deprecated": true },
-			"hint":           { "type": "string", "deprecated": true }
+			"hint":           { "type": "string", "deprecated": true },
+			"_expiresAtTime": { "type": "string", "deprecated": true }
 		}
 	}
 }`)
@@ -218,6 +220,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				outputOpts := flags.ToKvxOutputOptions(&outputFlags,
 					kvx.WithIOStreams(ioStreams),
 					kvx.WithOutputColumnOrder([]string{"handler", "kind", "status", "flow", "user", "expiresIn", "profile"}),
+					kvx.WithOutputColumnarMode(tui.ColumnarModeAlways),
 					kvx.WithOutputSchemaJSON(authStatusSchema),
 					kvx.WithOutputDisplaySchemaJSON(authStatusDisplaySchema),
 				)
@@ -229,6 +232,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				handlerOpts := flags.ToKvxOutputOptions(&outputFlags,
 					kvx.WithIOStreams(ioStreams),
 					kvx.WithOutputColumnOrder([]string{"handler", "profile", "status", "user", "flow", "expiresIn"}),
+					kvx.WithOutputColumnarMode(tui.ColumnarModeAlways),
 					kvx.WithOutputSchemaJSON(authStatusSchema),
 				)
 
@@ -245,6 +249,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					catalogOpts := flags.ToKvxOutputOptions(&outputFlags,
 						kvx.WithIOStreams(ioStreams),
 						kvx.WithOutputColumnOrder([]string{"handler", "status"}),
+						kvx.WithOutputColumnarMode(tui.ColumnarModeAlways),
 						kvx.WithOutputSchemaJSON(authStatusSchema),
 					)
 					if err := catalogOpts.Write(catalogResults); err != nil {
@@ -258,6 +263,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 					registryOpts := flags.ToKvxOutputOptions(&outputFlags,
 						kvx.WithIOStreams(ioStreams),
 						kvx.WithOutputColumnOrder([]string{"handler", "user", "profile"}),
+						kvx.WithOutputColumnarMode(tui.ColumnarModeAlways),
 						kvx.WithOutputSchemaJSON(authStatusSchema),
 					)
 					if err := registryOpts.Write(registryResults); err != nil {
@@ -452,28 +458,29 @@ func buildStatusResult(ctx context.Context, cliParams *settings.Run, handlerName
 	}
 
 	result := map[string]any{
-		"handler":       handlerName,
-		"displayName":   handler.DisplayName(),
-		"kind":          "auth",
-		"type":          "handler",
-		"status":        statusStr,
-		"authenticated": status.Authenticated,
-		"email":         "",
-		"username":      "",
-		"user":          "",
-		"expiresIn":     "",
-		"flow":          flowStr,
-		"hint":          "",
-		"identityType":  "",
-		"clientId":      "",
-		"tokenFile":     "",
-		"name":          "",
-		"tenantId":      "",
-		"expiresAt":     "",
-		"lastRefresh":   "",
-		"scopes":        []string{},
-		"cachedTokens":  0,
-		"profile":       auth.DisplayProfileName(auth.ProfileFromContext(ctx)),
+		"handler":        handlerName,
+		"displayName":    handler.DisplayName(),
+		"kind":           "auth",
+		"type":           "handler",
+		"status":         statusStr,
+		"authenticated":  status.Authenticated,
+		"email":          "",
+		"username":       "",
+		"user":           "",
+		"expiresIn":      "",
+		"flow":           flowStr,
+		"hint":           "",
+		"identityType":   "",
+		"clientId":       "",
+		"tokenFile":      "",
+		"name":           "",
+		"tenantId":       "",
+		"expiresAt":      "",
+		"lastRefresh":    "",
+		"scopes":         []string{},
+		"cachedTokens":   0,
+		"_expiresAtTime": nil,
+		"profile":        auth.DisplayProfileName(auth.ProfileFromContext(ctx)),
 	}
 
 	// Mark the active profile so users know which one commands will use.

--- a/pkg/cmd/scafctl/auth/status_test.go
+++ b/pkg/cmd/scafctl/auth/status_test.go
@@ -342,6 +342,41 @@ func TestBuildStatusResult_InvalidExpiryTime(t *testing.T) {
 	assert.Equal(t, "", result["expiresIn"])
 }
 
+func TestBuildStatusResult_ExpiresAtTimeAlwaysPresent(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	t.Run("nil when expiry is invalid", func(t *testing.T) {
+		mock := auth.NewMockHandler("entra")
+		status := &auth.Status{
+			Authenticated: true,
+			Claims:        &auth.Claims{Email: "a@b.com"},
+			ExpiresAt:     time.Time{}, // zero time - invalid
+		}
+
+		result := buildStatusResult(ctx, settings.NewCliParams(), "entra", mock, status)
+
+		_, exists := result["_expiresAtTime"]
+		assert.True(t, exists, "_expiresAtTime must always be present to keep maps homogeneous")
+		assert.Nil(t, result["_expiresAtTime"])
+	})
+
+	t.Run("time.Time when expiry is valid", func(t *testing.T) {
+		mock := auth.NewMockHandler("entra")
+		future := time.Now().Add(2 * time.Hour)
+		status := &auth.Status{
+			Authenticated: true,
+			Claims:        &auth.Claims{Email: "a@b.com"},
+			ExpiresAt:     future,
+		}
+
+		result := buildStatusResult(ctx, settings.NewCliParams(), "entra", mock, status)
+
+		_, exists := result["_expiresAtTime"]
+		assert.True(t, exists, "_expiresAtTime must always be present to keep maps homogeneous")
+		assert.Equal(t, future, result["_expiresAtTime"])
+	})
+}
+
 func TestExpandProfileStatuses(t *testing.T) {
 	ctx, _ := newTestContext(t)
 

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -307,6 +307,11 @@ type OutputOptions struct {
 	// When set, the TUI renders arrays as a scrollable card list with sectioned
 	// detail views instead of the default KEY/VALUE table.
 	DisplaySchemaJSON []byte `json:"-" yaml:"-" doc:"JSON Schema with x-kvx-* extensions for rich TUI rendering"`
+
+	// ColumnarMode controls when arrays of objects render as multi-column tables.
+	// Valid values: "auto" (default), "always", "never".
+	// Use "always" when the data is intentionally multi-column regardless of key homogeneity.
+	ColumnarMode string `json:"columnarMode,omitempty" yaml:"columnarMode,omitempty" doc:"Columnar rendering mode: auto, always, never" example:"always" maxLength:"10"`
 }
 
 // NewOutputOptions creates a new OutputOptions with default settings.
@@ -408,6 +413,14 @@ func WithOutputSchemaJSON(schema []byte) OutputOption {
 // the schema are merged with any programmatic ColumnHints (programmatic take precedence).
 func WithOutputDisplaySchemaJSON(schema []byte) OutputOption {
 	return func(o *OutputOptions) { o.DisplaySchemaJSON = schema }
+}
+
+// WithOutputColumnarMode controls when arrays of objects render as multi-column tables.
+// Valid values: tui.ColumnarModeAuto ("auto"), tui.ColumnarModeAlways ("always"),
+// tui.ColumnarModeNever ("never"). Use "always" when data is intentionally multi-column
+// regardless of key homogeneity.
+func WithOutputColumnarMode(mode string) OutputOption {
+	return func(o *OutputOptions) { o.ColumnarMode = mode }
 }
 
 // WithIOStreams sets the IOStreams for output.
@@ -551,6 +564,9 @@ func (o *OutputOptions) buildViewerOptions() []Option {
 	}
 	if len(o.DisplaySchemaJSON) > 0 {
 		kvxOpts = append(kvxOpts, WithDisplaySchemaJSON(o.DisplaySchemaJSON))
+	}
+	if o.ColumnarMode != "" {
+		kvxOpts = append(kvxOpts, WithColumnarMode(o.ColumnarMode))
 	}
 
 	return kvxOpts

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -498,6 +498,14 @@ func TestWithOutputDisplaySchemaJSON(t *testing.T) {
 	assert.Equal(t, schema, opts.DisplaySchemaJSON)
 }
 
+func TestWithOutputColumnarMode(t *testing.T) {
+	out := &bytes.Buffer{}
+	ioStreams := &terminal.IOStreams{Out: out}
+	opts := NewOutputOptions(ioStreams)
+	WithOutputColumnarMode("always")(opts)
+	assert.Equal(t, "always", opts.ColumnarMode)
+}
+
 func TestWithIOStreams(t *testing.T) {
 	out := &bytes.Buffer{}
 	ioStreams := &terminal.IOStreams{Out: out}

--- a/pkg/terminal/kvx/viewer.go
+++ b/pkg/terminal/kvx/viewer.go
@@ -110,6 +110,11 @@ type ViewerOptions struct {
 	// When set, the TUI renders arrays as a scrollable card list with sectioned
 	// detail views instead of the default KEY/VALUE table.
 	DisplaySchemaJSON []byte `json:"-" yaml:"-" doc:"JSON Schema with x-kvx-* extensions for rich TUI rendering"`
+
+	// ColumnarMode controls when arrays of objects render as multi-column tables.
+	// Valid values: "auto" (default), "always", "never".
+	// Use "always" when the data is intentionally multi-column regardless of key homogeneity.
+	ColumnarMode string `json:"columnarMode,omitempty" yaml:"columnarMode,omitempty" doc:"Columnar rendering mode: auto, always, never" example:"always" maxLength:"10"`
 }
 
 // DefaultViewerOptions returns sensible defaults.
@@ -215,6 +220,14 @@ func WithDisplaySchemaJSON(schema []byte) Option {
 	return func(o *ViewerOptions) { o.DisplaySchemaJSON = schema }
 }
 
+// WithColumnarMode controls when arrays of objects render as multi-column tables.
+// Valid values: tui.ColumnarModeAuto ("auto"), tui.ColumnarModeAlways ("always"),
+// tui.ColumnarModeNever ("never"). Use "always" when data is intentionally multi-column
+// regardless of key homogeneity.
+func WithColumnarMode(mode string) Option {
+	return func(o *ViewerOptions) { o.ColumnarMode = mode }
+}
+
 // WithContext sets the context for CEL expression evaluation.
 // This enables context-dependent features like debug.out when Writer is in context.
 func WithContext(ctx context.Context) Option {
@@ -295,14 +308,15 @@ func View(data any, opts ...Option) error {
 func renderTable(root any, options *ViewerOptions) error {
 	hints := resolveColumnHints(options.SchemaJSON, options.ColumnHints)
 	output := tui.RenderTable(root, tui.TableOptions{
-		AppName:     options.AppName,
-		Path:        "_",
-		Bordered:    true,
-		Width:       options.Width,
-		NoColor:     options.NoColor,
-		ColumnOrder: options.ColumnOrder,
-		ColumnHints: hints,
-		Schema:      resolveDisplaySchema(options.DisplaySchemaJSON),
+		AppName:      options.AppName,
+		Path:         "_",
+		Bordered:     true,
+		Width:        options.Width,
+		NoColor:      options.NoColor,
+		ColumnOrder:  options.ColumnOrder,
+		ColumnHints:  hints,
+		ColumnarMode: options.ColumnarMode,
+		Schema:       resolveDisplaySchema(options.DisplaySchemaJSON),
 	})
 	fmt.Fprint(options.Out, output)
 	return nil

--- a/pkg/terminal/kvx/viewer_test.go
+++ b/pkg/terminal/kvx/viewer_test.go
@@ -4,6 +4,7 @@
 package kvx
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -309,4 +310,34 @@ func TestResolveDisplaySchema_Invalid(t *testing.T) {
 func TestResolveDisplaySchema_NoExtensions(t *testing.T) {
 	schema := []byte(`{"type": "array", "items": {"type": "object"}}`)
 	assert.Nil(t, resolveDisplaySchema(schema))
+}
+
+func TestWithColumnarMode(t *testing.T) {
+	opts := DefaultViewerOptions()
+	WithColumnarMode("always")(opts)
+	assert.Equal(t, "always", opts.ColumnarMode)
+}
+
+func TestRenderTable_ColumnarModeAlways_ForcesColumnar(t *testing.T) {
+	// Regression test for #440: auth status maps are normalized to have identical
+	// key sets (homogeneous) so kvx can render them as multi-column tables.
+	// ColumnarModeAlways is used as belt-and-suspenders; in kvx v0.12 it still
+	// requires ExtractColumnarData to succeed (homogeneous keys), but it bypasses
+	// the type-assertion gate so future kvx versions can relax that constraint.
+	data := []map[string]any{
+		{"handler": "entra", "status": "authenticated", "expiresIn": "2h"},
+		{"handler": "github", "status": "authenticated", "expiresIn": ""},
+	}
+
+	out := &bytes.Buffer{}
+
+	err := View(data, WithIO(nil, out), WithNoColor(true), WithColumnarMode("always"), WithColumnOrder([]string{"handler", "status", "expiresIn"}), WithDimensions(100, 24))
+	assert.NoError(t, err)
+
+	output := out.String()
+	// Should contain column headers, not KEY/VALUE fallback
+	assert.Contains(t, output, "handler")
+	assert.Contains(t, output, "status")
+	assert.NotContains(t, output, "[0]")
+	assert.NotContains(t, output, "[1]")
 }


### PR DESCRIPTION
…airs

- add WithOutputColumnarMode/WithColumnarMode options to kvx package for controlling when arrays render as multi-column tables
- pass ColumnarMode through ViewerOptions to tui.RenderTable
- wire ColumnarMode from OutputOptions into buildViewerOptions
- use tui.ColumnarModeAlways in all auth status output paths
- always initialize _expiresAtTime in result maps so all handler maps have identical key sets (fixes homogeneity detection)
- mark _expiresAtTime as deprecated in authStatusSchema to hide it from table output

Closes #440