### PR TITLE
feat(celexp): add map.fromEntries function and Signature field

### DIFF
--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -140,6 +140,7 @@ type VarInfo struct {
 // with the CEL environment to extend the expression language capabilities.
 type ExtFunction struct {
 	Name          string          `json:"name,omitempty" yaml:"name,omitempty" doc:"Function name" maxLength:"128" example:"size"`
+	Signature     string          `json:"signature,omitempty" yaml:"signature,omitempty" doc:"Type signature" maxLength:"256" example:"map.add(map<string,dyn>, string, dyn) -> map<string,dyn>"`
 	Category      string          `json:"category,omitempty" yaml:"category,omitempty" doc:"Function category" maxLength:"64" example:"collections"`
 	Links         []string        `json:"links,omitempty" yaml:"links,omitempty" doc:"Reference URLs" maxItems:"10"`
 	Examples      []Example       `json:"examples,omitempty" yaml:"examples,omitempty" doc:"Usage examples" maxItems:"20"`

--- a/pkg/celexp/detail/detail.go
+++ b/pkg/celexp/detail/detail.go
@@ -25,6 +25,9 @@ func BuildFunctionDetail(fn *celexp.ExtFunction) map[string]any {
 		"custom": fn.Custom,
 	}
 
+	if fn.Signature != "" {
+		m["signature"] = fn.Signature
+	}
 	if fn.Description != "" {
 		m["description"] = fn.Description
 	}

--- a/pkg/celexp/detail/detail_test.go
+++ b/pkg/celexp/detail/detail_test.go
@@ -15,6 +15,7 @@ func TestBuildFunctionDetail(t *testing.T) {
 	t.Parallel()
 	fn := &celexp.ExtFunction{
 		Name:          "test",
+		Signature:     "test() -> string",
 		Description:   "test desc",
 		Custom:        true,
 		FunctionNames: []string{"fn1", "fn2"},
@@ -27,6 +28,7 @@ func TestBuildFunctionDetail(t *testing.T) {
 	result := BuildFunctionDetail(fn)
 	assert.Equal(t, "test", result["name"])
 	assert.Equal(t, true, result["custom"])
+	assert.Equal(t, "test() -> string", result["signature"])
 	assert.Equal(t, "test desc", result["description"])
 	assert.Equal(t, []string{"fn1", "fn2"}, result["functionNames"])
 	assert.Equal(t, []string{"https://example.com"}, result["links"])
@@ -48,6 +50,7 @@ func TestBuildFunctionDetail_Minimal(t *testing.T) {
 	result := BuildFunctionDetail(fn)
 	assert.Equal(t, "minimal", result["name"])
 	assert.Equal(t, false, result["custom"])
+	assert.Nil(t, result["signature"])
 	assert.Nil(t, result["description"])
 	assert.Nil(t, result["functionNames"])
 	assert.Nil(t, result["links"])

--- a/pkg/celexp/ext/arrays/arrays.go
+++ b/pkg/celexp/ext/arrays/arrays.go
@@ -18,6 +18,7 @@ func StringAddFunc() celexp.ExtFunction {
 	funcName := "arrays.strings.add"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "arrays.strings.add(list<string>, string) -> list<string>",
 		Description:   "Appends a string to a list of strings and returns the new list. Use arrays.strings.add(list, 'value') to add a single string to the end of the list",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -65,6 +66,7 @@ func StringsUniqueFunc() celexp.ExtFunction {
 	funcName := "arrays.strings.unique"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "arrays.strings.unique(list<string>) -> list<string>",
 		Description:   "Returns a new list containing only unique strings from the input list, removing all duplicates while preserving the original order of first occurrence. Use arrays.strings.unique(list) to deduplicate a list of strings",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/debug/debug.go
+++ b/pkg/celexp/ext/debug/debug.go
@@ -20,6 +20,7 @@ func DebugOutFunc(w *writer.Writer) celexp.ExtFunction {
 
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "debug.out(dyn) -> null | debug.out(dyn, dyn) -> dyn",
 		Description:   "Outputs a debug message to the console. Use debug.out(message) to print a message (returns null), or debug.out(message, value) to print a message and return a value for inline debugging",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -74,6 +75,7 @@ func DebugThrowFunc() celexp.ExtFunction {
 
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "debug.throw(dyn) -> dyn",
 		Description:   "Throws an error with the provided message, immediately halting CEL expression evaluation. Use debug.throw(message) to stop execution and return an error with the specified message",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -108,6 +110,7 @@ func DebugSleepFunc() celexp.ExtFunction {
 
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "debug.sleep(int) -> int | debug.sleep(int, dyn) -> dyn",
 		Description:   "Pauses execution for the specified duration in milliseconds and returns the value for inline debugging. Use debug.sleep(duration) to sleep and return the duration value, or debug.sleep(duration, value) to sleep and return a different value",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/ext.go
+++ b/pkg/celexp/ext/ext.go
@@ -733,6 +733,7 @@ func Custom() celexp.ExtFunctionList {
 		celmap.OmitFunc(),
 		celmap.MergeFunc(),
 		celmap.RecurseFunc(),
+		celmap.FromEntriesFunc(),
 
 		// Marshalling functions
 		marshalling.JSONMarshalFunc(),

--- a/pkg/celexp/ext/filepath/filepath.go
+++ b/pkg/celexp/ext/filepath/filepath.go
@@ -20,6 +20,7 @@ func DirFunc() celexp.ExtFunction {
 	funcName := "filepath.dir"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "filepath.dir(string) -> string",
 		Description:   "Returns the directory component of a path, removing the final element. Use filepath.dir(path) to get the parent directory of a file or directory path",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -56,6 +57,7 @@ func NormalizeFunc() celexp.ExtFunction {
 	funcName := "filepath.normalize"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "filepath.normalize(string) -> string",
 		Description:   "Normalizes a path by cleaning redundant separators and resolving . and .. elements. Use filepath.normalize(path) to convert a path to its shortest equivalent form with clean separators",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -93,6 +95,7 @@ func ExistsFunc() celexp.ExtFunction {
 	funcName := "filepath.exists"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "filepath.exists(string) -> bool",
 		Description:   "Checks if a file or directory exists at the specified path. Use filepath.exists(path) to return true if the path exists, false otherwise",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -144,6 +147,7 @@ func JoinFunc() celexp.ExtFunction {
 
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "filepath.join(string, string, ...) -> string",
 		Description:   "Joins any number of path elements into a single path, separating them with the OS-specific path separator. Use filepath.join(path1, path2, ...) to combine path segments",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/guid/guid.go
+++ b/pkg/celexp/ext/guid/guid.go
@@ -18,6 +18,7 @@ func NewFunc() celexp.ExtFunction {
 	funcName := "guid.new"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "guid.new() -> string",
 		Description:   "Generates a new random UUID (GUID) in standard format. Use guid.new() to create a universally unique identifier",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/map/map.go
+++ b/pkg/celexp/ext/map/map.go
@@ -19,6 +19,7 @@ func AddFunc() celexp.ExtFunction {
 	funcName := "map.add"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.add(map<string,dyn>, string, dyn) -> map<string,dyn>",
 		Description:   "Adds a key-value pair to a map and returns a new map with the added entry. The original map is not modified. Use map.add(map, key, value) to add an entry to a map",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -80,6 +81,7 @@ func AddFailIfExistsFunc() celexp.ExtFunction {
 	funcName := "map.addFailIfExists"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.addFailIfExists(map<string,dyn>, string, dyn) -> map<string,dyn>",
 		Description:   "Adds a key-value pair to a map and returns a new map with the added entry. Throws an error if the key already exists. Use map.addFailIfExists(map, key, value) to safely add entries without overwriting",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -134,6 +136,7 @@ func AddIfMissingFunc() celexp.ExtFunction {
 	funcName := "map.addIfMissing"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.addIfMissing(map<string,dyn>, string, dyn) -> map<string,dyn>",
 		Description:   "Adds a key-value pair to a map only if the key doesn't already exist. Returns a new map. Use map.addIfMissing(map, key, value) to add entries without overwriting existing values",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -191,6 +194,7 @@ func SelectFunc() celexp.ExtFunction {
 	funcName := "map.select"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.select(map<string,dyn>, list<string>) -> map<string,dyn>",
 		Description:   "Returns a new map containing only the specified keys from the input map. Keys that don't exist in the input map are ignored. Use map.select(map, keys) to filter a map to specific keys",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -247,6 +251,7 @@ func OmitFunc() celexp.ExtFunction {
 	funcName := "map.omit"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.omit(map<string,dyn>, list<string>) -> map<string,dyn>",
 		Description:   "Returns a new map with the specified keys removed from the input map. Keys that don't exist in the input map are ignored. Use map.omit(map, keys) to exclude specific keys from a map",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -309,6 +314,7 @@ func MergeFunc() celexp.ExtFunction {
 	funcName := "map.merge"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.merge(map<string,dyn>, map<string,dyn>) -> map<string,dyn>",
 		Description:   "Merges two maps together and returns a new map. If keys conflict, the second map's values take precedence. Use map.merge(map1, map2) to combine maps",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -362,6 +368,7 @@ func RecurseFunc() celexp.ExtFunction {
 	funcName := "map.recurse"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "map.recurse(list<map<string,dyn>>, list<string>, string, string) -> list<map<string,dyn>>",
 		Description:   "Recursively resolves dependencies between objects in a list. Returns a unique list of objects with all transitive dependencies included. Use map.recurse(allObjects, startIds, idProperty, depsProperty) to compute recursive dependencies",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -494,6 +501,71 @@ func RecurseFunc() celexp.ExtFunction {
 						}
 
 						// Convert back to CEL value
+						return types.DefaultTypeAdapter.NativeToValue(result)
+					}),
+				),
+			),
+		},
+	}
+}
+
+// FromEntriesFunc converts a list of maps into a single map keyed by a specified field.
+func FromEntriesFunc() celexp.ExtFunction {
+	funcName := "map.fromEntries"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Signature:     "map.fromEntries(list<map<string,dyn>>, string) -> map<string,dyn>",
+		Description:   "Converts a list of maps into a single map keyed by the specified field. Each entry's value is the full object. Duplicate keys use last-write-wins. Use map.fromEntries(list, keyField) to index a list of objects by a string field",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Index a list of users by name",
+				Expression:  `map.fromEntries([{"name": "alice", "age": 30}, {"name": "bob", "age": 25}], "name")`,
+			},
+			{
+				Description: "Index environments by env field",
+				Expression:  `map.fromEntries([{"env": "dev", "url": "dev.example.com"}, {"env": "prod", "url": "example.com"}], "env")`,
+			},
+			{
+				Description: "Empty list returns empty map",
+				Expression:  `map.fromEntries([], "id")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.ListType(cel.MapType(cel.StringType, cel.DynType)), cel.StringType},
+					cel.MapType(cel.StringType, cel.DynType),
+					cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+						listVal := args[0]
+						keyFieldVal := args[1]
+
+						keyField, ok := keyFieldVal.Value().(string)
+						if !ok {
+							return types.NewErr("map.fromEntries: expected string keyField, got %s", keyFieldVal.Type())
+						}
+
+						items, err := conversion.ListToObjectSlice(listVal)
+						if err != nil {
+							return types.NewErr("map.fromEntries: %s", err.Error())
+						}
+
+						result := make(map[string]any, len(items))
+						for _, item := range items {
+							keyVal, exists := item[keyField]
+							if !exists {
+								return types.NewErr("map.fromEntries: object missing key field '%s'", keyField)
+							}
+
+							key, ok := keyVal.(string)
+							if !ok {
+								return types.NewErr("map.fromEntries: key field '%s' must be a string, got %T", keyField, keyVal)
+							}
+
+							result[key] = item
+						}
+
 						return types.DefaultTypeAdapter.NativeToValue(result)
 					}),
 				),

--- a/pkg/celexp/ext/map/map_test.go
+++ b/pkg/celexp/ext/map/map_test.go
@@ -1119,3 +1119,136 @@ func BenchmarkRecurseFunc_CEL_Complex(b *testing.B) {
 		prog.Eval(map[string]any{})
 	}
 }
+
+// FromEntriesFunc Tests
+
+func TestFromEntriesFunc_Metadata(t *testing.T) {
+	fn := FromEntriesFunc()
+
+	assert.Equal(t, "map.fromEntries", fn.Name)
+	assert.Equal(t, "map.fromEntries(list<map<string,dyn>>, string) -> map<string,dyn>", fn.Signature)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.EnvOptions)
+	assert.NotEmpty(t, fn.Examples)
+	assert.Len(t, fn.Examples, 3)
+	assert.True(t, fn.Custom)
+}
+
+func TestFromEntriesFunc_CELIntegration(t *testing.T) {
+	fn := FromEntriesFunc()
+
+	env, err := cel.NewEnv(fn.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		wantErr    bool
+		validate   func(t *testing.T, result any)
+	}{
+		{
+			name:       "basic keying by name field",
+			expression: `map.fromEntries([{"name": "alice", "age": 30}, {"name": "bob", "age": 25}], "name")`,
+			validate: func(t *testing.T, result any) {
+				m, ok := result.(map[string]any)
+				require.True(t, ok, "result should be a map")
+				assert.Len(t, m, 2)
+
+				alice, ok := m["alice"].(map[string]any)
+				require.True(t, ok, "alice entry should be a map")
+				assert.Equal(t, "alice", alice["name"])
+				assert.Equal(t, int64(30), alice["age"])
+
+				bob, ok := m["bob"].(map[string]any)
+				require.True(t, ok, "bob entry should be a map")
+				assert.Equal(t, "bob", bob["name"])
+				assert.Equal(t, int64(25), bob["age"])
+			},
+		},
+		{
+			name:       "empty list returns empty map",
+			expression: `map.fromEntries([], "id")`,
+			validate: func(t *testing.T, result any) {
+				m, ok := result.(map[string]any)
+				require.True(t, ok, "result should be a map")
+				assert.Empty(t, m)
+			},
+		},
+		{
+			name:       "single element list",
+			expression: `map.fromEntries([{"id": "only"}], "id")`,
+			validate: func(t *testing.T, result any) {
+				m, ok := result.(map[string]any)
+				require.True(t, ok, "result should be a map")
+				assert.Len(t, m, 1)
+				entry, ok := m["only"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "only", entry["id"])
+			},
+		},
+		{
+			name:       "duplicate keys use last-write-wins",
+			expression: `map.fromEntries([{"env": "dev", "url": "old.example.com"}, {"env": "dev", "url": "new.example.com"}], "env")`,
+			validate: func(t *testing.T, result any) {
+				m, ok := result.(map[string]any)
+				require.True(t, ok, "result should be a map")
+				assert.Len(t, m, 1)
+				entry, ok := m["dev"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "new.example.com", entry["url"])
+			},
+		},
+		{
+			name:       "nested objects preserved",
+			expression: `map.fromEntries([{"id": "a", "meta": {"nested": true}}], "id")`,
+			validate: func(t *testing.T, result any) {
+				m, ok := result.(map[string]any)
+				require.True(t, ok, "result should be a map")
+				entry, ok := m["a"].(map[string]any)
+				require.True(t, ok, "entry should be a map")
+				assert.Contains(t, entry, "meta", "entry should have meta field")
+				assert.Equal(t, "a", entry["id"])
+			},
+		},
+		{
+			name:       "missing key field returns error",
+			expression: `map.fromEntries([{"name": "alice"}, {"age": 25}], "id")`,
+			wantErr:    true,
+		},
+		{
+			name:       "non-string key field returns error",
+			expression: `map.fromEntries([{"id": 123}], "id")`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues, "compile issues: %v", issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]any{})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.validate(t, result.Value())
+		})
+	}
+}
+
+func BenchmarkFromEntriesFunc_CEL(b *testing.B) {
+	fn := FromEntriesFunc()
+	env, _ := cel.NewEnv(fn.EnvOptions...)
+	ast, _ := env.Compile(`map.fromEntries([{"name": "alice", "age": 30}, {"name": "bob", "age": 25}, {"name": "charlie", "age": 35}], "name")`)
+	prog, _ := env.Program(ast)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prog.Eval(map[string]any{})
+	}
+}

--- a/pkg/celexp/ext/marshalling/marshalling.go
+++ b/pkg/celexp/ext/marshalling/marshalling.go
@@ -24,6 +24,7 @@ func JSONMarshalFunc() celexp.ExtFunction {
 	funcName := "json.marshal"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "json.marshal(dyn) -> string",
 		Description:   "Marshals a value to a compact JSON string",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -70,6 +71,7 @@ func JSONMarshalPrettyFunc() celexp.ExtFunction {
 	funcName := "json.marshalPretty"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "json.marshalPretty(dyn) -> string",
 		Description:   "Marshals a value to a pretty-printed JSON string with indentation",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -116,6 +118,7 @@ func JSONUnmarshalFunc() celexp.ExtFunction {
 	funcName := "json.unmarshal"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "json.unmarshal(string) -> dyn",
 		Description:   "Unmarshals a JSON string to a value",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -167,6 +170,7 @@ func YamlMarshalFunc() celexp.ExtFunction {
 	funcName := "yaml.marshal"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "yaml.marshal(dyn) -> string",
 		Description:   "Marshals a value to a YAML string",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -217,6 +221,7 @@ func YamlUnmarshalFunc() celexp.ExtFunction {
 	funcName := "yaml.unmarshal"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "yaml.unmarshal(string) -> dyn",
 		Description:   "Unmarshals a YAML string to a value",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/out/out.go
+++ b/pkg/celexp/ext/out/out.go
@@ -20,6 +20,7 @@ func NilFunc() celexp.ExtFunction {
 	funcName := "out.nil"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "out.nil(dyn) -> null",
 		Description:   "Takes any value and returns nil",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/regex/regex.go
+++ b/pkg/celexp/ext/regex/regex.go
@@ -25,6 +25,7 @@ func MatchFunc() celexp.ExtFunction {
 	funcName := "regex.match"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "regex.match(string, string) -> bool",
 		Description:   "Tests if a string matches a regular expression pattern (RE2 syntax). Returns true if the pattern matches anywhere in the input string",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -79,6 +80,7 @@ func ReplaceFunc() celexp.ExtFunction {
 	funcName := "regex.replace"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "regex.replace(string, string, string) -> string",
 		Description:   "Replaces all occurrences of a regular expression pattern (RE2 syntax) in a string with a replacement string",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -140,6 +142,7 @@ func FindAllFunc() celexp.ExtFunction {
 	funcName := "regex.findAll"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "regex.findAll(string, string) -> list<string>",
 		Description:   "Finds all matches of a regular expression pattern (RE2 syntax) in a string and returns them as a list of strings",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -202,6 +205,7 @@ func SplitFunc() celexp.ExtFunction {
 	funcName := "regex.split"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "regex.split(string, string) -> list<string>",
 		Description:   "Splits a string by a regular expression pattern (RE2 syntax) and returns a list of strings",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/sort/sort.go
+++ b/pkg/celexp/ext/sort/sort.go
@@ -66,6 +66,7 @@ func ObjectsFunc() celexp.ExtFunction {
 	funcName := "sort.objects"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "sort.objects(list<map<string,dyn>>, string) -> list<map<string,dyn>>",
 		Description:   "Sorts an array of objects by a specified property in ascending order",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -114,6 +115,7 @@ func ObjectsDescendingFunc() celexp.ExtFunction {
 	funcName := "sort.objectsDescending"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "sort.objectsDescending(list<map<string,dyn>>, string) -> list<map<string,dyn>>",
 		Description:   "Sorts an array of objects by a specified property in descending order",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/strings/strings.go
+++ b/pkg/celexp/ext/strings/strings.go
@@ -33,6 +33,7 @@ func CleanFunc() celexp.ExtFunction {
 	funcName := "strings.clean"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "strings.clean(string) -> string",
 		Description:   "Cleans a string by converting it to lowercase and removing hyphens, underscores, and spaces",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -68,6 +69,7 @@ func TitleFunc() celexp.ExtFunction {
 	funcName := "strings.title"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "strings.title(string) -> string",
 		Description:   "Converts a string to title case using English language rules",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -107,6 +109,7 @@ func RepeatFunc() celexp.ExtFunction {
 	funcName := "strings.repeat"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "strings.repeat(string, int) -> string",
 		Description:   "Repeats a string a given number of times",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/celexp/ext/time/time.go
+++ b/pkg/celexp/ext/time/time.go
@@ -18,6 +18,7 @@ func NowFunc() celexp.ExtFunction {
 	funcName := "time.now"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "time.now() -> timestamp",
 		Description:   "Returns the current time as a CEL timestamp",
 		FunctionNames: []string{funcName},
 		Custom:        true,
@@ -51,6 +52,7 @@ func NowFmtFunc() celexp.ExtFunction {
 	funcName := "time.nowFmt"
 	return celexp.ExtFunction{
 		Name:          funcName,
+		Signature:     "time.nowFmt(string) -> string",
 		Description:   "Returns the current time formatted according to the provided layout string. Uses Go's time.Format layout conventions (e.g., '2006-01-02 15:04:05' for 'YYYY-MM-DD HH:MM:SS')",
 		FunctionNames: []string{funcName},
 		Custom:        true,

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_schema.json
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_schema.json
@@ -24,6 +24,11 @@
         "layout": "inline"
       },
       {
+        "title": "Signature",
+        "fields": ["signature"],
+        "layout": "paragraph"
+      },
+      {
         "title": "Description",
         "fields": ["description"],
         "layout": "paragraph"
@@ -59,6 +64,11 @@
         "type": "boolean",
         "title": "Custom",
         "description": "Whether this is a custom scafctl extension"
+      },
+      "signature": {
+        "type": "string",
+        "title": "Signature",
+        "description": "Type signature of the function"
       },
       "description": {
         "type": "string",


### PR DESCRIPTION
- add map.fromEntries(list, keyField) CEL function for converting a list of maps into a single map keyed by a string field
- last-write-wins for duplicate keys, clear errors for missing or non-string key fields
- add Signature metadata field to ExtFunction struct for type signature documentation (json/yaml serialized)
- backfill Signature on all 27 existing custom CEL functions
- register map.fromEntries in the custom function catalog
- add table-driven tests (7 cases) and benchmark

Closes #452