### PR TITLE
fix(plugin): stop serializing resolver context in gRPC calls

### DIFF
--- a/docs/design/plugin-protocol-efficiency.md
+++ b/docs/design/plugin-protocol-efficiency.md
@@ -1,0 +1,233 @@
+---
+title: "Plugin Protocol Efficiency"
+weight: 40
+---
+
+# Plugin Protocol Efficiency
+
+## Problem
+
+When a plugin provider is called via gRPC, the entire resolver context (`_` map) is serialized into every `ExecuteProviderRequest`. For solutions with large accumulated resolver data, this causes gRPC `ResourceExhausted` errors because the message exceeds the hardcoded 4MB gRPC max message size limit.
+
+The problem is compounded by `forEach`, which makes N separate gRPC calls (one per iteration), each carrying the full context.
+
+**Reference**: [GitHub Issue #451](https://github.com/oakwood-commons/scafctl/issues/451)
+
+---
+
+## Current State
+
+> **Updated**: The data flow below reflects the state **after** P0 was implemented. The resolver context (`_`) is no longer sent over the wire.
+
+### Data flow per ExecuteProvider call (post-P0)
+
+~~~text
+Host (engine)                              Plugin (gRPC server)
+     |                                          |
+     |  ExecuteProviderRequest {                 |
+     |    input:             ~1-100KB            |
+     |    context:           empty  <-- pruned   |
+     |    parameters:        ~1-10KB             |
+     |    solution_metadata: ~500B               |
+     |    iteration_context: ~1KB                |
+     |    ...flags/strings                       |
+     |  }                                        |
+     |------------------------------------------>|
+     |                                           |
+     |  ExecuteProviderResponse {                |
+     |    output: ~1-100KB                       |
+     |  }                                        |
+     |<------------------------------------------|
+~~~
+
+### Prior state (before P0)
+
+The `context` field carried the full `_` map (all resolved resolver values), which could reach 1–100+ MB for data-heavy solutions. This caused `ResourceExhausted` gRPC errors when the message exceeded the 4 MB default limit.
+
+### Why sending `_` was wrong
+
+1. **The engine resolves all ValueRefs before calling the plugin.** By the time `ExecuteProvider` is called, every `expr:`, `rslvr:`, and `tmpl:` reference has been evaluated to a concrete value. The plugin receives fully resolved `input` -- it has no use for `_`.
+
+2. **Sending `_` was a side-channel.** Providers declare an input schema via `Descriptor()`. That schema is the provider's API contract. Accessing `_` directly bypasses input validation, creates invisible dependencies, and makes provider behavior non-deterministic.
+
+3. **Terraform does not do this.** Terraform sends only the provider's configured arguments across the plugin boundary, never the full state. This is the principle of least privilege applied to plugin communication.
+
+4. **The gRPC max message size was hardcoded at 4MB.** The Go gRPC library default `MaxRecvMsgSize` is 4,194,304 bytes. scafctl now configures this to 64MB (see P0 below), and the resolver context is no longer included in messages.
+
+---
+
+## Changes
+
+> **Status**: P0 is implemented and shipped. P1–P3 are planned future phases.
+
+### P0: Prune resolver context from plugin calls ✅
+
+**What**: Stop serializing `resolverContext` into `ExecuteProviderRequest.Context`.
+
+**Where**: `buildExecuteProviderRequest()` in `pkg/plugin/grpc.go` -- remove the `resolverContext` key from `contextData`. On the server side, `applyRequestContext()` already handles missing context gracefully (the `if resolverCtx, ok := ...` guard returns false).
+
+**Why this is safe**:
+
+- The engine resolves all ValueRefs before the gRPC call. Plugins receive concrete input values.
+- No plugin in the SDK or known ecosystem reads `_` from context. The `InputResolver` on the plugin side creates an empty map when no resolver context is present -- this is the correct behavior.
+- Built-in providers (CEL, debug) that do read `_` run in-process and never go through gRPC. They are unaffected.
+- This is an alpha tool. Breaking changes are expected.
+
+**Server-side behavior**: `applyRequestContext()` will simply not set resolver context on the Go context. `provider.ResolverContextFromContext()` returns `(nil, false)`. `NewInputResolver` handles this by creating an empty map. No crash, no behavior change for well-behaved plugins.
+
+### P0: Configurable gRPC max message size ✅
+
+**What**: Add `GRPCDialOptions` with `grpc.MaxCallRecvMsgSize(N)` and `grpc.MaxCallSendMsgSize(N)` to the `plugin.ClientConfig`. Expose the value via settings.
+
+**Where**:
+
+- `pkg/plugin/client.go` -- add `GRPCDialOptions` to `plugin.ClientConfig`
+- `pkg/settings/` -- add `Plugin.GRPCMaxMessageSize` with a default (64MB)
+- `pkg/plugin/pool.go` -- thread the setting through to `connectPlugin`
+
+**Why**: Even after pruning resolver context, legitimately large inputs (e.g., a 10MB HCL file) or large outputs can exceed 4MB. A configurable limit provides a safety valve without requiring code changes.
+
+**Default**: 64MB (`67108864`). This matches common gRPC production defaults and is large enough for any reasonable provider payload while still protecting against unbounded allocation.
+
+### P1: Batch execution for forEach (planned)
+
+**What**: Add a `BatchExecuteProvider` RPC to the plugin protocol that sends all forEach items in a single request.
+
+**Current behavior**: forEach with 1000 items = 1000 separate gRPC round-trips, each with full serialization overhead (parameters, metadata, context flags). This is the biggest performance bottleneck for data-heavy solutions.
+
+**New behavior**: The host sends a single `BatchExecuteProviderRequest` containing the common fields once, plus a `repeated IterationItem items` array. The plugin processes all items and returns a `repeated IterationResult results` array.
+
+**Protocol addition**:
+
+~~~protobuf
+message BatchExecuteProviderRequest {
+  string provider_name = 1;
+  bytes common_input = 2;        // Shared inputs (non-forEach-variable fields)
+  repeated IterationItem items = 3;
+  bool dry_run = 4;
+  string execution_mode = 5;
+  string working_directory = 6;
+  string output_directory = 7;
+  string conflict_strategy = 8;
+  bool backup = 9;
+  bytes parameters = 10;
+  SolutionMeta solution_metadata = 11;
+}
+
+message IterationItem {
+  bytes input_overrides = 1;     // Per-item input values (merged with common_input)
+  IterationContext iteration_context = 2;
+}
+
+message BatchExecuteProviderResponse {
+  repeated IterationResult results = 1;
+  string error = 2;              // Batch-level error (aborts all)
+}
+
+message IterationResult {
+  int32 index = 1;
+  bytes output = 2;
+  string error = 3;
+  int32 exit_code = 4;
+  repeated Diagnostic diagnostics = 5;
+}
+~~~
+
+**Backward compatibility**: Plugins that don't implement `BatchExecuteProvider` return `codes.Unimplemented`. The host falls back to individual `ExecuteProvider` calls per iteration (current behavior). No breakage for existing plugins.
+
+**Host-side logic** (in `pkg/resolver/executor.go`):
+
+1. Check if the provider supports batch execution (capability on descriptor, or attempt + fallback)
+2. If supported: collect all forEach items, build `BatchExecuteProviderRequest`, single RPC call
+3. If not supported: fall back to current per-item `ExecuteProvider` loop
+
+**Concurrency**: The plugin controls internal parallelism for batch execution. The `forEach.concurrency` field from the solution YAML can be sent as a hint in the batch request.
+
+### P1: Host-side input validation before gRPC call (planned)
+
+**What**: Validate resolved inputs against the provider's schema on the host side before serializing and sending the gRPC request.
+
+**Where**: `pkg/resolver/executor.go` -- after resolving all inputs and before calling `prov.Execute()`, validate against the cached descriptor schema.
+
+**Current behavior**: Invalid inputs (wrong type, missing required field, constraint violation) cross the gRPC boundary, get deserialized on the plugin side, fail validation there, serialize the error, send it back, and get deserialized on the host side. A full wasted round-trip.
+
+**New behavior**: The host validates inputs against the descriptor's JSON Schema before the call. If validation fails, the error is returned immediately with a clear message indicating which input violated which constraint. The plugin can still re-validate (defense in depth).
+
+**Edge case**: Some plugins may accept inputs not declared in their schema (passthrough/dynamic inputs). If the schema has `additionalProperties: true` or no schema is defined, skip host-side validation.
+
+### P2: Move static data to ConfigureProvider (planned)
+
+**What**: Send solution parameters and solution metadata once during `ConfigureProvider` instead of on every `ExecuteProvider` call.
+
+**Where**:
+
+- `pkg/plugin/grpc.go` -- add `parameters` and `solution_metadata` fields to `ConfigureProviderRequest`
+- `pkg/plugin/grpc.go` -- remove them from `buildExecuteProviderRequest` (or mark deprecated)
+- Plugin SDK server side -- store configured parameters and metadata, merge into context for each `ExecuteProvider` call
+
+**Why**: Parameters and solution metadata are immutable for the lifetime of an execution. Sending them on every call (especially with forEach) is redundant serialization.
+
+**Protocol consideration**: This requires a plugin SDK update. For backward compatibility, the host can send parameters in both `ConfigureProvider` and `ExecuteProvider` initially, then drop them from `ExecuteProvider` in a future protocol version.
+
+### P3: Response size bounds (planned)
+
+**What**: Set `grpc.MaxCallRecvMsgSize` on the client to bound response sizes. Log a warning when responses exceed a threshold (e.g., 80% of the limit).
+
+**Why**: A misbehaving plugin returning an unbounded response can OOM the host. The same `GRPCMaxMessageSize` setting from P0 applies bidirectionally.
+
+---
+
+## What We Are NOT Doing
+
+### Selective context (send only referenced resolver keys)
+
+Rejected. The engine resolves all ValueRefs before calling the plugin, so the plugin never needs `_` at all. Selective context is a half-measure -- it still sends data the plugin shouldn't access. Full pruning is the correct approach.
+
+### Opt-in context via plugin capability flag
+
+Rejected. No plugin should access `_` directly. If a legitimate use case surfaces, the right solution is an explicit `contextKeys` field on the provider source in the solution YAML:
+
+~~~yaml
+- provider: some-plugin
+  contextKeys: [config, environment]
+  inputs:
+    operation: parse
+~~~
+
+This is explicit, minimal, auditable, and bounded. Build it when someone needs it, not before.
+
+### Response streaming for large outputs
+
+Deferred. `ExecuteProviderStream` already handles stdout/stderr streaming. Streaming the final result payload would require a new chunked protocol and is not justified until we have a concrete use case exceeding the 64MB default.
+
+---
+
+## Implementation Order
+
+| Phase | Items | Scope | Breaking | Status |
+|-------|-------|-------|----------|--------|
+| 1 | P0: Prune context + configurable max message size | `pkg/plugin/`, `pkg/settings/` | Yes (plugin protocol) | ✅ Shipped |
+| 2 | P1: Host-side input validation | `pkg/resolver/` | No | Planned |
+| 3 | P1: Batch execution | Plugin SDK + `pkg/plugin/` + `pkg/resolver/` | No (additive) | Planned |
+| 4 | P2: Move static data to ConfigureProvider | Plugin SDK + `pkg/plugin/` | No (additive, then deprecate) | Planned |
+| 5 | P3: Response size bounds | `pkg/plugin/` | No | Planned |
+
+Phase 1 resolves the immediate issue (#451). Each subsequent phase is independently valuable and can be shipped separately.
+
+---
+
+## Testing
+
+- **P0 context pruning** ✅: `TestBuildExecuteProviderRequest_RoundTrip` asserts `req.Context` is empty. `TestBuildExecuteProviderRequest_ResolverContextPruned` creates 100 resolvers × 10KB each and verifies no context is sent.
+- **P0 max message size** ✅: `TestWithGRPCMaxMessageSize_SetsClientOption` and `TestWithGRPCMaxMessageSize_DefaultUsedWhenZero` cover the client option. Full e2e plugin tests pass with the new dial options.
+- **P1 batch execution** (planned): Test forEach with 100+ items via batch RPC. Verify results match per-item execution. Test fallback when plugin doesn't implement batch.
+- **P1 host-side validation** (planned): Test that invalid inputs fail before the gRPC call with schema-specific error messages.
+- **P2 static data** (planned): Verify parameters and metadata are available in plugin context after ConfigureProvider, even when not sent in ExecuteProvider.
+
+---
+
+## Risks
+
+- **Phase 1 is a breaking protocol change.** Third-party plugins that read `resolverContext` from the request context will get an empty map. This is intentional -- they should use declared inputs instead. A lint rule can help surface this during solution development.
+- **Batch execution changes the error model.** Per-item errors vs batch-level errors need clear semantics. A single poisoned item should not abort the entire batch unless the plugin explicitly chooses to.
+- **Plugin SDK must be updated in lockstep for Phase 3+.** The proto definitions live in `scafctl-plugin-sdk`. Phases 1-2 only touch the host side.

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -289,6 +289,37 @@ This is separate from the hashicorp/go-plugin handshake `ProtocolVersion`, which
 
 The plugin client caches provider descriptors after the first `GetProviderDescriptor` call to avoid repeated gRPC round-trips. The cache is protected by a `sync.RWMutex` for safe concurrent access. Descriptors are immutable once loaded.
 
+### gRPC Message Size
+
+scafctl configures both `MaxCallRecvMsgSize` and `MaxCallSendMsgSize` on the gRPC dial options. The default is **64 MB** (`67108864` bytes). This replaces the gRPC library default of 4 MB and accommodates legitimately large provider inputs (e.g., a large HCL file) or large outputs.
+
+Adjust via config when needed:
+
+```yaml
+plugins:
+  grpcMaxMessageSize: 134217728  # 128 MB
+```
+
+Or with the CLI:
+
+```bash
+scafctl config set plugins.grpcMaxMessageSize 134217728
+```
+
+> **Note**: This limit applies only to the host side (the client's dial options). The plugin server side has a separate default from the gRPC library. For very large messages, both the host config and the plugin SDK's server options must be tuned. See [Plugin Protocol Efficiency](plugin-protocol-efficiency.md) for background.
+
+### Resolver Context and the gRPC Boundary
+
+scafctl resolves all `expr:`, `rslvr:`, and `tmpl:` ValueRefs in the solution **before** making any gRPC call. Plugins receive fully resolved, concrete input values. The resolver context (`_` map) is **not** sent to plugins.
+
+This is intentional and correct:
+
+- **Providers declare an input schema via `Descriptor()`.** That schema is the API contract. Inputs validated against the schema are the only data providers should need.
+- **The engine does the resolution work.** By the time a plugin is called, all dependencies are resolved. Passing `_` would be redundant data that bypasses the schema.
+- **Keeping `_` off the wire eliminates a class of gRPC `ResourceExhausted` errors** for solutions with large accumulated resolver data (see [issue #451](https://github.com/oakwood-commons/scafctl/issues/451)).
+
+Built-in providers (CEL, go-template, validation, static, parameter) run in-process and can access the resolver context directly via `ResolverContextFromContext(ctx)`. Plugin providers must declare all their dependencies as explicit inputs.
+
 ### Schema Round-Trip
 
 Provider descriptors carry both structured `Schema`/`OutputSchemas` fields and raw JSON bytes (`raw_schema`, `raw_output_schemas`). The raw bytes are preferred for lossless round-tripping of `jsonschema.Schema`; the structured fields serve as a backward-compatible fallback for older plugins.

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -384,6 +384,8 @@ Override paths with XDG environment variables or SCAFCTL_SECRETS_DIR.
 | `resolver.concurrency` | int | `4` | Max parallel resolver execution |
 | `action.timeout` | duration | `10m` | Overall action timeout |
 | `action.concurrency` | int | `4` | Max parallel action execution |
+| `plugins.grpcMaxMessageSize` | int | `67108864` | Max gRPC message size in bytes for plugin communication (64 MB default). Increase for very large provider inputs/outputs |
+| `plugins.fetchCooldown` | duration | `5m` | Cooldown between failed plugin auto-fetch retries |
 | `auth.entra.*` | object | — | Entra (Azure AD) auth handler config |
 | `auth.github.hostname` | string | `github.com` | GitHub hostname (or GHES hostname) |
 | `auth.github.clientId` | string | built-in | OAuth App client ID |

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -357,6 +357,12 @@ plugins:
   # Default: "5m"
   # fetchCooldown: "5m"
 
+  # Maximum gRPC message size in bytes for plugin communication.
+  # Applies to both send and receive directions (host side).
+  # Increase if plugin providers handle very large inputs or outputs.
+  # Minimum: 1048576 (1 MB). Default: 67108864 (64 MB).
+  # grpcMaxMessageSize: 67108864
+
 # =============================================================================
 # Catalogs - Registered solution catalogs
 # =============================================================================

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -232,6 +232,10 @@ func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.R
 	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))
 	}
+	// Wire gRPC max message size from config
+	if cfg != nil && cfg.Plugins.GRPCMaxMessageSize > 0 {
+		poolOpts = append(poolOpts, plugin.WithClientOptions(plugin.WithGRPCMaxMessageSize(cfg.Plugins.GRPCMaxMessageSize)))
+	}
 	pool := plugin.NewPool(pluginFetcher, reg, *lgr, poolOpts...)
 	return pool, ctx
 }

--- a/pkg/cmd/scafctl/mcp/serve_test.go
+++ b/pkg/cmd/scafctl/mcp/serve_test.go
@@ -168,4 +168,30 @@ func TestBuildMCPPluginPool(t *testing.T) {
 		assert.Nil(t, opts, "no auth client opts when no auth registry")
 		assert.Equal(t, 0, pool.ClientOptsLen(), "pool should have no client opts without auth registry")
 	})
+
+	t.Run("wires gRPC max message size from config", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		cfg := &config.Config{
+			Plugins: config.PluginsConfig{
+				GRPCMaxMessageSize: 128 * 1024 * 1024, // 128 MB
+			},
+		}
+		pool, _ := buildMCPPluginPool(context.Background(), cfg, reg, &lgr)
+		defer pool.Shutdown()
+
+		// Exactly one client option should be added for the gRPC max message size.
+		assert.Equal(t, 1, pool.ClientOptsLen(), "pool should have exactly one client opt for gRPC max message size")
+	})
+
+	t.Run("zero GRPCMaxMessageSize is noop", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		cfg := &config.Config{} // GRPCMaxMessageSize defaults to 0
+		pool, _ := buildMCPPluginPool(context.Background(), cfg, reg, &lgr)
+		defer pool.Shutdown()
+
+		// No extra client opts should be added when size is zero.
+		assert.Equal(t, 0, pool.ClientOptsLen(), "zero GRPCMaxMessageSize should not add a client opt")
+	})
 }

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -598,7 +598,7 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 	if o.ShowMetrics && o.IOStreams != nil {
 		opts = append(opts, prepare.WithMetrics(o.IOStreams.ErrOut))
 	}
-	opts = o.appendClientPluginOptions(opts)
+	opts = o.appendClientPluginOptions(ctx, opts)
 
 	// Wire auth host deps so that plugin providers can request auth tokens
 	// from the host process via gRPC HostService.
@@ -718,7 +718,7 @@ func (o *sharedResolverOptions) prepareSolutionForExecution(ctx context.Context)
 	return result.Solution, result.Registry, result.SolutionDir, result.Cleanup, result.ProviderCtx, nil
 }
 
-func (o *sharedResolverOptions) appendClientPluginOptions(opts []prepare.Option) []prepare.Option {
+func (o *sharedResolverOptions) appendClientPluginOptions(ctx context.Context, opts []prepare.Option) []prepare.Option {
 	if o.CliParams == nil {
 		return opts
 	}
@@ -730,6 +730,9 @@ func (o *sharedResolverOptions) appendClientPluginOptions(opts []prepare.Option)
 	}))
 	if logger.IsDebugLevel(o.CliParams.MinLogLevel) {
 		opts = append(opts, prepare.WithClientOptions(plugin.WithDebugLogging()))
+	}
+	if cfg := config.FromContext(ctx); cfg != nil && cfg.Plugins.GRPCMaxMessageSize > 0 {
+		opts = append(opts, prepare.WithClientOptions(plugin.WithGRPCMaxMessageSize(cfg.Plugins.GRPCMaxMessageSize)))
 	}
 
 	return opts

--- a/pkg/cmd/scafctl/run/common_coverage_test.go
+++ b/pkg/cmd/scafctl/run/common_coverage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -230,7 +231,7 @@ func TestSharedResolverOptions_GetEffectiveResolverConfig_NoFlagsChanged(t *test
 func TestSharedResolverOptions_AppendClientPluginOptions_NoCliParams(t *testing.T) {
 	t.Parallel()
 
-	opts := (&sharedResolverOptions{}).appendClientPluginOptions(nil)
+	opts := (&sharedResolverOptions{}).appendClientPluginOptions(context.Background(), nil)
 	assert.Len(t, opts, 0)
 }
 
@@ -240,7 +241,7 @@ func TestSharedResolverOptions_AppendClientPluginOptions_NonDebug(t *testing.T) 
 	cliParams := settings.NewCliParams()
 	cliParams.MinLogLevel = logger.LevelInfo
 
-	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(nil)
+	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(context.Background(), nil)
 	assert.Len(t, opts, 1)
 }
 
@@ -250,8 +251,38 @@ func TestSharedResolverOptions_AppendClientPluginOptions_Debug(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	cliParams.MinLogLevel = logger.LevelDebug
 
-	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(nil)
+	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(context.Background(), nil)
 	assert.Len(t, opts, 2)
+}
+
+func TestSharedResolverOptions_AppendClientPluginOptions_GRPCMaxMessageSize(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	cliParams.MinLogLevel = logger.LevelInfo
+
+	cfg := &config.Config{
+		Plugins: config.PluginsConfig{
+			GRPCMaxMessageSize: 128 * 1024 * 1024, // 128 MB
+		},
+	}
+	ctx := config.WithConfig(context.Background(), cfg)
+	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(ctx, nil)
+	// 1 provider config opt + 1 gRPC max message size opt
+	assert.Len(t, opts, 2, "should have provider config opt and gRPC max message size opt")
+}
+
+func TestSharedResolverOptions_AppendClientPluginOptions_GRPCMaxMessageSizeZeroIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	cliParams.MinLogLevel = logger.LevelInfo
+
+	cfg := &config.Config{} // GRPCMaxMessageSize defaults to 0
+	ctx := config.WithConfig(context.Background(), cfg)
+	opts := (&sharedResolverOptions{CliParams: cliParams}).appendClientPluginOptions(ctx, nil)
+	// Only 1 provider config opt -- zero size must not add a client opt
+	assert.Len(t, opts, 1, "zero GRPCMaxMessageSize should not add a client opt")
 }
 
 // ── shouldRedactSensitive tests ───────────────────────────────────────────────

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -304,6 +304,10 @@ func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fe
 	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))
 	}
+	// Wire gRPC max message size from config
+	if cfg.Plugins.GRPCMaxMessageSize > 0 {
+		poolOpts = append(poolOpts, plugin.WithClientOptions(plugin.WithGRPCMaxMessageSize(cfg.Plugins.GRPCMaxMessageSize)))
+	}
 	pool := plugin.NewPool(fetcher, reg, *lgr, poolOpts...)
 	for _, c := range preloaded {
 		// Query the client for provider names it registered so the pool can

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -185,3 +185,43 @@ func TestBuildPluginPool_AllowedPlugins(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, plugin.ErrPluginNotAllowed)
 }
+
+func TestBuildPluginPool_GRPCMaxMessageSize(t *testing.T) {
+	// When cfg.Plugins.GRPCMaxMessageSize is non-zero, buildPluginPool should
+	// wire it as a client option so plugin processes use the configured limit.
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{AllowExternal: true},
+		},
+		Plugins: config.PluginsConfig{
+			GRPCMaxMessageSize: 128 * 1024 * 1024, // 128 MB
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	defer pool.Shutdown()
+
+	// Exactly one client option should have been added (the gRPC max message size).
+	assert.Equal(t, 1, pool.ClientOptsLen(), "pool should have exactly one client opt for gRPC max message size")
+}
+
+func TestBuildPluginPool_GRPCMaxMessageSizeZeroIsNoop(t *testing.T) {
+	// When cfg.Plugins.GRPCMaxMessageSize is zero (default), no extra client
+	// option should be added -- connectPlugin will use the default internally.
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{AllowExternal: true},
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	defer pool.Shutdown()
+
+	assert.Equal(t, 0, pool.ClientOptsLen(), "zero GRPCMaxMessageSize should not add a client opt")
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -655,6 +655,11 @@ type PluginsConfig struct {
 	// auto-fetch failure. Prevents repeated timeout penalties during network
 	// outages. Use Go duration syntax (e.g., "5m", "30s"). Default: 5m.
 	FetchCooldown string `json:"fetchCooldown,omitempty" yaml:"fetchCooldown,omitempty" mapstructure:"fetchCooldown" doc:"Cooldown between failed auto-fetch retries" maxLength:"20" example:"5m"`
+
+	// GRPCMaxMessageSize is the maximum gRPC message size in bytes for plugin
+	// communication. Applies to both send and receive directions. Default: 64MB.
+	// Increase this if plugin providers handle very large inputs or outputs.
+	GRPCMaxMessageSize int `json:"grpcMaxMessageSize,omitempty" yaml:"grpcMaxMessageSize,omitempty" mapstructure:"grpcMaxMessageSize" doc:"Maximum gRPC message size in bytes for plugin communication" minimum:"1048576" example:"67108864"`
 }
 
 // PluginSignaturesConfig holds Sigstore/cosign verification settings for plugins.

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -18,16 +18,34 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"google.golang.org/grpc"
 )
 
 // pluginConfig holds the parameters needed to create a plugin client.
 type pluginConfig struct {
-	handshake    *HandshakeConfigData
-	pluginName   string
-	grpcPlugin   plugin.Plugin
-	cmdFn        func(string) *exec.Cmd // builds the exec.Cmd for the plugin binary
-	logger       hclog.Logger           // if nil, a null logger is used
-	startTimeout time.Duration          // if >0, bounds plugin startup/handshake
+	handshake          *HandshakeConfigData
+	pluginName         string
+	grpcPlugin         plugin.Plugin
+	cmdFn              func(string) *exec.Cmd // builds the exec.Cmd for the plugin binary
+	logger             hclog.Logger           // if nil, a null logger is used
+	startTimeout       time.Duration          // if >0, bounds plugin startup/handshake
+	grpcMaxMessageSize int                    // if >0, overrides default gRPC max message size
+}
+
+// resolveGRPCMaxMessageSize returns the effective gRPC max message size.
+// A zero or negative value (unset) falls back to DefaultGRPCMaxMessageSize.
+// A positive value below MinGRPCMaxMessageSize is clamped to MinGRPCMaxMessageSize,
+// matching the minimum:"1048576" validation tag on the config struct and
+// ensuring a misconfigured value is never more permissive than the minimum.
+func resolveGRPCMaxMessageSize(size int) int {
+	if size <= 0 {
+		return settings.DefaultGRPCMaxMessageSize
+	}
+	if size < settings.MinGRPCMaxMessageSize {
+		return settings.MinGRPCMaxMessageSize
+	}
+	return size
 }
 
 // connectPlugin creates a go-plugin client, connects, and dispenses the named plugin.
@@ -39,6 +57,8 @@ func connectPlugin(pluginPath string, cfg pluginConfig) (any, *plugin.Client, er
 	if cmdFn == nil {
 		cmdFn = pluginCmd
 	}
+
+	maxMsgSize := resolveGRPCMaxMessageSize(cfg.grpcMaxMessageSize)
 
 	//nolint:noctx // Context not available at plugin initialization time
 	clientConfig := &plugin.ClientConfig{
@@ -56,6 +76,14 @@ func connectPlugin(pluginPath string, cfg pluginConfig) (any, *plugin.Client, er
 		// output during normal command invocations. When debug mode is active
 		// the caller provides a real logger via pluginConfig.logger.
 		Logger: pluginLogger(cfg.logger),
+		// Override the default 4MB gRPC max message size to handle
+		// legitimately large provider inputs and outputs.
+		GRPCDialOptions: []grpc.DialOption{
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(maxMsgSize),
+				grpc.MaxCallSendMsgSize(maxMsgSize),
+			),
+		},
 	}
 	if cfg.startTimeout > 0 {
 		clientConfig.StartTimeout = cfg.startTimeout
@@ -216,10 +244,11 @@ type Client struct {
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	hostDeps     *HostServiceDeps
-	sanitizeEnv  bool          // strip sensitive env vars from plugin process
-	debugLog     bool          // emit plugin startup/lifecycle debug traces
-	startTimeout time.Duration // bounds plugin startup/handshake
+	hostDeps           *HostServiceDeps
+	sanitizeEnv        bool          // strip sensitive env vars from plugin process
+	debugLog           bool          // emit plugin startup/lifecycle debug traces
+	startTimeout       time.Duration // bounds plugin startup/handshake
+	grpcMaxMessageSize int           // overrides default gRPC max message size
 }
 
 // WithHostDeps provides host-side dependencies (secrets, auth) that are
@@ -255,6 +284,15 @@ func WithDebugLogging() ClientOption {
 func WithStartTimeout(d time.Duration) ClientOption {
 	return func(o *clientOptions) {
 		o.startTimeout = d
+	}
+}
+
+// WithGRPCMaxMessageSize sets the maximum gRPC message size in bytes for
+// plugin communication. This applies to both send and receive directions.
+// If not set, defaults to settings.DefaultGRPCMaxMessageSize (64 MB).
+func WithGRPCMaxMessageSize(size int) ClientOption {
+	return func(o *clientOptions) {
+		o.grpcMaxMessageSize = size
 	}
 }
 
@@ -320,12 +358,13 @@ func newClientWithConnector(
 		connectFn,
 		func(o clientOptions, logger hclog.Logger, cmdFn func(string) *exec.Cmd) pluginConfig {
 			return pluginConfig{
-				handshake:    HandshakeConfig,
-				pluginName:   PluginName,
-				grpcPlugin:   &GRPCPlugin{HostDeps: o.hostDeps},
-				cmdFn:        cmdFn,
-				logger:       logger,
-				startTimeout: o.startTimeout,
+				handshake:          HandshakeConfig,
+				pluginName:         PluginName,
+				grpcPlugin:         &GRPCPlugin{HostDeps: o.hostDeps},
+				cmdFn:              cmdFn,
+				logger:             logger,
+				startTimeout:       o.startTimeout,
+				grpcMaxMessageSize: o.grpcMaxMessageSize,
 			}
 		},
 		func(raw any) (ProviderPlugin, error) {
@@ -463,12 +502,13 @@ func newAuthHandlerClientWithConnector(
 		connectFn,
 		func(o clientOptions, logger hclog.Logger, cmdFn func(string) *exec.Cmd) pluginConfig {
 			return pluginConfig{
-				handshake:    AuthHandlerHandshakeConfig,
-				pluginName:   AuthHandlerPluginName,
-				grpcPlugin:   &AuthHandlerGRPCPlugin{HostDeps: o.hostDeps},
-				cmdFn:        cmdFn,
-				logger:       logger,
-				startTimeout: o.startTimeout,
+				handshake:          AuthHandlerHandshakeConfig,
+				pluginName:         AuthHandlerPluginName,
+				grpcPlugin:         &AuthHandlerGRPCPlugin{HostDeps: o.hostDeps},
+				cmdFn:              cmdFn,
+				logger:             logger,
+				startTimeout:       o.startTimeout,
+				grpcMaxMessageSize: o.grpcMaxMessageSize,
 			}
 		},
 		func(raw any) (AuthHandlerPlugin, error) {

--- a/pkg/plugin/client_test.go
+++ b/pkg/plugin/client_test.go
@@ -13,6 +13,8 @@ import (
 	hplugin "github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 func TestWithDebugLogging_SetsClientOption(t *testing.T) {
@@ -25,6 +27,40 @@ func TestWithStartTimeout_SetsClientOption(t *testing.T) {
 	var o clientOptions
 	WithStartTimeout(5 * time.Second)(&o)
 	assert.Equal(t, 5*time.Second, o.startTimeout)
+}
+
+func TestWithGRPCMaxMessageSize_SetsClientOption(t *testing.T) {
+	var o clientOptions
+	WithGRPCMaxMessageSize(128 * 1024 * 1024)(&o)
+	assert.Equal(t, 128*1024*1024, o.grpcMaxMessageSize)
+}
+
+func TestWithGRPCMaxMessageSize_ZeroValueIsInitialState(t *testing.T) {
+	var o clientOptions
+	// An unmodified clientOptions must start at zero; connectPlugin applies
+	// the default via resolveGRPCMaxMessageSize when the value is zero.
+	assert.Equal(t, 0, o.grpcMaxMessageSize)
+}
+
+func TestResolveGRPCMaxMessageSize(t *testing.T) {
+	defaultSize := settings.DefaultGRPCMaxMessageSize
+
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{name: "zero uses default", input: 0, want: defaultSize},
+		{name: "negative uses default", input: -1, want: defaultSize},
+		{name: "below minimum clamps to minimum", input: settings.MinGRPCMaxMessageSize - 1, want: settings.MinGRPCMaxMessageSize},
+		{name: "exactly minimum is accepted", input: settings.MinGRPCMaxMessageSize, want: settings.MinGRPCMaxMessageSize},
+		{name: "large value is accepted", input: 128 * 1024 * 1024, want: 128 * 1024 * 1024},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveGRPCMaxMessageSize(tc.input))
+		})
+	}
 }
 
 func TestPluginLogger_DefaultsToNullWhenNil(t *testing.T) {

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -715,21 +715,17 @@ func marshalSolutionMeta(ctx context.Context) *proto.SolutionMeta {
 // buildExecuteProviderRequest constructs an ExecuteProviderRequest with all
 // context values serialized from the Go context. Returns an error if any
 // required serialization fails.
+//
+// NOTE: Resolver context (_) is intentionally NOT sent to plugins. The engine
+// resolves all ValueRefs (expr:, rslvr:, tmpl:) before the gRPC call, so
+// plugins only need the concrete input values. Sending the full _ map would
+// bloat every request (often exceeding the gRPC 4MB default) and create an
+// implicit side-channel that bypasses the provider's declared input schema.
+// See: https://github.com/oakwood-commons/scafctl/issues/451
 func buildExecuteProviderRequest(ctx context.Context, providerName string, inputBytes []byte) (*proto.ExecuteProviderRequest, error) {
-	// Encode resolver context
-	contextData := make(map[string]any)
-	if resolverCtx, ok := provider.ResolverContextFromContext(ctx); ok {
-		contextData["resolverContext"] = resolverCtx
-	}
-	contextBytes, err := json.Marshal(contextData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode context: %w", err)
-	}
-
 	req := &proto.ExecuteProviderRequest{
 		ProviderName: providerName,
 		Input:        inputBytes,
-		Context:      contextBytes,
 		DryRun:       provider.DryRunFromContext(ctx),
 	}
 

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -257,6 +257,31 @@ func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 	var params map[string]any
 	require.NoError(t, json.Unmarshal(req.Parameters, &params))
 	assert.Equal(t, "us-east-1", params["region"])
+
+	// Resolver context must NOT be serialized into the request (issue #451).
+	// The engine resolves all ValueRefs before the gRPC call, so plugins
+	// only need concrete input values.
+	assert.Empty(t, req.Context, "resolver context should not be sent to plugins")
+}
+
+func TestBuildExecuteProviderRequest_ResolverContextPruned(t *testing.T) {
+	// Even with a large resolver context on the Go context, the gRPC request
+	// should not contain it. This prevents ResourceExhausted errors when the
+	// resolver context exceeds the gRPC max message size.
+	largeCtx := make(map[string]any, 100)
+	for i := range 100 {
+		largeCtx[fmt.Sprintf("resolver_%d", i)] = map[string]any{
+			"data": strings.Repeat("x", 10000),
+		}
+	}
+	ctx := provider.WithResolverContext(context.Background(), largeCtx)
+
+	req, err := buildExecuteProviderRequest(ctx, "test-provider", []byte(`{"key":"value"}`))
+	require.NoError(t, err)
+
+	assert.Empty(t, req.Context, "resolver context must not be serialized into plugin requests")
+	assert.Equal(t, "test-provider", req.ProviderName)
+	assert.JSONEq(t, `{"key":"value"}`, string(req.Input))
 }
 
 func TestHostServiceServer_SecretStore_Nil(t *testing.T) {
@@ -1002,6 +1027,8 @@ func BenchmarkBuildExecuteProviderRequest(b *testing.B) {
 	ctx = provider.WithWorkingDirectory(ctx, "/work")
 	ctx = provider.WithOutputDirectory(ctx, "/out")
 	ctx = provider.WithParameters(ctx, map[string]any{"region": "us-east-1"})
+	// Resolver context is set on the Go context but should NOT be serialized
+	// into the gRPC request (pruned per issue #451).
 	ctx = provider.WithResolverContext(ctx, map[string]any{"r1": map[string]any{"v": 1}})
 
 	inputBytes, _ := json.Marshal(map[string]any{"key": "value"})

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -161,6 +161,22 @@ const (
 	DefaultGoTemplateCacheSize = 10000
 )
 
+// Plugin defaults
+const (
+	// DefaultGRPCMaxMessageSize is the default maximum gRPC message size for
+	// plugin communication (64 MB). The Go gRPC library default is 4 MB, which
+	// is too small for solutions with legitimately large provider inputs or
+	// outputs (e.g., large HCL files, API responses). This applies to both
+	// send and receive directions.
+	DefaultGRPCMaxMessageSize = 64 * 1024 * 1024
+
+	// MinGRPCMaxMessageSize is the minimum accepted gRPC message size (1 MB).
+	// Values below this floor are treated as misconfiguration and the default
+	// is used instead. Matches the minimum:"1048576" validation tag on the
+	// config struct.
+	MinGRPCMaxMessageSize = 1024 * 1024
+)
+
 // API server defaults
 const (
 	// DefaultAPIPort is the default port for the API server.


### PR DESCRIPTION
The resolver context (`_`) was being included in every ExecuteProvider gRPC request, causing ResourceExhausted errors when solutions with many resolvers exceeded the 4 MB gRPC default message size limit.

- Remove `resolverContext` from `buildExecuteProviderRequest`; plugins receive only concrete input values, not the full resolver state -- the engine resolves all ValueRefs before any gRPC call is made
- Add `resolveGRPCMaxMessageSize` helper that applies a 64 MB default and enforces a 1 MB minimum floor, matching the `minimum:"1048576"` validation tag on the config struct
- Add `WithGRPCMaxMessageSize` client option and wire it through `connectPlugin` via `GRPCDialOptions`
- Expose `plugins.grpcMaxMessageSize` config field so operators can tune the host-side limit when needed
- Add `MinGRPCMaxMessageSize` and `DefaultGRPCMaxMessageSize` constants to `pkg/settings`
- Wire config-driven override in both API server and MCP server `buildPluginPool` / `buildMCPPluginPool`

Closes #451
