### PR TITLE
feat(provider): add relativeTo input to file provider for consistent path anchoring

### DIFF
--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -18,6 +18,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+
+	scafpath "github.com/oakwood-commons/scafctl/pkg/filepath"
 )
 
 // ProviderName is the name of this provider.
@@ -139,6 +141,19 @@ func NewFileProvider() *FileProvider {
 						"For example, with stripSuffix '.tmpl', 'main.go.tmpl' becomes 'main.go'. "+
 						"Applied before outputPath template if both are set.",
 					schemahelper.WithExample(".tmpl")),
+				"relativeTo": schemahelper.StringProp(
+					"Base directory anchor for relative path resolution. "+
+						"solution: resolve relative to the solution file's directory, bypassing the "+
+						"WorkingDirectory override set in action contexts -- useful for consistent reads and writes "+
+						"near the solution file regardless of where the CLI is invoked from. "+
+						"cwd: resolve relative to the process working directory. "+
+						"auto (default): uses --output-dir as anchor in action mode when set (with containment "+
+						"validation); otherwise WorkingDirectory takes precedence over SolutionDirectory. "+
+						"Note: solution and cwd anchors enforce --output-dir containment when --output-dir is set, "+
+						"returning an error if the resolved path would escape that directory.",
+					schemahelper.WithEnum("auto", "solution", "cwd"),
+					schemahelper.WithExample("solution"),
+					schemahelper.WithDefault("auto")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -250,6 +265,71 @@ func (p *FileProvider) Descriptor() *provider.Descriptor {
 	return p.descriptor
 }
 
+// resolvePathRel resolves a file path according to the relativeTo input.
+//
+//   - "solution": resolves relative to the solution file's directory,
+//     bypassing the WorkingDirectory override that is set in action contexts.
+//     Falls back to os.Getwd() when no solution directory is available (e.g.
+//     stdin / catalog runs without a bundle).
+//   - "cwd": resolves relative to the process working directory
+//     (WorkingDirectory from context, then os.Getwd()).
+//   - "auto" or "": delegates to provider.ResolvePath, which uses output-dir
+//     as the anchor in action mode when set, otherwise WorkingDirectory takes
+//     precedence over SolutionDirectory.
+//
+// For "solution" and "cwd", when the caller is in action mode with an
+// output-dir set, the resolved path is validated to ensure it does not escape
+// that output directory. This preserves the containment guarantee that
+// provider.ResolvePath provides for the "auto" path.
+func resolvePathRel(ctx context.Context, path, relativeTo string) (string, error) {
+	if filepath.IsAbs(path) || scafpath.HasWindowsDrivePrefix(path) ||
+		strings.HasPrefix(path, "/") || strings.HasPrefix(path, "\\") {
+		return filepath.Clean(path), nil
+	}
+
+	var resolved string
+	switch relativeTo {
+	case "solution":
+		if solDir, ok := provider.SolutionDirectoryFromContext(ctx); ok && solDir != "" {
+			resolved = filepath.Join(solDir, path)
+		} else {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return "", err
+			}
+			resolved = abs
+		}
+	case "cwd":
+		if cwd, ok := provider.WorkingDirectoryFromContext(ctx); ok && cwd != "" {
+			resolved = filepath.Join(cwd, path)
+		} else {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return "", err
+			}
+			resolved = abs
+		}
+	default: // "auto" or ""
+		return provider.ResolvePath(ctx, path)
+	}
+
+	// When output-dir is active in action mode, validate that the explicitly
+	// anchored path does not escape it. Mirrors the containment check that
+	// provider.ResolvePath performs for the "auto" path; gated on CapabilityAction
+	// to avoid spurious resolver failures when an output-dir happens to be set.
+	if mode, modeOK := provider.ExecutionModeFromContext(ctx); modeOK && mode == provider.CapabilityAction {
+		if outputDir, ok := provider.OutputDirectoryFromContext(ctx); ok && outputDir != "" {
+			resolved = filepath.Clean(resolved)
+			if err := provider.ValidatePathContainment(outputDir, resolved); err != nil {
+				return "", fmt.Errorf("path %q resolves to %q which is outside output directory %q: %w",
+					path, resolved, outputDir, err)
+			}
+		}
+	}
+
+	return filepath.Clean(resolved), nil
+}
+
 // Execute performs the filesystem operation.
 func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
@@ -265,9 +345,11 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName, "operation", operation)
 
+	relativeTo, _ := inputs["relativeTo"].(string)
+
 	// write-tree uses basePath instead of path
 	if operation == "write-tree" {
-		return p.executeWriteTreeDispatch(ctx, inputs)
+		return p.executeWriteTreeDispatch(ctx, inputs, relativeTo)
 	}
 
 	path, ok := inputs["path"].(string)
@@ -277,8 +359,8 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 
 	lgr.V(1).Info("executing file operation", "provider", ProviderName, "operation", operation, "path", path)
 
-	// Resolve path: in action mode with output-dir, resolves against output-dir; otherwise CWD
-	absPath, err := provider.ResolvePath(ctx, path)
+	// Resolve path honoring the relativeTo input.
+	absPath, err := resolvePathRel(ctx, path, relativeTo)
 	if err != nil {
 		return nil, fmt.Errorf("%s: invalid path: %w", ProviderName, err)
 	}
@@ -529,7 +611,7 @@ func (p *FileProvider) executeDelete(absPath string) (*provider.Output, error) {
 }
 
 // executeWriteTreeDispatch handles the write-tree operation routing (dry-run vs live).
-func (p *FileProvider) executeWriteTreeDispatch(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+func (p *FileProvider) executeWriteTreeDispatch(ctx context.Context, inputs map[string]any, relativeTo string) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
 	basePath, ok := inputs["basePath"].(string)
@@ -537,7 +619,7 @@ func (p *FileProvider) executeWriteTreeDispatch(ctx context.Context, inputs map[
 		return nil, fmt.Errorf("%s: basePath is required for write-tree operation", ProviderName)
 	}
 
-	absBasePath, err := provider.ResolvePath(ctx, basePath)
+	absBasePath, err := resolvePathRel(ctx, basePath, relativeTo)
 	if err != nil {
 		return nil, fmt.Errorf("%s: invalid basePath: %w", ProviderName, err)
 	}

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -2396,3 +2396,237 @@ func TestFileProvider_WhatIf_Operations(t *testing.T) {
 		})
 	}
 }
+
+// --- relativeTo tests ---
+
+func TestResolvePathRel_Auto_UsesResolvePath(t *testing.T) {
+	// "auto" (empty) should behave identically to provider.ResolvePath.
+	// When no WorkingDirectory or SolutionDirectory is in context, both
+	// resolve via os.Getwd().
+	ctx := context.Background()
+
+	got, err := resolvePathRel(ctx, "foo.txt", "auto")
+	require.NoError(t, err)
+
+	cwd, _ := os.Getwd()
+	assert.Equal(t, filepath.Join(cwd, "foo.txt"), got)
+}
+
+func TestResolvePathRel_Solution_UsesSolutionDir(t *testing.T) {
+	solDir := t.TempDir()
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	// Also set a WorkingDirectory to confirm it is ignored for "solution".
+	ctx = provider.WithWorkingDirectory(ctx, t.TempDir())
+
+	got, err := resolvePathRel(ctx, "output/result.yaml", "solution")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(solDir, "output/result.yaml"), got)
+}
+
+func TestResolvePathRel_Solution_FallsBackToCwd_WhenNoSolutionDir(t *testing.T) {
+	ctx := context.Background()
+
+	got, err := resolvePathRel(ctx, "output/result.yaml", "solution")
+	require.NoError(t, err)
+
+	cwd, _ := os.Getwd()
+	assert.Equal(t, filepath.Join(cwd, "output/result.yaml"), got)
+}
+
+func TestResolvePathRel_Cwd_UsesWorkingDirectory(t *testing.T) {
+	cwdDir := t.TempDir()
+	ctx := provider.WithWorkingDirectory(context.Background(), cwdDir)
+	// Also set a SolutionDirectory to confirm it is ignored for "cwd".
+	ctx = provider.WithSolutionDirectory(ctx, t.TempDir())
+
+	got, err := resolvePathRel(ctx, "out/file.txt", "cwd")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(cwdDir, "out/file.txt"), got)
+}
+
+func TestResolvePathRel_Cwd_FallsBackToOsGetwd_WhenNoContextCwd(t *testing.T) {
+	ctx := context.Background()
+
+	got, err := resolvePathRel(ctx, "out/file.txt", "cwd")
+	require.NoError(t, err)
+
+	cwd, _ := os.Getwd()
+	assert.Equal(t, filepath.Join(cwd, "out/file.txt"), got)
+}
+
+func TestResolvePathRel_AbsPath_ReturnedUnchanged(t *testing.T) {
+	solDir := t.TempDir()
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+
+	absPath := filepath.FromSlash("/absolute/path/to/file.txt")
+	for _, rel := range []string{"solution", "cwd", "auto", ""} {
+		got, err := resolvePathRel(ctx, absPath, rel)
+		require.NoError(t, err, "relativeTo=%q", rel)
+		assert.Equal(t, absPath, got, "relativeTo=%q", rel)
+	}
+}
+
+func TestFileProvider_Execute_Read_RelativeTo_Solution(t *testing.T) {
+	// Create a "solution directory" with a file inside it.
+	solDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(solDir, "data.txt"), []byte("from-solution-dir"), 0o600)
+	require.NoError(t, err)
+
+	// Simulate action context: WorkingDirectory points elsewhere.
+	otherDir := t.TempDir()
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	ctx = provider.WithWorkingDirectory(ctx, otherDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	p := NewFileProvider()
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "read",
+		"path":       "data.txt", // relative — without relativeTo this would look in otherDir
+		"relativeTo": "solution",
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, "from-solution-dir", data["content"])
+}
+
+func TestFileProvider_Execute_Read_RelativeTo_Auto_InActionContext_UsesCwd(t *testing.T) {
+	// Default (auto) in action context without --output-dir: WorkingDirectory wins.
+	solDir := t.TempDir()
+	cwdDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(cwdDir, "data.txt"), []byte("from-cwd"), 0o600)
+	require.NoError(t, err)
+
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	ctx = provider.WithWorkingDirectory(ctx, cwdDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	p := NewFileProvider()
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "read",
+		"path":      "data.txt",
+		// relativeTo not set → "auto" behaviour
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, "from-cwd", data["content"])
+}
+
+func TestFileProvider_WriteTree_RelativeTo_Solution(t *testing.T) {
+	// basePath is relative — with relativeTo:solution it should anchor to solDir.
+	solDir := t.TempDir()
+	cwdDir := t.TempDir()
+
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	ctx = provider.WithWorkingDirectory(ctx, cwdDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	p := NewFileProvider()
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "write-tree",
+		"basePath":   "generated",
+		"relativeTo": "solution",
+		"entries": []any{
+			map[string]any{"path": "hello.txt", "content": "world"},
+		},
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, filepath.Join(solDir, "generated"), data["basePath"])
+
+	content, err := os.ReadFile(filepath.Join(solDir, "generated", "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(content))
+}
+
+func TestFileProvider_Execute_Write_RelativeTo_Solution(t *testing.T) {
+	// The primary motivating use case from issue 448:
+	// an action write with relativeTo:solution anchors to the solution directory,
+	// not the CWD, even in action context where WorkingDirectory is set.
+	solDir := t.TempDir()
+	cwdDir := t.TempDir()
+
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	ctx = provider.WithWorkingDirectory(ctx, cwdDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	p := NewFileProvider()
+	result, err := p.Execute(ctx, map[string]any{
+		"operation":  "write",
+		"path":       "output/result.txt",
+		"content":    "from-solution-anchor",
+		"createDirs": true,
+		"relativeTo": "solution",
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	expectedPath := filepath.Join(solDir, "output/result.txt")
+	assert.Equal(t, expectedPath, data["path"])
+
+	// Verify the file landed in solDir, not cwdDir.
+	content, err := os.ReadFile(expectedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "from-solution-anchor", string(content))
+
+	// Verify file was NOT written to cwdDir.
+	_, statErr := os.Stat(filepath.Join(cwdDir, "output/result.txt"))
+	assert.True(t, os.IsNotExist(statErr), "file should not exist under cwdDir")
+}
+
+func TestResolvePathRel_OutputDir_ContainmentEnforced_Solution(t *testing.T) {
+	// When --output-dir is set and relativeTo is "solution", paths that
+	// escape the output-dir must be rejected.
+	solDir := t.TempDir()
+	outputDir := t.TempDir() // separate directory
+
+	// Anchoring to solDir with a traversal that would escape outputDir.
+	ctx := provider.WithSolutionDirectory(context.Background(), solDir)
+	ctx = provider.WithOutputDirectory(ctx, outputDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	// A plain relative path that resolves inside solDir (which is outside outputDir)
+	// should be rejected.
+	_, err := resolvePathRel(ctx, "output.txt", "solution")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "outside output directory")
+}
+
+func TestResolvePathRel_OutputDir_ContainmentEnforced_Cwd(t *testing.T) {
+	cwdDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	ctx := provider.WithWorkingDirectory(context.Background(), cwdDir)
+	ctx = provider.WithOutputDirectory(ctx, outputDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	_, err := resolvePathRel(ctx, "output.txt", "cwd")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "outside output directory")
+}
+
+func TestResolvePathRel_OutputDir_ContainmentAllowed_WhenInsideOutputDir(t *testing.T) {
+	// When the solution dir IS the output dir, resolution should succeed.
+	outputDir := t.TempDir()
+
+	ctx := provider.WithSolutionDirectory(context.Background(), outputDir)
+	ctx = provider.WithOutputDirectory(ctx, outputDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	got, err := resolvePathRel(ctx, "result.txt", "solution")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(outputDir, "result.txt"), got)
+}
+
+func TestResolvePathRel_Auto_NoOutputDirContainmentCheck(t *testing.T) {
+	// "auto" behaviour is unchanged: when output-dir is set it becomes the anchor
+	// and containment is checked by provider.ResolvePath, not by resolvePathRel.
+	outputDir := t.TempDir()
+	ctx := provider.WithOutputDirectory(context.Background(), outputDir)
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+
+	// provider.ResolvePath will anchor to outputDir and validate containment;
+	// traversal should be rejected.
+	_, err := resolvePathRel(ctx, "../../escape.txt", "auto")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "output directory")
+}

--- a/pkg/provider/path.go
+++ b/pkg/provider/path.go
@@ -97,9 +97,16 @@ func AbsFromContext(ctx context.Context, path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-// validatePathContainment verifies that resolved is inside or equal to baseDir.
+// ValidatePathContainment verifies that resolved is inside or equal to baseDir.
 // Both paths must already be cleaned/absolute. Symlinks in the resolved path are
 // evaluated to prevent escaping the base directory via symlink indirection.
+// Callers that need to validate paths outside this package (e.g. providers with
+// explicit relativeTo overrides) should use this function.
+func ValidatePathContainment(baseDir, resolved string) error {
+	return validatePathContainment(baseDir, resolved)
+}
+
+// validatePathContainment is the internal implementation.
 func validatePathContainment(baseDir, resolved string) error {
 	// Resolve symlinks on the base directory so comparisons are consistent.
 	realBase, err := evalSymlinksExisting(baseDir)

--- a/pkg/provider/path_test.go
+++ b/pkg/provider/path_test.go
@@ -201,6 +201,18 @@ func TestResolvePath_TraversalAttack(t *testing.T) {
 	}
 }
 
+func TestValidatePathContainment_ExportedWrapper(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Path inside baseDir must succeed.
+	inside := filepath.Join(baseDir, "sub", "file.txt")
+	require.NoError(t, ValidatePathContainment(baseDir, inside))
+
+	// Lexical traversal escaping baseDir must fail.
+	outside := filepath.Join(baseDir, "..", "escaped.txt")
+	assert.Error(t, ValidatePathContainment(baseDir, outside))
+}
+
 func TestValidatePathContainment_SymlinkEscape(t *testing.T) {
 	// Create a temp dir structure: baseDir/link -> /tmp (or another outside dir)
 	baseDir := t.TempDir()


### PR DESCRIPTION
Fixes the path resolution asymmetry between resolver and action contexts (issue #448). In resolver phase only SolutionDirectory is set, so relative paths anchor to the solution file. In action phase WithWorkingDirectory is injected, causing WorkingDirectory to win and silently shifting the anchor to the process CWD.

- Add relativeTo input (auto | solution | cwd) to the file provider schema for all operations (read, write, exists, delete, write-tree)
- solution: always anchors relative paths to the solution file directory, bypassing the WorkingDirectory override present in action contexts
- cwd: always anchors to the process working directory
- auto (default): preserves existing behaviour -- no breaking change
- Export ValidatePathContainment from pkg/provider for use by providers that resolve paths outside the standard ResolvePath flow
- Enforce --output-dir containment for solution and cwd anchors the same way provider.ResolvePath does for auto mode; path traversal that would escape the output sandbox is rejected with a descriptive error
- Strengthen absolute-path guard in resolvePathRel to match ResolvePath: include HasWindowsDrivePrefix and backslash-prefix checks

19 new tests covering unit resolution, integration read/write, output-dir containment enforcement, and cross-mode fallback behaviour.

Closes #448
