### PR TITLE
fix(mcp): reload config per-request so auth profile switches take effect

### DIFF
--- a/.github/instructions/go-testing.instructions.md
+++ b/.github/instructions/go-testing.instructions.md
@@ -34,6 +34,18 @@ go test -race ./...
 go test -cover ./...
 ```
 
+### Coverage Profile Output
+
+When generating coverage profiles (`-coverprofile`), always write to `temp/` (gitignored scratch directory). Never write coverage files to the repo root.
+
+```bash
+# Correct
+go test -coverprofile temp/cover.out ./pkg/some/package/...
+
+# Wrong -- pollutes repo root
+go test -coverprofile cover.out ./pkg/some/package/...
+```
+
 ### Coverage Targets
 
 | Code Type | Package Target | Patch Target |

--- a/pkg/mcp/config_reloader.go
+++ b/pkg/mcp/config_reloader.go
@@ -1,0 +1,65 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// configReloader provides cached, TTL-based config reloading from disk.
+// It avoids re-reading the config file on every MCP request while still
+// picking up changes (e.g. auth profile switches) within the TTL window.
+type configReloader struct {
+	mu       sync.Mutex
+	cached   *config.Config
+	loadedAt time.Time
+	ttl      time.Duration
+	logger   logr.Logger
+}
+
+// newConfigReloader creates a reloader that caches config for the given TTL.
+// An initial config snapshot may be provided; if nil, the first call to
+// Config() will load from disk.
+func newConfigReloader(initial *config.Config, ttl time.Duration, logger logr.Logger) *configReloader {
+	r := &configReloader{
+		cached: initial,
+		ttl:    ttl,
+		logger: logger,
+	}
+	if initial != nil {
+		r.loadedAt = time.Now()
+	}
+	return r
+}
+
+// Config returns the current configuration. If the cached value is older
+// than the TTL, the config is re-read from disk. If the disk read fails,
+// the stale cached value is returned (never returns nil if a prior load
+// succeeded).
+func (r *configReloader) Config() *config.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cached != nil && time.Since(r.loadedAt) < r.ttl {
+		return r.cached
+	}
+
+	// Reset the global singleton first so Global() re-reads from disk
+	// instead of returning its cached in-memory value.
+	config.ResetGlobal()
+
+	cfg, err := config.Global()
+	if err != nil {
+		r.logger.V(1).Info("config reload failed, using cached value", "error", err)
+		return r.cached
+	}
+
+	r.cached = cfg
+	r.loadedAt = time.Now()
+	return r.cached
+}

--- a/pkg/mcp/config_reloader_test.go
+++ b/pkg/mcp/config_reloader_test.go
@@ -1,0 +1,174 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigReloader(t *testing.T) {
+	t.Run("returns initial config within TTL", func(t *testing.T) {
+		initial := &config.Config{Version: 1}
+		r := newConfigReloader(initial, 10*time.Minute, logr.Discard())
+
+		got := r.Config()
+		require.NotNil(t, got)
+		assert.Equal(t, 1, got.Version)
+	})
+
+	t.Run("returns cached config when TTL not expired", func(t *testing.T) {
+		initial := &config.Config{Version: 1}
+		r := newConfigReloader(initial, 10*time.Minute, logr.Discard())
+
+		// Two successive calls should return the same pointer.
+		first := r.Config()
+		second := r.Config()
+		assert.Same(t, first, second)
+	})
+
+	t.Run("reloads from disk when TTL expired", func(t *testing.T) {
+		initial := &config.Config{Version: 1}
+		r := newConfigReloader(initial, 0, logr.Discard()) // TTL=0 → always stale
+
+		// Reset global so Global() tries to load fresh. With no config
+		// file on disk it will fail, falling back to the cached value.
+		config.ResetGlobal()
+
+		got := r.Config()
+		require.NotNil(t, got, "should return cached value when disk load fails")
+	})
+
+	t.Run("nil initial attempts disk load", func(t *testing.T) {
+		r := newConfigReloader(nil, 10*time.Minute, logr.Discard())
+		config.ResetGlobal()
+
+		// With no cached value, Config() attempts disk load via Global().
+		// If a config file exists on disk it returns it; otherwise nil.
+		// Either outcome is valid — the key invariant is no panic.
+		_ = r.Config()
+	})
+}
+
+func TestFreshConfigContext(t *testing.T) {
+	t.Run("overlays fresh config onto merged context", func(t *testing.T) {
+		initial := &config.Config{Version: 10}
+		srv, err := NewServer(
+			WithServerConfig(initial),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		ctx := srv.freshConfigContext(context.Background())
+		got := config.FromContext(ctx)
+		require.NotNil(t, got)
+		assert.Equal(t, 10, got.Version)
+	})
+
+	t.Run("nil reloader falls through to mergeContext", func(t *testing.T) {
+		initial := &config.Config{Version: 5}
+		srv, err := NewServer(
+			WithServerConfig(initial),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		// Force nil reloader to exercise fallback path.
+		srv.cfgReloader = nil
+
+		ctx := srv.freshConfigContext(context.Background())
+		got := config.FromContext(ctx)
+		require.NotNil(t, got)
+		assert.Equal(t, 5, got.Version)
+	})
+}
+
+func TestResolveConfig(t *testing.T) {
+	t.Run("delegates to reloader when present", func(t *testing.T) {
+		initial := &config.Config{Version: 42}
+		srv, err := NewServer(
+			WithServerConfig(initial),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		got := srv.resolveConfig()
+		require.NotNil(t, got)
+		assert.Equal(t, 42, got.Version)
+	})
+
+	t.Run("falls back to s.config when reloader is nil", func(t *testing.T) {
+		cfg := &config.Config{Version: 7}
+		srv, err := NewServer(
+			WithServerConfig(cfg),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+		srv.cfgReloader = nil
+
+		got := srv.resolveConfig()
+		require.NotNil(t, got)
+		assert.Equal(t, 7, got.Version)
+	})
+
+	t.Run("falls back to context config when reloader and s.config are nil", func(t *testing.T) {
+		ctxCfg := &config.Config{Version: 3}
+		ctx := config.WithConfig(context.Background(), ctxCfg)
+		srv, err := NewServer(
+			WithServerName("testcli"),
+			WithServerContext(ctx),
+		)
+		require.NoError(t, err)
+		srv.cfgReloader = nil
+		srv.config = nil
+
+		got := srv.resolveConfig()
+		require.NotNil(t, got)
+		assert.Equal(t, 3, got.Version)
+	})
+
+	t.Run("falls back to Global when all else is nil", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+		srv.cfgReloader = nil
+		srv.config = nil
+		srv.ctx = context.Background() // no config in context
+
+		// Global() may or may not find a config file on disk.
+		// The key invariant is no panic.
+		config.ResetGlobal()
+		_ = srv.resolveConfig()
+	})
+
+	t.Run("returns nil when everything fails", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+		srv.cfgReloader = nil
+		srv.config = nil
+		srv.ctx = nil // nil context triggers Global() fallback
+
+		config.ResetGlobal()
+		// With no config file on disk, Global() will fail.
+		// resolveConfig should return nil gracefully.
+		_ = srv.resolveConfig()
+	})
+}
+
+func BenchmarkConfigReloader_CachedHit(b *testing.B) {
+	r := newConfigReloader(&config.Config{Version: 1}, 10*time.Minute, logr.Discard())
+	b.ResetTimer()
+	for range b.N {
+		r.Config()
+	}
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -27,6 +27,11 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
+// configReloaderTTL is how long the MCP server caches config before
+// re-reading from disk. Keeps long-lived sessions responsive to config
+// changes (e.g. auth profile switches) without hitting disk every request.
+const configReloaderTTL = 2 * time.Second
+
 // Server wraps the mcp-go MCPServer and holds shared dependencies
 // that tool handlers need.
 type Server struct {
@@ -57,6 +62,10 @@ type Server struct {
 	// initialization and idle eviction. When set, provider tool handlers
 	// auto-resolve official plugins on demand.
 	pluginPool *plugin.Pool
+
+	// cfgReloader provides TTL-based config reloading so long-lived MCP
+	// sessions pick up config changes (e.g. auth profile switches).
+	cfgReloader *configReloader
 
 	// descriptorCache persists provider descriptors to disk so schemas
 	// are available without spawning plugin processes.
@@ -451,15 +460,19 @@ func buildInstructions(name, supplemental string) string {
 	return base + "\n\n" + supplemental
 }
 
-// resolveConfig returns the effective configuration by checking, in order:
+// resolveConfig returns the effective configuration. When a config reloader
+// is present (normal operation), it delegates to the reloader which applies
+// TTL-based caching and re-reads from disk as needed. This ensures long-lived
+// MCP sessions pick up config changes (e.g. auth profile switches).
+//
+// Fallback order when no reloader is set (e.g. tests):
 //  1. s.config (set during NewServer via WithServerConfig)
 //  2. config.FromContext(s.ctx) (set during PersistentPreRun)
 //  3. config.Global() (loads from disk)
-//
-// This ensures catalog-related handlers see the same config as get_config,
-// even when the MCP server was created without an explicit config reference
-// (e.g. config file doesn't exist at startup but is created later).
 func (s *Server) resolveConfig() *config.Config {
+	if s.cfgReloader != nil {
+		return s.cfgReloader.Config()
+	}
 	if s.config != nil {
 		return s.config
 	}
@@ -560,6 +573,15 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		s.logger = logr.Discard()
 	}
 
+	// Initialize the config reloader so long-lived MCP sessions pick up
+	// config changes from disk (e.g. auth profile switches via CLI).
+	// Seed with the best available initial config: explicit → context → nil.
+	initialCfg := cfg.config
+	if initialCfg == nil {
+		initialCfg = config.FromContext(s.ctx)
+	}
+	s.cfgReloader = newConfigReloader(initialCfg, configReloaderTTL, s.logger)
+
 	// Build server options for mcp-go
 	serverOpts := []server.ServerOption{
 		server.WithToolCapabilities(true),
@@ -618,6 +640,19 @@ func (s *Server) Close() {
 	// No-op currently; kept for future resource cleanup and API stability.
 }
 
+// freshConfigContext returns a context with the latest config overlaid.
+// Called per-request by each transport's context func so that tool handlers
+// always see up-to-date configuration (e.g. after an auth profile switch).
+func (s *Server) freshConfigContext(ctx context.Context) context.Context {
+	merged := mergeContext(ctx, s.ctx)
+	if s.cfgReloader != nil {
+		if cfg := s.cfgReloader.Config(); cfg != nil {
+			return config.WithConfig(merged, cfg)
+		}
+	}
+	return merged
+}
+
 // Serve starts the MCP server on stdio transport (blocking).
 // Server context values (auth registry, config, settings, logger) are
 // automatically injected into the transport's request context so that
@@ -625,7 +660,7 @@ func (s *Server) Close() {
 // MCPServer().AddTool() -- can access them.
 func (s *Server) Serve(opts ...server.StdioOption) error {
 	contextOpt := server.WithStdioContextFunc(func(ctx context.Context) context.Context {
-		return mergeContext(ctx, s.ctx)
+		return s.freshConfigContext(ctx)
 	})
 	allOpts := make([]server.StdioOption, len(opts)+1)
 	copy(allOpts, opts)
@@ -637,7 +672,7 @@ func (s *Server) Serve(opts ...server.StdioOption) error {
 // Server context values are injected into every request context (see Serve).
 func (s *Server) ServeSSE(addr string, opts ...server.SSEOption) error {
 	contextOpt := server.WithSSEContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
-		return mergeContext(ctx, s.ctx)
+		return s.freshConfigContext(ctx)
 	})
 	allOpts := make([]server.SSEOption, len(opts)+1)
 	copy(allOpts, opts)
@@ -651,7 +686,7 @@ func (s *Server) ServeSSE(addr string, opts ...server.SSEOption) error {
 // Server context values are injected into every request context (see Serve).
 func (s *Server) ServeHTTP(addr string, opts ...server.StreamableHTTPOption) error {
 	contextOpt := server.WithHTTPContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
-		return mergeContext(ctx, s.ctx)
+		return s.freshConfigContext(ctx)
 	})
 	allOpts := make([]server.StreamableHTTPOption, len(opts)+1)
 	copy(allOpts, opts)
@@ -670,7 +705,7 @@ func (s *Server) Handler(opts ...server.StreamableHTTPOption) http.Handler {
 		return s.httpServer
 	}
 	contextOpt := server.WithHTTPContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
-		return mergeContext(ctx, s.ctx)
+		return s.freshConfigContext(ctx)
 	})
 	allOpts := make([]server.StreamableHTTPOption, len(opts)+1)
 	copy(allOpts, opts)

--- a/pkg/solution/get/resolve.go
+++ b/pkg/solution/get/resolve.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	pathlib "path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/filepath"
@@ -150,6 +151,16 @@ func (o *Getter) FindAllSolutions() []DiscoveryResult {
 				})
 			}
 		}
+	}
+
+	// When in action mode, ensure action files sort before solution files
+	// regardless of folder priority. Without this, a solution.yaml in a
+	// higher-priority folder (e.g. scafctl/) would beat an actions.yaml
+	// in the root directory.
+	if o.discoveryMode == settings.DiscoveryModeAction && len(results) > 1 {
+		sort.SliceStable(results, func(i, j int) bool {
+			return results[i].IsActionFile && !results[j].IsActionFile
+		})
 	}
 
 	// Update lastDiscovery with first result for backward compatibility.

--- a/pkg/solution/get/resolve_test.go
+++ b/pkg/solution/get/resolve_test.go
@@ -146,6 +146,60 @@ func TestFindAllSolutions(t *testing.T) {
 		disc := getter.LastDiscoveryResult()
 		assert.Equal(t, results[0].Path, disc.Path)
 	})
+
+	t.Run("action mode prioritizes action files over subfolder solution files", func(t *testing.T) {
+		t.Parallel()
+		// Simulates: scafctl/solution.yaml exists in a higher-priority folder,
+		// actions.yaml exists at root. In action mode, actions.yaml should
+		// be returned first despite folder ordering.
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"actions.yaml":          true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeAction),
+		)
+		results := getter.FindAllSolutions()
+
+		require.Len(t, results, 2)
+		assert.Equal(t, "actions.yaml", results[0].Path, "action file should come first in action mode")
+		assert.True(t, results[0].IsActionFile)
+		assert.Equal(t, "scafctl/solution.yaml", results[1].Path)
+		assert.False(t, results[1].IsActionFile)
+	})
+
+	t.Run("default mode does not reorder action files", func(t *testing.T) {
+		t.Parallel()
+		// In default mode, folder priority should be preserved — scafctl/
+		// folder files come before root files.
+		existingFiles := map[string]bool{
+			"scafctl/solution.yaml": true,
+			"actions.yaml":          true,
+		}
+		customStatFunc := func(path string) (os.FileInfo, error) {
+			if existingFiles[path] {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("not found")
+		}
+
+		getter := NewGetter(
+			WithStatFunc(customStatFunc),
+			WithDiscoveryMode(settings.DiscoveryModeDefault),
+		)
+		results := getter.FindAllSolutions()
+
+		require.Len(t, results, 2)
+		assert.Equal(t, "scafctl/solution.yaml", results[0].Path, "subfolder should come first in default mode")
+	})
 }
 
 func TestResolve(t *testing.T) {


### PR DESCRIPTION
- add configReloader with mutex-guarded TTL-based caching (2s) that re-reads config from disk when stale
- replace frozen mergeContext calls in all four transports (stdio, SSE, HTTP, Handler) with freshConfigContext
- update resolveConfig to delegate to reloader first, preserving fallback chain for tests
- fix action-mode discovery to prioritize action files over subfolder solution files via stable sort
- add coverage profile output path guidance to go-testing instructions to prevent stray files in repo root

Closes #450
