### PR TITLE
feat(celexp): add CEL cost limit diagnostics, configurable threshold, and arrays.groupBy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 
 ```bash
 # Build
-go build -ldflags "-s -w -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X main.BuildVersion=dev -X main.Commit=$(git rev-parse HEAD)" -o dist/scafctl ./cmd/scafctl/scafctl.go
+go build -ldflags "-w -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X main.BuildVersion=dev -X main.Commit=$(git rev-parse HEAD)" -o dist/scafctl ./cmd/scafctl/scafctl.go
 
 # Test
 go test ./...                    # Run all tests

--- a/.github/instructions/cel-extensions.instructions.md
+++ b/.github/instructions/cel-extensions.instructions.md
@@ -1,0 +1,162 @@
+---
+description: "CEL extension function rules for scafctl. Covers file layout, ExtFunction struct, naming, types, conversion, error handling, registration, testing, and documentation. Use when creating or editing CEL extension functions."
+applyTo: "pkg/celexp/ext/**/*.go"
+---
+
+# CEL Extension Functions
+
+CEL extensions are custom functions that extend the CEL expression language
+with scafctl-specific capabilities. They are registered at startup and
+available in all CEL evaluation contexts (resolvers, conditions, transforms).
+
+## File Layout
+
+```
+pkg/celexp/ext/<namespace>/
+    <func>.go           # Function implementation
+    <func>_test.go      # Tests + benchmarks
+```
+
+One file per function (or per closely related group). The namespace directory
+matches the CEL function prefix (e.g., `arrays/` for `arrays.*` functions).
+
+## ExtFunction Struct
+
+Every function returns `celexp.ExtFunction` from a constructor:
+
+```go
+func GroupByFunc() celexp.ExtFunction {
+    funcName := "arrays.groupBy"
+    return celexp.ExtFunction{
+        Name:          funcName,
+        Signature:     "arrays.groupBy(list<map<string,dyn>>, string) -> map<string, list<map<string,dyn>>>",
+        Description:   "Groups a list of objects by a field value. Use arrays.groupBy(list, fieldName) to create a map of grouped items",
+        FunctionNames: []string{funcName},
+        Custom:        true,
+        Examples: []celexp.Example{
+            {
+                Description: "Group items by category",
+                Expression:  `arrays.groupBy([{"name": "a", "cat": "x"}, {"name": "b", "cat": "x"}], "cat")`,
+            },
+        },
+        EnvOptions: []cel.EnvOption{
+            cel.Function(funcName,
+                cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+                    []*cel.Type{/* input types */},
+                    /* return type */,
+                    cel.BinaryBinding(func(arg1, arg2 ref.Val) ref.Val {
+                        // implementation
+                    }),
+                ),
+            ),
+        },
+    }
+}
+```
+
+## Naming Conventions
+
+| Convention | Rule | Example |
+|-----------|------|---------|
+| Function name | `<namespace>.<camelCase>` | `arrays.groupBy`, `map.fromEntries` |
+| Constructor | `<PascalCase>Func()` | `GroupByFunc()`, `FromEntriesFunc()` |
+| Overload ID | `strings.ReplaceAll(funcName, ".", "_")` | `arrays_groupBy` |
+| Custom flag | Always `true` for scafctl functions | `Custom: true` |
+
+## CEL Type Patterns
+
+Common type signatures for list/map operations:
+
+```go
+// Input: list of objects
+cel.ListType(cel.MapType(cel.StringType, cel.DynType))
+
+// Input: list of strings
+cel.ListType(cel.StringType)
+
+// Output: map with string keys
+cel.MapType(cel.StringType, cel.DynType)
+
+// Output: map with list values
+cel.MapType(cel.StringType, cel.ListType(cel.MapType(cel.StringType, cel.DynType)))
+```
+
+## Conversion Helpers
+
+Use helpers from `pkg/celexp/conversion/` for Go <-> CEL type conversion:
+
+```go
+// CEL list -> Go slice of maps
+items, err := conversion.ListToObjectSlice(listVal)
+
+// CEL list -> Go slice of strings
+strs, err := conversion.ListToStringSlice(listVal)
+
+// Go value -> CEL value
+return types.DefaultTypeAdapter.NativeToValue(result)
+
+// Go value -> CEL ref.Val (deep conversion)
+return conversion.GoToCelValue(result)
+```
+
+## Binding Types
+
+| Args | Binding | Use |
+|------|---------|-----|
+| 1 | `cel.UnaryBinding(func(ref.Val) ref.Val)` | Single argument |
+| 2 | `cel.BinaryBinding(func(ref.Val, ref.Val) ref.Val)` | Two arguments |
+| 3+ | `cel.FunctionBinding(func(...ref.Val) ref.Val)` | Variadic |
+
+## Error Handling
+
+Return errors via `types.NewErr` with the function name prefix:
+
+```go
+return types.NewErr("arrays.groupBy: expected string key, got %s", val.Type())
+return types.NewErr("arrays.groupBy: %s", err.Error())
+```
+
+Do NOT panic or return Go errors. CEL functions must return `ref.Val`.
+
+## Registration
+
+Add the function to `Custom()` in `pkg/celexp/ext/ext.go` under the
+appropriate namespace comment:
+
+```go
+func Custom() celexp.ExtFunctionList {
+    funcs := celexp.ExtFunctionList{
+        // Arrays functions
+        arrays.StringAddFunc(),
+        arrays.StringsUniqueFunc(),
+        arrays.GroupByFunc(),          // <-- add here
+        // ...
+    }
+```
+
+## Testing
+
+- Table-driven tests covering: happy path, empty input, error cases, edge cases
+- Benchmark test for performance-critical functions
+- Test CEL evaluation end-to-end (compile + eval), not just the Go function
+
+```go
+func TestGroupByFunc(t *testing.T) {
+    fn := arrays.GroupByFunc()
+    env, _ := cel.NewEnv(fn.EnvOptions...)
+    // compile and eval with test data
+}
+
+func BenchmarkGroupByFunc(b *testing.B) {
+    // setup once, eval in loop
+}
+```
+
+## Documentation
+
+After adding a function, update the cel-patterns skill:
+`.github/skills/cel-patterns/SKILL.md` -- add the function under the correct
+namespace heading in "Custom scafctl Functions".
+
+Only document implemented functions. Never add planned/aspirational functions
+to the skill file.

--- a/.github/skills/cel-patterns/SKILL.md
+++ b/.github/skills/cel-patterns/SKILL.md
@@ -100,60 +100,103 @@ cel.bind(x, _.long_expression, x + "_suffix")  // Bind intermediate values
 
 ## Custom scafctl Functions
 
-Registered via `ext.Custom()` in `pkg/celexp/ext/`:
+Registered via `ext.Custom()` in `pkg/celexp/ext/`. Only functions listed here
+are implemented. Check `ext.Custom()` for the authoritative list.
 
-### Regex
+### Arrays (`pkg/celexp/ext/arrays/`)
 
 ```cel
-regex.match("^[a-z]+$", _.name)           // Boolean match
-regex.replace("[0-9]+", _.input, "X")     // Replace matches
-regex.findAll("[a-z]+", _.input)          // List of matches
-regex.split("[,;]", _.input)              // Split by pattern
+arrays.strings.add(["a", "b"], "c")       // Append string -> ["a","b","c"]
+arrays.strings.unique(["a", "b", "a"])     // Deduplicate -> ["a","b"]
+arrays.groupBy([{"k":"a","v":1},{"k":"b","v":2},{"k":"a","v":3}], "k")
+// -> {"a": [{"k":"a","v":1},{"k":"a","v":3}], "b": [{"k":"b","v":2}]}
+// O(n) single-pass grouping -- avoids quadratic CEL comprehension cost
 ```
 
-### Arrays
+### Debug (`pkg/celexp/ext/debug/`)
 
 ```cel
-arrays.groupBy(_.items, "category")       // Group by field -> map
-arrays.from(5, i, i * 2)                 // Generate: [0,2,4,6,8]
-arrays.partition(_.items, 3)              // Chunk into groups of 3
-arrays.window(_.items, 2)                 // Sliding window of size 2
+debug.out(_.value)                         // Print value to writer (requires Writer)
+debug.throw("something went wrong")       // Throw error for debugging
+debug.sleep(1000)                          // Sleep N milliseconds (testing only)
 ```
 
-### Map
+Note: `debug.out` is NOT included in `ext.Custom()` / `ext.All()` because it
+requires a Writer parameter. It is added separately via `debug.DebugOutFunc(w)`.
+
+### Filepath (`pkg/celexp/ext/filepath/`)
 
 ```cel
-map.toMap(_.pairs, "key", "value")        // List of objects -> map
-map.keys(_.config)                        // List of keys
-map.values(_.config)                      // List of values
+filepath.dir("/path/to/file.txt")          // Directory: "/path/to"
+filepath.normalize("path//to/../file")     // Clean path
+filepath.exists("/path/to/file")           // File exists check
+filepath.join("path", "to", "file")        // Join segments
 ```
 
-### GUID
+### GUID (`pkg/celexp/ext/guid/`)
 
 ```cel
-guid.new()                                // UUID v4
+guid.new()                                 // UUID v4
 ```
 
-### Time
+### Map (`pkg/celexp/ext/map/`)
 
 ```cel
-time.now()                                // Current timestamp
-time.toDate("2024-01-15T00:00:00Z")      // Parse ISO date
-time.formatDate(_.timestamp, "2006-01-02") // Format date
-time.parseDate("2024-01-15", "2006-01-02") // Parse with layout
+map.add(_.config, "key", "value")          // Add key-value pair
+map.addFailIfExists(_.m, "k", "v")         // Add, error if key exists
+map.addIfMissing(_.m, "k", "v")            // Add only if key missing
+map.select(_.config, ["key1", "key2"])     // Pick keys
+map.omit(_.config, ["secret"])             // Remove keys
+map.merge(_.base, _.overrides)             // Merge maps (right wins)
+map.recurse(_.nested, "children", expr)    // Recursive tree operation
+map.fromEntries(_.list, "name")            // List of objects -> map keyed by field
 ```
 
-### Sort
+### Marshalling (`pkg/celexp/ext/marshalling/`)
 
 ```cel
-sort.sortBy(_.items, "name")              // Sort objects by field
+json.marshal(_.data)                       // Compact JSON string
+json.marshalPretty(_.data)                 // Pretty-printed JSON
+json.unmarshal(_.jsonString)               // Parse JSON string
+yaml.marshal(_.data)                       // YAML string
+yaml.unmarshal(_.yamlString)               // Parse YAML string
 ```
 
-### Output
+### Output (`pkg/celexp/ext/out/`)
 
 ```cel
-out.print("Processing: " + _.name)        // Print to terminal
-debug.debug("Debug value: " + string(_.x)) // Debug output
+out.nil()                                  // Returns null value
+```
+
+### Regex (`pkg/celexp/ext/regex/`)
+
+```cel
+regex.match("^[a-z]+$", _.name)            // Boolean match
+regex.replace("[0-9]+", _.input, "X")      // Replace matches
+regex.findAll("[a-z]+", _.input)           // List of matches
+regex.split("[,;]", _.input)               // Split by pattern
+```
+
+### Sort (`pkg/celexp/ext/sort/`)
+
+```cel
+sort.objects(_.items, "name")              // Sort objects by field (ascending)
+sort.objectsDescending(_.items, "score")   // Sort objects by field (descending)
+```
+
+### Strings (`pkg/celexp/ext/strings/`)
+
+```cel
+strings.clean(_.messy)                     // Normalize whitespace
+strings.title(_.name)                      // Title Case
+strings.repeat(_.char, 5)                  // Repeat string N times
+```
+
+### Time (`pkg/celexp/ext/time/`)
+
+```cel
+time.now()                                 // Current UTC timestamp (RFC3339)
+time.nowFmt("2006-01-02")                  // Current time with Go layout format
 ```
 
 ## Common Patterns
@@ -220,3 +263,39 @@ has(_.config) && has(_.config.database) && has(_.config.database.host)
 - `pkg/celexp/env/`: CEL environment setup, extension loading, caching
 - `pkg/celexp/ext/`: Custom function registration (regex, arrays, map, guid, time, sort, out)
 - `pkg/provider/builtin/celprovider/`: CEL provider for transform phase
+
+## Cost Limits
+
+CEL expressions have a runtime cost limit (default: 1,000,000) to prevent
+runaway computations. The limit is enforced by cel-go's cost tracker.
+
+### Error Diagnostics
+
+When a cost limit is exceeded, the error includes actual cost, limit, and expression:
+
+```
+CEL expression cost limit exceeded (actual cost: 1500000, limit: 1000000)
+for expression "[large].map(x, x.filter(...))": runtime cost limit exceeded
+```
+
+### Per-Solution Override
+
+Solutions can lower the cost limit via `spec.options.cel.costLimit`:
+
+```yaml
+spec:
+  options:
+    cel:
+      costLimit: 500000  # Tighter limit for this solution
+```
+
+The effective limit is `min(solutionLimit, globalLimit)` -- solutions cannot
+raise the limit above the operator-configured global default.
+
+### Avoiding High-Cost Patterns
+
+| Pattern | Cost | Alternative |
+|---------|------|-------------|
+| `list.filter(x, list2.exists(y, ...))` | O(n*m) | Use `arrays.groupBy` + lookup |
+| `list.map(x, list.filter(...))` | O(n^2) | Pre-group with `arrays.groupBy` |
+| Nested `map` + `filter` | Multiplicative | Single-pass with custom extension |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,6 @@ builds:
       - arm64
     ldflags:
           - -w
-          - -s
           - -X main.Commit={{.Commit}}
           - -X main.BuildVersion={{.Version}}
           - -X main.BuildTime={{.Date}}

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 
 	"github.com/google/cel-go/cel"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/conversion"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
@@ -196,6 +198,12 @@ type compileConfig struct {
 func WithContext(ctx context.Context) Option {
 	return func(c *compileConfig) {
 		c.ctx = ctx
+		// Propagate context-level cost limit so that callers using
+		// WithContext alone (e.g. provider input resolution) honour
+		// the solution-level limit without an explicit WithCostLimit.
+		if limit, ok := CostLimitFromContext(ctx); ok && limit > 0 {
+			c.costLimit = &limit
+		}
 	}
 }
 
@@ -315,6 +323,10 @@ type CompileResult struct {
 	// Expression is the original expression that was compiled
 	Expression Expression
 
+	// costLimit is the cost limit applied during compilation.
+	// Used to enrich error messages when cost is exceeded.
+	costLimit uint64
+
 	// declaredVars maps variable names to their declared CEL types.
 	// This is populated during compilation and used for runtime type validation.
 	// Use ValidateVars() to check if evaluation variables match these declarations.
@@ -405,6 +417,7 @@ func (e Expression) Compile(envOpts []cel.EnvOption, opts ...Option) (*CompileRe
 		return &CompileResult{
 			Program:      prog,
 			Expression:   e,
+			costLimit:    *config.costLimit,
 			declaredVars: nil, // Use CompileWithVarDecls() for variable type tracking
 			envOpts:      envOpts,
 		}, nil
@@ -460,6 +473,7 @@ func (e Expression) Compile(envOpts []cel.EnvOption, opts ...Option) (*CompileRe
 	return &CompileResult{
 		Program:      prog,
 		Expression:   e,
+		costLimit:    *config.costLimit,
 		declaredVars: nil, // Use CompileWithVarDecls() for variable type tracking
 		envOpts:      envOpts,
 	}, nil
@@ -508,8 +522,22 @@ func (r *CompileResult) EvalWithContext(ctx context.Context, vars map[string]any
 		return nil, err
 	}
 
-	out, _, err := r.Program.ContextEval(ctx, vars)
+	out, details, err := r.Program.ContextEval(ctx, vars)
 	if err != nil {
+		// Enrich cost-limit errors with actual cost vs limit
+		if r.costLimit > 0 && isCostLimitError(err) {
+			actualCost := uint64(0)
+			if details != nil {
+				if ac := details.ActualCost(); ac != nil {
+					actualCost = *ac
+				}
+			}
+			return nil, fmt.Errorf(
+				"CEL expression cost limit exceeded (actual cost: %d, limit: %d) for expression %q: %w",
+				actualCost, r.costLimit, r.Expression, err,
+			)
+		}
+
 		// Enhanced error with variable type information
 		varTypes := make(map[string]string)
 		for k, v := range vars {
@@ -535,7 +563,27 @@ func (r *CompileResult) EvalWithContext(ctx context.Context, vars map[string]any
 		)
 	}
 
+	// Log actual cost at debug level for proactive optimization
+	if r.costLimit > 0 && details != nil {
+		if ac := details.ActualCost(); ac != nil {
+			lgr := logger.FromContext(ctx)
+			lgr.V(2).Info("CEL expression evaluated",
+				"expression", truncateExpr(string(r.Expression), 120),
+				"actualCost", *ac,
+				"costLimit", r.costLimit,
+			)
+		}
+	}
+
 	return out.Value(), nil
+}
+
+// isCostLimitError checks if an evaluation error is a cost limit exceeded error.
+// NOTE: cel-go does not export a structured error type for cost limit violations,
+// so we rely on matching the error message string. If cel-go changes the wording
+// of "cost limit" in its error, this function will need updating.
+func isCostLimitError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "cost limit")
 }
 
 // EvalAs evaluates the compiled CEL program and converts the result to the specified type T.

--- a/pkg/celexp/celexp_context_test.go
+++ b/pkg/celexp/celexp_context_test.go
@@ -231,3 +231,43 @@ func BenchmarkCompile_WithContext(b *testing.B) {
 		_, _ = expr.Compile(envOpts, WithContext(ctx))
 	}
 }
+
+func TestWithContext_PropagatesCostLimit(t *testing.T) {
+	t.Run("context cost limit applied via WithContext", func(t *testing.T) {
+		ctx := ContextWithCostLimit(context.Background(), 1)
+		expr := Expression("[1,2,3,4,5].map(x, x * 2)")
+
+		result, err := expr.Compile(nil, WithContext(ctx))
+		require.NoError(t, err)
+
+		_, err = result.EvalWithContext(ctx, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cost limit")
+	})
+
+	t.Run("explicit WithCostLimit overrides context limit", func(t *testing.T) {
+		// Context has a very low limit that would fail
+		ctx := ContextWithCostLimit(context.Background(), 1)
+		expr := Expression("[1,2,3,4,5].map(x, x * 2)")
+
+		// Explicit WithCostLimit with a high limit should succeed
+		result, err := expr.Compile(nil, WithContext(ctx), WithCostLimit(1000000))
+		require.NoError(t, err)
+
+		val, err := result.EvalWithContext(ctx, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("no context limit uses global default", func(t *testing.T) {
+		ctx := context.Background()
+		expr := Expression("1 + 2")
+
+		result, err := expr.Compile(nil, WithContext(ctx))
+		require.NoError(t, err)
+
+		val, err := result.Eval(nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), val)
+	})
+}

--- a/pkg/celexp/celexp_new_test.go
+++ b/pkg/celexp/celexp_new_test.go
@@ -207,7 +207,7 @@ func TestTypeConversionHelpers(t *testing.T) {
 
 // TestCostLimitProtection tests that cost limits prevent expensive expressions
 func TestCostLimitProtection(t *testing.T) {
-	t.Run("very low cost limit triggers error", func(t *testing.T) {
+	t.Run("very low cost limit triggers error with diagnostics", func(t *testing.T) {
 		// Create an expression that will exceed a very low cost limit
 		expr := Expression("[1,2,3,4,5].map(x, x * 2)")
 		lowCost := uint64(1) // Extremely low limit
@@ -221,8 +221,11 @@ func TestCostLimitProtection(t *testing.T) {
 		// Evaluation should fail due to cost limit
 		_, err = result.Eval(nil)
 		assert.Error(t, err)
-		// The error contains "operation cancelled" when cost limit exceeded
-		assert.Contains(t, err.Error(), "cost limit")
+		// The enriched error should contain actual cost, limit, and the expression
+		assert.Contains(t, err.Error(), "cost limit exceeded")
+		assert.Contains(t, err.Error(), "actual cost:")
+		assert.Contains(t, err.Error(), "limit: 1")
+		assert.Contains(t, err.Error(), "[1,2,3,4,5].map(x, x * 2)")
 	})
 
 	t.Run("reasonable cost limit allows normal expressions", func(t *testing.T) {

--- a/pkg/celexp/context.go
+++ b/pkg/celexp/context.go
@@ -50,6 +50,23 @@ const (
 	VarPlan = "__plan"
 )
 
+type costLimitContextKey struct{}
+
+// ContextWithCostLimit returns a new context with a solution-level CEL cost limit.
+// This allows solutions to override the global default cost limit for all CEL
+// evaluations within their scope. The caller is responsible for clamping to the
+// global limit before calling this function (see execute.ApplySolutionCELCostLimit).
+func ContextWithCostLimit(ctx context.Context, limit uint64) context.Context {
+	return context.WithValue(ctx, costLimitContextKey{}, limit)
+}
+
+// CostLimitFromContext returns the solution-level cost limit from context, if set.
+// Returns 0, false if no solution-level override is present.
+func CostLimitFromContext(ctx context.Context) (uint64, bool) {
+	v, ok := ctx.Value(costLimitContextKey{}).(uint64)
+	return v, ok
+}
+
 // BuildCELContext creates CEL environment options and variables for evaluation.
 // This is a common pattern used throughout scafctl for setting up CEL execution contexts.
 //
@@ -153,17 +170,20 @@ func EvaluateExpression(
 	// and additional variables at top level
 	envOpts, celVars := BuildCELContext(rootData, additionalVars)
 
-	// Create expression and add WithContext to the compile options
+	// Create expression and add WithContext to the compile options.
+	// WithContext propagates context-level cost limits automatically;
+	// explicit caller opts are appended last so they can override.
 	expr := Expression(exprStr)
 	compileOpts := append([]Option{WithContext(ctx)}, opts...)
+
 	compiled, err := expr.Compile(envOpts, compileOpts...)
 	if err != nil {
 		availableVars := describeAvailableVars(rootData, additionalVars)
 		return nil, fmt.Errorf("failed to compile expression %q: %w\nAvailable variables: %s", exprStr, err, availableVars)
 	}
 
-	// Evaluate the expression
-	result, err := compiled.Eval(celVars)
+	// Evaluate the expression with context for cost tracking and cancellation
+	result, err := compiled.EvalWithContext(ctx, celVars)
 	if err != nil {
 		availableVars := describeAvailableVars(rootData, additionalVars)
 		dataShape := describeDataShape(rootData)
@@ -304,4 +324,14 @@ func describeElementTypes(v reflect.Value) string {
 		return typeNames[0]
 	}
 	return strings.Join(typeNames, "|")
+}
+
+// truncateExpr truncates an expression string for log output.
+// Uses rune count to avoid splitting multi-byte UTF-8 characters.
+func truncateExpr(expr string, maxLen int) string {
+	runes := []rune(expr)
+	if len(runes) <= maxLen {
+		return expr
+	}
+	return string(runes[:maxLen]) + "..."
 }

--- a/pkg/celexp/context_test.go
+++ b/pkg/celexp/context_test.go
@@ -682,3 +682,61 @@ func TestDescribeType_Struct(t *testing.T) {
 	result := describeType(myStruct{X: 1})
 	assert.Contains(t, result, "myStruct")
 }
+
+func TestContextWithCostLimit(t *testing.T) {
+	ctx := context.Background()
+
+	// No limit set
+	limit, ok := CostLimitFromContext(ctx)
+	assert.False(t, ok)
+	assert.Equal(t, uint64(0), limit)
+
+	// Set a limit
+	ctx = ContextWithCostLimit(ctx, 500000)
+	limit, ok = CostLimitFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(500000), limit)
+}
+
+func TestEvaluateExpression_ContextCostLimit(t *testing.T) {
+	ctx := context.Background()
+
+	// Set a very low cost limit via context — should cause cost limit error
+	ctx = ContextWithCostLimit(ctx, 1)
+
+	_, err := EvaluateExpression(ctx, "[1,2,3,4,5].map(x, x * 2)", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost limit")
+}
+
+func TestEvaluateExpression_ContextCostLimitAllowsNormal(t *testing.T) {
+	ctx := context.Background()
+
+	// Set a reasonable cost limit via context — should allow normal expressions
+	ctx = ContextWithCostLimit(ctx, 1000000)
+
+	result, err := EvaluateExpression(ctx, "1 + 2", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result)
+}
+
+func TestTruncateExpr(t *testing.T) {
+	t.Run("short expression unchanged", func(t *testing.T) {
+		assert.Equal(t, "1 + 2", truncateExpr("1 + 2", 10))
+	})
+
+	t.Run("exact length unchanged", func(t *testing.T) {
+		assert.Equal(t, "12345", truncateExpr("12345", 5))
+	})
+
+	t.Run("long expression truncated", func(t *testing.T) {
+		got := truncateExpr("abcdefghij", 5)
+		assert.Equal(t, "abcde...", got)
+	})
+
+	t.Run("multi-byte runes not split", func(t *testing.T) {
+		// 5 runes of 3 bytes each = 15 bytes; truncate at 3 runes
+		got := truncateExpr("日本語漢字", 3)
+		assert.Equal(t, "日本語...", got)
+	})
+}

--- a/pkg/celexp/ext/arrays/groupby.go
+++ b/pkg/celexp/ext/arrays/groupby.go
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package arrays
+
+import (
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/conversion"
+)
+
+// GroupByFunc returns a CEL extension function that groups a list of objects by a specified field.
+// The function takes a list of maps and a field name, returning a map where keys are the distinct
+// field values and values are lists of objects with that field value. This runs in O(n) time,
+// avoiding the O(n^2) cost of CEL comprehension-based grouping patterns.
+func GroupByFunc() celexp.ExtFunction {
+	funcName := "arrays.groupBy"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Signature:     "arrays.groupBy(list<map<string,dyn>>, string) -> map<string, list<map<string,dyn>>>",
+		Description:   "Groups a list of objects by a field value, returning a map of grouped items. Use arrays.groupBy(list, fieldName) to efficiently group objects without quadratic CEL cost",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Group items by category",
+				Expression:  `arrays.groupBy([{"name": "a", "cat": "x"}, {"name": "b", "cat": "x"}, {"name": "c", "cat": "y"}], "cat")`,
+			},
+			{
+				Description: "Group environments by region",
+				Expression:  `arrays.groupBy([{"env": "dev", "region": "us"}, {"env": "prod", "region": "eu"}, {"env": "staging", "region": "us"}], "region")`,
+			},
+			{
+				Description: "Empty list returns empty map",
+				Expression:  `arrays.groupBy([], "key")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{
+						cel.ListType(cel.MapType(cel.StringType, cel.DynType)),
+						cel.StringType,
+					},
+					cel.MapType(cel.StringType, cel.ListType(cel.MapType(cel.StringType, cel.DynType))),
+					cel.BinaryBinding(func(listVal, keyFieldVal ref.Val) ref.Val {
+						keyField, ok := keyFieldVal.Value().(string)
+						if !ok {
+							return types.NewErr("arrays.groupBy: expected string keyField, got %s", keyFieldVal.Type())
+						}
+
+						items, err := conversion.ListToObjectSlice(listVal)
+						if err != nil {
+							return types.NewErr("arrays.groupBy: %s", err.Error())
+						}
+
+						// Single-pass O(n) grouping
+						groups := make(map[string][]map[string]any)
+						for _, item := range items {
+							keyVal, exists := item[keyField]
+							if !exists {
+								return types.NewErr("arrays.groupBy: object missing key field %q", keyField)
+							}
+
+							key, ok := keyVal.(string)
+							if !ok {
+								return types.NewErr("arrays.groupBy: key field %q must be a string, got %T", keyField, keyVal)
+							}
+
+							groups[key] = append(groups[key], item)
+						}
+
+						// Convert to map[string]any for CEL compatibility
+						result := make(map[string]any, len(groups))
+						for k, v := range groups {
+							result[k] = v
+						}
+
+						return types.DefaultTypeAdapter.NativeToValue(result)
+					}),
+				),
+			),
+		},
+	}
+}

--- a/pkg/celexp/ext/arrays/groupby_test.go
+++ b/pkg/celexp/ext/arrays/groupby_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package arrays
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func evalGroupBy(t *testing.T, env *cel.Env, expression string) map[string]any {
+	t.Helper()
+
+	ast, issues := env.Compile(expression)
+	require.Nil(t, issues, "compilation failed: %v", issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	result, _, err := prog.Eval(map[string]any{})
+	require.NoError(t, err)
+
+	// Round-trip through JSON for stable comparison
+	b, err := json.Marshal(result.Value())
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	return got
+}
+
+func TestGroupBy_CELIntegration(t *testing.T) {
+	groupByFunc := GroupByFunc()
+
+	env, err := cel.NewEnv(groupByFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	t.Run("group by category", func(t *testing.T) {
+		got := evalGroupBy(t, env, `arrays.groupBy([{"name": "a", "cat": "x"}, {"name": "b", "cat": "x"}, {"name": "c", "cat": "y"}], "cat")`)
+		assert.Len(t, got, 2)
+		assert.Len(t, got["x"], 2)
+		assert.Len(t, got["y"], 1)
+	})
+
+	t.Run("single group", func(t *testing.T) {
+		got := evalGroupBy(t, env, `arrays.groupBy([{"k": "a"}, {"k": "a"}], "k")`)
+		assert.Len(t, got, 1)
+		assert.Len(t, got["a"], 2)
+	})
+
+	t.Run("each item in its own group", func(t *testing.T) {
+		got := evalGroupBy(t, env, `arrays.groupBy([{"k": "a"}, {"k": "b"}, {"k": "c"}], "k")`)
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		got := evalGroupBy(t, env, `arrays.groupBy([], "key")`)
+		assert.Empty(t, got)
+	})
+
+	t.Run("extra fields preserved", func(t *testing.T) {
+		got := evalGroupBy(t, env, `arrays.groupBy([{"env": "dev", "region": "us", "id": 1}, {"env": "prod", "region": "us", "id": 2}], "region")`)
+		assert.Len(t, got, 1)
+		items := got["us"].([]any)
+		assert.Len(t, items, 2)
+		first := items[0].(map[string]any)
+		assert.Equal(t, "dev", first["env"])
+	})
+}
+
+func TestGroupBy_Errors(t *testing.T) {
+	groupByFunc := GroupByFunc()
+
+	env, err := cel.NewEnv(groupByFunc.EnvOptions...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		errContain string
+	}{
+		{
+			name:       "missing key field",
+			expression: `arrays.groupBy([{"name": "a"}], "missing")`,
+			errContain: "missing key field",
+		},
+		{
+			name:       "non-string key value",
+			expression: `arrays.groupBy([{"k": 123}], "k")`,
+			errContain: "must be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.Nil(t, issues)
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			_, _, err = prog.Eval(map[string]any{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContain)
+		})
+	}
+}
+
+func TestGroupBy_Metadata(t *testing.T) {
+	f := GroupByFunc()
+	assert.Equal(t, "arrays.groupBy", f.Name)
+	assert.True(t, f.Custom)
+	assert.NotEmpty(t, f.Description)
+	assert.NotEmpty(t, f.Examples)
+	assert.NotEmpty(t, f.EnvOptions)
+}
+
+func BenchmarkGroupBy(b *testing.B) {
+	groupByFunc := GroupByFunc()
+
+	env, err := cel.NewEnv(groupByFunc.EnvOptions...)
+	require.NoError(b, err)
+
+	ast, issues := env.Compile(`arrays.groupBy([{"k":"a","v":1},{"k":"b","v":2},{"k":"a","v":3},{"k":"c","v":4},{"k":"b","v":5}], "k")`)
+	require.Nil(b, issues)
+
+	prog, err := env.Program(ast)
+	require.NoError(b, err)
+
+	vars := map[string]any{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, _, _ = prog.Eval(vars)
+	}
+}

--- a/pkg/celexp/ext/ext.go
+++ b/pkg/celexp/ext/ext.go
@@ -711,6 +711,7 @@ func Custom() celexp.ExtFunctionList {
 		// Arrays functions
 		arrays.StringAddFunc(),
 		arrays.StringsUniqueFunc(),
+		arrays.GroupByFunc(),
 
 		// Debug functions (debug.DebugOutFunc excluded - requires Writer, add separately)
 		debug.DebugThrowFunc(),

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -511,6 +511,9 @@ func (o *sharedResolverOptions) executeResolvers(
 
 	executor := resolver.NewExecutor(resolverAdapter, executorOpts...)
 
+	// Apply solution-level CEL cost limit if configured
+	ctx = execute.ApplySolutionCELCostLimit(ctx, sol)
+
 	// Attach solution metadata to the context so providers (e.g., metadata) can access it.
 	ctx = provider.WithSolutionMetadata(ctx, solutionMetaFromSolution(sol))
 

--- a/pkg/cmd/scafctl/run/execute.go
+++ b/pkg/cmd/scafctl/run/execute.go
@@ -27,17 +27,6 @@ func ValidateSolution(ctx context.Context, sol *solution.Solution, reg *provider
 	return execute.ValidateSolution(ctx, sol, reg)
 }
 
-// ExecuteResolvers delegates to pkg/solution/execute.Resolvers.
-func ExecuteResolvers(
-	ctx context.Context,
-	sol *solution.Solution,
-	params map[string]any,
-	reg *provider.Registry,
-	cfg ResolverExecutionConfig,
-) (*ResolverExecutionResult, error) {
-	return execute.Resolvers(ctx, sol, params, reg, cfg)
-}
-
 // ResolverExecutionConfigFromContext delegates to pkg/solution/execute.ResolverExecutionConfigFromContext.
 func ResolverExecutionConfigFromContext(ctx context.Context) ResolverExecutionConfig {
 	return execute.ResolverExecutionConfigFromContext(ctx)

--- a/pkg/cmd/scafctl/run/execute_test.go
+++ b/pkg/cmd/scafctl/run/execute_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidateSolution(t *testing.T) {
@@ -51,18 +50,5 @@ func TestResolverExecutionConfig(t *testing.T) {
 		cfg := ResolverExecutionConfigFromContext(context.Background())
 		assert.NotZero(t, cfg.Timeout)
 		assert.NotZero(t, cfg.PhaseTimeout)
-	})
-}
-
-func TestExecuteResolvers(t *testing.T) {
-	t.Run("empty resolvers returns empty data", func(t *testing.T) {
-		sol := &solution.Solution{}
-		sol.Metadata.Name = "test"
-		reg := provider.NewRegistry()
-
-		result, err := ExecuteResolvers(context.Background(), sol, nil, reg, ResolverExecutionConfig{})
-		require.NoError(t, err)
-		assert.Empty(t, result.Data)
-		assert.NotNil(t, result.Context)
 	})
 }

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -160,6 +161,9 @@ func Resolvers(
 		executorOpts = append(executorOpts, resolver.WithSkipTransform(true))
 	}
 	executor := resolver.NewExecutor(adapter, executorOpts...)
+
+	// Apply solution-level CEL cost limit if configured
+	ctx = ApplySolutionCELCostLimit(ctx, sol)
 
 	// Execute resolvers
 	resultCtx, err := executor.Execute(ctx, resolvers, params)
@@ -318,6 +322,9 @@ func Actions(
 	// Attach solution metadata to the context.
 	ctx = provider.WithSolutionMetadata(ctx, toSolutionMeta(sol))
 
+	// Apply solution-level CEL cost limit if configured
+	ctx = ApplySolutionCELCostLimit(ctx, sol)
+
 	// When OutputDir is set, resolve to an absolute path and inject it into
 	// the context for action-mode providers.
 	if cfg.OutputDir != "" {
@@ -460,4 +467,39 @@ func toSolutionMeta(sol *solution.Solution) *provider.SolutionMeta {
 		meta.Version = sol.Metadata.Version.String()
 	}
 	return meta
+}
+
+// ApplySolutionCELCostLimit injects the solution's CEL cost limit into the context
+// if the solution defines one. The effective limit is min(solutionLimit, globalLimit)
+// so that solutions cannot raise the limit above the operator-configured global default.
+// When global limiting is disabled (globalLimit == 0), solution overrides are ignored.
+func ApplySolutionCELCostLimit(ctx context.Context, sol *solution.Solution) context.Context {
+	if sol.Spec.Options == nil || sol.Spec.Options.CEL == nil || sol.Spec.Options.CEL.CostLimit == nil {
+		return ctx
+	}
+
+	solutionLimit := *sol.Spec.Options.CEL.CostLimit
+	if solutionLimit == 0 {
+		return ctx
+	}
+
+	globalLimit := celexp.GetDefaultCostLimit()
+	if globalLimit == 0 {
+		// Global limiting is disabled; don't let a solution impose one.
+		return ctx
+	}
+
+	effectiveLimit := solutionLimit
+	if solutionLimit > globalLimit {
+		effectiveLimit = globalLimit
+	}
+
+	lgr := logger.FromContext(ctx)
+	lgr.V(1).Info("applying solution-level CEL cost limit",
+		"solutionLimit", solutionLimit,
+		"globalLimit", globalLimit,
+		"effectiveLimit", effectiveLimit,
+	)
+
+	return celexp.ContextWithCostLimit(ctx, effectiveLimit)
 }

--- a/pkg/solution/execute/execute_test.go
+++ b/pkg/solution/execute/execute_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -224,4 +225,67 @@ func TestResolversForPreview_NoResolvers(t *testing.T) {
 	result, err := ResolversForPreview(ctx, sol, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+func TestApplySolutionCELCostLimit(t *testing.T) {
+	t.Run("no options returns same context", func(t *testing.T) {
+		ctx := context.Background()
+		sol := &solution.Solution{}
+
+		got := ApplySolutionCELCostLimit(ctx, sol)
+		_, ok := celexp.CostLimitFromContext(got)
+		assert.False(t, ok)
+	})
+
+	t.Run("cost limit zero returns same context", func(t *testing.T) {
+		ctx := context.Background()
+		sol := &solution.Solution{}
+		zero := uint64(0)
+		sol.Spec.Options = &solution.SpecOptions{
+			CEL: &solution.CELOptions{CostLimit: &zero},
+		}
+
+		got := ApplySolutionCELCostLimit(ctx, sol)
+		_, ok := celexp.CostLimitFromContext(got)
+		assert.False(t, ok)
+	})
+
+	t.Run("solution limit applied when below global", func(t *testing.T) {
+		globalLimit := celexp.GetDefaultCostLimit()
+		if globalLimit == 0 {
+			t.Skip("global limit is disabled; solution overrides are ignored")
+		}
+
+		ctx := context.Background()
+		sol := &solution.Solution{}
+		limit := uint64(100)
+		sol.Spec.Options = &solution.SpecOptions{
+			CEL: &solution.CELOptions{CostLimit: &limit},
+		}
+
+		got := ApplySolutionCELCostLimit(ctx, sol)
+		effective, ok := celexp.CostLimitFromContext(got)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(100), effective)
+	})
+
+	t.Run("solution limit capped at global limit", func(t *testing.T) {
+		ctx := context.Background()
+		sol := &solution.Solution{}
+		limit := uint64(99999999) // way above default
+		sol.Spec.Options = &solution.SpecOptions{
+			CEL: &solution.CELOptions{CostLimit: &limit},
+		}
+
+		globalLimit := celexp.GetDefaultCostLimit()
+		got := ApplySolutionCELCostLimit(ctx, sol)
+		effective, ok := celexp.CostLimitFromContext(got)
+		if globalLimit > 0 {
+			assert.True(t, ok)
+			assert.Equal(t, globalLimit, effective)
+		} else {
+			// When global limit is disabled (0), solution overrides are ignored
+			assert.False(t, ok)
+		}
+	})
 }

--- a/pkg/solution/spec.go
+++ b/pkg/solution/spec.go
@@ -26,6 +26,24 @@ type Spec struct {
 
 	// Testing groups all test-related configuration (test cases and config) under one property.
 	Testing *soltesting.TestSuite `json:"testing,omitempty" yaml:"testing,omitempty" doc:"Test suite configuration"`
+
+	// Options holds optional tuning parameters for the solution.
+	Options *SpecOptions `json:"options,omitempty" yaml:"options,omitempty" doc:"Optional solution-level configuration"`
+}
+
+// SpecOptions holds optional tuning parameters for a solution.
+type SpecOptions struct {
+	// CEL configures CEL expression evaluation for this solution.
+	CEL *CELOptions `json:"cel,omitempty" yaml:"cel,omitempty" doc:"CEL expression evaluation options"`
+}
+
+// CELOptions configures CEL expression evaluation at the solution level.
+type CELOptions struct {
+	// CostLimit overrides the global CEL cost limit for this solution.
+	// The effective limit is min(solutionLimit, globalLimit) — a solution
+	// cannot raise the limit above the operator-configured global default.
+	// Set to 0 to use the global default.
+	CostLimit *uint64 `json:"costLimit,omitempty" yaml:"costLimit,omitempty" doc:"CEL cost limit override (0 = use global default)" example:"2000000"`
 }
 
 // ResolversToSlice converts the Resolvers map to a slice for execution.

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -618,7 +618,7 @@ tasks:
       - mkdir -p {{.DIST}}
       - >
         GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build
-        -ldflags '-s -w {{.LDFLAGS}}'
+        -ldflags '-w {{.LDFLAGS}}'
         -trimpath
         -o {{.DIST}}/{{.OUTPUT_FILE}} {{.MAIN_PACKAGE}}
       - cmd: '{{ if eq .GOOS "darwin" }}codesign --force --sign - {{.DIST}}/{{.OUTPUT_FILE}}{{ end }}'
@@ -643,7 +643,7 @@ tasks:
       - mkdir -p {{.DIST}}/home/default
       - >
         GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build
-        -ldflags '-s -w {{.LDFLAGS}}' -trimpath
+        -ldflags '-w {{.LDFLAGS}}' -trimpath
         -o {{.DIST}}/home/default/{{.OUTPUT_FILE}} {{.MAIN_PACKAGE}}
       - cd {{.DIST}}
       - |

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -32,23 +32,25 @@ import (
 var binaryPath string
 
 func TestMain(m *testing.M) {
-	// Build the binary once for all tests
-	tmpDir, err := os.MkdirTemp("", "scafctl-integration-*")
-	if err != nil {
+	// Build the binary once for all tests.
+	// Use a project-local directory instead of os.TempDir() to avoid
+	// Windows Defender false positives on freshly-built Go binaries in temp.
+	projectRoot := findProjectRoot()
+	distDir := filepath.Join(projectRoot, "dist")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(tmpDir)
 
-	binaryPath = filepath.Join(tmpDir, "scafctl")
+	binaryPath = filepath.Join(distDir, "scafctl-integration-test")
 	if runtime.GOOS == "windows" {
 		binaryPath += ".exe"
 	}
 
-	// Build from project root
-	projectRoot := findProjectRoot()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", binaryPath, "./cmd/scafctl/scafctl.go")
+	cmd := exec.CommandContext(ctx, "go", "build",
+		"-ldflags", "-w",
+		"-o", binaryPath, "./cmd/scafctl/scafctl.go")
 	cmd.Dir = projectRoot
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 
@@ -57,7 +59,9 @@ func TestMain(m *testing.M) {
 		panic("failed to build scafctl: " + err.Error() + "\n" + string(output))
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.Remove(binaryPath) // best-effort cleanup
+	os.Exit(code)
 }
 
 func findProjectRoot() string {


### PR DESCRIPTION
- enrich cost-limit errors with actual cost, limit, and expression
- add per-solution CEL cost limit via spec.options.cel.costLimit clamped to min(solutionLimit, globalLimit)
- propagate cost limit through context so CLI and execute paths both enforce it
- add arrays.groupBy CEL extension for O(n) grouping (avoids quadratic comprehension patterns that hit cost limits)
- use rune-aware truncation for expression logging
- remove dead run.ExecuteResolvers delegation function
- remove -s from ldflags to prevent Windows Defender false positives on stripped Go binaries
- move integration test binary output to dist/ with -w ldflags

Closes #447