### PR TITLE
fix(http): preserve parsed body type when using collectPath with auto ParseJson

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oakwood-commons/scafctl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/bubbletea/v2 v2.0.6

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -595,7 +595,7 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		if pagCfg.BodyTemplate != "" && !methodSupportsBody(method) {
 			return nil, fmt.Errorf("%s: pagination bodyTemplate requires method POST, PUT, or PATCH (got %q)", ProviderName, method)
 		}
-		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg)
+		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg, autoParseJSON)
 	}
 
 	// Build the execute function for potential polling

--- a/pkg/provider/builtin/httpprovider/pagination.go
+++ b/pkg/provider/builtin/httpprovider/pagination.go
@@ -280,6 +280,7 @@ func (p *HTTPProvider) executePaginated(
 	method, urlStr, bodyContent string,
 	headers map[string]any,
 	pagCfg *paginationConfig,
+	autoParseJSON bool,
 ) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
@@ -460,7 +461,7 @@ func (p *HTTPProvider) executePaginated(
 	lgr.V(1).Info("pagination finished", "totalPages", pageCount, "totalItems", len(allItems))
 
 	// Build output
-	return p.buildPaginatedOutput(lastResponse, allItems, pageCount)
+	return p.buildPaginatedOutput(lastResponse, allItems, pageCount, autoParseJSON)
 }
 
 // doRequest performs a single HTTP request and returns the parsed response.
@@ -928,17 +929,33 @@ func (p *HTTPProvider) evaluateBodyTemplate(
 }
 
 // buildPaginatedOutput constructs the provider output for paginated requests.
-func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, items []any, pageCount int) (*provider.Output, error) {
-	// Marshal collected items to JSON for the body field
-	var bodyStr string
-	if len(items) > 0 {
-		bodyBytes, err := json.Marshal(items)
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to marshal collected items: %w", ProviderName, err)
+// When autoParseJSON is true the body field contains the collected items as a
+// structured []any value, matching the behaviour of non-paginated requests with
+// autoParseJson: true. When false (the default) the body is serialized to a
+// JSON string for backward compatibility.
+func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, items []any, pageCount int, autoParseJSON bool) (*provider.Output, error) {
+	var bodyValue any
+	if autoParseJSON {
+		// Return the items as a structured value so downstream CEL expressions
+		// can access fields directly (e.g. _.myResolver.body[0].id).
+		if items == nil {
+			bodyValue = []any{}
+		} else {
+			bodyValue = items
 		}
-		bodyStr = string(bodyBytes)
 	} else {
-		bodyStr = "[]"
+		// Serialize to JSON string for backward compatibility.
+		var bodyStr string
+		if len(items) > 0 {
+			bodyBytes, err := json.Marshal(items)
+			if err != nil {
+				return nil, fmt.Errorf("%s: failed to marshal collected items: %w", ProviderName, err)
+			}
+			bodyStr = string(bodyBytes)
+		} else {
+			bodyStr = "[]"
+		}
+		bodyValue = bodyStr
 	}
 
 	var lastStatusCode int
@@ -951,7 +968,7 @@ func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, ite
 	return &provider.Output{
 		Data: map[string]any{
 			"statusCode": lastStatusCode,
-			"body":       bodyStr,
+			"body":       bodyValue,
 			"headers":    lastHeaders,
 			"pages":      pageCount,
 			"totalItems": len(items),

--- a/pkg/provider/builtin/httpprovider/pagination_test.go
+++ b/pkg/provider/builtin/httpprovider/pagination_test.go
@@ -1947,3 +1947,91 @@ func TestHTTPProvider_Pagination_BodyTemplate_ShortPage_StopSignal(t *testing.T)
 	// Should stop at page 3 because page 3 has fewer items than pageSize.
 	assert.Equal(t, 3, data["pages"])
 }
+
+// --- autoParseJson + pagination tests ---
+
+func TestHTTPProvider_Paginated_AutoParseJson_Body_IsSlice(t *testing.T) {
+	t.Parallel()
+
+	// Two-page server: each page returns a JSON array fragment.
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		page++
+		switch page {
+		case 1:
+			_, _ = w.Write([]byte(`{"items":[{"id":1},{"id":2}],"next":"` + r.Host + `/page2"}`))
+		default:
+			_, _ = w.Write([]byte(`{"items":[{"id":3}]}`))
+		}
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":           server.URL,
+		"method":        "GET",
+		"autoParseJson": true,
+		"pagination": map[string]any{
+			"strategy":       "cursor",
+			"maxPages":       5,
+			"nextTokenPath":  "body.next",
+			"nextTokenParam": "cursor",
+			"collectPath":    "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+
+	// With autoParseJson: true the body must be a []any, not a string.
+	body, ok := data["body"].([]any)
+	require.True(t, ok, "body should be []any when autoParseJson is true with collectPath pagination")
+	assert.Len(t, body, 3)
+
+	first, ok := body[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), first["id"])
+}
+
+func TestHTTPProvider_Paginated_AutoParseJson_False_Body_IsString(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"id":1}]}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "GET",
+		// autoParseJson NOT set
+		"pagination": map[string]any{
+			"strategy":    "cursor",
+			"maxPages":    2,
+			"nextURLPath": "body.next", // empty on only page -> stops
+			"collectPath": "body.items",
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data := output.Data.(map[string]any)
+
+	// Without autoParseJson the body must remain a JSON string.
+	_, ok := data["body"].(string)
+	assert.True(t, ok, "body should be a JSON string when autoParseJson is false")
+}


### PR DESCRIPTION
When autoParseJson: true was set with a paginated request using collectPath, the collected items were re-serialized to a JSON string in buildPaginatedOutput, discarding the parsed []any value. Downstream CEL expressions received a string instead of a structured list, requiring a json.unmarshal() workaround.

- Thread autoParseJSON bool through executePaginated into buildPaginatedOutput
- When autoParseJSON is true, return collected items as []any directly
- When false, preserve existing string serialization for backward compat
- Add two tests: one confirming []any body, one confirming string body

Closes #445
