### PR TITLE
feat(provider): add default input to parameter provider

### DIFF
--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -1126,6 +1126,85 @@ Output:
 }
 ```
 
+### Default Values
+
+The parameter provider supports an optional `default` input that provides a
+fallback value when the parameter is not passed via `-r` flags. This is simpler
+than using a multi-step fallback chain with `onError: continue` and a `static`
+provider.
+
+Create a file called `param-default-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: param-default-demo
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: environment
+              default: development
+```
+
+Running without `-r` uses the default:
+
+{{< tabs "run-resolver-tutorial-cmd-23b" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f param-default-demo.yaml -o json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f param-default-demo.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output:
+
+```json
+{
+  "env": "development"
+}
+```
+
+Running with `-r` overrides the default:
+
+{{< tabs "run-resolver-tutorial-cmd-23c" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f param-default-demo.yaml environment=staging -o json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f param-default-demo.yaml environment=staging -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output:
+
+```json
+{
+  "env": "staging"
+}
+```
+
+> **Note:** The `default` input must be a literal value. The resolver executor
+> resolves all inputs before calling the provider, so a ValueRef default (e.g.
+> `default: {rslvr: fallback}`) would be evaluated even when the parameter
+> exists. Use the `onError: continue` fallback chain pattern when you need a
+> dynamic default.
+
 ### Parameter Key Validation
 
 Parameter keys are validated against the solution's parameter-type resolver names.

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -20,47 +20,56 @@ metadata:
 
 spec:
   resolvers:
-    # String parameter with default (using fallback chain)
+    # String parameter with inline default
+    # When "name" is not passed via -r, the default value "World" is used.
+    # The "default" input must be a literal value (not a ValueRef).
     name:
       description: User name from CLI or default
       type: string
       resolve:
         with:
           - provider: parameter
-            onError: continue
             inputs:
               key: name
-          - provider: static
-            inputs:
-              value: "World"
-    
-    # Integer parameter with default
+              default: "World"
+
+    # Integer parameter with inline default
     count:
       description: Repetition count
       type: int
       resolve:
         with:
           - provider: parameter
-            onError: continue
             inputs:
               key: count
-          - provider: static
-            inputs:
-              value: 3
-    
-    # Boolean parameter
+              default: 3
+
+    # Boolean parameter with inline default
     uppercase:
       description: Whether to uppercase the output
       type: bool
       resolve:
         with:
           - provider: parameter
-            onError: continue
             inputs:
               key: uppercase
+              default: false
+
+    # String parameter using fallback chain (alternative pattern)
+    # Use onError: continue + static provider when you need a dynamic
+    # fallback (e.g. a ValueRef or expression) instead of a literal default.
+    region:
+      description: Deployment region from CLI or fallback chain
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: region
           - provider: static
             inputs:
-              value: false
+              value: "us-east-1"
     
     # Computed greeting using parameters
     greeting:

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -102,11 +102,13 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 					schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
 					schemahelper.WithPattern(`^[A-Za-z_][A-Za-z0-9_.\-]*$`),
 					schemahelper.WithExample("env")),
+				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
+					schemahelper.WithExample("fallback")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"value":  schemahelper.AnyProp("The parameter value (typed based on parsing rules)", schemahelper.WithExample("prod")),
-					"exists": schemahelper.BoolProp("Whether the parameter was provided via CLI", schemahelper.WithExample(true)),
+					"exists": schemahelper.BoolProp("Whether the value came from a CLI-provided parameter (false when using the default value)", schemahelper.WithExample(true)),
 					"type":   schemahelper.StringProp("Detected type of the value", schemahelper.WithExample("string")),
 				}),
 			},
@@ -117,6 +119,14 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 					YAML: `provider: parameter
 inputs:
   key: env`,
+				},
+				{
+					Name:        "Get parameter with default",
+					Description: "Retrieve a parameter, falling back to a default when not provided",
+					YAML: `provider: parameter
+inputs:
+  key: env
+  default: development`,
 				},
 				{
 					Name:        "Get array parameter",
@@ -188,6 +198,20 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 	// Look up the parameter
 	rawValue, exists := params[key]
 	if !exists {
+		if def, hasDefault := inputs["default"]; hasDefault {
+			parsedDefault, err := p.parseValue(ctx, def)
+			if err != nil {
+				return nil, fmt.Errorf("%s: failed to parse default for parameter %q: %w", ProviderName, key, err)
+			}
+			lgr.V(1).Info("provider completed", "provider", ProviderName)
+			return &provider.Output{
+				Data: parsedDefault,
+				Metadata: map[string]any{
+					"exists": false,
+					"type":   detectType(parsedDefault),
+				},
+			}, nil
+		}
 		return nil, fmt.Errorf("%s: parameter %q not provided", ProviderName, key)
 	}
 

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -6,10 +6,18 @@ package parameterprovider
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -370,4 +378,211 @@ func TestParameterProvider_Descriptor(t *testing.T) {
 	// Check schema
 	assert.Contains(t, desc.Schema.Properties, "key")
 	assert.Contains(t, desc.Schema.Required, "key")
+	assert.Contains(t, desc.Schema.Properties, "default")
+	assert.NotContains(t, desc.Schema.Required, "default")
+}
+
+func TestParameterProvider_Execute_Default_UsedWhenKeyMissing(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":     "env",
+		"default": "development",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "development", output.Data)
+	assert.Equal(t, false, output.Metadata["exists"])
+	assert.Equal(t, "string", output.Metadata["type"])
+}
+
+func TestParameterProvider_Execute_Default_NotUsedWhenKeyPresent(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"env": "production",
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":     "env",
+		"default": "development",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "production", output.Data)
+	assert.Equal(t, true, output.Metadata["exists"])
+}
+
+func TestParameterProvider_Execute_Default_TypedValues(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	tests := []struct {
+		name         string
+		defaultVal   any
+		expectedData any
+		expectedType string
+	}{
+		{"string literal", "fallback", "fallback", "string"},
+		{"bool string true", "true", true, "boolean"},
+		{"integer string", "42", int64(42), "integer"},
+		{"csv string", "a,b,c", []string{"a", "b", "c"}, "array"},
+		{"already-bool", true, true, "boolean"},
+		{"already-int", int64(99), int64(99), "integer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := p.Execute(ctx, map[string]any{
+				"key":     "missing",
+				"default": tt.defaultVal,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			assert.Equal(t, tt.expectedData, output.Data)
+			assert.Equal(t, false, output.Metadata["exists"])
+			assert.Equal(t, tt.expectedType, output.Metadata["type"])
+		})
+	}
+}
+
+func TestParameterProvider_Execute_NoDefault_StillErrors(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key": "env",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "not provided")
+}
+
+func TestWithHTTPClient_ExercisesOption(t *testing.T) {
+	t.Parallel()
+	allow := true
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	mock := &MockHTTPClient{Err: errors.New("mock-error")}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	_, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	assert.ErrorContains(t, err, "mock-error")
+}
+
+func TestParameterProvider_ParseValue_HTTP_Success(t *testing.T) {
+	t.Parallel()
+	allow := true
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	mock := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("remote-value")),
+		},
+	}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	result, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	require.NoError(t, err)
+	assert.Equal(t, "remote-value", result)
+}
+
+func TestParameterProvider_ParseValue_HTTP_NonOKStatus(t *testing.T) {
+	t.Parallel()
+	allow := true
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	mock := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+	}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	_, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	assert.ErrorContains(t, err, "404")
+}
+
+func TestDefaultFileOps_ReadFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.txt")
+	require.NoError(t, os.WriteFile(path, []byte("file-content"), 0o600))
+
+	ops := &DefaultFileOps{}
+	content, err := ops.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "file-content", string(content))
+}
+
+func TestDefaultFileOps_ReadFile_Missing(t *testing.T) {
+	t.Parallel()
+	ops := &DefaultFileOps{}
+	_, err := ops.ReadFile(filepath.Join(t.TempDir(), "nonexistent.txt"))
+	assert.Error(t, err)
+}
+
+func TestDefaultHTTPClient_Get(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := &DefaultHTTPClient{client: httpc.NewClient(&httpc.ClientConfig{
+		Timeout:      settings.DefaultHTTPTimeout,
+		RetryMax:     0,
+		RetryWaitMin: settings.DefaultHTTPRetryWaitMinimum,
+		RetryWaitMax: settings.DefaultHTTPRetryWaitMaximum,
+	})}
+
+	resp, err := c.Get(context.Background(), srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestParameterProvider_Execute_Default_ParseError(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	// "-" triggers a parse error in parseValue (stdin should have been resolved)
+	output, err := p.Execute(ctx, map[string]any{
+		"key":     "env",
+		"default": "-",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "failed to parse default")
+	assert.Contains(t, err.Error(), "stdin value")
+}
+
+func TestParameterProvider_Execute_DryRun_WithDefault_IgnoresDefault(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	// dry-run is active, key is absent, default is provided
+	ctx := provider.WithDryRun(context.Background(), true)
+	ctx = provider.WithParameters(ctx, map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":     "env",
+		"default": "should-not-appear",
+	})
+
+	// dry-run fires before default check — always returns the dry-run sentinel
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "[DRY-RUN] Not retrieved", output.Data)
+	assert.True(t, output.Metadata["dryRun"].(bool))
 }


### PR DESCRIPTION
- Add optional `default` input field to parameter provider schema; returns the default value (with exists: false) when the named parameter is absent from CLI-provided -r flags
- Default values pass through the same parseValue pipeline as regular parameters, supporting typed coercion (bool, int, float, CSV, JSON, file://, http://)
- Update OutputSchemas "exists" description to clarify it is false when the default is used, not only when the key is missing
- Add tests: default used when key absent, default not used when key present, typed defaults (bool/int/csv), no-default error preserved, default parse error path, dry-run + default interaction documented
- Add tests for previously-uncovered code paths: DefaultHTTPClient.Get, DefaultFileOps.ReadFile, WithHTTPClient option, HTTP success/non-OK status, raising package coverage from 77.3% to 92.8%

Closes #420