### PR TITLE
feat(mcp): proxy upstream MCP server tools with auth token injection

### DIFF
--- a/pkg/config/sanitize.go
+++ b/pkg/config/sanitize.go
@@ -19,6 +19,7 @@ type SanitizedConfig struct {
 	Auth       SanitizedAuth      `json:"auth" yaml:"auth" doc:"Authentication configuration (redacted)"`
 	Build      BuildConfig        `json:"build" yaml:"build" doc:"Build configuration"`
 	APIServer  APIServerConfig    `json:"apiServer,omitempty" yaml:"apiServer,omitempty" doc:"REST API server configuration"`
+	MCP        SanitizedMCPConfig `json:"mcp,omitempty" yaml:"mcp,omitempty" doc:"MCP server configuration (URLs redacted)"`
 }
 
 // SanitizedCatalog redacts auth tokens from catalog config.
@@ -68,6 +69,21 @@ type SanitizedGCPAuth struct {
 	Project                   string   `json:"project,omitempty" yaml:"project,omitempty" doc:"GCP project ID" maxLength:"256" example:"my-gcp-project"`
 }
 
+// SanitizedMCPConfig mirrors MCPConfig but with URLs redacted.
+type SanitizedMCPConfig struct {
+	Servers map[string]SanitizedMCPServerConfig `json:"servers,omitempty" yaml:"servers,omitempty" doc:"Upstream MCP server configurations (URLs redacted)"`
+}
+
+// SanitizedMCPServerConfig contains only non-sensitive upstream MCP server fields.
+type SanitizedMCPServerConfig struct {
+	Enabled    *bool               `json:"enabled,omitempty" yaml:"enabled,omitempty" doc:"Whether this upstream server is active"`
+	URL        string              `json:"url,omitempty" yaml:"url,omitempty" doc:"Upstream URL (redacted)"`
+	Auth       MCPServerAuthConfig `json:"auth,omitempty" yaml:"auth,omitempty" doc:"Authentication configuration"`
+	Timeout    string              `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Request timeout"`
+	ToolPrefix string              `json:"toolPrefix,omitempty" yaml:"toolPrefix,omitempty" doc:"Prefix added to upstream tool names"`
+	Tools      []string            `json:"tools,omitempty" yaml:"tools,omitempty" doc:"Tool name allowlist patterns"`
+}
+
 // SanitizeConfig creates a sanitized copy of the config with sensitive values redacted.
 func SanitizeConfig(cfg *Config) SanitizedConfig {
 	s := SanitizedConfig{
@@ -80,6 +96,24 @@ func SanitizeConfig(cfg *Config) SanitizedConfig {
 		Action:     cfg.Action,
 		Build:      cfg.Build,
 		APIServer:  cfg.APIServer,
+	}
+
+	// Sanitize MCP upstream servers — redact URLs.
+	if len(cfg.MCP.Servers) > 0 {
+		s.MCP.Servers = make(map[string]SanitizedMCPServerConfig, len(cfg.MCP.Servers))
+		for name, srv := range cfg.MCP.Servers {
+			sanitized := SanitizedMCPServerConfig{
+				Enabled:    srv.Enabled,
+				Auth:       srv.Auth,
+				Timeout:    srv.Timeout,
+				ToolPrefix: srv.ToolPrefix,
+				Tools:      srv.Tools,
+			}
+			if srv.URL != "" {
+				sanitized.URL = RedactedValue
+			}
+			s.MCP.Servers[name] = sanitized
+		}
 	}
 
 	// Sanitize catalogs

--- a/pkg/config/sanitize_test.go
+++ b/pkg/config/sanitize_test.go
@@ -75,4 +75,57 @@ func TestSanitizeConfig(t *testing.T) {
 		assert.Equal(t, "token", sanitized.Catalogs[0].Auth.Type)
 		assert.Equal(t, "MY_TOKEN", sanitized.Catalogs[0].Auth.TokenEnvVar)
 	})
+
+	t.Run("MCP upstream URLs redacted", func(t *testing.T) {
+		enabled := true
+		cfg := &Config{
+			MCP: MCPConfig{
+				Servers: map[string]MCPServerConfig{
+					"internal": {
+						Enabled: &enabled,
+						URL:     "http://svc.cluster.local:8080/mcp",
+						Auth: MCPServerAuthConfig{
+							Handler: "entra",
+							Scope:   "api://app-id/.default",
+						},
+						Timeout:    "60s",
+						ToolPrefix: "remote_",
+						Tools:      []string{"deploy_*"},
+					},
+				},
+			},
+		}
+
+		sanitized := SanitizeConfig(cfg)
+		require.Len(t, sanitized.MCP.Servers, 1)
+
+		srv := sanitized.MCP.Servers["internal"]
+		assert.Equal(t, RedactedValue, srv.URL, "URL should be redacted")
+		assert.Equal(t, &enabled, srv.Enabled)
+		assert.Equal(t, "entra", srv.Auth.Handler)
+		assert.Equal(t, "api://app-id/.default", srv.Auth.Scope)
+		assert.Equal(t, "60s", srv.Timeout)
+		assert.Equal(t, "remote_", srv.ToolPrefix)
+		assert.Equal(t, []string{"deploy_*"}, srv.Tools)
+	})
+
+	t.Run("MCP empty URL not redacted", func(t *testing.T) {
+		cfg := &Config{
+			MCP: MCPConfig{
+				Servers: map[string]MCPServerConfig{
+					"no-url": {URL: ""},
+				},
+			},
+		}
+
+		sanitized := SanitizeConfig(cfg)
+		assert.Equal(t, "", sanitized.MCP.Servers["no-url"].URL)
+	})
+
+	t.Run("MCP nil servers unchanged", func(t *testing.T) {
+		cfg := &Config{}
+
+		sanitized := SanitizeConfig(cfg)
+		assert.Nil(t, sanitized.MCP.Servers)
+	})
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -31,6 +31,7 @@ type Config struct {
 	APIServer  APIServerConfig  `json:"apiServer,omitempty" yaml:"apiServer,omitempty" mapstructure:"apiServer" doc:"REST API server configuration"`
 	Discovery  DiscoveryConfig  `json:"discovery,omitempty" yaml:"discovery,omitempty" mapstructure:"discovery" doc:"Auto-discovery configuration"`
 	Plugins    PluginsConfig    `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin management configuration"`
+	MCP        MCPConfig        `json:"mcp,omitempty" yaml:"mcp,omitempty" mapstructure:"mcp" doc:"MCP server configuration"`
 }
 
 // DiscoveryStrategy controls how a remote catalog discovers available artifacts.
@@ -970,4 +971,53 @@ type IdentityFieldMapping struct {
 
 type TokenPassThroughConfig struct {
 	AllowedHeaders []string `json:"allowedHeaders,omitempty" yaml:"allowedHeaders,omitempty" mapstructure:"allowedHeaders" doc:"Allowed token header suffixes without the X-Authorization- prefix" maxItems:"50"`
+}
+
+// MCPConfig holds MCP server configuration.
+type MCPConfig struct {
+	// Servers maps upstream MCP server names to their configurations.
+	// Each entry defines a remote MCP server whose tools are auto-discovered
+	// and proxied through the local MCP server with auth token injection.
+	Servers map[string]MCPServerConfig `json:"servers,omitempty" yaml:"servers,omitempty" mapstructure:"servers" doc:"Upstream MCP server configurations"`
+}
+
+// MCPServerConfig configures a single upstream MCP server.
+type MCPServerConfig struct {
+	// Enabled controls whether this upstream server is active. Defaults to true
+	// when the entry is present.
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" mapstructure:"enabled" doc:"Whether this upstream server is active (default: true)"`
+
+	// URL is the Streamable HTTP endpoint of the remote MCP server.
+	URL string `json:"url" yaml:"url" mapstructure:"url" doc:"Streamable HTTP URL of the remote MCP server" maxLength:"2048" example:"https://my-mcp-server.example.com/mcp"`
+
+	// Auth configures token injection for requests to this upstream server.
+	Auth MCPServerAuthConfig `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth" doc:"Authentication configuration for the upstream server"`
+
+	// Timeout is the request timeout for upstream calls. Use Go duration syntax.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout" doc:"Request timeout for upstream calls" maxLength:"20" example:"30s"`
+
+	// ToolPrefix is an optional prefix added to all tools from this upstream
+	// server to avoid name collisions with local tools.
+	ToolPrefix string `json:"toolPrefix,omitempty" yaml:"toolPrefix,omitempty" mapstructure:"toolPrefix" doc:"Prefix added to upstream tool names" maxLength:"64" example:"upstream_"`
+
+	// Tools is an optional allowlist of glob patterns for tool names.
+	// An empty list means all tools are proxied.
+	Tools []string `json:"tools,omitempty" yaml:"tools,omitempty" mapstructure:"tools" doc:"Tool name allowlist patterns (glob, empty = all)" maxItems:"100"`
+}
+
+// IsEnabled returns whether the upstream server is enabled. Defaults to true.
+func (c MCPServerConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// MCPServerAuthConfig configures auth token injection for an upstream MCP server.
+type MCPServerAuthConfig struct {
+	// Handler is the name of the auth handler to use (e.g. "entra", "gcp", "github").
+	Handler string `json:"handler,omitempty" yaml:"handler,omitempty" mapstructure:"handler" doc:"Auth handler name for token injection" maxLength:"64" example:"entra"`
+
+	// Scope is the OAuth scope to request when acquiring tokens.
+	Scope string `json:"scope,omitempty" yaml:"scope,omitempty" mapstructure:"scope" doc:"OAuth scope for token requests" maxLength:"1024" example:"api://app-id/.default"`
 }

--- a/pkg/mcp/capabilities.go
+++ b/pkg/mcp/capabilities.go
@@ -171,6 +171,8 @@ const (
 	SourceCore CapabilitySource = "core"
 	// SourcePlugin marks capabilities registered by plugins or embedders.
 	SourcePlugin CapabilitySource = "plugin"
+	// SourceUpstream marks capabilities proxied from an upstream MCP server.
+	SourceUpstream CapabilitySource = "upstream"
 )
 
 // Capability describes a single MCP tool or prompt.
@@ -208,6 +210,8 @@ func (s *Server) ListCapabilities() []Capability {
 		source := SourcePlugin
 		if _, ok := s.coreTools[t.Name]; ok {
 			source = SourceCore
+		} else if _, ok := s.upstreamTools[t.Name]; ok {
+			source = SourceUpstream
 		}
 		c := Capability{
 			Kind:        CapabilityTool,

--- a/pkg/mcp/capabilities_test.go
+++ b/pkg/mcp/capabilities_test.go
@@ -148,6 +148,8 @@ func TestListCapabilities_EmbedderTools(t *testing.T) {
 					coreCount++
 				case SourcePlugin:
 					pluginCount++
+				case SourceUpstream:
+					// not expected in this test
 				}
 			}
 		}
@@ -202,6 +204,8 @@ func TestListCapabilities_EmbedderPrompts(t *testing.T) {
 					corePrompts++
 				case SourcePlugin:
 					pluginPrompts++
+				case SourceUpstream:
+					// not expected in this test
 				}
 			}
 		}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -21,6 +22,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/mcp/upstream"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
@@ -71,6 +73,18 @@ type Server struct {
 	// are available without spawning plugin processes.
 	descriptorCache *plugin.DescriptorCache
 
+	// upstreamProxies tracks upstream MCP server proxies keyed by server name.
+	upstreamProxies map[string]*upstream.Proxy
+
+	// upstreamTools tracks tool names that are proxied from upstream servers.
+	// Maps tool name -> upstream server name.
+	upstreamTools map[string]string
+
+	// upstreamMu guards upstream registration state. Unlike sync.Once,
+	// this allows retrying after transient failures.
+	upstreamMu         sync.Mutex
+	upstreamRegistered bool
+
 	// sseServer is the SSE transport server (nil for stdio).
 	sseServer *server.SSEServer
 	// httpServer is the Streamable HTTP transport server (nil for stdio).
@@ -95,6 +109,7 @@ type serverConfig struct {
 	supplementalInstructions string
 	rootCmd                  *cobra.Command
 	pluginPool               *plugin.Pool
+	upstreamServers          map[string]config.MCPServerConfig
 }
 
 // WithRootCommand sets the cobra root command for CLI introspection tools.
@@ -214,6 +229,20 @@ func WithErrorLog(lgr *log.Logger) ServerOption {
 func WithSupplementalInstructions(instructions string) ServerOption {
 	return func(c *serverConfig) {
 		c.supplementalInstructions = instructions
+	}
+}
+
+// WithUpstreamServer adds an upstream MCP server whose tools are
+// auto-discovered and proxied through the local server. Auth tokens are
+// injected automatically using the configured auth handler.
+//
+// Multiple upstream servers can be added by calling this option multiple times.
+func WithUpstreamServer(name string, cfg config.MCPServerConfig) ServerOption {
+	return func(c *serverConfig) {
+		if c.upstreamServers == nil {
+			c.upstreamServers = make(map[string]config.MCPServerConfig)
+		}
+		c.upstreamServers[name] = cfg
 	}
 }
 
@@ -538,16 +567,18 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	}
 
 	s := &Server{
-		ctx:         mcpCtx,
-		version:     cfg.version,
-		name:        cfg.name,
-		registry:    cfg.registry,
-		authReg:     cfg.authReg,
-		config:      cfg.config,
-		rootCmd:     cfg.rootCmd,
-		pluginPool:  cfg.pluginPool,
-		coreTools:   make(map[string]struct{}, 64),
-		corePrompts: make(map[string]struct{}, 16),
+		ctx:             mcpCtx,
+		version:         cfg.version,
+		name:            cfg.name,
+		registry:        cfg.registry,
+		authReg:         cfg.authReg,
+		config:          cfg.config,
+		rootCmd:         cfg.rootCmd,
+		pluginPool:      cfg.pluginPool,
+		coreTools:       make(map[string]struct{}, 64),
+		corePrompts:     make(map[string]struct{}, 16),
+		upstreamTools:   make(map[string]string),
+		upstreamProxies: make(map[string]*upstream.Proxy),
 	}
 
 	// Ensure the official provider registry is available in the server
@@ -632,12 +663,144 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	// Register all prompts
 	s.registerAllPrompts()
 
+	// Merge upstream servers from config and explicit options.
+	// Check both WithServerConfig and config from context (WithServerContext)
+	// so embedders who supply config via either path get upstream proxies.
+	upstreamConfigs := make(map[string]config.MCPServerConfig)
+	if cfg.config != nil {
+		for name, serverCfg := range cfg.config.MCP.Servers {
+			upstreamConfigs[name] = serverCfg
+		}
+	} else if ctxCfg := config.FromContext(mcpCtx); ctxCfg != nil {
+		for name, serverCfg := range ctxCfg.MCP.Servers {
+			upstreamConfigs[name] = serverCfg
+		}
+	}
+	// Explicit WithUpstreamServer options override config entries.
+	for name, serverCfg := range cfg.upstreamServers {
+		upstreamConfigs[name] = serverCfg
+	}
+
+	// Create upstream proxies (actual connection is lazy).
+	for name, serverCfg := range upstreamConfigs {
+		if !serverCfg.IsEnabled() {
+			s.logger.V(1).Info("upstream server disabled, skipping", "upstream", name)
+			continue
+		}
+		if serverCfg.URL == "" {
+			s.logger.Error(nil, "upstream server has no URL, skipping", "upstream", name)
+			continue
+		}
+		proxy := upstream.NewProxy(name, serverCfg, s.authReg, s.logger, s.name)
+		s.upstreamProxies[name] = proxy
+	}
+
 	return s, nil
 }
 
-// Close releases resources owned by the server. Safe to call multiple times.
+// Close releases resources owned by the server. Safe to call multiple times
+// and concurrently with Serve*/Handler/Info.
 func (s *Server) Close() {
-	// No-op currently; kept for future resource cleanup and API stability.
+	s.upstreamMu.Lock()
+	proxies := s.upstreamProxies
+	s.upstreamProxies = make(map[string]*upstream.Proxy)
+	s.upstreamRegistered = false
+	s.upstreamMu.Unlock()
+
+	for name, proxy := range proxies {
+		if err := proxy.Close(); err != nil {
+			s.logger.Error(err, "failed to close upstream proxy", "upstream", name)
+		}
+	}
+}
+
+// registerUpstreamTools connects to each upstream proxy, discovers its tools,
+// and registers proxy handlers on the local server. Safe to call from
+// multiple Serve*/Handler/Info methods. On full success the registration is
+// sealed; on partial or total failure it can be retried on the next call so
+// that transient startup/auth errors are not permanent.
+func (s *Server) registerUpstreamTools(ctx context.Context) error {
+	s.upstreamMu.Lock()
+	defer s.upstreamMu.Unlock()
+
+	if s.upstreamRegistered {
+		return nil
+	}
+
+	err := s.doRegisterUpstreamTools(ctx)
+	if err == nil {
+		s.upstreamRegistered = true
+	}
+	return err
+}
+
+// doRegisterUpstreamTools performs upstream tool discovery and registration.
+// Called via registerUpstreamTools with mutex guard; retryable on failure.
+func (s *Server) doRegisterUpstreamTools(ctx context.Context) error {
+	if len(s.upstreamProxies) == 0 {
+		return nil
+	}
+
+	// Sort upstream names for deterministic registration order.
+	names := make([]string, 0, len(s.upstreamProxies))
+	for name := range s.upstreamProxies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Build a set of all currently registered tool names so we can detect
+	// collisions with core, embedder/plugin, and other upstream tools.
+	registeredTools := make(map[string]struct{}, len(s.coreTools))
+	for _, st := range s.mcpServer.ListTools() {
+		registeredTools[st.Tool.Name] = struct{}{}
+	}
+
+	var errs []error
+	for _, name := range names {
+		proxy := s.upstreamProxies[name]
+		tools, err := proxy.ListTools(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("upstream %q: %w", name, err))
+			continue
+		}
+
+		for _, tool := range tools {
+			toolName := tool.Name
+
+			// Detect collisions with any already-registered tool (core,
+			// embedder/plugin, or previously registered upstream).
+			if _, exists := registeredTools[toolName]; exists {
+				if existingUpstream, isDup := s.upstreamTools[toolName]; isDup && existingUpstream == name {
+					// Already registered by this upstream in a prior attempt -- skip silently.
+					continue
+				} else if _, isCoreConflict := s.coreTools[toolName]; isCoreConflict {
+					s.logger.Error(nil, "upstream tool conflicts with core tool, skipping",
+						"tool", toolName, "upstream", name)
+				} else if isDup {
+					s.logger.Error(nil, "upstream tool name collision, skipping duplicate",
+						"tool", toolName, "upstream", name, "existing_upstream", existingUpstream)
+				} else {
+					s.logger.Error(nil, "upstream tool conflicts with existing tool, skipping",
+						"tool", toolName, "upstream", name)
+				}
+				continue
+			}
+
+			// Capture proxy for the closure.
+			p := proxy
+			s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return p.CallTool(ctx, request.Params.Name, request.GetArguments())
+			})
+			s.upstreamTools[toolName] = name
+			registeredTools[toolName] = struct{}{}
+			s.logger.V(1).Info("registered upstream tool", "tool", toolName, "upstream", name)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
 // freshConfigContext returns a context with the latest config overlaid.
@@ -659,6 +822,11 @@ func (s *Server) freshConfigContext(ctx context.Context) context.Context {
 // all tool handlers -- including those registered by embedders via
 // MCPServer().AddTool() -- can access them.
 func (s *Server) Serve(opts ...server.StdioOption) error {
+	// Discover and register upstream tools before serving.
+	if err := s.registerUpstreamTools(s.ctx); err != nil {
+		s.logger.Error(err, "failed to register upstream tools")
+	}
+
 	contextOpt := server.WithStdioContextFunc(func(ctx context.Context) context.Context {
 		return s.freshConfigContext(ctx)
 	})
@@ -671,6 +839,11 @@ func (s *Server) Serve(opts ...server.StdioOption) error {
 // ServeSSE starts the MCP server on SSE transport at the given address.
 // Server context values are injected into every request context (see Serve).
 func (s *Server) ServeSSE(addr string, opts ...server.SSEOption) error {
+	// Discover and register upstream tools before serving.
+	if err := s.registerUpstreamTools(s.ctx); err != nil {
+		s.logger.Error(err, "failed to register upstream tools")
+	}
+
 	contextOpt := server.WithSSEContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
 		return s.freshConfigContext(ctx)
 	})
@@ -685,6 +858,11 @@ func (s *Server) ServeSSE(addr string, opts ...server.SSEOption) error {
 // ServeHTTP starts the MCP server on Streamable HTTP transport at the given address.
 // Server context values are injected into every request context (see Serve).
 func (s *Server) ServeHTTP(addr string, opts ...server.StreamableHTTPOption) error {
+	// Discover and register upstream tools before serving.
+	if err := s.registerUpstreamTools(s.ctx); err != nil {
+		s.logger.Error(err, "failed to register upstream tools")
+	}
+
 	contextOpt := server.WithHTTPContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
 		return s.freshConfigContext(ctx)
 	})
@@ -701,6 +879,11 @@ func (s *Server) ServeHTTP(addr string, opts ...server.StreamableHTTPOption) err
 // If the HTTP server was already created (by a prior call to Handler or ServeHTTP),
 // the existing instance is returned and opts are ignored.
 func (s *Server) Handler(opts ...server.StreamableHTTPOption) http.Handler {
+	// Discover and register upstream tools before returning the handler.
+	if err := s.registerUpstreamTools(s.ctx); err != nil {
+		s.logger.Error(err, "failed to register upstream tools")
+	}
+
 	if s.httpServer != nil {
 		return s.httpServer
 	}
@@ -794,6 +977,10 @@ func (s *Server) NotifyToolsChanged(ctx context.Context) error {
 // Info returns the server's tool and resource information as JSON.
 // Used by `scafctl mcp serve --info`.
 func (s *Server) Info() ([]byte, error) {
+	// Ensure upstream tools are registered so info output matches runtime.
+	if err := s.registerUpstreamTools(s.ctx); err != nil {
+		s.logger.Error(err, "failed to register upstream tools for info")
+	}
 	type toolInfo struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`

--- a/pkg/mcp/tools_config.go
+++ b/pkg/mcp/tools_config.go
@@ -71,6 +71,7 @@ func (s *Server) handleGetConfig(_ context.Context, request mcp.CallToolRequest)
 		"auth":       sanitized.Auth,
 		"build":      sanitized.Build,
 		"apiServer":  sanitized.APIServer,
+		"mcp":        sanitized.MCP,
 	}
 
 	sectionData, ok := validSections[section]

--- a/pkg/mcp/upstream/upstream.go
+++ b/pkg/mcp/upstream/upstream.go
@@ -1,0 +1,274 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package upstream provides MCP upstream server proxying with automatic
+// auth token injection. It connects to remote MCP servers, discovers their
+// tools, and registers them as local tools that transparently forward
+// tools/call requests with authentication.
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// DefaultTimeout is the default request timeout for upstream MCP server calls.
+const DefaultTimeout = 30 * time.Second
+
+// Proxy manages a connection to a single upstream MCP server.
+// It lazily connects on the first ListTools or CallTool request.
+type Proxy struct {
+	name       string
+	clientName string
+	cfg        config.MCPServerConfig
+	logger     logr.Logger
+
+	authReg *auth.Registry
+
+	mu           sync.Mutex
+	client       *mcpclient.Client
+	tools        []mcp.Tool
+	toolsFetched bool
+}
+
+// NewProxy creates a new upstream proxy for the named server.
+// clientName is the MCP client identity advertised during Initialize
+// (typically the embedder's binary name).
+func NewProxy(name string, cfg config.MCPServerConfig, authReg *auth.Registry, logger logr.Logger, clientName string) *Proxy {
+	if clientName == "" {
+		clientName = settings.CliBinaryName
+	}
+	return &Proxy{
+		name:       name,
+		clientName: clientName,
+		cfg:        cfg,
+		authReg:    authReg,
+		logger:     logger.WithValues("upstream", name),
+	}
+}
+
+// Name returns the upstream server name.
+func (p *Proxy) Name() string {
+	return p.name
+}
+
+// connect establishes the connection to the upstream server.
+// Must be called with p.mu held.
+func (p *Proxy) connect(ctx context.Context) error {
+	if p.client != nil {
+		return nil
+	}
+
+	p.logger.V(1).Info("connecting to upstream MCP server", "url", p.cfg.URL)
+
+	var transportOpts []transport.StreamableHTTPCOption
+
+	// Apply request timeout from config (falls back to DefaultTimeout).
+	timeout := DefaultTimeout
+	if p.cfg.Timeout != "" {
+		parsed, err := time.ParseDuration(p.cfg.Timeout)
+		if err != nil {
+			return fmt.Errorf("upstream %q: invalid timeout %q: %w", p.name, p.cfg.Timeout, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("upstream %q: timeout must be positive, got %q", p.name, p.cfg.Timeout)
+		}
+		timeout = parsed
+	}
+	transportOpts = append(transportOpts, transport.WithHTTPTimeout(timeout))
+
+	// Inject auth headers if an auth handler is configured.
+	if p.cfg.Auth.Handler != "" {
+		headerFunc := p.buildAuthHeaderFunc()
+		transportOpts = append(transportOpts, transport.WithHTTPHeaderFunc(headerFunc))
+	}
+
+	t, err := transport.NewStreamableHTTP(p.cfg.URL, transportOpts...)
+	if err != nil {
+		return fmt.Errorf("upstream %q: failed to create transport: %w", p.name, err)
+	}
+
+	c := mcpclient.NewClient(t)
+
+	// Use the configured timeout for the handshake so a hanging upstream
+	// cannot block connect() indefinitely.
+	connectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := c.Start(connectCtx); err != nil {
+		return fmt.Errorf("upstream %q: failed to start transport: %w", p.name, err)
+	}
+
+	_, err = c.Initialize(connectCtx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{
+				Name:    p.clientName,
+				Version: settings.VersionInformation.BuildVersion,
+			},
+		},
+	})
+	if err != nil {
+		_ = c.Close()
+		return fmt.Errorf("upstream %q: initialize failed: %w", p.name, err)
+	}
+
+	p.client = c
+	p.logger.V(1).Info("connected to upstream MCP server")
+	return nil
+}
+
+// buildAuthHeaderFunc returns a transport.HTTPHeaderFunc that injects
+// auth tokens from the configured auth handler.
+func (p *Proxy) buildAuthHeaderFunc() transport.HTTPHeaderFunc {
+	return func(ctx context.Context) map[string]string {
+		if p.authReg == nil || p.cfg.Auth.Handler == "" {
+			return nil
+		}
+
+		handler, err := p.authReg.GetContext(ctx, p.cfg.Auth.Handler)
+		if err != nil {
+			p.logger.Error(err, "upstream auth handler not found", "handler", p.cfg.Auth.Handler)
+			return nil
+		}
+
+		token, err := handler.GetToken(ctx, auth.TokenOptions{
+			Scope: p.cfg.Auth.Scope,
+		})
+		if err != nil {
+			p.logger.Error(err, "upstream auth token acquisition failed", "handler", p.cfg.Auth.Handler)
+			return nil
+		}
+
+		tokenType := token.TokenType
+		if tokenType == "" {
+			tokenType = "Bearer"
+		}
+		return map[string]string{
+			"Authorization": tokenType + " " + token.AccessToken,
+		}
+	}
+}
+
+// ListTools connects lazily and returns the upstream server's tools.
+// Tools are cached after the first successful fetch.
+func (p *Proxy) ListTools(ctx context.Context) ([]mcp.Tool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err := p.connect(ctx); err != nil {
+		return nil, err
+	}
+
+	// Use cached tools if available (including empty results).
+	if p.toolsFetched {
+		return p.tools, nil
+	}
+
+	result, err := p.client.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("upstream %q: list tools failed: %w", p.name, err)
+	}
+
+	tools := filterTools(result.Tools, p.cfg.Tools)
+	tools = prefixTools(tools, p.cfg.ToolPrefix)
+	p.tools = tools
+	p.toolsFetched = true
+
+	p.logger.Info("discovered upstream tools", "count", len(tools))
+	return tools, nil
+}
+
+// CallTool forwards a tool call to the upstream server.
+func (p *Proxy) CallTool(ctx context.Context, name string, arguments map[string]any) (*mcp.CallToolResult, error) {
+	p.mu.Lock()
+	if err := p.connect(ctx); err != nil {
+		p.mu.Unlock()
+		return nil, err
+	}
+	c := p.client
+	p.mu.Unlock()
+
+	// Strip the tool prefix to get the original upstream tool name.
+	remoteName := name
+	if p.cfg.ToolPrefix != "" {
+		remoteName = strings.TrimPrefix(name, p.cfg.ToolPrefix)
+	}
+
+	result, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      remoteName,
+			Arguments: arguments,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("upstream %q: call tool %q failed: %w", p.name, remoteName, err)
+	}
+
+	return result, nil
+}
+
+// Close shuts down the upstream connection.
+func (p *Proxy) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.client != nil {
+		err := p.client.Close()
+		p.client = nil
+		p.tools = nil
+		p.toolsFetched = false
+		return err
+	}
+	return nil
+}
+
+// filterTools returns only tools whose names match the allowlist patterns.
+// An empty allowlist means all tools are allowed.
+func filterTools(tools []mcp.Tool, patterns []string) []mcp.Tool {
+	if len(patterns) == 0 {
+		return tools
+	}
+
+	var filtered []mcp.Tool
+	for _, tool := range tools {
+		for _, pattern := range patterns {
+			matched, err := path.Match(pattern, tool.Name)
+			if err != nil {
+				// Invalid pattern -- skip it.
+				continue
+			}
+			if matched {
+				filtered = append(filtered, tool)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// prefixTools adds a prefix to all tool names. If prefix is empty, tools are
+// returned unchanged.
+func prefixTools(tools []mcp.Tool, prefix string) []mcp.Tool {
+	if prefix == "" {
+		return tools
+	}
+	prefixed := make([]mcp.Tool, len(tools))
+	for i, tool := range tools {
+		tool.Name = prefix + tool.Name
+		prefixed[i] = tool
+	}
+	return prefixed
+}

--- a/pkg/mcp/upstream/upstream_test.go
+++ b/pkg/mcp/upstream/upstream_test.go
@@ -1,0 +1,494 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package upstream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// newMockUpstreamServer creates a test MCP server with the given tools.
+func newMockUpstreamServer(t *testing.T, tools map[string]string) *server.MCPServer {
+	t.Helper()
+	mcpServer := server.NewMCPServer("mock-upstream", "1.0.0",
+		server.WithToolCapabilities(true),
+	)
+	for name, response := range tools {
+		resp := response // capture
+		mcpServer.AddTool(
+			mcp.NewTool(name, mcp.WithDescription("mock tool: "+name)),
+			func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultText(resp), nil
+			},
+		)
+	}
+	return mcpServer
+}
+
+func TestProxy_ListTools(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"tool_a": "response_a",
+		"tool_b": "response_b",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{
+		URL: ts.URL,
+	}
+	proxy := NewProxy("test-upstream", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	tools, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tools, 2)
+
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	assert.Contains(t, names, "tool_a")
+	assert.Contains(t, names, "tool_b")
+}
+
+func TestProxy_ListTools_Cached(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"tool_a": "response_a",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{URL: ts.URL}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	tools1, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tools1, 1)
+
+	tools2, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, tools1, tools2)
+}
+
+func TestProxy_CallTool(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"greet": "hello world",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{URL: ts.URL}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	_, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+
+	result, err := proxy.CallTool(context.Background(), "greet", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "hello world", textContent.Text)
+}
+
+func TestProxy_CallTool_WithPrefix(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"greet": "hello prefixed",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{
+		URL:        ts.URL,
+		ToolPrefix: "upstream_",
+	}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	tools, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "upstream_greet", tools[0].Name)
+
+	result, err := proxy.CallTool(context.Background(), "upstream_greet", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "hello prefixed", textContent.Text)
+}
+
+func TestProxy_CallTool_LazyConnect(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"greet": "hello lazy",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{URL: ts.URL}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	result, err := proxy.CallTool(context.Background(), "greet", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "hello lazy", textContent.Text)
+}
+
+func TestProxy_Close(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"tool_a": "response_a",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{URL: ts.URL}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+
+	_, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+
+	err = proxy.Close()
+	assert.NoError(t, err)
+
+	// Close again should be safe (idempotent).
+	err = proxy.Close()
+	assert.NoError(t, err)
+}
+
+func TestProxy_Name(t *testing.T) {
+	proxy := NewProxy("my-upstream", config.MCPServerConfig{}, nil, logr.Discard(), "")
+	assert.Equal(t, "my-upstream", proxy.Name())
+}
+
+func TestProxy_ClientName(t *testing.T) {
+	t.Run("custom name", func(t *testing.T) {
+		proxy := NewProxy("test", config.MCPServerConfig{}, nil, logr.Discard(), "mycli")
+		assert.Equal(t, "mycli", proxy.clientName)
+	})
+	t.Run("empty falls back to default", func(t *testing.T) {
+		proxy := NewProxy("test", config.MCPServerConfig{}, nil, logr.Discard(), "")
+		assert.Equal(t, settings.CliBinaryName, proxy.clientName)
+	})
+}
+
+func TestProxy_ConnectError(t *testing.T) {
+	cfg := config.MCPServerConfig{
+		URL: "http://127.0.0.1:1", // nothing listening
+	}
+	proxy := NewProxy("bad", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	_, err := proxy.ListTools(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bad")
+}
+
+func TestProxy_BuildAuthHeaderFunc_NoAuthReg(t *testing.T) {
+	proxy := NewProxy("test", config.MCPServerConfig{
+		Auth: config.MCPServerAuthConfig{Handler: "entra"},
+	}, nil, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	assert.Nil(t, headers)
+}
+
+func TestProxy_BuildAuthHeaderFunc_NoHandler(t *testing.T) {
+	proxy := NewProxy("test", config.MCPServerConfig{}, nil, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	assert.Nil(t, headers)
+}
+
+func TestProxy_ToolFilter_WithAllowlist(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"auth_login":  "ok",
+		"auth_logout": "ok",
+		"data_query":  "ok",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{
+		URL:   ts.URL,
+		Tools: []string{"auth_*"},
+	}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	tools, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tools, 2)
+
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	assert.Contains(t, names, "auth_login")
+	assert.Contains(t, names, "auth_logout")
+	assert.NotContains(t, names, "data_query")
+}
+
+func TestFilterTools(t *testing.T) {
+	tools := []mcp.Tool{
+		mcp.NewTool("auth_login"),
+		mcp.NewTool("auth_logout"),
+		mcp.NewTool("data_query"),
+		mcp.NewTool("data_insert"),
+		mcp.NewTool("admin_reset"),
+	}
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     []string
+	}{
+		{
+			name:     "empty patterns allows all",
+			patterns: nil,
+			want:     []string{"auth_login", "auth_logout", "data_query", "data_insert", "admin_reset"},
+		},
+		{
+			name:     "wildcard allows all",
+			patterns: []string{"*"},
+			want:     []string{"auth_login", "auth_logout", "data_query", "data_insert", "admin_reset"},
+		},
+		{
+			name:     "prefix pattern",
+			patterns: []string{"auth_*"},
+			want:     []string{"auth_login", "auth_logout"},
+		},
+		{
+			name:     "multiple patterns",
+			patterns: []string{"auth_*", "admin_*"},
+			want:     []string{"auth_login", "auth_logout", "admin_reset"},
+		},
+		{
+			name:     "no match",
+			patterns: []string{"nonexistent_*"},
+			want:     nil,
+		},
+		{
+			name:     "exact match",
+			patterns: []string{"data_query"},
+			want:     []string{"data_query"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterTools(tools, tt.patterns)
+			gotNames := make([]string, len(got))
+			for i, tool := range got {
+				gotNames[i] = tool.Name
+			}
+			if tt.want == nil {
+				assert.Empty(t, got)
+			} else {
+				assert.Equal(t, tt.want, gotNames)
+			}
+		})
+	}
+}
+
+func TestPrefixTools(t *testing.T) {
+	tools := []mcp.Tool{
+		mcp.NewTool("tool_a"),
+		mcp.NewTool("tool_b"),
+	}
+
+	t.Run("empty prefix is no-op", func(t *testing.T) {
+		result := prefixTools(tools, "")
+		assert.Equal(t, tools, result)
+	})
+
+	t.Run("applies prefix", func(t *testing.T) {
+		result := prefixTools(tools, "remote_")
+		require.Len(t, result, 2)
+		assert.Equal(t, "remote_tool_a", result[0].Name)
+		assert.Equal(t, "remote_tool_b", result[1].Name)
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		_ = prefixTools(tools, "remote_")
+		assert.Equal(t, "tool_a", tools[0].Name)
+		assert.Equal(t, "tool_b", tools[1].Name)
+	})
+}
+
+func TestMCPServerConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := config.MCPServerConfig{}
+		assert.True(t, cfg.IsEnabled())
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		enabled := true
+		cfg := config.MCPServerConfig{Enabled: &enabled}
+		assert.True(t, cfg.IsEnabled())
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		enabled := false
+		cfg := config.MCPServerConfig{Enabled: &enabled}
+		assert.False(t, cfg.IsEnabled())
+	})
+}
+
+func TestProxy_BuildAuthHeaderFunc_Success(t *testing.T) {
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.GetTokenResult = &auth.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+	}
+
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mockHandler))
+
+	proxy := NewProxy("test", config.MCPServerConfig{
+		Auth: config.MCPServerAuthConfig{
+			Handler: "entra",
+			Scope:   "api://my-scope",
+		},
+	}, reg, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	require.NotNil(t, headers)
+	assert.Equal(t, "Bearer test-access-token", headers["Authorization"])
+	require.Len(t, mockHandler.GetTokenCalls, 1)
+	assert.Equal(t, "api://my-scope", mockHandler.GetTokenCalls[0].Scope)
+}
+
+func TestProxy_BuildAuthHeaderFunc_CustomTokenType(t *testing.T) {
+	mockHandler := auth.NewMockHandler("github")
+	mockHandler.GetTokenResult = &auth.Token{
+		AccessToken: "ghp_abc123",
+		TokenType:   "token",
+	}
+
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mockHandler))
+
+	proxy := NewProxy("test", config.MCPServerConfig{
+		Auth: config.MCPServerAuthConfig{Handler: "github"},
+	}, reg, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	require.NotNil(t, headers)
+	assert.Equal(t, "token ghp_abc123", headers["Authorization"])
+}
+
+func TestProxy_BuildAuthHeaderFunc_EmptyTokenType(t *testing.T) {
+	mockHandler := auth.NewMockHandler("test-handler")
+	mockHandler.GetTokenResult = &auth.Token{
+		AccessToken: "my-token",
+		TokenType:   "", // empty => defaults to Bearer
+	}
+
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mockHandler))
+
+	proxy := NewProxy("test", config.MCPServerConfig{
+		Auth: config.MCPServerAuthConfig{Handler: "test-handler"},
+	}, reg, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	require.NotNil(t, headers)
+	assert.Equal(t, "Bearer my-token", headers["Authorization"])
+}
+
+func TestProxy_BuildAuthHeaderFunc_GetTokenError(t *testing.T) {
+	mockHandler := auth.NewMockHandler("entra")
+	mockHandler.GetTokenErr = assert.AnError
+
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mockHandler))
+
+	proxy := NewProxy("test", config.MCPServerConfig{
+		Auth: config.MCPServerAuthConfig{Handler: "entra"},
+	}, reg, logr.Discard(), "")
+
+	fn := proxy.buildAuthHeaderFunc()
+	headers := fn(context.Background())
+	assert.Nil(t, headers)
+}
+
+func TestProxy_Connect_Timeout(t *testing.T) {
+	mcpServer := newMockUpstreamServer(t, map[string]string{
+		"tool_a": "response_a",
+	})
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
+	defer ts.Close()
+
+	cfg := config.MCPServerConfig{
+		URL:     ts.URL,
+		Timeout: "5s",
+	}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	tools, err := proxy.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tools, 1)
+}
+
+func TestProxy_Connect_InvalidTimeout(t *testing.T) {
+	cfg := config.MCPServerConfig{
+		URL:     "http://127.0.0.1:1",
+		Timeout: "not-a-duration",
+	}
+	proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+	defer proxy.Close()
+
+	_, err := proxy.ListTools(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timeout")
+}
+
+func TestProxy_Connect_ZeroTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{name: "zero", timeout: "0"},
+		{name: "zero_seconds", timeout: "0s"},
+		{name: "negative", timeout: "-5s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.MCPServerConfig{
+				URL:     "http://127.0.0.1:1",
+				Timeout: tt.timeout,
+			}
+			proxy := NewProxy("test", cfg, nil, logr.Discard(), "")
+			defer proxy.Close()
+
+			_, err := proxy.ListTools(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "timeout must be positive")
+		})
+	}
+}

--- a/pkg/mcp/upstream_integration_test.go
+++ b/pkg/mcp/upstream_integration_test.go
@@ -1,0 +1,385 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/mcp/upstream"
+)
+
+// newTestUpstreamMCPServer creates a mock upstream MCP server for integration tests.
+func newTestUpstreamMCPServer(t *testing.T, tools map[string]string) *httptest.Server {
+	t.Helper()
+	srv := mcpserver.NewMCPServer("test-upstream", "1.0.0",
+		mcpserver.WithToolCapabilities(true),
+	)
+	for name, response := range tools {
+		resp := response
+		srv.AddTool(
+			mcp.NewTool(name, mcp.WithDescription("mock: "+name)),
+			func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultText(resp), nil
+			},
+		)
+	}
+	return mcpserver.NewTestStreamableHTTPServer(srv)
+}
+
+func TestWithUpstreamServer(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"remote_tool": "remote_result",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("test", config.MCPServerConfig{
+			URL: ts.URL,
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	assert.Len(t, srv.upstreamProxies, 1)
+	assert.Contains(t, srv.upstreamProxies, "test")
+}
+
+func TestRegisterUpstreamTools_ViaCoreServer(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"remote_greet": "hello",
+		"remote_calc":  "42",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("backend", config.MCPServerConfig{
+			URL: ts.URL,
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	// Upstream tools should be tracked.
+	assert.Contains(t, srv.upstreamTools, "remote_greet")
+	assert.Contains(t, srv.upstreamTools, "remote_calc")
+	assert.Equal(t, "backend", srv.upstreamTools["remote_greet"])
+}
+
+func TestRegisterUpstreamTools_Idempotent(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"tool_x": "result",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("test", config.MCPServerConfig{
+			URL: ts.URL,
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	// Call twice -- should only register once (sealed after success).
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, srv.upstreamTools, 1)
+}
+
+func TestRegisterUpstreamTools_RetriesOnFailure(t *testing.T) {
+	// First attempt: upstream is unreachable.
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("bad", config.MCPServerConfig{
+			URL:     "http://127.0.0.1:1",
+			Timeout: "200ms",
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.Error(t, err)
+	assert.Empty(t, srv.upstreamTools)
+
+	// Replace the proxy with one pointing at a live server.
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"recovered_tool": "ok",
+	})
+	defer ts.Close()
+
+	srv.upstreamProxies["bad"].Close()
+	srv.upstreamProxies["bad"] = upstream.NewProxy(
+		"bad", config.MCPServerConfig{URL: ts.URL}, nil, logr.Discard(), srv.name,
+	)
+
+	// Second attempt should succeed now.
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, srv.upstreamTools, "recovered_tool")
+}
+
+func TestRegisterUpstreamTools_SkipsCoreToolCollision(t *testing.T) {
+	// Create an upstream that exposes a tool with the same name as a core tool.
+	coreName := ""
+	for name := range coreToolNames() {
+		coreName = name
+		break
+	}
+	require.NotEmpty(t, coreName, "need at least one core tool name")
+
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		coreName:    "should-be-skipped",
+		"safe_tool": "allowed",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("conflict", config.MCPServerConfig{
+			URL: ts.URL,
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	// Core-conflicting tool should be skipped.
+	assert.NotContains(t, srv.upstreamTools, coreName)
+	// Non-conflicting tool should be registered.
+	assert.Contains(t, srv.upstreamTools, "safe_tool")
+}
+
+func TestRegisterUpstreamTools_ConfigBased(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"cfg_tool": "from-config",
+	})
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Version: 1,
+		MCP: config.MCPConfig{
+			Servers: map[string]config.MCPServerConfig{
+				"from-config": {URL: ts.URL},
+			},
+		},
+	}
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithServerConfig(cfg),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	assert.Len(t, srv.upstreamProxies, 1)
+	assert.Contains(t, srv.upstreamProxies, "from-config")
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, srv.upstreamTools, "cfg_tool")
+}
+
+func TestRegisterUpstreamTools_OptionOverridesConfig(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"overridden_tool": "from-option",
+	})
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Version: 1,
+		MCP: config.MCPConfig{
+			Servers: map[string]config.MCPServerConfig{
+				"srv": {URL: "http://127.0.0.1:1"}, // bad URL in config
+			},
+		},
+	}
+
+	// Option with same name should override the config entry.
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithServerConfig(cfg),
+		WithUpstreamServer("srv", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, srv.upstreamTools, "overridden_tool")
+}
+
+func TestRegisterUpstreamTools_DisabledServer(t *testing.T) {
+	disabled := false
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("disabled", config.MCPServerConfig{
+			URL:     "http://127.0.0.1:1",
+			Enabled: &disabled,
+		}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	// Disabled servers should not create proxies.
+	assert.Empty(t, srv.upstreamProxies)
+}
+
+func TestServerClose_ClosesUpstreamProxies(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"tool_a": "a",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("test", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+
+	// Connect the proxy.
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	// Close should not panic.
+	srv.Close()
+	// Double close should be safe.
+	srv.Close()
+}
+
+func TestServerClose_ConcurrentWithRegister(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"tool_a": "a",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("test", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+
+	// Run Close and registerUpstreamTools concurrently to verify no race.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		srv.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		_ = srv.registerUpstreamTools(context.Background())
+	}()
+	wg.Wait()
+}
+
+func TestUpstreamTools_InListCapabilities(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"upstream_only_tool": "data",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("remote", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	caps := srv.ListCapabilities()
+	found := false
+	for _, c := range caps {
+		if c.Name == "upstream_only_tool" {
+			found = true
+			assert.Equal(t, SourceUpstream, c.Source)
+			assert.Equal(t, CapabilityTool, c.Kind)
+			break
+		}
+	}
+	assert.True(t, found, "upstream tool should appear in ListCapabilities")
+}
+
+func TestInfo_IncludesUpstreamTools(t *testing.T) {
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"info_upstream_tool": "data",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("info-test", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	// Info() should trigger upstream registration automatically.
+	infoJSON, err := srv.Info()
+	require.NoError(t, err)
+	assert.Contains(t, string(infoJSON), "info_upstream_tool")
+}
+
+func TestRegisterUpstreamTools_SkipsEmbedderToolCollision(t *testing.T) {
+	// Register a tool via the embedder API before upstream discovery.
+	ts := newTestUpstreamMCPServer(t, map[string]string{
+		"custom_embedder_tool": "should-be-skipped",
+		"unique_upstream":      "allowed",
+	})
+	defer ts.Close()
+
+	srv, err := NewServer(
+		WithServerLogger(logr.Discard()),
+		WithUpstreamServer("emb-test", config.MCPServerConfig{URL: ts.URL}),
+	)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	// Simulate embedder adding a tool before Serve is called.
+	srv.MCPServer().AddTool(
+		mcp.NewTool("custom_embedder_tool", mcp.WithDescription("embedder tool")),
+		func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("embedder"), nil
+		},
+	)
+
+	err = srv.registerUpstreamTools(context.Background())
+	require.NoError(t, err)
+
+	// Embedder-conflicting tool should be skipped.
+	assert.NotContains(t, srv.upstreamTools, "custom_embedder_tool")
+	// Non-conflicting tool should be registered.
+	assert.Contains(t, srv.upstreamTools, "unique_upstream")
+}
+
+// coreToolNames returns the set of core tool names from a fresh server.
+func coreToolNames() map[string]struct{} {
+	srv, err := NewServer(WithServerLogger(logr.Discard()))
+	if err != nil {
+		return nil
+	}
+	return srv.coreTools
+}


### PR DESCRIPTION
- add MCPConfig, MCPServerConfig, MCPServerAuthConfig types with full struct tags and IsEnabled() default-true helper
- add upstream.Proxy with lazy connect, tool discovery, prefix/filter support, and automatic auth header injection via configurable handler
- wire upstream proxies into Server with sync.Once registration across all Serve*/Handler entry points
- detect and skip tool name collisions (core and upstream-to-upstream) with deterministic registration order
- add SourceUpstream capability source for ListCapabilities
- expose WithUpstreamServer() option for embedder API and merge with config-based upstream server definitions
- expose MCP config section via get_config tool and SanitizedConfig
- add upstream_test.go (21 tests, 89% coverage) and upstream_integration_test.go (9 tests) covering proxy lifecycle, auth header variants, tool filtering, prefixing, collisions, and config-based registration

Closes #467