### PR TITLE
fix(auth): resolve active profile in GetToken for provider-level auth

### DIFF
--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -319,6 +319,14 @@ func (h *Handler) PurgeExpiredTokens(ctx context.Context) (int, error) {
 
 // Status returns the current authentication state.
 func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
+	// Resolve the active profile when none is explicitly set in context.
+	// Same as GetToken: ensures callers like MCP auth_status see the active profile.
+	if auth.ProfileFromContext(ctx) == "" && !auth.IsProfileResolved(ctx) {
+		if profile := auth.ResolveActiveProfile(ctx, h.cfg.Name); profile != "" {
+			ctx = auth.WithProfile(ctx, profile)
+		}
+	}
+
 	if err := h.ensureSecrets(); err != nil {
 		return &auth.Status{Authenticated: false, Reason: "secrets store unavailable"}, nil //nolint:nilerr // graceful degradation
 	}
@@ -344,6 +352,17 @@ func (h *Handler) Status(ctx context.Context) (*auth.Status, error) {
 // GetToken returns a valid access token, refreshing if necessary.
 // If tokenExchange is configured, returns the derived token.
 func (h *Handler) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	// Resolve the active profile when none is explicitly set in context.
+	// This ensures provider-level auth (e.g. HTTP provider's authProvider input)
+	// respects --auth-profile, SCAFCTL_AUTH_PROFILE, and config-level activeProfile.
+	// Skip when IsProfileResolved is true -- this means the caller already resolved
+	// the profile (e.g. "auth token --profile built-in" normalizing to default).
+	if auth.ProfileFromContext(ctx) == "" && !auth.IsProfileResolved(ctx) {
+		if profile := auth.ResolveActiveProfile(ctx, h.cfg.Name); profile != "" {
+			ctx = auth.WithProfile(ctx, profile)
+		}
+	}
+
 	if err := h.ensureSecrets(); err != nil {
 		return nil, err
 	}

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -1072,3 +1072,119 @@ func TestHandler_PurgeExpiredTokens_NilCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 }
+
+func TestHandler_GetToken_ResolvesActiveProfile(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, store := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.Name = "github"
+		cfg.ClientSecret = "test-secret"
+	})
+
+	// Store a refresh token under the "work" profile key.
+	_ = store.Set(context.Background(), secretKeyPrefix+"github.work."+secretKeyRefreshSuffix, []byte("good-refresh"))
+
+	// Build a context with config-level activeProfile but NO explicit WithProfile.
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			GitHub: &config.GitHubAuthConfig{ActiveProfile: "work"},
+		},
+	})
+
+	// GetToken should resolve the active profile from config and find the token.
+	token, err := h.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+}
+
+func TestHandler_GetToken_ExplicitProfileTakesPrecedence(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, store := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.Name = "github"
+		cfg.ClientSecret = "test-secret"
+	})
+
+	// Store refresh token ONLY under the "explicit" profile.
+	// The "config" profile has no token — if GetToken mistakenly uses it, the test fails.
+	_ = store.Set(context.Background(), secretKeyPrefix+"github.explicit."+secretKeyRefreshSuffix, []byte("good-refresh"))
+
+	// Context has config-level activeProfile="config" but explicit WithProfile="explicit".
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			GitHub: &config.GitHubAuthConfig{ActiveProfile: "config"},
+		},
+	})
+	ctx = auth.WithProfile(ctx, "explicit")
+
+	// Explicit profile should win — only the "explicit" profile has a valid token.
+	token, err := h.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+}
+
+func TestHandler_GetToken_GlobalFlagProfileResolved(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, store := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.Name = "github"
+		cfg.ClientSecret = "test-secret"
+	})
+
+	// Store refresh token under the "flag" profile.
+	_ = store.Set(context.Background(), secretKeyPrefix+"github.flag."+secretKeyRefreshSuffix, []byte("good-refresh"))
+
+	// Context has global --auth-profile flag set but no explicit WithProfile.
+	ctx := auth.WithGlobalProfile(context.Background(), "flag")
+
+	token, err := h.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+}
+
+func TestHandler_GetToken_NoProfileFallsBackToDefault(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, store := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.ClientSecret = "test-secret"
+	})
+
+	// Store refresh token under default (no profile) key.
+	_ = store.Set(context.Background(), secretKeyPrefix+"test-provider."+secretKeyRefreshSuffix, []byte("good-refresh"))
+
+	// No profile anywhere — should use default key as before.
+	token, err := h.GetToken(context.Background(), auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+}
+
+func TestHandler_GetToken_ProfileResolvedSkipsReResolution(t *testing.T) {
+	srv := newTestOAuthServer(t)
+	defer srv.Close()
+
+	h, store := newTestHandler(t, srv, func(cfg *config.CustomOAuth2Config) {
+		cfg.Name = "github"
+		cfg.ClientSecret = "test-secret"
+	})
+
+	// Store refresh token ONLY under the default (built-in) profile key.
+	_ = store.Set(context.Background(), secretKeyPrefix+"github."+secretKeyRefreshSuffix, []byte("good-refresh"))
+
+	// Config has activeProfile="work", but the caller marked profile as resolved
+	// (simulating "auth token --profile built-in" which normalizes to default).
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			GitHub: &config.GitHubAuthConfig{ActiveProfile: "work"},
+		},
+	})
+	ctx = auth.WithProfileResolved(ctx)
+
+	// GetToken should use the built-in (default) profile, NOT re-resolve to "work".
+	token, err := h.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+}

--- a/pkg/auth/profile.go
+++ b/pkg/auth/profile.go
@@ -33,6 +33,9 @@ const profileContextKey contextKey = "auth.profile"
 // globalProfileContextKey stores the global --auth-profile flag value.
 const globalProfileContextKey contextKey = "auth.globalProfile"
 
+// profileResolvedContextKey marks that profile resolution has been performed.
+const profileResolvedContextKey contextKey = "auth.profileResolved"
+
 // validProfileName matches ASCII alphanumeric plus - and _.
 var validProfileName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
@@ -101,6 +104,20 @@ func WithGlobalProfile(ctx context.Context, profile string) context.Context {
 func GlobalProfileFromContext(ctx context.Context) string {
 	profile, _ := ctx.Value(globalProfileContextKey).(string)
 	return profile
+}
+
+// WithProfileResolved marks the context as having completed profile resolution.
+// This prevents GetToken from re-resolving the profile when a caller has already
+// determined the correct profile (including explicitly choosing the built-in profile).
+func WithProfileResolved(ctx context.Context) context.Context {
+	return context.WithValue(ctx, profileResolvedContextKey, true)
+}
+
+// IsProfileResolved returns true if profile resolution has already been performed
+// for this context. When true, GetToken skips its automatic profile fallback.
+func IsProfileResolved(ctx context.Context) bool {
+	v, _ := ctx.Value(profileResolvedContextKey).(bool)
+	return v
 }
 
 // NormalizeProfileName maps the reserved names "built-in" and "default" to the

--- a/pkg/auth/profile_test.go
+++ b/pkg/auth/profile_test.go
@@ -182,3 +182,13 @@ func TestDisplayProfileName(t *testing.T) {
 		})
 	}
 }
+
+func TestWithProfileResolved_IsProfileResolved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	assert.False(t, IsProfileResolved(ctx))
+
+	ctx = WithProfileResolved(ctx)
+	assert.True(t, IsProfileResolved(ctx))
+}

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -127,6 +127,11 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				}
 				ctx = auth.WithProfile(ctx, effectiveProfile)
 			}
+			// Mark profile as resolved so GetToken doesn't re-resolve.
+			// This is needed when --profile built-in normalizes to "" (default).
+			if profileExplicit {
+				ctx = auth.WithProfileResolved(ctx)
+			}
 
 			// --force is an alias for --force-refresh
 			if force {

--- a/pkg/mcp/tools_auth.go
+++ b/pkg/mcp/tools_auth.go
@@ -91,7 +91,7 @@ type authHandlerStatus struct {
 }
 
 // handleAuthStatus reports auth provider status.
-func (s *Server) handleAuthStatus(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleAuthStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if s.authReg == nil {
 		return mcp.NewToolResultJSON(map[string]any{
 			"handlers": []any{},
@@ -100,7 +100,6 @@ func (s *Server) handleAuthStatus(_ context.Context, req mcp.CallToolRequest) (*
 	}
 
 	// Extract optional profile parameter
-	ctx := s.ctx
 	if profileVal, ok := req.GetArguments()["profile"].(string); ok && profileVal != "" {
 		if normalized := auth.NormalizeProfileName(profileVal); normalized != "" {
 			if err := auth.ValidateProfileName(normalized); err != nil {

--- a/pkg/plugin/coverage_test.go
+++ b/pkg/plugin/coverage_test.go
@@ -1977,6 +1977,34 @@ func TestHostServiceServer_GetAuthToken_ExplicitProfileOverridesResolver(t *test
 	assert.Equal(t, "personal", auth.ProfileFromContext(capturedCtx))
 }
 
+func TestHostServiceServer_GetAuthToken_BuiltInProfileMarksResolved(t *testing.T) {
+	var capturedCtx context.Context
+	deps := HostServiceDeps{
+		AuthTokenFunc: func(ctx context.Context, handler, scope string, _ int64, _ bool) (*proto.GetAuthTokenResponse, error) {
+			capturedCtx = ctx
+			return &proto.GetAuthTokenResponse{
+				AccessToken: "default-tok",
+				TokenType:   "Bearer",
+			}, nil
+		},
+	}
+	server := &HostServiceServer{Deps: deps}
+
+	// "built-in" normalizes to "" via NormalizeProfileName, but the context
+	// should be marked as resolved to prevent downstream re-resolution.
+	resp, err := server.GetAuthToken(context.Background(), &proto.GetAuthTokenRequest{
+		HandlerName: "github",
+		Scope:       "repo",
+		Profile:     "built-in",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "default-tok", resp.AccessToken)
+	// Profile should be empty (built-in normalizes to "").
+	assert.Empty(t, auth.ProfileFromContext(capturedCtx))
+	// But it should be marked as resolved so GetToken doesn't re-resolve.
+	assert.True(t, auth.IsProfileResolved(capturedCtx), "context should be marked as profile-resolved")
+}
+
 func TestHostServiceClient_GetAuthToken_Success(t *testing.T) {
 	mock := &mockHostServiceClient{
 		getAuthTokenResp: &proto.GetAuthTokenResponse{

--- a/pkg/plugin/grpc_host.go
+++ b/pkg/plugin/grpc_host.go
@@ -350,8 +350,12 @@ func (h *HostServiceServer) GetAuthToken(ctx context.Context, req *proto.GetAuth
 					Error: fmt.Sprintf("invalid profile from plugin: %v", err),
 				}, nil
 			}
+			ctx = auth.WithProfile(ctx, profile)
 		}
-		ctx = auth.WithProfile(ctx, profile)
+		// Mark profile as resolved even when normalized to "" (built-in/default).
+		// This prevents downstream GetToken from re-resolving the active profile
+		// from config, which would override an explicit built-in selection.
+		ctx = auth.WithProfileResolved(ctx)
 	}
 
 	resp, err := h.Deps.AuthTokenFunc(ctx, req.HandlerName, req.Scope, req.MinValidForSeconds, req.ForceRefresh)

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -178,6 +178,15 @@ func (w *AuthHandlerWrapper) Status(ctx context.Context) (*auth.Status, error) {
 		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
 	defer span.End()
 
+	// Resolve the active profile on the host side before the gRPC boundary.
+	// Context values don't cross process boundaries, so the profile must be
+	// set here for AuthHandlerGRPCClient to include it in the request.
+	if auth.ProfileFromContext(ctx) == "" && !auth.IsProfileResolved(ctx) {
+		if profile := auth.ResolveActiveProfile(ctx, w.handlerName); profile != "" {
+			ctx = auth.WithProfile(ctx, profile)
+		}
+	}
+
 	return w.client.plugin.GetStatus(ctx, w.handlerName)
 }
 
@@ -186,6 +195,15 @@ func (w *AuthHandlerWrapper) GetToken(ctx context.Context, opts auth.TokenOption
 	ctx, span := authTracer.Start(ctx, "auth.plugin.get_token",
 		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
 	defer span.End()
+
+	// Resolve the active profile on the host side before the gRPC boundary.
+	// Context values don't cross process boundaries, so the profile must be
+	// set here for AuthHandlerGRPCClient to include it in the request.
+	if auth.ProfileFromContext(ctx) == "" && !auth.IsProfileResolved(ctx) {
+		if profile := auth.ResolveActiveProfile(ctx, w.handlerName); profile != "" {
+			ctx = auth.WithProfile(ctx, profile)
+		}
+	}
 
 	req := TokenRequest{
 		Scope:        opts.Scope,

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -415,3 +415,93 @@ func TestAuthHandlerWrapper_ApplyOverrides_PreservesHostConfig(t *testing.T) {
 	assert.Equal(t, "mycli", mock.lastConfig.BinaryName, "BinaryName should be preserved")
 	assert.Equal(t, "work", mock.lastConfig.Profile, "Profile should be preserved")
 }
+
+func TestAuthHandlerWrapper_Status_ResolvesActiveProfile(t *testing.T) {
+	t.Parallel()
+	var capturedProfile string
+	mock := &MockAuthHandlerPlugin{
+		statusFunc: func(ctx context.Context, _ string) (*auth.Status, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &auth.Status{Authenticated: true}, nil
+		},
+	}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "github"})
+
+	// Set up config with activeProfile = "work".
+	cfg := &config.Config{}
+	cfg.Auth.GitHub = &config.GitHubAuthConfig{ActiveProfile: "work"}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	status, err := wrapper.Status(ctx)
+	require.NoError(t, err)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, "work", capturedProfile, "should resolve active profile from config")
+}
+
+func TestAuthHandlerWrapper_Status_ExplicitProfileTakesPrecedence(t *testing.T) {
+	t.Parallel()
+	var capturedProfile string
+	mock := &MockAuthHandlerPlugin{
+		statusFunc: func(ctx context.Context, _ string) (*auth.Status, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &auth.Status{Authenticated: true}, nil
+		},
+	}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "github"})
+
+	cfg := &config.Config{}
+	cfg.Auth.GitHub = &config.GitHubAuthConfig{ActiveProfile: "work"}
+	ctx := config.WithConfig(context.Background(), cfg)
+	ctx = auth.WithProfile(ctx, "staging")
+
+	_, err := wrapper.Status(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "staging", capturedProfile, "explicit profile should take precedence")
+}
+
+func TestAuthHandlerWrapper_GetToken_ResolvesActiveProfile(t *testing.T) {
+	t.Parallel()
+	var capturedProfile string
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(ctx context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &TokenResponse{AccessToken: "tok"}, nil
+		},
+	}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "github"})
+
+	cfg := &config.Config{}
+	cfg.Auth.GitHub = &config.GitHubAuthConfig{ActiveProfile: "work"}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	token, err := wrapper.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "tok", token.AccessToken)
+	assert.Equal(t, "work", capturedProfile, "should resolve active profile from config")
+}
+
+func TestAuthHandlerWrapper_GetToken_ProfileResolvedSkipsReResolution(t *testing.T) {
+	t.Parallel()
+	var capturedProfile string
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(ctx context.Context, _ string, _ TokenRequest) (*TokenResponse, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &TokenResponse{AccessToken: "tok"}, nil
+		},
+	}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "github"})
+
+	// Config has activeProfile "work", but context is marked as resolved (built-in).
+	cfg := &config.Config{}
+	cfg.Auth.GitHub = &config.GitHubAuthConfig{ActiveProfile: "work"}
+	ctx := config.WithConfig(context.Background(), cfg)
+	ctx = auth.WithProfileResolved(ctx)
+
+	_, err := wrapper.GetToken(ctx, auth.TokenOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, capturedProfile, "should not re-resolve when already resolved")
+}


### PR DESCRIPTION
- call ResolveActiveProfile at the top of GetToken when no explicit profile is set in context, before any cache or secret lookups
- ensures HTTP provider authProvider, --auth-profile flag, env var, and config-level activeProfile are all respected
- add tests for config-level profile resolution, explicit profile precedence, global flag resolution, and default fallback

Closes #469
