### PR TITLE
feat(mcp): add per-request auth profile switching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.9.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b h1:0hECYesH
 github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0 h1:EE4FnUT+RjyUsAYDZ8C6YKK7fPjpckTA/6otlQz5nzk=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.8.0/go.mod h1:FiF5Nx8FqKxsfYqr93NnHVVVQLUaV6rPOY7Nu6dOIsg=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.9.0 h1:IiPapohzmwnVp6bxomBJLt87e6IAjszZF9IyWwym5Qw=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.9.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/mcp/config_reloader_test.go
+++ b/pkg/mcp/config_reloader_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,6 +88,47 @@ func TestFreshConfigContext(t *testing.T) {
 		got := config.FromContext(ctx)
 		require.NotNil(t, got)
 		assert.Equal(t, 5, got.Version)
+	})
+
+	t.Run("applies profile override when set", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerConfig(&config.Config{Version: 1}),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		profile := "work"
+		srv.profileOverride.Store(&profile)
+
+		ctx := srv.freshConfigContext(context.Background())
+		assert.Equal(t, "work", auth.ProfileFromContext(ctx))
+	})
+
+	t.Run("no profile override leaves context unchanged", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerConfig(&config.Config{Version: 1}),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		ctx := srv.freshConfigContext(context.Background())
+		assert.Empty(t, auth.ProfileFromContext(ctx))
+	})
+
+	t.Run("cleared profile override leaves context unchanged", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerConfig(&config.Config{Version: 1}),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		// Set then clear.
+		profile := "work"
+		srv.profileOverride.Store(&profile)
+		srv.profileOverride.Store((*string)(nil))
+
+		ctx := srv.freshConfigContext(context.Background())
+		assert.Empty(t, auth.ProfileFromContext(ctx))
 	})
 }
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -89,6 +90,14 @@ type Server struct {
 	sseServer *server.SSEServer
 	// httpServer is the Streamable HTTP transport server (nil for stdio).
 	httpServer *server.StreamableHTTPServer
+
+	// profileOverride holds an optional auth profile name set via the
+	// auth_set_profile MCP tool. When non-empty, freshConfigContext injects
+	// it into every request context so all tool calls use that profile.
+	// Stored as *string so atomic.Value can distinguish "never set" (nil)
+	// from "set to a named profile" (non-empty *string). The code never
+	// stores an empty string — clearing is done by storing nil.
+	profileOverride atomic.Value // *string
 }
 
 // ServerOption configures the MCP server.
@@ -455,7 +464,7 @@ Tool Latency Guide (helps optimize tool selection):
   ⚡ Instant (in-memory, no I/O):
     get_solution_schema, list_providers, get_provider_schema, list_lint_rules,
     explain_lint_rule, explain_kind, validate_expression, evaluate_cel,
-    get_run_command, list_auth_handlers, get_config_paths, get_version
+    get_run_command, list_auth_handlers, auth_set_profile, get_config_paths, get_version
   🔄 Fast (local file I/O):
     inspect_solution, lint_solution, diff_solution, list_catalog, catalog_inspect,
     list_examples, get_example, scaffold_solution, extract_resolver_refs,
@@ -810,8 +819,12 @@ func (s *Server) freshConfigContext(ctx context.Context) context.Context {
 	merged := mergeContext(ctx, s.ctx)
 	if s.cfgReloader != nil {
 		if cfg := s.cfgReloader.Config(); cfg != nil {
-			return config.WithConfig(merged, cfg)
+			merged = config.WithConfig(merged, cfg)
 		}
+	}
+	// Apply session-level profile override set by auth_set_profile tool.
+	if p, ok := s.profileOverride.Load().(*string); ok && p != nil && *p != "" {
+		merged = auth.WithProfile(merged, *p)
 	}
 	return merged
 }

--- a/pkg/mcp/tools_auth.go
+++ b/pkg/mcp/tools_auth.go
@@ -13,8 +13,42 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 )
 
+// profileFromRequest extracts and validates an optional "profile" parameter
+// from an MCP tool request. Returns the normalized profile name and any
+// validation error. Returns ("", nil) when no profile is specified.
+func profileFromRequest(args map[string]any) (string, error) {
+	profileVal, ok := args["profile"].(string)
+	if !ok || profileVal == "" {
+		return "", nil
+	}
+	normalized := auth.NormalizeProfileName(profileVal)
+	if normalized == "" {
+		return "", nil
+	}
+	if err := auth.ValidateProfileName(normalized); err != nil {
+		return "", fmt.Errorf("invalid profile: %w", err)
+	}
+	return normalized, nil
+}
+
 // registerAuthTools registers all auth-related MCP tools.
 func (s *Server) registerAuthTools() {
+	authSetProfileTool := mcp.NewTool("auth_set_profile",
+		mcp.WithDescription("Set the auth profile for the current MCP session. All subsequent tool calls "+
+			"will use this profile's credentials until changed or cleared. Pass an empty string or 'default' to "+
+			"reset to the startup default. Use auth_status to verify the active identity after switching."),
+		mcp.WithTitleAnnotation("Set Auth Profile"),
+		mcp.WithToolIcons(toolIcons["auth"]),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("profile",
+			mcp.Description("Auth profile name to activate (e.g., 'work', 'personal'). Omit or pass 'default' to reset to startup default."),
+		),
+	)
+	s.addTool(authSetProfileTool, s.handleSetProfile)
+
 	authStatusTool := mcp.NewTool("auth_status",
 		mcp.WithDescription("Report which auth handlers (e.g. entra, gcp, github) are configured and whether their tokens are valid. Auth handlers manage authentication and identity — they are NOT solution providers. Helps verify authentication is set up correctly before attempting operations that require it."),
 		mcp.WithTitleAnnotation("Auth Status"),
@@ -99,14 +133,12 @@ func (s *Server) handleAuthStatus(ctx context.Context, req mcp.CallToolRequest) 
 		})
 	}
 
-	// Extract optional profile parameter
-	if profileVal, ok := req.GetArguments()["profile"].(string); ok && profileVal != "" {
-		if normalized := auth.NormalizeProfileName(profileVal); normalized != "" {
-			if err := auth.ValidateProfileName(normalized); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid profile: %v", err)), nil
-			}
-			ctx = auth.WithProfile(ctx, normalized)
-		}
+	profile, err := profileFromRequest(req.GetArguments())
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if profile != "" {
+		ctx = auth.WithProfile(ctx, profile)
 	}
 
 	handlers := s.authReg.All()
@@ -236,13 +268,12 @@ func (s *Server) handleListCachedTokens(ctx context.Context, req mcp.CallToolReq
 	args := req.GetArguments()
 	handlerFilter, _ := args["handler"].(string)
 
-	if profileVal, ok := args["profile"].(string); ok && profileVal != "" {
-		if normalized := auth.NormalizeProfileName(profileVal); normalized != "" {
-			if err := auth.ValidateProfileName(normalized); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid profile: %v", err)), nil
-			}
-			ctx = auth.WithProfile(ctx, normalized)
-		}
+	profile, err := profileFromRequest(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if profile != "" {
+		ctx = auth.WithProfile(ctx, profile)
 	}
 
 	names := s.authReg.List()
@@ -340,13 +371,12 @@ func (s *Server) handlePurgeExpiredTokens(ctx context.Context, req mcp.CallToolR
 	args := req.GetArguments()
 	handlerFilter, _ := args["handler"].(string)
 
-	if profileVal, ok := args["profile"].(string); ok && profileVal != "" {
-		if normalized := auth.NormalizeProfileName(profileVal); normalized != "" {
-			if err := auth.ValidateProfileName(normalized); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid profile: %v", err)), nil
-			}
-			ctx = auth.WithProfile(ctx, normalized)
-		}
+	profile, err := profileFromRequest(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if profile != "" {
+		ctx = auth.WithProfile(ctx, profile)
 	}
 
 	names := s.authReg.List()
@@ -401,5 +431,30 @@ func (s *Server) handlePurgeExpiredTokens(ctx context.Context, req mcp.CallToolR
 	return mcp.NewToolResultJSON(map[string]any{
 		"handlers":    results,
 		"totalPurged": total,
+	})
+}
+
+// handleSetProfile sets or clears the session-level auth profile override.
+func (s *Server) handleSetProfile(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	profileVal := req.GetString("profile", "")
+	normalized := auth.NormalizeProfileName(profileVal)
+
+	// Empty or built-in/default → clear the override.
+	if normalized == "" || profileVal == "" {
+		s.profileOverride.Store((*string)(nil))
+		return mcp.NewToolResultJSON(map[string]any{
+			"profile": "default",
+			"message": "Auth profile reset to startup default",
+		})
+	}
+
+	if err := auth.ValidateProfileName(normalized); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid profile: %v", err)), nil
+	}
+
+	s.profileOverride.Store(&normalized)
+	return mcp.NewToolResultJSON(map[string]any{
+		"profile": normalized,
+		"message": fmt.Sprintf("Auth profile set to %q for this session. All subsequent tool calls will use this profile.", normalized),
 	})
 }

--- a/pkg/mcp/tools_auth_test.go
+++ b/pkg/mcp/tools_auth_test.go
@@ -589,3 +589,135 @@ func (m *mcpMinimalHandler) InjectAuth(_ context.Context, _ *http.Request, _ aut
 }
 
 var _ auth.Handler = (*mcpMinimalHandler)(nil)
+
+func TestProfileFromRequest(t *testing.T) {
+	t.Run("empty args returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+
+	t.Run("missing profile key returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"other": "value"})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+
+	t.Run("empty string returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": ""})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+
+	t.Run("valid profile returns normalized", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": "work"})
+		assert.NoError(t, err)
+		assert.Equal(t, "work", profile)
+	})
+
+	t.Run("built-in alias returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": "built-in"})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+
+	t.Run("default alias returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": "default"})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+
+	t.Run("invalid profile returns error", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": "has spaces"})
+		assert.Error(t, err)
+		assert.Empty(t, profile)
+		assert.Contains(t, err.Error(), "invalid profile")
+	})
+
+	t.Run("non-string type returns empty", func(t *testing.T) {
+		profile, err := profileFromRequest(map[string]any{"profile": 42})
+		assert.NoError(t, err)
+		assert.Empty(t, profile)
+	})
+}
+
+func TestHandleSetProfile(t *testing.T) {
+	t.Run("sets profile", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_set_profile"
+		request.Params.Arguments = map[string]any{"profile": "work"}
+
+		result, err := srv.handleSetProfile(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "work")
+
+		// Verify the override was stored.
+		p := srv.profileOverride.Load().(*string)
+		require.NotNil(t, p)
+		assert.Equal(t, "work", *p)
+	})
+
+	t.Run("clears with empty string", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Set first.
+		v := "work"
+		srv.profileOverride.Store(&v)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_set_profile"
+		request.Params.Arguments = map[string]any{"profile": ""}
+
+		result, err := srv.handleSetProfile(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "default")
+
+		p := srv.profileOverride.Load().(*string)
+		assert.Nil(t, p)
+	})
+
+	t.Run("clears with default alias", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		v := "personal"
+		srv.profileOverride.Store(&v)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_set_profile"
+		request.Params.Arguments = map[string]any{"profile": "default"}
+
+		result, err := srv.handleSetProfile(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		p := srv.profileOverride.Load().(*string)
+		assert.Nil(t, p)
+	})
+
+	t.Run("rejects invalid profile", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "auth_set_profile"
+		request.Params.Arguments = map[string]any{"profile": "has spaces"}
+
+		result, err := srv.handleSetProfile(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "invalid profile")
+	})
+}

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	provdetail "github.com/oakwood-commons/scafctl/pkg/provider/detail"
@@ -153,6 +154,10 @@ func (s *Server) registerProviderTools() {
 				"Only applies to official/plugin providers. When set, that exact version is loaded "+
 				"(fetching from the catalog if not already cached). Without this, the version is "+
 				"resolved automatically from the catalog."),
+		),
+		mcp.WithString("profile",
+			mcp.Description("Optional auth profile to use for this call (e.g., 'work', 'personal'). "+
+				"Overrides the session default for this single request. Use auth_set_profile to change the session default."),
 		),
 	)
 	s.addTool(runProviderTool, s.handleRunProvider)
@@ -443,6 +448,17 @@ func (s *Server) handleRunProvider(ctx context.Context, request mcp.CallToolRequ
 	capability := request.GetString("capability", "")
 	dryRun := request.GetBool("dry_run", false)
 	pluginVersion := request.GetString("plugin_version", "")
+
+	// Per-call auth profile override.
+	profile, profileErr := profileFromRequest(request.GetArguments())
+	if profileErr != nil {
+		return newStructuredError(ErrCodeInvalidInput, profileErr.Error(),
+			WithField("profile"),
+		), nil
+	}
+	if profile != "" {
+		ctx = auth.WithProfile(ctx, profile)
+	}
 
 	if s.registry == nil {
 		return newStructuredError(ErrCodeConfigError, "provider registry not available",

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -371,6 +371,53 @@ func TestHandleRunProvider(t *testing.T) {
 		assert.Contains(t, text, "INVALID_INPUT")
 	})
 
+	t.Run("rejects invalid profile", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_provider"
+		request.Params.Arguments = map[string]any{
+			"provider": "static",
+			"inputs":   map[string]any{"value": "hello"},
+			"profile":  "has spaces",
+		}
+
+		result, err := srv.handleRunProvider(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "INVALID_INPUT")
+	})
+
+	t.Run("accepts valid profile", func(t *testing.T) {
+		reg, err := builtin.DefaultRegistry(context.Background())
+		require.NoError(t, err)
+		srv, err := NewServer(
+			WithServerRegistry(reg),
+			WithServerVersion("test"),
+		)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "run_provider"
+		request.Params.Arguments = map[string]any{
+			"provider": "static",
+			"inputs":   map[string]any{"value": "hello"},
+			"profile":  "work",
+		}
+
+		result, err := srv.handleRunProvider(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
 	t.Run("returns error when registry nil", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
 	"github.com/oakwood-commons/scafctl-plugin-sdk/plugin/proto"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -332,6 +333,11 @@ func applyRequestContext(ctx context.Context, req *proto.ExecuteProviderRequest)
 
 	// Solution metadata
 	ctx = unmarshalSolutionMeta(ctx, req.SolutionMetadata)
+
+	// Auth profile
+	if req.AuthProfile != "" {
+		ctx = auth.WithProfile(ctx, req.AuthProfile)
+	}
 
 	return ctx, nil
 }
@@ -777,6 +783,11 @@ func buildExecuteProviderRequest(ctx context.Context, providerName string, input
 
 	// Solution metadata
 	req.SolutionMetadata = marshalSolutionMeta(ctx)
+
+	// Auth profile
+	if profile := auth.ProfileFromContext(ctx); profile != "" {
+		req.AuthProfile = profile
+	}
 
 	return req, nil
 }

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl-plugin-sdk/plugin/proto"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
@@ -234,6 +235,7 @@ func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 		Name:    "test-sol",
 		Version: "2.0.0",
 	})
+	ctx = auth.WithProfile(ctx, "work")
 
 	req, err := buildExecuteProviderRequest(ctx, "my-provider", []byte(`{"hello":"world"}`))
 	require.NoError(t, err)
@@ -258,10 +260,50 @@ func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(req.Parameters, &params))
 	assert.Equal(t, "us-east-1", params["region"])
 
+	assert.Equal(t, "work", req.AuthProfile)
+
 	// Resolver context must NOT be serialized into the request (issue #451).
 	// The engine resolves all ValueRefs before the gRPC call, so plugins
 	// only need concrete input values.
 	assert.Empty(t, req.Context, "resolver context should not be sent to plugins")
+}
+
+func TestBuildExecuteProviderRequest_AuthProfile(t *testing.T) {
+	t.Run("sets auth profile from context", func(t *testing.T) {
+		ctx := auth.WithProfile(context.Background(), "personal")
+		req, err := buildExecuteProviderRequest(ctx, "test", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Equal(t, "personal", req.AuthProfile)
+	})
+
+	t.Run("empty when no profile in context", func(t *testing.T) {
+		req, err := buildExecuteProviderRequest(context.Background(), "test", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Empty(t, req.AuthProfile)
+	})
+}
+
+func TestApplyRequestContext_AuthProfile(t *testing.T) {
+	t.Run("sets profile from request", func(t *testing.T) {
+		req := &proto.ExecuteProviderRequest{
+			ProviderName: "test",
+			Input:        []byte(`{}`),
+			AuthProfile:  "work",
+		}
+		ctx, err := applyRequestContext(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "work", auth.ProfileFromContext(ctx))
+	})
+
+	t.Run("no profile when empty", func(t *testing.T) {
+		req := &proto.ExecuteProviderRequest{
+			ProviderName: "test",
+			Input:        []byte(`{}`),
+		}
+		ctx, err := applyRequestContext(context.Background(), req)
+		require.NoError(t, err)
+		assert.Empty(t, auth.ProfileFromContext(ctx))
+	})
 }
 
 func TestBuildExecuteProviderRequest_ResolverContextPruned(t *testing.T) {


### PR DESCRIPTION
- add auth_set_profile tool for session-level profile override
- add per-call profile param to run_provider for single-request override
- extract profileFromRequest helper to deduplicate validation in 4 handlers
- fix freshConfigContext early-return that skipped profile injection
- wire AuthProfile through plugin gRPC boundary (build + apply)
- bump scafctl-plugin-sdk to v0.9.0 for auth_profile proto field
- add auth_set_profile to server instructions instant tool list

Closes #473
