### PR TITLE
feat(plugin): add plugins update and plugins prune commands

### DIFF
--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -882,7 +882,7 @@ func validateSources(action *Action, section string, errs *AggregatedValidationE
 // validateGlobSafety rejects absolute patterns and path traversal segments
 // to prevent fingerprinting files outside the solution tree.
 func validateGlobSafety(pattern string) error {
-	if filepath.IsAbs(pattern) {
+	if filepath.IsAbs(pattern) || strings.HasPrefix(pattern, "/") {
 		return fmt.Errorf("absolute patterns not allowed: %q", pattern)
 	}
 	for _, seg := range strings.Split(filepath.Clean(pattern), string(filepath.Separator)) {

--- a/pkg/cmd/scafctl/plugins/plugins.go
+++ b/pkg/cmd/scafctl/plugins/plugins.go
@@ -29,11 +29,15 @@ func CommandPlugins(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			Commands:
 			  install  - Pre-fetch plugin binaries declared in a solution
 			  list     - List cached plugin binaries
+			  update   - Update cached plugins to newer versions
+			  prune    - Remove old cached plugin versions
 		`), settings.CliBinaryName, cliParams.BinaryName),
 	}
 
 	cmd.AddCommand(CommandInstall(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, path))
+	cmd.AddCommand(CommandUpdate(cliParams, ioStreams, path))
+	cmd.AddCommand(CommandPrune(cliParams, ioStreams, path))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/plugins/plugins_test.go
+++ b/pkg/cmd/scafctl/plugins/plugins_test.go
@@ -22,13 +22,15 @@ func TestCommandPlugins(t *testing.T) {
 	assert.True(t, cmd.SilenceUsage)
 	assert.Nil(t, cmd.RunE, "parent plugins command should not have RunE")
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 2, "should have 2 subcommands: install, list")
+	require.Len(t, subCmds, 4, "should have 4 subcommands: install, list, update, prune")
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
 		cmdNames[i] = c.Name()
 	}
 	assert.Contains(t, cmdNames, "install")
 	assert.Contains(t, cmdNames, "list")
+	assert.Contains(t, cmdNames, "update")
+	assert.Contains(t, cmdNames, "prune")
 }
 
 func TestCommandInstall(t *testing.T) {

--- a/pkg/cmd/scafctl/plugins/prune.go
+++ b/pkg/cmd/scafctl/plugins/prune.go
@@ -1,0 +1,175 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// PruneOptions holds options for the prune command.
+type PruneOptions struct {
+	CliParams *settings.Run
+	IOStreams *terminal.IOStreams
+	CacheDir  string
+	Keep      int
+	All       bool
+	Force     bool
+	DryRun    bool
+	flags.KvxOutputFlags
+}
+
+// pruneResultItem is the display-friendly representation of a pruned entry.
+type pruneResultItem struct {
+	Name      string `json:"name" yaml:"name"`
+	Version   string `json:"version" yaml:"version"`
+	Platform  string `json:"platform" yaml:"platform"`
+	Size      int64  `json:"size" yaml:"size"`
+	SizeHuman string `json:"sizeHuman" yaml:"sizeHuman"`
+}
+
+// pruneColumnHints controls table column display for prune results.
+var pruneColumnHints = map[string]tui.ColumnHint{
+	"name":      {MaxWidth: 25, Priority: 10},
+	"version":   {MaxWidth: 15, Priority: 9},
+	"platform":  {MaxWidth: 15, Priority: 8},
+	"sizeHuman": {MaxWidth: 10, Priority: 6, DisplayName: "SIZE"},
+	"size":      {Hidden: true},
+}
+
+// CommandPrune creates the prune subcommand.
+func CommandPrune(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &PruneOptions{
+		CliParams:      cliParams,
+		IOStreams:      ioStreams,
+		KvxOutputFlags: flags.KvxOutputFlags{AppName: cliParams.BinaryName},
+	}
+
+	cmd := &cobra.Command{
+		Use:          "prune [plugin-name ...]",
+		Short:        "Remove old cached plugin versions",
+		SilenceUsage: true,
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Remove old cached plugin versions, keeping only the most recent
+			version(s) per plugin.
+
+			By default, keeps the latest version of each plugin and removes
+			all older versions. Use --keep to retain more versions.
+
+			Examples:
+			  # Remove old versions, keep latest per plugin
+			  scafctl plugins prune
+
+			  # Prune specific plugins only
+			  scafctl plugins prune exec github
+
+			  # Keep 2 most recent versions
+			  scafctl plugins prune --keep 2
+
+			  # Preview what would be removed
+			  scafctl plugins prune --dry-run
+
+			  # Remove everything (empty the cache)
+			  scafctl plugins prune --all --force
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx := writer.WithWriter(cmd.Context(), w)
+
+			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
+				kvx.WithIOStreams(ioStreams),
+				kvx.WithOutputColumnHints(pruneColumnHints),
+				kvx.WithOutputColumnOrder([]string{"name", "version", "platform", "sizeHuman"}),
+			)
+
+			return runPrune(ctx, opts, args, kvxOpts)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Keep, "keep", 1, "Number of versions to retain per plugin")
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Remove ALL cached plugins (requires --force)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip confirmation for destructive operations")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview without deleting")
+	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+
+	return cmd
+}
+
+func runPrune(ctx context.Context, opts *PruneOptions, args []string, kvxOpts *kvx.OutputOptions) error {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	cacheDir := opts.CacheDir
+	if cacheDir == "" {
+		binaryName := opts.CliParams.BinaryName
+		if binaryName == "" {
+			binaryName = settings.CliBinaryName
+		}
+		cacheDir = settings.PluginCacheDirFor(binaryName)
+	}
+
+	cache := plugin.NewCache(cacheDir)
+
+	pruneOpts := plugin.PruneOptions{
+		Keep:  opts.Keep,
+		Names: args,
+		All:   opts.All,
+		Force: opts.Force,
+	}
+
+	summary, err := cache.Prune(pruneOpts, opts.DryRun)
+	if err != nil {
+		w.Errorf("%v", err)
+		return err
+	}
+
+	if len(summary.Removed) == 0 {
+		w.PlainStderrf("Nothing to prune — cache is already clean.")
+		return kvxOpts.Write([]pruneResultItem{})
+	}
+
+	// Build display items.
+	items := make([]pruneResultItem, 0, len(summary.Removed))
+	for _, r := range summary.Removed {
+		items = append(items, pruneResultItem{
+			Name:      r.Name,
+			Version:   r.Version,
+			Platform:  r.Platform,
+			Size:      r.Size,
+			SizeHuman: formatBytes(r.Size),
+		})
+	}
+
+	if opts.DryRun {
+		w.PlainStderrf("Dry run: would remove %d version(s), freeing %s:", len(summary.Removed), formatBytes(summary.TotalFreed))
+	}
+
+	if err := kvxOpts.Write(items); err != nil {
+		return fmt.Errorf("rendering output: %w", err)
+	}
+
+	if !opts.DryRun {
+		w.PlainStderrf("Pruned %d version(s), freed %s.", len(summary.Removed), formatBytes(summary.TotalFreed))
+	}
+
+	return nil
+}

--- a/pkg/cmd/scafctl/plugins/prune_test.go
+++ b/pkg/cmd/scafctl/plugins/prune_test.go
@@ -1,0 +1,316 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedTestCache(t *testing.T, cacheDir, name, version string) {
+	t.Helper()
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+	platformKey := goos + "-" + goarch
+	dir := filepath.Join(cacheDir, name, version, platformKey)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, binName), []byte("bin-"+version), 0o755))
+}
+
+func TestRunPrune_EmptyCache(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		Keep:      1,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+}
+
+func TestRunPrune_RemovesOldVersions(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "github", "2.0.0")
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      1,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	// Should report the removed version in output.
+	assert.Contains(t, outBuf.String(), "1.0.0")
+}
+
+func TestRunPrune_DryRun(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "exec", "0.1.0")
+	seedTestCache(t, cacheDir, "exec", "0.2.0")
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      1,
+		DryRun:    true,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	// Verify file still exists (dry run).
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	binName := "exec"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	_, statErr := os.Stat(filepath.Join(cacheDir, "exec", "0.1.0", platform, binName))
+	assert.NoError(t, statErr, "file should still exist after dry run")
+}
+
+func TestRunPrune_FilterByName(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "github", "2.0.0")
+	seedTestCache(t, cacheDir, "exec", "0.1.0")
+	seedTestCache(t, cacheDir, "exec", "0.2.0")
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      1,
+	}
+
+	err := runPrune(ctx, opts, []string{"github"}, kvxOpts)
+	require.NoError(t, err)
+
+	assert.Contains(t, outBuf.String(), "github")
+	assert.NotContains(t, outBuf.String(), "exec")
+}
+
+func TestRunPrune_AllRequiresForce(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		All:       true,
+		Force:     false,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all requires --force")
+}
+
+func TestRunPrune_AllWithForce(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "exec", "0.5.0")
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		All:       true,
+		Force:     true,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	assert.Contains(t, outBuf.String(), "github")
+	assert.Contains(t, outBuf.String(), "exec")
+}
+
+func TestRunPrune_NoWriter_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	kvxOpts := kvx.NewOutputOptions(nil)
+
+	opts := &PruneOptions{
+		CliParams: settings.NewCliParams(),
+		CacheDir:  t.TempDir(),
+		Keep:      1,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestRunPrune_KeepMultiple(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "github", "2.0.0")
+	seedTestCache(t, cacheDir, "github", "3.0.0")
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      2,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	// Should only remove 1.0.0.
+	assert.Contains(t, outBuf.String(), "1.0.0")
+	assert.NotContains(t, outBuf.String(), "2.0.0")
+	assert.NotContains(t, outBuf.String(), "3.0.0")
+}
+
+func TestCommandPrune_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandPrune(cliParams, ioStreams, "scafctl/plugins")
+
+	assert.NotNil(t, cmd.Flags().Lookup("keep"))
+	assert.NotNil(t, cmd.Flags().Lookup("all"))
+	assert.NotNil(t, cmd.Flags().Lookup("force"))
+	assert.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	assert.NotNil(t, cmd.Flags().Lookup("cache-dir"))
+}
+
+func TestCommandPrune_ExecuteContext_EmptyCache(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandPrune(cliParams, ioStreams, "scafctl/plugins")
+	cmd.SetArgs([]string{"--cache-dir", t.TempDir()})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+}
+
+func TestCommandPrune_ExecuteContext_AllNoForce(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandPrune(cliParams, ioStreams, "scafctl/plugins")
+	cmd.SetArgs([]string{"--all", "--cache-dir", t.TempDir()})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+}
+
+func TestRunPrune_DefaultCacheDir(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	// Empty CacheDir → uses default. Should not panic.
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  "",
+		Keep:      1,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+}

--- a/pkg/cmd/scafctl/plugins/update.go
+++ b/pkg/cmd/scafctl/plugins/update.go
@@ -1,0 +1,326 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// UpdateOptions holds options for the update command.
+type UpdateOptions struct {
+	CliParams *settings.Run
+	IOStreams *terminal.IOStreams
+	CacheDir  string
+	Target    string
+	Platform  string
+	NoCache   bool
+	DryRun    bool
+	All       bool
+	flags.KvxOutputFlags
+}
+
+// updateResultItem is the display-friendly representation of an update entry.
+type updateResultItem struct {
+	Name       string `json:"name" yaml:"name"`
+	OldVersion string `json:"oldVersion" yaml:"oldVersion"`
+	NewVersion string `json:"newVersion" yaml:"newVersion"`
+	Status     string `json:"status" yaml:"status"`
+}
+
+// updateColumnHints controls table column display for update results.
+var updateColumnHints = map[string]tui.ColumnHint{
+	"name":       {MaxWidth: 25, Priority: 10},
+	"oldVersion": {MaxWidth: 15, Priority: 9, DisplayName: "FROM"},
+	"newVersion": {MaxWidth: 15, Priority: 8, DisplayName: "TO"},
+	"status":     {MaxWidth: 12, Priority: 7},
+}
+
+// CommandUpdate creates the update subcommand.
+func CommandUpdate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &UpdateOptions{
+		CliParams:      cliParams,
+		IOStreams:      ioStreams,
+		KvxOutputFlags: flags.KvxOutputFlags{AppName: cliParams.BinaryName},
+	}
+
+	cmd := &cobra.Command{
+		Use:          "update [plugin-name ...]",
+		Short:        "Update cached plugins to newer versions",
+		SilenceUsage: true,
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Check for and install newer versions of cached plugins.
+
+			Plugin names can include an exact version (name@version) to pin
+			to a specific release. Use --target to constrain how far updates
+			are allowed to move (latest, minor, patch).
+
+			Examples:
+			  # Update all cached plugins to latest
+			  scafctl plugins update --all
+
+			  # Preview updates without downloading
+			  scafctl plugins update --all --dry-run
+
+			  # Update specific plugins
+			  scafctl plugins update github exec
+
+			  # Update to exact version
+			  scafctl plugins update exec@0.6.0
+
+			  # Constrain to same major version
+			  scafctl plugins update --all --target minor
+
+			  # Constrain to same minor version
+			  scafctl plugins update github --target patch
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx := writer.WithWriter(cmd.Context(), w)
+
+			lgr := logger.FromContext(cmd.Context())
+			if lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+
+			kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
+				kvx.WithIOStreams(ioStreams),
+				kvx.WithOutputColumnHints(updateColumnHints),
+				kvx.WithOutputColumnOrder([]string{"name", "oldVersion", "newVersion", "status"}),
+			)
+
+			return runUpdate(ctx, opts, args, kvxOpts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Update all cached plugins (required when no positional args)")
+	cmd.Flags().StringVar(&opts.Target, "target", "latest", "Version boundary: latest, minor (same major/^), patch (same minor/~)")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview what would change without downloading")
+	cmd.Flags().StringVar(&opts.Platform, "platform", "", "Target platform override")
+	cmd.Flags().BoolVar(&opts.NoCache, "no-cache", false, "Force fresh fetch from catalog")
+	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+
+	return cmd
+}
+
+func runUpdate(ctx context.Context, opts *UpdateOptions, args []string, kvxOpts *kvx.OutputOptions) error {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	// Parse name@version from args.
+	var names []string
+	var pinned map[string]string // name -> exact version
+	for _, arg := range args {
+		name, ver := parseNameVersion(arg)
+		names = append(names, name)
+		if ver != "" {
+			if pinned == nil {
+				pinned = make(map[string]string)
+			}
+			pinned[name] = ver
+		}
+	}
+
+	if len(names) == 0 && !opts.All {
+		err := fmt.Errorf("no plugin names specified; use positional args or --all")
+		w.Errorf("%s", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	// Validate target.
+	target := plugin.UpdateTarget(opts.Target)
+	switch target {
+	case plugin.UpdateTargetLatest, plugin.UpdateTargetMinor, plugin.UpdateTargetPatch:
+		// valid
+	default:
+		err := fmt.Errorf("invalid --target %q (valid: latest, minor, patch)", opts.Target)
+		w.Errorf("%s", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+
+	cacheDir := opts.CacheDir
+	if cacheDir == "" {
+		binaryName := opts.CliParams.BinaryName
+		if binaryName == "" {
+			binaryName = settings.CliBinaryName
+		}
+		cacheDir = settings.PluginCacheDirFor(binaryName)
+	}
+
+	cache := plugin.NewCache(cacheDir)
+
+	// Build catalog chain.
+	appCfg := config.FromContext(ctx)
+	lgr := logger.FromContext(ctx)
+	var chainLogger logr.Logger
+	if lgr != nil {
+		chainLogger = *lgr
+	} else {
+		chainLogger = logr.Discard()
+	}
+
+	chain, err := catalog.BuildCatalogChain(appCfg, auth.RegistryFromContext(ctx), chainLogger)
+	if err != nil {
+		w.Errorf("failed to build catalog chain: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	catalogFetcher := catalog.NewPluginFetcher(chain, chainLogger)
+
+	// Plan updates.
+	plan, err := plugin.PlanUpdates(ctx, cache, catalogFetcher, plugin.UpdateOptions{
+		Names:    names,
+		All:      opts.All,
+		Target:   target,
+		Platform: opts.Platform,
+	})
+	if err != nil {
+		w.Errorf("failed to plan updates: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	// Resolve effective platform for pinned version lookups.
+	pinnedPlatform := opts.Platform
+	if pinnedPlatform == "" {
+		pinnedPlatform = plugin.CurrentPlatform()
+	}
+
+	// Apply pinned versions — override plan entries.
+	for name, ver := range pinned {
+		found := false
+		for i := range plan.Updates {
+			if plan.Updates[i].Name == name {
+				plan.Updates[i].NewVersion = ver
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Add pinned version even if plan didn't detect it as an update.
+			_, currentVer, ok := cache.GetLatestCached(name, pinnedPlatform)
+			if !ok {
+				plan.Failed = append(plan.Failed, plugin.UpdateError{
+					Name:  name,
+					Error: "not found in cache; use 'plugins install' to add it",
+				})
+				continue
+			}
+			_, inferredKind := plugin.PluginKindFromCacheKey(name)
+			if ver != currentVer {
+				plan.Updates = append(plan.Updates, plugin.UpdateEntry{
+					Name:       name,
+					OldVersion: currentVer,
+					NewVersion: ver,
+					Kind:       string(inferredKind),
+				})
+			}
+		}
+	}
+
+	// Report failures.
+	for _, f := range plan.Failed {
+		w.WarnStderrf("%s: %s", f.Name, f.Error)
+	}
+
+	if len(plan.Updates) == 0 {
+		w.PlainStderrf("All plugins are up to date.")
+		return kvxOpts.Write([]updateResultItem{})
+	}
+
+	// Build display items.
+	items := make([]updateResultItem, 0, len(plan.Updates))
+	for _, u := range plan.Updates {
+		status := "pending"
+		items = append(items, updateResultItem{
+			Name:       u.Name,
+			OldVersion: u.OldVersion,
+			NewVersion: u.NewVersion,
+			Status:     status,
+		})
+	}
+
+	if opts.DryRun {
+		w.PlainStderrf("Dry run: %d plugin(s) would be updated:", len(plan.Updates))
+		return kvxOpts.Write(items)
+	}
+
+	// Perform the updates by fetching new versions.
+	w.PlainStderrf("Updating %d plugin(s)...", len(plan.Updates))
+
+	fetcher := plugin.NewFetcher(plugin.FetcherConfig{
+		Catalog:    chain,
+		Cache:      cache,
+		Platform:   opts.Platform,
+		NoCache:    opts.NoCache,
+		BinaryName: settings.BinaryNameFromContext(ctx),
+		Logger:     chainLogger,
+	})
+
+	var deps []solution.PluginDependency
+	for _, u := range plan.Updates {
+		bareName, kind := plugin.PluginKindFromCacheKey(u.Name)
+		deps = append(deps, solution.PluginDependency{
+			Name:    bareName,
+			Kind:    kind,
+			Version: u.NewVersion,
+		})
+	}
+
+	results, err := fetcher.FetchPlugins(ctx, deps, nil)
+	if err != nil {
+		w.Errorf("failed to fetch updates: %v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
+	}
+
+	// Build result display.
+	resultItems := make([]updateResultItem, 0, len(results))
+	for i, r := range results {
+		status := "updated"
+		if r.FromCache {
+			status = "cached"
+		}
+		resultItems = append(resultItems, updateResultItem{
+			Name:       r.Name,
+			OldVersion: plan.Updates[i].OldVersion,
+			NewVersion: r.Version,
+			Status:     status,
+		})
+	}
+
+	if err := kvxOpts.Write(resultItems); err != nil {
+		return fmt.Errorf("rendering output: %w", err)
+	}
+
+	// Invalidate descriptor cache.
+	descCache := plugin.NewDescriptorCache("", 0)
+	descCache.InvalidateAll()
+
+	w.PlainStderrf("Updated %d plugin(s).", len(results))
+	return nil
+}

--- a/pkg/cmd/scafctl/plugins/update_test.go
+++ b/pkg/cmd/scafctl/plugins/update_test.go
@@ -1,0 +1,339 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunUpdate_NoArgsNoAll_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		Target:    "latest",
+	}
+
+	err := runUpdate(ctx, opts, nil, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no plugin names specified")
+}
+
+func TestRunUpdate_InvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		Target:    "invalid",
+		All:       true,
+	}
+
+	err := runUpdate(ctx, opts, nil, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --target")
+}
+
+func TestRunUpdate_EmptyCache_AllUpToDate(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		Target:    "latest",
+		All:       true,
+	}
+
+	// With empty cache + --all, no plugins to update.
+	err := runUpdate(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+}
+
+func TestRunUpdate_PluginNotInCache(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  t.TempDir(),
+		Target:    "latest",
+	}
+
+	// Plugin not in cache — should return an error suggesting 'plugins install'.
+	err := runUpdate(ctx, opts, []string{"nonexistent"}, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in cache")
+}
+
+func TestRunUpdate_DryRun_AllUpToDate(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	// Empty cache → --all reports all up to date.
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		All:       true,
+		DryRun:    true,
+	}
+
+	err := runUpdate(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	// Should emit empty JSON array.
+	var items []updateResultItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	assert.Empty(t, items)
+}
+
+func TestRunUpdate_PinnedVersion_NotInCache(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, stderrBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		All:       true,
+	}
+
+	// Pass pinned version for something not in cache — should warn on stderr.
+	err := runUpdate(ctx, opts, []string{"ghost@1.0.0"}, kvxOpts)
+	// With --all mode and pinned name not in cache, PlanUpdates succeeds
+	// (all path is empty), then pinned version lookup fails → warning + empty result.
+	require.NoError(t, err)
+	assert.Contains(t, stderrBuf.String(), "not found in cache")
+
+	var items []updateResultItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	assert.Empty(t, items)
+}
+
+func TestRunUpdate_PinnedVersion_AlreadyCurrent(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "exec", "1.0.0")
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		All:       true,
+	}
+
+	// Pin to the same version that's already cached → nothing to do.
+	err := runUpdate(ctx, opts, []string{"exec@1.0.0"}, kvxOpts)
+	require.NoError(t, err)
+
+	var items []updateResultItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	assert.Empty(t, items)
+}
+
+func TestRunUpdate_PinnedVersion_DifferentVersion_DryRun(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, stderrBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "exec", "1.0.0")
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		All:       true,
+		DryRun:    true,
+	}
+
+	// Pin to different version → should show as pending update in dry-run.
+	err := runUpdate(ctx, opts, []string{"exec@2.0.0"}, kvxOpts)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderrBuf.String(), "Dry run")
+
+	var items []updateResultItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 1)
+	assert.Equal(t, "exec", items[0].Name)
+	assert.Equal(t, "1.0.0", items[0].OldVersion)
+	assert.Equal(t, "2.0.0", items[0].NewVersion)
+	assert.Equal(t, "pending", items[0].Status)
+}
+
+func TestRunUpdate_NoWriter_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Context without a writer.
+	ctx := t.Context()
+	kvxOpts := kvx.NewOutputOptions(nil)
+
+	opts := &UpdateOptions{
+		CliParams: settings.NewCliParams(),
+		CacheDir:  t.TempDir(),
+		Target:    "latest",
+	}
+
+	err := runUpdate(ctx, opts, []string{"foo"}, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writer not initialized")
+}
+
+func TestRunUpdate_DryRun_WithCachedPlugin(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, stderrBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		DryRun:    true,
+	}
+
+	// Plugin in cache but no catalog available → PlanUpdates will fail
+	// catalog resolution (nil fetcher) after getting version from cache.
+	// This actually triggers the catalog chain build which needs config.
+	// Instead, test with --all which doesn't need catalog if we seed + pin.
+	opts.All = true
+	// Pinned version (different) → bypasses catalog.
+	err := runUpdate(ctx, opts, []string{"github@2.0.0"}, kvxOpts)
+	require.NoError(t, err)
+	assert.Contains(t, stderrBuf.String(), "Dry run")
+
+	var items []updateResultItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 1)
+	assert.Equal(t, "github", items[0].Name)
+}
+
+func TestCommandUpdate_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/plugins")
+
+	assert.NotNil(t, cmd.Flags().Lookup("all"))
+	assert.NotNil(t, cmd.Flags().Lookup("target"))
+	assert.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	assert.NotNil(t, cmd.Flags().Lookup("platform"))
+	assert.NotNil(t, cmd.Flags().Lookup("no-cache"))
+	assert.NotNil(t, cmd.Flags().Lookup("cache-dir"))
+}
+
+func TestCommandUpdate_ExecuteContext_AllDryRun(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/plugins")
+	cmd.SetArgs([]string{"--all", "--dry-run", "--cache-dir", t.TempDir()})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+}
+
+func TestCommandUpdate_ExecuteContext_NoArgs(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandUpdate(cliParams, ioStreams, "scafctl/plugins")
+	cmd.SetArgs([]string{})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+}

--- a/pkg/fingerprint/glob.go
+++ b/pkg/fingerprint/glob.go
@@ -32,7 +32,7 @@ func ExpandGlobs(baseDir string, patterns []string) ([]string, error) {
 
 		// Reject absolute patterns and path traversal to prevent
 		// fingerprinting files outside the solution tree.
-		if filepath.IsAbs(pattern) {
+		if filepath.IsAbs(pattern) || strings.HasPrefix(pattern, "/") {
 			return nil, fmt.Errorf("%w: absolute patterns not allowed: %q", ErrPatternInvalid, pattern)
 		}
 		for _, seg := range strings.Split(filepath.Clean(pattern), string(filepath.Separator)) {
@@ -60,9 +60,10 @@ func ExpandGlobs(baseDir string, patterns []string) ([]string, error) {
 			if rel == ".." || strings.HasPrefix(rel, "../") || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				return nil, fmt.Errorf("%w: match %q escapes base directory", ErrPatternInvalid, m)
 			}
-			if _, exists := seen[rel]; !exists {
-				seen[rel] = struct{}{}
-				result = append(result, rel)
+			normalized := filepath.ToSlash(rel)
+			if _, exists := seen[normalized]; !exists {
+				seen[normalized] = struct{}{}
+				result = append(result, normalized)
 			}
 		}
 	}

--- a/pkg/plugin/pruner.go
+++ b/pkg/plugin/pruner.go
@@ -1,0 +1,189 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// PruneOptions configures a prune operation.
+type PruneOptions struct {
+	// Keep is the number of most recent versions to retain per plugin.
+	// Defaults to 1 if <= 0.
+	Keep int
+
+	// Names limits pruning to the specified plugin names.
+	// If empty, all cached plugins are pruned.
+	Names []string
+
+	// Platform limits pruning to the specified platform.
+	// If empty, all platforms are pruned.
+	Platform string
+
+	// All removes all cached plugins (requires Force).
+	All bool
+
+	// Force skips confirmation for destructive operations.
+	Force bool
+}
+
+// PruneResult describes the outcome of a prune operation for a single plugin version.
+type PruneResult struct {
+	Name     string `json:"name" yaml:"name" doc:"Plugin name"`
+	Version  string `json:"version" yaml:"version" doc:"Removed version"`
+	Platform string `json:"platform" yaml:"platform" doc:"Platform"`
+	Path     string `json:"path" yaml:"path" doc:"Removed path"`
+	Size     int64  `json:"size" yaml:"size" doc:"Freed bytes"`
+}
+
+// PruneSummary holds the full result of a prune operation.
+type PruneSummary struct {
+	Removed    []PruneResult `json:"removed" yaml:"removed" doc:"Removed entries"`
+	TotalFreed int64         `json:"totalFreed" yaml:"totalFreed" doc:"Total bytes freed"`
+}
+
+// Prune removes old cached plugin versions according to the given options.
+// It returns the list of removed entries. If dryRun is true, nothing is
+// deleted but the results reflect what would be removed.
+func (c *Cache) Prune(opts PruneOptions, dryRun bool) (*PruneSummary, error) {
+	if opts.Keep <= 0 {
+		opts.Keep = 1
+	}
+
+	if opts.All && !opts.Force {
+		return nil, fmt.Errorf("--all requires --force to confirm removal of all cached plugins")
+	}
+
+	if opts.All {
+		return c.pruneAll(dryRun)
+	}
+
+	all, err := c.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing cached plugins: %w", err)
+	}
+
+	// Filter by names if specified.
+	nameSet := make(map[string]bool, len(opts.Names))
+	for _, n := range opts.Names {
+		nameSet[n] = true
+	}
+
+	// Group by (name, platform).
+	type groupKey struct {
+		name     string
+		platform string
+	}
+	groups := make(map[groupKey][]CachedPlugin)
+	for _, p := range all {
+		if len(nameSet) > 0 && !nameSet[p.Name] {
+			continue
+		}
+		if opts.Platform != "" && p.Platform != opts.Platform {
+			continue
+		}
+		key := groupKey{name: p.Name, platform: p.Platform}
+		groups[key] = append(groups[key], p)
+	}
+
+	var summary PruneSummary
+
+	// Sort group keys for deterministic output ordering.
+	keys := make([]groupKey, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].name != keys[j].name {
+			return keys[i].name < keys[j].name
+		}
+		return keys[i].platform < keys[j].platform
+	})
+
+	for _, key := range keys {
+		plugins := groups[key]
+		removals := selectPruneTargets(plugins, opts.Keep)
+		for _, r := range removals {
+			if !dryRun {
+				versionDir := filepath.Dir(filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform)))
+				platformDir := filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform))
+				if err := os.RemoveAll(platformDir); err != nil {
+					return nil, fmt.Errorf("removing %s@%s (%s): %w", r.Name, r.Version, r.Platform, err)
+				}
+				// Clean up empty version directory.
+				cleanEmptyDir(versionDir)
+			}
+			summary.Removed = append(summary.Removed, PruneResult(r))
+			summary.TotalFreed += r.Size
+		}
+	}
+
+	return &summary, nil
+}
+
+// pruneAll removes the entire cache contents.
+func (c *Cache) pruneAll(dryRun bool) (*PruneSummary, error) {
+	all, err := c.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing cached plugins: %w", err)
+	}
+
+	var summary PruneSummary
+	for _, p := range all {
+		summary.Removed = append(summary.Removed, PruneResult(p))
+		summary.TotalFreed += p.Size
+	}
+
+	if !dryRun {
+		entries, err := os.ReadDir(c.dir)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("reading cache directory: %w", err)
+		}
+		for _, entry := range entries {
+			if err := os.RemoveAll(filepath.Join(c.dir, entry.Name())); err != nil {
+				return nil, fmt.Errorf("removing %s: %w", entry.Name(), err)
+			}
+		}
+	}
+
+	return &summary, nil
+}
+
+// selectPruneTargets selects which plugins from a same-name, same-platform
+// group should be removed (keeping the newest `keep` versions).
+func selectPruneTargets(plugins []CachedPlugin, keep int) []CachedPlugin {
+	if len(plugins) <= keep {
+		return nil
+	}
+
+	// Sort by semver descending (newest first).
+	sort.Slice(plugins, func(i, j int) bool {
+		vi, ei := semver.NewVersion(plugins[i].Version)
+		vj, ej := semver.NewVersion(plugins[j].Version)
+		if ei != nil || ej != nil {
+			// Fallback to lexicographic for non-semver.
+			return plugins[i].Version > plugins[j].Version
+		}
+		return vi.GreaterThan(vj)
+	})
+
+	// Everything after the first `keep` entries gets removed.
+	return plugins[keep:]
+}
+
+// cleanEmptyDir removes a directory if it is empty.
+func cleanEmptyDir(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	if len(entries) == 0 {
+		os.Remove(dir)
+	}
+}

--- a/pkg/plugin/pruner_test.go
+++ b/pkg/plugin/pruner_test.go
@@ -1,0 +1,289 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedCache(t *testing.T, cacheDir, name, version string) {
+	t.Helper()
+	platform := CurrentPlatform()
+	platformKey := PlatformCacheKey(platform)
+	dir := filepath.Join(cacheDir, name, version, platformKey)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, binName), []byte("binary-"+version), 0o755))
+}
+
+func TestPrune_RemovesOldVersions(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "1.1.0")
+	seedCache(t, cacheDir, "github", "1.2.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1}, false)
+	require.NoError(t, err)
+
+	assert.Len(t, summary.Removed, 2)
+	assert.Greater(t, summary.TotalFreed, int64(0))
+
+	// Only latest should remain.
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+	assert.Equal(t, "1.2.0", remaining[0].Version)
+}
+
+func TestPrune_KeepsMultipleVersions(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "exec", "0.3.0")
+	seedCache(t, cacheDir, "exec", "0.4.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 2}, false)
+	require.NoError(t, err)
+
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "0.3.0", summary.Removed[0].Version)
+
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2)
+}
+
+func TestPrune_DryRun_DoesNotDelete(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1}, true)
+	require.NoError(t, err)
+
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "1.0.0", summary.Removed[0].Version)
+
+	// Files should still exist.
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2)
+}
+
+func TestPrune_FiltersByName(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+	seedCache(t, cacheDir, "exec", "0.1.0")
+	seedCache(t, cacheDir, "exec", "0.2.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1, Names: []string{"github"}}, false)
+	require.NoError(t, err)
+
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "github", summary.Removed[0].Name)
+
+	// exec should still have both versions.
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	execCount := 0
+	for _, r := range remaining {
+		if r.Name == "exec" {
+			execCount++
+		}
+	}
+	assert.Equal(t, 2, execCount)
+}
+
+func TestPrune_All_RequiresForce(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+
+	cache := NewCache(cacheDir)
+	_, err := cache.Prune(PruneOptions{All: true, Force: false}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all requires --force")
+}
+
+func TestPrune_All_WithForce(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{All: true, Force: true}, false)
+	require.NoError(t, err)
+
+	assert.Len(t, summary.Removed, 2)
+
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+}
+
+func TestPrune_EmptyCache(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1}, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, summary.Removed)
+	assert.Equal(t, int64(0), summary.TotalFreed)
+}
+
+func TestPrune_NothingToRemove(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1}, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, summary.Removed)
+}
+
+func TestSelectPruneTargets_SemverOrder(t *testing.T) {
+	t.Parallel()
+
+	plugins := []CachedPlugin{
+		{Name: "github", Version: "1.0.0", Platform: "linux/amd64", Size: 100},
+		{Name: "github", Version: "1.10.0", Platform: "linux/amd64", Size: 100},
+		{Name: "github", Version: "1.2.0", Platform: "linux/amd64", Size: 100},
+	}
+
+	targets := selectPruneTargets(plugins, 1)
+	assert.Len(t, targets, 2)
+	// Should keep 1.10.0 (newest), remove 1.0.0 and 1.2.0.
+	for _, r := range targets {
+		assert.NotEqual(t, "1.10.0", r.Version)
+	}
+}
+
+func TestSelectPruneTargets_KeepAllWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	plugins := []CachedPlugin{
+		{Name: "exec", Version: "0.1.0", Platform: "linux/amd64", Size: 50},
+	}
+
+	targets := selectPruneTargets(plugins, 2)
+	assert.Nil(t, targets)
+}
+
+func TestPrune_FiltersByPlatform(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	// Seed current platform.
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	cache := NewCache(cacheDir)
+	// Filter by a non-matching platform — should find nothing to prune.
+	summary, err := cache.Prune(PruneOptions{Keep: 1, Platform: "fakeos/fakearch"}, false)
+	require.NoError(t, err)
+	assert.Empty(t, summary.Removed)
+}
+
+func TestPrune_AllWithForce_DryRun(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{All: true, Force: true}, true)
+	require.NoError(t, err)
+
+	// Should list everything as removed.
+	assert.Len(t, summary.Removed, 2)
+	assert.Greater(t, summary.TotalFreed, int64(0))
+
+	// But files should still exist.
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2)
+}
+
+func TestPrune_DefaultKeepZero(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	cache := NewCache(cacheDir)
+	// Keep=0 should default to 1.
+	summary, err := cache.Prune(PruneOptions{Keep: 0}, false)
+	require.NoError(t, err)
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "1.0.0", summary.Removed[0].Version)
+}
+
+func TestPrune_MultiplePlugins(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+	seedCache(t, cacheDir, "github", "3.0.0")
+	seedCache(t, cacheDir, "exec", "0.1.0")
+	seedCache(t, cacheDir, "exec", "0.2.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 1}, false)
+	require.NoError(t, err)
+	// github: remove 1.0.0 + 2.0.0, exec: remove 0.1.0.
+	assert.Len(t, summary.Removed, 3)
+
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2) // github@3.0.0 + exec@0.2.0
+}
+
+func TestSelectPruneTargets_NonSemverFallback(t *testing.T) {
+	t.Parallel()
+
+	plugins := []CachedPlugin{
+		{Name: "custom", Version: "abc", Platform: "linux/amd64", Size: 100},
+		{Name: "custom", Version: "xyz", Platform: "linux/amd64", Size: 100},
+		{Name: "custom", Version: "mno", Platform: "linux/amd64", Size: 100},
+	}
+
+	targets := selectPruneTargets(plugins, 1)
+	assert.Len(t, targets, 2)
+	// Lexicographic descending: xyz > mno > abc → keep xyz.
+	for _, r := range targets {
+		assert.NotEqual(t, "xyz", r.Version)
+	}
+}

--- a/pkg/plugin/updater.go
+++ b/pkg/plugin/updater.go
@@ -1,0 +1,209 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// UpdateTarget specifies the semver boundary for updates.
+type UpdateTarget string
+
+const (
+	// UpdateTargetLatest allows updates to any newer version.
+	UpdateTargetLatest UpdateTarget = "latest"
+
+	// UpdateTargetMinor constrains updates within the same major version (^).
+	// For 0.x versions, constrains to same minor (0.x.y only).
+	UpdateTargetMinor UpdateTarget = "minor"
+
+	// UpdateTargetPatch constrains updates within the same minor version (~).
+	UpdateTargetPatch UpdateTarget = "patch"
+)
+
+// UpdateOptions configures an update operation.
+type UpdateOptions struct {
+	// Names limits updates to the specified plugin cache keys.
+	// If empty and All is true, all cached plugins are updated.
+	Names []string
+
+	// All updates all cached plugins. Required when Names is empty.
+	All bool
+
+	// Target specifies the semver constraint boundary.
+	Target UpdateTarget
+
+	// Platform overrides the target platform. If empty, CurrentPlatform() is used.
+	Platform string
+}
+
+// UpdatePlan describes what an update operation would do.
+type UpdatePlan struct {
+	Updates  []UpdateEntry `json:"updates" yaml:"updates" doc:"Plugins with available updates"`
+	UpToDate []string      `json:"upToDate" yaml:"upToDate" doc:"Plugins already at latest"`
+	Failed   []UpdateError `json:"failed,omitempty" yaml:"failed,omitempty" doc:"Plugins that failed resolution"`
+}
+
+// UpdateEntry describes a single pending update.
+type UpdateEntry struct {
+	Name       string `json:"name" yaml:"name" doc:"Plugin cache key"`
+	OldVersion string `json:"oldVersion" yaml:"oldVersion" doc:"Currently cached version"`
+	NewVersion string `json:"newVersion" yaml:"newVersion" doc:"Available version"`
+	Kind       string `json:"kind" yaml:"kind" doc:"Plugin kind (provider or auth-handler)"`
+}
+
+// UpdateError describes a resolution failure for a plugin.
+type UpdateError struct {
+	Name  string `json:"name" yaml:"name" doc:"Plugin cache key"`
+	Error string `json:"error" yaml:"error" doc:"Error message"`
+}
+
+// PluginKindFromCacheKey infers the plugin kind and bare name from a cache key.
+// Cache keys for auth-handlers are prefixed with "auth-handler-".
+func PluginKindFromCacheKey(cacheKey string) (name string, kind solution.PluginKind) {
+	if strings.HasPrefix(cacheKey, "auth-handler-") {
+		return strings.TrimPrefix(cacheKey, "auth-handler-"), solution.PluginKindAuthHandler
+	}
+	return cacheKey, solution.PluginKindProvider
+}
+
+// PlanUpdates checks the catalog for newer versions of cached plugins and
+// returns an UpdatePlan describing what would change.
+func PlanUpdates(ctx context.Context, cache *Cache, catalogFetcher *catalog.PluginFetcher, opts UpdateOptions) (*UpdatePlan, error) {
+	if len(opts.Names) == 0 && !opts.All {
+		return nil, fmt.Errorf("no plugin names specified; use positional args or --all")
+	}
+
+	platform := opts.Platform
+	if platform == "" {
+		platform = CurrentPlatform()
+	}
+
+	target := opts.Target
+	if target == "" {
+		target = UpdateTargetLatest
+	}
+
+	// Determine which plugins to check.
+	var cacheKeys []string
+	if opts.All {
+		all, err := cache.List()
+		if err != nil {
+			return nil, fmt.Errorf("listing cached plugins: %w", err)
+		}
+		// Deduplicate names that have binaries for the target platform.
+		seen := make(map[string]bool)
+		for _, p := range all {
+			if p.Platform == platform && !seen[p.Name] {
+				seen[p.Name] = true
+				cacheKeys = append(cacheKeys, p.Name)
+			}
+		}
+		sort.Strings(cacheKeys)
+	} else {
+		cacheKeys = opts.Names
+	}
+
+	plan := &UpdatePlan{}
+
+	for _, cacheKey := range cacheKeys {
+		_, currentVer, ok := cache.GetLatestCached(cacheKey, platform)
+		if !ok {
+			if opts.All {
+				// Skip silently when iterating all — the plugin may
+				// exist for a different platform.
+				continue
+			}
+			return nil, fmt.Errorf("plugin %q not found in cache; use 'plugins install' to add it", cacheKey)
+		}
+
+		name, kind := PluginKindFromCacheKey(cacheKey)
+		artifactKind := pluginKindToArtifactKind(kind)
+
+		// Build version constraint based on target.
+		constraint := buildUpdateConstraint(currentVer, target)
+
+		info, err := catalogFetcher.ResolvePlugin(ctx, name, artifactKind, constraint)
+		if err != nil {
+			plan.Failed = append(plan.Failed, UpdateError{
+				Name:  cacheKey,
+				Error: err.Error(),
+			})
+			continue
+		}
+
+		var resolvedVer string
+		if info.Reference.Version != nil {
+			resolvedVer = info.Reference.Version.String()
+		}
+
+		if resolvedVer == "" || resolvedVer == currentVer {
+			plan.UpToDate = append(plan.UpToDate, cacheKey)
+			continue
+		}
+
+		// Compare to ensure it's actually newer.
+		current, err := semver.NewVersion(currentVer)
+		if err != nil {
+			plan.UpToDate = append(plan.UpToDate, cacheKey)
+			continue
+		}
+		resolved, err := semver.NewVersion(resolvedVer)
+		if err != nil {
+			plan.UpToDate = append(plan.UpToDate, cacheKey)
+			continue
+		}
+		if !resolved.GreaterThan(current) {
+			plan.UpToDate = append(plan.UpToDate, cacheKey)
+			continue
+		}
+
+		plan.Updates = append(plan.Updates, UpdateEntry{
+			Name:       cacheKey,
+			OldVersion: currentVer,
+			NewVersion: resolvedVer,
+			Kind:       string(kind),
+		})
+	}
+
+	return plan, nil
+}
+
+// buildUpdateConstraint returns a semver constraint string based on the
+// current version and the target boundary.
+func buildUpdateConstraint(currentVer string, target UpdateTarget) string {
+	switch target {
+	case UpdateTargetLatest:
+		return ""
+
+	case UpdateTargetMinor:
+		v, err := semver.NewVersion(currentVer)
+		if err != nil {
+			return "" // latest
+		}
+		// For 0.x: constrain to same minor (equivalent to ~0.x.0).
+		if v.Major() == 0 {
+			return fmt.Sprintf(">=%s, <0.%d.0", currentVer, v.Minor()+1)
+		}
+		// For 1.x+: constrain to same major (^).
+		return fmt.Sprintf(">=%s, <%d.0.0", currentVer, v.Major()+1)
+
+	case UpdateTargetPatch:
+		v, err := semver.NewVersion(currentVer)
+		if err != nil {
+			return "" // latest
+		}
+		// Constrain to same minor (~).
+		return fmt.Sprintf(">=%s, <%d.%d.0", currentVer, v.Major(), v.Minor()+1)
+	}
+
+	return ""
+}

--- a/pkg/plugin/updater_test.go
+++ b/pkg/plugin/updater_test.go
@@ -1,0 +1,371 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginKindFromCacheKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		cacheKey string
+		wantName string
+		wantKind solution.PluginKind
+	}{
+		{"github", "github", solution.PluginKindProvider},
+		{"exec", "exec", solution.PluginKindProvider},
+		{"auth-handler-github", "github", solution.PluginKindAuthHandler},
+		{"auth-handler-entra", "entra", solution.PluginKindAuthHandler},
+		{"auth-handler-gcp", "gcp", solution.PluginKindAuthHandler},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cacheKey, func(t *testing.T) {
+			t.Parallel()
+			name, kind := PluginKindFromCacheKey(tt.cacheKey)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantKind, kind)
+		})
+	}
+}
+
+func TestBuildUpdateConstraint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		currentVer string
+		target     UpdateTarget
+		want       string
+	}{
+		{"latest returns empty", "1.2.3", UpdateTargetLatest, ""},
+		{"minor for 1.x", "1.2.3", UpdateTargetMinor, ">=1.2.3, <2.0.0"},
+		{"minor for 2.x", "2.0.0", UpdateTargetMinor, ">=2.0.0, <3.0.0"},
+		{"minor for 0.x constrains to same minor", "0.4.2", UpdateTargetMinor, ">=0.4.2, <0.5.0"},
+		{"patch for 1.2.x", "1.2.3", UpdateTargetPatch, ">=1.2.3, <1.3.0"},
+		{"patch for 0.4.x", "0.4.0", UpdateTargetPatch, ">=0.4.0, <0.5.0"},
+		{"invalid version returns empty", "not-semver", UpdateTargetMinor, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildUpdateConstraint(tt.currentVer, tt.target)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPlanUpdates_RequiresNamesOrAll(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache(t.TempDir())
+	_, err := PlanUpdates(t.Context(), cache, nil, UpdateOptions{
+		Names: nil,
+		All:   false,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no plugin names specified")
+}
+
+func TestPlanUpdates_PluginNotInCache(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache(t.TempDir())
+	// Use a nil catalogFetcher — it should return an error for explicit names not in cache.
+	_, err := PlanUpdates(t.Context(), cache, nil, UpdateOptions{
+		Names: []string{"nonexistent"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in cache")
+}
+
+// mockCatalogForUpdater implements catalog.Catalog for updater tests.
+type mockCatalogForUpdater struct {
+	resolveFunc func(ctx context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error)
+}
+
+func (m *mockCatalogForUpdater) Name() string { return "mock" }
+
+func (m *mockCatalogForUpdater) Resolve(ctx context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+	if m.resolveFunc != nil {
+		return m.resolveFunc(ctx, ref)
+	}
+	return catalog.ArtifactInfo{}, fmt.Errorf("not found")
+}
+
+func (m *mockCatalogForUpdater) Store(context.Context, catalog.Reference, []byte, []byte, map[string]string, bool) (catalog.ArtifactInfo, error) {
+	return catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalogForUpdater) Fetch(context.Context, catalog.Reference) ([]byte, catalog.ArtifactInfo, error) {
+	return nil, catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalogForUpdater) FetchWithBundle(context.Context, catalog.Reference) ([]byte, []byte, catalog.ArtifactInfo, error) {
+	return nil, nil, catalog.ArtifactInfo{}, nil
+}
+
+func (m *mockCatalogForUpdater) List(context.Context, catalog.ArtifactKind, string) ([]catalog.ArtifactInfo, error) {
+	return nil, nil
+}
+
+func (m *mockCatalogForUpdater) Exists(context.Context, catalog.Reference) (bool, error) {
+	return false, nil
+}
+
+func (m *mockCatalogForUpdater) Delete(context.Context, catalog.Reference) error { return nil }
+
+func seedUpdaterCache(t *testing.T, cacheDir, name, version string) {
+	t.Helper()
+	platform := CurrentPlatform()
+	platformKey := PlatformCacheKey(platform)
+	dir := filepath.Join(cacheDir, name, version, platformKey)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, binName), []byte("bin-"+version), 0o755))
+}
+
+func TestPlanUpdates_AllWithCachedPlugins_UpdateAvailable(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "github", "1.0.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			v := semver.MustParse("2.0.0")
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name, Version: v},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		All:    true,
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Updates, 1)
+	assert.Equal(t, "github", plan.Updates[0].Name)
+	assert.Equal(t, "1.0.0", plan.Updates[0].OldVersion)
+	assert.Equal(t, "2.0.0", plan.Updates[0].NewVersion)
+	assert.Equal(t, string(solution.PluginKindProvider), plan.Updates[0].Kind)
+}
+
+func TestPlanUpdates_AllWithCachedPlugins_UpToDate(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "exec", "1.5.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			// Return same version as cached.
+			v := semver.MustParse("1.5.0")
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name, Version: v},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		All:    true,
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Updates)
+	assert.Contains(t, plan.UpToDate, "exec")
+}
+
+func TestPlanUpdates_CatalogResolutionFails(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "github", "1.0.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, _ catalog.Reference) (catalog.ArtifactInfo, error) {
+			return catalog.ArtifactInfo{}, fmt.Errorf("network timeout")
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		Names:  []string{"github"},
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Updates)
+	require.Len(t, plan.Failed, 1)
+	assert.Equal(t, "github", plan.Failed[0].Name)
+	assert.Contains(t, plan.Failed[0].Error, "network timeout")
+}
+
+func TestPlanUpdates_PlatformFilter(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	// Seed for the current platform — when we filter by a different platform, it shouldn't find it.
+	seedUpdaterCache(t, cacheDir, "github", "1.0.0")
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(&mockCatalogForUpdater{}, logr.Discard())
+
+	// Use a platform that doesn't match our cached binaries.
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		All:      true,
+		Target:   UpdateTargetLatest,
+		Platform: "fakeos/fakearch",
+	})
+	require.NoError(t, err)
+	// No plugins for fakeos/fakearch → nothing to update.
+	assert.Empty(t, plan.Updates)
+	assert.Empty(t, plan.UpToDate)
+}
+
+func TestPlanUpdates_AuthHandlerCacheKey(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "auth-handler-github", "0.3.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			// Confirm the name is stripped (bare name "github", not "auth-handler-github").
+			if ref.Name != "github" {
+				return catalog.ArtifactInfo{}, fmt.Errorf("unexpected name: %s", ref.Name)
+			}
+			v := semver.MustParse("0.4.0")
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name, Version: v},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		Names:  []string{"auth-handler-github"},
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Updates, 1)
+	assert.Equal(t, "auth-handler-github", plan.Updates[0].Name)
+	assert.Equal(t, string(solution.PluginKindAuthHandler), plan.Updates[0].Kind)
+}
+
+func TestPlanUpdates_ResolvedVersionNotNewer(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "exec", "2.0.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			// Return an older version (shouldn't happen but tests the branch).
+			v := semver.MustParse("1.5.0")
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name, Version: v},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		Names:  []string{"exec"},
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Updates)
+	assert.Contains(t, plan.UpToDate, "exec")
+}
+
+func TestPlanUpdates_EmptyResolvedVersion(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "github", "1.0.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			// No version in the resolved info.
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		Names:  []string{"github"},
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Updates)
+	assert.Contains(t, plan.UpToDate, "github")
+}
+
+func TestPlanUpdates_DefaultTarget(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "github", "1.0.0")
+
+	mock := &mockCatalogForUpdater{
+		resolveFunc: func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+			v := semver.MustParse("2.0.0")
+			return catalog.ArtifactInfo{
+				Reference: catalog.Reference{Name: ref.Name, Version: v},
+				Catalog:   "mock",
+			}, nil
+		},
+	}
+
+	cache := NewCache(cacheDir)
+	fetcher := catalog.NewPluginFetcher(mock, logr.Discard())
+
+	// Empty target should default to "latest".
+	plan, err := PlanUpdates(t.Context(), cache, fetcher, UpdateOptions{
+		Names: []string{"github"},
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Updates, 1)
+	assert.Equal(t, "2.0.0", plan.Updates[0].NewVersion)
+}

--- a/pkg/state/store_test.go
+++ b/pkg/state/store_test.go
@@ -95,7 +95,7 @@ func TestResolveStatePath_Traversal(t *testing.T) {
 
 func TestResolveStatePath_Absolute(t *testing.T) {
 	t.Parallel()
-	abs := "/tmp/test-state.json"
+	abs := filepath.Join(t.TempDir(), "test-state.json")
 	result, err := ResolveStatePath(abs)
 	require.NoError(t, err)
 	assert.Equal(t, abs, result)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6693,6 +6693,8 @@ func TestIntegration_Plugins_Help(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "install")
 	assert.Contains(t, stdout, "list")
+	assert.Contains(t, stdout, "update")
+	assert.Contains(t, stdout, "prune")
 }
 
 // TestIntegration_Plugins_Install_Help verifies the plugins install command shows help.


### PR DESCRIPTION
- add `plugins update` command to check catalog for newer plugin versions and fetch updates (supports --target latest/minor/patch, --dry-run, pinned versions via name@version syntax)
- add `plugins prune` command to remove old cached plugin versions (supports --keep, --all --force, --dry-run, name filtering)
- add PlanUpdates() domain logic with semver constraint building for minor/patch-bounded updates
- add Cache.Prune() domain logic with deterministic map iteration, version sorting, and empty directory cleanup
- add PluginKindFromCacheKey() to infer provider vs auth-handler from cache key prefix
- fix cross-platform absolute path detection in validateGlobSafety and ExpandGlobs (Unix-style /path not detected on Windows)
- normalize ExpandGlobs output to forward slashes for consistent cross-platform results
- fix TestResolveStatePath_Absolute to use platform-appropriate temp directory instead of hardcoded /tmp

Closes #477
