### PR TITLE
feat(plugin): skip locked files during prune and support --keep 0

### DIFF
--- a/pkg/cmd/scafctl/plugins/prune.go
+++ b/pkg/cmd/scafctl/plugins/prune.go
@@ -142,8 +142,20 @@ func runPrune(ctx context.Context, opts *PruneOptions, args []string, kvxOpts *k
 		return err
 	}
 
-	if len(summary.Removed) == 0 {
+	if len(summary.Removed) == 0 && len(summary.Skipped) == 0 {
 		w.PlainStderrf("Nothing to prune — cache is already clean.")
+		return kvxOpts.Write([]pruneResultItem{})
+	}
+
+	if len(summary.Removed) == 0 && len(summary.Skipped) > 0 {
+		for _, s := range summary.Skipped {
+			if s.Version != "" {
+				w.WarnStderrf("Skipped %s@%s (%s): %s", s.Name, s.Version, s.Platform, s.Reason)
+			} else {
+				w.WarnStderrf("Skipped %s: %s", s.Name, s.Reason)
+			}
+		}
+		w.PlainStderrf("Nothing pruned — all targets are locked or in use.")
 		return kvxOpts.Write([]pruneResultItem{})
 	}
 
@@ -169,6 +181,14 @@ func runPrune(ctx context.Context, opts *PruneOptions, args []string, kvxOpts *k
 
 	if !opts.DryRun {
 		w.PlainStderrf("Pruned %d version(s), freed %s.", len(summary.Removed), formatBytes(summary.TotalFreed))
+	}
+
+	for _, s := range summary.Skipped {
+		if s.Version != "" {
+			w.WarnStderrf("Skipped %s@%s (%s): %s", s.Name, s.Version, s.Platform, s.Reason)
+		} else {
+			w.WarnStderrf("Skipped %s: %s", s.Name, s.Reason)
+		}
 	}
 
 	return nil

--- a/pkg/cmd/scafctl/plugins/prune_test.go
+++ b/pkg/cmd/scafctl/plugins/prune_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -313,4 +314,134 @@ func TestRunPrune_DefaultCacheDir(t *testing.T) {
 
 	err := runPrune(ctx, opts, nil, kvxOpts)
 	require.NoError(t, err)
+}
+
+func TestRunPrune_AllSkipped_ShowsWarnings(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "github", "2.0.0")
+
+	// Make both platform directories non-removable.
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	for _, ver := range []string{"1.0.0", "2.0.0"} {
+		dir := filepath.Join(cacheDir, "github", ver, platform)
+		if err := os.Chmod(dir, 0o555); err != nil {
+			t.Skip("cannot restrict permissions on this platform")
+		}
+		t.Cleanup(func() { os.Chmod(dir, 0o755) })
+	}
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      0,
+		Force:     true,
+	}
+
+	err := runPrune(ctx, opts, []string{"github"}, kvxOpts)
+	require.NoError(t, err)
+
+	stderrOut := errBuf.String()
+	if !strings.Contains(stderrOut, "Skipped") {
+		// On platforms where chmod doesn't block removal (Windows),
+		// the entries get removed instead of skipped.
+		t.Skip("platform allowed removal despite chmod")
+	}
+	assert.Contains(t, stderrOut, "Nothing pruned")
+}
+
+func TestRunPrune_PartialSkip_ShowsRemovedAndWarnings(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "github", "2.0.0")
+
+	// Lock only v1.0.0.
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	lockedDir := filepath.Join(cacheDir, "github", "1.0.0", platform)
+	if err := os.Chmod(lockedDir, 0o555); err != nil {
+		t.Skip("cannot restrict permissions on this platform")
+	}
+	t.Cleanup(func() { os.Chmod(lockedDir, 0o755) })
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Keep:      0,
+		Force:     true,
+	}
+
+	err := runPrune(ctx, opts, []string{"github"}, kvxOpts)
+	require.NoError(t, err)
+
+	stderrOut := errBuf.String()
+	if !strings.Contains(stderrOut, "Skipped") {
+		t.Skip("platform allowed removal despite chmod")
+	}
+	// Should still report the successfully removed version.
+	assert.Contains(t, outBuf.String(), "2.0.0")
+	assert.Contains(t, stderrOut, "Pruned")
+	assert.Contains(t, stderrOut, "Skipped")
+}
+
+func TestRunPrune_SkippedWithoutVersion_ShowsNameOnly(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "github", "1.0.0")
+	seedTestCache(t, cacheDir, "exec", "0.5.0")
+
+	// Lock the entire github directory for pruneAll.
+	if err := os.Chmod(filepath.Join(cacheDir, "github"), 0o555); err != nil {
+		t.Skip("cannot restrict permissions on this platform")
+	}
+	t.Cleanup(func() { os.Chmod(filepath.Join(cacheDir, "github"), 0o755) })
+
+	opts := &PruneOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		All:       true,
+		Force:     true,
+	}
+
+	err := runPrune(ctx, opts, nil, kvxOpts)
+	require.NoError(t, err)
+
+	stderrOut := errBuf.String()
+	if !strings.Contains(stderrOut, "Skipped") {
+		t.Skip("platform allowed removal despite chmod")
+	}
+	// pruneAll skips with Name only (no version), so the warning should
+	// use the name-only format.
+	assert.Contains(t, stderrOut, "Skipped github:")
 }

--- a/pkg/plugin/pruner.go
+++ b/pkg/plugin/pruner.go
@@ -42,26 +42,38 @@ type PruneResult struct {
 	Size     int64  `json:"size" yaml:"size" doc:"Freed bytes"`
 }
 
+// PruneSkipped describes an entry that could not be removed.
+type PruneSkipped struct {
+	Name     string `json:"name" yaml:"name" doc:"Plugin name"`
+	Version  string `json:"version,omitempty" yaml:"version,omitempty" doc:"Skipped version"`
+	Platform string `json:"platform,omitempty" yaml:"platform,omitempty" doc:"Platform"`
+	Reason   string `json:"reason" yaml:"reason" doc:"Why removal failed"`
+}
+
 // PruneSummary holds the full result of a prune operation.
 type PruneSummary struct {
-	Removed    []PruneResult `json:"removed" yaml:"removed" doc:"Removed entries"`
-	TotalFreed int64         `json:"totalFreed" yaml:"totalFreed" doc:"Total bytes freed"`
+	Removed    []PruneResult  `json:"removed" yaml:"removed" doc:"Removed entries"`
+	Skipped    []PruneSkipped `json:"skipped,omitempty" yaml:"skipped,omitempty" doc:"Entries that could not be removed"`
+	TotalFreed int64          `json:"totalFreed" yaml:"totalFreed" doc:"Total bytes freed"`
 }
 
 // Prune removes old cached plugin versions according to the given options.
 // It returns the list of removed entries. If dryRun is true, nothing is
 // deleted but the results reflect what would be removed.
 func (c *Cache) Prune(opts PruneOptions, dryRun bool) (*PruneSummary, error) {
-	if opts.Keep <= 0 {
-		opts.Keep = 1
-	}
-
 	if opts.All && !opts.Force {
 		return nil, fmt.Errorf("--all requires --force to confirm removal of all cached plugins")
 	}
 
 	if opts.All {
 		return c.pruneAll(dryRun)
+	}
+
+	// For targeted prune: keep=0 removes everything for the named plugins.
+	if opts.Keep == 0 && opts.Force && len(opts.Names) > 0 {
+		// Intentional full removal of specific plugins -- allow it.
+	} else if opts.Keep <= 0 {
+		opts.Keep = 1
 	}
 
 	all, err := c.List()
@@ -114,13 +126,24 @@ func (c *Cache) Prune(opts PruneOptions, dryRun bool) (*PruneSummary, error) {
 				versionDir := filepath.Dir(filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform)))
 				platformDir := filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform))
 				if err := os.RemoveAll(platformDir); err != nil {
-					return nil, fmt.Errorf("removing %s@%s (%s): %w", r.Name, r.Version, r.Platform, err)
+					summary.Skipped = append(summary.Skipped, PruneSkipped{
+						Name:     r.Name,
+						Version:  r.Version,
+						Platform: r.Platform,
+						Reason:   err.Error(),
+					})
+					continue
 				}
 				// Clean up empty version directory.
 				cleanEmptyDir(versionDir)
 			}
 			summary.Removed = append(summary.Removed, PruneResult(r))
 			summary.TotalFreed += r.Size
+		}
+		// If all versions were removed, clean up the name directory.
+		if !dryRun && opts.Keep == 0 && len(removals) > 0 {
+			nameDir := filepath.Join(c.dir, key.name)
+			cleanEmptyDir(nameDir)
 		}
 	}
 
@@ -147,7 +170,20 @@ func (c *Cache) pruneAll(dryRun bool) (*PruneSummary, error) {
 		}
 		for _, entry := range entries {
 			if err := os.RemoveAll(filepath.Join(c.dir, entry.Name())); err != nil {
-				return nil, fmt.Errorf("removing %s: %w", entry.Name(), err)
+				summary.Skipped = append(summary.Skipped, PruneSkipped{
+					Name:   entry.Name(),
+					Reason: err.Error(),
+				})
+				// Recalculate removed: exclude entries under this name.
+				filtered := summary.Removed[:0]
+				for _, r := range summary.Removed {
+					if r.Name != entry.Name() {
+						filtered = append(filtered, r)
+					} else {
+						summary.TotalFreed -= r.Size
+					}
+				}
+				summary.Removed = filtered
 			}
 		}
 	}

--- a/pkg/plugin/pruner_test.go
+++ b/pkg/plugin/pruner_test.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -286,4 +287,176 @@ func TestSelectPruneTargets_NonSemverFallback(t *testing.T) {
 	for _, r := range targets {
 		assert.NotEqual(t, "xyz", r.Version)
 	}
+}
+
+func TestPrune_KeepZero_WithForceAndName(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{Keep: 0, Force: true, Names: []string{"github"}}, false)
+	require.NoError(t, err)
+
+	// All github versions removed, exec untouched.
+	assert.Len(t, summary.Removed, 2)
+	for _, r := range summary.Removed {
+		assert.Equal(t, "github", r.Name)
+	}
+
+	remaining, err := cache.List()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+	assert.Equal(t, "exec", remaining[0].Name)
+}
+
+func TestPrune_KeepZero_WithoutForce_DefaultsToOne(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	cache := NewCache(cacheDir)
+	// Keep=0 without force should default to 1.
+	summary, err := cache.Prune(PruneOptions{Keep: 0, Names: []string{"github"}}, false)
+	require.NoError(t, err)
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "1.0.0", summary.Removed[0].Version)
+}
+
+func TestPrune_KeepZero_WithoutNames_DefaultsToOne(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	cache := NewCache(cacheDir)
+	// Keep=0 with force but no names should default to 1.
+	summary, err := cache.Prune(PruneOptions{Keep: 0, Force: true}, false)
+	require.NoError(t, err)
+	assert.Len(t, summary.Removed, 1)
+	assert.Equal(t, "1.0.0", summary.Removed[0].Version)
+}
+
+func TestPrune_SkipsLockedFiles(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "github", "2.0.0")
+
+	// Make the v1.0.0 platform directory non-removable via chmod.
+	cache := NewCache(cacheDir)
+	binPath := cache.binaryPath("github", "1.0.0", CurrentPlatform())
+	platformDir := filepath.Dir(binPath)
+	if err := os.Chmod(platformDir, 0o555); err != nil {
+		t.Skip("cannot restrict permissions on this platform")
+	}
+	t.Cleanup(func() { os.Chmod(platformDir, 0o755) })
+
+	summary, err := cache.Prune(PruneOptions{Keep: 0, Force: true, Names: []string{"github"}}, false)
+	require.NoError(t, err)
+
+	// At least one entry should be skipped due to permission error.
+	if len(summary.Skipped) == 0 {
+		t.Skip("OS allowed removal despite chmod -- platform does not enforce")
+	}
+	assert.NotEmpty(t, summary.Skipped)
+	assert.NotEmpty(t, summary.Skipped[0].Reason)
+}
+
+func TestPruneAll_SkipsLockedEntry_RecalculatesRemoved(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	// Lock the github directory so pruneAll can't remove it.
+	githubDir := filepath.Join(cacheDir, "github")
+	if err := os.Chmod(githubDir, 0o555); err != nil {
+		t.Skip("cannot restrict permissions on this platform")
+	}
+	t.Cleanup(func() { os.Chmod(githubDir, 0o755) })
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{All: true, Force: true}, false)
+	require.NoError(t, err)
+
+	if len(summary.Skipped) == 0 {
+		t.Skip("OS allowed removal despite chmod -- platform does not enforce")
+	}
+
+	// github should be skipped, exec should be removed.
+	assert.Len(t, summary.Skipped, 1)
+	assert.Equal(t, "github", summary.Skipped[0].Name)
+	assert.Empty(t, summary.Skipped[0].Version, "pruneAll skips use name only, no version")
+
+	// Only exec should be in Removed (github was recalculated out).
+	for _, r := range summary.Removed {
+		assert.Equal(t, "exec", r.Name, "github entries should have been recalculated out of Removed")
+	}
+}
+
+func TestPruneAll_SkipsLockedEntry_DryRunUnaffected(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+	seedCache(t, cacheDir, "exec", "0.5.0")
+
+	// Lock github -- but dry run should not attempt removal.
+	githubDir := filepath.Join(cacheDir, "github")
+	if err := os.Chmod(githubDir, 0o555); err != nil {
+		t.Skip("cannot restrict permissions on this platform")
+	}
+	t.Cleanup(func() { os.Chmod(githubDir, 0o755) })
+
+	cache := NewCache(cacheDir)
+	summary, err := cache.Prune(PruneOptions{All: true, Force: true}, true)
+	require.NoError(t, err)
+
+	// Dry run lists everything as removed; skipped is empty.
+	assert.Len(t, summary.Removed, 2)
+	assert.Empty(t, summary.Skipped)
+}
+
+func TestPrune_KeepZero_CleansNameDirectory(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	seedCache(t, cacheDir, "github", "1.0.0")
+
+	cache := NewCache(cacheDir)
+	_, err := cache.Prune(PruneOptions{Keep: 0, Force: true, Names: []string{"github"}}, false)
+	require.NoError(t, err)
+
+	// The name directory should be cleaned up when all versions are removed.
+	_, statErr := os.Stat(filepath.Join(cacheDir, "github"))
+	assert.True(t, os.IsNotExist(statErr), "name directory should be removed when empty")
+}
+
+func TestPruneSkipped_OmitsEmptyFields_JSON(t *testing.T) {
+	t.Parallel()
+
+	// Verify omitempty works: Version/Platform should not appear when empty.
+	s := PruneSkipped{Name: "test", Reason: "locked"}
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), `"version"`)
+	assert.NotContains(t, string(data), `"platform"`)
+
+	// With values set, they should appear.
+	s2 := PruneSkipped{Name: "test", Version: "1.0.0", Platform: "linux/amd64", Reason: "locked"}
+	data2, err := json.Marshal(s2)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data2), `"version"`)
+	assert.Contains(t, string(data2), `"platform"`)
 }


### PR DESCRIPTION
- continue pruning when individual entries cannot be removed (e.g.,
  locked .exe on Windows) instead of returning a hard error
- add PruneSkipped type to PruneSummary for reporting skipped entries
- allow --keep 0 --force <name> to fully remove a named plugin
- CLI emits per-entry warnings for skipped files and a summary when
  all targets are locked
- add tests for keep=0 with/without force, skip-on-permission-error

Relates to #414