### PR TITLE
fix(mcp): refresh config context per tool call via middleware

### DIFF
--- a/pkg/mcp/config_reloader_test.go
+++ b/pkg/mcp/config_reloader_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -204,6 +206,87 @@ func TestResolveConfig(t *testing.T) {
 		// With no config file on disk, Global() will fail.
 		// resolveConfig should return nil gracefully.
 		_ = srv.resolveConfig()
+	})
+}
+
+func TestToolMiddleware_RefreshesContextPerCall(t *testing.T) {
+	t.Run("profile override visible through middleware dispatch", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerConfig(&config.Config{Version: 1}),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		// Register a probe tool that captures the profile from its context.
+		// capturedProfile is written inside the handler and read after CallTool
+		// returns.  This is safe because InProcessClient.CallTool dispatches
+		// synchronously — the handler completes before CallTool returns.
+		var capturedProfile string
+		srv.mcpServer.AddTool(mcp.NewTool("probe_profile"), func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: capturedProfile}},
+			}, nil
+		})
+
+		// Create an in-process client that dispatches through the middleware chain.
+		c, err := mcpclient.NewInProcessClient(srv.mcpServer)
+		require.NoError(t, err)
+		defer c.Close()
+
+		_, err = c.Initialize(t.Context(), mcp.InitializeRequest{})
+		require.NoError(t, err)
+
+		// Call before setting profile -- should be empty.
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "probe_profile"
+		_, err = c.CallTool(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, capturedProfile, "no profile override yet")
+
+		// Set profile override (simulates auth_set_profile).
+		profile := "personal"
+		srv.profileOverride.Store(&profile)
+
+		// Call again -- middleware should refresh context with new profile.
+		_, err = c.CallTool(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "personal", capturedProfile, "middleware should inject fresh profile")
+	})
+
+	t.Run("cleared profile override is not visible", func(t *testing.T) {
+		srv, err := NewServer(
+			WithServerConfig(&config.Config{Version: 1}),
+			WithServerName("testcli"),
+		)
+		require.NoError(t, err)
+
+		// See first subtest for synchronous-dispatch safety rationale.
+		var capturedProfile string
+		srv.mcpServer.AddTool(mcp.NewTool("probe_profile2"), func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			capturedProfile = auth.ProfileFromContext(ctx)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: "ok"}},
+			}, nil
+		})
+
+		c, err := mcpclient.NewInProcessClient(srv.mcpServer)
+		require.NoError(t, err)
+		defer c.Close()
+
+		_, err = c.Initialize(t.Context(), mcp.InitializeRequest{})
+		require.NoError(t, err)
+
+		// Set then clear profile.
+		profile := "work"
+		srv.profileOverride.Store(&profile)
+		srv.profileOverride.Store((*string)(nil))
+
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "probe_profile2"
+		_, err = c.CallTool(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, capturedProfile, "cleared override should not appear")
 	})
 }
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -666,6 +666,18 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	// Register all tools
 	s.registerTools()
 
+	// Install tool handler middleware that refreshes the context on every
+	// tool call.  The stdio transport calls its contextFunc once at startup
+	// (not per-request), so session-level state changes (e.g. profile
+	// override from auth_set_profile) would otherwise be invisible to
+	// subsequent tool handlers.  This middleware is transport-agnostic and
+	// harmless for SSE/HTTP where the transport already refreshes per-request.
+	s.mcpServer.Use(func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return next(s.freshConfigContext(ctx), req)
+		}
+	})
+
 	// Register all resources
 	s.registerResources()
 
@@ -813,8 +825,11 @@ func (s *Server) doRegisterUpstreamTools(ctx context.Context) error {
 }
 
 // freshConfigContext returns a context with the latest config overlaid.
-// Called per-request by each transport's context func so that tool handlers
-// always see up-to-date configuration (e.g. after an auth profile switch).
+// Called per tool call via the Use() middleware registered in NewServer, and
+// additionally by each transport's context func.  The middleware ensures that
+// even transports that call their context func only once (stdio) still see
+// up-to-date configuration on every tool invocation (e.g. after an auth
+// profile switch via auth_set_profile).
 func (s *Server) freshConfigContext(ctx context.Context) context.Context {
 	merged := mergeContext(ctx, s.ctx)
 	if s.cfgReloader != nil {

--- a/pkg/solution/soltesting/runner.go
+++ b/pkg/solution/soltesting/runner.go
@@ -1057,6 +1057,11 @@ func attachCommandOutput(result *TestResult, cmdOutput *CommandOutput) {
 
 // buildEnvMap builds the environment variable map for a test.
 // Precedence: process env → testConfig.env → testCase.env → <BINARY>_SANDBOX_DIR.
+//
+// After all values are set, any occurrence of ${<BINARY>_SANDBOX_DIR} in env
+// values is expanded to the actual sandbox path. This allows test YAMLs to
+// derive paths (e.g., XDG_STATE_HOME) from the sandbox directory, which is
+// guaranteed to be an OS-native absolute path on every platform.
 func (r *Runner) buildEnvMap(tc *TestCase, testConfig *TestConfig, sandboxPath string, extraEnv map[string]string) map[string]any {
 	env := make(map[string]any)
 
@@ -1078,7 +1083,17 @@ func (r *Runner) buildEnvMap(tc *TestCase, testConfig *TestConfig, sandboxPath s
 	}
 
 	// Always set sandbox dir
-	env[settings.SafeEnvPrefix(r.appName())+"_SANDBOX_DIR"] = sandboxPath
+	sandboxEnvKey := settings.SafeEnvPrefix(r.appName()) + "_SANDBOX_DIR"
+	env[sandboxEnvKey] = sandboxPath
+
+	// Expand ${<BINARY>_SANDBOX_DIR} references in env values so test YAMLs
+	// can build cross-platform absolute paths from the sandbox root.
+	placeholder := "${" + sandboxEnvKey + "}"
+	for k, v := range env {
+		if s, ok := v.(string); ok && strings.Contains(s, placeholder) {
+			env[k] = strings.ReplaceAll(s, placeholder, sandboxPath)
+		}
+	}
 
 	return env
 }

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -636,6 +636,26 @@ func TestBuildEnvMap_WithExtraEnv(t *testing.T) {
 	assert.Equal(t, "from-extra", env["OVERLAP"], "extraEnv should override tc.Env")
 }
 
+func TestBuildEnvMap_ExpandsSandboxDir(t *testing.T) {
+	r := &Runner{}
+
+	tc := &TestCase{
+		Env: map[string]string{
+			"XDG_STATE_HOME": "${SCAFCTL_SANDBOX_DIR}/state-home",
+			"PLAIN_VAR":      "no-expansion",
+		},
+	}
+
+	sandboxPath := filepath.Join(os.TempDir(), "scafctl-test-12345")
+	env := r.buildEnvMap(tc, nil, sandboxPath, nil)
+
+	assert.Equal(t, sandboxPath+"/state-home", env["XDG_STATE_HOME"],
+		"${SCAFCTL_SANDBOX_DIR} should be expanded to the sandbox path")
+	assert.Equal(t, "no-expansion", env["PLAIN_VAR"],
+		"values without the placeholder should not be modified")
+	assert.Equal(t, sandboxPath, env["SCAFCTL_SANDBOX_DIR"])
+}
+
 func TestMergeEnvForStep(t *testing.T) {
 	envMap := map[string]any{
 		"A": "1",

--- a/tests/integration/solutions/state/dynamic-enabled/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-enabled/solution.yaml
@@ -59,15 +59,13 @@ spec:
         args: ["-o", "json"]
         tags: [state, dynamic-enabled, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynen-disabled
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-disabled && mkdir -p /tmp/scafctl-it-state-dynen-disabled/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           # Pre-seed state with greeting = from-state
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynen-disabled/scafctl/dynamic-enabled-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-disabled"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -82,14 +80,12 @@ spec:
         args: ["-o", "json", "-r", "use_state=false"]
         tags: [state, dynamic-enabled]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynen-false
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-false && mkdir -p /tmp/scafctl-it-state-dynen-false/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynen-false/scafctl/dynamic-enabled-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-false"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -104,14 +100,12 @@ spec:
         args: ["-o", "json", "-r", "use_state=true"]
         tags: [state, dynamic-enabled]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynen-enabled
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-enabled && mkdir -p /tmp/scafctl-it-state-dynen-enabled/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"saved-hello"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynen-enabled/scafctl/dynamic-enabled-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-enabled"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "saved-hello"
@@ -126,11 +120,9 @@ spec:
         args: ["-o", "json", "-r", "use_state=true"]
         tags: [state, dynamic-enabled]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynen-nofile
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-nofile && mkdir -p /tmp/scafctl-it-state-dynen-nofile/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-nofile"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -145,14 +137,12 @@ spec:
         args: ["-o", "json", "-r", "use_state=true", "-r", "greeting=cli-hello"]
         tags: [state, dynamic-enabled]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynen-override
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-override && mkdir -p /tmp/scafctl-it-state-dynen-override/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynen-override/scafctl/dynamic-enabled-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynen-override"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "cli-hello"

--- a/tests/integration/solutions/state/dynamic-path/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-path/solution.yaml
@@ -59,11 +59,9 @@ spec:
         args: ["-o", "json", "-r", "project=alpha"]
         tags: [state, dynamic-path, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynpath-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-first && mkdir -p /tmp/scafctl-it-state-dynpath-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "default-config"
@@ -78,14 +76,12 @@ spec:
         args: ["-o", "json", "-r", "project=beta"]
         tags: [state, dynamic-path]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynpath-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-preseeded && mkdir -p /tmp/scafctl-it-state-dynpath-preseeded/scafctl/dynamic"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-config"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynpath-preseeded/scafctl/dynamic/beta.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "beta-config"
@@ -100,15 +96,13 @@ spec:
         args: ["-o", "json", "-r", "project=gamma"]
         tags: [state, dynamic-path]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-dynpath-iso
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-iso && mkdir -p /tmp/scafctl-it-state-dynpath-iso/scafctl/dynamic"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic"
           # Pre-seed for project "beta" only
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-only"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-dynpath-iso/scafctl/dynamic/beta.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-dynpath-iso"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "default-config"

--- a/tests/integration/solutions/state/immutable-overwrite/solution.yaml
+++ b/tests/integration/solutions/state/immutable-overwrite/solution.yaml
@@ -50,11 +50,9 @@ spec:
         args: ["-o", "json"]
         tags: [state, immutable, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-overwrite-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-first && mkdir -p /tmp/scafctl-it-overwrite-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
             message: "First write should succeed"
@@ -70,14 +68,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, immutable]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-overwrite-same
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-same && mkdir -p /tmp/scafctl-it-overwrite-same/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"value":{"value":"fixed-value","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-overwrite-same/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-same"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode == 0
             message: "Same-value write should succeed silently"
@@ -93,14 +89,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, immutable, negative]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-overwrite-blocked
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-blocked && mkdir -p /tmp/scafctl-it-overwrite-blocked/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"value":{"value":"original-locked","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-overwrite-blocked/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-blocked"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode != 0
             message: "Should fail when trying to overwrite immutable entry with different value"
@@ -118,14 +112,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, immutable]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-overwrite-allowed
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-allowed && mkdir -p /tmp/scafctl-it-overwrite-allowed/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-overwrite-allowed/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-overwrite-allowed"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode == 0
             message: "Should succeed when immutables section has no conflict"

--- a/tests/integration/solutions/state/immutable/solution.yaml
+++ b/tests/integration/solutions/state/immutable/solution.yaml
@@ -71,11 +71,9 @@ spec:
         extends: [_base]
         tags: [smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-first && mkdir -p /tmp/scafctl-it-immutable-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.locked_id == "generated-id-001"
             message: "Immutable resolver should fall through to static on first run"
@@ -89,14 +87,12 @@ spec:
         description: Writing same value to immutable entry succeeds silently
         extends: [_base]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-noop
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-noop && mkdir -p /tmp/scafctl-it-immutable-noop/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"locked_id":{"value":"generated-id-001","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-immutable-noop/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-noop"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.locked_id == "generated-id-001"
             message: "Resolver should produce its static value matching state"
@@ -108,14 +104,12 @@ spec:
         description: Immutable value verified against state after resolve from saved params
         extends: [_base]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-preseeded && mkdir -p /tmp/scafctl-it-immutable-preseeded/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"immutables":{"locked_id":{"value":"locked-from-state","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-immutable-preseeded/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.locked_id == "locked-from-state"
             message: "Immutable resolver should return value from saved parameters"
@@ -129,14 +123,12 @@ spec:
         args: ["-o", "json", "-r", "locked_id=override-attempt"]
         tags: [state, immutable]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-ignore
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-ignore && mkdir -p /tmp/scafctl-it-immutable-ignore/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"immutables":{"locked_id":{"value":"locked-from-state","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-immutable-ignore/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-ignore"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode != 0
             message: "Should fail when parameter differs from locked immutable"
@@ -151,14 +143,12 @@ spec:
         extends: [_base]
         args: ["-o", "json", "-r", "mutable_value=updated-value"]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-mutable
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-mutable && mkdir -p /tmp/scafctl-it-immutable-mutable/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"mutable_value":"old-value"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-immutable-mutable/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-mutable"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.mutable_value == "updated-value"
             message: "Parameter should override mutable state value"
@@ -171,14 +161,12 @@ spec:
         extends: [_base]
         args: ["-o", "json", "-r", "locked_id=permanent-id", "-r", "mutable_value=fresh-value"]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-immutable-contrast
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-immutable-contrast && mkdir -p /tmp/scafctl-it-immutable-contrast/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"permanent-id","mutable_value":"old-mutable"},"immutables":{"locked_id":{"value":"permanent-id","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-immutable-contrast/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-immutable-contrast"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.locked_id == "permanent-id"
             message: "Immutable value should remain locked (same value resolves)"

--- a/tests/integration/solutions/state/persistence/solution.yaml
+++ b/tests/integration/solutions/state/persistence/solution.yaml
@@ -62,11 +62,9 @@ spec:
         extends: [_base]
         tags: [smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-first-run
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-first-run && mkdir -p /tmp/scafctl-it-state-first-run/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-first-run"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.greeting == "hello-world"
             message: "First run should fall through to static default"
@@ -77,14 +75,12 @@ spec:
         description: Verify parameter provider reads from pre-seeded state parameters
         extends: [_base]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-preseeded && mkdir -p /tmp/scafctl-it-state-preseeded/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-persistence","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"hello-from-state","counter":"99"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-preseeded/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.greeting == "hello-from-state"
             message: "Parameter provider should read pre-seeded value from state"

--- a/tests/integration/solutions/state/render-solution/solution.yaml
+++ b/tests/integration/solutions/state/render-solution/solution.yaml
@@ -67,11 +67,9 @@ spec:
         args: ["-o", "json"]
         tags: [state, render, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-rendersol-empty
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-empty && mkdir -p /tmp/scafctl-it-state-rendersol-empty/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-empty"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("default-target")
@@ -88,14 +86,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, render]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-rendersol-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-preseeded && mkdir -p /tmp/scafctl-it-state-rendersol-preseeded/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"prod-cluster","app_version":"3.2.1"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-rendersol-preseeded/scafctl/render-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/render-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("prod-cluster")
@@ -112,11 +108,9 @@ spec:
         args: ["-o", "json"]
         tags: [state, render, readonly]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-rendersol-nowrite
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-nowrite && mkdir -p /tmp/scafctl-it-state-rendersol-nowrite/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-nowrite"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
 
@@ -129,14 +123,12 @@ spec:
         args: ["-o", "json", "-r", "target=edge"]
         tags: [state, render]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-rendersol-param
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-param && mkdir -p /tmp/scafctl-it-state-rendersol-param/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"cached-target"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-rendersol-param/scafctl/render-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-rendersol-param"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/render-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("edge")

--- a/tests/integration/solutions/state/render/solution.yaml
+++ b/tests/integration/solutions/state/render/solution.yaml
@@ -56,11 +56,9 @@ spec:
         args: ["-o", "json"]
         tags: [state, render]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-render-empty
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-render-empty && mkdir -p /tmp/scafctl-it-state-render-empty/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-render-empty"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "fallback-default"
@@ -77,14 +75,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, render]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-render-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-render-preseeded && mkdir -p /tmp/scafctl-it-state-render-preseeded/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"cached-from-state"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-render-preseeded/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-render-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "cached-from-state"
@@ -101,14 +97,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, render, immutable]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-render-immutable
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-render-immutable && mkdir -p /tmp/scafctl-it-state-render-immutable/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"immutable-cached"},"immutables":{"cached_name":{"value":"immutable-cached","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-render-immutable/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-render-immutable"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "immutable-cached"

--- a/tests/integration/solutions/state/run-action/solution.yaml
+++ b/tests/integration/solutions/state/run-action/solution.yaml
@@ -83,11 +83,9 @@ spec:
         args: ["lint", "-o", "json"]
         tags: [state, run-action, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runact-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-first && mkdir -p /tmp/scafctl-it-state-runact-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -103,14 +101,12 @@ spec:
         args: ["build", "-o", "json"]
         tags: [state, run-action]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runact-reads
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-reads && mkdir -p /tmp/scafctl-it-state-runact-reads/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production","version":"2.5.0"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-runact-reads/scafctl/run-action-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-reads"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-action-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -129,14 +125,12 @@ spec:
         args: ["deploy", "-o", "json", "-r", "env=canary"]
         tags: [state, run-action]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runact-override
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-override && mkdir -p /tmp/scafctl-it-state-runact-override/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-runact-override/scafctl/run-action-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-override"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-action-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -152,11 +146,9 @@ spec:
         args: ["deploy", "-o", "json"]
         tags: [state, run-action]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runact-deps
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-deps && mkdir -p /tmp/scafctl-it-state-runact-deps/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runact-deps"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"

--- a/tests/integration/solutions/state/run-solution/solution.yaml
+++ b/tests/integration/solutions/state/run-solution/solution.yaml
@@ -66,11 +66,9 @@ spec:
         args: ["-o", "json"]
         tags: [state, run-solution, smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runsol-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-first && mkdir -p /tmp/scafctl-it-state-runsol-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -89,14 +87,12 @@ spec:
         args: ["-o", "json"]
         tags: [state, run-solution]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runsol-preseeded
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-preseeded && mkdir -p /tmp/scafctl-it-state-runsol-preseeded/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production","build_id":"build-042"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-runsol-preseeded/scafctl/run-solution-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-preseeded"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-solution-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -114,14 +110,12 @@ spec:
         args: ["-o", "json", "-r", "target=canary"]
         tags: [state, run-solution]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runsol-override
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-override && mkdir -p /tmp/scafctl-it-state-runsol-override/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-runsol-override/scafctl/run-solution-state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-override"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-solution-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -137,11 +131,9 @@ spec:
         args: ["-o", "json", "-r", "target=dev"]
         tags: [state, run-solution, command-info]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-runsol-cmdinfo
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-cmdinfo && mkdir -p /tmp/scafctl-it-state-runsol-cmdinfo/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-runsol-cmdinfo"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"

--- a/tests/integration/solutions/state/save-verify/solution.yaml
+++ b/tests/integration/solutions/state/save-verify/solution.yaml
@@ -77,11 +77,9 @@ spec:
         extends: [_base]
         tags: [smoke]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-save-first
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-save-first && mkdir -p /tmp/scafctl-it-state-save-first/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-save-first"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.name == "default-name"
             message: "First run should use static default"
@@ -97,14 +95,12 @@ spec:
         description: Second run reads values from state parameters (simulated via pre-seed)
         extends: [_base]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-save-second
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-save-second && mkdir -p /tmp/scafctl-it-state-save-second/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"saved-name","count":"42","enabled_flag":"false"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-save-second/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-save-second"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.name == "saved-name"
             message: "Parameter provider should return persisted string value"
@@ -121,11 +117,9 @@ spec:
         extends: [_base]
         args: ["-o", "json", "-r", "name=custom-name"]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-save-param
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-save-param && mkdir -p /tmp/scafctl-it-state-save-param/scafctl"
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-save-param"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.name == "custom-name"
             message: "Parameter should override static default"
@@ -140,14 +134,12 @@ spec:
         extends: [_base]
         args: ["-o", "json", "-r", "name=new-name"]
         env:
-          XDG_STATE_HOME: /tmp/scafctl-it-state-save-overwrite
+          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "rm -rf /tmp/scafctl-it-state-save-overwrite && mkdir -p /tmp/scafctl-it-state-save-overwrite/scafctl"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"old-name"},"immutables":{},"fingerprints":{}}'
-              > /tmp/scafctl-it-state-save-overwrite/scafctl/state.json
-        cleanup:
-          - command: "rm -rf /tmp/scafctl-it-state-save-overwrite"
+              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
         assertions:
           - expression: __output.name == "new-name"
             message: "Parameter should win over stale state value"


### PR DESCRIPTION
- add Use() middleware in NewServer that calls freshConfigContext on
  every tool invocation, ensuring session-level state changes (e.g.
  profile override) are visible regardless of transport
- stdio transport calls its contextFunc once at startup, so without
  this middleware profile switches via auth_set_profile were invisible
- middleware is transport-agnostic; harmless double-call for SSE/HTTP
- add TestToolMiddleware_RefreshesContextPerCall with two subtests
  using InProcessClient to verify profile injection and clearing
- fix state integration tests: replace hardcoded /tmp paths with
  sandbox-relative ${SCAFCTL_SANDBOX_DIR} expansion in buildEnvMap
- adrg/xdg silently ignores XDG_STATE_HOME when filepath.IsAbs
  returns false (Unix paths lack drive letter on Windows)
- update all 10 state test solutions and remove unnecessary cleanup
- add TestBuildEnvMap_ExpandsSandboxDir

Closes #483