### PR TITLE
feat(plugin): catalog-level enforcement for plugin allowlists in API mode

### DIFF
--- a/pkg/catalog/allowlist.go
+++ b/pkg/catalog/allowlist.go
@@ -1,0 +1,133 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+)
+
+// AllowlistCatalog wraps any Catalog and rejects artifact names not in the
+// allowed set. When the allowlist is nil, all artifacts are permitted
+// (transparent pass-through). This enables per-catalog artifact restriction
+// without modifying individual catalog implementations.
+type AllowlistCatalog struct {
+	inner   Catalog
+	allowed map[string]bool // nil means allow all
+}
+
+var (
+	_ Catalog              = (*AllowlistCatalog)(nil)
+	_ PlatformAwareCatalog = (*AllowlistCatalog)(nil)
+)
+
+// NewAllowlistCatalog wraps a catalog with an artifact name allowlist.
+// If allowedArtifacts is nil, all artifacts are permitted (transparent pass-through).
+// If allowedArtifacts is non-nil but empty, all artifacts are denied.
+func NewAllowlistCatalog(inner Catalog, allowedArtifacts []string) *AllowlistCatalog {
+	var allowed map[string]bool
+	if allowedArtifacts != nil {
+		allowed = make(map[string]bool, len(allowedArtifacts))
+		for _, name := range allowedArtifacts {
+			allowed[name] = true
+		}
+	}
+	return &AllowlistCatalog{
+		inner:   inner,
+		allowed: allowed,
+	}
+}
+
+// isAllowed returns true if the artifact name is permitted by the allowlist.
+func (c *AllowlistCatalog) isAllowed(name string) bool {
+	return c.allowed == nil || c.allowed[name]
+}
+
+// Name returns the underlying catalog's name.
+func (c *AllowlistCatalog) Name() string {
+	return c.inner.Name()
+}
+
+// Store delegates to the underlying catalog without restriction.
+// Allowlists govern reads (Resolve/Fetch), not writes.
+func (c *AllowlistCatalog) Store(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error) {
+	return c.inner.Store(ctx, ref, content, bundleData, annotations, force)
+}
+
+// Fetch retrieves an artifact, rejecting names not in the allowlist.
+func (c *AllowlistCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
+	if !c.isAllowed(ref.Name) {
+		return nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	return c.inner.Fetch(ctx, ref)
+}
+
+// FetchWithBundle retrieves an artifact and bundle, rejecting names not in the allowlist.
+func (c *AllowlistCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
+	if !c.isAllowed(ref.Name) {
+		return nil, nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	return c.inner.FetchWithBundle(ctx, ref)
+}
+
+// Resolve finds the best matching version, rejecting names not in the allowlist.
+func (c *AllowlistCatalog) Resolve(ctx context.Context, ref Reference) (ArtifactInfo, error) {
+	if !c.isAllowed(ref.Name) {
+		return ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	return c.inner.Resolve(ctx, ref)
+}
+
+// List delegates to the underlying catalog. Listing is not restricted by
+// the allowlist to preserve discovery/enumeration capabilities.
+func (c *AllowlistCatalog) List(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error) {
+	return c.inner.List(ctx, kind, name)
+}
+
+// Exists checks if an artifact exists, rejecting names not in the allowlist.
+func (c *AllowlistCatalog) Exists(ctx context.Context, ref Reference) (bool, error) {
+	if !c.isAllowed(ref.Name) {
+		return false, nil
+	}
+	return c.inner.Exists(ctx, ref)
+}
+
+// Delete delegates to the underlying catalog without restriction.
+// Allowlists govern reads, not mutations.
+func (c *AllowlistCatalog) Delete(ctx context.Context, ref Reference) error {
+	return c.inner.Delete(ctx, ref)
+}
+
+// FetchByPlatform fetches a platform-specific binary, rejecting names not in
+// the allowlist. If the inner catalog does not implement PlatformAwareCatalog,
+// returns an ArtifactNotFoundError.
+func (c *AllowlistCatalog) FetchByPlatform(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error) {
+	if !c.isAllowed(ref.Name) {
+		return nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	pac, ok := c.inner.(PlatformAwareCatalog)
+	if !ok {
+		return nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	return pac.FetchByPlatform(ctx, ref, platform)
+}
+
+// ListPlatforms returns the platforms available for a multi-platform artifact,
+// rejecting names not in the allowlist. If the inner catalog does not implement
+// PlatformAwareCatalog, returns an ArtifactNotFoundError.
+func (c *AllowlistCatalog) ListPlatforms(ctx context.Context, ref Reference) ([]string, error) {
+	if !c.isAllowed(ref.Name) {
+		return nil, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	pac, ok := c.inner.(PlatformAwareCatalog)
+	if !ok {
+		return nil, &ArtifactNotFoundError{Reference: ref, Catalog: c.inner.Name()}
+	}
+	return pac.ListPlatforms(ctx, ref)
+}
+
+// Inner returns the wrapped catalog. Useful for type assertions on the
+// underlying implementation when needed.
+func (c *AllowlistCatalog) Inner() Catalog {
+	return c.inner
+}

--- a/pkg/catalog/allowlist_test.go
+++ b/pkg/catalog/allowlist_test.go
@@ -1,0 +1,182 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allowlistMock is a minimal Catalog implementation for testing the allowlist wrapper.
+type allowlistMock struct {
+	name string
+}
+
+func (m *allowlistMock) Name() string { return m.name }
+func (m *allowlistMock) Store(_ context.Context, _ Reference, _, _ []byte, _ map[string]string, _ bool) (ArtifactInfo, error) {
+	return ArtifactInfo{}, nil
+}
+
+func (m *allowlistMock) Fetch(_ context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
+	return []byte("data"), ArtifactInfo{Reference: ref}, nil
+}
+
+func (m *allowlistMock) FetchWithBundle(_ context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
+	return []byte("data"), []byte("bundle"), ArtifactInfo{Reference: ref}, nil
+}
+
+func (m *allowlistMock) Resolve(_ context.Context, ref Reference) (ArtifactInfo, error) {
+	return ArtifactInfo{Reference: ref}, nil
+}
+
+func (m *allowlistMock) List(_ context.Context, _ ArtifactKind, _ string) ([]ArtifactInfo, error) {
+	return []ArtifactInfo{{Reference: Reference{Name: "listed"}}}, nil
+}
+
+func (m *allowlistMock) Exists(_ context.Context, _ Reference) (bool, error) {
+	return true, nil
+}
+
+func (m *allowlistMock) Delete(_ context.Context, _ Reference) error {
+	return nil
+}
+
+func TestAllowlistCatalog_NilAllowlistPermitsAll(t *testing.T) {
+	inner := &allowlistMock{name: "test-catalog"}
+	cat := NewAllowlistCatalog(inner, nil)
+
+	ctx := context.Background()
+	ref := Reference{Name: "anything", Kind: ArtifactKindProvider}
+
+	info, err := cat.Resolve(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, "anything", info.Reference.Name)
+
+	data, _, err := cat.Fetch(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+
+	exists, err := cat.Exists(ctx, ref)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestAllowlistCatalog_EmptySliceDeniesAll(t *testing.T) {
+	inner := &allowlistMock{name: "test-catalog"}
+	cat := NewAllowlistCatalog(inner, []string{})
+
+	ctx := context.Background()
+	ref := Reference{Name: "anything", Kind: ArtifactKindProvider}
+
+	_, err := cat.Resolve(ctx, ref)
+	require.Error(t, err)
+	var notFound *ArtifactNotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestAllowlistCatalog_AllowedArtifactPassesThrough(t *testing.T) {
+	inner := &allowlistMock{name: "official"}
+	cat := NewAllowlistCatalog(inner, []string{"exec", "git"})
+
+	ctx := context.Background()
+
+	// Resolve allowed
+	info, err := cat.Resolve(ctx, Reference{Name: "exec", Kind: ArtifactKindProvider})
+	require.NoError(t, err)
+	assert.Equal(t, "exec", info.Reference.Name)
+
+	// Fetch allowed
+	data, _, err := cat.Fetch(ctx, Reference{Name: "git", Kind: ArtifactKindProvider})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+
+	// FetchWithBundle allowed
+	content, bundle, _, err := cat.FetchWithBundle(ctx, Reference{Name: "exec", Kind: ArtifactKindProvider})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), content)
+	assert.Equal(t, []byte("bundle"), bundle)
+
+	// Exists allowed
+	exists, err := cat.Exists(ctx, Reference{Name: "exec", Kind: ArtifactKindProvider})
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestAllowlistCatalog_RejectedArtifactReturnsNotFound(t *testing.T) {
+	inner := &allowlistMock{name: "official"}
+	cat := NewAllowlistCatalog(inner, []string{"exec", "git"})
+
+	ctx := context.Background()
+	ref := Reference{Name: "malicious-plugin", Kind: ArtifactKindProvider}
+
+	// Resolve rejected
+	_, err := cat.Resolve(ctx, ref)
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+	assert.Contains(t, err.Error(), "official")
+
+	// Fetch rejected
+	_, _, err = cat.Fetch(ctx, ref)
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+
+	// FetchWithBundle rejected
+	_, _, _, err = cat.FetchWithBundle(ctx, ref) //nolint:dogsled // testing error path only
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+
+	// Exists rejected
+	exists, err := cat.Exists(ctx, ref)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestAllowlistCatalog_ListNotRestricted(t *testing.T) {
+	inner := &allowlistMock{name: "official"}
+	cat := NewAllowlistCatalog(inner, []string{"exec"})
+
+	ctx := context.Background()
+	results, err := cat.List(ctx, ArtifactKindProvider, "")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "listed", results[0].Reference.Name)
+}
+
+func TestAllowlistCatalog_NameDelegatesToInner(t *testing.T) {
+	inner := &allowlistMock{name: "my-catalog"}
+	cat := NewAllowlistCatalog(inner, []string{"exec"})
+
+	assert.Equal(t, "my-catalog", cat.Name())
+}
+
+func TestAllowlistCatalog_InnerReturnsWrapped(t *testing.T) {
+	inner := &allowlistMock{name: "inner"}
+	cat := NewAllowlistCatalog(inner, nil)
+
+	assert.Equal(t, inner, cat.Inner())
+}
+
+func TestAllowlistCatalog_StoreDelegatesToInner(t *testing.T) {
+	inner := &allowlistMock{name: "test"}
+	cat := NewAllowlistCatalog(inner, []string{"exec"})
+
+	// Store is not gated by allowlist (writes are unrestricted)
+	ctx := context.Background()
+	ref := Reference{Name: "not-in-allowlist", Kind: ArtifactKindProvider}
+	_, err := cat.Store(ctx, ref, []byte("content"), nil, nil, false)
+	assert.NoError(t, err)
+}
+
+func TestAllowlistCatalog_DeleteDelegatesToInner(t *testing.T) {
+	inner := &allowlistMock{name: "test"}
+	cat := NewAllowlistCatalog(inner, []string{"exec"})
+
+	ctx := context.Background()
+	ref := Reference{Name: "not-in-allowlist", Kind: ArtifactKindProvider}
+	err := cat.Delete(ctx, ref)
+	assert.NoError(t, err)
+}

--- a/pkg/catalog/chain_builder.go
+++ b/pkg/catalog/chain_builder.go
@@ -11,6 +11,49 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/config"
 )
 
+// PluginPolicy describes what is allowed from a single catalog.
+type PluginPolicy struct {
+	AllowAll bool     // true = wildcard ("catalog/*"), Plugins is ignored
+	Plugins  []string // explicit plugin names (only meaningful when AllowAll is false)
+}
+
+type ChainCatalogOptions struct {
+	allowedCatalogs     map[string]bool
+	perCatalogArtifacts map[string]PluginPolicy
+}
+
+type ChainCatalogOption func(*ChainCatalogOptions)
+
+func WithAllowedCatalogs(catalogNames []string) ChainCatalogOption {
+	return func(opt *ChainCatalogOptions) {
+		if len(catalogNames) == 0 {
+			return
+		}
+		if opt.allowedCatalogs == nil {
+			opt.allowedCatalogs = make(map[string]bool)
+		}
+		for _, name := range catalogNames {
+			opt.allowedCatalogs[name] = true
+		}
+	}
+}
+
+// WithPerCatalogArtifacts restricts which artifacts each catalog may serve.
+// The map keys are catalog names; values describe the policy for that catalog.
+// Catalogs present with AllowAll=true are unrestricted. Catalogs present with
+// an explicit Plugins list are wrapped with an AllowlistCatalog. Catalogs NOT
+// in the map are wrapped with an empty allowlist (deny all) when restrictions
+// are active.
+func WithPerCatalogArtifacts(perCatalog map[string]PluginPolicy) ChainCatalogOption {
+	return func(opt *ChainCatalogOptions) {
+		opt.perCatalogArtifacts = perCatalog
+	}
+}
+
+func isCatalogAllowed(name string, allowed map[string]bool) bool {
+	return allowed == nil || allowed[name]
+}
+
 // BuildCatalogChain creates a ChainCatalog from the application configuration.
 //
 // The chain order is deterministic:
@@ -20,14 +63,23 @@ import (
 //
 // If authRegistry is provided, catalogs with an authProvider field will use
 // the corresponding auth handler for dynamic token injection.
-func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger logr.Logger) (*ChainCatalog, error) {
+func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger logr.Logger, opts ...ChainCatalogOption) (*ChainCatalog, error) {
 	var catalogs []Catalog
+
+	// Apply options
+	var options ChainCatalogOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 
 	// 1. Local catalog always comes first.
 	localCat, err := NewLocalCatalog(logger)
-	if err != nil {
+	switch {
+	case err != nil:
 		logger.V(1).Info("local catalog not available", "error", err)
-	} else {
+	case !isCatalogAllowed(localCat.Name(), options.allowedCatalogs):
+		logger.V(1).Info("local catalog not in allowed list, skipping")
+	default:
 		catalogs = append(catalogs, localCat)
 	}
 
@@ -51,6 +103,11 @@ func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger l
 				continue
 			}
 
+			if !isCatalogAllowed(catCfg.Name, options.allowedCatalogs) {
+				logger.V(1).Info("catalog not in allowed list, skipping", "catalog", catCfg.Name)
+				continue
+			}
+
 			remoteCat, remoteCatErr := buildRemoteCatalog(catCfg, credStore, authRegistry, logger)
 			if remoteCatErr != nil {
 				continue
@@ -60,7 +117,9 @@ func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger l
 
 		// 3. Official catalog always comes last (unless disabled).
 		if !cfg.Settings.DisableOfficialCatalog {
-			if officialCfg, ok := cfg.GetCatalog(config.CatalogNameOfficial); ok {
+			if !isCatalogAllowed(config.CatalogNameOfficial, options.allowedCatalogs) {
+				logger.V(1).Info("official catalog not in allowed list, skipping")
+			} else if officialCfg, ok := cfg.GetCatalog(config.CatalogNameOfficial); ok {
 				officialCat, officialErr := buildRemoteCatalog(*officialCfg, credStore, authRegistry, logger)
 				if officialErr == nil {
 					catalogs = append(catalogs, officialCat)
@@ -71,6 +130,22 @@ func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger l
 
 	if len(catalogs) == 0 {
 		return nil, fmt.Errorf("no catalogs available (local catalog could not be initialized)")
+	}
+
+	// Wrap catalogs with per-catalog artifact allowlists when configured.
+	if options.perCatalogArtifacts != nil {
+		for i, cat := range catalogs {
+			policy, ok := options.perCatalogArtifacts[cat.Name()]
+			switch {
+			case ok && policy.AllowAll:
+				// Wildcard: no restriction needed
+			case ok:
+				catalogs[i] = NewAllowlistCatalog(cat, policy.Plugins)
+			default:
+				// Catalog not in policy map: deny all when restrictions are active
+				catalogs[i] = NewAllowlistCatalog(cat, []string{})
+			}
+		}
 	}
 
 	return NewChainCatalog(logger, catalogs...)

--- a/pkg/catalog/chain_test.go
+++ b/pkg/catalog/chain_test.go
@@ -16,117 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockCatalog implements the Catalog interface for testing.
-type mockCatalog struct {
-	name                string
-	artifacts           map[string]mockArtifact
-	listFunc            func(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error)
-	storeFunc           func(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error)
-	deleteFunc          func(ctx context.Context, ref Reference) error
-	fetchFunc           func(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error)
-	fetchWithBundleFunc func(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error)
-	resolveFunc         func(ctx context.Context, ref Reference) (ArtifactInfo, error)
-}
-
-type mockArtifact struct {
-	content    []byte
-	bundleData []byte
-	info       ArtifactInfo
-}
-
-func newMockCatalog(name string) *mockCatalog {
-	return &mockCatalog{
-		name:      name,
-		artifacts: make(map[string]mockArtifact),
-	}
-}
-
-func (m *mockCatalog) addArtifact(ref Reference, content []byte, annotations map[string]string) {
-	m.artifacts[ref.String()] = mockArtifact{
-		content: content,
-		info: ArtifactInfo{
-			Reference:   ref,
-			Digest:      fmt.Sprintf("sha256:mock-%s", ref.String()),
-			Annotations: annotations,
-			Catalog:     m.name,
-		},
-	}
-}
-
-func (m *mockCatalog) Name() string { return m.name }
-
-func (m *mockCatalog) Store(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error) {
-	if m.storeFunc != nil {
-		return m.storeFunc(ctx, ref, content, bundleData, annotations, force)
-	}
-	info := ArtifactInfo{Reference: ref, Catalog: m.name}
-	m.artifacts[ref.String()] = mockArtifact{content: content, bundleData: bundleData, info: info}
-	return info, nil
-}
-
-func (m *mockCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
-	if m.fetchFunc != nil {
-		return m.fetchFunc(ctx, ref)
-	}
-	a, ok := m.artifacts[ref.String()]
-	if !ok {
-		return nil, ArtifactInfo{}, ErrArtifactNotFound
-	}
-	return a.content, a.info, nil
-}
-
-func (m *mockCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
-	if m.fetchWithBundleFunc != nil {
-		return m.fetchWithBundleFunc(ctx, ref)
-	}
-	a, ok := m.artifacts[ref.String()]
-	if !ok {
-		return nil, nil, ArtifactInfo{}, ErrArtifactNotFound
-	}
-	return a.content, a.bundleData, a.info, nil
-}
-
-func (m *mockCatalog) Resolve(ctx context.Context, ref Reference) (ArtifactInfo, error) {
-	if m.resolveFunc != nil {
-		return m.resolveFunc(ctx, ref)
-	}
-	a, ok := m.artifacts[ref.String()]
-	if !ok {
-		return ArtifactInfo{}, ErrArtifactNotFound
-	}
-	return a.info, nil
-}
-
-func (m *mockCatalog) List(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error) {
-	if m.listFunc != nil {
-		return m.listFunc(ctx, kind, name)
-	}
-	var results []ArtifactInfo
-	for _, a := range m.artifacts {
-		if name != "" && a.info.Reference.Name != name {
-			continue
-		}
-		if a.info.Reference.Kind != kind {
-			continue
-		}
-		results = append(results, a.info)
-	}
-	return results, nil
-}
-
-func (m *mockCatalog) Exists(ctx context.Context, ref Reference) (bool, error) {
-	_, ok := m.artifacts[ref.String()]
-	return ok, nil
-}
-
-func (m *mockCatalog) Delete(ctx context.Context, ref Reference) error {
-	if m.deleteFunc != nil {
-		return m.deleteFunc(ctx, ref)
-	}
-	delete(m.artifacts, ref.String())
-	return nil
-}
-
 func testRef(name, version string) Reference {
 	ref := Reference{
 		Kind: ArtifactKindProvider,
@@ -765,4 +654,140 @@ func TestBuildCatalogChain_SkipsReservedNamesFromMiddle(t *testing.T) {
 	middle, ok := chain.catalogs[1].(*RemoteCatalog)
 	require.True(t, ok)
 	assert.Equal(t, "my-catalog", middle.name)
+}
+
+func TestBuildCatalogChain_WithAllowedCatalogs_ExcludesLocal(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cfg := &config.Config{
+		Catalogs: []config.CatalogConfig{
+			{
+				Name: config.CatalogNameOfficial,
+				Type: config.CatalogTypeOCI,
+				URL:  "ghcr.io/example",
+			},
+		},
+	}
+
+	// Only allow "official" — local should be excluded.
+	chain, err := BuildCatalogChain(cfg, nil, logr.Discard(), WithAllowedCatalogs([]string{config.CatalogNameOfficial}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	for _, cat := range chain.catalogs {
+		assert.NotEqual(t, LocalCatalogName, cat.Name())
+	}
+}
+
+func TestBuildCatalogChain_WithAllowedCatalogs_ExcludesOfficial(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cfg := &config.Config{
+		Catalogs: []config.CatalogConfig{
+			{
+				Name: config.CatalogNameOfficial,
+				Type: config.CatalogTypeOCI,
+				URL:  "ghcr.io/example",
+			},
+		},
+	}
+
+	// Only allow "local" — official should be excluded.
+	chain, err := BuildCatalogChain(cfg, nil, logr.Discard(), WithAllowedCatalogs([]string{LocalCatalogName}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	for _, cat := range chain.catalogs {
+		assert.NotEqual(t, config.CatalogNameOfficial, cat.Name())
+	}
+}
+
+func TestBuildCatalogChain_WithPerCatalogArtifacts_DenyDefault(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Policy only mentions "other-catalog" — local should be wrapped with deny-all.
+	chain, err := BuildCatalogChain(nil, nil, logr.Discard(), WithPerCatalogArtifacts(map[string]PluginPolicy{
+		"other-catalog": {Plugins: []string{"foo"}},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	// Local catalog should be wrapped with an empty allowlist (deny all).
+	wrapped, ok := chain.catalogs[0].(*AllowlistCatalog)
+	require.True(t, ok, "expected local catalog to be wrapped in AllowlistCatalog")
+	assert.Equal(t, LocalCatalogName, wrapped.Name())
+	assert.False(t, wrapped.isAllowed("anything"))
+}
+
+func TestBuildCatalogChain_WithPerCatalogArtifacts_EmptyMapDeniesAll(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Empty map (e.g. allowedPlugins: []) — all catalogs should be denied.
+	chain, err := BuildCatalogChain(nil, nil, logr.Discard(), WithPerCatalogArtifacts(map[string]PluginPolicy{}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	// Local catalog should be wrapped with deny-all.
+	wrapped, ok := chain.catalogs[0].(*AllowlistCatalog)
+	require.True(t, ok, "expected local catalog to be wrapped in AllowlistCatalog")
+	assert.False(t, wrapped.isAllowed("exec"))
+	assert.False(t, wrapped.isAllowed("anything"))
+}
+
+func TestBuildCatalogChain_WithPerCatalogArtifacts_Wildcard(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Wildcard policy for local — should not be wrapped.
+	chain, err := BuildCatalogChain(nil, nil, logr.Discard(), WithPerCatalogArtifacts(map[string]PluginPolicy{
+		LocalCatalogName: {AllowAll: true},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	// Wildcard means no wrapping — underlying type should be *LocalCatalog.
+	assert.IsType(t, &LocalCatalog{}, chain.catalogs[0])
+}
+
+func TestBuildCatalogChain_WithPerCatalogArtifacts_ExplicitList(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Explicit list for local catalog — only "exec" is allowed.
+	chain, err := BuildCatalogChain(nil, nil, logr.Discard(), WithPerCatalogArtifacts(map[string]PluginPolicy{
+		LocalCatalogName: {Plugins: []string{"exec"}},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	wrapped, ok := chain.catalogs[0].(*AllowlistCatalog)
+	require.True(t, ok, "expected local catalog to be wrapped in AllowlistCatalog")
+	assert.True(t, wrapped.isAllowed("exec"))
+	assert.False(t, wrapped.isAllowed("git"))
+}
+
+func TestBuildCatalogChain_WithPerCatalogArtifacts_OfficialDenyDefault(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cfg := &config.Config{
+		Catalogs: []config.CatalogConfig{
+			{
+				Name: config.CatalogNameOfficial,
+				Type: config.CatalogTypeOCI,
+				URL:  "ghcr.io/example",
+			},
+		},
+	}
+
+	// Policy only mentions local — official should be wrapped with deny-all.
+	chain, err := BuildCatalogChain(cfg, nil, logr.Discard(), WithPerCatalogArtifacts(map[string]PluginPolicy{
+		LocalCatalogName: {AllowAll: true},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	// Find the official catalog in the chain (should be last).
+	last := chain.catalogs[len(chain.catalogs)-1]
+	wrapped, ok := last.(*AllowlistCatalog)
+	require.True(t, ok, "expected official catalog to be wrapped in AllowlistCatalog")
+	assert.Equal(t, config.CatalogNameOfficial, wrapped.Name())
+	assert.False(t, wrapped.isAllowed("exec"))
 }

--- a/pkg/catalog/mock.go
+++ b/pkg/catalog/mock.go
@@ -1,0 +1,174 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"fmt"
+)
+
+// mockCatalog implements Catalog for testing with pluggable return functions.
+type mockCatalog struct {
+	name                string
+	artifacts           map[string]mockArtifact
+	storeFunc           func(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error)
+	fetchFunc           func(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error)
+	fetchWithBundleFunc func(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error)
+	resolveFunc         func(ctx context.Context, ref Reference) (ArtifactInfo, error)
+	listFunc            func(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error)
+	existsFunc          func(ctx context.Context, ref Reference) (bool, error)
+	deleteFunc          func(ctx context.Context, ref Reference) error
+}
+
+type mockArtifact struct {
+	content    []byte
+	bundleData []byte
+	info       ArtifactInfo
+}
+
+// MockOption configures a mock catalog.
+type MockOption func(*mockCatalog)
+
+// NewMockCatalog creates a Catalog for testing with the given name and options.
+func NewMockCatalog(name string, opts ...MockOption) Catalog {
+	m := &mockCatalog{
+		name:      name,
+		artifacts: make(map[string]mockArtifact),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// WithResolveFunc sets the Resolve implementation.
+func WithResolveFunc(fn func(ctx context.Context, ref Reference) (ArtifactInfo, error)) MockOption {
+	return func(m *mockCatalog) { m.resolveFunc = fn }
+}
+
+// WithFetchFunc sets the Fetch implementation.
+func WithFetchFunc(fn func(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error)) MockOption {
+	return func(m *mockCatalog) { m.fetchFunc = fn }
+}
+
+// WithFetchBundleFunc sets the FetchWithBundle implementation.
+func WithFetchBundleFunc(fn func(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error)) MockOption {
+	return func(m *mockCatalog) { m.fetchWithBundleFunc = fn }
+}
+
+// WithStoreFunc sets the Store implementation.
+func WithStoreFunc(fn func(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error)) MockOption {
+	return func(m *mockCatalog) { m.storeFunc = fn }
+}
+
+// WithListFunc sets the List implementation.
+func WithListFunc(fn func(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error)) MockOption {
+	return func(m *mockCatalog) { m.listFunc = fn }
+}
+
+// WithExistsFunc sets the Exists implementation.
+func WithExistsFunc(fn func(ctx context.Context, ref Reference) (bool, error)) MockOption {
+	return func(m *mockCatalog) { m.existsFunc = fn }
+}
+
+// WithDeleteFunc sets the Delete implementation.
+func WithDeleteFunc(fn func(ctx context.Context, ref Reference) error) MockOption {
+	return func(m *mockCatalog) { m.deleteFunc = fn }
+}
+
+func newMockCatalog(name string) *mockCatalog {
+	return &mockCatalog{
+		name:      name,
+		artifacts: make(map[string]mockArtifact),
+	}
+}
+
+func (m *mockCatalog) addArtifact(ref Reference, content []byte, annotations map[string]string) {
+	m.artifacts[ref.String()] = mockArtifact{
+		content: content,
+		info: ArtifactInfo{
+			Reference:   ref,
+			Digest:      fmt.Sprintf("sha256:mock-%s", ref.String()),
+			Annotations: annotations,
+			Catalog:     m.name,
+		},
+	}
+}
+
+func (m *mockCatalog) Name() string { return m.name }
+
+func (m *mockCatalog) Store(ctx context.Context, ref Reference, content, bundleData []byte, annotations map[string]string, force bool) (ArtifactInfo, error) {
+	if m.storeFunc != nil {
+		return m.storeFunc(ctx, ref, content, bundleData, annotations, force)
+	}
+	info := ArtifactInfo{Reference: ref, Catalog: m.name}
+	m.artifacts[ref.String()] = mockArtifact{content: content, bundleData: bundleData, info: info}
+	return info, nil
+}
+
+func (m *mockCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
+	if m.fetchFunc != nil {
+		return m.fetchFunc(ctx, ref)
+	}
+	a, ok := m.artifacts[ref.String()]
+	if !ok {
+		return nil, ArtifactInfo{}, ErrArtifactNotFound
+	}
+	return a.content, a.info, nil
+}
+
+func (m *mockCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
+	if m.fetchWithBundleFunc != nil {
+		return m.fetchWithBundleFunc(ctx, ref)
+	}
+	a, ok := m.artifacts[ref.String()]
+	if !ok {
+		return nil, nil, ArtifactInfo{}, ErrArtifactNotFound
+	}
+	return a.content, a.bundleData, a.info, nil
+}
+
+func (m *mockCatalog) Resolve(ctx context.Context, ref Reference) (ArtifactInfo, error) {
+	if m.resolveFunc != nil {
+		return m.resolveFunc(ctx, ref)
+	}
+	a, ok := m.artifacts[ref.String()]
+	if !ok {
+		return ArtifactInfo{}, ErrArtifactNotFound
+	}
+	return a.info, nil
+}
+
+func (m *mockCatalog) List(ctx context.Context, kind ArtifactKind, name string) ([]ArtifactInfo, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, kind, name)
+	}
+	var results []ArtifactInfo
+	for _, a := range m.artifacts {
+		if name != "" && a.info.Reference.Name != name {
+			continue
+		}
+		if a.info.Reference.Kind != kind {
+			continue
+		}
+		results = append(results, a.info)
+	}
+	return results, nil
+}
+
+func (m *mockCatalog) Exists(ctx context.Context, ref Reference) (bool, error) {
+	if m.existsFunc != nil {
+		return m.existsFunc(ctx, ref)
+	}
+	_, ok := m.artifacts[ref.String()]
+	return ok, nil
+}
+
+func (m *mockCatalog) Delete(ctx context.Context, ref Reference) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, ref)
+	}
+	delete(m.artifacts, ref.String())
+	return nil
+}

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/api/endpoints"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
@@ -134,6 +135,41 @@ func runServe(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("initializing provider registry: %w", err)
 	}
 
+	// Build server identity registry for API-mode token retrieval.
+	identityReg, err := sidregistry.TokenProviderRegistry(ctx, &cfg.APIServer, lgr)
+	if err != nil {
+		return fmt.Errorf("building identity registry: %w", err)
+	}
+	// Build token provider registry for unified token retrieval in API mode.
+	tsReg, err := tokenprovider.Build(runmode.API, nil, identityReg)
+	if err != nil {
+		return fmt.Errorf("building token provider registry: %w", err)
+	}
+
+	ctx = tokenprovider.WithRegistry(ctx, tsReg)
+
+	// Parse plugin allowlist at startup boundary (validates "catalog/plugin" format).
+	var (
+		bareNames  []string
+		perCatalog map[string]catalog.PluginPolicy
+	)
+	if len(cfg.APIServer.Plugins.AllowedPlugins) > 0 {
+		parsed, parseErr := plugin.ParseAllowedPlugins(cfg.APIServer.Plugins.AllowedPlugins)
+		if parseErr != nil {
+			return fmt.Errorf("invalid plugin allowlist: %w", parseErr)
+		}
+		bareNames = plugin.BareNames(parsed)
+		perCatalog = plugin.GroupByCatalog(parsed)
+	}
+
+	// AllowedCatalogs controls which catalogs participate in the chain.
+	catalogNames := cfg.APIServer.Plugins.AllowedCatalogs
+
+	// If a catalog is in allowedCatalogs but has no plugins assigned in
+	// allowedPlugins, backfill it with a deny-all policy so
+	// BuildCatalogChain wraps it with an empty allowlist.
+	perCatalog = populateCatalogPolicies(catalogNames, perCatalog)
+
 	// Build official provider registry for auto-resolution
 	var officialReg *official.Registry
 	if cfg.Settings.DisableOfficialProviders {
@@ -142,44 +178,33 @@ func runServe(ctx context.Context, opts *Options) error {
 		officialReg = official.NewRegistry()
 	}
 
-	// Build plugin fetcher for auto-fetching plugin binaries from catalogs
+	// Build plugin fetcher for auto-fetching plugin binaries from catalogs.
+	// Chain construction respects catalog and per-catalog artifact allowlists.
 	var pluginFetcher *plugin.Fetcher
 	if fetcher, fetchErr := prepare.BuildPluginFetcherWithConfig(ctx, prepare.PluginFetcherOverrides{
-		AllowedCatalogs: cfg.APIServer.Plugins.AllowedCatalogs,
+		AllowedCatalogs:      catalogNames,
+		ChainAllowedCatalogs: catalogNames,
+		PerCatalogArtifacts:  perCatalog,
 	}); fetchErr == nil {
 		pluginFetcher = fetcher
 	} else {
 		lgr.V(1).Info("plugin fetcher not available; official providers will not be pre-loaded", "error", fetchErr)
 	}
 
-	// Pre-load all official providers into the registry at server startup.
-	// This avoids per-request gRPC spawn overhead and ensures the extracted
-	// providers (exec, directory, git, etc.) are available for all endpoints.
+	// Pre-load official providers (filtered by per-catalog allowlist).
 	var pluginClients []*plugin.Client
 	if officialReg != nil && pluginFetcher != nil {
-		clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, pluginFetcher)
+		var preloadOpts []PreLoadOption
+		preloadOpts = configurePreloadOptions(perCatalog, preloadOpts, official.CatalogName)
+		clients, preloadErr := preloadOfficialProviders(ctx, reg, officialReg, pluginFetcher, preloadOpts...)
 		if preloadErr != nil {
 			lgr.V(0).Info("warning: some official providers could not be pre-loaded", "error", preloadErr)
 		}
 		pluginClients = clients
 	}
 
-	// Create plugin pool for managing external plugin lifecycle.
-	// Pre-loaded official providers are adopted into the pool so their
-	// lifecycle (shutdown) is managed consistently.
-	pluginPool := buildPluginPool(ctx, cfg, pluginFetcher, reg, lgr, pluginClients)
-
-	// Build server identity registry for API-mode token retrieval.
-	identityReg, err := sidregistry.TokenProviderRegistry(ctx, &cfg.APIServer, lgr)
-	if err != nil {
-		return fmt.Errorf("building identity registry: %w", err)
-	}
-
-	// Build token provider registry for unified token retrieval in API mode.
-	tsReg, err := tokenprovider.Build(runmode.API, nil, identityReg)
-	if err != nil {
-		return fmt.Errorf("building token provider registry: %w", err)
-	}
+	// Create plugin pool (bare-name fast-reject for external plugins).
+	pluginPool := buildPluginPool(ctx, cfg, pluginFetcher, reg, lgr, pluginClients, bareNames)
 
 	// Build server options
 	serverOpts := []api.ServerOption{
@@ -229,6 +254,62 @@ func runServe(ctx context.Context, opts *Options) error {
 	return srv.Start()
 }
 
+func populateCatalogPolicies(catalogNames []string, perCatalog map[string]catalog.PluginPolicy) map[string]catalog.PluginPolicy {
+	if len(catalogNames) > 0 {
+		if perCatalog == nil {
+			perCatalog = make(map[string]catalog.PluginPolicy, len(catalogNames))
+		}
+		for _, name := range catalogNames {
+			if _, exists := perCatalog[name]; !exists {
+				perCatalog[name] = catalog.PluginPolicy{Plugins: []string{}}
+			}
+		}
+	}
+	return perCatalog
+}
+
+func configurePreloadOptions(perCatalog map[string]catalog.PluginPolicy, preloadOpts []PreLoadOption, catalogName string) []PreLoadOption {
+	// When perCatalog is nil (no allowlist configured), no filter is applied.
+	if perCatalog != nil {
+		// An allowlist is configured; determine official catalog policy.
+		policy, ok := perCatalog[catalogName]
+		switch {
+		case !ok:
+			// catalog absent from policy map: deny all.
+			preloadOpts = append(preloadOpts, WithAllowedPlugins([]string{}))
+		case policy.AllowAll:
+			// Wildcard ("catalog/*"): no filter needed.
+		default:
+			// Explicit list of allowed plugins.
+			preloadOpts = append(preloadOpts, WithAllowedPlugins(policy.Plugins))
+		}
+	}
+	return preloadOpts
+}
+
+type preLoadOptions struct {
+	allowedPlugins map[string]bool
+}
+
+type PreLoadOption func(*preLoadOptions)
+
+func WithAllowedPlugins(plugins []string) PreLoadOption {
+	return func(opts *preLoadOptions) {
+		if plugins == nil {
+			// nil means "no filter" — leave allowedPlugins unchanged.
+			return
+		}
+		// Non-nil (including empty) sets an explicit allowlist.
+		// An empty slice means "deny all".
+		if opts.allowedPlugins == nil {
+			opts.allowedPlugins = make(map[string]bool, len(plugins))
+		}
+		for _, p := range plugins {
+			opts.allowedPlugins[p] = true
+		}
+	}
+}
+
 // preloadOfficialProviders fetches all official providers and registers them
 // into the provider registry. This is called at server startup so that
 // extracted providers (exec, directory, git, etc.) are immediately available
@@ -242,26 +323,15 @@ func preloadOfficialProviders(
 	reg *provider.Registry,
 	officialReg *official.Registry,
 	fetcher *plugin.Fetcher,
+	opts ...PreLoadOption,
 ) ([]*plugin.Client, error) {
+	options := &preLoadOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
 	lgr := logger.FromContext(ctx)
 
-	// Build plugin dependencies for all official providers
-	providers := officialReg.Names()
-	deps := make([]solution.PluginDependency, 0, len(providers))
-	for _, name := range providers {
-		p, ok := officialReg.Get(name)
-		if !ok {
-			continue
-		}
-		// Skip providers already in the registry (e.g., builtins)
-		if reg.Has(name) {
-			if lgr != nil {
-				lgr.V(1).Info("official provider already registered, skipping pre-load", "provider", name)
-			}
-			continue
-		}
-		deps = append(deps, p.ToPluginDependency())
-	}
+	deps := buildPreloadDeps(officialReg, reg, options, lgr)
 
 	if len(deps) == 0 {
 		return nil, nil
@@ -301,16 +371,49 @@ func preloadOfficialProviders(
 	return clients, nil
 }
 
+// buildPreloadDeps determines which official providers need to be fetched
+// based on the allowlist and what's already registered.
+func buildPreloadDeps(
+	officialReg *official.Registry,
+	reg *provider.Registry,
+	options *preLoadOptions,
+	lgr *logr.Logger,
+) []solution.PluginDependency {
+	providers := officialReg.Names()
+	deps := make([]solution.PluginDependency, 0, len(providers))
+	for _, name := range providers {
+		if options.allowedPlugins != nil && !options.allowedPlugins[name] {
+			if lgr != nil {
+				lgr.V(1).Info("official provider not allowed, skipping pre-load", "provider", name)
+			}
+			continue
+		}
+		p, ok := officialReg.Get(name)
+		if !ok {
+			continue
+		}
+		// Skip providers already in the registry (e.g., builtins)
+		if reg.Has(name) {
+			if lgr != nil {
+				lgr.V(1).Info("official provider already registered, skipping pre-load", "provider", name)
+			}
+			continue
+		}
+		deps = append(deps, p.ToPluginDependency())
+	}
+	return deps
+}
+
 // buildPluginPool creates a Pool configured from the API server settings and
 // adopts any pre-loaded official plugin clients into it.
-func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fetcher, reg *provider.Registry, lgr *logr.Logger, preloaded []*plugin.Client) *plugin.Pool {
+func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fetcher, reg *provider.Registry, lgr *logr.Logger, preloaded []*plugin.Client, allowedPluginNames []string) *plugin.Pool {
 	poolOpts := []plugin.PoolOption{
 		plugin.WithIdleTimeout(5 * time.Minute),
 		plugin.WithMaxPlugins(50),
 		plugin.WithDisableExternal(!cfg.APIServer.Plugins.AllowExternal),
 	}
-	if len(cfg.APIServer.Plugins.AllowedPlugins) > 0 {
-		poolOpts = append(poolOpts, plugin.WithAllowedPlugins(cfg.APIServer.Plugins.AllowedPlugins))
+	if len(allowedPluginNames) > 0 {
+		poolOpts = append(poolOpts, plugin.WithAllowedPlugins(allowedPluginNames))
 	}
 	// Wire auth host dependencies so plugins can use host auth
 	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -135,7 +136,7 @@ func TestBuildPluginPool_AuthWiring(t *testing.T) {
 		},
 	}
 
-	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, nil)
 	defer pool.Shutdown()
 
 	// Pool should have been created (non-nil) with auth options forwarded.
@@ -156,7 +157,7 @@ func TestBuildPluginPool_SanitizesEnv(t *testing.T) {
 		},
 	}
 
-	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, nil)
 	defer pool.Shutdown()
 
 	// API server pools sanitize env by default
@@ -176,7 +177,7 @@ func TestBuildPluginPool_AllowedPlugins(t *testing.T) {
 		},
 	}
 
-	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, []string{"foo", "bar"})
 	defer pool.Shutdown()
 
 	// Verify that a non-allowed plugin is rejected
@@ -201,7 +202,7 @@ func TestBuildPluginPool_GRPCMaxMessageSize(t *testing.T) {
 		},
 	}
 
-	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, nil)
 	defer pool.Shutdown()
 
 	// Exactly one client option should have been added (the gRPC max message size).
@@ -220,8 +221,167 @@ func TestBuildPluginPool_GRPCMaxMessageSizeZeroIsNoop(t *testing.T) {
 		},
 	}
 
-	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil)
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, nil)
 	defer pool.Shutdown()
 
 	assert.Equal(t, 0, pool.ClientOptsLen(), "zero GRPCMaxMessageSize should not add a client opt")
+}
+
+func TestBuildPreloadDeps(t *testing.T) {
+	tests := []struct {
+		name         string
+		providers    []official.Provider
+		registered   []string
+		allowed      []string // nil means no allowlist (allow all)
+		wantDepNames []string
+	}{
+		{
+			name: "allowlist filters to only permitted providers",
+			providers: []official.Provider{
+				{Name: "exec", CatalogRef: "exec", DefaultVersion: "1.0.0"},
+				{Name: "git", CatalogRef: "git", DefaultVersion: "1.0.0"},
+				{Name: "directory", CatalogRef: "directory", DefaultVersion: "1.0.0"},
+			},
+			allowed:      []string{"exec", "directory"},
+			wantDepNames: []string{"exec", "directory"},
+		},
+		{
+			name: "nil allowlist permits all providers",
+			providers: []official.Provider{
+				{Name: "exec", CatalogRef: "exec", DefaultVersion: "1.0.0"},
+				{Name: "git", CatalogRef: "git", DefaultVersion: "1.0.0"},
+			},
+			allowed:      nil,
+			wantDepNames: []string{"exec", "git"},
+		},
+		{
+			name: "allowlist with no matches produces empty deps",
+			providers: []official.Provider{
+				{Name: "exec", CatalogRef: "exec", DefaultVersion: "1.0.0"},
+			},
+			allowed:      []string{"nonexistent"},
+			wantDepNames: nil,
+		},
+		{
+			name: "already-registered providers are skipped",
+			providers: []official.Provider{
+				{Name: "http", CatalogRef: "http", DefaultVersion: "1.0.0"},
+				{Name: "git", CatalogRef: "git", DefaultVersion: "1.0.0"},
+			},
+			registered:   []string{"http"},
+			wantDepNames: []string{"git"},
+		},
+		{
+			name: "combined allowlist and already registered",
+			providers: []official.Provider{
+				{Name: "http", CatalogRef: "http", DefaultVersion: "1.0.0"},
+				{Name: "git", CatalogRef: "git", DefaultVersion: "1.0.0"},
+				{Name: "directory", CatalogRef: "directory", DefaultVersion: "1.0.0"},
+			},
+			registered:   []string{"http"},
+			allowed:      []string{"http", "git"},
+			wantDepNames: []string{"git"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			officialReg := official.NewRegistryFrom(tt.providers)
+
+			var reg *provider.Registry
+			if len(tt.registered) > 0 {
+				reg, _ = builtin.DefaultRegistry(context.Background())
+			} else {
+				reg = provider.NewRegistry()
+			}
+
+			var options preLoadOptions
+			if tt.allowed != nil {
+				options.allowedPlugins = make(map[string]bool, len(tt.allowed))
+				for _, a := range tt.allowed {
+					options.allowedPlugins[a] = true
+				}
+			}
+
+			lgr := logr.Discard()
+			deps := buildPreloadDeps(officialReg, reg, &options, &lgr)
+
+			var gotNames []string
+			for _, d := range deps {
+				gotNames = append(gotNames, d.Name)
+			}
+
+			assert.ElementsMatch(t, tt.wantDepNames, gotNames)
+		})
+	}
+}
+
+func TestConfigurePreloadOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		perCatalog     map[string]catalog.PluginPolicy
+		catalogName    string
+		wantOptsLen    int
+		wantNilAllowed bool
+		wantAllowed    map[string]bool
+	}{
+		{
+			name:           "nil perCatalog applies no filter",
+			perCatalog:     nil,
+			catalogName:    "official",
+			wantOptsLen:    0,
+			wantNilAllowed: true,
+		},
+		{
+			name:           "wildcard policy applies no filter",
+			perCatalog:     map[string]catalog.PluginPolicy{"official": {AllowAll: true}},
+			catalogName:    "official",
+			wantOptsLen:    0,
+			wantNilAllowed: true,
+		},
+		{
+			name:           "catalog absent from map denies all",
+			perCatalog:     map[string]catalog.PluginPolicy{"other": {Plugins: []string{"foo"}}},
+			catalogName:    "official",
+			wantOptsLen:    1,
+			wantNilAllowed: false,
+			wantAllowed:    map[string]bool{},
+		},
+		{
+			name:           "explicit list filters to named plugins",
+			perCatalog:     map[string]catalog.PluginPolicy{"official": {Plugins: []string{"exec", "git"}}},
+			catalogName:    "official",
+			wantOptsLen:    1,
+			wantNilAllowed: false,
+			wantAllowed:    map[string]bool{"exec": true, "git": true},
+		},
+		{
+			name:           "empty map with catalog absent denies all",
+			perCatalog:     map[string]catalog.PluginPolicy{},
+			catalogName:    "official",
+			wantOptsLen:    1,
+			wantNilAllowed: false,
+			wantAllowed:    map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := configurePreloadOptions(tt.perCatalog, nil, tt.catalogName)
+
+			assert.Len(t, opts, tt.wantOptsLen)
+
+			options := &preLoadOptions{}
+			for _, opt := range opts {
+				opt(options)
+			}
+
+			if tt.wantNilAllowed {
+				assert.Nil(t, options.allowedPlugins)
+			} else {
+				require.NotNil(t, options.allowedPlugins)
+				assert.Equal(t, tt.wantAllowed, options.allowedPlugins)
+			}
+		})
+	}
 }

--- a/pkg/plugin/allowlist.go
+++ b/pkg/plugin/allowlist.go
@@ -1,0 +1,155 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+)
+
+// allowedPluginPattern validates the "catalog/plugin" format.
+// Both segments must be lowercase alphanumeric with hyphens.
+// Also accepts "catalog/*" as a wildcard (all plugins from that catalog).
+var allowedPluginPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]/(\*|[a-z0-9][a-z0-9-]*[a-z0-9])$`)
+
+// AllowedPlugin represents a qualified plugin reference in "catalog/pluginName" format.
+// It encodes both the catalog a plugin may be fetched from and the plugin name.
+type AllowedPlugin string
+
+// Validate checks that the AllowedPlugin matches the required "catalog/plugin" format.
+func (a AllowedPlugin) Validate() error {
+	s := string(a)
+	if s == "" {
+		return fmt.Errorf("allowed plugin must not be empty")
+	}
+	if !strings.Contains(s, "/") {
+		return fmt.Errorf("allowed plugin %q must be in catalog/plugin format", s)
+	}
+	if !allowedPluginPattern.MatchString(s) {
+		return fmt.Errorf("allowed plugin %q does not match required pattern (lowercase alphanumeric and hyphens, e.g. official/exec)", s)
+	}
+	return nil
+}
+
+// Catalog returns the catalog segment (left of the slash).
+func (a AllowedPlugin) Catalog() string {
+	parts := strings.SplitN(string(a), "/", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+// Plugin returns the plugin name segment (right of the slash).
+func (a AllowedPlugin) Plugin() string {
+	parts := strings.SplitN(string(a), "/", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+// IsWildcard returns true if this entry uses the "catalog/*" wildcard syntax,
+// meaning all plugins from that catalog are permitted.
+func (a AllowedPlugin) IsWildcard() bool {
+	return a.Plugin() == "*"
+}
+
+// ParseAllowedPlugins parses and validates a slice of raw "catalog/plugin" strings.
+func ParseAllowedPlugins(raw []string) ([]AllowedPlugin, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	result := make([]AllowedPlugin, 0, len(raw))
+	for _, s := range raw {
+		ap := AllowedPlugin(s)
+		if err := ap.Validate(); err != nil {
+			return nil, fmt.Errorf("parsing allowed plugins: %w", err)
+		}
+		result = append(result, ap)
+	}
+	return result, nil
+}
+
+// GroupByCatalog groups parsed AllowedPlugin entries by catalog name.
+// Wildcard entries ("catalog/*") set AllowAll=true for that catalog.
+// Explicit entries after a wildcard for the same catalog are ignored.
+func GroupByCatalog(plugins []AllowedPlugin) map[string]catalog.PluginPolicy {
+	if len(plugins) == 0 {
+		return nil
+	}
+	result := make(map[string]catalog.PluginPolicy, len(plugins))
+	for _, p := range plugins {
+		cat := p.Catalog()
+		if p.IsWildcard() {
+			result[cat] = catalog.PluginPolicy{AllowAll: true}
+			continue
+		}
+		existing := result[cat]
+		if !existing.AllowAll {
+			existing.Plugins = append(existing.Plugins, p.Plugin())
+			result[cat] = existing
+		}
+	}
+	return result
+}
+
+// PolicyPlugins returns the plugin list for a specific catalog from the policy map.
+// For wildcard catalogs (AllowAll=true), returns nil (meaning unrestricted).
+// For absent catalogs, returns nil.
+func PolicyPlugins(policies map[string]catalog.PluginPolicy, catalogName string) []string {
+	if policies == nil {
+		return nil
+	}
+	policy, ok := policies[catalogName]
+	if !ok {
+		return nil
+	}
+	if policy.AllowAll {
+		return nil
+	}
+	return policy.Plugins
+}
+
+// BareNames extracts just the plugin name (right of the slash) from each entry.
+// Wildcard entries are skipped since they don't map to a single plugin name.
+// Used for pool-level and preload-level fast-reject allowlists that don't need
+// catalog qualification.
+func BareNames(plugins []AllowedPlugin) []string {
+	if len(plugins) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(plugins))
+	for _, p := range plugins {
+		if p.IsWildcard() {
+			continue
+		}
+		names = append(names, p.Plugin())
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// CatalogNames extracts the unique catalog names from the plugin list.
+// Used to derive the WithAllowedCatalogs set for chain construction.
+func CatalogNames(plugins []AllowedPlugin) []string {
+	if len(plugins) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(plugins))
+	names := make([]string, 0, len(plugins))
+	for _, p := range plugins {
+		cat := p.Catalog()
+		if !seen[cat] {
+			seen[cat] = true
+			names = append(names, cat)
+		}
+	}
+	return names
+}

--- a/pkg/plugin/allowlist_test.go
+++ b/pkg/plugin/allowlist_test.go
@@ -1,0 +1,276 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowedPlugin_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   AllowedPlugin
+		wantErr string
+	}{
+		{name: "valid official/exec", input: "official/exec"},
+		{name: "valid internal/my-plugin", input: "internal/my-plugin"},
+		{name: "valid with numbers", input: "catalog1/provider2"},
+		{name: "empty", input: "", wantErr: "must not be empty"},
+		{name: "no slash", input: "exec", wantErr: "must be in catalog/plugin format"},
+		{name: "uppercase", input: "Official/Exec", wantErr: "does not match required pattern"},
+		{name: "spaces", input: "official/ exec", wantErr: "does not match required pattern"},
+		{name: "trailing slash", input: "official/", wantErr: "does not match required pattern"},
+		{name: "leading slash", input: "/exec", wantErr: "does not match required pattern"},
+		{name: "double slash", input: "official//exec", wantErr: "does not match required pattern"},
+		{name: "underscores", input: "my_catalog/my_plugin", wantErr: "does not match required pattern"},
+		{name: "single char segments", input: "a/b", wantErr: "does not match required pattern"},
+		{name: "starts with hyphen", input: "-catalog/exec", wantErr: "does not match required pattern"},
+		{name: "ends with hyphen", input: "catalog-/exec", wantErr: "does not match required pattern"},
+		{name: "wildcard official/*", input: "official/*"},
+		{name: "wildcard internal/*", input: "internal/*"},
+		{name: "bare wildcard", input: "*/exec", wantErr: "does not match required pattern"},
+		{name: "double wildcard", input: "*/*", wantErr: "does not match required pattern"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAllowedPlugin_Catalog(t *testing.T) {
+	tests := []struct {
+		input AllowedPlugin
+		want  string
+	}{
+		{"official/exec", "official"},
+		{"internal/my-plugin", "internal"},
+		{"no-slash", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, tt.input.Catalog())
+	}
+}
+
+func TestAllowedPlugin_Plugin(t *testing.T) {
+	tests := []struct {
+		input AllowedPlugin
+		want  string
+	}{
+		{"official/exec", "exec"},
+		{"internal/my-plugin", "my-plugin"},
+		{"no-slash", ""},
+		{"official/*", "*"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, tt.input.Plugin())
+	}
+}
+
+func TestAllowedPlugin_IsWildcard(t *testing.T) {
+	assert.True(t, AllowedPlugin("official/*").IsWildcard())
+	assert.True(t, AllowedPlugin("internal/*").IsWildcard())
+	assert.False(t, AllowedPlugin("official/exec").IsWildcard())
+	assert.False(t, AllowedPlugin("official/git").IsWildcard())
+}
+
+func TestParseAllowedPlugins(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []AllowedPlugin
+		wantErr string
+	}{
+		{
+			name:  "nil input",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:  "valid entries",
+			input: []string{"official/exec", "official/git", "internal/custom"},
+			want:  []AllowedPlugin{"official/exec", "official/git", "internal/custom"},
+		},
+		{
+			name:    "invalid entry fails early",
+			input:   []string{"official/exec", "bad"},
+			wantErr: "must be in catalog/plugin format",
+		},
+		{
+			name:  "wildcard entry",
+			input: []string{"official/*"},
+			want:  []AllowedPlugin{"official/*"},
+		},
+		{
+			name:  "mixed wildcard and explicit",
+			input: []string{"official/*", "internal/custom"},
+			want:  []AllowedPlugin{"official/*", "internal/custom"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAllowedPlugins(tt.input)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGroupByCatalog(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []AllowedPlugin
+		want  map[string]catalog.PluginPolicy
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "single catalog explicit",
+			input: []AllowedPlugin{"official/exec", "official/git"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {Plugins: []string{"exec", "git"}},
+			},
+		},
+		{
+			name:  "multiple catalogs explicit",
+			input: []AllowedPlugin{"official/exec", "internal/custom", "official/git"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {Plugins: []string{"exec", "git"}},
+				"internal": {Plugins: []string{"custom"}},
+			},
+		},
+		{
+			name:  "wildcard catalog",
+			input: []AllowedPlugin{"official/*"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {AllowAll: true},
+			},
+		},
+		{
+			name:  "wildcard overrides explicit same catalog",
+			input: []AllowedPlugin{"official/exec", "official/*"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {AllowAll: true},
+			},
+		},
+		{
+			name:  "explicit after wildcard ignored",
+			input: []AllowedPlugin{"official/*", "official/exec"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {AllowAll: true},
+			},
+		},
+		{
+			name:  "mixed wildcard and explicit different catalogs",
+			input: []AllowedPlugin{"official/*", "internal/custom"},
+			want: map[string]catalog.PluginPolicy{
+				"official": {AllowAll: true},
+				"internal": {Plugins: []string{"custom"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GroupByCatalog(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBareNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []AllowedPlugin
+		want  []string
+	}{
+		{name: "nil", input: nil, want: nil},
+		{
+			name:  "extracts plugin names",
+			input: []AllowedPlugin{"official/exec", "internal/custom"},
+			want:  []string{"exec", "custom"},
+		},
+		{
+			name:  "skips wildcards",
+			input: []AllowedPlugin{"official/*", "internal/custom"},
+			want:  []string{"custom"},
+		},
+		{
+			name:  "all wildcards returns nil",
+			input: []AllowedPlugin{"official/*", "internal/*"},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BareNames(tt.input))
+		})
+	}
+}
+
+func TestCatalogNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []AllowedPlugin
+		want  []string
+	}{
+		{name: "nil", input: nil, want: nil},
+		{
+			name:  "deduplicates catalogs",
+			input: []AllowedPlugin{"official/exec", "official/git", "internal/custom"},
+			want:  []string{"official", "internal"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CatalogNames(tt.input))
+		})
+	}
+}
+
+func TestPolicyPlugins(t *testing.T) {
+	policies := map[string]catalog.PluginPolicy{
+		"official": {AllowAll: true},
+		"internal": {Plugins: []string{"custom", "git"}},
+	}
+
+	// Wildcard catalog returns nil (unrestricted)
+	assert.Nil(t, PolicyPlugins(policies, "official"))
+
+	// Explicit catalog returns plugin list
+	assert.Equal(t, []string{"custom", "git"}, PolicyPlugins(policies, "internal"))
+
+	// Absent catalog returns nil
+	assert.Nil(t, PolicyPlugins(policies, "unknown"))
+
+	// Nil map returns nil
+	assert.Nil(t, PolicyPlugins(nil, "official"))
+}

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -225,22 +225,28 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 				// If a version constraint is specified, verify the cached version satisfies it.
 				satisfies, _ := cachedVersionSatisfies(dep.Version, cachedVer)
 				if satisfies {
-					// Security: reject cached plugins when an allowlist is configured
-					// but cache lacks catalog origin metadata.
+					// Security: when an allowlist is configured but the cache
+					// lacks catalog origin metadata, skip the cache hit and
+					// fall through to catalog resolution so provenance can be
+					// properly verified.
 					if err := f.checkCatalogAllowed(""); err != nil {
-						return FetchResult{}, fmt.Errorf("cached plugin %s: %w", dep.Name, err)
+						f.logger.V(0).Info("cached plugin lacks origin metadata, re-fetching from catalog for allowlist verification",
+							"name", dep.Name,
+							"version", cachedVer,
+							"reason", err.Error())
+					} else {
+						f.logger.V(1).Info("using cached plugin (no lock file)",
+							"name", dep.Name,
+							"version", cachedVer,
+							"path", cachedPath)
+						return FetchResult{
+							Name:      dep.Name,
+							Kind:      dep.Kind,
+							Version:   cachedVer,
+							Path:      cachedPath,
+							FromCache: true,
+						}, nil
 					}
-					f.logger.V(1).Info("using cached plugin (no lock file)",
-						"name", dep.Name,
-						"version", cachedVer,
-						"path", cachedPath)
-					return FetchResult{
-						Name:      dep.Name,
-						Kind:      dep.Kind,
-						Version:   cachedVer,
-						Path:      cachedPath,
-						FromCache: true,
-					}, nil
 				}
 			}
 		}

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -705,7 +705,14 @@ func TestFetcher_CacheFallback_AllowlistRejects(t *testing.T) {
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, pluginName), []byte("#!/bin/sh\n"), 0o755))
 
+	// Provide a catalog named "test" (not in allowlist) so the fallthrough
+	// to catalog resolution resolves from a disallowed catalog.
+	cat := newMockCatalog() // name = "test"
+	ref := testRef(pluginName, "")
+	cat.addArtifact(ref, []byte("#!/bin/sh\n"))
+
 	f := NewFetcher(FetcherConfig{
+		Catalog:         cat,
 		Cache:           NewCache(cacheDir),
 		Platform:        platform,
 		Logger:          logr.Discard(),
@@ -717,10 +724,12 @@ func TestFetcher_CacheFallback_AllowlistRejects(t *testing.T) {
 	}
 
 	// No lock file provided — fetcher uses cache-first path.
-	// Allowlist is set, cached entry has unknown origin → rejected.
+	// Allowlist is set, cached entry has unknown origin → falls through to
+	// catalog resolution. Catalog resolves from "test" which is not in the
+	// allowlist → rejected.
 	_, err := f.FetchPlugins(context.Background(), deps, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot verify against allowlist")
+	assert.Contains(t, err.Error(), "not in the allowed catalogs list")
 }
 
 // ── RegisterCachedPlugin tests ──────────────────────────────────────────────

--- a/pkg/provider/official/official.go
+++ b/pkg/provider/official/official.go
@@ -15,6 +15,11 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
 
+const (
+	// CatalogName is the name of the OCI catalog where official providers are published.
+	CatalogName = "official"
+)
+
 type contextKey struct{}
 
 // WithRegistry stores an official provider registry in the context.

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -885,8 +885,16 @@ func BuildPluginFetcher(ctx context.Context) (*plugin.Fetcher, error) {
 // BuildPluginFetcherWithConfig can override. Other fields (Catalog,
 // BinaryName, Logger, Cache) are always derived from context.
 type PluginFetcherOverrides struct {
-	// AllowedCatalogs restricts which catalog names plugins may be fetched from.
+	// AllowedCatalogs restricts which catalog names plugins may be fetched from
+	// (Fetcher-level post-resolve check, belt-and-suspenders).
 	AllowedCatalogs []string
+	// ChainAllowedCatalogs restricts which catalogs are included in the chain
+	// during construction. Catalogs not in this list are excluded entirely.
+	ChainAllowedCatalogs []string
+	// PerCatalogArtifacts restricts which artifact names each catalog may serve.
+	// Keys are catalog names, values describe the policy for that catalog.
+	// Each matching catalog is wrapped with an AllowlistCatalog decorator.
+	PerCatalogArtifacts map[string]catalog.PluginPolicy
 	// Platform overrides the target platform. If empty, auto-detected.
 	Platform string
 	// NoCache bypasses the local cache when true.
@@ -909,7 +917,16 @@ func BuildPluginFetcherWithConfig(ctx context.Context, override PluginFetcherOve
 	}
 	appCfg := config.FromContext(ctx)
 	authReg := auth.RegistryFromContext(ctx)
-	catalogChain, err := catalog.BuildCatalogChain(appCfg, authReg, fetcherLogger)
+
+	var chainOpts []catalog.ChainCatalogOption
+	if override.ChainAllowedCatalogs != nil {
+		chainOpts = append(chainOpts, catalog.WithAllowedCatalogs(override.ChainAllowedCatalogs))
+	}
+	if override.PerCatalogArtifacts != nil {
+		chainOpts = append(chainOpts, catalog.WithPerCatalogArtifacts(override.PerCatalogArtifacts))
+	}
+
+	catalogChain, err := catalog.BuildCatalogChain(appCfg, authReg, fetcherLogger, chainOpts...)
 	if err != nil {
 		fetcherLogger.V(1).Info("catalog chain not available, plugin auto-fetch disabled", "error", err)
 		return nil, fmt.Errorf("building catalog chain: %w", err)

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/api"
 	"github.com/oakwood-commons/scafctl/pkg/api/endpoints"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -2046,6 +2047,14 @@ func TestAPI_SolutionRun_AllowedCatalogs_Rejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(pluginBinDir+"/"+pluginName, []byte("#!/bin/sh\n"), 0o755))
 
 	fetcher := plugin.NewFetcher(plugin.FetcherConfig{
+		Catalog: catalog.NewMockCatalog("untrusted-registry",
+			catalog.WithResolveFunc(func(_ context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error) {
+				return catalog.ArtifactInfo{
+					Reference: ref,
+					Catalog:   "untrusted-registry",
+				}, nil
+			}),
+		),
 		Cache:           plugin.NewCache(cacheDir),
 		Platform:        platform,
 		AllowedCatalogs: []string{"approved-only"},


### PR DESCRIPTION



## Description
- Add AllowedPlugin typedef with catalog/plugin parsing, validation, and grouping helpers (ParseAllowedPlugins, GroupByCatalog, BareNames, CatalogNames)
- Implement AllowlistCatalog decorator that rejects artifact names not in the per-catalog allowed set
- Implement PlatformAwareCatalog on AllowlistCatalog so multi-platform plugin fetches (OCI image indexes) work through the wrapper
- Add WithPerCatalogArtifacts chain option to wrap catalogs at construction time
- Wire serve command: parse apiServer.plugins.allowedPlugins at startup, derive per-catalog maps and bare-name lists, pass to BuildPluginFetcherWithConfig, preloadOfficialProviders, and buildPluginPool
- preloadOfficialProviders filters official providers against the per-catalog allowlist before fetching, skipping non-approved plugins
- Soften Fetcher cache behavior: when allowlist is configured and cache lacks origin metadata, fall through to catalog resolution instead of hard-failing


```yaml
plugins:
  allowedPlugins: [official/*, internal/exec]
  allowedCatalogs:
    - official
    - internal
  ```

## Allowlist Semantics

1. **AllowedCatalogs** — if not empty, only plugins from these catalogs can be fetched.
   > Even special catalogs like `local` or `official` must be explicitly listed if you wish to fetch from them.

2. If **AllowedCatalogs** is empty, all catalogs (and their plugins) are permitted.

3. **AllowedPlugins** format:
   - `catalogName/pluginName` — allow a specific plugin from a specific catalog
   - `catalogName/*` — allow all plugins from a catalog

4. If a catalog appears in **AllowedCatalogs** (e.g. `[mycatalog]`) but has no matching entries in **AllowedPlugins**, no plugins can be fetched from that catalog.

5. If **AllowedCatalogs** is not empty, special catalogs like `local` or `official` must also be listed explicitly to allow fetching plugins from them.

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
