### PR TITLE
feat(provider)!: auto-create dirs and auto-serialize content in file provider

### DIFF
--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -5,6 +5,7 @@ package fileprovider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -88,9 +89,9 @@ func NewFileProvider() *FileProvider {
 				"content": schemahelper.StringProp("Content to write (required for write operation)",
 					schemahelper.WithExample("data: value"),
 					schemahelper.WithMaxLength(10485760)),
-				"createDirs": schemahelper.BoolProp("Create parent directories if they don't exist (for write operation)",
+				"createDirs": schemahelper.BoolProp("Create parent directories if they don't exist (for write operation). Defaults to true.",
 					schemahelper.WithExample(true),
-					schemahelper.WithDefault(false)),
+					schemahelper.WithDefault(true)),
 				"encoding": schemahelper.StringProp("File encoding for read/write operations",
 					schemahelper.WithExample("utf-8"),
 					schemahelper.WithDefault("utf-8"),
@@ -106,7 +107,7 @@ func NewFileProvider() *FileProvider {
 						[]string{"path"},
 						map[string]*jsonschema.Schema{
 							"path":    schemahelper.StringProp("Relative file path within basePath"),
-							"content": schemahelper.StringProp("File content to write"),
+							"content": schemahelper.AnyProp("File content to write. Strings are written as-is; non-string values (maps, arrays, numbers, bools) are auto-serialized to JSON."),
 							"onConflict": schemahelper.StringProp("Per-entry conflict resolution strategy override",
 								schemahelper.WithEnum("error", "overwrite", "skip", "skip-unchanged", "append")),
 							"dedupe": schemahelper.BoolProp("Per-entry deduplication override (only valid with append strategy)"),
@@ -216,15 +217,14 @@ inputs:
   path: ./config.yaml`,
 				},
 				{
-					Name:        "Write file with directory creation",
-					Description: "Write content to a file, creating parent directories if needed",
+					Name:        "Write file",
+					Description: "Write content to a file. Parent directories are created automatically (set createDirs: false to disable).",
 					YAML: `name: write-output
 provider: file
 inputs:
   operation: write
   path: ./output/data/result.txt
-  content: "Generated content"
-  createDirs: true`,
+  content: "Generated content"`,
 				},
 				{
 					Name:        "Check file existence",
@@ -451,7 +451,12 @@ func (p *FileProvider) executeWrite(ctx context.Context, absPath string, inputs 
 		return nil, fmt.Errorf("content is required for write operation")
 	}
 
-	createDirs, _ := inputs["createDirs"].(bool)
+	// createDirs defaults to true when not explicitly set.
+	createDirsPtr := boolPtrFromInputs(inputs, "createDirs")
+	if v, exists := inputs["createDirs"]; exists && v != nil && createDirsPtr == nil {
+		return nil, fmt.Errorf("createDirs must be a boolean, got %T", v)
+	}
+	createDirs := createDirsPtr == nil || *createDirsPtr
 
 	// Parse permissions — default to 0600 (owner read/write only).
 	fileMode := os.FileMode(0o600)
@@ -960,9 +965,16 @@ func (p *FileProvider) parseWriteTreeEntries(inputs map[string]any) ([]writeTree
 			// Skip directory entries (no content key) silently.
 			continue
 		}
-		content, ok := contentRaw.(string)
-		if !ok {
-			return nil, fmt.Errorf("entries[%d].content must be a string, got %T", i, contentRaw)
+		var content string
+		switch c := contentRaw.(type) {
+		case string:
+			content = c
+		default:
+			serialized, err := json.MarshalIndent(contentRaw, "", "  ")
+			if err != nil {
+				return nil, fmt.Errorf("entries[%d].content: failed to serialize %T to JSON: %w", i, contentRaw, err)
+			}
+			content = string(serialized)
 		}
 
 		entryOnConflict, _ := entry["onConflict"].(string)

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -5,6 +5,7 @@ package fileprovider
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -198,9 +199,10 @@ func TestFileProvider_Execute_Write_InvalidPath(t *testing.T) {
 
 	ctx := context.Background()
 	inputs := map[string]any{
-		"operation": "write",
-		"path":      "/nonexistent/deeply/nested/path/file.txt",
-		"content":   "test",
+		"operation":  "write",
+		"path":       "/nonexistent/deeply/nested/path/file.txt",
+		"content":    "test",
+		"createDirs": false,
 	}
 
 	result, err := p.Execute(ctx, inputs)
@@ -1170,6 +1172,161 @@ func TestFileProvider_WriteTree_MissingEntryContent_Skipped(t *testing.T) {
 	assert.Equal(t, 0, data["filesWritten"])
 }
 
+func TestFileProvider_Execute_Write_AutoCreateDirs(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	tmpFile := filepath.Join(tmpDir, "auto", "nested", "dir", "test.txt")
+	content := "auto-created dirs"
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write",
+		"path":      tmpFile,
+		"content":   content,
+		// createDirs not set — should default to true
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+
+	readContent, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(readContent))
+}
+
+func TestFileProvider_Execute_Write_CreateDirsFalse(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	tmpFile := filepath.Join(tmpDir, "no", "auto", "create", "test.txt")
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation":  "write",
+		"path":       tmpFile,
+		"content":    "should fail",
+		"createDirs": false,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestFileProvider_Execute_Write_CreateDirsInvalidType(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation":  "write",
+		"path":       tmpFile,
+		"content":    "test",
+		"createDirs": "false", // string instead of bool
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "createDirs must be a boolean")
+}
+
+func TestFileProvider_WriteTree_ContentMapAutoSerialize(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	mapContent := map[string]any{
+		"name":    "test",
+		"version": "1.0.0",
+	}
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "config.json", "content": mapContent},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 1, data["filesWritten"])
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	// Verify it's valid JSON matching the input
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(written, &parsed))
+	assert.Equal(t, "test", parsed["name"])
+	assert.Equal(t, "1.0.0", parsed["version"])
+}
+
+func TestFileProvider_WriteTree_ContentArrayAutoSerialize(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	arrayContent := []any{"one", "two", "three"}
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "list.json", "content": arrayContent},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 1, data["filesWritten"])
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, "list.json"))
+	require.NoError(t, err)
+
+	var parsed []any
+	require.NoError(t, json.Unmarshal(written, &parsed))
+	assert.Len(t, parsed, 3)
+}
+
+func TestFileProvider_WriteTree_ContentNumericAutoSerialize(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "count.txt", "content": 42},
+		},
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 1, data["filesWritten"])
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, "count.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "42", string(written))
+}
+
 func TestFileProvider_WriteTree_MixedFilesAndDirectories(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
@@ -1208,7 +1365,7 @@ func TestFileProvider_WriteTree_MixedFilesAndDirectories(t *testing.T) {
 	assert.Equal(t, "LOGO", string(content2))
 }
 
-func TestFileProvider_WriteTree_NonStringContentErrors(t *testing.T) {
+func TestFileProvider_WriteTree_NonStringContentAutoSerialized(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
 
@@ -1223,9 +1380,13 @@ func TestFileProvider_WriteTree_NonStringContentErrors(t *testing.T) {
 
 	result, err := p.Execute(ctx, inputs)
 
-	assert.Error(t, err)
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "entries[0].content must be a string")
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, 1, data["filesWritten"])
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "123", string(written))
 }
 
 func TestFileProvider_WriteTree_DryRun(t *testing.T) {


### PR DESCRIPTION
- change createDirs default from false to true for write operation, matching write-tree's existing auto-mkdir behavior
- auto-serialize non-string content (maps, arrays, numbers, bools) to JSON in write-tree entries instead of rejecting with an error
- update entry content schema from StringProp to AnyProp
- update example to reflect new createDirs default

BREAKING CHANGE: file provider write operation now creates parent directories by default. Set createDirs: false to restore old behavior. write-tree entries with non-string content are now auto-serialized to JSON instead of returning an error.

Closes #446
Closes #449
