### PR TITLE
fix(catalog): resolve plugin updates from remote catalogs and add windows/arm64

### DIFF
--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -665,6 +665,7 @@ When `PluginFetcher.FetchPlugin()` is called:
 - `darwin/amd64`
 - `darwin/arm64`
 - `windows/amd64`
+- `windows/arm64`
 
 ### Building Multi-Platform Artifacts
 

--- a/docs/tutorials/multi-platform-plugin-build.md
+++ b/docs/tutorials/multi-platform-plugin-build.md
@@ -25,6 +25,7 @@ binary for the current platform.
 | `darwin/amd64` | macOS Intel |
 | `darwin/arm64` | macOS Apple Silicon |
 | `windows/amd64` | Windows x86-64 |
+| `windows/arm64` | Windows ARM64 (e.g. Surface Pro X, Snapdragon) |
 
 ## Prerequisites
 

--- a/pkg/catalog/chain_builder.go
+++ b/pkg/catalog/chain_builder.go
@@ -76,6 +76,58 @@ func BuildCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger l
 	return NewChainCatalog(logger, catalogs...)
 }
 
+// BuildRemoteCatalogChain creates a ChainCatalog containing only remote
+// catalogs (user/embedder catalogs and the official catalog). The local
+// filesystem catalog is excluded.
+//
+// This is used by operations that need to check remote registries for newer
+// versions without being shadowed by locally cached artifacts (e.g. plugin
+// update checks).
+func BuildRemoteCatalogChain(cfg *config.Config, authRegistry *auth.Registry, logger logr.Logger) (*ChainCatalog, error) {
+	var catalogs []Catalog
+
+	var credStore *CredentialStore
+	if cfg != nil {
+		cs, credErr := NewCredentialStore(logger)
+		if credErr != nil {
+			logger.V(1).Info("credential store not available, remote catalogs will use anonymous auth", "error", credErr)
+		} else {
+			credStore = cs
+		}
+
+		for _, catCfg := range cfg.Catalogs {
+			if catCfg.Name == config.CatalogNameLocal || catCfg.Name == config.CatalogNameOfficial {
+				continue
+			}
+
+			if catCfg.Type != config.CatalogTypeOCI || catCfg.URL == "" {
+				continue
+			}
+
+			remoteCat, remoteCatErr := buildRemoteCatalog(catCfg, credStore, authRegistry, logger)
+			if remoteCatErr != nil {
+				continue
+			}
+			catalogs = append(catalogs, remoteCat)
+		}
+
+		if !cfg.Settings.DisableOfficialCatalog {
+			if officialCfg, ok := cfg.GetCatalog(config.CatalogNameOfficial); ok {
+				officialCat, officialErr := buildRemoteCatalog(*officialCfg, credStore, authRegistry, logger)
+				if officialErr == nil {
+					catalogs = append(catalogs, officialCat)
+				}
+			}
+		}
+	}
+
+	if len(catalogs) == 0 {
+		return nil, fmt.Errorf("no remote catalogs available")
+	}
+
+	return NewChainCatalog(logger, catalogs...)
+}
+
 // buildRemoteCatalog creates a RemoteCatalog from a CatalogConfig.
 func buildRemoteCatalog(catCfg config.CatalogConfig, credStore *CredentialStore, authRegistry *auth.Registry, logger logr.Logger) (*RemoteCatalog, error) {
 	return BuildRemoteCatalogFromConfig(catCfg, credStore, authRegistry, logger)

--- a/pkg/catalog/chain_builder_test.go
+++ b/pkg/catalog/chain_builder_test.go
@@ -31,6 +31,56 @@ func TestBuildRemoteCatalog_ParsesURL(t *testing.T) {
 	assert.Equal(t, "test", remoteCat.Name())
 }
 
+func TestBuildRemoteCatalogChain_ExcludesLocal(t *testing.T) {
+	t.Parallel()
+
+	logger := logr.Discard()
+
+	cfg := &config.Config{
+		Catalogs: []config.CatalogConfig{
+			{
+				Name: "my-registry",
+				Type: config.CatalogTypeOCI,
+				URL:  "oci://ghcr.io/myorg",
+			},
+		},
+	}
+
+	chain, err := BuildRemoteCatalogChain(cfg, nil, logger)
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+
+	// Verify no catalog in the chain is the local catalog.
+	for _, cat := range chain.Catalogs() {
+		assert.NotEqual(t, LocalCatalogName, cat.Name(),
+			"BuildRemoteCatalogChain must not include the local catalog")
+	}
+}
+
+func TestBuildRemoteCatalogChain_NilConfig_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	chain, err := BuildRemoteCatalogChain(nil, nil, logr.Discard())
+	assert.Nil(t, chain)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no remote catalogs available")
+}
+
+func TestBuildRemoteCatalogChain_NoCatalogs_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Settings: config.Settings{
+			DisableOfficialCatalog: true,
+		},
+	}
+
+	chain, err := BuildRemoteCatalogChain(cfg, nil, logr.Discard())
+	assert.Nil(t, chain)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no remote catalogs available")
+}
+
 func TestBuildRemoteCatalogFromConfig_AuthProvider_UsesGetRegistered(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/catalog/multiplatform.go
+++ b/pkg/catalog/multiplatform.go
@@ -16,6 +16,7 @@ var SupportedPluginPlatforms = []string{
 	"darwin/amd64",
 	"darwin/arm64",
 	"windows/amd64",
+	"windows/arm64",
 }
 
 // PlatformBinary pairs a platform string (e.g. "linux/amd64") with the

--- a/pkg/catalog/multiplatform_test.go
+++ b/pkg/catalog/multiplatform_test.go
@@ -161,5 +161,6 @@ func TestSupportedPluginPlatforms(t *testing.T) {
 	assert.Contains(t, SupportedPluginPlatforms, "darwin/amd64")
 	assert.Contains(t, SupportedPluginPlatforms, "darwin/arm64")
 	assert.Contains(t, SupportedPluginPlatforms, "windows/amd64")
-	assert.Len(t, SupportedPluginPlatforms, 5)
+	assert.Contains(t, SupportedPluginPlatforms, "windows/arm64")
+	assert.Len(t, SupportedPluginPlatforms, 6)
 }

--- a/pkg/cmd/scafctl/build/plugin.go
+++ b/pkg/cmd/scafctl/build/plugin.go
@@ -52,7 +52,7 @@ func CommandBuildPlugin(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 
 			  --platform <os/arch>=<path>
 
-			Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
+			Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64
 
 			The resulting artifact is stored as an OCI image index (fat manifest) with one
 			manifest per platform. At runtime, scafctl automatically selects the correct

--- a/pkg/cmd/scafctl/plugins/update.go
+++ b/pkg/cmd/scafctl/plugins/update.go
@@ -185,13 +185,19 @@ func runUpdate(ctx context.Context, opts *UpdateOptions, args []string, kvxOpts 
 		chainLogger = logr.Discard()
 	}
 
-	chain, err := catalog.BuildCatalogChain(appCfg, auth.RegistryFromContext(ctx), chainLogger)
+	chain, err := catalog.BuildRemoteCatalogChain(appCfg, auth.RegistryFromContext(ctx), chainLogger)
 	if err != nil {
-		w.Errorf("failed to build catalog chain: %v", err)
-		return exitcode.WithCode(err, exitcode.CatalogError)
+		// Remote catalogs may not be configured (e.g. offline, no config).
+		// Proceed without a catalog — pinned versions and empty caches still
+		// work. PlanUpdates will fail for non-pinned plugins that need
+		// catalog resolution, which is the correct behavior.
+		chainLogger.V(1).Info("remote catalog chain not available, proceeding without catalog", "error", err)
 	}
 
-	catalogFetcher := catalog.NewPluginFetcher(chain, chainLogger)
+	var catalogFetcher *catalog.PluginFetcher
+	if chain != nil {
+		catalogFetcher = catalog.NewPluginFetcher(chain, chainLogger)
+	}
 
 	// Plan updates.
 	plan, err := plugin.PlanUpdates(ctx, cache, catalogFetcher, plugin.UpdateOptions{
@@ -268,6 +274,13 @@ func runUpdate(ctx context.Context, opts *UpdateOptions, args []string, kvxOpts 
 	if opts.DryRun {
 		w.PlainStderrf("Dry run: %d plugin(s) would be updated:", len(plan.Updates))
 		return kvxOpts.Write(items)
+	}
+
+	// Guard: downloading requires a remote catalog chain.
+	if chain == nil {
+		err := fmt.Errorf("cannot download updates: no remote catalogs available")
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.CatalogError)
 	}
 
 	// Perform the updates by fetching new versions.

--- a/pkg/cmd/scafctl/plugins/update_test.go
+++ b/pkg/cmd/scafctl/plugins/update_test.go
@@ -296,6 +296,34 @@ func TestRunUpdate_DryRun_WithCachedPlugin(t *testing.T) {
 	assert.Equal(t, "github", items[0].Name)
 }
 
+func TestRunUpdate_PinnedVersion_NoCatalog_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	kvxOpts := kvx.NewOutputOptions(ioStreams)
+	kvxOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	seedTestCache(t, cacheDir, "exec", "1.0.0")
+
+	opts := &UpdateOptions{
+		CliParams: cliParams,
+		IOStreams: ioStreams,
+		CacheDir:  cacheDir,
+		Target:    "latest",
+		All:       true,
+	}
+
+	// Pinned to different version with no catalog → should error (not panic).
+	err := runUpdate(ctx, opts, []string{"exec@2.0.0"}, kvxOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no remote catalogs available")
+}
+
 func TestCommandUpdate_FlagsRegistered(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mcp/tools_catalog_multiplatform.go
+++ b/pkg/mcp/tools_catalog_multiplatform.go
@@ -35,7 +35,7 @@ func (s *Server) registerCatalogMultiPlatformTools() {
 	s.addTool(listPlatformsTool, s.handleCatalogListPlatforms)
 
 	buildPluginTool := mcp.NewTool("build_plugin",
-		mcp.WithDescription("Build a multi-platform plugin artifact into the local catalog as an OCI image index. Each platform entry maps an OS/architecture pair to a local binary path. Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64. Use this to package cross-compiled plugin binaries for distribution."),
+		mcp.WithDescription("Build a multi-platform plugin artifact into the local catalog as an OCI image index. Each platform entry maps an OS/architecture pair to a local binary path. Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64. Use this to package cross-compiled plugin binaries for distribution."),
 		mcp.WithTitleAnnotation("Build Plugin"),
 		mcp.WithToolIcons(toolIcons["plugin"]),
 		mcp.WithReadOnlyHintAnnotation(false),

--- a/pkg/plugin/updater.go
+++ b/pkg/plugin/updater.go
@@ -77,6 +77,9 @@ func PluginKindFromCacheKey(cacheKey string) (name string, kind solution.PluginK
 
 // PlanUpdates checks the catalog for newer versions of cached plugins and
 // returns an UpdatePlan describing what would change.
+//
+// If catalogFetcher is nil, all plugins that require catalog resolution are
+// reported as failed with a "no remote catalogs configured" error.
 func PlanUpdates(ctx context.Context, cache *Cache, catalogFetcher *catalog.PluginFetcher, opts UpdateOptions) (*UpdatePlan, error) {
 	if len(opts.Names) == 0 && !opts.All {
 		return nil, fmt.Errorf("no plugin names specified; use positional args or --all")
@@ -127,6 +130,14 @@ func PlanUpdates(ctx context.Context, cache *Cache, catalogFetcher *catalog.Plug
 
 		name, kind := PluginKindFromCacheKey(cacheKey)
 		artifactKind := pluginKindToArtifactKind(kind)
+
+		if catalogFetcher == nil {
+			plan.Failed = append(plan.Failed, UpdateError{
+				Name:  cacheKey,
+				Error: "no remote catalogs configured; cannot check for updates",
+			})
+			continue
+		}
 
 		// Build version constraint based on target.
 		constraint := buildUpdateConstraint(currentVer, target)

--- a/pkg/plugin/updater_test.go
+++ b/pkg/plugin/updater_test.go
@@ -95,6 +95,26 @@ func TestPlanUpdates_PluginNotInCache(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found in cache")
 }
 
+func TestPlanUpdates_NilFetcher_ReportsFailed(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	seedUpdaterCache(t, cacheDir, "exec", "1.0.0")
+
+	cache := NewCache(cacheDir)
+
+	// Nil catalogFetcher with a cached plugin — should report it as failed, not panic.
+	plan, err := PlanUpdates(t.Context(), cache, nil, UpdateOptions{
+		All:    true,
+		Target: UpdateTargetLatest,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Updates)
+	require.Len(t, plan.Failed, 1)
+	assert.Equal(t, "exec", plan.Failed[0].Name)
+	assert.Contains(t, plan.Failed[0].Error, "no remote catalogs configured")
+}
+
 // mockCatalogForUpdater implements catalog.Catalog for updater tests.
 type mockCatalogForUpdater struct {
 	resolveFunc func(ctx context.Context, ref catalog.Reference) (catalog.ArtifactInfo, error)


### PR DESCRIPTION
- add BuildRemoteCatalogChain() that excludes the local catalog, preventing locally cached versions from shadowing remote updates
- switch plugins update to use remote-only chain for version checks
- handle nil catalog fetcher gracefully in PlanUpdates when no remote catalogs are configured
- add windows/arm64 to SupportedPluginPlatforms
- update help text, MCP tool descriptions, and docs to include windows/arm64

Closes #485
Closes #404