### PR TITLE
feat(lint): add missing-fallback-source rule for all-conditional resolvers

### DIFF
--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -485,7 +485,55 @@ Only keep explicit `dependsOn` for ordering without a data dependency:
               command: deploy.sh
 ```
 
-## 8. Using Lint with the MCP Server
+## 8. Missing Fallback Source
+
+The `missing-fallback-source` rule warns when all sources in a resolver's `resolve.with` have `when` conditions, leaving no unconditional fallback. If none of the conditions are met at runtime, the resolver fails with "no sources produced a value".
+
+```yaml
+# WARNING: all resolve sources have 'when' conditions with no unconditional fallback
+spec:
+  resolvers:
+    endpoint:
+      resolve:
+        with:
+          - provider: static
+            when:
+              expr: '_.environment == "prod"'
+            inputs:
+              value: https://api.prod.example.com
+          - provider: static
+            when:
+              expr: '_.environment == "staging"'
+            inputs:
+              value: https://api.staging.example.com
+```
+
+If `_.environment` is `"dev"`, neither condition matches and the resolver fails.
+
+**Fix**: Add an unconditional source as a fallback (typically at the end):
+
+```yaml
+    endpoint:
+      resolve:
+        with:
+          - provider: static
+            when:
+              expr: '_.environment == "prod"'
+            inputs:
+              value: https://api.prod.example.com
+          - provider: static
+            when:
+              expr: '_.environment == "staging"'
+            inputs:
+              value: https://api.staging.example.com
+          - provider: static
+            inputs:
+              value: https://api.dev.example.com
+```
+
+The unconditional source acts as a default when no other condition is satisfied.
+
+## 9. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -58,6 +58,23 @@ spec:
             inputs:
               value: "slow"
 
+    # missing-fallback-source (all sources conditional, no fallback)
+    conditional_only:
+      type: string
+      description: All sources are conditional with no fallback
+      resolve:
+        with:
+          - provider: static
+            when:
+              expr: '_.main_output == "prod"'
+            inputs:
+              value: "prod-value"
+          - provider: static
+            when:
+              expr: '_.main_output == "staging"'
+            inputs:
+              value: "staging-value"
+
     # non-validation-provider in validate block
     wrong_validate:
       type: string
@@ -131,6 +148,7 @@ spec:
         - empty_validate
         - loose_schema
         - no_desc
+        - conditional_only
       resolve:
         with:
           - provider: static

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -233,6 +233,23 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 						"resolve-foreach")
 				}
 			}
+
+			// Warn if all sources have 'when' conditions with no unconditional fallback.
+			if len(res.Resolve.With) > 0 {
+				allConditional := true
+				for _, step := range res.Resolve.With {
+					if step.When == nil || step.When.Expr == nil || strings.TrimSpace(string(*step.When.Expr)) == "true" {
+						allConditional = false
+						break
+					}
+				}
+				if allConditional {
+					result.addFinding(SeverityWarning, "structure", location+".resolve",
+						"all resolve sources have 'when' conditions with no unconditional fallback; resolver will fail if no condition is met",
+						"Add a source without a 'when' condition (e.g. a static provider) as a fallback",
+						"missing-fallback-source")
+				}
+			}
 		}
 
 		// Check for empty transform.with / validate.with arrays.

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -593,4 +594,155 @@ func TestLintResolvers_HyphenatedName(t *testing.T) {
 	assert.Contains(t, hyphenFindings[0].Message, "my-resolver")
 	assert.Contains(t, hyphenFindings[0].Message, "my_resolver")
 	assert.Equal(t, SeverityInfo, hyphenFindings[0].Severity)
+}
+
+// ---- missing-fallback-source ----
+
+func TestLintResolvers_MissingFallbackSource_AllConditional(t *testing.T) {
+	expr1 := celexp.Expression("_.authenticated == true")
+	expr2 := celexp.Expression("_.fallbackEnabled == true")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("http", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"myResolver": {
+			Description: "all sources conditional",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "http", When: &resolver.Condition{Expr: &expr1}},
+					{Provider: "http", When: &resolver.Condition{Expr: &expr2}},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := map[string]bool{"myResolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	var findings []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "missing-fallback-source" {
+			findings = append(findings, f)
+		}
+	}
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+	assert.Equal(t, "resolvers.myResolver.resolve", findings[0].Location)
+	assert.Contains(t, findings[0].Message, "no unconditional fallback")
+}
+
+func TestLintResolvers_MissingFallbackSource_HasUnconditionalSource(t *testing.T) {
+	expr1 := celexp.Expression("_.authenticated == true")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("http", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"myResolver": {
+			Description: "has unconditional fallback",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "http", When: &resolver.Condition{Expr: &expr1}},
+					{Provider: "static"},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := map[string]bool{"myResolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-fallback-source", f.RuleName,
+			"should not warn when an unconditional source exists")
+	}
+}
+
+func TestLintResolvers_MissingFallbackSource_WhenTrue(t *testing.T) {
+	exprCond := celexp.Expression("_.environment == 'prod'")
+	exprTrue := celexp.Expression("true")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("http", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"myResolver": {
+			Description: "has when: true fallback",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "http", When: &resolver.Condition{Expr: &exprCond}},
+					{Provider: "static", When: &resolver.Condition{Expr: &exprTrue}},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := map[string]bool{"myResolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-fallback-source", f.RuleName,
+			"should not warn when a source has when: true (always passes)")
+	}
+}
+
+func TestLintResolvers_MissingFallbackSource_WhenTrueWithWhitespace(t *testing.T) {
+	exprCond := celexp.Expression("_.environment == 'prod'")
+	exprTrue := celexp.Expression("  true  ")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("http", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"myResolver": {
+			Description: "has when: '  true  ' with whitespace",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "http", When: &resolver.Condition{Expr: &exprCond}},
+					{Provider: "static", When: &resolver.Condition{Expr: &exprTrue}},
+				},
+			},
+		},
+	}
+
+	referencedResolvers := map[string]bool{"myResolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-fallback-source", f.RuleName,
+			"should not warn when a source has when: '  true  ' (whitespace-padded true)")
+	}
+}
+
+func TestLintResolvers_MissingFallbackSource_NoResolvePhase(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"myResolver": {
+			Description: "no resolve phase",
+		},
+	}
+
+	referencedResolvers := map[string]bool{"myResolver": true}
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-fallback-source", f.RuleName,
+			"should not warn when there is no resolve phase")
+	}
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -305,6 +305,17 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "An empty validate.with array is almost certainly unintentional. The validate phase will be silently skipped, which may cause unexpected behavior.",
 		Fix:         "Either add validation rules to the with array or remove the validate section entirely.",
 	},
+	"missing-fallback-source": {
+		Rule:        "missing-fallback-source",
+		Severity:    string(SeverityWarning),
+		Category:    "structure",
+		Description: "All sources in a resolver's resolve.with list have 'when' conditions with no unconditional fallback.",
+		Why:         "If every source has a 'when' condition and none of the conditions are met at runtime, the resolver will fail with 'no sources produced a value'. Adding an unconditional fallback (e.g. a static provider) ensures the resolver always produces a value.",
+		Fix:         "Add a source without a 'when' condition as the last entry in resolve.with. A static provider with a sensible default is a common pattern.",
+		Examples: []string{
+			"# Problem: all sources are conditional\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: '_.authenticated == true'\n    - provider: http\n      when:\n        expr: '_.fallbackEnabled == true'\n\n# Fix: add unconditional fallback\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: '_.authenticated == true'\n    - provider: static\n      inputs:\n        value: default-value",
+		},
+	},
 	"null-resolver": {
 		Rule:        "null-resolver",
 		Severity:    string(SeverityError),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 41 rules — update this when new rules are added
-	assert.Equal(t, 41, len(KnownRules), "expected 41 known lint rules")
+	// We expect exactly 42 rules — update this when new rules are added
+	assert.Equal(t, 42, len(KnownRules), "expected 42 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -44,7 +44,7 @@ func (s *Server) registerLintTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("rule",
 			mcp.Required(),
-			mcp.Description("The lint rule name to explain (e.g., 'unused-resolver', 'invalid-expression', 'missing-provider')"),
+			mcp.Description("The lint rule name to explain (e.g., 'unused-resolver', 'invalid-expression', 'missing-provider', 'missing-fallback-source')"),
 		),
 	)
 	s.addTool(explainLintRuleTool, s.handleExplainLintRule)

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -560,6 +560,7 @@ func statusToProto(s *auth.Status) *proto.GetStatusResponse {
 	}
 	return &proto.GetStatusResponse{
 		Authenticated:   s.Authenticated,
+		Reason:          s.Reason,
 		Claims:          claimsToProto(s.Claims),
 		ExpiresAtUnix:   s.ExpiresAt.Unix(),
 		LastRefreshUnix: s.LastRefresh.Unix(),
@@ -578,6 +579,7 @@ func protoToStatus(resp *proto.GetStatusResponse) *auth.Status {
 	}
 	return &auth.Status{
 		Authenticated: resp.Authenticated,
+		Reason:        resp.Reason,
 		Claims:        protoToClaims(resp.Claims),
 		ExpiresAt:     time.Unix(resp.ExpiresAtUnix, 0),
 		LastRefresh:   time.Unix(resp.LastRefreshUnix, 0),

--- a/pkg/plugin/grpc_auth_coverage_test.go
+++ b/pkg/plugin/grpc_auth_coverage_test.go
@@ -85,6 +85,7 @@ func TestStatusRoundTrip(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	original := &auth.Status{
 		Authenticated: true,
+		Reason:        "token validated successfully",
 		Claims: &auth.Claims{
 			Email: "user@example.com",
 			Name:  "Test User",
@@ -107,6 +108,7 @@ func TestStatusRoundTrip(t *testing.T) {
 	require.NotNil(t, roundTripped)
 
 	assert.Equal(t, original.Authenticated, roundTripped.Authenticated)
+	assert.Equal(t, original.Reason, roundTripped.Reason)
 	assert.Equal(t, original.TenantID, roundTripped.TenantID)
 	assert.Equal(t, original.ClientID, roundTripped.ClientID)
 	assert.Equal(t, original.TokenFile, roundTripped.TokenFile)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -7098,6 +7098,47 @@ func TestIntegration_RunResolver_UnknownParamKeyNoSuggestion(t *testing.T) {
 	assert.Contains(t, stderr, "does not accept input")
 }
 
+// TestIntegration_Lint_MissingFallbackSource verifies missing-fallback-source lint rule detects all-conditional resolvers.
+func TestIntegration_Lint_MissingFallbackSource(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fallback-test
+  version: 1.0.0
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: dev
+    endpoint:
+      resolve:
+        with:
+          - provider: static
+            when:
+              expr: '_.environment == "prod"'
+            inputs:
+              value: https://api.prod.example.com
+          - provider: static
+            when:
+              expr: '_.environment == "staging"'
+            inputs:
+              value: https://api.staging.example.com
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", solutionFile, "-o", "json")
+
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
+	assert.Contains(t, stdout, "missing-fallback-source")
+}
+
 // TestIntegration_Lint_UnreachableTestPath verifies unreachable-test-path lint rule detects bad test file references.
 func TestIntegration_Lint_UnreachableTestPath(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
- new lint rule warns when all resolve.with sources have 'when' conditions with no unconditional fallback
- add rule metadata, examples, and documentation in linting tutorial
- add unit tests covering conditional-only, unconditional fallback, when:true, and no-resolve-phase cases
- add integration test and lint-stress-test example resolver
- update MCP explain-lint-rule tool description to mention new rule
- propagate Reason field in gRPC auth status proto round-trip

Closes #488