### PR TITLE
fix(cli): show full schema for cached plugin providers in get provider

### DIFF
--- a/pkg/cmd/scafctl/get/provider/provider.go
+++ b/pkg/cmd/scafctl/get/provider/provider.go
@@ -208,10 +208,27 @@ func (o *Options) RunGetProvider(ctx context.Context, name string) error {
 			if op, found := officialReg.Get(name); found {
 				lgr.V(1).Info("found provider in official registry", "name", name, "catalogRef", op.CatalogRef)
 
-				// Structured output for -o flag (including quiet) or interactive mode.
-				// Quiet mode is handled by kvx (produces no output), consistent with built-in providers.
+				// Attempt to load full schema from cached binary.
+				cache := plugin.NewCache(settings.PluginCacheDirFor(o.BinaryName))
+				if binPath, version, cached := cache.GetLatestBinary(op.CatalogRef); cached {
+					lgr.V(1).Info("probing cached official plugin for full schema", "name", name, "catalogRef", op.CatalogRef, "path", binPath)
+					desc, probeErr := plugin.ProbePluginDescriptor(ctx, binPath, name)
+					if probeErr == nil {
+						if (o.Output == "auto" || o.Output == "") && !o.Interactive {
+							return o.printProviderDetail(ctx, desc)
+						}
+						output := provdetail.BuildProviderDetail(*desc)
+						output["source"] = "official"
+						output["version"] = version
+						return o.writeOutput(ctx, output)
+					}
+					lgr.V(1).Info("failed to probe official plugin descriptor, falling back to minimal metadata", "name", name, "error", probeErr)
+				}
+
+				// Fallback: minimal metadata with hint.
 				if (o.Output != "" && o.Output != "auto") || o.Interactive {
 					detail := official.Detail(op)
+					detail["hint"] = fmt.Sprintf("Run '%s plugins install %s' to fetch the plugin and view full schema", o.BinaryName, op.CatalogRef)
 					return o.writeOutput(ctx, detail)
 				}
 
@@ -219,7 +236,8 @@ func (o *Options) RunGetProvider(ctx context.Context, name string) error {
 				w := writer.FromContext(ctx)
 				if w != nil {
 					w.Plainlnf("Provider %q is an official plugin provider (catalog: %s, version: %s).\n"+
-						"It is auto-fetched on first use in a solution. Use 'plugins install' to pre-fetch.", name, op.CatalogRef, op.DefaultVersion)
+						"It is auto-fetched on first use in a solution. Use '%s plugins install %s' to pre-fetch and view full schema.",
+						name, op.CatalogRef, op.DefaultVersion, o.BinaryName, op.CatalogRef)
 				}
 				return nil
 			}
@@ -231,11 +249,26 @@ func (o *Options) RunGetProvider(ctx context.Context, name string) error {
 		// Fallback: check the local plugin cache.
 		cache := plugin.NewCache(settings.PluginCacheDirFor(o.BinaryName))
 		if binPath, version, found := cache.GetLatestBinary(name); found {
-			// Validate the cached binary actually exposes providers before reporting it.
+			// Probe the cached binary for its full descriptor.
+			lgr.V(1).Info("probing cached plugin for full schema", "name", name, "path", binPath)
+			if desc, probeErr := plugin.ProbePluginDescriptor(ctx, binPath, name); probeErr == nil {
+				lgr.V(1).Info("found provider in plugin cache with full descriptor", "name", name, "version", version)
+				if (o.Output == "auto" || o.Output == "") && !o.Interactive {
+					return o.printProviderDetail(ctx, desc)
+				}
+				output := provdetail.BuildProviderDetail(*desc)
+				output["source"] = "local"
+				output["version"] = version
+				output["path"] = binPath
+				return o.writeOutput(ctx, output)
+			}
+			lgr.V(1).Info("cached binary failed full probe", "name", name, "path", binPath)
+
+			// Validate the cached binary at least exposes providers before reporting it.
 			if _, ok := plugin.ProbePluginDescription(ctx, binPath, name); !ok {
 				lgr.V(1).Info("cached binary is not a valid provider plugin", "name", name, "path", binPath)
 			} else {
-				lgr.V(1).Info("found provider in plugin cache", "name", name, "version", version, "path", binPath)
+				lgr.V(1).Info("found provider in plugin cache (minimal info)", "name", name, "version", version, "path", binPath)
 				w := writer.FromContext(ctx)
 				cachedDetail := map[string]any{
 					"name":    name,

--- a/pkg/cmd/scafctl/get/provider/provider_probe_test.go
+++ b/pkg/cmd/scafctl/get/provider/provider_probe_test.go
@@ -1,0 +1,260 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/adrg/xdg"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	echoPluginOnce sync.Once
+	echoPluginPath string
+)
+
+// buildEchoPlugin compiles the echo example plugin and returns its path.
+// The binary is built once and reused across tests.
+func buildEchoPlugin(t *testing.T) string {
+	t.Helper()
+	echoPluginOnce.Do(func() {
+		// Project root is 5 levels up from pkg/cmd/scafctl/get/provider/
+		projectRoot, err := filepath.Abs(filepath.Join("..", "..", "..", "..", ".."))
+		if err != nil {
+			t.Fatalf("failed to resolve project root: %v", err)
+		}
+		tmpDir, err := os.MkdirTemp("", "scafctl-echo-plugin-*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		binName := "scafctl-plugin-echo"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		binPath := filepath.Join(tmpDir, binName)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./examples/plugins/echo/main.go")
+		cmd.Dir = projectRoot
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to build echo plugin: %v\n%s", err, output)
+		}
+		echoPluginPath = binPath
+	})
+	require.NotEmpty(t, echoPluginPath, "echo plugin build failed")
+	return echoPluginPath
+}
+
+func TestOptions_RunGetProvider_OfficialProviderProbeSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+
+	echoPath := buildEchoPlugin(t)
+
+	t.Run("returns_full_schema_for_official_provider_structured", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		// Place the echo plugin in the expected cache location.
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "echo-plugin", "1.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		cachedBin := filepath.Join(binDir, pluginBinaryName("echo-plugin"))
+		// Copy the built echo plugin binary to the cache location.
+		data, err := os.ReadFile(echoPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(cachedBin, data, 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "echo", CatalogRef: "echo-plugin", DefaultVersion: "1.0.0", Description: "Echo provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err = options.RunGetProvider(ctx, "echo")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		// Should return full schema from probed plugin, not a hint.
+		assert.NotContains(t, output, "hint", "should not fallback to hint when probe succeeds")
+		assert.Contains(t, output, "echo")
+		assert.Contains(t, output, "official")
+
+		// Verify it's valid JSON with schema fields.
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		assert.Equal(t, "official", result["source"])
+		assert.Equal(t, "1.0.0", result["version"])
+	})
+
+	t.Run("returns_full_schema_for_official_provider_default_output", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "echo-plugin", "1.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		cachedBin := filepath.Join(binDir, pluginBinaryName("echo-plugin"))
+		data, err := os.ReadFile(echoPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(cachedBin, data, 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: ""},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "echo", CatalogRef: "echo-plugin", DefaultVersion: "1.0.0", Description: "Echo provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err = options.RunGetProvider(ctx, "echo")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		// Default output shows the detailed provider view.
+		assert.Contains(t, output, "echo")
+		assert.NotContains(t, output, "plugins install", "should not show install hint when probe succeeds")
+	})
+}
+
+func TestOptions_RunGetProvider_CacheProbeSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+
+	echoPath := buildEchoPlugin(t)
+
+	t.Run("returns_full_schema_for_cached_plugin_structured", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		// Place the echo plugin under its own name in the cache.
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "echo", "2.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		cachedBin := filepath.Join(binDir, pluginBinaryName("echo"))
+		data, err := os.ReadFile(echoPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(cachedBin, data, 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		// No official registry — goes to cache fallback.
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		err = options.RunGetProvider(ctx, "echo")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		assert.Equal(t, "local", result["source"])
+		assert.Equal(t, "2.0.0", result["version"])
+		assert.Contains(t, output, "echo")
+	})
+
+	t.Run("returns_full_detail_for_cached_plugin_default_output", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "echo", "2.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		cachedBin := filepath.Join(binDir, pluginBinaryName("echo"))
+		data, err := os.ReadFile(echoPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(cachedBin, data, 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: ""},
+		}
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		err = options.RunGetProvider(ctx, "echo")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		// Default output prints the detailed provider view.
+		assert.Contains(t, output, "echo")
+		assert.Contains(t, output, "Echo Provider")
+	})
+}

--- a/pkg/cmd/scafctl/get/provider/provider_test.go
+++ b/pkg/cmd/scafctl/get/provider/provider_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -24,6 +26,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// pluginBinaryName returns the platform-appropriate binary filename.
+// On Windows, plugin binaries have an .exe suffix to match Cache.binaryPath.
+func pluginBinaryName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
 
 // mockProvider implements provider.Provider for testing
 type mockProvider struct {
@@ -379,6 +390,240 @@ func TestOptions_RunGetProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOptions_RunGetProvider_OfficialProviderWithoutCache(t *testing.T) {
+	t.Run("returns_hint_in_structured_output_when_plugin_not_cached", func(t *testing.T) {
+		// Isolate from real plugin cache.
+		t.Setenv("XDG_CACHE_HOME", t.TempDir())
+		xdg.Reload()
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "github", CatalogRef: "gh-plugin", DefaultVersion: "latest", Description: "GitHub provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "github")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "github")
+		assert.Contains(t, output, "hint")
+		assert.Contains(t, output, "plugins install")
+		assert.Contains(t, output, "gh-plugin", "hint should reference CatalogRef, not provider name")
+	})
+
+	t.Run("returns_human_text_in_default_output_when_plugin_not_cached", func(t *testing.T) {
+		// Isolate from real plugin cache.
+		t.Setenv("XDG_CACHE_HOME", t.TempDir())
+		xdg.Reload()
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{
+			Out:    &outBuf,
+			ErrOut: &outBuf,
+		}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: ""},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "github", CatalogRef: "gh-plugin", DefaultVersion: "latest", Description: "GitHub provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "github")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "github")
+		assert.Contains(t, output, "official plugin provider")
+		assert.Contains(t, output, "plugins install")
+		assert.Contains(t, output, "gh-plugin", "install hint should reference CatalogRef, not provider name")
+	})
+}
+
+func TestOptions_RunGetProvider_OfficialProviderWithCachedBinary(t *testing.T) {
+	t.Run("falls_back_to_hint_when_probe_fails_structured", func(t *testing.T) {
+		// Create a fake cached binary that exists but isn't a valid plugin.
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		// Set up fake binary at the expected cache path.
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "gh-plugin", "1.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		binPath := filepath.Join(binDir, pluginBinaryName("gh-plugin"))
+		require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "github", CatalogRef: "gh-plugin", DefaultVersion: "latest", Description: "GitHub provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "github")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		// Should fall back to hint since probe fails on a fake binary.
+		assert.Contains(t, output, "hint")
+		assert.Contains(t, output, "gh-plugin")
+	})
+
+	t.Run("falls_back_to_human_text_when_probe_fails_default", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "gh-plugin", "1.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		binPath := filepath.Join(binDir, pluginBinaryName("gh-plugin"))
+		require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: ""},
+		}
+
+		officialReg := official.NewRegistryFrom([]official.Provider{
+			{Name: "github", CatalogRef: "gh-plugin", DefaultVersion: "latest", Description: "GitHub provider"},
+		})
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+		ctx = official.WithRegistry(ctx, officialReg)
+
+		err := options.RunGetProvider(ctx, "github")
+		require.NoError(t, err)
+
+		output := outBuf.String()
+		assert.Contains(t, output, "official plugin provider")
+		assert.Contains(t, output, "gh-plugin")
+	})
+}
+
+func TestOptions_RunGetProvider_PluginCacheWithProbeFallback(t *testing.T) {
+	t.Run("falls_back_to_minimal_info_when_probe_fails_structured", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		// Create a fake cached plugin binary (not a valid plugin process).
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "my-plugin", "2.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		binPath := filepath.Join(binDir, pluginBinaryName("my-plugin"))
+		require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+
+		// No official registry — so it goes to the plugin cache fallback.
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		err := options.RunGetProvider(ctx, "my-plugin")
+		// The probe fails and the ProbePluginDescription also fails — provider not found.
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "my-plugin")
+	})
+
+	t.Run("falls_back_to_human_text_when_probe_fails_default", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+
+		platform := runtime.GOOS + "-" + runtime.GOARCH
+		binDir := filepath.Join(cacheDir, "scafctl", "plugins", "my-plugin", "2.0.0", platform)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		binPath := filepath.Join(binDir, pluginBinaryName("my-plugin"))
+		require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+		var outBuf bytes.Buffer
+		ioStreams := &terminal.IOStreams{Out: &outBuf, ErrOut: &outBuf}
+		cliParams := &settings.Run{BinaryName: "scafctl"}
+		reg := provider.NewRegistry(provider.WithAllowOverwrite(true))
+
+		options := &Options{
+			IOStreams:      ioStreams,
+			CliParams:      cliParams,
+			BinaryName:     "scafctl",
+			registry:       reg,
+			KvxOutputFlags: flags.KvxOutputFlags{Output: ""},
+		}
+
+		w := writer.New(ioStreams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		err := options.RunGetProvider(ctx, "my-plugin")
+		// Same as above — probe fails, description probe also fails.
+		assert.Error(t, err)
+	})
 }
 
 func TestOptions_filterProviders(t *testing.T) {
@@ -927,6 +1172,10 @@ func TestOptions_RunListProviders_IncludesOfficialProviders(t *testing.T) {
 
 func TestOptions_RunGetProvider_FallsBackToOfficialRegistry(t *testing.T) {
 	t.Run("shows_info_for_official_provider_not_in_builtin_registry", func(t *testing.T) {
+		// Isolate from real plugin cache so the probe doesn't find a cached binary.
+		t.Setenv("XDG_CACHE_HOME", t.TempDir())
+		xdg.Reload()
+
 		var outBuf bytes.Buffer
 		ioStreams := &terminal.IOStreams{
 			Out:    &outBuf,

--- a/pkg/plugin/describe.go
+++ b/pkg/plugin/describe.go
@@ -5,9 +5,11 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 // CachedPluginInfo describes a cached plugin with metadata obtained by
@@ -90,4 +92,71 @@ func ProbePluginDescription(ctx context.Context, binaryPath, name string) (strin
 	}
 
 	return wrapper.Descriptor().Description, true
+}
+
+// ProbePluginDescriptor starts a plugin binary, queries the named provider's
+// full descriptor, then kills the process. Returns nil and an error on failure.
+// This is a short-lived probe — it does not register the provider in any registry.
+func ProbePluginDescriptor(ctx context.Context, binaryPath, providerName string) (*provider.Descriptor, error) {
+	lgr := logr.FromContextOrDiscard(ctx)
+
+	const maxProbeTimeout = 10 * time.Second
+
+	// Guard against malfunctioning plugins that hang indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, maxProbeTimeout)
+	defer cancel()
+
+	// Short-circuit if the caller already cancelled — avoid spawning a process.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Derive startup timeout from the context deadline so it cannot outlive the caller.
+	startTimeout := maxProbeTimeout
+	if dl, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(dl); remaining < startTimeout {
+			startTimeout = remaining
+		}
+	}
+
+	client, err := NewClient(binaryPath, WithStartTimeout(startTimeout), WithSanitizedEnv())
+	if err != nil {
+		return nil, fmt.Errorf("starting plugin binary %s: %w", binaryPath, err)
+	}
+	defer client.Kill()
+
+	providers, err := client.GetProviders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying plugin providers from %s: %w", binaryPath, err)
+	}
+
+	// Find the requested provider name among available providers.
+	targetName := providerName
+	found := false
+	for _, p := range providers {
+		if p == providerName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		if len(providers) == 0 {
+			return nil, fmt.Errorf("plugin exposes no providers")
+		}
+		lgr.V(1).Info("requested provider not found in plugin",
+			"requested", providerName, "available", providers)
+		return nil, fmt.Errorf("provider %q not found in plugin (available: %v)", providerName, providers)
+	}
+
+	wrapper, err := NewProviderWrapper(client, targetName, WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("getting provider descriptor: %w", err)
+	}
+
+	desc := wrapper.Descriptor()
+	if desc == nil {
+		return nil, fmt.Errorf("plugin returned nil descriptor for %q", targetName)
+	}
+
+	return desc, nil
 }

--- a/pkg/plugin/describe_test.go
+++ b/pkg/plugin/describe_test.go
@@ -5,9 +5,16 @@ package plugin
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDescribeCachedPlugins_SkipsNamesInSkipSet(t *testing.T) {
@@ -42,7 +49,135 @@ func TestDescribeCachedPlugins_EmptyInput(t *testing.T) {
 
 func TestProbePluginDescription_InvalidBinary(t *testing.T) {
 	t.Parallel()
-	desc, ok := ProbePluginDescription(context.Background(), "/nonexistent/binary", "test")
+	missingPath := filepath.Join(t.TempDir(), "nonexistent", "binary")
+	desc, ok := ProbePluginDescription(context.Background(), missingPath, "test")
 	assert.Empty(t, desc)
 	assert.False(t, ok)
+}
+
+func TestProbePluginDescriptor_InvalidBinary(t *testing.T) {
+	t.Parallel()
+	missingPath := filepath.Join(t.TempDir(), "nonexistent", "binary")
+	desc, err := ProbePluginDescriptor(context.Background(), missingPath, "test")
+	assert.Nil(t, desc)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "starting plugin binary")
+	assert.Contains(t, err.Error(), missingPath, "error should include the binary path for diagnostics")
+}
+
+func TestProbePluginDescriptor_NonExecutableFile(t *testing.T) {
+	t.Parallel()
+	// Create a file without execute permission.
+	tmp := filepath.Join(t.TempDir(), "not-executable")
+	require.NoError(t, os.WriteFile(tmp, []byte("not a binary"), 0o600))
+	desc, err := ProbePluginDescriptor(context.Background(), tmp, "test")
+	assert.Nil(t, desc)
+	assert.Error(t, err)
+}
+
+func TestProbePluginDescriptor_CancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+	missingPath := filepath.Join(t.TempDir(), "nonexistent", "binary")
+	desc, err := ProbePluginDescriptor(ctx, missingPath, "test")
+	assert.Nil(t, desc)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled, "should short-circuit on cancelled context before starting binary")
+}
+
+var (
+	echoPluginOnce sync.Once
+	echoPluginPath string
+)
+
+// buildEchoPlugin compiles the echo example plugin once for reuse.
+func buildEchoPlugin(t *testing.T) string {
+	t.Helper()
+	echoPluginOnce.Do(func() {
+		// pkg/plugin/ is 2 levels from root.
+		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+		if err != nil {
+			t.Fatalf("failed to resolve project root: %v", err)
+		}
+		tmpDir, err := os.MkdirTemp("", "scafctl-echo-plugin-*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		binName := "scafctl-plugin-echo"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		binPath := filepath.Join(tmpDir, binName)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./examples/plugins/echo/main.go")
+		cmd.Dir = projectRoot
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to build echo plugin: %v\n%s", err, output)
+		}
+		echoPluginPath = binPath
+	})
+	require.NotEmpty(t, echoPluginPath, "echo plugin build failed")
+	return echoPluginPath
+}
+
+func TestProbePluginDescriptor_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+	echoPath := buildEchoPlugin(t)
+
+	desc, err := ProbePluginDescriptor(context.Background(), echoPath, "echo")
+	require.NoError(t, err)
+	require.NotNil(t, desc)
+	assert.Equal(t, "echo", desc.Name)
+	assert.Equal(t, "Echo Provider", desc.DisplayName)
+	assert.NotEmpty(t, desc.Description)
+	assert.NotNil(t, desc.Schema)
+}
+
+func TestProbePluginDescriptor_ProviderNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+	echoPath := buildEchoPlugin(t)
+
+	desc, err := ProbePluginDescriptor(context.Background(), echoPath, "nonexistent")
+	assert.Nil(t, desc)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in plugin")
+}
+
+func TestProbePluginDescription_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+	echoPath := buildEchoPlugin(t)
+
+	desc, ok := ProbePluginDescription(context.Background(), echoPath, "echo")
+	assert.True(t, ok)
+	assert.NotEmpty(t, desc)
+}
+
+func TestDescribeCachedPlugins_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plugin probe test in short mode (requires go build)")
+	}
+	echoPath := buildEchoPlugin(t)
+
+	cached := []CachedPlugin{
+		{Name: "echo", Version: "1.0.0", Path: echoPath},
+	}
+
+	result := DescribeCachedPlugins(context.Background(), cached, nil)
+	require.Len(t, result, 1)
+	assert.Equal(t, "echo", result[0].Name)
+	assert.Equal(t, "1.0.0", result[0].Version)
+	assert.NotEmpty(t, result[0].Description)
 }


### PR DESCRIPTION
- add ProbePluginDescriptor() to start a plugin binary and query its full provider descriptor via short-lived probe
- probe cached official plugins before falling back to minimal metadata
- probe local plugin cache for full descriptor before basic validation
- include "hint" field in structured output when plugin is not cached, directing users to run `plugins install`
- use binary name from settings in hint messages for embedder safety

Closes #492