### PR TITLE
feat(lint): add transform-shape-mismatch rule

### DIFF
--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -533,7 +533,75 @@ If `_.environment` is `"dev"`, neither condition matches and the resolver fails.
 
 The unconditional source acts as a default when no other condition is satisfied.
 
-## 9. Using Lint with the MCP Server
+## 9. Transform Shape Mismatch
+
+The `transform-shape-mismatch` rule warns when a transform step accesses provider-specific fields (like `__self.body`) but the resolve chain includes a fallback that produces a different shape. When the fallback path is taken at runtime, the transform will fail because the expected fields don't exist.
+
+```yaml
+# WARNING: transform accesses '__self.body' but static fallback produces []
+spec:
+  resolvers:
+    api_data:
+      description: Fetch data from API with empty fallback
+      resolve:
+        with:
+          - provider: http
+            when:
+              expr: 'has(_.credentials)'
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body.items'
+```
+
+When `_.credentials` is not set, the static fallback returns `[]` (an array). The transform then tries to access `__self.body` on an array, which fails.
+
+**Fix**: Add a `when` guard to the transform step so it only runs when the structured shape is present:
+
+```yaml
+      transform:
+        with:
+          - provider: cel
+            when:
+              expr: 'type(__self) != list_type'
+            inputs:
+              expression: '__self.body.items'
+```
+
+Or use `has()` to check for the field:
+
+```yaml
+      transform:
+        with:
+          - provider: cel
+            when:
+              expr: 'type(__self) == map_type && has(__self.body)'
+            inputs:
+              expression: '__self.body.items'
+```
+
+For more details:
+
+{{< tabs "linting-tutorial-cmd-12" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint explain transform-shape-mismatch
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain transform-shape-mismatch
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## 10. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -135,6 +135,25 @@ spec:
             inputs:
               expression: "_.bad_provider + _.guarded"
 
+    # transform-shape-mismatch (transform accesses __self.body but static fallback returns [])
+    shape_mismatch:
+      description: Resolver with mismatched transform shape
+      resolve:
+        with:
+          - provider: http
+            when:
+              expr: 'has(_.main_output)'
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body.items'
+
     # used resolver so not everything is unused
     main_output:
       type: string
@@ -149,6 +168,7 @@ spec:
         - loose_schema
         - no_desc
         - conditional_only
+        - shape_mismatch
       resolve:
         with:
           - provider: static

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -307,6 +307,10 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 
 		// Check for redundant dependsOn entries that are already inferred.
 		lintRedundantDependsOn(res, location, result, registry)
+
+		// Check for transform steps accessing provider-specific fields when
+		// the resolve chain includes a fallback with a different output shape.
+		lintTransformShapeMismatch(name, res, location, result, registry)
 	}
 }
 
@@ -407,6 +411,134 @@ func lintRedundantDependsOn(res *resolver.Resolver, location string, result *Res
 			fmt.Sprintf("dependsOn contains redundant entries already inferred from value references: %s", strings.Join(redundant, ", ")),
 			"Remove the redundant entries; only keep dependsOn for ordering dependencies not referenced by value",
 			"redundant-depends-on")
+	}
+}
+
+// lintTransformShapeMismatch detects resolvers where the transform phase accesses
+// provider-specific fields (like __self.body) but the resolve chain includes a
+// fallback with a different output shape (e.g., static returning a scalar/array).
+func lintTransformShapeMismatch(_ string, res *resolver.Resolver, location string, result *Result, registry *provider.Registry) {
+	if res.Resolve == nil || res.Transform == nil {
+		return
+	}
+	if len(res.Resolve.With) < 2 || len(res.Transform.With) == 0 {
+		return
+	}
+
+	// Determine which resolve steps produce structured output (map with known fields)
+	// versus scalar/array output.
+	type sourceShape struct {
+		isStructured bool
+		fields       map[string]bool // known output fields (e.g., "body", "statusCode", "headers")
+	}
+
+	shapes := make([]sourceShape, len(res.Resolve.With))
+	hasStructured := false
+	hasNonStructured := false
+
+	for i, step := range res.Resolve.With {
+		if step.Provider == "static" || step.Provider == "" {
+			// Check if the static value is a map — if so, treat it as structured.
+			if valRef, ok := step.Inputs["value"]; ok && valRef != nil {
+				if m, isMap := valRef.Literal.(map[string]any); isMap && len(m) > 0 {
+					fields := make(map[string]bool, len(m))
+					for k := range m {
+						fields[k] = true
+					}
+					shapes[i] = sourceShape{isStructured: true, fields: fields}
+					hasStructured = true
+					continue
+				}
+			}
+			shapes[i] = sourceShape{isStructured: false}
+			hasNonStructured = true
+			continue
+		}
+
+		// Check the provider's output schema for CapabilityFrom (resolve phase).
+		if registry != nil {
+			if p, exists := registry.Get(step.Provider); exists {
+				desc := p.Descriptor()
+				if schema, ok := desc.OutputSchemas[provider.CapabilityFrom]; ok && schema != nil && len(schema.Properties) > 0 {
+					fields := make(map[string]bool, len(schema.Properties))
+					for fieldName := range schema.Properties {
+						fields[fieldName] = true
+					}
+					shapes[i] = sourceShape{isStructured: true, fields: fields}
+					hasStructured = true
+					continue
+				}
+			}
+		}
+
+		// If we can't determine the shape, assume it might be structured
+		// but don't flag — we only flag when we're confident about a mismatch.
+		shapes[i] = sourceShape{isStructured: true}
+		hasStructured = true
+	}
+
+	// Only proceed if the resolve chain has both structured and non-structured sources.
+	if !hasStructured || !hasNonStructured {
+		return
+	}
+
+	// Collect all known fields from structured providers.
+	structuredFields := make(map[string]bool)
+	for _, s := range shapes {
+		if s.isStructured {
+			for f := range s.fields {
+				structuredFields[f] = true
+			}
+		}
+	}
+
+	// If we couldn't determine specific fields, fall back to well-known HTTP fields.
+	if len(structuredFields) == 0 {
+		structuredFields = map[string]bool{
+			"body":       true,
+			"statusCode": true,
+			"headers":    true,
+		}
+	}
+
+	// Scan transform steps for __self.<field> access without a when guard.
+	for i, step := range res.Transform.With {
+		stepLocation := fmt.Sprintf("%s.transform.with[%d]", location, i)
+
+		// Skip if the transform step has a when guard.
+		if step.When != nil && step.When.Expr != nil && strings.TrimSpace(string(*step.When.Expr)) != "" && strings.TrimSpace(string(*step.When.Expr)) != "true" {
+			continue
+		}
+
+		// Scan all inputs for __self.<field> references.
+		for _, val := range step.Inputs {
+			if val == nil {
+				continue
+			}
+
+			var exprText string
+			if val.Expr != nil {
+				exprText = string(*val.Expr)
+			} else if val.Tmpl != nil {
+				exprText = string(*val.Tmpl)
+			} else if s, ok := val.Literal.(string); ok {
+				exprText = s
+			}
+			if exprText == "" {
+				continue
+			}
+
+			for field := range structuredFields {
+				pattern := "__self." + field
+				if strings.Contains(exprText, pattern) {
+					result.addFinding(SeverityWarning, "provider", stepLocation,
+						fmt.Sprintf("transform accesses '__self.%s' but the resolve chain includes a fallback that produces a different shape — add a 'when' condition to guard the transform", field),
+						fmt.Sprintf("Add a when guard, e.g.: when: { expr: \"type(__self) == map_type && has(__self.%s)\" }", field),
+						"transform-shape-mismatch")
+					return // One finding per resolver is sufficient.
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1722,3 +1722,245 @@ func TestLintImmutableResolvers_NotImmutable(t *testing.T) {
 	findings := filterFindingsByRule(result, "immutable-requires-state")
 	assert.Empty(t, findings)
 }
+
+func newHTTPFakeProvider() *fakeProvider {
+	return &fakeProvider{
+		desc: &provider.Descriptor{
+			Name:       "http",
+			APIVersion: "v1",
+			Version:    semver.MustParse("1.0.0"),
+			Schema: &jsonschema.Schema{
+				Type:       "object",
+				Properties: map[string]*jsonschema.Schema{},
+			},
+			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+				provider.CapabilityFrom: {
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"statusCode": {Type: "integer"},
+						"body":       {Type: "string"},
+						"headers":    {Type: "object"},
+					},
+				},
+			},
+			Description:  "HTTP provider",
+			Capabilities: []provider.Capability{provider.CapabilityFrom},
+		},
+	}
+}
+
+func TestLintTransformShapeMismatch(t *testing.T) {
+	bodyExpr := celexp.Expression("__self.body.items")
+	guardExpr := celexp.Expression("type(__self) == map_type && has(__self.body)")
+	credExpr := celexp.Expression("has(_.credentials)")
+	statusExpr := celexp.Expression("__self.statusCode == 200")
+	tmplContent := gotmpl.GoTemplatingContent("{{ .__self.body }}")
+	safeExpr := celexp.Expression("size(__self) > 0")
+
+	tests := []struct {
+		name        string
+		resolver    *resolver.Resolver
+		expectRule  bool
+		description string
+	}{
+		{
+			name: "flagged: http + static, transform accesses __self.body without guard",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: []any{}}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}}},
+					},
+				},
+			},
+			expectRule: true,
+		},
+		{
+			name: "flagged: http + static, transform accesses __self.statusCode",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http"},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: ""}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &statusExpr}}},
+					},
+				},
+			},
+			expectRule: true,
+		},
+		{
+			name: "flagged: http + static, go template accesses __self.body",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http"},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: ""}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "go-template", Inputs: map[string]*spec.ValueRef{"template": {Tmpl: &tmplContent}}},
+					},
+				},
+			},
+			expectRule: true,
+		},
+		{
+			name: "flagged: http + static, transform accesses __self.body via literal string",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: []any{}}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Literal: "__self.body"}}},
+					},
+				},
+			},
+			expectRule: true,
+		},
+		{
+			name: "not flagged: static fallback is a map with same shape",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: map[string]any{"body": "", "statusCode": 0}}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "not flagged: transform has a when guard",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: []any{}}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{
+							Provider: "cel",
+							When:     &resolver.Condition{Expr: &guardExpr},
+							Inputs:   map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}},
+						},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "not flagged: single resolve source",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http"},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "not flagged: both sources are same provider type",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "http"},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "not flagged: transform does not access structured fields",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http"},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: ""}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &safeExpr}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "not flagged: no transform phase",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http"},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: ""}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sol := &solution.Solution{
+				APIVersion: "scafctl.io/v1",
+				Kind:       "Solution",
+				Metadata:   solution.Metadata{Name: "test"},
+				Spec: solution.Spec{
+					Resolvers: map[string]*resolver.Resolver{
+						"api_data": tt.resolver,
+					},
+				},
+			}
+
+			reg := provider.NewRegistry()
+			require.NoError(t, reg.Register(newHTTPFakeProvider()))
+			require.NoError(t, reg.Register(newFakeProvider("static", map[string]*jsonschema.Schema{"value": {Type: "string"}})))
+			require.NoError(t, reg.Register(newFakeProvider("cel", map[string]*jsonschema.Schema{"expression": {Type: "string"}})))
+			require.NoError(t, reg.Register(newFakeProvider("go-template", map[string]*jsonschema.Schema{"template": {Type: "string"}})))
+
+			result := Solution(sol, "test.yaml", reg)
+			findings := filterFindingsByRule(result, "transform-shape-mismatch")
+
+			if tt.expectRule {
+				assert.NotEmpty(t, findings, "expected transform-shape-mismatch finding")
+				assert.Equal(t, SeverityWarning, findings[0].Severity)
+			} else {
+				assert.Empty(t, findings, "expected no transform-shape-mismatch finding")
+			}
+		})
+	}
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -414,6 +414,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Redundant (inferred from expr):\nimageRef:\n  dependsOn: [registry, namespace]\n  resolve:\n    with:\n      - provider: cel\n        inputs:\n          expression:\n            expr: _.registry + \"/\" + _.namespace\n\n# Correct (no explicit dependsOn needed):\nimageRef:\n  resolve:\n    with:\n      - provider: cel\n        inputs:\n          expression:\n            expr: _.registry + \"/\" + _.namespace",
 		},
 	},
+	"transform-shape-mismatch": {
+		Rule:        "transform-shape-mismatch",
+		Severity:    string(SeverityWarning),
+		Category:    "provider",
+		Description: "A transform step accesses provider-specific fields (e.g., __self.body) but the resolve chain includes a fallback that produces a different shape.",
+		Why:         "When a resolve chain has both a provider returning a structured object (e.g., http returns {statusCode, body, headers}) and a static fallback returning a scalar or array, transform steps accessing provider-specific fields will fail at runtime when the fallback path is taken.",
+		Fix:         "Add a 'when' condition to the transform step to guard against the shape mismatch, e.g.:\n  when:\n    expr: 'type(__self) == map_type && has(__self.body)'",
+		Examples: []string{
+			"# Problem: transform assumes http shape but static fallback is []\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: 'has(_.credentials)'\n      inputs:\n        url: https://api.example.com/data\n    - provider: static\n      inputs:\n        value: []\ntransform:\n  with:\n    - provider: cel\n      inputs:\n        expression: '__self.body.items'\n\n# Fix: add a when guard on the transform step\ntransform:\n  with:\n    - provider: cel\n      when:\n        expr: 'type(__self) != list_type'\n      inputs:\n        expression: '__self.body.items'",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 42 rules — update this when new rules are added
-	assert.Equal(t, 42, len(KnownRules), "expected 42 known lint rules")
+	// We expect exactly 43 rules — update this when new rules are added
+	assert.Equal(t, 43, len(KnownRules), "expected 43 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -7177,6 +7177,47 @@ spec:
 	assert.Contains(t, stdout, "unreachable-test-path")
 }
 
+// TestIntegration_Lint_TransformShapeMismatch verifies transform-shape-mismatch lint rule
+// detects when transform accesses provider-specific fields but resolve chain has a fallback
+// with a different output shape.
+func TestIntegration_Lint_TransformShapeMismatch(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: shape-mismatch-test
+  version: 1.0.0
+spec:
+  resolvers:
+    api_data:
+      description: Fetch data with static fallback
+      resolve:
+        with:
+          - provider: http
+            when:
+              expr: 'true'
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body'
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", solutionFile, "-o", "json")
+
+	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
+	assert.Contains(t, stdout, "transform-shape-mismatch")
+}
+
 // TestIntegration_MCPServeInfo_ExplainConcepts verifies explain_concepts tool is registered.
 func TestIntegration_MCPServeInfo_ExplainConcepts(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
- detect resolvers where transform accesses provider-specific fields (e.g., __self.body) but the resolve chain includes a fallback with a different output shape (e.g., static returning scalar/array)
- use provider registry output schemas to determine structured fields
- skip flagging when transform steps have a when guard
- add rule metadata to KnownRules with explanation and examples
- add unit tests covering flagged and non-flagged scenarios
- add integration test for CLI lint output
- add example to lint-stress-test solution
- document the rule in the linting tutorial

Closes #496