### PR TITLE
fix(settings)!: exclude action files from default discovery mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,7 +69,7 @@ When no `-f` flag is provided, all CLI commands use the unified `Resolve()` func
 
 1. Returns the explicit `-f` path if provided.
 2. Returns the positional argument if provided (catalog reference).
-3. Auto-discovers solution files by searching folder prefixes (`scafctl/`, `.scafctl/`, `.`) combined with file names (`solution.yaml`, `solution.yml`, `scafctl.yaml`, `scafctl.yml`, `solution.json`, `scafctl.json`, `taskfile.yaml`, `taskfile.yml`, `actions.yaml`, `actions.yml`).
+3. Auto-discovers solution files by searching folder prefixes (`scafctl/`, `.scafctl/`, `.`) combined with file names (`solution.yaml`, `solution.yml`, `scafctl.yaml`, `scafctl.yml`, `solution.json`, `scafctl.json`, `taskfile.yaml`, `taskfile.yml`). Action file names (`actions.yaml`, `actions.yml`) are only searched in `DiscoveryModeAction` (used by `run action`).
 
 **Multi-match ambiguity handling** uses risk levels:
 - **Low-risk** (`DiscoveryRiskLow`): uses first match, emits a warning about other matches. Used by `run`, `lint`, `test`.

--- a/docs/design/auto-discovery-resolution.md
+++ b/docs/design/auto-discovery-resolution.md
@@ -74,10 +74,12 @@ The search combines folder prefixes with file names in this order:
 6. `scafctl.json`
 7. `taskfile.yaml`
 8. `taskfile.yml`
-9. `actions.yaml`
-10. `actions.yml`
 
-This produces 30 candidate paths checked in priority order (3 folders x 10 names).
+Action file names (`actions.yaml`, `actions.yml`) are only searched when
+`DiscoveryModeAction` is active (e.g., `run action`). They are not included
+in the default search list.
+
+This produces 24 candidate paths checked in priority order (3 folders x 8 names).
 
 ### FindAllSolutions vs FindSolution
 
@@ -97,10 +99,13 @@ of available solutions in a workspace.
 
 ## Behavior Examples
 
+The `Using ...` and multi-match messages below are emitted via `writer.Verbosef`
+and only appear when `--verbose` is enabled.
+
 ### Single match (common case)
 
 ~~~
-$ scafctl lint
+$ scafctl lint --verbose
 Using solution.yaml
 ...
 ~~~
@@ -108,9 +113,9 @@ Using solution.yaml
 ### Multiple matches, low-risk command
 
 ~~~
-$ scafctl lint
+$ scafctl lint --verbose
 Using solution.yaml
-WARNING: Multiple solution files found (also: actions.yaml); using first match
+WARNING: Multiple solution files found (also: taskfile.yaml); using first match
 ...
 ~~~
 
@@ -118,7 +123,7 @@ WARNING: Multiple solution files found (also: actions.yaml); using first match
 
 ~~~
 $ scafctl build solution
-Error: multiple solution files found: solution.yaml, actions.yaml; use -f/--file to specify which one
+Error: multiple solution files found: solution.yaml, taskfile.yaml; use -f/--file to specify which one
 ~~~
 
 ## API

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -290,7 +290,7 @@ func DefaultPluginCacheDir() string {
 type DiscoveryMode int
 
 const (
-	// DiscoveryModeDefault searches all known file names (current behavior).
+	// DiscoveryModeDefault searches solution and taskfile names (excludes action files).
 	DiscoveryModeDefault DiscoveryMode = iota
 	// DiscoveryModeAction searches action files first, then falls back to solution files.
 	DiscoveryModeAction
@@ -322,6 +322,8 @@ func SolutionFoldersFor(binaryName string) []string {
 }
 
 // SolutionFileNamesFor returns the solution file names for the given binary name.
+// Action file names (actions.yaml/yml) are intentionally excluded; they are only
+// returned by [ActionFileNamesFor] for use with [DiscoveryModeAction].
 func SolutionFileNamesFor(binaryName string) []string {
 	return []string{
 		"solution.yaml",
@@ -332,8 +334,6 @@ func SolutionFileNamesFor(binaryName string) []string {
 		fmt.Sprintf("%s.json", binaryName),
 		"taskfile.yaml",
 		"taskfile.yml",
-		"actions.yaml",
-		"actions.yml",
 	}
 }
 
@@ -352,23 +352,9 @@ func ActionFileNamesFor(binaryName string) []string {
 	}
 }
 
-// SolutionOnlyFileNamesFor returns file names excluding actions.yaml/yml.
-func SolutionOnlyFileNamesFor(binaryName string) []string {
-	return []string{
-		"solution.yaml",
-		"solution.yml",
-		fmt.Sprintf("%s.yaml", binaryName),
-		fmt.Sprintf("%s.yml", binaryName),
-		"solution.json",
-		fmt.Sprintf("%s.json", binaryName),
-		"taskfile.yaml",
-		"taskfile.yml",
-	}
-}
-
 // FileNamesForMode returns the appropriate file name list based on mode and binary name.
 // When customActionFiles is non-empty and mode is DiscoveryModeAction, those file names
-// are used instead of the defaults (with solution files appended as fallback).
+// are used instead of the defaults (with solution and taskfile names appended as fallback).
 func FileNamesForMode(mode DiscoveryMode, binaryName string, customActionFiles []string) []string {
 	switch mode {
 	case DiscoveryModeDefault:
@@ -376,11 +362,11 @@ func FileNamesForMode(mode DiscoveryMode, binaryName string, customActionFiles [
 	case DiscoveryModeAction:
 		if len(customActionFiles) > 0 {
 			// Concat avoids mutating the caller's backing array.
-			return slices.Concat(customActionFiles, SolutionOnlyFileNamesFor(binaryName))
+			return slices.Concat(customActionFiles, SolutionFileNamesFor(binaryName))
 		}
 		return ActionFileNamesFor(binaryName)
 	case DiscoveryModeSolution:
-		return SolutionOnlyFileNamesFor(binaryName)
+		return SolutionFileNamesFor(binaryName)
 	default:
 		return SolutionFileNamesFor(binaryName)
 	}

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -96,14 +96,14 @@ func TestSolutionFileNamesFor(t *testing.T) {
 		{
 			name:        "default binary name",
 			binaryName:  "scafctl",
-			wantLen:     10,
-			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json", "taskfile.yaml", "taskfile.yml", "actions.yaml", "actions.yml"},
+			wantLen:     8,
+			mustContain: []string{"solution.yaml", "scafctl.yaml", "scafctl.json", "taskfile.yaml", "taskfile.yml"},
 		},
 		{
 			name:        "custom binary name",
 			binaryName:  "mycli",
-			wantLen:     10,
-			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json", "taskfile.yaml", "taskfile.yml", "actions.yaml", "actions.yml"},
+			wantLen:     8,
+			mustContain: []string{"solution.yaml", "mycli.yaml", "mycli.json", "taskfile.yaml", "taskfile.yml"},
 		},
 	}
 	for _, tt := range tests {
@@ -206,9 +206,9 @@ func TestTaskfileNotInActionMode(t *testing.T) {
 	assert.NotContains(t, actionFiles, "taskfile.yml")
 }
 
-func TestTaskfileInSolutionOnlyMode(t *testing.T) {
+func TestTaskfileInSolutionMode(t *testing.T) {
 	t.Parallel()
-	solFiles := SolutionOnlyFileNamesFor("scafctl")
+	solFiles := SolutionFileNamesFor("scafctl")
 	assert.Contains(t, solFiles, "taskfile.yaml")
 	assert.Contains(t, solFiles, "taskfile.yml")
 }
@@ -217,21 +217,17 @@ func TestTaskfilePriority(t *testing.T) {
 	t.Parallel()
 	files := SolutionFileNamesFor("scafctl")
 	taskIdx := -1
-	actionIdx := -1
 	solutionIdx := -1
 	for i, f := range files {
 		switch f {
 		case "taskfile.yaml":
 			taskIdx = i
-		case "actions.yaml":
-			actionIdx = i
 		case "solution.yaml":
 			solutionIdx = i
 		}
 	}
-	// taskfile.yaml should come after solution.yaml but before actions.yaml
+	// taskfile.yaml should come after solution.yaml
 	assert.Greater(t, taskIdx, solutionIdx, "taskfile.yaml should come after solution.yaml")
-	assert.Less(t, taskIdx, actionIdx, "taskfile.yaml should come before actions.yaml")
 }
 
 func TestSafeEnvPrefix(t *testing.T) {
@@ -265,9 +261,9 @@ func TestActionFileNamesFor(t *testing.T) {
 	assert.Contains(t, names, "mycli.yaml")
 }
 
-func TestSolutionOnlyFileNamesFor(t *testing.T) {
+func TestSolutionFileNamesFor_ExcludesActionFiles(t *testing.T) {
 	t.Parallel()
-	names := SolutionOnlyFileNamesFor("mycli")
+	names := SolutionFileNamesFor("mycli")
 	for _, n := range names {
 		assert.False(t, IsActionFile(n), "should not contain action files: %s", n)
 	}
@@ -307,11 +303,12 @@ func TestFileNamesForMode(t *testing.T) {
 		wantNotContains   string
 	}{
 		{
-			name:         "default mode returns all",
-			mode:         DiscoveryModeDefault,
-			binaryName:   "scafctl",
-			wantFirst:    "solution.yaml",
-			wantContains: "actions.yaml",
+			name:            "default mode excludes actions",
+			mode:            DiscoveryModeDefault,
+			binaryName:      "scafctl",
+			wantFirst:       "solution.yaml",
+			wantContains:    "taskfile.yaml",
+			wantNotContains: "actions.yaml",
 		},
 		{
 			name:         "action mode prefers actions",

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -591,8 +591,8 @@ func TestGetPossibleSolutionPaths(t *testing.T) {
 	t.Run("returns all possible paths", func(t *testing.T) {
 		paths := PossibleSolutionPaths()
 
-		// Should have 3 folders * 10 filenames = 30 paths
-		assert.Len(t, paths, 30)
+		// Should have 3 folders * 8 filenames = 24 paths
+		assert.Len(t, paths, 24)
 	})
 
 	t.Run("contains expected paths", func(t *testing.T) {

--- a/pkg/solution/get/resolve_test.go
+++ b/pkg/solution/get/resolve_test.go
@@ -176,10 +176,9 @@ func TestFindAllSolutions(t *testing.T) {
 		assert.False(t, results[1].IsActionFile)
 	})
 
-	t.Run("default mode does not reorder action files", func(t *testing.T) {
+	t.Run("default mode does not discover action files", func(t *testing.T) {
 		t.Parallel()
-		// In default mode, folder priority should be preserved — scafctl/
-		// folder files come before root files.
+		// In default mode, actions.yaml should NOT be discovered.
 		existingFiles := map[string]bool{
 			"scafctl/solution.yaml": true,
 			"actions.yaml":          true,
@@ -197,8 +196,8 @@ func TestFindAllSolutions(t *testing.T) {
 		)
 		results := getter.FindAllSolutions()
 
-		require.Len(t, results, 2)
-		assert.Equal(t, "scafctl/solution.yaml", results[0].Path, "subfolder should come first in default mode")
+		require.Len(t, results, 1)
+		assert.Equal(t, "scafctl/solution.yaml", results[0].Path, "only solution file should be found")
 	})
 }
 


### PR DESCRIPTION
- remove actions.yaml/yml from SolutionFileNamesFor()
- delete redundant SolutionOnlyFileNamesFor() function
- update FileNamesForMode to use SolutionFileNamesFor for DiscoveryModeSolution and DiscoveryModeDefault
- update DiscoveryModeDefault comment to reflect new behavior
- update auto-discovery design doc and copilot instructions to match the 8-name / 24-path search list

BREAKING CHANGE: DiscoveryModeDefault no longer discovers actions.yaml/actions.yml. Only DiscoveryModeAction (used by `run action`) searches action files. Commands that previously found actions.yaml via default discovery will no longer match those files.

Closes #498

