### PR TITLE
feat(state)!: resolve state paths relative to solution directory and add fingerprint.scope

### DIFF
--- a/docs/design/state/fingerprint-input-hashing-plan.md
+++ b/docs/design/state/fingerprint-input-hashing-plan.md
@@ -353,10 +353,9 @@ trigger a **one-time re-execution** (`ReasonFirstRun` on missing inputs hash).
 
 ## 12. Non-Goals
 
-- **Exclude list for inputs**: Not implementing `fingerprint.exclude` to skip
-  specific inputs. Documented limitation for now; can be added in a follow-up
-  if demand arises.
+- **Exclude list for inputs**: Not implementing per-input `fingerprint.exclude`.
+  Use `fingerprint.scope: files` to skip all input hashing instead.
 - **Partial input hashing**: Not differentiating static vs dynamic inputs. All
-  resolved inputs are hashed uniformly.
+  resolved inputs are hashed uniformly (when scope is `all`).
 - **Input-only fingerprinting**: `sources` is still required to opt into
   fingerprinting. Actions without `sources` run every time, as before.

--- a/docs/design/state/fingerprinting.md
+++ b/docs/design/state/fingerprinting.md
@@ -174,7 +174,34 @@ Sources []string `json:"sources,omitempty" yaml:"sources,omitempty" doc:"Glob pa
 // from the last successful run, the action is skipped. Manual edits to
 // generated files will trigger re-execution.
 Generates []string `json:"generates,omitempty" yaml:"generates,omitempty" doc:"Glob patterns for output files" maxItems:"100"`
+
+// Fingerprint controls fingerprint behavior for up-to-date checks.
+// By default (scope: all), both file hashes and resolved input hashes are checked.
+// Set scope to "files" to skip input hashing when inputs contain volatile values.
+// Requires sources to be set.
+Fingerprint *FingerprintConfig `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty" doc:"Fingerprint configuration for up-to-date checks"`
 ~~~
+
+#### FingerprintConfig
+
+~~~go
+// FingerprintScope controls which data is included in up-to-date fingerprint checks.
+type FingerprintScope string // "all" (default) | "files"
+
+// FingerprintConfig controls fingerprint behavior for an action.
+type FingerprintConfig struct {
+    Scope FingerprintScope `json:"scope,omitempty" yaml:"scope,omitempty"`
+}
+~~~
+
+| Scope | Behavior |
+|-------|----------|
+| `all` (default) | Check file hashes (Phase 1) AND resolved input hashes (Phase 2). Both must match for skip. |
+| `files` | Check file hashes only. Input changes are ignored. Useful when inputs contain volatile values (timestamps, build IDs) that change every run. |
+
+When `scope: files`, the executor skips Phase 2 (input hashing) and `Record()` does not store an inputs hash. This prevents ghost state (stored hashes that are never compared).
+
+**Lint rule**: `fingerprint-without-sources` (warning) fires when `fingerprint` is set but `sources` is empty, since fingerprinting has no effect without source files.
 
 ### 4.7 New Skip Reason
 

--- a/docs/design/state/state-missing-features-plan.md
+++ b/docs/design/state/state-missing-features-plan.md
@@ -91,7 +91,7 @@ destructive in annotations (it mutates state data).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `path` | string | Yes | State file path relative to `paths.StateDir()` |
+| `path` | string | Yes | State file path (relative to solution directory, or absolute) |
 | `key` | string | Yes | State entry key |
 | `value` | string | Yes | Value to store (string -- same as CLI behavior) |
 | `type` | string | No | Type annotation (default: `"string"`) |

--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -241,9 +241,9 @@ Solution identity (name, version) is already in `metadata` and does not need to 
 
 ### Storage Location
 
-The built-in `file` provider backend stores files under `paths.StateDir()` (`$XDG_STATE_HOME/scafctl/`), which is already defined and documented in `pkg/paths/`. This is the XDG-canonical location for user-specific state data like logs, history, and session state.
+The built-in `file` provider backend resolves relative state paths against the solution file's parent directory (via `provider.SolutionDirectoryFromContext`). This keeps state files co-located with the solution that owns them. Absolute paths are used as-is.
 
-On macOS: `~/.local/state/scafctl/`
+CLI state commands (`scafctl state list`, `get`, `set`, `delete`, `clear`) resolve relative `--path` values against the XDG state directory (`$XDG_STATE_HOME/scafctl/`, i.e. `~/.local/state/scafctl/` on macOS).
 
 ---
 
@@ -355,16 +355,16 @@ The built-in `file` provider supports state persistence via `CapabilityState`. S
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `operation` | string (enum: `state_load`, `state_save`, `state_delete`) | Yes | Operation to perform |
-| `path` | string | Yes | File path relative to `paths.StateDir()` |
+| `path` | string | Yes | File path (relative to solution directory, or absolute) |
 | `data` | object | For `state_save` | The full `Data` object to persist |
 
 ### Operations
 
 | Operation | Behavior |
 |-----------|----------|
-| `state_load` | Reads JSON from `paths.StateDir()/<path>`. Returns empty state structure if file does not exist (first run). |
-| `state_save` | Writes `Data` as JSON to `paths.StateDir()/<path>`. Creates directories as needed. Uses atomic write (temp + rename). |
-| `state_delete` | Removes the state file at `paths.StateDir()/<path>`. |
+| `state_load` | Reads JSON from the resolved path (relative to solution directory). Returns empty state structure if file does not exist (first run). |
+| `state_save` | Writes `Data` as JSON to the resolved path. Creates directories as needed. Uses atomic write (temp + rename). |
+| `state_delete` | Removes the state file at the resolved path. |
 
 ### Dry-Run Behavior
 
@@ -513,7 +513,7 @@ A `scafctl state` command group provides manual state management, mirroring the 
 | `scafctl state delete --path <file> --key <key>` | Delete a key |
 | `scafctl state clear --path <file>` | Clear all values |
 
-- `--path` is relative to `paths.StateDir()`
+- `--path` is relative to the XDG state directory (`paths.StateDir()`) for CLI commands
 - `list` and `get` support `-o table/json/yaml/quiet` via `kvx.OutputOptions`
 
 ---

--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -117,7 +117,7 @@ The parameters `username=alice` and `region=eu-west-1` are now saved to `~/.loca
 
 - **state.enabled** -- Activates state persistence. Can be a literal `true`, a CEL expression, or template. Because state is loaded before resolvers run, resolver references (`rslvr:...`) are not supported here.
 - **state.backend.provider** -- The provider that handles persistence. Use `file` for local files.
-- **state.backend.inputs.path** -- Where to store the state file, relative to the XDG state directory (`~/.local/state/scafctl/` on macOS/Linux).
+- **state.backend.inputs.path** -- Where to store the state file. Relative paths are resolved against the solution file's parent directory. Absolute paths are used as-is. CLI state commands (`scafctl state list`, etc.) resolve relative paths against the XDG state directory (`~/.local/state/scafctl/`).
 
 No per-resolver configuration is needed. All CLI parameters are persisted automatically when state is enabled.
 
@@ -501,7 +501,7 @@ scafctl state clear --path state-demo.json
 {{< /tabs >}}
 
 > [!NOTE]
-> `scafctl state list` and `scafctl state get` support `-o json`, `-o yaml`, and `-o quiet` output formats. The `--path` flag is relative to the XDG state directory. Use an absolute path to reference files outside the state directory.
+> `scafctl state list` and `scafctl state get` support `-o json`, `-o yaml`, and `-o quiet` output formats. The `--path` flag is relative to the XDG state directory (`~/.local/state/scafctl/`). Use an absolute path to reference files outside the state directory.
 
 ---
 

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -578,7 +578,18 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 
 	// Phase 2: Input-based fingerprint check (only when files were fresh).
 	// Compares resolved inputs hash against stored state to detect resolver changes.
+	// Skipped when fingerprint.scope is "files" (user opted out of input hashing).
 	if filesFresh {
+		scope := fingerprintScope(action.Action)
+		if scope == FingerprintScopeFiles {
+			// scope: files — skip input check, files alone determine freshness
+			e.actionContext.MarkSkipped(actionName, SkipReasonUpToDate)
+			if e.progressCallback != nil {
+				e.progressCallback.OnActionSkipped(actionName, string(SkipReasonUpToDate))
+			}
+			return nil
+		}
+
 		fpResult, fpErr := e.fingerprintChecker.CheckInputs(ctx, actionName, resolvedInputs)
 		if fpErr != nil {
 			logger.FromContext(ctx).V(0).Info("fingerprint inputs check failed, executing action",
@@ -693,7 +704,12 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 
 	// Record fingerprint after successful execution
 	if e.fingerprintChecker != nil && len(action.Sources) > 0 {
-		if recordErr := e.fingerprintChecker.Record(ctx, actionName, action.Sources, action.Generates, e.cwd, resolvedInputs); recordErr != nil {
+		scope := fingerprintScope(action.Action)
+		var recordInputs map[string]any
+		if scope != FingerprintScopeFiles {
+			recordInputs = resolvedInputs
+		}
+		if recordErr := e.fingerprintChecker.Record(ctx, actionName, action.Sources, action.Generates, e.cwd, recordInputs); recordErr != nil {
 			logger.FromContext(ctx).V(0).Info("fingerprint record failed",
 				"action", actionName, "error", recordErr.Error())
 		}
@@ -864,3 +880,12 @@ func (NoOpProgressCallback) OnPhaseStart(_ int, _ []string)             {}
 func (NoOpProgressCallback) OnPhaseComplete(_ int)                      {}
 func (NoOpProgressCallback) OnFinallyStart()                            {}
 func (NoOpProgressCallback) OnFinallyComplete()                         {}
+
+// fingerprintScope returns the effective fingerprint scope for an action.
+// Returns FingerprintScopeAll when no fingerprint config is set.
+func fingerprintScope(act *Action) FingerprintScope {
+	if act.Fingerprint == nil {
+		return FingerprintScopeAll
+	}
+	return act.Fingerprint.Scope.OrDefault()
+}

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -1402,3 +1402,151 @@ func TestExecutor_Execute_FingerprintInputsChanged(t *testing.T) {
 	assert.Equal(t, StatusSkipped, result.Actions["generate"].Status)
 	assert.Equal(t, SkipReasonUpToDate, result.Actions["generate"].SkipReason)
 }
+
+func TestExecutor_Execute_FingerprintScopeFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/template.tpl", []byte("hello"), 0o644))
+
+	execCount := 0
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			execCount++
+			return &provider.Output{Data: map[string]any{"result": "ok"}}, nil
+		},
+	})
+
+	stateData := state.NewData()
+	fpChecker := fingerprint.NewChecker(stateData)
+
+	// First run with scope: files — should execute (first run)
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"generate": {
+				Provider: "test-provider",
+				Sources:  []string{"*.tpl"},
+				Fingerprint: &FingerprintConfig{
+					Scope: FingerprintScopeFiles,
+				},
+				Inputs: map[string]*spec.ValueRef{
+					"env": {Literal: "staging"},
+				},
+			},
+		},
+	}
+
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	_, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount)
+
+	// Second run: same files, different inputs — should SKIP because scope=files
+	workflow2 := &Workflow{
+		Actions: map[string]*Action{
+			"generate": {
+				Provider: "test-provider",
+				Sources:  []string{"*.tpl"},
+				Fingerprint: &FingerprintConfig{
+					Scope: FingerprintScopeFiles,
+				},
+				Inputs: map[string]*spec.ValueRef{
+					"env": {Literal: "production"},
+				},
+			},
+		},
+	}
+
+	executor2 := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	result, err := executor2.Execute(context.Background(), workflow2)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount) // NOT incremented — inputs ignored
+	assert.Equal(t, StatusSkipped, result.Actions["generate"].Status)
+	assert.Equal(t, SkipReasonUpToDate, result.Actions["generate"].SkipReason)
+
+	// Verify no inputs hash was stored in state
+	inputsHash := fingerprint.LoadInputsHash(stateData, "generate")
+	assert.Empty(t, inputsHash, "inputs hash should not be stored when scope=files")
+}
+
+func TestExecutor_Execute_FingerprintScopeAll_IsDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/template.tpl", []byte("hello"), 0o644))
+
+	execCount := 0
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			execCount++
+			return &provider.Output{Data: map[string]any{"result": "ok"}}, nil
+		},
+	})
+
+	stateData := state.NewData()
+	fpChecker := fingerprint.NewChecker(stateData)
+
+	// First run with no fingerprint config (default = scope: all)
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"generate": {
+				Provider: "test-provider",
+				Sources:  []string{"*.tpl"},
+				Inputs: map[string]*spec.ValueRef{
+					"env": {Literal: "staging"},
+				},
+			},
+		},
+	}
+
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	_, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount)
+
+	// Second run: same files, different inputs — should RE-EXECUTE (scope=all checks inputs)
+	workflow2 := &Workflow{
+		Actions: map[string]*Action{
+			"generate": {
+				Provider: "test-provider",
+				Sources:  []string{"*.tpl"},
+				Inputs: map[string]*spec.ValueRef{
+					"env": {Literal: "production"},
+				},
+			},
+		},
+	}
+
+	executor2 := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	_, err = executor2.Execute(context.Background(), workflow2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, execCount) // Incremented — inputs changed triggers re-execution
+}

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -95,6 +95,12 @@ type Action struct {
 	// generated files will trigger re-execution.
 	Generates []string `json:"generates,omitempty" yaml:"generates,omitempty" doc:"Glob patterns for output files" maxItems:"100"`
 
+	// Fingerprint controls fingerprint behavior for up-to-date checks.
+	// By default (scope: all), both file hashes and resolved input hashes are checked.
+	// Set scope to "files" to skip input hashing when inputs contain volatile values.
+	// Requires sources to be set.
+	Fingerprint *FingerprintConfig `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty" doc:"Fingerprint configuration for up-to-date checks"`
+
 	// When is a condition that must evaluate to true for the action to execute.
 	// If false, the action is skipped with SkipReasonCondition.
 	When *spec.Condition `json:"when,omitempty" yaml:"when,omitempty" doc:"Condition for execution (skipped if false)"`
@@ -156,6 +162,44 @@ func (m ResultSchemaMode) OrDefault() ResultSchemaMode {
 		return ResultSchemaModeError
 	}
 	return m
+}
+
+// FingerprintScope controls which data is included in up-to-date fingerprint checks.
+type FingerprintScope string
+
+const (
+	// FingerprintScopeAll includes file hashes and resolved input hashes (default).
+	FingerprintScopeAll FingerprintScope = "all"
+
+	// FingerprintScopeFiles includes only file hashes (sources + generates), skipping input hashing.
+	FingerprintScopeFiles FingerprintScope = "files"
+)
+
+// IsValid returns true if the fingerprint scope is valid.
+func (s FingerprintScope) IsValid() bool {
+	switch s {
+	case FingerprintScopeAll, FingerprintScopeFiles, "":
+		return true
+	default:
+		return false
+	}
+}
+
+// OrDefault returns the scope or the default (FingerprintScopeAll) if empty.
+func (s FingerprintScope) OrDefault() FingerprintScope {
+	if s == "" {
+		return FingerprintScopeAll
+	}
+	return s
+}
+
+// FingerprintConfig controls fingerprint behavior for an action.
+type FingerprintConfig struct {
+	// Scope controls which data is included in the fingerprint check.
+	// "all" (default) checks both file hashes and resolved input hashes.
+	// "files" checks only file hashes (sources + generates), useful when
+	// inputs contain volatile values like timestamps that change every run.
+	Scope FingerprintScope `json:"scope,omitempty" yaml:"scope,omitempty" doc:"Fingerprint scope: all (files+inputs) or files (files only)" maxLength:"16" example:"files" default:"all"`
 }
 
 // RetryConfig defines automatic retry behavior for failed actions.

--- a/pkg/action/types_test.go
+++ b/pkg/action/types_test.go
@@ -299,3 +299,27 @@ func TestResultSchemaMode_OrDefault(t *testing.T) {
 	assert.Equal(t, ResultSchemaModeWarn, ResultSchemaModeWarn.OrDefault())
 	assert.Equal(t, ResultSchemaModeIgnore, ResultSchemaModeIgnore.OrDefault())
 }
+
+func TestFingerprintScope_IsValid(t *testing.T) {
+	tests := []struct {
+		scope    FingerprintScope
+		expected bool
+	}{
+		{FingerprintScopeAll, true},
+		{FingerprintScopeFiles, true},
+		{"", true},
+		{"invalid", false},
+		{"inputs", false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.scope), func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.scope.IsValid())
+		})
+	}
+}
+
+func TestFingerprintScope_OrDefault(t *testing.T) {
+	assert.Equal(t, FingerprintScopeAll, FingerprintScope("").OrDefault())
+	assert.Equal(t, FingerprintScopeAll, FingerprintScopeAll.OrDefault())
+	assert.Equal(t, FingerprintScopeFiles, FingerprintScopeFiles.OrDefault())
+}

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -877,6 +877,16 @@ func validateSources(action *Action, section string, errs *AggregatedValidationE
 			Message:    "generates requires sources to be set",
 		})
 	}
+
+	// Validate fingerprint.scope
+	if action.Fingerprint != nil && !action.Fingerprint.Scope.IsValid() {
+		errs.AddError(&ValidationError{
+			Section:    section,
+			ActionName: action.Name,
+			Field:      "fingerprint.scope",
+			Message:    fmt.Sprintf("fingerprint.scope must be 'all' or 'files', got %q", action.Fingerprint.Scope),
+		})
+	}
 }
 
 // validateGlobSafety rejects absolute patterns and path traversal segments

--- a/pkg/action/validation_test.go
+++ b/pkg/action/validation_test.go
@@ -1171,3 +1171,63 @@ func TestValidateSources_RejectsTraversalInGenerates(t *testing.T) {
 	assert.Contains(t, errs.Errors[0].Message, "path traversal not allowed")
 	assert.Equal(t, "generates", errs.Errors[0].Field)
 }
+
+func TestValidateSources_InvalidFingerprintScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		scope   FingerprintScope
+		wantErr bool
+	}{
+		{name: "valid all", scope: FingerprintScopeAll, wantErr: false},
+		{name: "valid files", scope: FingerprintScopeFiles, wantErr: false},
+		{name: "valid empty", scope: "", wantErr: false},
+		{name: "invalid typo", scope: "file", wantErr: true},
+		{name: "invalid unknown", scope: "none", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			action := &Action{
+				Name:     "build",
+				Provider: "exec",
+				Sources:  []string{"src/**/*.go"},
+				Fingerprint: &FingerprintConfig{
+					Scope: tt.scope,
+				},
+			}
+			errs := &AggregatedValidationError{}
+			validateSources(action, "workflow.actions", errs)
+
+			if tt.wantErr {
+				require.NotEmpty(t, errs.Errors)
+				assert.Equal(t, "fingerprint.scope", errs.Errors[len(errs.Errors)-1].Field)
+				assert.Contains(t, errs.Errors[len(errs.Errors)-1].Message, "fingerprint.scope must be")
+			} else {
+				for _, e := range errs.Errors {
+					assert.NotEqual(t, "fingerprint.scope", e.Field)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateWorkflow_InvalidFingerprintScope(t *testing.T) {
+	t.Parallel()
+	w := &Workflow{
+		Actions: map[string]*Action{
+			"build": {
+				Provider: "exec",
+				Sources:  []string{"*.go"},
+				Fingerprint: &FingerprintConfig{
+					Scope: "file",
+				},
+			},
+		},
+	}
+	err := ValidateWorkflow(w, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fingerprint.scope must be")
+}

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -768,6 +768,15 @@ func (o *SolutionOptions) loadStateIntoContext(ctx context.Context, sol *solutio
 		return ctx, params, nil
 	}
 
+	// Set solution directory so the file state backend can resolve relative
+	// state paths against the directory containing the solution file.
+	// Skip pseudo-paths (catalog:, remote:, URLs) — they are not filesystem paths.
+	if solPath := sol.GetPath(); solPath != "" && !strings.Contains(solPath, ":") {
+		if _, ok := provider.SolutionDirectoryFromContext(ctx); !ok {
+			ctx = provider.WithSolutionDirectory(ctx, filepath.Dir(solPath))
+		}
+	}
+
 	stateMgr := state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
 	cmdInfo := state.CommandInfo{
 		Subcommand: "render solution",

--- a/pkg/cmd/scafctl/state/clear.go
+++ b/pkg/cmd/scafctl/state/clear.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -30,7 +31,7 @@ func CommandClear(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 				return fmt.Errorf("writer not initialized in context")
 			}
 
-			sd, err := state.LoadFromFile(path)
+			sd, err := state.LoadFromFile(path, paths.StateDir())
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)
@@ -38,7 +39,7 @@ func CommandClear(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			}
 
 			// Verify the file actually exists (LoadFromFile returns empty for non-existent).
-			resolved, resolveErr := state.ResolveStatePath(path)
+			resolved, resolveErr := state.ResolveStatePath(path, paths.StateDir())
 			if resolveErr != nil {
 				w.Errorf("%v", resolveErr)
 				return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
@@ -54,7 +55,7 @@ func CommandClear(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comma
 			sd.Immutables = make(map[string]*state.ImmutableEntry)
 			sd.Fingerprints = make(map[string]*state.FingerprintEntry)
 
-			if err := state.SaveToFile(path, sd); err != nil {
+			if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 				err := fmt.Errorf("failed to save state: %w", err)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.GeneralError)

--- a/pkg/cmd/scafctl/state/delete.go
+++ b/pkg/cmd/scafctl/state/delete.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -34,7 +35,7 @@ func CommandDelete(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 				return fmt.Errorf("writer not initialized in context")
 			}
 
-			sd, err := state.LoadFromFile(path)
+			sd, err := state.LoadFromFile(path, paths.StateDir())
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)
@@ -42,7 +43,7 @@ func CommandDelete(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 			}
 
 			// Verify the file actually exists (LoadFromFile returns empty for non-existent).
-			resolved, resolveErr := state.ResolveStatePath(path)
+			resolved, resolveErr := state.ResolveStatePath(path, paths.StateDir())
 			if resolveErr != nil {
 				w.Errorf("%v", resolveErr)
 				return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
@@ -56,7 +57,7 @@ func CommandDelete(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 			// Check parameters first
 			if _, ok := sd.Parameters[key]; ok {
 				delete(sd.Parameters, key)
-				if err := state.SaveToFile(path, sd); err != nil {
+				if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 					err := fmt.Errorf("failed to save state: %w", err)
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.GeneralError)
@@ -73,7 +74,7 @@ func CommandDelete(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Comm
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}
 				delete(sd.Immutables, key)
-				if err := state.SaveToFile(path, sd); err != nil {
+				if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 					err := fmt.Errorf("failed to save state: %w", err)
 					w.Errorf("%v", err)
 					return exitcode.WithCode(err, exitcode.GeneralError)

--- a/pkg/cmd/scafctl/state/get.go
+++ b/pkg/cmd/scafctl/state/get.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -42,7 +43,7 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 			}
 
 			// Resolve and verify the file exists before loading.
-			resolved, err := state.ResolveStatePath(opts.Path)
+			resolved, err := state.ResolveStatePath(opts.Path, paths.StateDir())
 			if err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -53,7 +54,7 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string
 				return exitcode.WithCode(err, exitcode.FileNotFound)
 			}
 
-			sd, err := state.LoadFromFile(opts.Path)
+			sd, err := state.LoadFromFile(opts.Path, paths.StateDir())
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)

--- a/pkg/cmd/scafctl/state/list.go
+++ b/pkg/cmd/scafctl/state/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -48,7 +49,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			}
 
 			// Resolve and verify the file exists before loading.
-			resolved, err := state.ResolveStatePath(opts.Path)
+			resolved, err := state.ResolveStatePath(opts.Path, paths.StateDir())
 			if err != nil {
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -59,7 +60,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				return exitcode.WithCode(err, exitcode.FileNotFound)
 			}
 
-			sd, err := state.LoadFromFile(opts.Path)
+			sd, err := state.LoadFromFile(opts.Path, paths.StateDir())
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)

--- a/pkg/cmd/scafctl/state/set.go
+++ b/pkg/cmd/scafctl/state/set.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -37,7 +38,7 @@ func CommandSet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command
 				return fmt.Errorf("writer not initialized in context")
 			}
 
-			sd, err := state.LoadFromFile(path)
+			sd, err := state.LoadFromFile(path, paths.StateDir())
 			if err != nil {
 				err := fmt.Errorf("failed to load state: %w", err)
 				w.Errorf("%v", err)
@@ -67,7 +68,7 @@ func CommandSet(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command
 				sd.Parameters[key] = coerced
 			}
 
-			if err := state.SaveToFile(path, sd); err != nil {
+			if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 				err := fmt.Errorf("failed to save state: %w", err)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.GeneralError)

--- a/pkg/cmd/scafctl/state/state_test.go
+++ b/pkg/cmd/scafctl/state/state_test.go
@@ -33,7 +33,7 @@ func seedState(t *testing.T, path string) {
 	sd := state.NewData()
 	sd.Parameters["env"] = "prod"
 	sd.Parameters["count"] = float64(42)
-	require.NoError(t, state.SaveToFile(path, sd))
+	require.NoError(t, state.SaveToFile(path, "", sd))
 }
 
 // ── CommandState tests ────────────────────────────────────────────────────────
@@ -61,7 +61,7 @@ func TestCommandList_EmptyState(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "empty.json")
 	// Create an empty state file (commands now require the file to exist).
-	require.NoError(t, state.SaveToFile(path, state.NewData()))
+	require.NoError(t, state.SaveToFile(path, "", state.NewData()))
 	ctx, buf := newTestContext(t)
 
 	cliParams := &settings.Run{BinaryName: "testcli"}
@@ -155,7 +155,7 @@ func TestCommandSet_NewKey(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	require.Contains(t, sd.Parameters, "region")
 	assert.Equal(t, "us-east-1", sd.Parameters["region"])
@@ -166,7 +166,7 @@ func TestCommandSet_Immutable(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.json")
 	sd := state.NewData()
 	sd.Immutables["locked"] = &state.ImmutableEntry{Value: "v1", Type: "string", CreatedAt: time.Now().UTC()}
-	require.NoError(t, state.SaveToFile(path, sd))
+	require.NoError(t, state.SaveToFile(path, "", sd))
 
 	ctx, buf := newTestContext(t)
 	cmd := CommandSet(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
@@ -190,7 +190,7 @@ func TestCommandSet_TypedInt(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	// JSON round-trips int64 as float64
 	assert.Equal(t, float64(8080), sd.Parameters["port"])
@@ -208,7 +208,7 @@ func TestCommandSet_TypedBool(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	assert.Equal(t, true, sd.Parameters["enabled"])
 }
@@ -225,7 +225,7 @@ func TestCommandSet_TypedFloat(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	assert.Equal(t, 3.14, sd.Parameters["ratio"])
 }
@@ -296,7 +296,7 @@ func TestCommandDelete_Found(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Deleted")
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	assert.NotContains(t, sd.Parameters, "env")
 	assert.Contains(t, sd.Parameters, "count")
@@ -333,7 +333,7 @@ func TestCommandClear(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Cleared 2 entries")
 
-	sd, loadErr := state.LoadFromFile(path)
+	sd, loadErr := state.LoadFromFile(path, "")
 	require.NoError(t, loadErr)
 	assert.Empty(t, sd.Parameters)
 	assert.Empty(t, sd.Immutables)
@@ -343,7 +343,7 @@ func TestCommandClear_EmptyState(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "empty.json")
 	// Create an empty state file (commands now require the file to exist).
-	require.NoError(t, state.SaveToFile(path, state.NewData()))
+	require.NoError(t, state.SaveToFile(path, "", state.NewData()))
 
 	ctx, buf := newTestContext(t)
 	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -703,6 +703,21 @@ func lintAction(act *action.Action, location string, validDeps map[string]bool, 
 	if act.ResultSchema != nil {
 		lintResultSchema(act.ResultSchema, location+".resultSchema", result)
 	}
+
+	if act.Fingerprint != nil {
+		if len(act.Sources) == 0 {
+			result.addFinding(SeverityWarning, "workflow", location,
+				"fingerprint block has no effect without sources",
+				"Add sources patterns or remove the fingerprint block",
+				"fingerprint-without-sources")
+		}
+		if !act.Fingerprint.Scope.IsValid() {
+			result.addFinding(SeverityError, "workflow", location+".fingerprint.scope",
+				fmt.Sprintf("unknown fingerprint scope %q", act.Fingerprint.Scope),
+				"Use 'all' (check files and inputs) or 'files' (check files only)",
+				"invalid-fingerprint-scope")
+		}
+	}
 }
 
 func lintResultSchema(schema *jsonschema.Schema, location string, result *Result) {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1964,3 +1964,117 @@ func TestLintTransformShapeMismatch(t *testing.T) {
 		})
 	}
 }
+
+func TestLintAction_FingerprintWithoutSources(t *testing.T) {
+	t.Parallel()
+	reg := provider.NewRegistry()
+
+	tests := []struct {
+		name       string
+		action     *action.Action
+		expectRule bool
+	}{
+		{
+			name: "fingerprint with sources",
+			action: &action.Action{
+				Name:     "build",
+				Provider: "test",
+				Sources:  []string{"*.go"},
+				Fingerprint: &action.FingerprintConfig{
+					Scope: action.FingerprintScopeFiles,
+				},
+			},
+			expectRule: false,
+		},
+		{
+			name: "fingerprint without sources",
+			action: &action.Action{
+				Name:     "deploy",
+				Provider: "test",
+				Fingerprint: &action.FingerprintConfig{
+					Scope: action.FingerprintScopeFiles,
+				},
+			},
+			expectRule: true,
+		},
+		{
+			name: "no fingerprint no sources",
+			action: &action.Action{
+				Name:     "deploy",
+				Provider: "test",
+			},
+			expectRule: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sol := &solution.Solution{
+				Spec: solution.Spec{
+					Workflow: &action.Workflow{
+						Actions: map[string]*action.Action{
+							tt.action.Name: tt.action,
+						},
+					},
+				},
+			}
+			result := Solution(sol, "test.yaml", reg)
+			findings := filterFindingsByRule(result, "fingerprint-without-sources")
+			if tt.expectRule {
+				require.NotEmpty(t, findings)
+				assert.Equal(t, SeverityWarning, findings[0].Severity)
+			} else {
+				assert.Empty(t, findings)
+			}
+		})
+	}
+}
+
+func TestLintAction_InvalidFingerprintScope(t *testing.T) {
+	t.Parallel()
+	reg := provider.NewRegistry()
+
+	tests := []struct {
+		name       string
+		scope      action.FingerprintScope
+		expectRule bool
+	}{
+		{"valid scope all", action.FingerprintScopeAll, false},
+		{"valid scope files", action.FingerprintScopeFiles, false},
+		{"valid scope empty", "", false},
+		{"invalid scope", action.FingerprintScope("none"), true},
+		{"invalid scope typo", action.FingerprintScope("file"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sol := &solution.Solution{
+				Spec: solution.Spec{
+					Workflow: &action.Workflow{
+						Actions: map[string]*action.Action{
+							"build": {
+								Name:     "build",
+								Provider: "test",
+								Sources:  []string{"*.go"},
+								Fingerprint: &action.FingerprintConfig{
+									Scope: tt.scope,
+								},
+							},
+						},
+					},
+				},
+			}
+			result := Solution(sol, "test.yaml", reg)
+			findings := filterFindingsByRule(result, "invalid-fingerprint-scope")
+			if tt.expectRule {
+				require.NotEmpty(t, findings)
+				assert.Equal(t, SeverityError, findings[0].Severity)
+				assert.Contains(t, findings[0].Message, string(tt.scope))
+			} else {
+				assert.Empty(t, findings)
+			}
+		})
+	}
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -425,6 +425,28 @@ var KnownRules = map[string]RuleMeta{
 			"# Problem: transform assumes http shape but static fallback is []\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: 'has(_.credentials)'\n      inputs:\n        url: https://api.example.com/data\n    - provider: static\n      inputs:\n        value: []\ntransform:\n  with:\n    - provider: cel\n      inputs:\n        expression: '__self.body.items'\n\n# Fix: add a when guard on the transform step\ntransform:\n  with:\n    - provider: cel\n      when:\n        expr: 'type(__self) != list_type'\n      inputs:\n        expression: '__self.body.items'",
 		},
 	},
+	"fingerprint-without-sources": {
+		Rule:        "fingerprint-without-sources",
+		Severity:    string(SeverityWarning),
+		Category:    "workflow",
+		Description: "An action has a fingerprint block but no sources defined. Fingerprinting requires sources to function.",
+		Why:         "The fingerprint system hashes source files to determine whether an action is up-to-date. Without sources, there are no files to hash and the fingerprint block has no effect.",
+		Fix:         "Either add sources patterns to the action or remove the fingerprint block.",
+		Examples: []string{
+			"# Correct:\nactions:\n  build:\n    sources:\n      - 'src/**/*.go'\n    fingerprint:\n      scope: files\n    provider: exec\n    inputs:\n      command: go build",
+		},
+	},
+	"invalid-fingerprint-scope": {
+		Rule:        "invalid-fingerprint-scope",
+		Severity:    string(SeverityError),
+		Category:    "workflow",
+		Description: "The fingerprint.scope value is not a recognized option.",
+		Why:         "An unrecognized scope silently defaults to 'all', which may not be the intended behavior. Valid values are 'all' and 'files'.",
+		Fix:         "Set fingerprint.scope to 'all' (check both files and inputs) or 'files' (check files only).",
+		Examples: []string{
+			"# Correct:\nactions:\n  build:\n    sources:\n      - 'src/**/*.go'\n    fingerprint:\n      scope: files\n    provider: exec\n    inputs:\n      command: go build",
+		},
+	},
 }
 
 // ListRules returns all known lint rules sorted by severity (error > warning > info)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 43 rules — update this when new rules are added
-	assert.Equal(t, 43, len(KnownRules), "expected 43 known lint rules")
+	// We expect exactly 45 rules — update this when new rules are added
+	assert.Equal(t, 45, len(KnownRules), "expected 45 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/tools_state.go
+++ b/pkg/mcp/tools_state.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 )
 
@@ -105,7 +106,7 @@ func (s *Server) handleStateList(_ context.Context, request mcp.CallToolRequest)
 		), nil
 	}
 
-	sd, err := state.LoadFromFile(path)
+	sd, err := state.LoadFromFile(path, paths.StateDir())
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err),
 			WithSuggestion("Check that the path is correct and the file is valid JSON"),
@@ -184,7 +185,7 @@ func (s *Server) handleStateGet(_ context.Context, request mcp.CallToolRequest) 
 		), nil
 	}
 
-	sd, err := state.LoadFromFile(path)
+	sd, err := state.LoadFromFile(path, paths.StateDir())
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err)), nil
 	}
@@ -223,7 +224,7 @@ func (s *Server) handleStateDelete(_ context.Context, request mcp.CallToolReques
 		), nil
 	}
 
-	sd, err := state.LoadFromFile(path)
+	sd, err := state.LoadFromFile(path, paths.StateDir())
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err)), nil
 	}
@@ -234,7 +235,7 @@ func (s *Server) handleStateDelete(_ context.Context, request mcp.CallToolReques
 		// Delete a single key -- check parameters first, then immutables
 		if _, ok := sd.Parameters[key]; ok {
 			delete(sd.Parameters, key)
-			if err := state.SaveToFile(path, sd); err != nil {
+			if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 				return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
 			}
 			return mcp.NewToolResultJSON(map[string]any{
@@ -245,7 +246,7 @@ func (s *Server) handleStateDelete(_ context.Context, request mcp.CallToolReques
 
 		if _, ok := sd.Immutables[key]; ok {
 			delete(sd.Immutables, key)
-			if err := state.SaveToFile(path, sd); err != nil {
+			if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 				return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
 			}
 			return mcp.NewToolResultJSON(map[string]any{
@@ -265,7 +266,7 @@ func (s *Server) handleStateDelete(_ context.Context, request mcp.CallToolReques
 	sd.Parameters = make(map[string]any)
 	sd.Immutables = make(map[string]*state.ImmutableEntry)
 	sd.Fingerprints = make(map[string]*state.FingerprintEntry)
-	if err := state.SaveToFile(path, sd); err != nil {
+	if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
 	}
 
@@ -294,7 +295,7 @@ func (s *Server) handleStateSet(_ context.Context, request mcp.CallToolRequest) 
 
 	value := request.GetString("value", "")
 
-	sd, err := state.LoadFromFile(path)
+	sd, err := state.LoadFromFile(path, paths.StateDir())
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("failed to load state: %v", err),
 			WithSuggestion("Check that the path is correct and the file is valid JSON"),
@@ -313,7 +314,7 @@ func (s *Server) handleStateSet(_ context.Context, request mcp.CallToolRequest) 
 	// Default to parameters section
 	sd.Parameters[key] = coerced
 
-	if err := state.SaveToFile(path, sd); err != nil {
+	if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to save state: %v", err)), nil
 	}
 

--- a/pkg/mcp/tools_state_test.go
+++ b/pkg/mcp/tools_state_test.go
@@ -21,7 +21,7 @@ func seedTestState(t *testing.T, path string) {
 	sd := state.NewData()
 	sd.Parameters["env"] = "prod"
 	sd.Parameters["count"] = float64(42)
-	require.NoError(t, state.SaveToFile(path, sd))
+	require.NoError(t, state.SaveToFile(path, "", sd))
 }
 
 func newStateRequest(name string, args map[string]any) mcp.CallToolRequest {
@@ -146,7 +146,7 @@ func TestHandleStateDelete(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		// Verify key was deleted
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		assert.NotContains(t, sd.Parameters, "env")
 		assert.Contains(t, sd.Parameters, "count")
@@ -180,7 +180,7 @@ func TestHandleStateDelete(t *testing.T) {
 		assert.Contains(t, output["message"], "cleared 2 entries")
 
 		// Verify all entries gone
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		assert.Empty(t, sd.Parameters)
 		assert.Empty(t, sd.Immutables)
@@ -209,7 +209,7 @@ func TestHandleStateSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
 
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		require.Contains(t, sd.Parameters, "region")
 		assert.Equal(t, "us-east-1", sd.Parameters["region"])
@@ -227,7 +227,7 @@ func TestHandleStateSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
 
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		assert.Equal(t, "staging", sd.Parameters["env"])
 	})
@@ -236,7 +236,7 @@ func TestHandleStateSet(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "state.json")
 		sd := state.NewData()
 		sd.Immutables["locked"] = &state.ImmutableEntry{Value: "v1", Type: "string", CreatedAt: time.Now().UTC()}
-		require.NoError(t, state.SaveToFile(path, sd))
+		require.NoError(t, state.SaveToFile(path, "", sd))
 
 		result, err := srv.handleStateSet(context.Background(), newStateRequest("state_set", map[string]any{
 			"path":  path,
@@ -247,7 +247,7 @@ func TestHandleStateSet(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		// Parameters should have the new value; immutables remain unchanged
-		reloaded, loadErr := state.LoadFromFile(path)
+		reloaded, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		assert.Equal(t, "v2", reloaded.Parameters["locked"])
 		assert.Equal(t, "v1", reloaded.Immutables["locked"].Value)
@@ -266,7 +266,7 @@ func TestHandleStateSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
 
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		// JSON roundtrip converts int64 to float64
 		assert.Equal(t, float64(8080), sd.Parameters["port"])
@@ -285,7 +285,7 @@ func TestHandleStateSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
 
-		sd, loadErr := state.LoadFromFile(path)
+		sd, loadErr := state.LoadFromFile(path, "")
 		require.NoError(t, loadErr)
 		assert.Equal(t, true, sd.Parameters["debug"])
 	})

--- a/pkg/provider/builtin/fileprovider/file_state.go
+++ b/pkg/provider/builtin/fileprovider/file_state.go
@@ -151,13 +151,18 @@ func (p *FileProvider) dispatchStateOperation(ctx context.Context, operation str
 		return nil, fmt.Errorf("%s: path is required for state operations", ProviderName)
 	}
 
-	absPath, err := state.ResolveStatePath(statePath)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", ProviderName, err)
-	}
-
 	if provider.DryRunFromContext(ctx) {
 		return p.executeStateDryRun(operation)
+	}
+
+	// Use solution directory as base for relative state paths.
+	// Falls back to empty string which ResolveStatePath rejects for relative paths,
+	// ensuring callers must provide an explicit base directory.
+	baseDir, _ := provider.SolutionDirectoryFromContext(ctx)
+
+	absPath, err := state.ResolveStatePath(statePath, baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
 	}
 
 	switch operation {

--- a/pkg/provider/builtin/fileprovider/file_state_test.go
+++ b/pkg/provider/builtin/fileprovider/file_state_test.go
@@ -81,7 +81,9 @@ func TestFileProvider_StateDeleteNotFound(t *testing.T) {
 
 func TestFileProvider_StateDispatch(t *testing.T) {
 	p := NewFileProvider()
+	solDir := t.TempDir()
 	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityState)
+	ctx = provider.WithSolutionDirectory(ctx, solDir)
 
 	// Dispatch routes state_load through the Execute path
 	result, err := p.Execute(ctx, map[string]any{
@@ -92,6 +94,50 @@ func TestFileProvider_StateDispatch(t *testing.T) {
 	// state_load with non-existent file returns empty state
 	data := result.Data.(map[string]any)
 	assert.True(t, data["success"].(bool))
+}
+
+func TestFileProvider_StateDispatch_RelativeResolvesToSolutionDir(t *testing.T) {
+	p := NewFileProvider()
+	solDir := t.TempDir()
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityState)
+	ctx = provider.WithSolutionDirectory(ctx, solDir)
+
+	stateData := state.NewData()
+	stateData.Parameters["key"] = "value"
+
+	// Save with a relative path -- should resolve to solDir
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_save",
+		"path":      "my-state.json",
+		"data":      stateData,
+	})
+	require.NoError(t, err)
+
+	// Verify file exists in solution directory
+	_, err = os.Stat(filepath.Join(solDir, "my-state.json"))
+	require.NoError(t, err)
+
+	// Load back via relative path
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"path":      "my-state.json",
+	})
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["success"].(bool))
+}
+
+func TestFileProvider_StateDispatch_NoSolutionDir_RejectsRelative(t *testing.T) {
+	p := NewFileProvider()
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityState)
+
+	// Relative path without solution directory should error
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"path":      "relative/path.json",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base directory is required")
 }
 
 func TestFileProvider_StateDryRun(t *testing.T) {

--- a/pkg/state/store.go
+++ b/pkg/state/store.go
@@ -9,15 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/oakwood-commons/scafctl/pkg/paths"
 )
 
 // LoadFromFile reads and unmarshals a StateData JSON file.
 // If the file does not exist, it returns an empty StateData.
-// The path is resolved relative to paths.StateDir() unless absolute.
-func LoadFromFile(path string) (*Data, error) {
-	absPath, err := ResolveStatePath(path)
+// Relative paths are resolved against baseDir.
+func LoadFromFile(path, baseDir string) (*Data, error) {
+	absPath, err := ResolveStatePath(path, baseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -58,9 +56,9 @@ func LoadFromFile(path string) (*Data, error) {
 }
 
 // SaveToFile marshals and writes StateData to a JSON file using atomic write.
-// The path is resolved relative to paths.StateDir() unless absolute.
-func SaveToFile(path string, sd *Data) error {
-	absPath, err := ResolveStatePath(path)
+// Relative paths are resolved against baseDir.
+func SaveToFile(path, baseDir string, sd *Data) error {
+	absPath, err := ResolveStatePath(path, baseDir)
 	if err != nil {
 		return err
 	}
@@ -108,9 +106,9 @@ func SaveToFile(path string, sd *Data) error {
 }
 
 // ResolveStatePath resolves a state file path. Absolute paths are used as-is.
-// Relative paths are resolved against paths.StateDir().
+// Relative paths are resolved against baseDir.
 // Path traversal (../) is rejected.
-func ResolveStatePath(path string) (string, error) {
+func ResolveStatePath(path, baseDir string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("state path is required")
 	}
@@ -127,5 +125,9 @@ func ResolveStatePath(path string) (string, error) {
 		return filepath.Clean(path), nil
 	}
 
-	return filepath.Join(paths.StateDir(), cleaned), nil
+	if baseDir == "" {
+		return "", fmt.Errorf("base directory is required for relative state path: %s", path)
+	}
+
+	return filepath.Join(baseDir, cleaned), nil
 }

--- a/pkg/state/store_test.go
+++ b/pkg/state/store_test.go
@@ -16,7 +16,7 @@ func TestLoadFromFile_NotFound(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "missing.json")
 
-	sd, err := LoadFromFile(path)
+	sd, err := LoadFromFile(path, "")
 	require.NoError(t, err)
 	assert.Equal(t, SchemaVersionCurrent, sd.SchemaVersion)
 	assert.Empty(t, sd.Parameters)
@@ -30,10 +30,10 @@ func TestLoadFromFile_RoundTrip(t *testing.T) {
 	sd.Parameters["env"] = "prod"
 	sd.Metadata.Solution = "test-sol"
 
-	err := SaveToFile(path, sd)
+	err := SaveToFile(path, "", sd)
 	require.NoError(t, err)
 
-	loaded, err := LoadFromFile(path)
+	loaded, err := LoadFromFile(path, "")
 	require.NoError(t, err)
 	assert.Equal(t, "test-sol", loaded.Metadata.Solution)
 	require.Contains(t, loaded.Parameters, "env")
@@ -45,7 +45,7 @@ func TestLoadFromFile_InvalidJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bad.json")
 	require.NoError(t, os.WriteFile(path, []byte("{invalid"), 0o600))
 
-	_, err := LoadFromFile(path)
+	_, err := LoadFromFile(path, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
 }
@@ -57,7 +57,7 @@ func TestLoadFromFile_NilMapsNormalized(t *testing.T) {
 	content := `{"schemaVersion":1,"metadata":{},"command":{},"parameters":null,"immutables":null,"fingerprints":null}`
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-	loaded, err := LoadFromFile(path)
+	loaded, err := LoadFromFile(path, "")
 	require.NoError(t, err)
 	assert.NotNil(t, loaded.Parameters)
 	assert.NotNil(t, loaded.Immutables)
@@ -72,7 +72,7 @@ func TestSaveToFile_CreatesDirectory(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "subdir", "nested", "state.json")
 
-	err := SaveToFile(path, NewData())
+	err := SaveToFile(path, "", NewData())
 	require.NoError(t, err)
 
 	_, statErr := os.Stat(path)
@@ -81,14 +81,14 @@ func TestSaveToFile_CreatesDirectory(t *testing.T) {
 
 func TestResolveStatePath_EmptyPath(t *testing.T) {
 	t.Parallel()
-	_, err := ResolveStatePath("")
+	_, err := ResolveStatePath("", "/tmp")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
 
 func TestResolveStatePath_Traversal(t *testing.T) {
 	t.Parallel()
-	_, err := ResolveStatePath("../../../etc/passwd")
+	_, err := ResolveStatePath("../../../etc/passwd", "/tmp")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "traversal")
 }
@@ -96,14 +96,29 @@ func TestResolveStatePath_Traversal(t *testing.T) {
 func TestResolveStatePath_Absolute(t *testing.T) {
 	t.Parallel()
 	abs := filepath.Join(t.TempDir(), "test-state.json")
-	result, err := ResolveStatePath(abs)
+	result, err := ResolveStatePath(abs, "/should-be-ignored")
 	require.NoError(t, err)
 	assert.Equal(t, abs, result)
 }
 
+func TestResolveStatePath_RelativeWithBaseDir(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	result, err := ResolveStatePath("my-state.json", baseDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(baseDir, "my-state.json"), result)
+}
+
+func TestResolveStatePath_RelativeWithEmptyBaseDir(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveStatePath("my-state.json", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base directory is required")
+}
+
 func TestLoadFromFile_EmptyPath(t *testing.T) {
 	t.Parallel()
-	_, err := LoadFromFile("")
+	_, err := LoadFromFile("", "/tmp")
 	require.Error(t, err)
 }
 
@@ -113,7 +128,7 @@ func TestLoadFromFile_UnsupportedSchemaVersion(t *testing.T) {
 	err := os.WriteFile(path, []byte(`{"schemaVersion":999,"metadata":{},"parameters":{}}`), 0o600)
 	require.NoError(t, err)
 
-	_, err = LoadFromFile(path)
+	_, err = LoadFromFile(path, "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnsupportedSchemaVersion)
 	assert.Contains(t, err.Error(), "999")
@@ -121,7 +136,7 @@ func TestLoadFromFile_UnsupportedSchemaVersion(t *testing.T) {
 
 func TestSaveToFile_EmptyPath(t *testing.T) {
 	t.Parallel()
-	err := SaveToFile("", NewData())
+	err := SaveToFile("", "/tmp", NewData())
 	require.Error(t, err)
 }
 
@@ -131,12 +146,12 @@ func BenchmarkLoadFromFile(b *testing.B) {
 	for i := range 100 {
 		sd.Parameters[filepath.Join("key", string(rune('a'+i%26)))] = "value"
 	}
-	require.NoError(b, SaveToFile(path, sd))
+	require.NoError(b, SaveToFile(path, "", sd))
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = LoadFromFile(path)
+		_, _ = LoadFromFile(path, "")
 	}
 }
 
@@ -149,6 +164,6 @@ func BenchmarkSaveToFile(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		path := filepath.Join(dir, "bench.json")
-		_ = SaveToFile(path, sd)
+		_ = SaveToFile(path, "", sd)
 	}
 }

--- a/tests/integration/solutions/state/dynamic-enabled/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-enabled/solution.yaml
@@ -58,14 +58,11 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, dynamic-enabled, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           # Pre-seed state with greeting = from-state
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -79,13 +76,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "use_state=false"]
         tags: [state, dynamic-enabled]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -99,13 +93,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "use_state=true"]
         tags: [state, dynamic-enabled]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"saved-hello"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "saved-hello"
@@ -119,10 +110,6 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "use_state=true"]
         tags: [state, dynamic-enabled]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "hello-default"
@@ -136,13 +123,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "use_state=true", "-r", "greeting=cli-hello"]
         tags: [state, dynamic-enabled]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic-enabled-state.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.greeting == "cli-hello"

--- a/tests/integration/solutions/state/dynamic-path/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-path/solution.yaml
@@ -58,10 +58,6 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "project=alpha"]
         tags: [state, dynamic-path, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "default-config"
@@ -75,13 +71,11 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "project=beta"]
         tags: [state, dynamic-path]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/dynamic"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-config"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic/beta.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "beta-config"
@@ -95,14 +89,12 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "project=gamma"]
         tags: [state, dynamic-path]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic"
+          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/dynamic"
           # Pre-seed for project "beta" only
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-only"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/dynamic/beta.json
+              > $SCAFCTL_SANDBOX_DIR/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.config_value == "default-config"

--- a/tests/integration/solutions/state/immutable-overwrite/solution.yaml
+++ b/tests/integration/solutions/state/immutable-overwrite/solution.yaml
@@ -49,10 +49,6 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, immutable, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
             message: "First write should succeed"
@@ -67,13 +63,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, immutable]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"value":{"value":"fixed-value","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
             message: "Same-value write should succeed silently"
@@ -88,13 +81,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, immutable, negative]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"value":{"value":"original-locked","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode != 0
             message: "Should fail when trying to overwrite immutable entry with different value"
@@ -111,13 +101,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, immutable]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
             message: "Should succeed when immutables section has no conflict"

--- a/tests/integration/solutions/state/immutable/solution.yaml
+++ b/tests/integration/solutions/state/immutable/solution.yaml
@@ -70,10 +70,6 @@ spec:
         description: First run with empty state resolves from static defaults
         extends: [_base]
         tags: [smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.locked_id == "generated-id-001"
             message: "Immutable resolver should fall through to static on first run"
@@ -86,13 +82,10 @@ spec:
       same-value-noop:
         description: Writing same value to immutable entry succeeds silently
         extends: [_base]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"immutables":{"locked_id":{"value":"generated-id-001","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "generated-id-001"
             message: "Resolver should produce its static value matching state"
@@ -103,13 +96,10 @@ spec:
       locked-value-from-state:
         description: Immutable value verified against state after resolve from saved params
         extends: [_base]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"immutables":{"locked_id":{"value":"locked-from-state","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "locked-from-state"
             message: "Immutable resolver should return value from saved parameters"
@@ -122,13 +112,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json", "-r", "locked_id=override-attempt"]
         tags: [state, immutable]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"immutables":{"locked_id":{"value":"locked-from-state","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode != 0
             message: "Should fail when parameter differs from locked immutable"
@@ -142,13 +129,10 @@ spec:
         description: Mutable resolver accepts parameter override
         extends: [_base]
         args: ["-o", "json", "-r", "mutable_value=updated-value"]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"mutable_value":"old-value"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.mutable_value == "updated-value"
             message: "Parameter should override mutable state value"
@@ -160,13 +144,10 @@ spec:
         description: Immutable value blocks change while mutable value updated in same run
         extends: [_base]
         args: ["-o", "json", "-r", "locked_id=permanent-id", "-r", "mutable_value=fresh-value"]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"permanent-id","mutable_value":"old-mutable"},"immutables":{"locked_id":{"value":"permanent-id","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "permanent-id"
             message: "Immutable value should remain locked (same value resolves)"

--- a/tests/integration/solutions/state/persistence/solution.yaml
+++ b/tests/integration/solutions/state/persistence/solution.yaml
@@ -61,10 +61,6 @@ spec:
         description: Verify resolvers work on first run (empty state) using static defaults
         extends: [_base]
         tags: [smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.greeting == "hello-world"
             message: "First run should fall through to static default"
@@ -74,13 +70,10 @@ spec:
       state-preseeded:
         description: Verify parameter provider reads from pre-seeded state parameters
         extends: [_base]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-persistence","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"hello-from-state","counter":"99"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.greeting == "hello-from-state"
             message: "Parameter provider should read pre-seeded value from state"

--- a/tests/integration/solutions/state/render-solution/solution.yaml
+++ b/tests/integration/solutions/state/render-solution/solution.yaml
@@ -66,10 +66,6 @@ spec:
         command: [render, solution]
         args: ["-o", "json"]
         tags: [state, render, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("default-target")
@@ -85,13 +81,10 @@ spec:
         command: [render, solution]
         args: ["-o", "json"]
         tags: [state, render]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"prod-cluster","app_version":"3.2.1"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/render-state.json
+              > $SCAFCTL_SANDBOX_DIR/render-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("prod-cluster")
@@ -107,10 +100,6 @@ spec:
         command: [render, solution]
         args: ["-o", "json"]
         tags: [state, render, readonly]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
 
@@ -122,13 +111,10 @@ spec:
         command: [render, solution]
         args: ["-o", "json", "-r", "target=edge"]
         tags: [state, render]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"cached-target"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/render-state.json
+              > $SCAFCTL_SANDBOX_DIR/render-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.actions["deploy"].inputs["command"].contains("edge")

--- a/tests/integration/solutions/state/render/solution.yaml
+++ b/tests/integration/solutions/state/render/solution.yaml
@@ -55,10 +55,6 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, render]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "fallback-default"
@@ -74,13 +70,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, render]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"cached-from-state"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "cached-from-state"
@@ -96,13 +89,10 @@ spec:
         command: [run, resolver]
         args: ["-o", "json"]
         tags: [state, render, immutable]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"immutable-cached"},"immutables":{"cached_name":{"value":"immutable-cached","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.cached_name == "immutable-cached"

--- a/tests/integration/solutions/state/run-action/solution.yaml
+++ b/tests/integration/solutions/state/run-action/solution.yaml
@@ -82,10 +82,6 @@ spec:
         command: [run, action]
         args: ["lint", "-o", "json"]
         tags: [state, run-action, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -100,13 +96,10 @@ spec:
         command: [run, action]
         args: ["build", "-o", "json"]
         tags: [state, run-action]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production","version":"2.5.0"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-action-state.json
+              > $SCAFCTL_SANDBOX_DIR/run-action-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -124,13 +117,10 @@ spec:
         command: [run, action]
         args: ["deploy", "-o", "json", "-r", "env=canary"]
         tags: [state, run-action]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-action-state.json
+              > $SCAFCTL_SANDBOX_DIR/run-action-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -145,10 +135,6 @@ spec:
         command: [run, action]
         args: ["deploy", "-o", "json"]
         tags: [state, run-action]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"

--- a/tests/integration/solutions/state/run-solution/solution.yaml
+++ b/tests/integration/solutions/state/run-solution/solution.yaml
@@ -65,10 +65,6 @@ spec:
         command: [run, solution]
         args: ["-o", "json"]
         tags: [state, run-solution, smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -86,13 +82,10 @@ spec:
         command: [run, solution]
         args: ["-o", "json"]
         tags: [state, run-solution]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production","build_id":"build-042"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-solution-state.json
+              > $SCAFCTL_SANDBOX_DIR/run-solution-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -109,13 +102,10 @@ spec:
         command: [run, solution]
         args: ["-o", "json", "-r", "target=canary"]
         tags: [state, run-solution]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/run-solution-state.json
+              > $SCAFCTL_SANDBOX_DIR/run-solution-state.json
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"
@@ -130,10 +120,6 @@ spec:
         command: [run, solution]
         args: ["-o", "json", "-r", "target=dev"]
         tags: [state, run-solution, command-info]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __exitCode == 0
           - expression: __output.status == "succeeded"

--- a/tests/integration/solutions/state/save-verify/solution.yaml
+++ b/tests/integration/solutions/state/save-verify/solution.yaml
@@ -76,10 +76,6 @@ spec:
         description: First run resolves from defaults and persists to state
         extends: [_base]
         tags: [smoke]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.name == "default-name"
             message: "First run should use static default"
@@ -94,13 +90,10 @@ spec:
       second-run-from-state:
         description: Second run reads values from state parameters (simulated via pre-seed)
         extends: [_base]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"saved-name","count":"42","enabled_flag":"false"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.name == "saved-name"
             message: "Parameter provider should return persisted string value"
@@ -116,10 +109,6 @@ spec:
         description: Parameter value overrides static and is what gets saved
         extends: [_base]
         args: ["-o", "json", "-r", "name=custom-name"]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
-        init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
         assertions:
           - expression: __output.name == "custom-name"
             message: "Parameter should override static default"
@@ -133,13 +122,10 @@ spec:
         description: Parameter overrides existing state value on next run
         extends: [_base]
         args: ["-o", "json", "-r", "name=new-name"]
-        env:
-          XDG_STATE_HOME: "${SCAFCTL_SANDBOX_DIR}/state-home"
         init:
-          - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state-home/scafctl"
           - command: >-
               printf '{"schemaVersion":1,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"old-name"},"immutables":{},"fingerprints":{}}'
-              > $SCAFCTL_SANDBOX_DIR/state-home/scafctl/state.json
+              > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.name == "new-name"
             message: "Parameter should win over stale state value"


### PR DESCRIPTION
- resolve relative state paths against solution directory in file provider (CLI/MCP commands still resolve against XDG state dir)
- add baseDir parameter to ResolveStatePath, LoadFromFile, SaveToFile
- set solution directory in render command's loadStateIntoContext
- add fingerprint.scope field ("all" default, "files" skips input hashing) for actions with volatile/non-deterministic inputs
- skip Phase 2 input hash check and omit stored inputs hash when scope is "files"
- add lint rules: fingerprint-without-sources (warning), invalid-fingerprint-scope (error)
- update 10 functional test fixtures to use solution-relative paths
- update design docs and tutorial for new path resolution semantics

BREAKING CHANGE: ResolveStatePath, LoadFromFile, and SaveToFile now require a baseDir parameter. Callers must pass the base directory for relative path resolution (use paths.StateDir() for CLI/MCP, solution directory for file provider, or "" for tests with absolute paths).

Closes #504
Closes #508