### PR TITLE
feat(fingerprint): add fingerprint observability to dry-run and state commands

### DIFF
--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -399,7 +399,7 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	// override) so resolver paths resolve relative to the solution file.
 	// Pass actionCtx so WhatIf generation sees CLI overrides (output-dir, etc.).
 	if o.DryRun {
-		return o.executeDryRun(ctx, actionCtx, sol, reg, params, workflow)
+		return o.executeDryRun(ctx, actionCtx, sol, reg, params, workflow, stateData, originalCwd)
 	}
 
 	// Execute resolvers
@@ -479,13 +479,13 @@ func (o *ActionOptions) exitWithCode(ctx context.Context, err error, code int) e
 
 // executeDryRun delegates to SolutionOptions.executeDryRun which runs
 // resolvers (side-effect-free) and produces a structured WhatIf report.
-func (o *ActionOptions) executeDryRun(resolverCtx, actionCtx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any, workflow *action.Workflow) error {
+func (o *ActionOptions) executeDryRun(resolverCtx, actionCtx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any, workflow *action.Workflow, stateData *state.Data, cwd string) error {
 	s := &SolutionOptions{
 		sharedResolverOptions: o.sharedResolverOptions,
 		Verbose:               o.Verbose,
 		ShowExecution:         o.ShowExecution,
 	}
-	return s.executeDryRun(resolverCtx, actionCtx, sol, reg, params, workflow)
+	return s.executeDryRun(resolverCtx, actionCtx, sol, reg, params, workflow, stateData, cwd)
 }
 
 // resolveOutputDir validates and creates the output directory.

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -513,7 +513,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// action-phase WhatIf report uses actionCtx which has the working-dir
 	// override for accurate output-dir resolution.
 	if o.DryRun {
-		return o.executeDryRun(ctx, actionCtx, sol, reg, params, workflow)
+		return o.executeDryRun(ctx, actionCtx, sol, reg, params, workflow, stateData, originalCwd)
 	}
 
 	// Execute resolvers if present
@@ -599,7 +599,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 // override) so resolver paths resolve relative to the solution file.
 // actionCtx carries CLI overrides (output-dir, on-conflict, backup, working-dir)
 // so that dryrun.Generate / WhatIf sees the same context as real execution.
-func (o *SolutionOptions) executeDryRun(resolverCtx, actionCtx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any, workflow *action.Workflow) error {
+func (o *SolutionOptions) executeDryRun(resolverCtx, actionCtx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any, workflow *action.Workflow, stateData *state.Data, cwd string) error {
 	// Execute resolvers via the shared method so that IOStreams, progress
 	// callbacks, and CLI-flag-driven config are wired identically to the
 	// live execution path. Resolver providers are side-effect-free, so we
@@ -616,6 +616,8 @@ func (o *SolutionOptions) executeDryRun(resolverCtx, actionCtx context.Context, 
 		ResolverData: resolverData,
 		Verbose:      o.Verbose,
 		Workflow:     workflow,
+		StateData:    stateData,
+		Cwd:          cwd,
 	})
 	if err != nil {
 		return o.exitWithCode(resolverCtx, fmt.Errorf("dry-run failed: %w", err), exitcode.GeneralError)
@@ -692,6 +694,9 @@ func (o *SolutionOptions) writeDryRunTable(ctx context.Context, report *dryrun.R
 				for k, v := range act.DeferredInputs {
 					w.Plainlnf("    (deferred: %s = %s)", k, v)
 				}
+			}
+			if act.FingerprintStatus != "" {
+				w.Plainlnf("    (fingerprint: %s \u2014 %s)", act.FingerprintStatus, act.FingerprintReason)
 			}
 			if len(act.MaterializedInputs) > 0 {
 				w.Plainlnf("    Inputs:")

--- a/pkg/cmd/scafctl/run/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/run/solution_coverage_test.go
@@ -610,6 +610,51 @@ func TestSolutionOptions_writeDryRunTable(t *testing.T) {
 		assert.Contains(t, output, "build.output")
 		assert.Contains(t, output, "deferred")
 	})
+
+	t.Run("with fingerprint status", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		streams := &terminal.IOStreams{Out: &buf, ErrOut: &buf}
+		cliParams := settings.NewCliParams()
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(context.Background(), w)
+
+		opts := &SolutionOptions{}
+		report := &dryrun.Report{
+			Solution:    "fp-test",
+			HasWorkflow: true,
+			ActionPlan: []dryrun.WhatIfAction{
+				{
+					Name:              "build",
+					Phase:             0,
+					WhatIf:            "Would compile",
+					FingerprintStatus: "up-to-date",
+					FingerprintReason: "up-to-date",
+				},
+				{
+					Name:              "deploy",
+					Phase:             1,
+					WhatIf:            "Would deploy",
+					FingerprintStatus: "stale",
+					FingerprintReason: "sources changed",
+				},
+				{
+					Name:   "cleanup",
+					Phase:  1,
+					WhatIf: "Would cleanup",
+				},
+			},
+		}
+
+		err := opts.writeDryRunTable(ctx, report)
+		assert.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "fingerprint: up-to-date")
+		assert.Contains(t, output, "fingerprint: stale")
+		assert.Contains(t, output, "sources changed")
+		// cleanup has no fingerprint status — should not show fingerprint line
+		assert.NotContains(t, output, "fingerprint: )")
+	})
 }
 
 // Benchmarks

--- a/pkg/cmd/scafctl/state/clear.go
+++ b/pkg/cmd/scafctl/state/clear.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/fingerprint"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
@@ -16,58 +17,92 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// clearOptions holds the options for the clear command.
+type clearOptions struct {
+	Path             string
+	Action           string
+	FingerprintsOnly bool
+}
+
 // CommandClear creates the 'state clear' command.
 func CommandClear(_ *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
-	var path string
+	opts := &clearOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "clear",
-		Short: "Clear all state values",
-		Long:  "Remove all stored parameters, immutables, and fingerprints from a state file, preserving metadata.",
+		Short: "Clear state values",
+		Long:  "Remove stored parameters, immutables, and fingerprints from a state file, preserving metadata.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			w := writer.FromContext(ctx)
-			if w == nil {
-				return fmt.Errorf("writer not initialized in context")
-			}
-
-			sd, err := state.LoadFromFile(path, paths.StateDir())
-			if err != nil {
-				err := fmt.Errorf("failed to load state: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			// Verify the file actually exists (LoadFromFile returns empty for non-existent).
-			resolved, resolveErr := state.ResolveStatePath(path, paths.StateDir())
-			if resolveErr != nil {
-				w.Errorf("%v", resolveErr)
-				return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
-			}
-			if _, statErr := os.Stat(resolved); os.IsNotExist(statErr) {
-				err := fmt.Errorf("state file not found: %s", resolved)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.FileNotFound)
-			}
-
-			count := len(sd.Parameters) + len(sd.Immutables) + len(sd.Fingerprints)
-			sd.Parameters = make(map[string]any)
-			sd.Immutables = make(map[string]*state.ImmutableEntry)
-			sd.Fingerprints = make(map[string]*state.FingerprintEntry)
-
-			if err := state.SaveToFile(path, paths.StateDir(), sd); err != nil {
-				err := fmt.Errorf("failed to save state: %w", err)
-				w.Errorf("%v", err)
-				return exitcode.WithCode(err, exitcode.GeneralError)
-			}
-
-			w.Successf("Cleared %d entries\n", count)
-			return nil
+			return runClear(cmd, opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&path, "path", "", "State file path (relative to state directory)")
+	cmd.Flags().StringVar(&opts.Path, "path", "", "State file path (relative to state directory or absolute)")
+	cmd.Flags().StringVar(&opts.Action, "action", "", "Clear fingerprints for a specific action only")
+	cmd.Flags().BoolVar(&opts.FingerprintsOnly, "fingerprints-only", false, "Clear only fingerprint entries, keep parameters and immutables")
 	_ = cmd.MarkFlagRequired("path")
+	cmd.MarkFlagsMutuallyExclusive("action", "fingerprints-only")
 
 	return cmd
+}
+
+func runClear(cmd *cobra.Command, opts *clearOptions) error {
+	ctx := cmd.Context()
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	// Resolve and verify the file exists.
+	resolved, resolveErr := state.ResolveStatePath(opts.Path, paths.StateDir())
+	if resolveErr != nil {
+		w.Errorf("%v", resolveErr)
+		return exitcode.WithCode(resolveErr, exitcode.InvalidInput)
+	}
+	if _, statErr := os.Stat(resolved); os.IsNotExist(statErr) {
+		err := fmt.Errorf("state file not found: %s", resolved)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	sd, err := state.LoadFromFile(opts.Path, paths.StateDir())
+	if err != nil {
+		err := fmt.Errorf("failed to load state: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	count := clearEntries(sd, opts)
+
+	if err := state.SaveToFile(opts.Path, paths.StateDir(), sd); err != nil {
+		err := fmt.Errorf("failed to save state: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	w.Successf("Cleared %d entries\n", count)
+	return nil
+}
+
+// clearEntries removes entries from state data based on the clear options.
+// Returns the number of entries removed.
+func clearEntries(sd *state.Data, opts *clearOptions) int {
+	// --action: clear fingerprints for a specific action only
+	if opts.Action != "" {
+		return fingerprint.ClearAction(sd, opts.Action)
+	}
+
+	// --fingerprints-only: clear all fingerprints, keep parameters and immutables
+	if opts.FingerprintsOnly {
+		count := len(sd.Fingerprints)
+		sd.Fingerprints = make(map[string]*state.FingerprintEntry)
+		return count
+	}
+
+	// Default: clear everything
+	count := len(sd.Parameters) + len(sd.Immutables) + len(sd.Fingerprints)
+	sd.Parameters = make(map[string]any)
+	sd.Immutables = make(map[string]*state.ImmutableEntry)
+	sd.Fingerprints = make(map[string]*state.FingerprintEntry)
+	return count
 }

--- a/pkg/cmd/scafctl/state/fingerprints.go
+++ b/pkg/cmd/scafctl/state/fingerprints.go
@@ -1,0 +1,151 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/fingerprint"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/state"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// fingerprintsOptions holds the options for the fingerprints command.
+type fingerprintsOptions struct {
+	flags.KvxOutputFlags
+	Path   string
+	Action string
+}
+
+// CommandFingerprints creates the 'state fingerprints' command.
+func CommandFingerprints(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	opts := &fingerprintsOptions{
+		KvxOutputFlags: flags.KvxOutputFlags{AppName: cliParams.BinaryName},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "fingerprints",
+		Short: "List fingerprint entries grouped by action",
+		Long:  "Show fingerprint cache entries from a state file, grouped by action name.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFingerprints(cmd, opts, cliParams, ioStreams)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Path, "path", "", "State file path (relative to state directory or absolute)")
+	cmd.Flags().StringVar(&opts.Action, "action", "", "Filter to a specific action name")
+	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}
+
+func runFingerprints(cmd *cobra.Command, opts *fingerprintsOptions, cliParams *settings.Run, ioStreams *terminal.IOStreams) error {
+	ctx := cmd.Context()
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return fmt.Errorf("writer not initialized in context")
+	}
+
+	resolved, err := state.ResolveStatePath(opts.Path, paths.StateDir())
+	if err != nil {
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.InvalidInput)
+	}
+	if _, statErr := os.Stat(resolved); os.IsNotExist(statErr) {
+		err := fmt.Errorf("state file not found: %s", resolved)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	sd, err := state.LoadFromFile(opts.Path, paths.StateDir())
+	if err != nil {
+		err := fmt.Errorf("failed to load state: %w", err)
+		w.Errorf("%v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	actions := fingerprint.ListActions(sd)
+	if opts.Action != "" {
+		found := false
+		for _, a := range actions {
+			if a == opts.Action {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if !cliParams.IsQuiet {
+				w.WarnStderrf("No fingerprint entries found for action %q", opts.Action)
+			}
+			return nil
+		}
+		actions = []string{opts.Action}
+	}
+
+	if len(actions) == 0 {
+		if !cliParams.IsQuiet {
+			w.WarnStderr("No fingerprint entries found")
+		}
+		return nil
+	}
+
+	data := buildFingerprintRows(sd, actions)
+	kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
+	return kvxOpts.Write(data)
+}
+
+// buildFingerprintRows converts fingerprint state into a flat list of rows
+// for kvx output, sorted by action name then type.
+func buildFingerprintRows(sd *state.Data, actions []string) []map[string]any {
+	var data []map[string]any
+	for _, name := range actions {
+		keys := fingerprintKeysForAction(sd, name)
+		for _, key := range keys {
+			entry := sd.Fingerprints[key]
+			_, typ := splitFingerprintKey(key)
+			row := map[string]any{
+				"action": name,
+				"type":   typ,
+				"hash":   entry.Value,
+			}
+			if !entry.UpdatedAt.IsZero() {
+				row["updatedAt"] = entry.UpdatedAt.Format("2006-01-02T15:04:05Z")
+			}
+			data = append(data, row)
+		}
+	}
+	return data
+}
+
+// fingerprintKeysForAction returns all fingerprint keys for a given action, sorted.
+func fingerprintKeysForAction(sd *state.Data, actionName string) []string {
+	var keys []string
+	for key := range sd.Fingerprints {
+		if name, ok := fingerprint.ParseActionName(key); ok && name == actionName {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// splitFingerprintKey extracts the type suffix (sources, generates, inputs) from a
+// fingerprint key. Returns the action name and type.
+func splitFingerprintKey(key string) (string, string) {
+	name, typ, ok := fingerprint.SplitKey(key)
+	if !ok {
+		return "", ""
+	}
+	return name, typ
+}

--- a/pkg/cmd/scafctl/state/state.go
+++ b/pkg/cmd/scafctl/state/state.go
@@ -41,6 +41,7 @@ func CommandState(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 	cmd.AddCommand(CommandSet(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandDelete(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandClear(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandFingerprints(cliParams, ioStreams, cmdPath))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/state/state_test.go
+++ b/pkg/cmd/scafctl/state/state_test.go
@@ -53,6 +53,7 @@ func TestCommandState_HasSubcommands(t *testing.T) {
 	assert.Contains(t, names, "set")
 	assert.Contains(t, names, "delete")
 	assert.Contains(t, names, "clear")
+	assert.Contains(t, names, "fingerprints")
 }
 
 // ── List tests ────────────────────────────────────────────────────────────────
@@ -353,4 +354,253 @@ func TestCommandClear_EmptyState(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Cleared 0 entries")
+}
+
+// ── CommandFingerprints tests ────────────────────────────────────────────────
+
+func seedFingerprintState(t *testing.T, path string) {
+	t.Helper()
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc123", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:build:generates"] = &state.FingerprintEntry{Value: "def456", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:deploy:sources"] = &state.FingerprintEntry{Value: "ghi789", UpdatedAt: now}
+	require.NoError(t, state.SaveToFile(path, "", sd))
+}
+
+func TestCommandFingerprints_WithEntries(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fp.json")
+	seedFingerprintState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandFingerprints(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "build")
+	assert.Contains(t, buf.String(), "deploy")
+	assert.Contains(t, buf.String(), "sources")
+}
+
+func TestCommandFingerprints_FilterAction(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fp.json")
+	seedFingerprintState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandFingerprints(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--action", "build", "-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "build")
+	assert.NotContains(t, buf.String(), "deploy")
+}
+
+func TestCommandFingerprints_NoEntries(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "empty.json")
+	require.NoError(t, state.SaveToFile(path, "", state.NewData()))
+
+	ctx, buf := newTestContext(t)
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandFingerprints(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No fingerprint entries found")
+}
+
+func TestCommandFingerprints_MissingPath(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{Out: buf, ErrOut: buf}
+	cmd := CommandFingerprints(cliParams, ios, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag(s) \"path\" not set")
+}
+
+// ── CommandClear selective tests ─────────────────────────────────────────────
+
+func TestCommandClear_FingerprintsOnly(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fp.json")
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Parameters["env"] = "prod"
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc", UpdatedAt: now}
+	require.NoError(t, state.SaveToFile(path, "", sd))
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--fingerprints-only"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Cleared 1 entries")
+
+	reloaded, loadErr := state.LoadFromFile(path, "")
+	require.NoError(t, loadErr)
+	assert.Len(t, reloaded.Parameters, 1)
+	assert.Empty(t, reloaded.Fingerprints)
+}
+
+func TestCommandClear_Action(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fp.json")
+	seedFingerprintState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--action", "build"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Cleared 2 entries")
+
+	reloaded, loadErr := state.LoadFromFile(path, "")
+	require.NoError(t, loadErr)
+	assert.Len(t, reloaded.Fingerprints, 1)
+	assert.Contains(t, reloaded.Fingerprints, "__fingerprint:deploy:sources")
+}
+
+func TestCommandClear_ActionAndFingerprintsOnlyMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fp.json")
+	seedFingerprintState(t, path)
+
+	ctx, buf := newTestContext(t)
+	cmd := CommandClear(&settings.Run{BinaryName: "testcli"}, &terminal.IOStreams{Out: buf, ErrOut: buf}, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--path", path, "--action", "build", "--fingerprints-only"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "if any flags in the group [action fingerprints-only] are set none of the others can be")
+}
+
+// ── clearEntries unit tests ──────────────────────────────────────────────────
+
+func TestClearEntries_Default(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Parameters["env"] = "prod"
+	sd.Immutables["key"] = &state.ImmutableEntry{Value: "val", CreatedAt: now}
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc", UpdatedAt: now}
+
+	count := clearEntries(sd, &clearOptions{})
+	assert.Equal(t, 3, count)
+	assert.Empty(t, sd.Parameters)
+	assert.Empty(t, sd.Immutables)
+	assert.Empty(t, sd.Fingerprints)
+}
+
+func TestClearEntries_FingerprintsOnly(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Parameters["env"] = "prod"
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:deploy:sources"] = &state.FingerprintEntry{Value: "def", UpdatedAt: now}
+
+	count := clearEntries(sd, &clearOptions{FingerprintsOnly: true})
+	assert.Equal(t, 2, count)
+	assert.Len(t, sd.Parameters, 1)
+	assert.Empty(t, sd.Fingerprints)
+}
+
+func TestClearEntries_Action(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:build:generates"] = &state.FingerprintEntry{Value: "def", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:deploy:sources"] = &state.FingerprintEntry{Value: "ghi", UpdatedAt: now}
+
+	count := clearEntries(sd, &clearOptions{Action: "build"})
+	assert.Equal(t, 2, count)
+	assert.Len(t, sd.Fingerprints, 1)
+	assert.Contains(t, sd.Fingerprints, "__fingerprint:deploy:sources")
+}
+
+// ── buildFingerprintRows unit tests ──────────────────────────────────────────
+
+func TestBuildFingerprintRows(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	now := time.Now().UTC()
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc123", UpdatedAt: now}
+	sd.Fingerprints["__fingerprint:build:generates"] = &state.FingerprintEntry{Value: "def456", UpdatedAt: now}
+
+	rows := buildFingerprintRows(sd, []string{"build"})
+	require.Len(t, rows, 2)
+	assert.Equal(t, "build", rows[0]["action"])
+	assert.Equal(t, "generates", rows[0]["type"]) // sorted by key, generates < sources
+	assert.Equal(t, "def456", rows[0]["hash"])
+	assert.Equal(t, "build", rows[1]["action"])
+	assert.Equal(t, "sources", rows[1]["type"])
+	assert.Equal(t, "abc123", rows[1]["hash"])
+	_, hasUpdatedAt := rows[0]["updatedAt"]
+	assert.True(t, hasUpdatedAt, "non-zero timestamp should include updatedAt")
+}
+
+func TestBuildFingerprintRows_ZeroTimestamp(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	sd.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc123"}
+
+	rows := buildFingerprintRows(sd, []string{"build"})
+	require.Len(t, rows, 1)
+	assert.Equal(t, "abc123", rows[0]["hash"])
+	_, hasUpdatedAt := rows[0]["updatedAt"]
+	assert.False(t, hasUpdatedAt, "zero timestamp should omit updatedAt")
+}
+
+func TestBuildFingerprintRows_Empty(t *testing.T) {
+	t.Parallel()
+	sd := state.NewData()
+	rows := buildFingerprintRows(sd, nil)
+	assert.Nil(t, rows)
+}
+
+func TestSplitFingerprintKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key      string
+		wantName string
+		wantType string
+	}{
+		{"__fingerprint:build:sources", "build", "sources"},
+		{"__fingerprint:deploy:generates", "deploy", "generates"},
+		{"__fingerprint:test:inputs", "test", "inputs"},
+		{"not-a-key", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			name, typ := splitFingerprintKey(tt.key)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
 }

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -16,8 +16,10 @@ import (
 	"sort"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/fingerprint"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 )
 
 // Report is the full structured WhatIf dry-run output.
@@ -50,6 +52,8 @@ type WhatIfAction struct {
 	When               string            `json:"when,omitempty" yaml:"when,omitempty" doc:"Conditional expression" maxLength:"2048" example:"_.enabled == true"`
 	MaterializedInputs map[string]any    `json:"materializedInputs,omitempty" yaml:"materializedInputs,omitempty" doc:"Inputs resolved at plan time (only with --verbose)"`
 	DeferredInputs     map[string]string `json:"deferredInputs,omitempty" yaml:"deferredInputs,omitempty" doc:"Inputs deferred until runtime"`
+	FingerprintStatus  string            `json:"fingerprintStatus,omitempty" yaml:"fingerprintStatus,omitempty" doc:"Fingerprint cache status: up-to-date, stale, or error" maxLength:"32" example:"up-to-date"`
+	FingerprintReason  string            `json:"fingerprintReason,omitempty" yaml:"fingerprintReason,omitempty" doc:"Reason for fingerprint status" maxLength:"64" example:"sources changed"`
 }
 
 // Options controls the dry-run generation.
@@ -63,6 +67,12 @@ type Options struct {
 	ResolverData map[string]any `json:"-" yaml:"-"`
 	// Verbose includes MaterializedInputs in the report when true.
 	Verbose bool `json:"-" yaml:"-"`
+	// StateData is the loaded state for fingerprint up-to-date checks.
+	// When set, actions with sources are checked against stored fingerprints
+	// to report whether they would be skipped as up-to-date.
+	StateData *state.Data `json:"-" yaml:"-"`
+	// Cwd is the working directory for glob expansion during fingerprint checks.
+	Cwd string `json:"-" yaml:"-"`
 	// Workflow overrides the solution's workflow for report generation.
 	// When set, this workflow is used instead of sol.Spec.Workflow,
 	// allowing callers to pass a filtered workflow without mutating the solution.
@@ -172,6 +182,13 @@ func Generate(ctx context.Context, sol *solution.Solution, opts Options) (*Repor
 				// Generate WhatIf message from the provider
 				entry.WhatIf = describeWhatIf(ctx, reg, ea.Provider, ea.MaterializedInputs)
 
+				// Check fingerprint status for actions with sources
+				if len(ea.Sources) > 0 && opts.StateData != nil && opts.Cwd != "" {
+					entry.FingerprintStatus, entry.FingerprintReason = checkFingerprintStatus(
+						ctx, ea, opts.StateData, opts.Cwd,
+					)
+				}
+
 				// Only include MaterializedInputs in verbose mode
 				if opts.Verbose && len(ea.MaterializedInputs) > 0 {
 					entry.MaterializedInputs = ea.MaterializedInputs
@@ -212,4 +229,18 @@ func versionString(v fmt.Stringer) string {
 		return ""
 	}
 	return v.String()
+}
+
+// checkFingerprintStatus checks the fingerprint cache status for an action
+// with sources. Returns a human-readable status and reason.
+func checkFingerprintStatus(ctx context.Context, ea *action.ExpandedAction, sd *state.Data, cwd string) (string, string) {
+	checker := fingerprint.NewChecker(sd)
+	result, err := checker.CheckFiles(ctx, ea.ExpandedName, ea.Sources, ea.Generates, cwd)
+	if err != nil {
+		return "error", err.Error()
+	}
+	if !result.Stale {
+		return "up-to-date", string(result.Reason)
+	}
+	return "stale", string(result.Reason)
 }

--- a/pkg/dryrun/dryrun_test.go
+++ b/pkg/dryrun/dryrun_test.go
@@ -6,6 +6,8 @@ package dryrun
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -14,9 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/fingerprint"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 )
 
 // helpers
@@ -477,4 +481,130 @@ func TestGenerate_NilWorkflowOverrideFallsBack(t *testing.T) {
 	assert.True(t, report.HasWorkflow)
 	require.Len(t, report.ActionPlan, 1)
 	assert.Equal(t, "deploy", report.ActionPlan[0].Name)
+}
+
+// fingerprint status tests
+
+func TestGenerate_FingerprintStatus_FirstRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(srcFile, []byte("package main"), 0o600))
+
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"build": {
+				Provider: "shell",
+				Sources:  []string{"main.go"},
+			},
+		},
+	}
+
+	sd := state.NewData()
+	report, err := Generate(context.Background(), sol, Options{
+		StateData: sd,
+		Cwd:       tmpDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Equal(t, "stale", report.ActionPlan[0].FingerprintStatus)
+	assert.Equal(t, "first run", report.ActionPlan[0].FingerprintReason)
+}
+
+func TestGenerate_FingerprintStatus_UpToDate(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(srcFile, []byte("package main"), 0o600))
+
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"build": {
+				Provider: "shell",
+				Sources:  []string{"main.go"},
+			},
+		},
+	}
+
+	// Pre-populate state with matching hash
+	sd := state.NewData()
+	hash, err := fingerprint.HashFiles(tmpDir, []string{"main.go"})
+	require.NoError(t, err)
+	fingerprint.SaveHashes(sd, "build", hash, "", "")
+
+	report, err := Generate(context.Background(), sol, Options{
+		StateData: sd,
+		Cwd:       tmpDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Equal(t, "up-to-date", report.ActionPlan[0].FingerprintStatus)
+	assert.Equal(t, "up-to-date", report.ActionPlan[0].FingerprintReason)
+}
+
+func TestGenerate_FingerprintStatus_SourcesChanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(srcFile, []byte("package main"), 0o600))
+
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"build": {
+				Provider: "shell",
+				Sources:  []string{"main.go"},
+			},
+		},
+	}
+
+	// Pre-populate state with a different hash
+	sd := state.NewData()
+	fingerprint.SaveHashes(sd, "build", "sha256:old-hash", "", "")
+
+	report, err := Generate(context.Background(), sol, Options{
+		StateData: sd,
+		Cwd:       tmpDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Equal(t, "stale", report.ActionPlan[0].FingerprintStatus)
+	assert.Equal(t, "sources changed", report.ActionPlan[0].FingerprintReason)
+}
+
+func TestGenerate_FingerprintStatus_NoStateData(t *testing.T) {
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"build": {
+				Provider: "shell",
+				Sources:  []string{"main.go"},
+			},
+		},
+	}
+
+	// No StateData -- fingerprint status should be empty
+	report, err := Generate(context.Background(), sol, Options{})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Empty(t, report.ActionPlan[0].FingerprintStatus)
+	assert.Empty(t, report.ActionPlan[0].FingerprintReason)
+}
+
+func TestGenerate_FingerprintStatus_NoSources(t *testing.T) {
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"deploy": {Provider: "shell"},
+		},
+	}
+
+	sd := state.NewData()
+	report, err := Generate(context.Background(), sol, Options{
+		StateData: sd,
+		Cwd:       "/tmp",
+	})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Empty(t, report.ActionPlan[0].FingerprintStatus)
+	assert.Empty(t, report.ActionPlan[0].FingerprintReason)
 }

--- a/pkg/fingerprint/state.go
+++ b/pkg/fingerprint/state.go
@@ -5,6 +5,8 @@ package fingerprint
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/state"
@@ -99,4 +101,73 @@ func SaveHashes(data *state.Data, actionName, sourcesHash, generatesHash, inputs
 	} else {
 		delete(data.Fingerprints, inputsKey(actionName))
 	}
+}
+
+// KeyPrefix is the shared prefix for all fingerprint state keys.
+const KeyPrefix = "__fingerprint:"
+
+// ParseActionName extracts the action name from a fingerprint state key.
+// Returns the action name and true if the key is a valid fingerprint key,
+// or empty string and false otherwise.
+//
+// Keys have format: __fingerprint:<actionName>:<type>
+func ParseActionName(key string) (string, bool) {
+	if !strings.HasPrefix(key, KeyPrefix) {
+		return "", false
+	}
+	rest := key[len(KeyPrefix):]
+	lastColon := strings.LastIndex(rest, ":")
+	if lastColon <= 0 || lastColon == len(rest)-1 {
+		return "", false
+	}
+	return rest[:lastColon], true
+}
+
+// SplitKey parses a fingerprint state key into the action name and type
+// (sources, generates, or inputs). Returns empty strings and false if the
+// key is not a valid fingerprint key.
+func SplitKey(key string) (name, typ string, ok bool) {
+	name, ok = ParseActionName(key)
+	if !ok {
+		return "", "", false
+	}
+	// Key format: __fingerprint:<name>:<type>
+	typ = key[len(KeyPrefix)+len(name)+1:]
+	return name, typ, true
+}
+
+// ClearAction removes all fingerprint entries (sources, generates, inputs) for the
+// given action name from state data. Returns the number of entries removed.
+func ClearAction(data *state.Data, actionName string) int {
+	if data == nil || data.Fingerprints == nil {
+		return 0
+	}
+	removed := 0
+	for _, key := range []string{sourcesKey(actionName), generatesKey(actionName), inputsKey(actionName)} {
+		if _, ok := data.Fingerprints[key]; ok {
+			delete(data.Fingerprints, key)
+			removed++
+		}
+	}
+	return removed
+}
+
+// ListActions returns a deduplicated, sorted list of action names that have
+// fingerprint entries in the given state data.
+func ListActions(data *state.Data) []string {
+	if data == nil || len(data.Fingerprints) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for key := range data.Fingerprints {
+		if name, ok := ParseActionName(key); ok {
+			seen[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/pkg/fingerprint/state_test.go
+++ b/pkg/fingerprint/state_test.go
@@ -136,3 +136,117 @@ func TestLoadInputsHash(t *testing.T) {
 		assert.Equal(t, "inp789", LoadInputsHash(data, "build"))
 	})
 }
+
+func TestParseActionName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key      string
+		wantName string
+		wantOK   bool
+	}{
+		{"__fingerprint:build:sources", "build", true},
+		{"__fingerprint:deploy:generates", "deploy", true},
+		{"__fingerprint:my-action:inputs", "my-action", true},
+		{"__fingerprint:deploy[0]:sources", "deploy[0]", true},
+		{"not-a-fingerprint-key", "", false},
+		{"__fingerprint:", "", false},
+		{"__fingerprint:nocolon", "", false},
+		{"__fingerprint:build:", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			name, ok := ParseActionName(tt.key)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantName, name)
+		})
+	}
+}
+
+func TestClearAction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes all keys for action", func(t *testing.T) {
+		t.Parallel()
+		data := state.NewData()
+		now := time.Now().UTC()
+		data.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "abc", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:build:generates"] = &state.FingerprintEntry{Value: "def", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:build:inputs"] = &state.FingerprintEntry{Value: "ghi", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:deploy:sources"] = &state.FingerprintEntry{Value: "xyz", UpdatedAt: now}
+
+		removed := ClearAction(data, "build")
+		assert.Equal(t, 3, removed)
+		assert.Len(t, data.Fingerprints, 1)
+		assert.Contains(t, data.Fingerprints, "__fingerprint:deploy:sources")
+	})
+
+	t.Run("nil data returns zero", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ClearAction(nil, "build"))
+	})
+
+	t.Run("missing action returns zero", func(t *testing.T) {
+		t.Parallel()
+		data := state.NewData()
+		assert.Equal(t, 0, ClearAction(data, "nonexistent"))
+	})
+}
+
+func TestListActions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns sorted unique action names", func(t *testing.T) {
+		t.Parallel()
+		data := state.NewData()
+		now := time.Now().UTC()
+		data.Fingerprints["__fingerprint:deploy:sources"] = &state.FingerprintEntry{Value: "a", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:build:sources"] = &state.FingerprintEntry{Value: "b", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:build:generates"] = &state.FingerprintEntry{Value: "c", UpdatedAt: now}
+		data.Fingerprints["__fingerprint:test:inputs"] = &state.FingerprintEntry{Value: "d", UpdatedAt: now}
+
+		names := ListActions(data)
+		assert.Equal(t, []string{"build", "deploy", "test"}, names)
+	})
+
+	t.Run("nil data returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, ListActions(nil))
+	})
+
+	t.Run("empty fingerprints returns nil", func(t *testing.T) {
+		t.Parallel()
+		data := state.NewData()
+		assert.Nil(t, ListActions(data))
+	})
+}
+
+func TestSplitKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key      string
+		wantName string
+		wantType string
+		wantOK   bool
+	}{
+		{"__fingerprint:build:sources", "build", "sources", true},
+		{"__fingerprint:deploy:generates", "deploy", "generates", true},
+		{"__fingerprint:my-action:inputs", "my-action", "inputs", true},
+		{"__fingerprint:deploy[0]:sources", "deploy[0]", "sources", true},
+		{"not-a-fingerprint-key", "", "", false},
+		{"__fingerprint:", "", "", false},
+		{"__fingerprint:nocolon", "", "", false},
+		{"__fingerprint:build:", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			name, typ, ok := SplitKey(tt.key)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
+}

--- a/pkg/mcp/output_schemas.go
+++ b/pkg/mcp/output_schemas.go
@@ -226,7 +226,9 @@ var outputSchemaDryRun = json.RawMessage(`{
 					"dependencies": { "type": "array", "items": { "type": "string" } },
 					"when": { "type": "string" },
 					"materializedInputs": { "type": "object" },
-					"deferredInputs": { "type": "object" }
+					"deferredInputs": { "type": "object" },
+					"fingerprintStatus": { "type": "string", "description": "Fingerprint cache status: up-to-date, stale, or error" },
+					"fingerprintReason": { "type": "string", "description": "Reason for fingerprint status" }
 				}
 			}
 		},


### PR DESCRIPTION
- add FingerprintStatus and FingerprintReason fields to WhatIfAction so dry-run reports show whether actions would be skipped as up-to-date, stale, or errored
- thread state data and cwd through executeDryRun to enable fingerprint checking during dry-run plan generation
- render fingerprint status in table output (writeDryRunTable) and update MCP output schema with the new fields
- add `state fingerprints` subcommand to inspect fingerprint entries grouped by action name, with --action filter and kvx output
- add --action and --fingerprints-only flags to `state clear` for selective fingerprint clearing (mutually exclusive)
- export KeyPrefix and add SplitKey() to pkg/fingerprint for safe key parsing without duplicating magic strings
- add ParseActionName(), ClearAction(), and ListActions() domain helpers to pkg/fingerprint/state.go

Closes #505
Closes #506
