### PR TITLE
feat(mcp): add directory scanning to extract_resolver_refs tool

### DIFF
--- a/pkg/mcp/tools_refs.go
+++ b/pkg/mcp/tools_refs.go
@@ -14,12 +14,13 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver/refs"
 )
 
 // registerRefsTools registers resolver reference extraction tools.
 func (s *Server) registerRefsTools() {
 	extractRefssTool := mcp.NewTool("extract_resolver_refs",
-		mcp.WithDescription("Extract resolver references (_.resolverName patterns) from Go templates or CEL expressions. Returns a list of referenced resolver names, which should be used to populate the 'dependsOn' field. Accepts inline text or a file path."),
+		mcp.WithDescription("Extract resolver references (_.resolverName patterns) from Go templates or CEL expressions. Returns a list of referenced resolver names, which should be used to populate the 'dependsOn' field. Accepts inline text, a file path, or a directory path to scan all template files recursively."),
 		mcp.WithTitleAnnotation("Extract Resolver References"),
 		mcp.WithToolIcons(toolIcons["refs"]),
 		mcp.WithDeferLoading(true),
@@ -32,6 +33,12 @@ func (s *Server) registerRefsTools() {
 		),
 		mcp.WithString("file",
 			mcp.Description("Path to a template file to analyze"),
+		),
+		mcp.WithString("directory",
+			mcp.Description("Path to a directory to scan recursively for template files (.tpl, .tmpl, .gotmpl). Returns aggregated resolver references from all files."),
+		),
+		mcp.WithString("glob",
+			mcp.Description("Comma-separated glob patterns matched against the base filename when scanning a directory (e.g. '*.tpl,*.yaml'). Defaults to '*.tpl,*.tmpl,*.gotmpl'"),
 		),
 		mcp.WithString("type",
 			mcp.Description("Expression type: 'go-template' (default) or 'cel'"),
@@ -47,12 +54,31 @@ func (s *Server) registerRefsTools() {
 func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	text := request.GetString("text", "")
 	filePath := request.GetString("file", "")
+	directory := request.GetString("directory", "")
+	glob := request.GetString("glob", "")
 	exprType := request.GetString("type", "go-template")
 	cwd := request.GetString("cwd", "")
 
-	if text == "" && filePath == "" {
-		return newStructuredError(ErrCodeInvalidInput, "either 'text' or 'file' must be provided",
-			WithSuggestion("Provide inline expression text via 'text' or a file path via 'file'"),
+	if text == "" && filePath == "" && directory == "" {
+		return newStructuredError(ErrCodeInvalidInput, "either 'text', 'file', or 'directory' must be provided",
+			WithSuggestion("Provide inline expression text via 'text', a file path via 'file', or a directory path via 'directory'"),
+		), nil
+	}
+
+	// Reject ambiguous multi-input: only one of text/file/directory may be provided
+	inputCount := 0
+	if text != "" {
+		inputCount++
+	}
+	if filePath != "" {
+		inputCount++
+	}
+	if directory != "" {
+		inputCount++
+	}
+	if inputCount > 1 {
+		return newStructuredError(ErrCodeInvalidInput, "only one of 'text', 'file', or 'directory' may be provided",
+			WithSuggestion("Provide exactly one input source"),
 		), nil
 	}
 
@@ -62,6 +88,11 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 			WithField("cwd"),
 			WithSuggestion("Provide a valid existing directory path"),
 		), nil
+	}
+
+	// Handle directory scanning mode
+	if directory != "" {
+		return s.handleExtractRefsFromDirectory(ctx, directory, glob, exprType)
 	}
 
 	source := "inline"
@@ -91,7 +122,7 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 	case "go-template":
 		resolverNames, err = extractGoTemplateRefs(content)
 	case "cel":
-		resolverNames, err = extractCELRefs(content)
+		resolverNames, err = extractCELRefs(ctx, content)
 	default:
 		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unsupported type %q", exprType),
 			WithField("type"),
@@ -116,6 +147,66 @@ func (s *Server) handleExtractResolverRefs(_ context.Context, request mcp.CallTo
 		"count":      len(uniqueResolverNames(details)),
 		"details":    details,
 	})
+}
+
+// handleExtractRefsFromDirectory scans a directory recursively for template files
+// and returns aggregated resolver references from all matched files.
+func (s *Server) handleExtractRefsFromDirectory(ctx context.Context, directory, glob, exprType string) (*mcp.CallToolResult, error) {
+	resolved, err := provider.AbsFromContext(ctx, directory)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to resolve directory path: %v", err),
+			WithField("directory"),
+		), nil
+	}
+
+	globs := refs.ParseGlobs(glob)
+	scanResult, err := refs.ScanDirectory(ctx, resolved, globs, exprType)
+	if err != nil {
+		// Map domain errors to structured MCP errors
+		errMsg := err.Error()
+		switch {
+		case strings.Contains(errMsg, "unsupported expression type"):
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("unsupported type %q", exprType),
+				WithField("type"),
+				WithSuggestion("Use 'go-template' or 'cel'"),
+			), nil
+		case strings.Contains(errMsg, "not found"):
+			return newStructuredError(ErrCodeNotFound, fmt.Sprintf("directory %q not found: %v", directory, err),
+				WithField("directory"),
+				WithSuggestion("Check that the directory path exists and is accessible"),
+			), nil
+		case strings.Contains(errMsg, "is not a directory"):
+			return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("%q is not a directory", directory),
+				WithField("directory"),
+				WithSuggestion("Use 'file' parameter for single files, or provide a directory path"),
+			), nil
+		case strings.Contains(errMsg, "invalid glob pattern"):
+			return newStructuredError(ErrCodeInvalidInput, errMsg,
+				WithField("glob"),
+				WithSuggestion("Check glob syntax (e.g. unclosed character class)"),
+			), nil
+		default:
+			return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("failed to scan directory: %v", err),
+				WithField("directory"),
+			), nil
+		}
+	}
+
+	result := map[string]any{
+		"source":     "directory",
+		"sourceType": exprType,
+		"directory":  directory,
+		"references": scanResult.References,
+		"count":      scanResult.Count,
+		"details":    scanResult.Details,
+		"files":      scanResult.Files,
+		"filesCount": scanResult.FilesCount,
+	}
+	if len(scanResult.Warnings) > 0 {
+		result["warnings"] = scanResult.Warnings
+	}
+
+	return mcp.NewToolResultJSON(result)
 }
 
 // refDetail represents a resolver and its referenced fields.
@@ -152,9 +243,9 @@ func extractGoTemplateRefs(content string) ([]string, error) {
 }
 
 // extractCELRefs extracts resolver references from a CEL expression.
-func extractCELRefs(content string) ([]string, error) {
+func extractCELRefs(ctx context.Context, content string) ([]string, error) {
 	expr := celexp.Expression(content)
-	vars, err := expr.GetUnderscoreVariables(context.TODO())
+	vars, err := expr.GetUnderscoreVariables(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/tools_refs_test.go
+++ b/pkg/mcp/tools_refs_test.go
@@ -127,6 +127,39 @@ func TestHandleExtractResolverRefs(t *testing.T) {
 		assert.True(t, result.IsError)
 	})
 
+	t.Run("rejects multiple inputs", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"text": "{{ ._.appName }}",
+			"file": "/some/file.tpl",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := extractText(t, result)
+		assert.Contains(t, text, "only one of")
+	})
+
+	t.Run("rejects text and directory together", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"text":      "{{ ._.appName }}",
+			"directory": t.TempDir(),
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
 	t.Run("no refs returns empty list", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)
@@ -147,5 +180,197 @@ func TestHandleExtractResolverRefs(t *testing.T) {
 
 		count := data["count"].(float64)
 		assert.Equal(t, float64(0), count)
+	})
+
+	t.Run("scans directory recursively", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		// Create a temp directory with template files
+		tmpDir := t.TempDir()
+		err = os.WriteFile(filepath.Join(tmpDir, "main.tpl"), []byte("{{ ._.appName }} by {{ ._.author }}"), 0o644)
+		require.NoError(t, err)
+
+		subDir := filepath.Join(tmpDir, "partials")
+		require.NoError(t, os.MkdirAll(subDir, 0o755))
+		err = os.WriteFile(filepath.Join(subDir, "header.tpl"), []byte("{{ ._.projectTitle }}"), 0o644)
+		require.NoError(t, err)
+
+		// Non-matching file should be ignored
+		err = os.WriteFile(filepath.Join(tmpDir, "readme.md"), []byte("{{ ._.ignored }}"), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "extract_resolver_refs"
+		request.Params.Arguments = map[string]any{
+			"directory": tmpDir,
+			"type":      "go-template",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		assert.Equal(t, "directory", data["source"])
+		refs := data["references"].([]any)
+		assert.Contains(t, refs, "appName")
+		assert.Contains(t, refs, "author")
+		assert.Contains(t, refs, "projectTitle")
+		assert.NotContains(t, refs, "ignored")
+		assert.Equal(t, float64(3), data["count"])
+		assert.Equal(t, float64(2), data["filesCount"])
+	})
+
+	t.Run("scans directory with custom glob", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		err = os.WriteFile(filepath.Join(tmpDir, "config.yaml.tpl"), []byte("host: {{ ._.hostname }}"), 0o644)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(tmpDir, "main.go.tmpl"), []byte("package {{ ._.packageName }}"), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "extract_resolver_refs"
+		request.Params.Arguments = map[string]any{
+			"directory": tmpDir,
+			"type":      "go-template",
+			"glob":      "*.yaml.tpl",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		refs := data["references"].([]any)
+		assert.Contains(t, refs, "hostname")
+		assert.NotContains(t, refs, "packageName")
+	})
+
+	t.Run("directory not found returns error", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"directory": filepath.Join(t.TempDir(), "nonexistent", "subdir"),
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("empty directory returns zero results", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"directory": t.TempDir(),
+			"type":      "go-template",
+		}
+
+		// Empty directory returns empty results, not an error
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		assert.Equal(t, float64(0), data["count"])
+	})
+
+	t.Run("directory rejects unsupported type", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"directory": t.TempDir(),
+			"type":      "invalid-type",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("directory rejects invalid glob pattern", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"directory": t.TempDir(),
+			"type":      "go-template",
+			"glob":      "[a-",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+
+		text := extractText(t, result)
+		assert.Contains(t, text, "invalid glob pattern")
+	})
+
+	t.Run("directory surfaces unreadable file warnings", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		// Create a valid template file
+		err = os.WriteFile(filepath.Join(tmpDir, "good.tpl"), []byte("{{ ._.appName }}"), 0o644)
+		require.NoError(t, err)
+
+		// Create a file that's not readable (to trigger read warnings)
+		badDir := filepath.Join(tmpDir, "restricted")
+		require.NoError(t, os.MkdirAll(badDir, 0o755))
+		err = os.WriteFile(filepath.Join(badDir, "secret.tpl"), []byte("{{ ._.secret }}"), 0o000)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"directory": tmpDir,
+			"type":      "go-template",
+		}
+
+		result, err := srv.handleExtractResolverRefs(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+
+		// The good file should still be processed
+		refs := data["references"].([]any)
+		assert.Contains(t, refs, "appName")
+
+		// Warnings must be present for the unreadable file.
+		// On some platforms (e.g. running as root), file permissions may not
+		// produce the expected access denial -- skip assertion in that case.
+		warnings, ok := data["warnings"]
+		if !ok || len(warnings.([]any)) == 0 {
+			// Check if we can actually read the restricted file (e.g. running as root)
+			restrictedPath := filepath.Join(badDir, "secret.tpl")
+			if _, readErr := os.ReadFile(restrictedPath); readErr != nil {
+				t.Fatal("expected warnings for unreadable file, but none were returned")
+			}
+			t.Skip("platform/permissions did not produce unreadable file (likely running as root)")
+		}
+		assert.NotEmpty(t, warnings)
 	})
 }

--- a/pkg/resolver/refs/scan.go
+++ b/pkg/resolver/refs/scan.go
@@ -1,0 +1,267 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+)
+
+// DefaultTemplateGlobs are the file extensions scanned when no glob is specified.
+var DefaultTemplateGlobs = []string{"*.tpl", "*.tmpl", "*.gotmpl"}
+
+// FileRefs holds extracted resolver references for a single file.
+type FileRefs struct {
+	Path       string   `json:"path"`
+	References []string `json:"references"`
+	Details    []Detail `json:"details"`
+}
+
+// Detail represents a resolver and its referenced fields.
+type Detail struct {
+	Resolver string   `json:"resolver"`
+	Fields   []string `json:"fields"`
+}
+
+// ScanResult holds the aggregated result of a directory scan.
+type ScanResult struct {
+	References []string   `json:"references"`
+	Count      int        `json:"count"`
+	Details    []Detail   `json:"details"`
+	Files      []FileRefs `json:"files"`
+	FilesCount int        `json:"filesCount"`
+	Warnings   []string   `json:"warnings,omitempty"`
+}
+
+// ScanDirectory recursively scans a directory for template files matching the
+// given glob patterns and returns aggregated resolver references from all files.
+// The exprType must be "go-template" or "cel".
+func ScanDirectory(ctx context.Context, dir string, globs []string, exprType string) (*ScanResult, error) {
+	if exprType != "go-template" && exprType != "cel" {
+		return nil, fmt.Errorf("unsupported expression type %q: use 'go-template' or 'cel'", exprType)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("directory %q not found: %w", dir, err)
+		}
+		return nil, fmt.Errorf("cannot access directory %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", dir)
+	}
+
+	if len(globs) == 0 {
+		globs = DefaultTemplateGlobs
+	}
+
+	// Validate glob patterns up-front
+	for _, g := range globs {
+		if _, err := filepath.Match(g, ""); err != nil {
+			return nil, fmt.Errorf("invalid glob pattern %q: %w", g, err)
+		}
+	}
+
+	// Open a root-scoped handle to prevent symlink TOCTOU traversal (gosec G122)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open directory root: %w", err)
+	}
+	defer root.Close()
+
+	var files []FileRefs
+	var warnings []string
+	allRefs := make(map[string][]string) // resolver → fields (aggregated)
+
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			relPath, _ := filepath.Rel(dir, path)
+			warnings = append(warnings, fmt.Sprintf("skipped %q: %v", relPath, walkErr))
+			return nil //nolint:nilerr // surface as warning, continue scanning
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		// Check if file matches any glob pattern (matched against base filename)
+		name := d.Name()
+		matched := false
+		for _, g := range globs {
+			if m, _ := filepath.Match(g, name); m {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil
+		}
+
+		// Read file via root-scoped FS to avoid symlink TOCTOU
+		relPath, _ := filepath.Rel(dir, path)
+		fsPath := filepath.ToSlash(relPath) // io/fs requires forward slashes
+		data, readErr := fs.ReadFile(root.FS(), fsPath)
+		if readErr != nil {
+			warnings = append(warnings, fmt.Sprintf("could not read %q: %v", relPath, readErr))
+			return nil //nolint:nilerr // surface as warning, continue scanning
+		}
+
+		var paths []string
+		var extractErr error
+		switch exprType {
+		case "go-template":
+			paths, extractErr = extractTemplatePaths(string(data))
+		case "cel":
+			paths, extractErr = ExtractFromCEL(ctx, string(data))
+		}
+		if extractErr != nil {
+			warnings = append(warnings, fmt.Sprintf("parse error in %q: %v", relPath, extractErr))
+		}
+
+		if len(paths) == 0 {
+			return nil
+		}
+
+		details := BuildDetails(paths)
+		files = append(files, FileRefs{
+			Path:       relPath,
+			References: detailNames(details),
+			Details:    details,
+		})
+
+		// Aggregate into global map
+		for _, d := range details {
+			existing := allRefs[d.Resolver]
+			for _, f := range d.Fields {
+				found := false
+				for _, ef := range existing {
+					if ef == f {
+						found = true
+						break
+					}
+				}
+				if !found {
+					existing = append(existing, f)
+				}
+			}
+			allRefs[d.Resolver] = existing
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan directory: %w", err)
+	}
+
+	// Build aggregated details
+	aggregated := make([]Detail, 0, len(allRefs))
+	for name, fields := range allRefs {
+		sort.Strings(fields)
+		aggregated = append(aggregated, Detail{Resolver: name, Fields: fields})
+	}
+	sort.Slice(aggregated, func(i, j int) bool {
+		return aggregated[i].Resolver < aggregated[j].Resolver
+	})
+
+	return &ScanResult{
+		References: detailNames(aggregated),
+		Count:      len(aggregated),
+		Details:    aggregated,
+		Files:      files,
+		FilesCount: len(files),
+		Warnings:   warnings,
+	}, nil
+}
+
+// extractTemplatePaths returns full resolver dot-paths (e.g. "config.host")
+// from a Go template, preserving field access information for BuildDetails.
+func extractTemplatePaths(content string) ([]string, error) {
+	refs, err := gotmpl.GetGoTemplateReferences(content, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, ref := range refs {
+		if ref.Scoped {
+			continue
+		}
+
+		path := strings.TrimPrefix(ref.Path, ".")
+		if strings.HasPrefix(path, "_.") {
+			paths = append(paths, strings.TrimPrefix(path, "_."))
+		}
+	}
+
+	return paths, nil
+}
+
+// ParseGlobs splits a comma-separated glob string into trimmed patterns.
+// Returns DefaultTemplateGlobs if the input is empty.
+func ParseGlobs(glob string) []string {
+	if glob == "" {
+		return DefaultTemplateGlobs
+	}
+	parts := strings.Split(glob, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// BuildDetails groups raw resolver paths into resolver → fields mapping.
+func BuildDetails(paths []string) []Detail {
+	resolverFields := make(map[string][]string)
+	for _, p := range paths {
+		parts := strings.SplitN(p, ".", 2)
+		resolverName := parts[0]
+		if len(parts) > 1 {
+			field := parts[1]
+			found := false
+			for _, f := range resolverFields[resolverName] {
+				if f == field {
+					found = true
+					break
+				}
+			}
+			if !found {
+				resolverFields[resolverName] = append(resolverFields[resolverName], field)
+			}
+		} else {
+			if _, exists := resolverFields[resolverName]; !exists {
+				resolverFields[resolverName] = []string{}
+			}
+		}
+	}
+
+	details := make([]Detail, 0, len(resolverFields))
+	for name, fields := range resolverFields {
+		sort.Strings(fields)
+		details = append(details, Detail{Resolver: name, Fields: fields})
+	}
+	sort.Slice(details, func(i, j int) bool {
+		return details[i].Resolver < details[j].Resolver
+	})
+	return details
+}
+
+// detailNames extracts resolver names from a slice of Detail.
+func detailNames(details []Detail) []string {
+	names := make([]string, len(details))
+	for i, d := range details {
+		names[i] = d.Resolver
+	}
+	return names
+}

--- a/pkg/resolver/refs/scan_test.go
+++ b/pkg/resolver/refs/scan_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanDirectory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scans go-template files", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tpl"), []byte("{{ ._.appName }} {{ ._.config.host }}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "other.tpl"), []byte("{{ ._.port }}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("not a template"), 0o644))
+
+		result, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, result.Count)
+		assert.ElementsMatch(t, []string{"appName", "config", "port"}, result.References)
+		assert.Equal(t, 2, result.FilesCount)
+		assert.Empty(t, result.Warnings)
+	})
+
+	t.Run("scans CEL files", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "expr.tpl"), []byte(`_.appName + ":" + _.port`), 0o644))
+
+		result, err := ScanDirectory(context.Background(), dir, nil, "cel")
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"appName", "port"}, result.References)
+		assert.Equal(t, 1, result.FilesCount)
+	})
+
+	t.Run("custom glob patterns", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.yaml"), []byte("{{ ._.appName }}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "skip.tpl"), []byte("{{ ._.skipped }}"), 0o644))
+
+		result, err := ScanDirectory(context.Background(), dir, []string{"*.yaml"}, "go-template")
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"appName"}, result.References)
+		assert.Equal(t, 1, result.FilesCount)
+	})
+
+	t.Run("empty directory returns zero results", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		result, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, result.Count)
+		assert.Empty(t, result.Files)
+	})
+
+	t.Run("nonexistent directory returns error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := filepath.Join(t.TempDir(), "nonexistent", "subdir")
+		_, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("file path returns error", func(t *testing.T) {
+		t.Parallel()
+
+		f := filepath.Join(t.TempDir(), "file.txt")
+		require.NoError(t, os.WriteFile(f, []byte("hello"), 0o644))
+
+		_, err := ScanDirectory(context.Background(), f, nil, "go-template")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a directory")
+	})
+
+	t.Run("invalid glob pattern returns error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		_, err := ScanDirectory(context.Background(), dir, []string{"[a-"}, "go-template")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid glob pattern")
+	})
+
+	t.Run("unsupported expression type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		_, err := ScanDirectory(context.Background(), dir, nil, "jinja2")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported expression type")
+	})
+
+	t.Run("unreadable file surfaces warning", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("file permission test not reliable on Windows")
+		}
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "good.tpl"), []byte("{{ ._.appName }}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.tpl"), []byte("{{ ._.secret }}"), 0o000))
+
+		result, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.NoError(t, err)
+
+		// Verify good file was still processed
+		assert.Contains(t, result.References, "appName")
+
+		// Check if the file was actually unreadable
+		badPath := filepath.Join(dir, "bad.tpl")
+		if _, readErr := os.ReadFile(badPath); readErr != nil {
+			// File is truly unreadable, warnings must be present
+			require.NotEmpty(t, result.Warnings, "expected warnings for unreadable file")
+		} else {
+			t.Skip("platform did not restrict file access (likely running as root)")
+		}
+	})
+
+	t.Run("parse errors surface as warnings", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// Write an invalid go template
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.tpl"), []byte("{{ ._.appName }"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "good.tpl"), []byte("{{ ._.port }}"), 0o644))
+
+		result, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.NoError(t, err)
+
+		assert.Contains(t, result.References, "port")
+		assert.NotEmpty(t, result.Warnings)
+	})
+
+	t.Run("recursive subdirectory scanning", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "subdir")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "root.tpl"), []byte("{{ ._.rootRef }}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sub, "child.tpl"), []byte("{{ ._.childRef }}"), 0o644))
+
+		result, err := ScanDirectory(context.Background(), dir, nil, "go-template")
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"rootRef", "childRef"}, result.References)
+		assert.Equal(t, 2, result.FilesCount)
+	})
+}
+
+func TestParseGlobs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty returns defaults", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, DefaultTemplateGlobs, ParseGlobs(""))
+	})
+
+	t.Run("single pattern", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"*.yaml"}, ParseGlobs("*.yaml"))
+	})
+
+	t.Run("multiple patterns trimmed", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"*.tpl", "*.yaml"}, ParseGlobs("*.tpl, *.yaml"))
+	})
+}
+
+func TestBuildDetails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("groups fields by resolver", func(t *testing.T) {
+		t.Parallel()
+		paths := []string{"config.host", "config.port", "appName"}
+		details := BuildDetails(paths)
+
+		assert.Len(t, details, 2)
+		assert.Equal(t, Detail{Resolver: "appName", Fields: []string{}}, details[0])
+		assert.Equal(t, Detail{Resolver: "config", Fields: []string{"host", "port"}}, details[1])
+	})
+
+	t.Run("deduplicates fields", func(t *testing.T) {
+		t.Parallel()
+		paths := []string{"config.host", "config.host"}
+		details := BuildDetails(paths)
+
+		assert.Len(t, details, 1)
+		assert.Equal(t, []string{"host"}, details[0].Fields)
+	})
+}


### PR DESCRIPTION
- Add 'directory' parameter for recursive template file scanning
- Add 'glob' parameter to filter files (defaults to *.tpl,*.tmpl,*.gotmpl)
- Return aggregated resolver references across all matched files
- Include per-file breakdown with relative paths in response
- Add tests for directory scanning, custom glob, and error cases