### PR TITLE
feat(celexp): add url.encode and url.decode CEL extension functions

### DIFF
--- a/.github/skills/cel-patterns/SKILL.md
+++ b/.github/skills/cel-patterns/SKILL.md
@@ -90,6 +90,8 @@ math.max(a, b)    // Maximum
 ```cel
 base64.encode(bytes("hello"))   // Base64 encode
 base64.decode("aGVsbG8=")      // Base64 decode
+url.encode("hello world")      // URL form-encode -> "hello+world"
+url.decode("hello+world")      // URL form-decode -> "hello world"
 ```
 
 ### Bindings
@@ -182,6 +184,14 @@ regex.split("[,;]", _.input)               // Split by pattern
 ```cel
 sort.objects(_.items, "name")              // Sort objects by field (ascending)
 sort.objectsDescending(_.items, "score")   // Sort objects by field (descending)
+```
+
+### URL (`pkg/celexp/ext/url/`)
+
+```cel
+url.encode("hello world")                  // Form-encode -> "hello+world"
+url.decode("hello+world")                  // Form-decode -> "hello world"
+url.decode("hello%20world")                // Also decodes %XX -> "hello world"
 ```
 
 ### Strings (`pkg/celexp/ext/strings/`)

--- a/pkg/celexp/ext/ext.go
+++ b/pkg/celexp/ext/ext.go
@@ -21,6 +21,7 @@ import (
 	celsort "github.com/oakwood-commons/scafctl/pkg/celexp/ext/sort"
 	celstrings "github.com/oakwood-commons/scafctl/pkg/celexp/ext/strings"
 	celtime "github.com/oakwood-commons/scafctl/pkg/celexp/ext/time"
+	celurl "github.com/oakwood-commons/scafctl/pkg/celexp/ext/url"
 )
 
 var (
@@ -764,6 +765,10 @@ func Custom() celexp.ExtFunctionList {
 		// Time functions
 		celtime.NowFunc(),
 		celtime.NowFmtFunc(),
+
+		// URL functions
+		celurl.EncodeFunc(),
+		celurl.DecodeFunc(),
 	}
 
 	// Assign categories based on function name prefix
@@ -780,6 +785,7 @@ func Custom() celexp.ExtFunctionList {
 		"sort.":    "collections",
 		"strings.": "strings",
 		"time.":    "time",
+		"url.":     "encoding",
 	}
 	for i := range funcs {
 		if funcs[i].Category != "" {

--- a/pkg/celexp/ext/url/url.go
+++ b/pkg/celexp/ext/url/url.go
@@ -1,0 +1,104 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package url
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+)
+
+// EncodeFunc returns a CEL function that URL-encodes a string using
+// application/x-www-form-urlencoded encoding (spaces become +, special
+// characters become %XX). Suitable for query parameter values.
+//
+// Example usage:
+//
+//	url.encode("hello world") // Returns: "hello+world"
+func EncodeFunc() celexp.ExtFunction {
+	funcName := "url.encode"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Signature:     "url.encode(string) -> string",
+		Description:   "URL-encodes a string using application/x-www-form-urlencoded encoding (spaces become +). Use url.encode(value) to safely embed values in URL query parameters",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Encode a string with spaces",
+				Expression:  `url.encode("hello world")`,
+			},
+			{
+				Description: "Encode special characters for use in a URL query",
+				Expression:  `url.encode("key=value&other=a b")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType},
+					cel.StringType,
+					cel.UnaryBinding(func(value ref.Val) ref.Val {
+						str, ok := value.Value().(string)
+						if !ok {
+							return types.NewErr("url.encode: expected string argument, got %s", value.Type())
+						}
+						return types.String(url.QueryEscape(str))
+					}),
+				),
+			),
+		},
+	}
+}
+
+// DecodeFunc returns a CEL function that decodes a URL form-encoded string
+// (application/x-www-form-urlencoded). Both %XX sequences and "+" (as space)
+// are decoded.
+//
+// Example usage:
+//
+//	url.decode("hello+world") // Returns: "hello world"
+func DecodeFunc() celexp.ExtFunction {
+	funcName := "url.decode"
+	return celexp.ExtFunction{
+		Name:          funcName,
+		Signature:     "url.decode(string) -> string",
+		Description:   "Decodes a URL form-encoded string (application/x-www-form-urlencoded) back to its original form. Both %XX sequences and + (as space) are decoded. Use url.decode(encoded) to reverse url.encode",
+		FunctionNames: []string{funcName},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Decode a percent-encoded string",
+				Expression:  `url.decode("hello%20world")`,
+			},
+			{
+				Description: "Decode plus-encoded spaces",
+				Expression:  `url.decode("hello+world")`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(funcName,
+				cel.Overload(strings.ReplaceAll(funcName, ".", "_"),
+					[]*cel.Type{cel.StringType},
+					cel.StringType,
+					cel.UnaryBinding(func(value ref.Val) ref.Val {
+						str, ok := value.Value().(string)
+						if !ok {
+							return types.NewErr("url.decode: expected string argument, got %s", value.Type())
+						}
+						decoded, err := url.QueryUnescape(str)
+						if err != nil {
+							return types.NewErr("url.decode: %s", err.Error())
+						}
+						return types.String(decoded)
+					}),
+				),
+			),
+		},
+	}
+}

--- a/pkg/celexp/ext/url/url_test.go
+++ b/pkg/celexp/ext/url/url_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package url
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeFunc(t *testing.T) {
+	fn := EncodeFunc()
+	env, err := cel.NewEnv(append(fn.EnvOptions, cel.Variable("input", cel.StringType))...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple string no encoding needed",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "string with spaces",
+			input:    "hello world",
+			expected: "hello+world",
+		},
+		{
+			name:     "special characters",
+			input:    "key=value&other=test",
+			expected: "key%3Dvalue%26other%3Dtest",
+		},
+		{
+			name:     "unicode characters",
+			input:    "café",
+			expected: "caf%C3%A9",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "forward slashes",
+			input:    "path/to/resource",
+			expected: "path%2Fto%2Fresource",
+		},
+		{
+			name:     "already encoded string gets double-encoded",
+			input:    "hello%20world",
+			expected: "hello%2520world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(`url.encode(input)`)
+			require.Empty(t, issues.Errors())
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			out, _, err := prog.Eval(map[string]any{"input": tt.input})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, out.Value())
+		})
+	}
+}
+
+func TestDecodeFunc(t *testing.T) {
+	fn := DecodeFunc()
+	env, err := cel.NewEnv(append(fn.EnvOptions, cel.Variable("input", cel.StringType))...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no decoding needed",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "percent-encoded spaces",
+			input:    "hello%20world",
+			expected: "hello world",
+		},
+		{
+			name:     "plus-encoded spaces",
+			input:    "hello+world",
+			expected: "hello world",
+		},
+		{
+			name:     "special characters",
+			input:    "key%3Dvalue%26other%3Dtest",
+			expected: "key=value&other=test",
+		},
+		{
+			name:     "unicode characters",
+			input:    "caf%C3%A9",
+			expected: "café",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(`url.decode(input)`)
+			require.Empty(t, issues.Errors())
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			out, _, err := prog.Eval(map[string]any{"input": tt.input})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, out.Value())
+		})
+	}
+}
+
+func TestDecodeFunc_InvalidInput(t *testing.T) {
+	fn := DecodeFunc()
+	env, err := cel.NewEnv(append(fn.EnvOptions, cel.Variable("input", cel.StringType))...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`url.decode(input)`)
+	require.Empty(t, issues.Errors())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	// Invalid percent-encoding should produce an error
+	_, _, err = prog.Eval(map[string]any{"input": "%ZZ"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "url.decode:")
+}
+
+func TestEncodeFunc_Metadata(t *testing.T) {
+	fn := EncodeFunc()
+	assert.Equal(t, "url.encode", fn.Name)
+	assert.Equal(t, "url.encode(string) -> string", fn.Signature)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.Len(t, fn.FunctionNames, 1)
+}
+
+func TestDecodeFunc_Metadata(t *testing.T) {
+	fn := DecodeFunc()
+	assert.Equal(t, "url.decode", fn.Name)
+	assert.Equal(t, "url.decode(string) -> string", fn.Signature)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.Len(t, fn.FunctionNames, 1)
+}
+
+func BenchmarkEncodeFunc(b *testing.B) {
+	fn := EncodeFunc()
+	env, err := cel.NewEnv(append(fn.EnvOptions, cel.Variable("input", cel.StringType))...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ast, iss := env.Compile(`url.encode(input)`)
+	if iss.Err() != nil {
+		b.Fatal(iss.Err())
+	}
+	prog, err := env.Program(ast)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, _ = prog.Eval(map[string]any{"input": "hello world/path?query=value&key=café"})
+	}
+}
+
+func BenchmarkDecodeFunc(b *testing.B) {
+	fn := DecodeFunc()
+	env, err := cel.NewEnv(append(fn.EnvOptions, cel.Variable("input", cel.StringType))...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ast, iss := env.Compile(`url.decode(input)`)
+	if iss.Err() != nil {
+		b.Fatal(iss.Err())
+	}
+	prog, err := env.Program(ast)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, _ = prog.Eval(map[string]any{"input": "hello+world%2Fpath%3Fquery%3Dvalue%26key%3Dcaf%C3%A9"})
+	}
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -320,6 +320,7 @@ Expression Debugging:
     json.unmarshal(string) / json.marshal(value) -- JSON serialization
     yaml.unmarshal(string) / yaml.marshal(value) -- YAML serialization
     base64.encode(string) / base64.decode(string) -- Base64 encoding
+    url.encode(string) / url.decode(string) -- URL form-encoding (application/x-www-form-urlencoded)
     regex.match(pattern, string) / regex.replace(string, pattern, replacement)
     map.merge(map1, map2) -- deep-merge two maps
 

--- a/pkg/terminal/kvx/cel.go
+++ b/pkg/terminal/kvx/cel.go
@@ -81,10 +81,10 @@ func buildFunctionHints() map[string]string {
 			hints[extFunc.Name] = "e.g. yamlEncode(_.config)"
 		case "yamlDecode":
 			hints[extFunc.Name] = "e.g. yamlDecode(_.yamlStr)"
-		case "urlEncode":
-			hints[extFunc.Name] = "e.g. urlEncode(_.queryParam)"
-		case "urlDecode":
-			hints[extFunc.Name] = "e.g. urlDecode(_.encoded)"
+		case "url.encode":
+			hints[extFunc.Name] = "e.g. url.encode(_.queryParam)"
+		case "url.decode":
+			hints[extFunc.Name] = "e.g. url.decode(_.encoded)"
 
 		// String functions
 		case "regex.match":


### PR DESCRIPTION
- add url package with EncodeFunc (percent-encoding via QueryEscape) and DecodeFunc (percent-decoding via QueryUnescape)
- register url.encode and url.decode in the custom extension list under the 'encoding' category
- update MCP server help text to document the new functions
- update kvx hint map to use new namespaced function names
- include full test suite with table-driven tests, error cases, metadata assertions, and benchmarks