### PR TITLE
refactor(lint): migrate lint commands to kvx structured output with display schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/oakwood-commons/go-flight v1.0.1
 	github.com/oakwood-commons/httpc v0.1.0
-	github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b
+	github.com/oakwood-commons/kvx v0.14.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
 	github.com/oakwood-commons/scafctl-plugin-sdk v0.10.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/oakwood-commons/go-flight v1.0.1 h1:82TFTuJtE0BI4GUuWTSvAQHm9zAXTWWuI
 github.com/oakwood-commons/go-flight v1.0.1/go.mod h1:91490vC4QgOP+3T7ZFtjbNOJF9o8K5pxDnfNhptvE5g=
 github.com/oakwood-commons/httpc v0.1.0 h1:syQbjqerxGEVngGWOtyGhkwFFUnJekm+amnuKTO4vJQ=
 github.com/oakwood-commons/httpc v0.1.0/go.mod h1:vQ7KZ7NK7tF9Inqzikuo1HKozTw2Y0tHMp316PqwkEA=
-github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b h1:0hECYesHiHOqp+TBLHziM1xMgr9F1SiKaRIZSRY2aBQ=
-github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
+github.com/oakwood-commons/kvx v0.14.0 h1:P09NTQPf1ZDDcB25ZUtzL6KWqVVepav2BZRw3NmfZkI=
+github.com/oakwood-commons/kvx v0.14.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
 github.com/oakwood-commons/scafctl-plugin-sdk v0.10.0 h1:km2KASFp7Qh7JAJriLIaW37uD2MNZ7IA/MOSNqVvgeo=

--- a/pkg/cmd/scafctl/lint/explain_cmd.go
+++ b/pkg/cmd/scafctl/lint/explain_cmd.go
@@ -5,12 +5,15 @@ package lint
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -18,6 +21,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+//go:embed lint_explain_schema.json
+var lintExplainSchemaJSON []byte
 
 // ExplainOptions holds options for the lint explain command.
 type ExplainOptions struct {
@@ -76,6 +82,9 @@ func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 	return cCmd
 }
 
+// explainColumnOrder controls field display order in KVX visual output.
+var explainColumnOrder = []string{"rule", "severity", "category", "description", "why", "fix", "examples"}
+
 // Run executes the lint explain command.
 func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
 	if o.BinaryName == "" {
@@ -94,38 +103,54 @@ func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	// Handle structured output formats
-	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+		kvx.WithIOStreams(o.IOStreams),
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.CliParams.BinaryName+" lint explain"),
+		kvx.WithOutputDisplaySchemaJSON(lintExplainSchemaJSON),
+		kvx.WithOutputColumnOrder(explainColumnOrder),
+	)
+
+	// For structured formats (JSON/YAML/CSV/TOML), emit the full RuleMeta.
 	if kvx.IsStructuredFormat(outputOpts.Format) {
 		return outputOpts.Write(rule)
 	}
 
-	// Table output
-	w.Infof("Rule: %s\n", rule.Rule)
-	w.Plain("")
-	w.Plainf("Severity:    %s\n", rule.Severity)
-	w.Plainf("Category:    %s\n", rule.Category)
-	w.Plainf("Description: %s\n", rule.Description)
-	w.Plain("")
+	// For interactive mode, wrap in an array and use the rules list schema
+	// so the TUI enters list view and the user can drill into the detail view.
+	if o.KvxOutputFlags.Interactive {
+		interactiveOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+			kvx.WithIOStreams(o.IOStreams),
+			kvx.WithOutputContext(ctx),
+			kvx.WithOutputNoColor(o.CliParams.NoColor),
+			kvx.WithOutputAppName(o.CliParams.BinaryName+" lint explain"),
+			kvx.WithOutputDisplaySchemaJSON(lintRulesSchemaJSON),
+		)
+		return interactiveOpts.Write([]any{projectRule(rule)})
+	}
 
+	// For visual formats (auto/table/list), project to a map omitting empty fields.
+	return outputOpts.Write(projectRule(rule))
+}
+
+// projectRule converts a RuleMeta to a map with only non-empty fields for
+// visual rendering. Examples are formatted as a numbered list.
+func projectRule(rule pkglint.RuleMeta) map[string]any {
+	m := map[string]any{
+		"rule":        rule.Rule,
+		"severity":    rule.Severity,
+		"category":    rule.Category,
+		"description": rule.Description,
+	}
 	if rule.Why != "" {
-		w.Infof("Why:")
-		w.Plainf("  %s\n", rule.Why)
-		w.Plain("")
+		m["why"] = rule.Why
 	}
-
 	if rule.Fix != "" {
-		w.Infof("Fix:")
-		w.Plainf("  %s\n", rule.Fix)
-		w.Plain("")
+		m["fix"] = rule.Fix
 	}
-
 	if len(rule.Examples) > 0 {
-		w.Infof("Examples that trigger this rule:")
-		for _, ex := range rule.Examples {
-			w.Plainf("  • %s\n", ex)
-		}
+		m["examples"] = strings.Join(rule.Examples, "\n---\n")
 	}
-
-	return nil
+	return m
 }

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -8,6 +8,7 @@ package lint
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+//go:embed lint_schema.json
+var lintSchemaJSON []byte
 
 // Type aliases re-exporting from pkg/lint for backward compatibility.
 // Callers that import this package continue to work without modification.
@@ -58,13 +62,12 @@ func FilterBySeverity(result *Result, minSeverity string) *Result {
 
 // Options holds command flags and settings.
 type Options struct {
-	BinaryName string
-	File       string
-	Output     string
-	Severity   string
-	Expression string
-	CliParams  *settings.Run
-	IOStreams  *terminal.IOStreams
+	BinaryName     string
+	File           string
+	Severity       string
+	KvxOutputFlags flags.KvxOutputFlags
+	CliParams      *settings.Run
+	IOStreams      *terminal.IOStreams
 }
 
 // CommandLint creates the lint command.
@@ -104,11 +107,14 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			    - long-timeout        Timeout exceeds recommended maximum
 			    - unused-finally      Finally actions with no regular actions
 
-			OUTPUT FORMATS:
-			  table   Human-readable table (default)
+			SOME OUTPUT FORMATS:
+			  table   Human-readable bordered table
 			  json    JSON output for tooling integration
 			  yaml    YAML output
 			  quiet   Exit code only (0=clean, 1=issues found)
+
+			  Use -o to select a format, -i for interactive exploration,
+			  -e for CEL expression filtering, -w for per-finding filters.
 		`),
 		Example: strings.ReplaceAll(heredoc.Doc(`
 			# Lint a solution file
@@ -144,9 +150,8 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	}
 
 	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
-	cmd.Flags().StringVarP(&options.Output, "output", "o", "table", "Output format: table, json, yaml, quiet")
-	cmd.Flags().StringVarP(&options.Expression, "expression", "e", "", "CEL expression to filter/transform output data (e.g., '_.findings')")
 	cmd.Flags().StringVar(&options.Severity, "severity", "info", "Minimum severity to report: error, warning, info")
+	flags.AddKvxOutputFlagsToStruct(cmd, &options.KvxOutputFlags)
 
 	lintPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandRules(cliParams, ioStreams, lintPath))
@@ -160,10 +165,15 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 // message column is marked Flex so it absorbs remaining terminal width.
 func findingsColumnHints() map[string]tui.ColumnHint {
 	return map[string]tui.ColumnHint{
-		"severity": {MaxWidth: 8, DisplayName: "Severity"},
-		"ruleName": {MaxWidth: maxRuleWidth, DisplayName: "Rule"},
-		"location": {MaxWidth: maxLocationWidth, DisplayName: "Location"},
-		"message":  {DisplayName: "Message", Flex: true},
+		"severity":   {MaxWidth: 8, DisplayName: "Severity"},
+		"ruleName":   {MaxWidth: maxRuleWidth, DisplayName: "Rule"},
+		"location":   {MaxWidth: maxLocationWidth, DisplayName: "Location"},
+		"message":    {DisplayName: "Message", Flex: true},
+		"category":   {Hidden: true},
+		"suggestion": {Hidden: true},
+		"sourceFile": {Hidden: true},
+		"line":       {Hidden: true},
+		"column":     {Hidden: true},
 	}
 }
 
@@ -225,24 +235,22 @@ func runLint(ctx context.Context, opts *Options) error {
 	result := pkglint.Solution(sol, opts.File, registry)
 	result = pkglint.FilterBySeverity(result, opts.Severity)
 
-	if opts.Output == "quiet" {
+	if opts.KvxOutputFlags.Output == "quiet" {
 		if result.ErrorCount > 0 {
 			return exitcode.WithCode(fmt.Errorf("found %d errors", result.ErrorCount), exitcode.ValidationFailed)
 		}
 		return nil
 	}
 
-	kvxOpts := flags.NewKvxOutputOptionsFromFlags(
-		opts.Output,
-		false,
-		opts.Expression,
+	kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
+		kvx.WithIOStreams(opts.IOStreams),
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(opts.CliParams.NoColor),
 		kvx.WithOutputAppName(opts.BinaryName+" lint"),
+		kvx.WithOutputDisplaySchemaJSON(lintSchemaJSON),
 		kvx.WithOutputColumnHints(findingsColumnHints()),
 		kvx.WithOutputColumnOrder([]string{"severity", "ruleName", "location", "message"}),
 	)
-	kvxOpts.IOStreams = opts.IOStreams
 
 	// For table output, project findings to the four visible columns so
 	// the columnar renderer sees exactly 4 fields (not the full 9-field
@@ -250,13 +258,18 @@ func runLint(ctx context.Context, opts *Options) error {
 	// For structured formats (json/yaml), emit the full result with all
 	// fields and summary counts.
 	var outputData any = result
-	if !kvx.IsStructuredFormat(kvxOpts.Format) && opts.Expression == "" {
+	if !kvx.IsStructuredFormat(kvxOpts.Format) && opts.KvxOutputFlags.Expression == "" {
 		if len(result.Findings) == 0 {
 			w := writer.FromContext(ctx)
 			w.Success("No lint issues found.")
 			return nil
 		}
-		outputData = projectFindings(result.Findings)
+		if opts.KvxOutputFlags.Interactive {
+			// Interactive mode: pass full findings for rich detail view.
+			outputData = result.Findings
+		} else {
+			outputData = projectFindings(result.Findings)
+		}
 	}
 
 	if err := kvxOpts.Write(outputData); err != nil {

--- a/pkg/cmd/scafctl/lint/lint_explain_schema.json
+++ b/pkg/cmd/scafctl/lint/lint_explain_schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scafctl Lint Rule Detail",
+  "description": "Schema for a single scafctl lint rule with display extensions",
+  "type": "object",
+
+  "x-kvx-icon": "📋",
+
+  "x-kvx-detail": {
+    "titleField": "rule",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["rule", "severity", "category"],
+        "layout": "inline"
+      },
+      {
+        "title": "Description",
+        "fields": ["description"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Why",
+        "fields": ["why"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "How to Fix",
+        "fields": ["fix"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Examples",
+        "fields": ["examples"],
+        "layout": "paragraph"
+      }
+    ]
+  },
+
+  "properties": {
+    "rule": {
+      "type": "string",
+      "title": "Rule",
+      "description": "Kebab-case rule identifier"
+    },
+    "severity": {
+      "type": "string",
+      "title": "Severity",
+      "description": "Rule severity level (error, warning, info)"
+    },
+    "category": {
+      "type": "string",
+      "title": "Category",
+      "description": "Rule category (e.g., structure, naming, provider)"
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "Short summary of what the rule checks"
+    },
+    "why": {
+      "type": "string",
+      "title": "Why",
+      "description": "Rationale for the rule"
+    },
+    "fix": {
+      "type": "string",
+      "title": "Fix",
+      "description": "Concrete instructions for resolving a finding"
+    },
+    "examples": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Examples",
+      "description": "Sample YAML or commands that trigger the rule"
+    }
+  }
+}

--- a/pkg/cmd/scafctl/lint/lint_rules_schema.json
+++ b/pkg/cmd/scafctl/lint/lint_rules_schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scafctl Lint Rules",
+  "description": "Schema for scafctl lint rules catalog with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "📋",
+  "x-kvx-collectionTitle": "Lint Rules",
+
+  "x-kvx-list": {
+    "titleField": "rule",
+    "subtitleField": "description",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["severity", "category"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "rule",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["rule", "severity", "category"],
+        "layout": "inline"
+      },
+      {
+        "title": "Description",
+        "fields": ["description"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Why",
+        "fields": ["why"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "How to Fix",
+        "fields": ["fix"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Examples",
+        "fields": ["examples"],
+        "layout": "paragraph"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["rule", "severity", "category"],
+    "properties": {
+      "rule": {
+        "type": "string",
+        "title": "Rule",
+        "description": "Kebab-case rule identifier"
+      },
+      "severity": {
+        "type": "string",
+        "title": "Severity",
+        "description": "Rule severity level (error, warning, info)"
+      },
+      "category": {
+        "type": "string",
+        "title": "Category",
+        "description": "Rule category (e.g., structure, naming, provider)"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "Short summary of what the rule checks"
+      },
+      "why": {
+        "type": "string",
+        "title": "Why",
+        "description": "Rationale for the rule"
+      },
+      "fix": {
+        "type": "string",
+        "title": "Fix",
+        "description": "Concrete instructions for resolving a finding"
+      },
+      "examples": {
+        "type": "string",
+        "title": "Examples",
+        "description": "Sample YAML or commands that trigger the rule"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/lint/lint_schema.json
+++ b/pkg/cmd/scafctl/lint/lint_schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scafctl Lint Findings",
+  "description": "Schema for scafctl lint findings with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "🔍",
+  "x-kvx-collectionTitle": "Findings",
+
+  "x-kvx-list": {
+    "titleField": "ruleName",
+    "subtitleField": "message",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["severity"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "ruleName",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["severity", "ruleName", "location"],
+        "layout": "inline"
+      },
+      {
+        "title": "Message",
+        "fields": ["message"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Suggestion",
+        "fields": ["suggestion"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Source",
+        "fields": ["sourceFile", "line", "column"],
+        "layout": "inline"
+      },
+      {
+        "title": "Category",
+        "fields": ["category"],
+        "layout": "inline"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["severity", "ruleName", "message"],
+    "properties": {
+      "severity": {
+        "type": "string",
+        "title": "Severity",
+        "description": "Issue severity level (error, warning, info)"
+      },
+      "ruleName": {
+        "type": "string",
+        "title": "Rule",
+        "description": "Lint rule identifier"
+      },
+      "location": {
+        "type": "string",
+        "title": "Location",
+        "description": "Logical path of the issue in the solution"
+      },
+      "message": {
+        "type": "string",
+        "title": "Message",
+        "description": "Human-readable issue description"
+      },
+      "suggestion": {
+        "type": "string",
+        "title": "Suggestion",
+        "description": "Suggested fix for the issue"
+      },
+      "sourceFile": {
+        "type": "string",
+        "title": "Source File",
+        "description": "Source file path"
+      },
+      "line": {
+        "type": "integer",
+        "title": "Line",
+        "description": "Source line number"
+      },
+      "column": {
+        "type": "integer",
+        "title": "Column",
+        "description": "Source column number"
+      },
+      "category": {
+        "type": "string",
+        "title": "Category",
+        "description": "Lint rule category"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -5,10 +5,14 @@ package lint
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -49,9 +53,11 @@ func TestCommandLint_Flags(t *testing.T) {
 		defVal   string
 	}{
 		{"file", "file", ""},
-		{"output", "output", "table"},
+		{"output", "output", "auto"},
 		{"expression", "expression", ""},
 		{"severity", "severity", "info"},
+		{"interactive", "interactive", "false"},
+		{"where", "where", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -77,6 +83,115 @@ func TestCommandRules(t *testing.T) {
 	require.NotNil(t, cf, "--category flag should exist")
 }
 
+func TestRulesRun_JSONOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	var rules []pkglint.RuleMeta
+	err = json.Unmarshal(outBuf.Bytes(), &rules)
+	require.NoError(t, err, "output should be valid JSON")
+	assert.NotEmpty(t, rules, "should contain at least one rule")
+	assert.NotEmpty(t, rules[0].Rule, "rule name should be populated")
+}
+
+func TestRulesRun_TableOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams: ioStreams,
+		CliParams: cliParams,
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.NotEmpty(t, output)
+	// KVX table output should contain rule names
+	assert.True(t, strings.Contains(output, "unused-resolver") || strings.Contains(output, "empty-solution"),
+		"table output should contain at least one known rule name")
+}
+
+func TestRulesRun_EmptyResults(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams: ioStreams,
+		CliParams: cliParams,
+		Severity:  "nonexistent",
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	combined := outBuf.String() + errBuf.String()
+	assert.Contains(t, combined, "No rules match")
+}
+
+func TestRulesRun_EmptyResults_JSON(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		Severity:       "nonexistent",
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	var rules []pkglint.RuleMeta
+	err = json.Unmarshal(outBuf.Bytes(), &rules)
+	require.NoError(t, err, "output should be valid JSON")
+	assert.Empty(t, rules, "should be an empty array")
+}
+
+func TestRulesRun_SeverityFilter(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		Severity:       "error",
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	var rules []pkglint.RuleMeta
+	err = json.Unmarshal(outBuf.Bytes(), &rules)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rules)
+	for _, r := range rules {
+		assert.Equal(t, "error", r.Severity, "all rules should be error severity")
+	}
+}
+
 func TestCommandExplainRule(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
@@ -94,6 +209,250 @@ func TestCommandExplainRule_RequiresArg(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err, "should fail without rule-name argument")
+}
+
+// ── ExplainRun output format tests ───────────────────────────────────────────
+
+func TestExplainRun_JSONOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	var rule pkglint.RuleMeta
+	err = json.Unmarshal(outBuf.Bytes(), &rule)
+	require.NoError(t, err, "output should be valid JSON")
+	assert.Equal(t, "empty-solution", rule.Rule)
+	assert.Equal(t, "error", rule.Severity)
+	assert.Equal(t, "structure", rule.Category)
+	assert.NotEmpty(t, rule.Description)
+	assert.NotEmpty(t, rule.Why)
+	assert.NotEmpty(t, rule.Fix)
+	assert.NotEmpty(t, rule.Examples)
+}
+
+func TestExplainRun_YAMLOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "yaml"},
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "rule: empty-solution")
+	assert.Contains(t, output, "severity: error")
+	assert.Contains(t, output, "category: structure")
+}
+
+func TestExplainRun_TableOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "empty-solution")
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "structure")
+}
+
+func TestExplainRun_ListOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "list"},
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "empty-solution")
+	assert.Contains(t, output, "error")
+}
+
+func TestExplainRun_CSVOutput(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "csv"},
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.NotEmpty(t, output, "CSV output should not be empty")
+	assert.Contains(t, output, "empty-solution")
+}
+
+func TestExplainRun_UnknownRule(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+	}
+
+	err := opts.Run(ctx, "nonexistent-rule")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rule")
+	assert.Contains(t, err.Error(), "nonexistent-rule")
+}
+
+func TestExplainRun_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	cliParams.BinaryName = "mycli"
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "mycli",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+	}
+
+	err := opts.Run(ctx, "nonexistent-rule")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mycli lint rules", "error should reference embedder binary name")
+}
+
+func TestExplainRun_DefaultFormat(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &ExplainOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{}, // default (auto)
+	}
+
+	err := opts.Run(ctx, "empty-solution")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "empty-solution")
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "structure")
+}
+
+// ── projectRule tests ────────────────────────────────────────────────────────
+
+func TestProjectRule_IncludesAllFields(t *testing.T) {
+	t.Parallel()
+	rule := pkglint.RuleMeta{
+		Rule:        "test-rule",
+		Severity:    "warning",
+		Category:    "naming",
+		Description: "A test rule",
+		Why:         "Because testing",
+		Fix:         "Fix it",
+		Examples:    []string{"example1", "example2"},
+	}
+
+	m := projectRule(rule)
+	assert.Equal(t, "test-rule", m["rule"])
+	assert.Equal(t, "warning", m["severity"])
+	assert.Equal(t, "naming", m["category"])
+	assert.Equal(t, "A test rule", m["description"])
+	assert.Equal(t, "Because testing", m["why"])
+	assert.Equal(t, "Fix it", m["fix"])
+	assert.Equal(t, "example1\n---\nexample2", m["examples"])
+}
+
+func TestProjectRule_OmitsEmptyFields(t *testing.T) {
+	t.Parallel()
+	rule := pkglint.RuleMeta{
+		Rule:        "minimal-rule",
+		Severity:    "info",
+		Category:    "structure",
+		Description: "Minimal",
+	}
+
+	m := projectRule(rule)
+	assert.Equal(t, "minimal-rule", m["rule"])
+	assert.Equal(t, "info", m["severity"])
+	assert.Equal(t, "structure", m["category"])
+	assert.Equal(t, "Minimal", m["description"])
+	_, hasWhy := m["why"]
+	assert.False(t, hasWhy, "empty why should be omitted")
+	_, hasFix := m["fix"]
+	assert.False(t, hasFix, "empty fix should be omitted")
+	_, hasExamples := m["examples"]
+	assert.False(t, hasExamples, "empty examples should be omitted")
+}
+
+func TestProjectRule_SingleExample(t *testing.T) {
+	t.Parallel()
+	rule := pkglint.RuleMeta{
+		Rule:        "single-ex",
+		Severity:    "error",
+		Category:    "structure",
+		Description: "Has one example",
+		Examples:    []string{"only-one"},
+	}
+
+	m := projectRule(rule)
+	assert.Equal(t, "only-one", m["examples"])
+}
+
+// ── explainColumnHints tests ─────────────────────────────────────────────────
+
+func TestExplainColumnOrder_HasExpectedFields(t *testing.T) {
+	t.Parallel()
+	expected := []string{"rule", "severity", "category", "description", "why", "fix", "examples"}
+	assert.Equal(t, expected, explainColumnOrder)
 }
 
 func BenchmarkCommandLint(b *testing.B) {
@@ -184,12 +543,12 @@ spec:
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
-		File:       solPath,
-		Output:     "table",
-		Severity:   "info",
-		CliParams:  testCliParams(),
-		IOStreams:  ioStreams,
-		BinaryName: "scafctl",
+		File:           solPath,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
 	}
 	err := runLint(ctx, opts)
 	assert.NoError(t, err)
@@ -215,12 +574,12 @@ spec:
 	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
-		File:       solPath,
-		Output:     "table",
-		Severity:   "info",
-		CliParams:  testCliParams(),
-		IOStreams:  ioStreams,
-		BinaryName: "scafctl",
+		File:           solPath,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
 	}
 	err := runLint(ctx, opts)
 	// The null resolver should trigger lint findings. The error may come from
@@ -255,12 +614,12 @@ spec:
 	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
-		File:       solPath,
-		Output:     "json",
-		Severity:   "info",
-		CliParams:  testCliParams(),
-		IOStreams:  ioStreams,
-		BinaryName: "scafctl",
+		File:           solPath,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
 	}
 	err := runLint(ctx, opts)
 	assert.NoError(t, err)
@@ -292,12 +651,12 @@ spec:
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
-		File:       solPath,
-		Output:     "quiet",
-		Severity:   "info",
-		CliParams:  testCliParams(),
-		IOStreams:  ioStreams,
-		BinaryName: "scafctl",
+		File:           solPath,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "quiet"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
 	}
 	err := runLint(ctx, opts)
 	assert.NoError(t, err)
@@ -309,12 +668,12 @@ func TestRunLint_FileNotFound(t *testing.T) {
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
-		File:       "/nonexistent/solution.yaml",
-		Output:     "table",
-		Severity:   "info",
-		CliParams:  testCliParams(),
-		IOStreams:  ioStreams,
-		BinaryName: "scafctl",
+		File:           "/nonexistent/solution.yaml",
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
 	}
 	err := runLint(ctx, opts)
 	assert.Error(t, err)
@@ -336,4 +695,45 @@ func TestFilterBySeverityDelegate(t *testing.T) {
 	result := &pkglint.Result{}
 	filtered := FilterBySeverity(result, "error")
 	require.NotNil(t, filtered)
+}
+
+// ── Display Schema tests ─────────────────────────────────────────────────────
+
+func TestLintSchemaJSON_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(lintSchemaJSON), "lint_schema.json must be valid JSON")
+}
+
+func TestLintSchemaJSON_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(lintSchemaJSON)
+	require.NoError(t, err, "lint_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
+}
+
+func TestLintRulesSchemaJSON_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(lintRulesSchemaJSON), "lint_rules_schema.json must be valid JSON")
+}
+
+func TestLintRulesSchemaJSON_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(lintRulesSchemaJSON)
+	require.NoError(t, err, "lint_rules_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
+}
+
+func TestLintExplainSchemaJSON_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(lintExplainSchemaJSON), "lint_explain_schema.json must be valid JSON")
+}
+
+func TestLintExplainSchemaJSON_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(lintExplainSchemaJSON)
+	require.NoError(t, err, "lint_explain_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
 }

--- a/pkg/cmd/scafctl/lint/rules_cmd.go
+++ b/pkg/cmd/scafctl/lint/rules_cmd.go
@@ -5,11 +5,13 @@ package lint
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -18,6 +20,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+//go:embed lint_rules_schema.json
+var lintRulesSchemaJSON []byte
 
 // RulesOptions holds options for the lint rules command.
 type RulesOptions struct {
@@ -85,6 +90,14 @@ func CommandRules(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 	return cCmd
 }
 
+// rulesColumnHints controls column display widths and priorities for table output.
+var rulesColumnHints = map[string]tui.ColumnHint{
+	"rule":        {MaxWidth: 25, Priority: 10, DisplayName: "Rule"},
+	"severity":    {MaxWidth: 8, Priority: 9, DisplayName: "Severity"},
+	"category":    {MaxWidth: 15, Priority: 8, DisplayName: "Category"},
+	"description": {DisplayName: "Description", Flex: true},
+}
+
 // Run executes the lint rules command.
 func (o *RulesOptions) Run(ctx context.Context) error {
 	w := writer.FromContext(ctx)
@@ -118,42 +131,64 @@ func (o *RulesOptions) Run(ctx context.Context) error {
 		rules = filtered
 	}
 
-	// Handle structured output formats
-	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
-	if kvx.IsStructuredFormat(outputOpts.Format) {
-		return outputOpts.Write(rules)
-	}
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+		kvx.WithIOStreams(o.IOStreams),
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.CliParams.BinaryName+" lint rules"),
+		kvx.WithOutputDisplaySchemaJSON(lintRulesSchemaJSON),
+		kvx.WithOutputColumnOrder([]string{"rule", "severity", "category", "description"}),
+		kvx.WithOutputColumnHints(rulesColumnHints),
+	)
 
-	// Table output
 	if len(rules) == 0 {
+		if outputOpts.Format == kvx.OutputFormatQuiet {
+			return nil
+		}
+		if kvx.IsStructuredFormat(outputOpts.Format) {
+			return outputOpts.Write([]RuleMeta{})
+		}
 		w.Infof("No rules match the specified filters.")
 		return nil
 	}
 
-	// Find max lengths for alignment
-	maxRule := 0
-	maxSev := 0
-	maxCat := 0
-	for _, r := range rules {
-		if len(r.Rule) > maxRule {
-			maxRule = len(r.Rule)
-		}
-		if len(r.Severity) > maxSev {
-			maxSev = len(r.Severity)
-		}
-		if len(r.Category) > maxCat {
-			maxCat = len(r.Category)
+	// For structured formats (json/yaml), emit the full RuleMeta with all
+	// fields (why, fix, examples). For interactive mode, project with
+	// examples joined as a string for rich detail views. For visual formats
+	// (table/list), project to the four visible columns so KVX renders a
+	// columnar table instead of falling back to key-value list mode.
+	if kvx.IsStructuredFormat(outputOpts.Format) {
+		return outputOpts.Write(rules)
+	}
+	if o.KvxOutputFlags.Interactive {
+		return outputOpts.Write(projectRulesInteractive(rules))
+	}
+	return outputOpts.Write(projectRules(rules))
+}
+
+// projectRulesInteractive converts rules to maps with all fields for the
+// interactive detail view. Examples are joined into a single string so the
+// TUI renders them as formatted text rather than a raw JSON array.
+func projectRulesInteractive(rules []RuleMeta) []any {
+	rows := make([]any, len(rules))
+	for i, r := range rules {
+		rows[i] = projectRule(r)
+	}
+	return rows
+}
+
+// projectRules converts rules to maps with only the four table-visible columns.
+// This keeps the field count low so KVX renders a columnar table instead of
+// falling back to key-value list view.
+func projectRules(rules []RuleMeta) []any {
+	rows := make([]any, len(rules))
+	for i, r := range rules {
+		rows[i] = map[string]any{
+			"rule":        r.Rule,
+			"severity":    r.Severity,
+			"category":    r.Category,
+			"description": r.Description,
 		}
 	}
-
-	w.Infof("Lint Rules (%d)\n", len(rules))
-	w.Plain("")
-	w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, "RULE", maxSev, "SEVERITY", maxCat, "CATEGORY", "DESCRIPTION")
-	w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, strings.Repeat("─", maxRule), maxSev, strings.Repeat("─", maxSev), maxCat, strings.Repeat("─", maxCat), strings.Repeat("─", 40))
-
-	for _, r := range rules {
-		w.Plainf("%-*s  %-*s  %-*s  %s\n", maxRule, r.Rule, maxSev, r.Severity, maxCat, r.Category, r.Description)
-	}
-
-	return nil
+	return rows
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -11,25 +11,25 @@ import "sort"
 // their knowledge from this registry.
 type RuleMeta struct {
 	// Rule is the kebab-case rule identifier used in Finding.RuleName.
-	Rule string `json:"rule"`
+	Rule string `json:"rule" yaml:"rule"`
 
 	// Severity is one of "error", "warning", or "info".
-	Severity string `json:"severity"`
+	Severity string `json:"severity" yaml:"severity"`
 
 	// Category groups related rules (e.g. "structure", "naming", "provider").
-	Category string `json:"category"`
+	Category string `json:"category" yaml:"category"`
 
 	// Description is a short summary of what the rule checks.
-	Description string `json:"description"`
+	Description string `json:"description" yaml:"description"`
 
 	// Why explains the rationale for the rule.
-	Why string `json:"why"`
+	Why string `json:"why" yaml:"why"`
 
 	// Fix gives concrete instructions for resolving a finding.
-	Fix string `json:"fix"`
+	Fix string `json:"fix" yaml:"fix"`
 
 	// Examples optionally provide sample YAML or commands.
-	Examples []string `json:"examples,omitempty"`
+	Examples []string `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
 
 // KnownRules is the canonical registry of all lint rules.

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -700,7 +700,11 @@ func (o *OutputOptions) writeText(data any) error {
 	if cols := countDataColumns(outputData); cols > 0 {
 		width := o.terminalWidth()
 		if o.ColumnarMode != tui.ColumnarModeAlways && (width/(cols+1) < minColumnWidth || (piped && hasNestedValues(outputData))) {
-			output := tui.RenderList(outputData, true)
+			output := tui.RenderList(outputData, tui.ListOptions{
+				NoColor:       true,
+				ColumnOrder:   o.ColumnOrder,
+				HiddenColumns: hiddenColumnsFromHints(hints),
+			})
 			fmt.Fprint(o.IOStreams.Out, output)
 			return nil
 		}
@@ -714,11 +718,12 @@ func (o *OutputOptions) writeText(data any) error {
 	}
 
 	output := tui.RenderTable(outputData, tui.TableOptions{
-		Bordered:     false,
-		NoColor:      true,
-		ColumnOrder:  o.ColumnOrder,
-		ColumnHints:  hints,
-		ColumnarMode: o.ColumnarMode,
+		Bordered:      false,
+		NoColor:       true,
+		ColumnOrder:   o.ColumnOrder,
+		ColumnHints:   hints,
+		ColumnarMode:  o.ColumnarMode,
+		HiddenColumns: hiddenColumnsFromHints(hints),
 	})
 
 	// When piped on Windows the console defaults to OEM/CP437 encoding,

--- a/pkg/terminal/kvx/output_test.go
+++ b/pkg/terminal/kvx/output_test.go
@@ -655,7 +655,7 @@ func TestRenderList(t *testing.T) {
 		"name":    "scafctl",
 		"version": "1.0.0",
 	}
-	result, err := RenderList(data, true)
+	result, err := RenderList(data, tui.ListOptions{NoColor: true})
 	assert.NoError(t, err)
 	assert.Contains(t, result, "scafctl")
 }

--- a/pkg/terminal/kvx/viewer.go
+++ b/pkg/terminal/kvx/viewer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/oakwood-commons/kvx/pkg/core"
@@ -115,6 +116,10 @@ type ViewerOptions struct {
 	// Valid values: "auto" (default), "always", "never".
 	// Use "always" when the data is intentionally multi-column regardless of key homogeneity.
 	ColumnarMode string `json:"columnarMode,omitempty" yaml:"columnarMode,omitempty" doc:"Columnar rendering mode: auto, always, never" example:"always" maxLength:"10"`
+
+	// ArrayStyle controls how array indices are displayed in list rendering.
+	// Valid values: "index" (default), "numbered", "bullet", "none".
+	ArrayStyle string `json:"arrayStyle,omitempty" yaml:"arrayStyle,omitempty" doc:"Array index style for list rendering: index, numbered, bullet, none" example:"bullet" maxLength:"10"`
 }
 
 // DefaultViewerOptions returns sensible defaults.
@@ -228,6 +233,12 @@ func WithColumnarMode(mode string) Option {
 	return func(o *ViewerOptions) { o.ColumnarMode = mode }
 }
 
+// WithArrayStyle sets the array index display style for list rendering.
+// Valid values: "index" (default), "numbered", "bullet", "none".
+func WithArrayStyle(style string) Option {
+	return func(o *ViewerOptions) { o.ArrayStyle = style }
+}
+
 // WithContext sets the context for CEL expression evaluation.
 // This enables context-dependent features like debug.out when Writer is in context.
 func WithContext(ctx context.Context) Option {
@@ -311,15 +322,16 @@ func renderTable(root any, options *ViewerOptions) error {
 		root = normalizeSliceKeys(root)
 	}
 	output := tui.RenderTable(root, tui.TableOptions{
-		AppName:      options.AppName,
-		Path:         "_",
-		Bordered:     true,
-		Width:        options.Width,
-		NoColor:      options.NoColor,
-		ColumnOrder:  options.ColumnOrder,
-		ColumnHints:  hints,
-		ColumnarMode: options.ColumnarMode,
-		Schema:       resolveDisplaySchema(options.DisplaySchemaJSON),
+		AppName:       options.AppName,
+		Path:          "_",
+		Bordered:      true,
+		Width:         options.Width,
+		NoColor:       options.NoColor,
+		ColumnOrder:   options.ColumnOrder,
+		ColumnHints:   hints,
+		ColumnarMode:  options.ColumnarMode,
+		HiddenColumns: hiddenColumnsFromHints(hints),
+		Schema:        resolveDisplaySchema(options.DisplaySchemaJSON),
 	})
 	fmt.Fprint(options.Out, output)
 	return nil
@@ -355,9 +367,30 @@ func resolveColumnHints(schemaJSON []byte, programmatic map[string]tui.ColumnHin
 
 // renderList outputs data as a key-value list (non-interactive).
 func renderList(root any, options *ViewerOptions) error {
-	output := tui.RenderList(root, options.NoColor)
+	hints := resolveColumnHints(options.SchemaJSON, options.ColumnHints)
+	output := tui.RenderList(root, tui.ListOptions{
+		NoColor:       options.NoColor,
+		ArrayStyle:    options.ArrayStyle,
+		HiddenColumns: hiddenColumnsFromHints(hints),
+		ColumnOrder:   options.ColumnOrder,
+	})
 	fmt.Fprint(options.Out, output)
 	return nil
+}
+
+// hiddenColumnsFromHints extracts column names marked as Hidden from a ColumnHint map.
+func hiddenColumnsFromHints(hints map[string]tui.ColumnHint) []string {
+	if len(hints) == 0 {
+		return nil
+	}
+	var hidden []string
+	for k, v := range hints {
+		if v.Hidden {
+			hidden = append(hidden, k)
+		}
+	}
+	slices.Sort(hidden)
+	return hidden
 }
 
 // resolveDisplaySchema parses a DisplaySchemaJSON document and returns the
@@ -442,13 +475,13 @@ func RenderTable(data any, opts tui.TableOptions) (string, error) {
 
 // RenderList renders data as a non-interactive list string.
 // This is useful when you need the list output as a string rather than writing to a stream.
-func RenderList(data any, noColor bool) (string, error) {
+func RenderList(data any, opts tui.ListOptions) (string, error) {
 	root, err := core.LoadObject(data)
 	if err != nil {
 		return "", fmt.Errorf("failed to load data: %w", err)
 	}
 
-	return tui.RenderList(root, noColor), nil
+	return tui.RenderList(root, opts), nil
 }
 
 // Snapshot renders a non-interactive snapshot of the TUI and returns it as a string.

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6132,8 +6132,8 @@ func TestIntegration_LintRules_List(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "lint", "rules")
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "RULE")
-	assert.Contains(t, stdout, "SEVERITY")
+	assert.Contains(t, stdout, "Rule")
+	assert.Contains(t, stdout, "Severity")
 }
 
 func TestIntegration_LintRules_FilterSeverity(t *testing.T) {
@@ -6161,7 +6161,7 @@ func TestIntegration_LintExplain_KnownRule(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "lint", "explain", "missing-description")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "missing-description")
-	assert.Contains(t, stdout, "Severity")
+	assert.Contains(t, stdout, "severity")
 }
 
 func TestIntegration_LintExplain_UnknownRule(t *testing.T) {


### PR DESCRIPTION
## Description

- replace manual `Output`/`Expression` fields with shared `KvxOutputFlags` struct
- use `flags.AddKvxOutputFlagsToStruct` and `flags.ToKvxOutputOptions` consistently
- migrate `lint rules` command from manual table formatting to `kvx.Write()` with column hints
- refactor `explain` command to use `kvx.Write()` with column order and context options
- add `projectRule` helper to emit only non-empty fields in visual formats
- add `ArrayStyle` option and `hiddenColumnsFromHints` helper to kvx viewer
- update `RenderList` signature to accept `tui.ListOptions`
- embed JSON display schemas for `lint`, `rules`, and `explain` commands
- add interactive mode paths for rich TUI detail views
- hide auxiliary columns in findings table output
- add yaml struct tags to `RuleMeta` for structured output support
- add tests for all output formats, interactive mode, and severity filtering
- bump kvx dependency to latest

## Related Issues

- https://github.com/oakwood-commons/kvx/pull/70
- https://github.com/oakwood-commons/kvx/pull/72

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
