### PR TITLE
feat(state): add `saveOverrides` field for asymmetric load/save backend inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch
+- *(lint)* Add `state-save-override-state-ref` rule (error) to catch circular state provider references in saveOverrides
+- *(lint)* Add `state-github-no-save-branch` rule (info) to suggest save-specific branch configuration for GitHub state backends
 - *(cli)* [**breaking**] Unified solution auto-discovery and resolution chain across all commands (#260)
   - Add `taskfile.yaml` and `taskfile.yml` to default discovery search order (after solution/binary files, before actions)
   - All commands now use the same resolution chain: `-f` flag → positional catalog ref → auto-discovery

--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -102,7 +102,22 @@ State is declared via a top-level `state` field on the `Solution` struct, as a p
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string` | Yes | Name of a registered provider with `CapabilityState` (e.g., `"file"`) |
-| `inputs` | `map[string]*ValueRef` | Yes | Provider-specific inputs -- follows the same pattern as resolver provider inputs |
+| `inputs` | `map[string]*ValueRef` | Yes | Provider-specific inputs resolved at **both** load and save time. Must only use `literal`, `__params` expressions, or templates -- resolver references (`rslvr:`) and `_` in CEL are not available at load time. |
+| `saveOverrides` | `map[string]*ValueRef` | No | Provider-specific inputs resolved **only** at save time. Can use resolver references (`rslvr:`), `_` in CEL, and all other ValueRef forms. Keys that overlap with `inputs` override them at save time. |
+
+### Save-Time Inputs (`saveOverrides`)
+
+Some state backends need different configuration for load vs save. For example, a GitHub backend may read state from the `main` branch but write state to a feature branch determined at runtime by a resolver.
+
+`saveOverrides` are resolved only during `state_save` operations (after resolvers have executed). At load time, they are skipped entirely -- no errors are raised for resolver-dependent expressions.
+
+At save time, the final input map is computed as:
+
+```
+finalInputs = merge(resolvedInputs, resolvedSaveOverrides)
+```
+
+Where `saveOverrides` keys override `inputs` keys. This allows a provider to use a default value from `inputs` (e.g., `branch: main`) that gets overridden by a save-specific value (e.g., `branch: { rslvr: featureBranch }`).
 
 ### Example
 
@@ -372,18 +387,159 @@ During dry-run: `state_load` returns empty state, `state_save` and `state_delete
 
 ## GitHub Provider State Operations
 
-The `github` provider also supports `CapabilityState`, storing state as JSON files in a GitHub repository.
+The `github` provider also supports `CapabilityState`, storing state as JSON files in a GitHub repository. The GitHub backend supports asymmetric read/write targets: loading state from one branch (e.g., `main`) and saving to another (e.g., a feature branch created by the action workflow).
 
 ### Input Schema
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `operation` | string (enum: `state_load`, `state_save`, `state_delete`) | Yes | Operation to perform |
-| `owner` | string | Yes | Repository owner |
-| `repo` | string | Yes | Repository name |
-| `path` | string | Yes | File path in the repository |
-| `branch` | string | No | Branch name (defaults to default branch) |
-| `data` | object | For `state_save` | The full `Data` object to persist |
+| Field | Type | Required For | Description |
+|-------|------|-------------|-------------|
+| `operation` | string (enum: `state_load`, `state_save`, `state_delete`) | All | Operation to perform |
+| `owner` | string | All | Repository owner |
+| `repo` | string | All | Repository name |
+| `path` | string | All | File path in the repository |
+| `ref` | string | `state_load` | Branch/ref to read state from (e.g., `main`). Only needed at load time. |
+| `branch` | string | `state_save`, `state_delete` | Branch to write state to. Can reference a resolver via `saveOverrides`. |
+| `message` | string | No | Commit message (defaults to `"chore(state): update state"`) |
+| `data` | object | `state_save` | The full state data object to persist |
+
+### Asymmetric Read/Write Configuration
+
+The GitHub backend is designed for PR-based workflows where:
+
+1. State is **loaded** from the default branch (`main`) -- reflecting the last merged state
+2. State is **saved** to a feature branch -- alongside scaffolded files in the same PR
+
+This is achieved using `saveOverrides`:
+
+~~~yaml
+state:
+  enabled: true
+  backend:
+    provider: github
+    inputs:
+      owner: { literal: "my-org" }
+      repo: { literal: "my-repo" }
+      path: { expr: "'state/' + __params.app_name + '.json'" }
+      ref: { literal: "main" }
+    saveOverrides:
+      branch: { rslvr: featureBranch }
+      message: { expr: "'chore(state): save ' + __params.app_name" }
+~~~
+
+At load time: `ref` (from `inputs`) determines where to read. At save time: `branch` (from `saveOverrides`) determines where to write.
+
+### Concurrency: `expectedHeadOid`
+
+The GitHub `createCommitOnBranch` GraphQL mutation requires `expectedHeadOid`. The state provider fetches the current HEAD OID of the target branch immediately before committing. This serves two purposes:
+
+1. **API requirement** -- GitHub rejects commits without a valid `expectedHeadOid`
+2. **Lightweight optimistic locking** -- if a concurrent process committed to the same branch between the fetch and the commit, the mutation fails with a conflict error rather than silently overwriting
+
+On conflict, the provider returns an error: `"state save conflict: concurrent commit on branch <name>"`. The user re-runs to pick up the latest state.
+
+### Eventual Consistency in PR Workflows
+
+In PR-based workflows, state on `main` is eventually consistent:
+
+- State saved to a feature branch only reaches `main` when the PR merges
+- Until merge, subsequent `state_load` reads from `main` and gets the pre-PR state
+- This means immutables, fingerprints, and parameter replay reflect the last **merged** state
+
+This is semantically correct: state reflects what is committed/deployed, not what is proposed. Actions re-execute on subsequent runs because the previous run's state has not landed on `main` yet.
+
+### Operations
+
+| Operation | Behavior |
+|-----------|----------|
+| `state_load` | Read JSON file from `owner/repo/path@ref`. Return empty state on 404 (first run). |
+| `state_save` | Fetch HEAD OID of `branch`, call `createCommitOnBranch` with state JSON as file addition. Fail on OID conflict. |
+| `state_delete` | Fetch HEAD OID of `branch`, call `createCommitOnBranch` with file deletion. Idempotent on missing file. |
+
+### Dry-Run Behavior
+
+During dry-run: `state_load` returns empty state, `state_save` and `state_delete` report what-if actions without making API calls.
+
+### Full Workflow Example
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: deploy-infra
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: github
+    inputs:
+      owner: { literal: "my-org" }
+      repo: { literal: "infra-state" }
+      path: { expr: "'state/' + __params.app_name + '.json'" }
+      ref: { literal: "main" }
+    saveOverrides:
+      branch: { rslvr: featureBranch }
+      message: { expr: "'chore(state): update ' + __params.app_name" }
+spec:
+  resolvers:
+    appName:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "App Name"
+    featureBranch:
+      type: string
+      resolve:
+        with:
+          - expr: "'scafctl/' + _.appName + '/' + string(timestamp.now())"
+    clusterId:
+      type: string
+      immutable: true
+      saveToState: true
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              key: "clusterId"
+              required: false
+          - provider: exec
+            inputs:
+              command: "uuidgen"
+  workflow:
+    actions:
+      create-branch:
+        provider: github
+        inputs:
+          operation: create_branch
+          owner: { rslvr: org }
+          repo: { literal: "infra-state" }
+          branch: { rslvr: featureBranch }
+      commit-files:
+        dependsOn: [create-branch]
+        provider: github
+        inputs:
+          operation: create_commit
+          owner: { literal: "my-org" }
+          repo: { literal: "infra-state" }
+          branch: { rslvr: featureBranch }
+          message: "feat: scaffold infrastructure"
+          additions:
+            - path: main.tf
+              content: { rslvr: renderedTerraform }
+      open-pr:
+        dependsOn: [commit-files]
+        provider: github
+        inputs:
+          operation: create_pull_request
+          owner: { literal: "my-org" }
+          repo: { literal: "infra-state" }
+          branch: { rslvr: featureBranch }
+          base: main
+          title: { expr: "'feat: deploy ' + _.appName" }
+~~~
+
+After actions complete, the state manager saves state as a second commit on `featureBranch`. The PR contains both the scaffolded files and the state file.
 
 ### Future Backends
 
@@ -396,7 +552,7 @@ The backend is a provider capability, so new backends are just providers impleme
 | S3 (future) | `s3` (or plugin) | `bucket`, `key`, `region` |
 | HTTP API (future) | `http` (or plugin) | `url`, `method`, `headers` |
 
-No changes to `pkg/state/` or the core execution flow are needed to add a new backend.
+No changes to the resolver executor or provider executor are needed to add a new backend. The state manager handles all backend-specific input resolution (including the `saveOverrides` split) transparently.
 
 ---
 
@@ -412,7 +568,7 @@ The `enabled` and `backend.inputs` fields are resolved using CLI parameters (`-r
 
 3. **Evaluate `enabled`** -- Resolve the `ValueRef` using CLI params (`__params`). If falsy, skip state entirely and proceed with normal stateless execution.
 
-4. **Resolve backend inputs** -- Resolve all `ValueRef` inputs for the backend provider (e.g., the `path` template) using CLI params (`__params`).
+4. **Resolve backend inputs** -- Resolve all `ValueRef` inputs for the backend provider (e.g., the `path` template) using CLI params (`__params`). Only `inputs` are resolved at load time; `saveOverrides` are skipped.
 
 5. **Load state** -- Call the backend provider with `operation: load` via `provider.Execute()` with `WithExecutionMode(ctx, CapabilityState)`. This is a standalone provider call -- completely independent of the resolver system.
 
@@ -422,7 +578,7 @@ The `enabled` and `backend.inputs` fields are resolved using CLI parameters (`-r
 
 8. **Normal execution** -- `resolver.Executor.Execute()` runs. Resolvers with `saveToState: true` persist their results. The `state` provider reads/writes entries via context.
 
-9. **Flush** -- After all resolvers complete, collect results from `saveToState` resolvers, update state data, and call the backend provider with `operation: save`.
+9. **Flush** -- After all resolvers complete, resolve both `inputs` and `saveOverrides` (merged, `saveOverrides` overrides). Collect results from `saveToState` resolvers, update state data, and call the backend provider with `operation: save`.
 
 ### Integration Point
 
@@ -479,6 +635,8 @@ State loading happens in the command layer (`pkg/cmd/scafctl/run/common.go`) bef
 | `state.enabled` and `state.backend.inputs` must NOT contain resolver references (`rslvr:`) | State loads before resolvers run, so resolver outputs are not available |
 | `state.enabled` and `state.backend.inputs` must NOT reference the `state` provider | State must be loaded before the state provider can function -- circular dependency |
 | `state.backend.provider` must resolve to a registered provider with `CapabilityState` | Ensures the backend is valid |
+| `state.backend.saveOverrides` may contain resolver references (`rslvr:`) and `_` in CEL | These are only resolved at save time when resolver data is available |
+| `state.backend.saveOverrides` must NOT reference the `state` provider | Prevents circular dependency even at save time |
 
 ### Lint Warnings
 

--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -23,7 +23,8 @@ This tutorial walks you through using state persistence in scafctl. The state sy
 6. [Dynamic State Paths](#dynamic-state-paths)
 7. [CLI Commands](#cli-commands)
 8. [Command Behavior](#command-behavior)
-9. [Common Patterns](#common-patterns)
+9. [Save-Time Overrides](#save-time-overrides)
+10. [Common Patterns](#common-patterns)
 
 ---
 
@@ -552,6 +553,108 @@ Use `render solution` to preview what an action graph would look like with curre
 | `run solution` | Yes | Yes | After actions succeed |
 | `run action` | Yes | Yes | After actions succeed |
 | `render solution` | Yes | No (read-only) | -- |
+
+---
+
+## Save-Time Overrides
+
+Some workflows need different backend inputs at load time vs save time. For example, a GitHub backend may load state from the `main` branch but save state to a feature branch determined by a resolver. The `saveOverrides` field makes this possible.
+
+### The Problem
+
+Backend `inputs` are resolved at **both** load and save time. Because state loads before resolvers run, `inputs` cannot use resolver references (`rslvr:`) or `_` in CEL -- those values do not exist yet.
+
+But at save time, resolvers have already executed. `saveOverrides` lets you provide inputs that are only resolved at save time, when resolver data is available.
+
+### How It Works
+
+1. At **load time**: only `inputs` are resolved (using `__params` and literals).
+2. At **save time**: both `inputs` and `saveOverrides` are resolved. Keys in `saveOverrides` override keys in `inputs`.
+
+### Example: GitHub PR Workflow
+
+This pattern loads state from `main` and saves to a resolver-derived feature branch:
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: pr-workflow
+  version: 1.0.0
+
+state:
+  enabled: true
+  backend:
+    provider: github
+    inputs:
+      owner: { literal: "my-org" }
+      repo: { literal: "my-repo" }
+      path:
+        expr: "'state/' + __params.app_name + '.json'"
+      ref: { literal: "main" }
+    saveOverrides:
+      branch: { rslvr: featureBranch }
+      message:
+        expr: "'chore(state): update state for ' + _.app_name"
+
+spec:
+  resolvers:
+    app_name:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "app_name"
+
+    featureBranch:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "branch_name"
+~~~
+
+Run it:
+
+{{< tabs "state-tutorial-cmd-saveoverrides" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f ./pr-workflow.yaml \
+  -r app_name=my-app -r branch_name=feat/my-feature
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f ./pr-workflow.yaml `
+  -r app_name=my-app -r branch_name=feat/my-feature
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+At load time, state is read from `main` using the `ref` input. At save time, the `branch` from `saveOverrides` overrides the default, saving state to `feat/my-feature`. After the PR merges, subsequent runs load the merged state from `main`.
+
+### Lint Rules
+
+Two lint rules help validate `saveOverrides` configuration:
+
+| Rule | Severity | What It Catches |
+|------|----------|----------------|
+| `state-save-override-state-ref` | Error | `saveOverrides` referencing the `state` provider (circular dependency) |
+| `state-github-no-save-branch` | Info | GitHub backend without a save-specific branch (hint for PR workflows) |
+
+Run `scafctl lint` to check your configuration.
+
+### Restrictions
+
+- `saveOverrides` values **can** use `rslvr:`, `_` in CEL, and `__params`.
+- `saveOverrides` values **cannot** reference the `state` provider (circular dependency).
+- Keys in `saveOverrides` override same-named keys in `inputs` at save time only.
+- At load time, `saveOverrides` are completely ignored -- no errors are raised for resolver-dependent expressions.
+
+> [!TIP]
+> See [examples/solutions/state/github-state.yaml](https://github.com/oakwood-commons/scafctl/blob/main/examples/solutions/state/github-state.yaml) for a complete working example.
 
 ---
 

--- a/examples/solutions/state/README.md
+++ b/examples/solutions/state/README.md
@@ -28,6 +28,35 @@ scafctl run resolver -f solution.yaml
 scafctl state list --path state-example.json
 ~~~
 
+## github-state.yaml
+
+GitHub-based state persistence with PR workflows using `saveOverrides`.
+State is loaded from `main` and saved to a resolver-derived feature branch,
+enabling PR-based review of state changes.
+
+Requires the `github` provider plugin (>= 0.6.0).
+
+### First Run
+
+~~~sh
+scafctl run resolver -f ./github-state.yaml \
+  -r app_name=my-app -r branch_name=feat/my-feature -r environment=prod
+~~~
+
+### How it works
+
+- **Load**: reads state from `refs/heads/main` at `state/<app_name>.json`
+- **Save**: writes state to the `featureBranch` resolver value (e.g., `feat/my-feature`)
+- **saveOverrides**: the `branch` and `message` inputs are only resolved at
+  save time when resolver data (`_`) is available
+
+### Prerequisites
+
+~~~sh
+scafctl auth login github
+scafctl plugins install github
+~~~
+
 ### Clear State
 
 ~~~sh

--- a/examples/solutions/state/github-state.yaml
+++ b/examples/solutions/state/github-state.yaml
@@ -1,0 +1,80 @@
+# =============================================================================
+# GitHub State Backend Example (PR Workflow)
+# =============================================================================
+# Demonstrates GitHub-based state persistence with PR-based workflows using
+# saveOverrides. State is loaded from the main branch and saved to a
+# resolver-derived feature branch, enabling PR-based review of state changes.
+#
+# This example requires the github provider plugin (>= 0.6.0).
+#
+# Usage:
+#   First run:
+#     scafctl run resolver -f ./github-state.yaml \
+#       -r app_name=my-app -r branch_name=feat/my-feature
+#
+#   Subsequent runs (params replayed from state on main after PR merge):
+#     scafctl run resolver -f ./github-state.yaml
+#
+# Prerequisites:
+#   - GitHub authentication configured (scafctl auth login github)
+#   - github provider plugin installed (scafctl plugins install github)
+#   - Target repository exists with the configured path structure
+# =============================================================================
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: github-state-example
+  version: 1.0.0
+  description: |
+    GitHub-based state persistence with PR workflow.
+    Loads state from main, saves to a feature branch derived from a resolver.
+
+# State configuration:
+# - Loads from refs/heads/main (fixed ref in inputs)
+# - Saves to the branch specified in saveOverrides (resolved at save time)
+state:
+  enabled: true
+  backend:
+    provider: github
+    inputs:
+      owner: { literal: "my-org" }
+      repo: { literal: "my-repo" }
+      path:
+        expr: "'state/' + __params.app_name + '.json'"
+      ref: { literal: "main" }
+    saveOverrides:
+      branch: { rslvr: featureBranch }
+      message:
+        expr: "'chore(state): update state for ' + _.app_name"
+
+spec:
+  resolvers:
+    app_name:
+      description: Application name for state file path isolation
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "app_name"
+
+    featureBranch:
+      description: Target branch for saving state (e.g., feat/my-feature)
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "branch_name"
+
+    environment:
+      description: Deployment environment
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "environment"
+          - provider: static
+            inputs:
+              value: "dev"

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -1266,6 +1266,8 @@ func lintState(sol *solution.Solution, result *Result, registry *provider.Regist
 		return
 	}
 	lintStateResolverRefs(sol, result)
+	lintStateSaveOverrides(sol, result)
+	lintStateGitHubNoSaveBranch(sol, result)
 }
 
 // lintStateBackend validates the backend provider configuration.
@@ -1327,6 +1329,56 @@ func lintStateResolverRefs(sol *solution.Solution, result *Result) {
 				"Use a CEL expression referencing a CLI parameter instead (e.g. expr: \"__params.appName + '-state.json'\")",
 				"state-resolver-ref")
 		}
+	}
+}
+
+// lintStateSaveOverrides validates saveOverrides fields.
+// saveOverrides MAY contain rslvr: references (unlike inputs), but must NOT
+// reference the state provider (circular dependency).
+func lintStateSaveOverrides(sol *solution.Solution, result *Result) {
+	for key, vr := range sol.State.Backend.SaveOverrides {
+		location := fmt.Sprintf("state.backend.saveOverrides.%s", key)
+		if vr == nil {
+			result.addFinding(SeverityError, "provider", location,
+				fmt.Sprintf("input '%s' has no value (dangling YAML key)", key),
+				"Provide a value for the input or remove the key entirely",
+				"nil-provider-input")
+			continue
+		}
+		// Check for state provider references using ReferencedVariables
+		if vr.ReferencesVariable("__state") {
+			result.addFinding(SeverityError, "state", location,
+				fmt.Sprintf("saveOverrides input %q references the state provider, creating a circular dependency", key),
+				"Use a resolver reference (rslvr:) or CEL expression that does not depend on the state provider",
+				"state-save-override-state-ref")
+		}
+	}
+}
+
+// lintStateGitHubNoSaveBranch fires an info hint when the state backend is
+// github and neither inputs.branch nor saveOverrides.branch is configured.
+func lintStateGitHubNoSaveBranch(sol *solution.Solution, result *Result) {
+	if sol.State.Backend.Provider != "github" {
+		return
+	}
+
+	hasBranch := false
+
+	// Check inputs for branch
+	if _, ok := sol.State.Backend.Inputs["branch"]; ok {
+		hasBranch = true
+	}
+
+	// Check saveOverrides for branch
+	if _, ok := sol.State.Backend.SaveOverrides["branch"]; ok {
+		hasBranch = true
+	}
+
+	if !hasBranch {
+		result.addFinding(SeverityInfo, "state", "state.backend",
+			"GitHub state backend has no save branch configured",
+			"For PR workflows, create a resolver for the branch name and reference it:\n  saveOverrides:\n    branch: { rslvr: <your-branch-resolver> }\nThis ensures state is saved to the same branch as your scaffolded files",
+			"state-github-no-save-branch")
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1455,6 +1455,241 @@ func TestLintState_ResolverRefInBackendInputs(t *testing.T) {
 	assert.Contains(t, findings[0].Message, "app_name")
 }
 
+func TestLintState_SaveOverrideStateRef(t *testing.T) {
+	expr := celexp.Expression("__state.branch")
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"env": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Expr: &expr},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-save-override-state-ref")
+	assert.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "branch")
+}
+
+func TestLintState_SaveOverrideRslvrAllowed(t *testing.T) {
+	rslvrName := "featureBranch"
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"featureBranch": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Resolver: &rslvrName},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	// rslvr: is allowed in saveOverrides (unlike inputs)
+	findings := filterFindingsByRule(result, "state-resolver-ref")
+	assert.Empty(t, findings)
+	findings = filterFindingsByRule(result, "state-save-override-state-ref")
+	assert.Empty(t, findings)
+}
+
+func TestLintState_SaveOverrideNoFalsePositive(t *testing.T) {
+	// Expressions using 'state/' as a string prefix must NOT trigger the state-ref rule
+	expr := celexp.Expression("'state/' + _.branch")
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"branch": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"path": {Expr: &expr},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-save-override-state-ref")
+	assert.Empty(t, findings, "expression using 'state/' string should not trigger false positive")
+}
+
+func TestLintState_GitHubNoSaveBranch(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"env": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-github-no-save-branch")
+	assert.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Message, "no save branch")
+}
+
+func TestLintState_GitHubWithSaveBranchInOverrides(t *testing.T) {
+	rslvrName := "featureBranch"
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"featureBranch": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Resolver: &rslvrName},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-github-no-save-branch")
+	assert.Empty(t, findings) // branch is configured via saveOverrides
+}
+
+func TestLintState_GitHubWithBranchInInputs(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"env": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs: map[string]*spec.ValueRef{
+					"path":   {Literal: "state.json"},
+					"branch": {Literal: "main"},
+				},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("github", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-github-no-save-branch")
+	assert.Empty(t, findings) // branch is configured via inputs
+}
+
+func TestLintState_NonGitHubNoSaveBranchHint(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"env": {
+					Type:    "string",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}},
+				},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+	_ = reg.Register(newStateProvider("file", provider.CapabilityState))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "state-github-no-save-branch")
+	assert.Empty(t, findings) // hint only fires for github provider
+}
+
 func TestLintResolveForEach(t *testing.T) {
 	prov := newFakeProvider("http", map[string]*jsonschema.Schema{
 		"url": {Type: "string"},

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -384,6 +384,22 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "State configuration is resolved before resolver execution using only CLI parameters (-r flags) and environment data. Direct rslvr: references will fail at runtime because resolver results do not exist yet.",
 		Fix:         "Use a CEL expression referencing CLI parameters instead, e.g.:\n  path:\n    expr: \"__params.appName + '-state.json'\"\nwhere appName is passed via -r appName=myapp.",
 	},
+	"state-save-override-state-ref": {
+		Rule:        "state-save-override-state-ref",
+		Severity:    string(SeverityError),
+		Category:    "state",
+		Description: "A state.backend.saveOverrides field references the 'state' provider, creating a circular dependency.",
+		Why:         "The state provider reads from the state being saved, so referencing it in saveOverrides would create a circular dependency. Use resolver references or CEL expressions instead.",
+		Fix:         "Use a resolver reference (rslvr:) or CEL expression (expr:) that does not depend on the state provider.",
+	},
+	"state-github-no-save-branch": {
+		Rule:        "state-github-no-save-branch",
+		Severity:    string(SeverityInfo),
+		Category:    "state",
+		Description: "GitHub state backend has no save branch configured. For PR workflows, use saveOverrides to set the branch at save time.",
+		Why:         "Without a save-specific branch, state is saved to the same branch used for loading (typically main). For PR-based workflows, you likely want to save state to a feature branch derived from a resolver.",
+		Fix:         "Add a saveOverrides.branch field referencing a resolver:\n  saveOverrides:\n    branch: { rslvr: featureBranch }\nThis ensures state is saved to the same branch as your scaffolded files.",
+	},
 	"unused-suppression": {
 		Rule:        "unused-suppression",
 		Severity:    string(SeverityInfo),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 45 rules — update this when new rules are added
-	assert.Equal(t, 45, len(KnownRules), "expected 45 known lint rules")
+	// We expect exactly 47 rules — update this when new rules are added
+	assert.Equal(t, 47, len(KnownRules), "expected 47 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/solution/inspect/inspect.go
+++ b/pkg/solution/inspect/inspect.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
 )
 
 // SolutionExplanation holds structured explanation data for a solution.
@@ -42,6 +43,8 @@ type SolutionExplanation struct {
 
 	Source      string            `json:"source,omitempty" yaml:"source,omitempty" doc:"Source repository URL" maxLength:"500"`
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" doc:"Free-form key-value annotations"`
+
+	State *StateInfo `json:"state,omitempty" yaml:"state,omitempty" doc:"State persistence configuration"`
 
 	Tags        []string         `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Solution tags" maxItems:"50"`
 	Links       []LinkInfo       `json:"links,omitempty" yaml:"links,omitempty" doc:"Related links" maxItems:"50"`
@@ -89,6 +92,14 @@ type LinkInfo struct {
 type MaintainerInfo struct {
 	Name  string `json:"name" yaml:"name" doc:"Maintainer name" maxLength:"128" example:"Jane Doe"`
 	Email string `json:"email,omitempty" yaml:"email,omitempty" doc:"Maintainer email" maxLength:"256" example:"jane@example.com"`
+}
+
+// StateInfo holds structured information about state persistence configuration.
+type StateInfo struct {
+	Enabled      bool     `json:"enabled" yaml:"enabled" doc:"Whether state persistence is configured"`
+	Provider     string   `json:"provider" yaml:"provider" doc:"Backend provider name" maxLength:"253" example:"file"`
+	InputKeys    []string `json:"inputKeys,omitempty" yaml:"inputKeys,omitempty" doc:"Configured backend input keys" maxItems:"50"`
+	OverrideKeys []string `json:"overrideKeys,omitempty" yaml:"overrideKeys,omitempty" doc:"Configured saveOverrides keys" maxItems:"50"`
 }
 
 // FileDependencyInfo describes a file dependency discovered via static analysis.
@@ -175,6 +186,11 @@ func BuildSolutionExplanation(sol *solution.Solution) *SolutionExplanation {
 	if sol.Spec.HasActions() && sol.Spec.Workflow != nil {
 		exp.Actions = buildActionInfos(sol.Spec.Workflow.Actions, sm, "spec.workflow.actions")
 		exp.Finally = buildActionInfos(sol.Spec.Workflow.Finally, sm, "spec.workflow.finally")
+	}
+
+	// State
+	if sol.State != nil {
+		exp.State = buildStateInfo(sol)
 	}
 
 	// Tags
@@ -367,4 +383,44 @@ func extractPhases(r *resolver.Resolver) []string {
 		phases = append(phases, "validate")
 	}
 	return phases
+}
+
+// buildStateInfo extracts structured state persistence information from a solution.
+func buildStateInfo(sol *solution.Solution) *StateInfo {
+	info := &StateInfo{
+		Enabled:  stateEnabled(sol.State.Enabled),
+		Provider: sol.State.Backend.Provider,
+	}
+
+	info.InputKeys = sortedKeys(sol.State.Backend.Inputs)
+	info.OverrideKeys = sortedKeys(sol.State.Backend.SaveOverrides)
+
+	return info
+}
+
+// stateEnabled determines the effective enabled value from a ValueRef.
+// Returns true (the default) when the ValueRef is nil or contains a non-literal
+// expression (dynamic values are assumed enabled for inspect purposes).
+func stateEnabled(vr *spec.ValueRef) bool {
+	if vr == nil {
+		return true
+	}
+	if b, ok := vr.Literal.(bool); ok {
+		return b
+	}
+	// Non-literal (expr/tmpl) -- assume enabled for inspect display
+	return true
+}
+
+// sortedKeys returns the sorted keys of a map.
+func sortedKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/pkg/solution/inspect/inspect_test.go
+++ b/pkg/solution/inspect/inspect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -253,4 +255,113 @@ type testProvider struct {
 func (p *testProvider) Descriptor() *provider.Descriptor { return p.desc }
 func (p *testProvider) Execute(_ context.Context, _ any) (*provider.Output, error) {
 	return &provider.Output{}, nil
+}
+
+func TestBuildSolutionExplanation_NoState(t *testing.T) {
+	sol := &solution.Solution{}
+	sol.Metadata.Name = "no-state"
+
+	exp := BuildSolutionExplanation(sol)
+	assert.Nil(t, exp.State)
+}
+
+func TestBuildSolutionExplanation_WithState(t *testing.T) {
+	sol := &solution.Solution{
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs: map[string]*spec.ValueRef{
+					"path": {Literal: "state.json"},
+				},
+			},
+		},
+	}
+	sol.Metadata.Name = "with-state"
+
+	exp := BuildSolutionExplanation(sol)
+	require.NotNil(t, exp.State)
+	assert.True(t, exp.State.Enabled)
+	assert.Equal(t, "file", exp.State.Provider)
+	assert.Equal(t, []string{"path"}, exp.State.InputKeys)
+	assert.Nil(t, exp.State.OverrideKeys)
+}
+
+func TestBuildSolutionExplanation_WithSaveOverrides(t *testing.T) {
+	rslvrName := "featureBranch"
+	sol := &solution.Solution{
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs: map[string]*spec.ValueRef{
+					"owner": {Literal: "my-org"},
+					"repo":  {Literal: "my-repo"},
+					"path":  {Literal: "state.json"},
+				},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch":  {Resolver: &rslvrName},
+					"message": {Literal: "commit msg"},
+				},
+			},
+		},
+	}
+	sol.Metadata.Name = "with-overrides"
+
+	exp := BuildSolutionExplanation(sol)
+	require.NotNil(t, exp.State)
+	assert.Equal(t, "github", exp.State.Provider)
+	assert.Equal(t, []string{"owner", "path", "repo"}, exp.State.InputKeys)
+	assert.Equal(t, []string{"branch", "message"}, exp.State.OverrideKeys)
+}
+
+func TestBuildSolutionExplanation_StateDisabled(t *testing.T) {
+	sol := &solution.Solution{
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: false},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+			},
+		},
+	}
+	sol.Metadata.Name = "disabled-state"
+
+	exp := BuildSolutionExplanation(sol)
+	require.NotNil(t, exp.State)
+	assert.False(t, exp.State.Enabled)
+}
+
+func TestBuildSolutionExplanation_StateEnabledNil(t *testing.T) {
+	sol := &solution.Solution{
+		State: &state.Config{
+			Enabled: nil,
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs:   map[string]*spec.ValueRef{"path": {Literal: "state.json"}},
+			},
+		},
+	}
+	sol.Metadata.Name = "nil-enabled"
+
+	exp := BuildSolutionExplanation(sol)
+	require.NotNil(t, exp.State)
+	assert.True(t, exp.State.Enabled, "nil Enabled defaults to true")
+}
+
+func TestSortedKeys(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		result := sortedKeys[string](nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		result := sortedKeys(map[string]string{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns sorted", func(t *testing.T) {
+		result := sortedKeys(map[string]int{"c": 3, "a": 1, "b": 2})
+		assert.Equal(t, []string{"a", "b", "c"}, result)
+	})
 }

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -153,6 +153,18 @@ func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolv
 		return fmt.Errorf("state: resolve backend inputs for save: %w", err)
 	}
 
+	// Resolve save-only overrides (can use rslvr: and _ since resolvers have run)
+	if len(m.config.Backend.SaveOverrides) > 0 {
+		overrides, err := m.resolveSaveOverrides(ctx, resolverData, mergedParams)
+		if err != nil {
+			return fmt.Errorf("state: resolve save overrides: %w", err)
+		}
+		// Merge: saveOverrides keys override inputs keys
+		for k, v := range overrides {
+			backendInputs[k] = v
+		}
+	}
+
 	// Look up backend provider
 	backendProvider, err := m.getBackendProvider()
 	if err != nil {
@@ -210,6 +222,25 @@ func (m *Manager) resolveBackendInputs(ctx context.Context, resolverData, params
 		val, err := resolveWithParams(ctx, vr, resolverData, params)
 		if err != nil {
 			return nil, fmt.Errorf("resolve input %q: %w", key, err)
+		}
+		resolved[key] = val
+	}
+
+	return resolved, nil
+}
+
+// resolveSaveOverrides resolves all SaveOverrides ValueRefs.
+// These are only called at save time when resolver data (_) is available.
+func (m *Manager) resolveSaveOverrides(ctx context.Context, resolverData, params map[string]any) (map[string]any, error) {
+	resolved := make(map[string]any, len(m.config.Backend.SaveOverrides))
+
+	for key, vr := range m.config.Backend.SaveOverrides {
+		if vr == nil {
+			continue
+		}
+		val, err := resolveWithParams(ctx, vr, resolverData, params)
+		if err != nil {
+			return nil, fmt.Errorf("resolve save override %q: %w", key, err)
 		}
 		resolved[key] = val
 	}

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -770,3 +770,201 @@ func TestResolveWithParams(t *testing.T) {
 		assert.Contains(t, err.Error(), "empty value reference")
 	})
 }
+
+func TestManagerSave_SaveOverrides(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no saveOverrides backward compat", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		assert.Equal(t, "state.json", backend.saveCalls[0]["path"])
+	})
+
+	t.Run("saveOverrides with literal values", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": literalValueRef("feature-branch"),
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		assert.Equal(t, "feature-branch", backend.saveCalls[0]["branch"])
+		assert.Equal(t, "state.json", backend.saveCalls[0]["path"])
+	})
+
+	t.Run("saveOverrides with rslvr reference", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		branchResolver := "featureBranch"
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Resolver: &branchResolver},
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		resolverData := map[string]any{"featureBranch": "feat/my-feature"}
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, resolverData, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		assert.Equal(t, "feat/my-feature", backend.saveCalls[0]["branch"])
+	})
+
+	t.Run("saveOverrides with CEL expression using resolver data", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		expr := celexp.Expression("'feat/' + _.appName")
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Expr: &expr},
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		resolverData := map[string]any{"appName": "my-app"}
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, resolverData, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		assert.Equal(t, "feat/my-app", backend.saveCalls[0]["branch"])
+	})
+
+	t.Run("saveOverrides key overlaps with inputs key", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs: map[string]*spec.ValueRef{
+					"path":   literalValueRef("state.json"),
+					"branch": literalValueRef("main"),
+				},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": literalValueRef("feature-branch"),
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		// saveOverrides value should win
+		assert.Equal(t, "feature-branch", backend.saveCalls[0]["branch"])
+		// non-overridden input should remain
+		assert.Equal(t, "state.json", backend.saveCalls[0]["path"])
+	})
+
+	t.Run("saveOverrides ignored at load time", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		// saveOverrides with a rslvr: ref -- would fail if resolved at load time
+		branchResolver := "featureBranch"
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Resolver: &branchResolver},
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		// Load should succeed -- saveOverrides are not resolved
+		result, err := mgr.Load(context.Background(), nil, CommandInfo{Subcommand: "run solution"})
+		assert.NoError(t, err)
+		assert.False(t, result.Skipped)
+	})
+
+	t.Run("saveOverrides resolution error", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		expr := celexp.Expression("_.nonexistent.nested.value")
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": {Expr: &expr},
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "save overrides")
+	})
+
+	t.Run("saveOverrides with nil ValueRef entry", func(t *testing.T) {
+		t.Parallel()
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		cfg := &Config{
+			Enabled: literalValueRef(true),
+			Backend: Backend{
+				Provider: "mock-state",
+				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
+				SaveOverrides: map[string]*spec.ValueRef{
+					"branch": nil,
+				},
+			},
+		}
+		mgr := NewManager(cfg, reg, "test-version")
+		sd := NewData()
+		rctx := resolver.NewContext()
+		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
+		assert.NoError(t, err)
+		assert.Len(t, backend.saveCalls, 1)
+		// nil saveOverride should be skipped, not overwrite
+		_, hasBranch := backend.saveCalls[0]["branch"]
+		assert.False(t, hasBranch)
+	})
+}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -54,6 +54,15 @@ type Backend struct {
 	// Go templates spread resolver data at top level (e.g. {{ .name }}) and expose CLI
 	// parameters under __params (e.g. {{ .__params.project }}).
 	Inputs map[string]*spec.ValueRef `json:"inputs" yaml:"inputs" doc:"Provider-specific inputs (ValueRef for dynamic resolution)"`
+
+	// SaveOverrides are provider-specific inputs resolved only at save time when
+	// resolver data (_) is available. Keys that overlap with Inputs override them
+	// at save time. This enables patterns like loading state from a fixed branch
+	// (via Inputs) and saving to a resolver-derived branch (via SaveOverrides).
+	//
+	// At load time, SaveOverrides are completely ignored -- no errors are raised
+	// for resolver-dependent expressions.
+	SaveOverrides map[string]*spec.ValueRef `json:"saveOverrides,omitempty" yaml:"saveOverrides,omitempty" doc:"Save-time-only inputs that override Inputs keys"`
 }
 
 // Data is the complete persisted state structure.

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -468,7 +468,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|compose-demo/workflow|compose-demo/resolvers"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/solutions/state/save-overrides/solution.yaml
+++ b/tests/integration/solutions/state/save-overrides/solution.yaml
@@ -1,0 +1,106 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-state-save-overrides
+  version: 1.0.0
+  description: |
+    Functional tests for state backend saveOverrides.
+    Verifies that saveOverrides inputs are resolved only at save time (when
+    resolver data is available), merged with base inputs (overriding on
+    conflict), and completely ignored at load time.
+
+    The save-overrides mechanism allows different paths/config for load vs save.
+    This test uses the file provider where inputs.path is used at load time and
+    saveOverrides.path overrides it at save time with a resolver-derived value.
+
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: default-state.json
+    saveOverrides:
+      path:
+        expr: "'override-' + _.env + '.json'"
+
+spec:
+  resolvers:
+    env:
+      description: Environment name used to derive the save-time state path
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "env"
+          - provider: static
+            inputs:
+              value: "dev"
+
+    app_name:
+      description: Application name from parameter or default
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: "app_name"
+          - provider: static
+            inputs:
+              value: "my-app"
+
+  testing:
+    config:
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [render-defaults]
+
+    cases:
+      _base:
+        description: Base template for save-overrides tests
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [state, save-overrides]
+        assertions:
+          - expression: __exitCode == 0
+
+      # =====================================================================
+      # First run: empty state, saveOverrides.path resolves using _.env
+      # =====================================================================
+      first-run-resolves-overrides:
+        description: Save succeeds with saveOverrides using resolver data in CEL
+        extends: [_base]
+        args: ["-o", "json", "-r", "env=prod", "-r", "app_name=alpha"]
+        tags: [smoke]
+        assertions:
+          - expression: __output.env == "prod"
+          - expression: __output.app_name == "alpha"
+
+      # =====================================================================
+      # Load reads from inputs.path (default-state.json), not override path
+      # =====================================================================
+      load-uses-inputs-path:
+        description: State load reads from inputs.path, ignoring saveOverrides
+        extends: [_base]
+        args: ["-o", "json", "-r", "env=staging"]
+        init:
+          # Pre-seed at inputs.path -- this should be found at load time
+          - command: >-
+              printf '{"schemaVersion":1,"metadata":{"solution":"test-state-save-overrides","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"app_name":"from-default-path"},"immutables":{},"fingerprints":{}}'
+              > $SCAFCTL_SANDBOX_DIR/default-state.json
+        assertions:
+          - expression: __output.app_name == "from-default-path"
+            message: "State should load from inputs.path (default-state.json), not saveOverrides path"
+          - expression: __output.env == "staging"
+            message: "CLI param should override state"
+
+      # =====================================================================
+      # saveOverrides with literal values merge correctly
+      # =====================================================================
+      saveoverrides-literal:
+        description: Literal saveOverrides value is used without resolver data
+        extends: [_base]
+        assertions:
+          - expression: __output.env == "dev"
+            message: "Default env should resolve from static provider"
+


### PR DESCRIPTION
- Add SaveOverrides map to state Backend type, resolved only at save time when resolver data is available (rslvr: and _ in CEL are permitted)
- Merge saveOverrides over base inputs at save time; skip entirely at load
- Add resolveSaveOverrides method to state Manager with full merge logic
- Add lint rule `state-save-override-state-ref` (error) catching circular state provider references in saveOverrides
- Add lint rule `state-github-no-save-branch` (info) suggesting PR-workflow branch config for GitHub state backends
- Expose state config in solution inspect output via new StateInfo struct
- Add GitHub asymmetric read/write documentation and tutorial section
- Add example solution (github-state.yaml) and integration test for save-overrides with the file provider
- Exclude github-state example from e2e (requires plugin)