### PR TITLE
feat(resolver): add --action flag and fix catalog fallback for auto-discovered files

### DIFF
--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -11,10 +11,12 @@ import (
 	"io"
 	"os"
 	stdfilepath "path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/filepath"
 	"github.com/oakwood-commons/scafctl/pkg/flags"
@@ -42,6 +44,12 @@ type ResolverOptions struct {
 	// Names is the list of resolver names to execute (positional args).
 	// If empty, all resolvers are executed.
 	Names []string
+
+	// Actions scopes resolver output to one or more actions by name.
+	// When set, resolver names are extracted from each action's inputs
+	// and the resolver execution is filtered to only those resolvers
+	// (plus their transitive dependencies). Multiple values are unioned.
+	Actions []string
 
 	// SkipTransform skips the transform and validation phases,
 	// returning raw resolved values.
@@ -225,7 +233,16 @@ Examples:
   scafctl run resolver --progress -f ./my-solution.yaml
 
   # Show provider metrics
-  scafctl run resolver --show-metrics -f ./my-solution.yaml`, settings.CliBinaryName, cliParams.BinaryName),
+  scafctl run resolver --show-metrics -f ./my-solution.yaml
+
+  # Show only the resolvers consumed by a specific action
+  scafctl run resolver --action tag -f ./my-solution.yaml
+
+  # Union resolvers from multiple actions
+  scafctl run resolver --action tag --action release -f ./my-solution.yaml
+
+  # Run from catalog without -f (auto-fallback)
+  scafctl run resolver ford-proxy`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.ArbitraryArgs,
 		PreRun: func(cCmd *cobra.Command, args []string) {
 			// Track which flags were explicitly set by the user
@@ -251,6 +268,7 @@ Examples:
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
 	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
+	cCmd.Flags().StringArrayVar(&options.Actions, "action", nil, "Scope resolver output to the resolvers consumed by this action (repeatable)")
 
 	setResolverHelpFunc(cCmd)
 
@@ -339,13 +357,23 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 			exitcode.InvalidInput)
 	}
 
+	// Track whether the file was explicitly provided (via -f flag or as a
+	// positional unambiguous catalog reference). Auto-discovered files set
+	// o.File inside prepareSolutionForExecution, so we capture the state here
+	// to enable catalog fallback when auto-discovery finds a non-solution file.
+	fileWasExplicit := o.File != ""
+
 	// Prepare solution: load, set up registry, handle bundles
 	sol, reg, solutionDir, cleanup, providerCtx, err := o.prepareSolutionForExecution(ctx)
 	if err != nil {
-		// When no -f/--file was provided, auto-discovery failed to find a
-		// solution file, and the first positional arg looks like a catalog
-		// reference, retry using that arg as the solution source.
-		if o.File == "" && errors.Is(err, get.ErrNoSolutionFound) && len(o.Names) > 0 && get.IsCatalogReference(o.Names[0]) {
+		// When no explicit file was provided and auto-discovery either found
+		// nothing (ErrNoSolutionFound) or picked a known non-solution file
+		// (taskfile.yaml/yml), check if the first positional arg looks like a
+		// catalog reference and retry using it as the solution source.
+		// We intentionally do NOT retry when a real solution file was discovered
+		// but failed to parse -- that would mask useful validation errors.
+		canRetry := errors.Is(err, get.ErrNoSolutionFound) || isNonSolutionDiscoveryFile(o.File)
+		if !fileWasExplicit && canRetry && len(o.Names) > 0 && get.IsCatalogReference(o.Names[0]) {
 			o.File = o.Names[0]
 			o.Names = o.Names[1:]
 			lgr.V(1).Info("retrying with first positional arg as catalog reference", "file", o.File)
@@ -354,6 +382,15 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		if err != nil {
 			return o.exitWithCode(ctx, err, exitcode.FileNotFound)
 		}
+	}
+
+	// Validate mutually exclusive --action and positional resolver names.
+	// This check is placed after catalog fallback so that bare catalog names
+	// (parsed into o.Names) can be consumed by fallback first.
+	if len(o.Actions) > 0 && len(o.Names) > 0 {
+		return o.exitWithCode(ctx,
+			fmt.Errorf("--action and positional resolver names are mutually exclusive"),
+			exitcode.InvalidInput)
 	}
 	defer cleanup()
 	if providerCtx != nil {
@@ -410,6 +447,16 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 
 	// Get all resolvers, then filter by names if specified
 	allResolvers := sol.Spec.ResolversToSlice()
+
+	// --action: extract resolver names consumed by the specified action(s)
+	if len(o.Actions) > 0 {
+		actionNames, actionErr := o.resolveActionResolverNames(sol)
+		if actionErr != nil {
+			return o.exitWithCode(ctx, actionErr, exitcode.InvalidInput)
+		}
+		o.Names = actionNames
+		lgr.V(1).Info("--action resolved to resolver names", "actions", o.Actions, "resolvers", actionNames)
+	}
 
 	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
 	if len(params) > 0 {
@@ -692,6 +739,101 @@ func setResolverHelpFunc(cmd *cobra.Command) {
 			fmt.Fprint(c.OutOrStdout(), helpText)
 		}
 	})
+}
+
+// resolveActionResolverNames looks up the specified action(s) in the solution's
+// workflow and extracts the resolver names referenced by their inputs, forEach.in,
+// and when conditions. Multiple actions are unioned. Returns an error if the
+// solution has no workflow or an action does not exist.
+func (o *ResolverOptions) resolveActionResolverNames(sol *solution.Solution) ([]string, error) {
+	if !sol.Spec.HasWorkflow() {
+		return nil, fmt.Errorf("--action requires a solution with a workflow section, but %q has none", sol.Metadata.Name)
+	}
+
+	workflow := sol.Spec.Workflow
+	unioned := make(map[string]bool)
+
+	for _, actionName := range o.Actions {
+		act, found := workflow.Actions[actionName]
+		if !found {
+			// Also check finally actions
+			act, found = workflow.Finally[actionName]
+		}
+		if !found {
+			// Build available action names for the error message
+			available := make([]string, 0, len(workflow.Actions))
+			for name := range workflow.Actions {
+				available = append(available, name)
+			}
+			for name := range workflow.Finally {
+				available = append(available, name)
+			}
+			sort.Strings(available)
+			return nil, fmt.Errorf("action %q not found (available: %s)", actionName, strings.Join(available, ", "))
+		}
+
+		// Build a set of forEach alias names to exclude from extracted refs.
+		// These are iteration variables, not resolver names.
+		forEachAliases := make(map[string]bool)
+		if act.ForEach != nil {
+			if act.ForEach.Item != "" {
+				forEachAliases[act.ForEach.Item] = true
+			}
+			if act.ForEach.Index != "" {
+				forEachAliases[act.ForEach.Index] = true
+			}
+		}
+
+		// Extract resolver names from the action's inputs
+		for _, name := range resolver.ExtractRefsFromValueRefs(act.Inputs) {
+			if !forEachAliases[name] {
+				unioned[name] = true
+			}
+		}
+
+		// Extract from forEach.in if present
+		if act.ForEach != nil && act.ForEach.In != nil {
+			for _, name := range resolver.ExtractRefsFromValueRefs(map[string]*resolver.ValueRef{"in": act.ForEach.In}) {
+				unioned[name] = true
+			}
+		}
+
+		// Extract from the when condition if present
+		if act.When != nil && act.When.Expr != nil {
+			celExpr := celexp.Expression(*act.When.Expr)
+			vars, err := celExpr.GetUnderscoreVariables(context.TODO())
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse when condition for action %q: %w", actionName, err)
+			}
+			for _, v := range vars {
+				if !forEachAliases[v] {
+					unioned[v] = true
+				}
+			}
+		}
+	}
+
+	if len(unioned) == 0 {
+		if len(o.Actions) == 1 {
+			return nil, fmt.Errorf("action %q does not reference any resolvers in its inputs or conditions", o.Actions[0])
+		}
+		return nil, fmt.Errorf("actions %v do not reference any resolvers in their inputs or conditions", o.Actions)
+	}
+
+	names := make([]string, 0, len(unioned))
+	for name := range unioned {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// isNonSolutionDiscoveryFile returns true if the given path refers to a file
+// that auto-discovery may resolve but is not a valid solution file. When such
+// a file is found and loading fails, the catalog fallback is safe to try.
+func isNonSolutionDiscoveryFile(path string) bool {
+	base := stdfilepath.Base(path)
+	return base == "taskfile.yaml" || base == "taskfile.yml"
 }
 
 // extractSolutionPath determines the solution file path from:

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -2312,3 +2312,893 @@ func TestResolverOptions_Run_CatalogFallback(t *testing.T) {
 	assert.Equal(t, "my-solution", opts.File, "fallback should set File to the first positional arg")
 	assert.Empty(t, opts.Names, "fallback should remove the arg from Names")
 }
+
+func TestResolverOptions_Run_CatalogFallbackAfterAutoDiscoveryFailure(t *testing.T) {
+	// NOTE: no t.Parallel() — os.Chdir mutates process-global state.
+
+	// When auto-discovery finds a non-solution file (e.g. taskfile.yaml) and
+	// loading fails, the fallback should still fire if positional arg looks
+	// like a catalog reference. This tests the #501 fix.
+	tmpDir := t.TempDir()
+
+	// Create a non-solution YAML file that will be auto-discovered
+	taskfilePath := filepath.Join(tmpDir, "taskfile.yaml")
+	err := os.WriteFile(taskfilePath, []byte("version: '3'\ntasks:\n  build:\n    cmds:\n      - echo hi\n"), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Names: []string{"ford-proxy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	// Change to tmpDir so auto-discovery finds taskfile.yaml
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	err = opts.Run(ctx)
+	// The run will fail (no catalog configured), but we should see the
+	// fallback path was taken: File should be set to the catalog ref.
+	assert.Error(t, err)
+	assert.Equal(t, "ford-proxy", opts.File, "fallback should set File to catalog ref after auto-discovery load failure")
+	assert.Empty(t, opts.Names, "fallback should consume the positional arg")
+}
+
+func TestResolverOptions_Run_ActionFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: action-flag-test
+  version: 1.0.0
+spec:
+  resolvers:
+    repoUrl:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://github.com/example/repo"
+    version:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "1.2.3"
+    tagName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: "'v' + _.version"
+    unrelated:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "should-not-appear"
+  workflow:
+    actions:
+      tag:
+        provider: shell
+        inputs:
+          command:
+            tmpl: "git tag {{ ._.tagName }} {{ ._.repoUrl }}"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"tag"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include resolvers consumed by the "tag" action (tagName, repoUrl)
+	// and their transitive deps (version, since tagName depends on it)
+	assert.Contains(t, result, "repoUrl")
+	assert.Contains(t, result, "tagName")
+	assert.Contains(t, result, "version") // transitive dep of tagName
+	// Should NOT include unrelated resolver
+	assert.NotContains(t, result, "unrelated")
+}
+
+func TestResolverOptions_Run_ActionFlag_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: action-not-found-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command:
+            rslvr: greeting
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"nonexistent"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "action \"nonexistent\" not found")
+}
+
+func TestResolverOptions_Run_ActionFlag_NoWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-workflow-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"deploy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--action requires a solution with a workflow section")
+}
+
+func TestResolverOptions_Run_ActionFlagMutuallyExclusiveWithNames(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: mutual-exclusion-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      tag:
+        provider: shell
+        inputs:
+          command:
+            rslvr: greeting
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"tag"},
+		Names:   []string{"repoUrl"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--action and positional resolver names are mutually exclusive")
+}
+
+func TestResolverOptions_Run_ActionFlag_WhenCondition(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: when-condition-test
+  version: 1.0.0
+spec:
+  resolvers:
+    enabled:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: true
+    config:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "prod-config"
+    unrelated:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "skip-me"
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        when:
+          expr: "_.enabled == true"
+        inputs:
+          command:
+            rslvr: config
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"deploy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include "config" from inputs and "enabled" from when condition
+	assert.Contains(t, result, "config")
+	assert.Contains(t, result, "enabled")
+	// Should NOT include unrelated resolver
+	assert.NotContains(t, result, "unrelated")
+}
+
+func TestResolverOptions_Run_ActionFlag_LiteralOnlyInputs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: literal-only-test
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      echo:
+        provider: shell
+        inputs:
+          command: "echo hello"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"echo"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "action \"echo\" does not reference any resolvers in its inputs or conditions")
+}
+
+func TestResolverOptions_Run_ActionFlag_FinallyAction(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: finally-action-test
+  version: 1.0.0
+spec:
+  resolvers:
+    slackUrl:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://hooks.slack.com/xxx"
+    unrelated:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "skip-me"
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command: "echo deploy"
+    finally:
+      notify:
+        provider: shell
+        inputs:
+          command:
+            tmpl: "curl {{ ._.slackUrl }}"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"notify"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include slackUrl from finally action's template input
+	assert.Contains(t, result, "slackUrl")
+	// Should NOT include unrelated resolver
+	assert.NotContains(t, result, "unrelated")
+}
+
+func TestResolverOptions_Run_ActionFlag_ForEachIn(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: foreach-test
+  version: 1.0.0
+spec:
+  resolvers:
+    regions:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - us-east-1
+                - eu-west-1
+    config:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-config"
+    unrelated:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "skip-me"
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        forEach:
+          in:
+            rslvr: regions
+          item: region
+        inputs:
+          command:
+            rslvr: config
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"deploy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include both "regions" (from forEach.in) and "config" (from inputs template)
+	assert.Contains(t, result, "regions")
+	assert.Contains(t, result, "config")
+	// Should NOT include unrelated resolver
+	assert.NotContains(t, result, "unrelated")
+}
+
+func TestResolverOptions_Run_ActionFlag_MultiAction(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: multi-action-test
+  version: 1.0.0
+spec:
+  resolvers:
+    repoUrl:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://github.com/example/repo"
+    version:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "1.2.3"
+    slackUrl:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "https://hooks.slack.com/xxx"
+    unrelated:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "skip-me"
+  workflow:
+    actions:
+      tag:
+        provider: shell
+        inputs:
+          command:
+            rslvr: repoUrl
+      notify:
+        provider: shell
+        inputs:
+          url:
+            rslvr: slackUrl
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"tag", "notify"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include resolvers from both actions
+	assert.Contains(t, result, "repoUrl")
+	assert.Contains(t, result, "slackUrl")
+	// Should NOT include unrelated resolver
+	assert.NotContains(t, result, "unrelated")
+}
+
+func TestResolverOptions_Run_ActionFlag_ForEachAliasExcluded(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: foreach-alias-test
+  version: 1.0.0
+spec:
+  resolvers:
+    regions:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - us-east-1
+                - eu-west-1
+    config:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-config"
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        forEach:
+          in:
+            rslvr: regions
+          item: region
+          index: idx
+        inputs:
+          command:
+            tmpl: "deploy {{ ._.config }} to {{ .region }} ({{ .idx }})"
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"deploy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should include "regions" (from forEach.in) and "config" (from template)
+	assert.Contains(t, result, "regions")
+	assert.Contains(t, result, "config")
+	// "region" and "idx" are forEach aliases, NOT resolvers
+	assert.NotContains(t, result, "region")
+	assert.NotContains(t, result, "idx")
+}
+
+func TestResolverOptions_Run_ActionFlag_CELParseError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cel-error-test
+  version: 1.0.0
+spec:
+  resolvers:
+    config:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        when:
+          expr: "_.config == true &&& invalid"
+        inputs:
+          command:
+            rslvr: config
+`
+	err := os.WriteFile(solutionPath, []byte(solutionContent), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Actions: []string{"deploy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse when condition for action \"deploy\"")
+}
+
+func TestResolverOptions_Run_CatalogFallbackNotFiredForMalformedSolution(t *testing.T) {
+	// NOTE: no t.Parallel() — os.Chdir mutates process-global state.
+
+	// When auto-discovery finds a real solution.yaml that is malformed,
+	// the catalog fallback should NOT fire — the user should see the real
+	// validation error instead of a confusing catalog lookup failure.
+	tmpDir := t.TempDir()
+
+	// Create a malformed solution.yaml (invalid apiVersion)
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	err := os.WriteFile(solutionPath, []byte("apiVersion: invalid/v99\nkind: Solution\nmetadata:\n  name: broken\n"), 0o600)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistry(),
+		},
+		Names: []string{"ford-proxy"},
+	}
+
+	lgr := logger.Get(0)
+	ctx := logger.WithLogger(context.Background(), lgr)
+
+	// Change to tmpDir so auto-discovery finds solution.yaml
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	err = opts.Run(ctx)
+	assert.Error(t, err)
+	// Should get the validation error, NOT a catalog lookup error.
+	// The fallback should NOT have consumed the first name as a catalog ref.
+	assert.NotEqual(t, "ford-proxy", opts.File, "fallback should NOT fire for a malformed solution.yaml")
+}

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -217,6 +218,22 @@ func extractDepsFromValueRef(ref *ValueRef, deps map[string]bool) {
 	}
 }
 
+// ExtractRefsFromValueRefs extracts all resolver names referenced by a set of
+// ValueRef values. This is useful for determining which resolvers an action
+// depends on based on its inputs map. The result is sorted for deterministic output.
+func ExtractRefsFromValueRefs(inputs map[string]*ValueRef) []string {
+	deps := make(map[string]bool)
+	for _, ref := range inputs {
+		extractDepsFromValueRef(ref, deps)
+	}
+	result := make([]string, 0, len(deps))
+	for dep := range deps {
+		result = append(result, dep)
+	}
+	sort.Strings(result)
+	return result
+}
+
 // extractDepsFromLiteral recursively extracts dependencies from literal values
 // that may contain CEL expression strings or Go template syntax
 func extractDepsFromLiteral(literal any, deps map[string]bool) {
@@ -244,6 +261,33 @@ func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]
 			}
 		}
 	case map[string]any:
+		// Check if this map represents a nested ValueRef ({rslvr: x}, {expr: "..."}, {tmpl: "..."}).
+		// This handles inputs like: env: {APP: {rslvr: appName}}
+		// We check for ValueRef-like keys and extract deps, but do NOT
+		// early-return — sibling fields may also contain references.
+		isValueRef := false
+		if rslvr, ok := v["rslvr"].(string); ok {
+			if !exclude[rslvr] {
+				deps[rslvr] = true
+			}
+			isValueRef = true
+		}
+		if expr, ok := v["expr"].(string); ok {
+			extractDepsFromExpression(expr, deps)
+			isValueRef = true
+		}
+		if tmpl, ok := v["tmpl"].(string); ok {
+			if len(exclude) > 0 {
+				extractDepsFromTemplateWithExclusions(tmpl, deps, exclude)
+			} else {
+				extractDepsFromTemplate(tmpl, deps)
+			}
+			isValueRef = true
+		}
+		if isValueRef {
+			return
+		}
+
 		// Check for go-template provider pattern: if this map has a "template"
 		// string and a "data" map, exclude data keys from template references.
 		// This prevents false-positive resolver dependencies when the template

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -1401,3 +1401,142 @@ func TestExtractDeps_GoTemplateDataExclusion(t *testing.T) {
 		assert.NotEqual(t, "appName", dep, "appName should not be a dependency (provided by data)")
 	}
 }
+
+func TestExtractRefsFromValueRefs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputs map[string]*ValueRef
+		want   map[string]bool
+	}{
+		{
+			name:   "nil inputs",
+			inputs: nil,
+			want:   map[string]bool{},
+		},
+		{
+			name:   "empty inputs",
+			inputs: map[string]*ValueRef{},
+			want:   map[string]bool{},
+		},
+		{
+			name: "direct resolver reference",
+			inputs: map[string]*ValueRef{
+				"target": {Resolver: stringPtr("environment")},
+			},
+			want: map[string]bool{"environment": true},
+		},
+		{
+			name: "CEL expression reference",
+			inputs: map[string]*ValueRef{
+				"url": {Expr: celExpPtr("_.config.host + ':' + string(_.config.port)")},
+			},
+			want: map[string]bool{"config": true},
+		},
+		{
+			name: "template reference",
+			inputs: map[string]*ValueRef{
+				"greeting": {Tmpl: tmplPtr("Hello {{ ._.username }}")},
+			},
+			want: map[string]bool{"username": true},
+		},
+		{
+			name: "multiple mixed references",
+			inputs: map[string]*ValueRef{
+				"target":  {Resolver: stringPtr("environment")},
+				"url":     {Expr: celExpPtr("_.config.host")},
+				"message": {Tmpl: tmplPtr("{{ ._.greeting }}")},
+				"literal": {Literal: "static-value"},
+			},
+			want: map[string]bool{"environment": true, "config": true, "greeting": true},
+		},
+		{
+			name: "literal value produces no refs",
+			inputs: map[string]*ValueRef{
+				"name": {Literal: "hello"},
+			},
+			want: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractRefsFromValueRefs(tt.inputs)
+			gotMap := make(map[string]bool, len(got))
+			for _, dep := range got {
+				gotMap[dep] = true
+			}
+			assert.Equal(t, tt.want, gotMap)
+		})
+	}
+}
+
+func TestExtractRefsFromValueRefs_NestedValueRefMaps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputs map[string]*ValueRef
+		want   []string
+	}{
+		{
+			name: "nested rslvr in literal map",
+			inputs: map[string]*ValueRef{
+				"env": {Literal: map[string]any{
+					"APP_NAME": map[string]any{"rslvr": "appName"},
+					"APP_PORT": "8080",
+				}},
+			},
+			want: []string{"appName"},
+		},
+		{
+			name: "nested expr in literal map",
+			inputs: map[string]*ValueRef{
+				"config": {Literal: map[string]any{
+					"url": map[string]any{"expr": "_.host + ':' + string(_.port)"},
+				}},
+			},
+			want: []string{"host", "port"},
+		},
+		{
+			name: "nested tmpl in literal map",
+			inputs: map[string]*ValueRef{
+				"labels": {Literal: map[string]any{
+					"version": map[string]any{"tmpl": "{{ ._.appVersion }}"},
+				}},
+			},
+			want: []string{"appVersion"},
+		},
+		{
+			name: "mixed nested and top-level refs",
+			inputs: map[string]*ValueRef{
+				"direct": {Resolver: stringPtr("directRef")},
+				"nested": {Literal: map[string]any{
+					"inner": map[string]any{"rslvr": "nestedRef"},
+				}},
+			},
+			want: []string{"directRef", "nestedRef"},
+		},
+		{
+			name: "deeply nested rslvr in array",
+			inputs: map[string]*ValueRef{
+				"items": {Literal: []any{
+					map[string]any{"rslvr": "first"},
+					map[string]any{"rslvr": "second"},
+					"plain-string",
+				}},
+			},
+			want: []string{"first", "second"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractRefsFromValueRefs(tt.inputs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- add --action flag to scope resolver output to resolvers consumed by a specific action (inputs, forEach.in, when)
- fix catalog fallback when auto-discovery finds a non-solution file (e.g. taskfile.yaml) by capturing file state before prepareSolutionForExecution overwrites it
- export ExtractRefsFromValueRefs in resolver package for extracting resolver names from ValueRef maps
- sort ExtractRefsFromValueRefs output and error message action lists for deterministic behavior
- add tests for when condition, forEach.in, finally action, literal-only inputs, and auto-discovery fallback paths

Closes #418
Closes #501