### PR TITLE
feat(lint): add resolver-cycle and missing-template-dependency rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### 🚀 Features
 
 - *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch
+- *(lint)* Add `resolver-cycle` rule (error) to detect circular dependencies in the resolver dependency graph
+- *(lint)* Add `missing-template-dependency` rule (warning) to detect render-tree resolvers missing template file dependencies
+- *(lint)* Change `hyphenated-name` severity from info to warning and recommend camelCase instead of underscores
+- *(lint)* Add template-file scanning to prevent false-positive `unused-resolver` warnings for resolvers only referenced in `.tpl` files
 - *(lint)* Add `state-save-override-state-ref` rule (error) to catch circular state provider references in saveOverrides
 - *(lint)* Add `state-github-no-save-branch` rule (info) to suggest save-specific branch configuration for GitHub state backends
 - *(cli)* [**breaking**] Unified solution auto-discovery and resolution chain across all commands (#260)

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -11,9 +11,9 @@ This tutorial covers using scafctl's lint commands to validate solution files, e
 
 scafctl includes a built-in linter that checks solution YAML files for:
 
-- **Schema violations** — Invalid field names, wrong types, missing required fields
-- **Best practices** — Missing descriptions, unused resolvers, naming conventions
-- **Correctness** — Broken resolver references, invalid CEL expressions, circular dependencies
+- **Schema violations** -- Invalid field names, wrong types, missing required fields
+- **Best practices** -- Missing descriptions, unused resolvers, naming conventions
+- **Correctness** -- Broken resolver references, invalid CEL expressions, circular dependencies
 
 ```mermaid
 flowchart LR
@@ -90,7 +90,7 @@ scafctl lint -f solution.yaml -o json
 
 ### Quiet Mode
 
-For scripts and CI pipelines — exit code only:
+For scripts and CI pipelines -- exit code only:
 
 {{< tabs "linting-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
@@ -199,12 +199,12 @@ scafctl lint explain missing-description
 
 This shows:
 
-- **Description** — What the rule checks
-- **Severity** — Error, warning, or info
-- **Category** — Which category (e.g., best-practice, correctness, schema)
-- **Why it matters** — Why this rule exists
-- **How to fix** — Step-by-step fix instructions
-- **Examples** — Before/after YAML showing the fix
+- **Description** -- What the rule checks
+- **Severity** -- Error, warning, or info
+- **Category** -- Which category (e.g., best-practice, correctness, schema)
+- **Why it matters** -- Why this rule exists
+- **How to fix** -- Step-by-step fix instructions
+- **Examples** -- Before/after YAML showing the fix
 
 ### JSON Output
 
@@ -291,7 +291,7 @@ metadata:
 ### Invalid Resolver Reference
 
 ```yaml
-# Before (triggers error — 'settings' doesn't exist)
+# Before (triggers error -- 'settings' doesn't exist)
 resolvers:
   config:
     type: string
@@ -323,7 +323,7 @@ resolvers:
 ### Unknown Fields
 
 ```yaml
-# Before (triggers error — 'deps' is not a valid field)
+# Before (triggers error -- 'deps' is not a valid field)
 resolvers:
   greeting:
     type: string
@@ -349,7 +349,7 @@ resolvers:
 ### Unreachable Test Path
 
 ```yaml
-# Before (triggers warning — file doesn't exist)
+# Before (triggers warning -- file doesn't exist)
 testing:
   cases:
     my-test:
@@ -394,7 +394,7 @@ scafctl lint explain unreachable-test-path
 The `hyphenated-name` rule warns when resolver names contain hyphens. While valid YAML, hyphens require quoting in CEL expressions:
 
 ```yaml
-# ⚠️ INFO: hyphenated names require quoting in CEL
+# WARNING: hyphenated names require quoting in CEL
 spec:
   resolvers:
     my-service-name:
@@ -414,12 +414,12 @@ spec:
               expression: '_["my-service-name"]'
 ```
 
-**Fix**: Use underscores instead of hyphens for CEL-friendly access:
+**Fix**: Use camelCase for CEL-friendly access:
 
 ```yaml
 spec:
   resolvers:
-    my_service_name:  # Can use _.my_service_name in CEL
+    myServiceName:  # Can use _.myServiceName in CEL
       resolve:
         with:
           - provider: static
@@ -427,14 +427,14 @@ spec:
               value: hello
 ```
 
-This is an **info**-level finding (not an error) because hyphenated names are valid — they just require bracket notation in CEL expressions.
+This is a **warning**-level finding (not an error) because hyphenated names are valid -- they just require bracket notation in CEL expressions.
 
 ## 7. Redundant dependsOn
 
 The `redundant-depends-on` rule detects when a resolver's `dependsOn` entries are already auto-inferred from value references. scafctl automatically infers dependencies from `expr:`, `rslvr:`, and `tmpl:` references -- explicit `dependsOn` is only needed for pure ordering dependencies (where a resolver must wait for another without referencing its value).
 
 ```yaml
-# ℹ️ INFO: dependsOn is redundant — all listed dependencies are already inferred
+# INFO: dependsOn is redundant -- all listed dependencies are already inferred
 spec:
   resolvers:
     registry:
@@ -601,18 +601,177 @@ scafctl lint explain transform-shape-mismatch
 {{% /tab %}}
 {{< /tabs >}}
 
-## 10. Using Lint with the MCP Server
+## 10. Resolver Cycles
+
+The `resolver-cycle` rule detects circular dependencies in the resolver dependency graph. Cycles prevent the DAG scheduler from ordering resolvers and always cause runtime failures.
+
+```yaml
+# ERROR: circular dependency detected
+spec:
+  resolvers:
+    alpha:
+      dependsOn: [beta]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: a
+
+    beta:
+      dependsOn: [alpha]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: b
+```
+
+The cycle `alpha -> beta -> alpha` means neither resolver can run first.
+
+**Fix**: Break the cycle by removing one of the dependencies. Often, the real pattern is that a `validate` block creates the cycle -- extract it into a separate resolver:
+
+```yaml
+spec:
+  resolvers:
+    alpha:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: inputA
+
+    beta:
+      dependsOn: [alpha]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression:
+                expr: '_.alpha + "-derived"'
+
+    # Validation extracted into its own resolver
+    validateAlpha:
+      dependsOn: [alpha, beta]
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression:
+                expr: '_.beta != ""'
+              message: "Beta must not be empty"
+```
+
+This is an **error**-level finding because cycles always prevent execution.
+
+For more details:
+
+{{< tabs "linting-tutorial-cmd-13" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint explain resolver-cycle
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain resolver-cycle
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## 11. Missing Template Dependencies
+
+The `missing-template-dependency` rule checks render-tree resolvers that process external template files (`.tpl`, `.tmpl`, `.gotmpl`). If a template file references a resolver name (e.g., `{{ .appName }}`) that isn't in the render-tree resolver's dependency graph, the lint warns you.
+
+```yaml
+# WARNING: render-tree resolver 'rendered' uses template files that reference
+# resolver 'port', but 'port' is not in its dependency graph
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+
+    port:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "8080"
+
+    templateFiles:
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    rendered:
+      dependsOn: [templateFiles, appName]  # Missing 'port'!
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: _
+```
+
+If `templates/main.tpl` contains `{{ .appName }} on port {{ .port }}`, the `port` resolver may not be resolved before the template renders, causing a "map has no entry for key" error at runtime.
+
+**Fix**: Add the missing resolver to `dependsOn`:
+
+```yaml
+    rendered:
+      dependsOn: [templateFiles, appName, port]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: _
+```
+
+This is a **warning**-level finding. The linter scans template files on disk to discover references that the DAG cannot auto-detect from the solution YAML alone.
+
+For more details:
+
+{{< tabs "linting-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint explain missing-template-dependency
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain missing-template-dependency
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## 12. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 
-- **`lint_solution` tool** — Same as `scafctl lint` but returns structured JSON to the AI
-- **`explain_lint_rule` tool** — Same as `scafctl lint explain`
-- **`validate_expressions` tool** — Validate CEL expressions without running them
+- **`lint_solution` tool** -- Same as `scafctl lint` but returns structured JSON to the AI
+- **`explain_lint_rule` tool** -- Same as `scafctl lint explain`
+- **`validate_expressions` tool** -- Validate CEL expressions without running them
 
-The AI agent can lint your solution as part of its workflow — for example, the `debug_solution` and `update_solution` prompts automatically include linting steps.
+The AI agent can lint your solution as part of its workflow -- for example, the `debug_solution` and `update_solution` prompts automatically include linting steps.
 
 ## Next Steps
 
-- [Eval Tutorial](eval-tutorial.md) — Validate and test expressions
-- [Functional Testing Tutorial](functional-testing.md) — Automated solution testing
-- [MCP Server Tutorial](mcp-server-tutorial.md) — AI-assisted development with linting
+- [Eval Tutorial](eval-tutorial.md) -- Validate and test expressions
+- [Functional Testing Tutorial](functional-testing.md) -- Automated solution testing
+- [MCP Server Tutorial](mcp-server-tutorial.md) -- AI-assisted development with linting

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -1,5 +1,10 @@
 # Lint stress-test solution -- intentionally triggers many lint rules.
 # Run: scafctl lint -f examples/solutions/lint-stress-test/solution.yaml
+#
+# Rules NOT triggered here (require special setups):
+#   resolver-cycle          -- cycles prevent solution loading entirely
+#   missing-template-dependency -- requires external .tpl files on disk
+#                                  (see tests/integration/solutions/lint-missing-template-dependency)
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -18,6 +23,16 @@ spec:
           - provider: nonexistent-provider
             inputs:
               value: hello
+
+    # hyphenated-name
+    my-hyphenated-name:
+      type: string
+      description: Resolver with hyphens triggers hyphenated-name warning
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hyphens bad"
 
     # invalid-expression (bad CEL in when)
     guarded:

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -97,7 +97,18 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 
 	referencedResolvers := collectReferencedResolvers(sol)
 
+	// Scan external template files on disk for resolver references.
+	// This prevents false-positive unused-resolver warnings for resolvers
+	// consumed only in .tpl files (not referenced in the solution YAML).
+	solutionDir := filepath.Dir(filePath)
+	templateFileRefs := collectTemplateFileResolverRefs(sol, solutionDir)
+	for ref := range templateFileRefs {
+		referencedResolvers[ref] = true
+	}
+
 	lintResolvers(sol, result, registry, referencedResolvers)
+	lintTemplateFileDependencies(sol, solutionDir, result, registry)
+	lintResolverCycles(sol, result, registry)
 	lintWorkflow(sol, result, registry)
 	lintState(sol, result, registry)
 	lintImmutableResolvers(sol, result)
@@ -184,10 +195,10 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 		}
 
 		if strings.Contains(name, "-") {
-			result.addFinding(SeverityInfo, "naming", location,
-				fmt.Sprintf("resolver name '%s' contains hyphens — use underscores for CEL compatibility (e.g., '%s')",
-					name, strings.ReplaceAll(name, "-", "_")),
-				"Hyphens in resolver names require quoting in CEL expressions. Use underscores for direct access: _.my_resolver",
+			result.addFinding(SeverityWarning, "naming", location,
+				fmt.Sprintf("resolver name '%s' contains hyphens — use camelCase for CEL compatibility (e.g., '%s')",
+					name, hyphensToCamelCase(name)),
+				"Hyphens in resolver names require quoting in CEL expressions: _[\"my-resolver\"] instead of _.myResolver",
 				"hyphenated-name")
 		}
 
@@ -542,6 +553,147 @@ func lintTransformShapeMismatch(_ string, res *resolver.Resolver, location strin
 	}
 }
 
+// lintResolverCycles checks for circular dependencies in the resolver dependency graph.
+// When a cycle involves a resolver with a validate block, the suggestion specifically
+// recommends extracting the validation into a separate resolver.
+func lintResolverCycles(sol *solution.Solution, result *Result, registry *provider.Registry) {
+	if sol.Spec.Resolvers == nil {
+		return
+	}
+
+	var lookup resolver.DescriptorLookup
+	if registry != nil {
+		lookup = registry.DescriptorLookup()
+	}
+
+	// Build the dependency map for all resolvers.
+	deps := make(map[string][]string, len(sol.Spec.Resolvers))
+	for name, res := range sol.Spec.Resolvers {
+		if res == nil {
+			continue
+		}
+		deps[name] = resolver.ExtractDependencies(res, lookup)
+	}
+
+	// Detect cycles using DFS-based cycle detection.
+	cycles := findResolverCycles(deps)
+	for _, cycle := range cycles {
+		// Check if any resolver in the cycle has a validate block.
+		hasValidate := false
+		for _, name := range cycle {
+			if res, ok := sol.Spec.Resolvers[name]; ok && res != nil && res.Validate != nil && len(res.Validate.With) > 0 {
+				hasValidate = true
+				break
+			}
+		}
+
+		location := fmt.Sprintf("resolvers.%s", cycle[0])
+		cycleStr := strings.Join(cycle, " → ")
+
+		suggestion := "Break the cycle by reordering dependencies or removing unnecessary references"
+		if hasValidate {
+			suggestion = "A validate block is part of this cycle. Extract the validation into a separate resolver that depends on all required values, breaking the cycle"
+		}
+
+		result.addFinding(SeverityError, "dependency", location,
+			fmt.Sprintf("circular dependency detected: %s", cycleStr),
+			suggestion,
+			"resolver-cycle")
+	}
+}
+
+// findResolverCycles detects all unique cycles in a dependency graph using DFS.
+// Returns a list of cycles, where each cycle is a list of resolver names
+// ending with the name that closes the cycle.
+func findResolverCycles(deps map[string][]string) [][]string {
+	const (
+		white = 0 // not visited
+		gray  = 1 // in current path
+		black = 2 // fully processed
+	)
+
+	color := make(map[string]int, len(deps))
+	path := make([]string, 0)
+	var cycles [][]string
+	reported := make(map[string]bool) // deduplicate cycles by canonical signature
+
+	var dfs func(node string)
+	dfs = func(node string) {
+		color[node] = gray
+		path = append(path, node)
+
+		for _, dep := range deps[node] {
+			if color[dep] == gray {
+				// Found a cycle: extract it from the path.
+				cycleStart := -1
+				for i, n := range path {
+					if n == dep {
+						cycleStart = i
+						break
+					}
+				}
+				if cycleStart >= 0 {
+					cycle := make([]string, len(path)-cycleStart+1)
+					copy(cycle, path[cycleStart:])
+					cycle[len(cycle)-1] = dep // close the cycle
+
+					// Deduplicate using a canonical signature derived from the
+					// whole cycle path so distinct cycles that share the same
+					// smallest node (e.g. a->b->a and a->c->a) are both reported.
+					key := canonicalCycleKey(cycle)
+					if !reported[key] {
+						reported[key] = true
+						cycles = append(cycles, cycle)
+					}
+				}
+			} else if color[dep] == white {
+				dfs(dep)
+			}
+		}
+
+		path = path[:len(path)-1]
+		color[node] = black
+	}
+
+	for node := range deps {
+		if color[node] == white {
+			dfs(node)
+		}
+	}
+
+	return cycles
+}
+
+// canonicalCycleKey builds a rotation-invariant signature for a cycle so that
+// the same directed cycle discovered from different start nodes deduplicates,
+// while genuinely distinct cycles (even those sharing their smallest node)
+// produce different keys. The input cycle is expected to end with the node that
+// closes it (i.e. cycle[len-1] == cycle[0]); that closing duplicate is dropped
+// before rotating the remaining nodes to start at the lexicographically
+// smallest member.
+func canonicalCycleKey(cycle []string) string {
+	nodes := cycle
+	if len(nodes) > 1 && nodes[0] == nodes[len(nodes)-1] {
+		nodes = nodes[:len(nodes)-1]
+	}
+	if len(nodes) == 0 {
+		return ""
+	}
+
+	start := 0
+	for i := 1; i < len(nodes); i++ {
+		if nodes[i] < nodes[start] {
+			start = i
+		}
+	}
+
+	rotated := make([]string, 0, len(nodes))
+	for i := 0; i < len(nodes); i++ {
+		rotated = append(rotated, nodes[(start+i)%len(nodes)])
+	}
+	return strings.Join(rotated, "\x00")
+}
+
 func lintWorkflow(sol *solution.Solution, result *Result, registry *provider.Registry) {
 	if sol.Spec.Workflow == nil {
 		return
@@ -855,6 +1007,18 @@ func validateCELSyntax(expr string) error {
 	return nil
 }
 
+// hyphensToCamelCase converts a hyphenated name to camelCase.
+// e.g., "my-resolver-name" -> "myResolverName"
+func hyphensToCamelCase(name string) string {
+	parts := strings.Split(name, "-")
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) > 0 {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
 // validateTemplateSyntax checks if a Go template is syntactically valid.
 // Delegates to gotmpl.ValidateSyntax so that sprig and custom extension
 // functions are registered during parsing, matching runtime behavior.
@@ -956,6 +1120,406 @@ func scanExpressionForResolverRefs(expr string, pattern *regexp.Regexp, refs map
 			}
 		}
 	}
+}
+
+// collectTemplateFileResolverRefs scans external template files on disk
+// for resolver references. It discovers template files via:
+//  1. bundle.include glob patterns (matching *.tpl, *.tmpl, *.gotmpl files)
+//  2. directory provider 'path' inputs from resolvers
+//
+// Returns a set of resolver names referenced in external template files.
+func collectTemplateFileResolverRefs(sol *solution.Solution, solutionDir string) map[string]bool {
+	refs := make(map[string]bool)
+	if solutionDir == "" {
+		return refs
+	}
+
+	// Collect template file paths from bundle.include globs and directory provider inputs.
+	templateFiles := discoverTemplateFiles(sol, solutionDir)
+
+	for _, absPath := range templateFiles {
+		fileRefs, err := resolverRefs.ExtractFromTemplateFile(absPath, "", "")
+		if err != nil {
+			continue // Skip files that can't be parsed (non-template files, syntax errors)
+		}
+		for _, ref := range fileRefs {
+			refs[ref] = true
+		}
+	}
+
+	return refs
+}
+
+// discoverTemplateFiles finds template files on disk from bundle.include patterns
+// and directory provider path inputs. Returns absolute paths.
+func discoverTemplateFiles(sol *solution.Solution, solutionDir string) []string {
+	seen := make(map[string]bool)
+	var files []string
+
+	addFile := func(absPath string) {
+		if seen[absPath] {
+			return
+		}
+		seen[absPath] = true
+		files = append(files, absPath)
+	}
+
+	templateExtensions := map[string]bool{
+		".tpl":    true,
+		".tmpl":   true,
+		".gotmpl": true,
+	}
+
+	isTemplateFile := func(path string) bool {
+		ext := filepath.Ext(path)
+		return templateExtensions[ext]
+	}
+
+	// 1. Scan bundle.include patterns for template files.
+	for _, pattern := range sol.Bundle.Include {
+		absPattern := filepath.Join(solutionDir, pattern)
+		matches, err := doublestar.FilepathGlob(absPattern)
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			if isTemplateFile(match) {
+				addFile(match)
+			}
+		}
+	}
+
+	// 2. Scan directory provider path inputs for template directories.
+	if sol.Spec.Resolvers != nil {
+		for _, res := range sol.Spec.Resolvers {
+			if res == nil || res.Resolve == nil {
+				continue
+			}
+			for _, step := range res.Resolve.With {
+				if step.Provider != "directory" {
+					continue
+				}
+				pathVal, ok := step.Inputs["path"]
+				if !ok || pathVal == nil {
+					continue
+				}
+				// Only handle literal string paths (not expressions/templates).
+				pathStr, ok := pathVal.Literal.(string)
+				if !ok || pathStr == "" {
+					continue
+				}
+
+				absPath := pathStr
+				if !filepath.IsAbs(absPath) {
+					absPath = filepath.Join(solutionDir, absPath)
+				}
+
+				// Walk the directory for template files, honoring the directory
+				// provider's literal recursive/filterGlob inputs.
+				walkDirectoryProviderTemplates(step, absPath, isTemplateFile, addFile)
+			}
+		}
+	}
+
+	return files
+}
+
+// directoryWalkOptions holds the subset of directory-provider inputs that the
+// lint heuristics can honor statically so discovery better matches the files
+// the provider would actually return at runtime. Non-literal (expr/tmpl) inputs
+// cannot be evaluated statically and fall back to permissive defaults.
+type directoryWalkOptions struct {
+	recursive  bool
+	filterGlob string
+}
+
+// readDirectoryWalkOptions extracts literal recursive and filterGlob inputs from
+// a directory-provider step. recursive defaults to false to match the directory
+// provider's runtime default (it does not descend into subdirectories unless
+// recursive: true is set); filterGlob defaults to empty (no additional
+// filtering).
+func readDirectoryWalkOptions(step resolver.ProviderSource) directoryWalkOptions {
+	opts := directoryWalkOptions{recursive: false}
+	if v, ok := step.Inputs["recursive"]; ok && v != nil {
+		if b, ok := v.Literal.(bool); ok {
+			opts.recursive = b
+		}
+	}
+	if v, ok := step.Inputs["filterGlob"]; ok && v != nil {
+		if s, ok := v.Literal.(string); ok && s != "" {
+			opts.filterGlob = s
+		}
+	}
+	return opts
+}
+
+// walkDirectoryProviderTemplates walks absPath collecting template files,
+// honoring the directory provider's literal recursive and filterGlob inputs.
+// When recursive is false, nested directories are skipped. When filterGlob is
+// set, files whose entry name (basename) does not match the glob are skipped --
+// matching the directory provider, which filters on entry names rather than the
+// full relative path; an invalid glob is ignored so discovery stays best-effort.
+func walkDirectoryProviderTemplates(step resolver.ProviderSource, absPath string, isTemplateFile func(string) bool, addFile func(string)) {
+	opts := readDirectoryWalkOptions(step)
+	_ = filepath.Walk(absPath, func(path string, info os.FileInfo, err error) error { //nolint:errcheck // best-effort scan
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// When not recursive, process the root directory but do not descend.
+			if !opts.recursive && path != absPath {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if opts.filterGlob != "" {
+			if matched, matchErr := doublestar.Match(opts.filterGlob, info.Name()); matchErr == nil && !matched {
+				return nil
+			}
+		}
+		if isTemplateFile(path) {
+			addFile(path)
+		}
+		return nil
+	})
+}
+
+// lintTemplateFileDependencies checks that resolvers using the go-template
+// provider with render-tree operation have all resolver names referenced in
+// their source template files listed in dependsOn (or reachable via the DAG).
+func lintTemplateFileDependencies(sol *solution.Solution, solutionDir string, result *Result, registry *provider.Registry) {
+	if sol.Spec.Resolvers == nil || solutionDir == "" {
+		return
+	}
+
+	var lookup resolver.DescriptorLookup
+	if registry != nil {
+		lookup = registry.DescriptorLookup()
+	}
+
+	for name, res := range sol.Spec.Resolvers {
+		if res == nil || res.Resolve == nil {
+			continue
+		}
+
+		for _, step := range res.Resolve.With {
+			if step.Provider != "go-template" {
+				continue
+			}
+
+			// Check if this is a render-tree operation.
+			opVal, ok := step.Inputs["operation"]
+			if !ok || opVal == nil {
+				continue
+			}
+			opStr, ok := opVal.Literal.(string)
+			if !ok || opStr != "render-tree" {
+				continue
+			}
+
+			// Find the source resolver for entries (usually a directory provider).
+			sourceResolverName := findEntriesSourceResolver(step, sol)
+			if sourceResolverName == "" {
+				continue
+			}
+
+			// Discover template files from the source resolver's directory provider.
+			templateFiles := discoverTemplateFilesFromResolver(sol, sourceResolverName, solutionDir)
+			if len(templateFiles) == 0 {
+				continue
+			}
+
+			// Honor any custom delimiters configured on the render-tree step so
+			// template parsing matches go-template runtime behavior.
+			leftDelim := stringInput(step, "leftDelim")
+			rightDelim := stringInput(step, "rightDelim")
+
+			// Top-level keys provided by a literal "data" map are local template
+			// context, not resolver references, and must not require dependsOn.
+			dataKeys := literalDataKeys(step)
+
+			// Collect all resolver names referenced in template files.
+			templateRefs := make(map[string]bool)
+			for _, f := range templateFiles {
+				fileRefs, err := resolverRefs.ExtractFromTemplateFile(f, leftDelim, rightDelim)
+				if err != nil {
+					continue
+				}
+				for _, ref := range fileRefs {
+					templateRefs[ref] = true
+				}
+			}
+
+			// Build the set of resolvers reachable from this resolver's dependency graph.
+			reachable := collectReachableDependencies(name, sol, lookup)
+
+			// Check for references not covered by dependsOn or inferred deps.
+			location := fmt.Sprintf("resolvers.%s", name)
+			for ref := range templateRefs {
+				// Skip self-reference and reserved names.
+				if ref == name || ref == "_" || strings.HasPrefix(ref, "__") {
+					continue
+				}
+				// Skip refs satisfied by a literal data map key, not a resolver.
+				if dataKeys[ref] {
+					continue
+				}
+				// Skip if the referenced resolver doesn't exist (could be a template variable).
+				if _, exists := sol.Spec.Resolvers[ref]; !exists {
+					continue
+				}
+				if !reachable[ref] {
+					result.addFinding(SeverityWarning, "dependency", location,
+						fmt.Sprintf("render-tree resolver '%s' uses template files that reference resolver '%s', but '%s' is not in its dependency graph",
+							name, ref, ref),
+						fmt.Sprintf("Add '%s' to the dependsOn list of resolver '%s'", ref, name),
+						"missing-template-dependency")
+				}
+			}
+		}
+	}
+}
+
+// stringInput returns the literal string value of the named step input, or an
+// empty string if the input is absent or not a string literal.
+func stringInput(step resolver.ProviderSource, key string) string {
+	val, ok := step.Inputs[key]
+	if !ok || val == nil {
+		return ""
+	}
+	s, ok := val.Literal.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// literalDataKeys returns the set of top-level keys from a render-tree step's
+// literal "data" map. These keys are local template context and must not be
+// treated as resolver references when checking template dependencies.
+func literalDataKeys(step resolver.ProviderSource) map[string]bool {
+	val, ok := step.Inputs["data"]
+	if !ok || val == nil || val.Literal == nil {
+		return nil
+	}
+	dataMap, ok := val.Literal.(map[string]any)
+	if !ok {
+		return nil
+	}
+	keys := make(map[string]bool, len(dataMap))
+	for k := range dataMap {
+		keys[k] = true
+	}
+	return keys
+}
+
+// findEntriesSourceResolver extracts the resolver name from a render-tree step's
+// entries input. Returns the resolver name if it's a direct rslvr: reference,
+// or tries to extract it from an expr: reference.
+func findEntriesSourceResolver(step resolver.ProviderSource, _ *solution.Solution) string {
+	entriesVal, ok := step.Inputs["entries"]
+	if !ok || entriesVal == nil {
+		return ""
+	}
+	if entriesVal.Resolver != nil {
+		return *entriesVal.Resolver
+	}
+	// Check expr for _.resolverName.entries or _["resolver-name"].entries pattern.
+	if entriesVal.Expr != nil {
+		expr := strings.TrimSpace(string(*entriesVal.Expr))
+		// Bracket notation: _["resolver-name"].entries or _['resolver-name'].entries
+		if strings.HasPrefix(expr, "_[") {
+			rest := strings.TrimPrefix(expr, "_[")
+			if len(rest) > 0 && (rest[0] == '"' || rest[0] == '\'') {
+				quote := rest[0]
+				rest = rest[1:]
+				if idx := strings.IndexByte(rest, quote); idx > 0 {
+					return rest[:idx]
+				}
+			}
+			return ""
+		}
+		// Dot notation: _.resolverName.entries
+		if strings.HasPrefix(expr, "_.") {
+			parts := strings.SplitN(strings.TrimPrefix(expr, "_."), ".", 2)
+			if len(parts) > 0 && parts[0] != "" {
+				return parts[0]
+			}
+		}
+	}
+	return ""
+}
+
+// discoverTemplateFilesFromResolver finds template files by looking at the
+// directory provider configuration of the given source resolver.
+func discoverTemplateFilesFromResolver(sol *solution.Solution, resolverName, solutionDir string) []string {
+	res, ok := sol.Spec.Resolvers[resolverName]
+	if !ok || res == nil || res.Resolve == nil {
+		return nil
+	}
+
+	for _, step := range res.Resolve.With {
+		if step.Provider != "directory" {
+			continue
+		}
+		pathVal, ok := step.Inputs["path"]
+		if !ok || pathVal == nil {
+			continue
+		}
+		pathStr, ok := pathVal.Literal.(string)
+		if !ok || pathStr == "" {
+			continue
+		}
+
+		absPath := pathStr
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(solutionDir, absPath)
+		}
+
+		templateExtensions := map[string]bool{
+			".tpl":    true,
+			".tmpl":   true,
+			".gotmpl": true,
+		}
+		isTemplateFile := func(path string) bool {
+			return templateExtensions[filepath.Ext(path)]
+		}
+
+		var files []string
+		walkDirectoryProviderTemplates(step, absPath, isTemplateFile, func(path string) {
+			files = append(files, path)
+		})
+		return files
+	}
+
+	return nil
+}
+
+// collectReachableDependencies returns all resolver names reachable from the
+// given resolver's dependency graph (direct + transitive). It uses
+// resolver.ExtractDependencies so that explicit dependsOn entries and
+// dependencies inferred from expr:, rslvr:, and tmpl: references are all
+// considered, avoiding false-positive missing-template-dependency warnings.
+func collectReachableDependencies(name string, sol *solution.Solution, lookup resolver.DescriptorLookup) map[string]bool {
+	reachable := make(map[string]bool)
+	var visit func(string)
+	visit = func(n string) {
+		res, ok := sol.Spec.Resolvers[n]
+		if !ok || res == nil {
+			return
+		}
+		for _, dep := range resolver.ExtractDependencies(res, lookup) {
+			if dep == "" || dep == n {
+				continue
+			}
+			if !reachable[dep] {
+				reachable[dep] = true
+				visit(dep)
+			}
+		}
+	}
+	visit(name)
+	return reachable
 }
 
 func lintTests(sol *solution.Solution, solutionPath string, result *Result) {
@@ -1286,10 +1850,15 @@ func lintStateBackend(sol *solution.Solution, result *Result, registry *provider
 
 	prov, found := registry.Get(backendName)
 	if !found {
-		result.addFinding(SeverityError, "state", location+".backend.provider",
-			fmt.Sprintf("state backend provider '%s' not found in registry", backendName),
-			"Use a registered provider with CapabilityState such as 'file' or 'http'. External providers like 'github' require an installed plugin",
-			"invalid-state-backend")
+		// If the provider is declared in bundle.plugins (or is an official
+		// provider), it will be resolved at runtime. We cannot verify
+		// capabilities at lint time, so skip the finding.
+		if !registry.Has(backendName) {
+			result.addFinding(SeverityError, "state", location+".backend.provider",
+				fmt.Sprintf("state backend provider '%s' not found in registry", backendName),
+				"Use a registered provider with CapabilityState such as 'file' or 'http'. External providers like 'github' require an installed plugin",
+				"invalid-state-backend")
+		}
 	} else {
 		desc := prov.Descriptor()
 		hasState := false

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -592,8 +593,8 @@ func TestLintResolvers_HyphenatedName(t *testing.T) {
 
 	require.Len(t, hyphenFindings, 1)
 	assert.Contains(t, hyphenFindings[0].Message, "my-resolver")
-	assert.Contains(t, hyphenFindings[0].Message, "my_resolver")
-	assert.Equal(t, SeverityInfo, hyphenFindings[0].Severity)
+	assert.Contains(t, hyphenFindings[0].Message, "myResolver")
+	assert.Equal(t, SeverityWarning, hyphenFindings[0].Severity)
 }
 
 // ---- missing-fallback-source ----
@@ -744,5 +745,840 @@ func TestLintResolvers_MissingFallbackSource_NoResolvePhase(t *testing.T) {
 	for _, f := range result.Findings {
 		assert.NotEqual(t, "missing-fallback-source", f.RuleName,
 			"should not warn when there is no resolve phase")
+	}
+}
+
+// ---- hyphensToCamelCase ----
+
+func TestHyphensToCamelCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"my-resolver", "myResolver"},
+		{"my-resolver-name", "myResolverName"},
+		{"simple", "simple"},
+		{"a-b-c", "aBC"},
+		{"already-camelCase", "alreadyCamelCase"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hyphensToCamelCase(tt.input))
+		})
+	}
+}
+
+// ---- resolver-cycle ----
+
+func TestLintResolverCycles_NoCycle(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	rslvrA := "resolverA"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"resolverA": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "hello"},
+					}},
+				},
+			},
+		},
+		"resolverB": {
+			DependsOn: []string{rslvrA},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Resolver: &rslvrA},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolverCycles(sol, result, reg)
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "resolver-cycle", f.RuleName, "no cycle should be detected")
+	}
+}
+
+func TestLintResolverCycles_SimpleCycle(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	rslvrA := "resolverA"
+	rslvrB := "resolverB"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"resolverA": {
+			DependsOn: []string{rslvrB},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Resolver: &rslvrB},
+					}},
+				},
+			},
+		},
+		"resolverB": {
+			DependsOn: []string{rslvrA},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Resolver: &rslvrA},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolverCycles(sol, result, reg)
+
+	var cycleFindings []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "resolver-cycle" {
+			cycleFindings = append(cycleFindings, f)
+		}
+	}
+
+	require.Len(t, cycleFindings, 1)
+	assert.Equal(t, SeverityError, cycleFindings[0].Severity)
+	assert.Contains(t, cycleFindings[0].Message, "circular dependency")
+}
+
+func TestLintResolverCycles_ValidateCycleSuggestion(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+	require.NoError(t, reg.Register(newFakeProviderWithCapabilities("validation", []provider.Capability{provider.CapabilityValidation})))
+
+	rslvrA := "resolverA"
+	rslvrB := "resolverB"
+	expr := celexp.Expression("_.resolverA == true")
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"resolverA": {
+			DependsOn: []string{rslvrB},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Resolver: &rslvrB},
+					}},
+				},
+			},
+		},
+		"resolverB": {
+			DependsOn: []string{rslvrA},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "default"},
+					}},
+				},
+			},
+			Validate: &resolver.ValidatePhase{
+				With: []resolver.ProviderValidation{
+					{
+						Provider: "validation",
+						Inputs: map[string]*spec.ValueRef{
+							"expression": {Expr: &expr},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolverCycles(sol, result, reg)
+
+	var cycleFindings []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "resolver-cycle" {
+			cycleFindings = append(cycleFindings, f)
+		}
+	}
+
+	require.Len(t, cycleFindings, 1)
+	assert.Contains(t, cycleFindings[0].Suggestion, "validate block",
+		"cycle involving validate block should suggest extracting validation")
+}
+
+// ---- collectTemplateFileResolverRefs ----
+
+func TestCollectTemplateFileResolverRefs(t *testing.T) {
+	// Create a temp directory with a template file.
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "templates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	tplContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .appName }}
+data:
+  region: {{ .region }}
+  cluster: {{ .clusterName }}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "config.tpl"), []byte(tplContent), 0o644))
+
+	sol := &solution.Solution{}
+	sol.Bundle = solution.Bundle{
+		Include: []string{"templates/**/*.tpl"},
+	}
+
+	refs := collectTemplateFileResolverRefs(sol, tmpDir)
+
+	assert.True(t, refs["appName"], "should find appName reference")
+	assert.True(t, refs["region"], "should find region reference")
+	assert.True(t, refs["clusterName"], "should find clusterName reference")
+}
+
+func TestCollectTemplateFileResolverRefs_DirectoryProvider(t *testing.T) {
+	// Create a temp directory with a template file.
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "mytemplates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	tplContent := `Hello {{ .userName }}`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "greeting.tpl"), []byte(tplContent), 0o644))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"templateSource": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "directory",
+						Inputs: map[string]*spec.ValueRef{
+							"path": {Literal: "mytemplates"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	refs := collectTemplateFileResolverRefs(sol, tmpDir)
+	assert.True(t, refs["userName"], "should find userName reference from directory provider path")
+}
+
+// ---- missing-template-dependency ----
+
+func TestLintTemplateFileDependencies_MissingDep(t *testing.T) {
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "templates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	tplContent := `name: {{ .appName }}
+env: {{ .environment }}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "config.tpl"), []byte(tplContent), 0o644))
+
+	sourceResolver := "templateSource"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"appName": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "myapp"},
+					}},
+				},
+			},
+		},
+		"environment": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "prod"},
+					}},
+				},
+			},
+		},
+		"templateSource": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "directory",
+						Inputs: map[string]*spec.ValueRef{
+							"path":           {Literal: "templates"},
+							"operation":      {Literal: "list"},
+							"includeContent": {Literal: true},
+						},
+					},
+				},
+			},
+		},
+		"rendered": {
+			// Only depends on templateSource, missing appName and environment.
+			DependsOn: []string{"templateSource"},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"operation": {Literal: "render-tree"},
+							"entries":   {Resolver: &sourceResolver},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintTemplateFileDependencies(sol, tmpDir, result, nil)
+
+	var depFindings []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "missing-template-dependency" {
+			depFindings = append(depFindings, f)
+		}
+	}
+
+	assert.GreaterOrEqual(t, len(depFindings), 1, "should find at least one missing dependency")
+
+	// Check that at least one of the missing refs is reported.
+	messages := make([]string, 0, len(depFindings))
+	for _, f := range depFindings {
+		messages = append(messages, f.Message)
+	}
+	allMessages := ""
+	for _, m := range messages {
+		allMessages += m + " "
+	}
+	assert.True(t,
+		(assert.ObjectsAreEqual(true, contains(allMessages, "appName")) ||
+			assert.ObjectsAreEqual(true, contains(allMessages, "environment"))),
+		"should mention appName or environment as missing dependency")
+}
+
+func TestLintTemplateFileDependencies_AllDepsPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "templates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	tplContent := `name: {{ .appName }}`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "config.tpl"), []byte(tplContent), 0o644))
+
+	sourceResolver := "templateSource"
+	appNameResolver := "appName"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"appName": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "myapp"},
+					}},
+				},
+			},
+		},
+		"templateSource": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "directory",
+						Inputs: map[string]*spec.ValueRef{
+							"path": {Literal: "templates"},
+						},
+					},
+				},
+			},
+		},
+		"rendered": {
+			DependsOn: []string{"templateSource", "appName"},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"operation": {Literal: "render-tree"},
+							"entries":   {Resolver: &sourceResolver},
+							"data":      {Resolver: &appNameResolver},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintTemplateFileDependencies(sol, tmpDir, result, nil)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-template-dependency", f.RuleName,
+			"should not report missing dependency when all deps are present")
+	}
+}
+
+func TestLintTemplateFileDependencies_CustomDelimiters(t *testing.T) {
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "templates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	// Template uses custom delimiters; default '{{' parsing would miss the ref.
+	tplContent := `name: <% .appName %>`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "config.tpl"), []byte(tplContent), 0o644))
+
+	sourceResolver := "templateSource"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"appName": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "myapp"},
+					}},
+				},
+			},
+		},
+		"templateSource": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "directory",
+						Inputs: map[string]*spec.ValueRef{
+							"path": {Literal: "templates"},
+						},
+					},
+				},
+			},
+		},
+		"rendered": {
+			// Missing appName dependency.
+			DependsOn: []string{"templateSource"},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"operation":  {Literal: "render-tree"},
+							"entries":    {Resolver: &sourceResolver},
+							"leftDelim":  {Literal: "<%"},
+							"rightDelim": {Literal: "%>"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintTemplateFileDependencies(sol, tmpDir, result, nil)
+
+	var found bool
+	for _, f := range result.Findings {
+		if f.RuleName == "missing-template-dependency" && contains(f.Message, "appName") {
+			found = true
+		}
+	}
+	assert.True(t, found, "should detect appName ref parsed with custom delimiters")
+}
+
+func TestLintTemplateFileDependencies_LiteralDataKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	tplDir := filepath.Join(tmpDir, "templates")
+	require.NoError(t, os.MkdirAll(tplDir, 0o755))
+
+	// Template references 'config', which is satisfied by a literal data map
+	// key, not the same-named resolver.
+	tplContent := `host: {{ .config }}`
+	require.NoError(t, os.WriteFile(filepath.Join(tplDir, "config.tpl"), []byte(tplContent), 0o644))
+
+	sourceResolver := "templateSource"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"config": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "unrelated"},
+					}},
+				},
+			},
+		},
+		"templateSource": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "directory",
+						Inputs: map[string]*spec.ValueRef{
+							"path": {Literal: "templates"},
+						},
+					},
+				},
+			},
+		},
+		"rendered": {
+			// Does not depend on the 'config' resolver, but provides 'config'
+			// as a literal data key, so no warning should be raised.
+			DependsOn: []string{"templateSource"},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"operation": {Literal: "render-tree"},
+							"entries":   {Resolver: &sourceResolver},
+							"data": {Literal: map[string]any{
+								"config": "local-value",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintTemplateFileDependencies(sol, tmpDir, result, nil)
+
+	for _, f := range result.Findings {
+		assert.NotEqual(t, "missing-template-dependency", f.RuleName,
+			"should not warn for refs satisfied by a literal data key")
+	}
+}
+
+// ---- findResolverCycles ----
+
+func TestFindResolverCycles_NoCycles(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {},
+	}
+	cycles := findResolverCycles(deps)
+	assert.Empty(t, cycles)
+}
+
+func TestFindResolverCycles_SimpleCycle(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+	}
+	cycles := findResolverCycles(deps)
+	assert.Len(t, cycles, 1)
+}
+
+func TestFindResolverCycles_SelfCycle(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"a"},
+	}
+	cycles := findResolverCycles(deps)
+	assert.Len(t, cycles, 1)
+}
+
+func TestFindResolverCycles_MultipleCycles(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+		"c": {"d"},
+		"d": {"c"},
+	}
+	cycles := findResolverCycles(deps)
+	assert.Len(t, cycles, 2)
+}
+
+func TestFindResolverCycles_DistinctCyclesSameSmallestNode(t *testing.T) {
+	// a->b->a and a->c->a share their smallest node "a" but are distinct cycles.
+	// Both must be reported (previously de-duplicated to one).
+	deps := map[string][]string{
+		"a": {"b", "c"},
+		"b": {"a"},
+		"c": {"a"},
+	}
+	cycles := findResolverCycles(deps)
+	assert.Len(t, cycles, 2)
+}
+
+func TestCanonicalCycleKey_RotationInvariant(t *testing.T) {
+	// The same directed cycle discovered from different start nodes yields the
+	// same key.
+	assert.Equal(t,
+		canonicalCycleKey([]string{"a", "b", "c", "a"}),
+		canonicalCycleKey([]string{"b", "c", "a", "b"}),
+	)
+	assert.Equal(t,
+		canonicalCycleKey([]string{"a", "b", "c", "a"}),
+		canonicalCycleKey([]string{"c", "a", "b", "c"}),
+	)
+}
+
+func TestCanonicalCycleKey_DistinctCycles(t *testing.T) {
+	// Distinct cycles sharing the smallest node produce different keys.
+	assert.NotEqual(t,
+		canonicalCycleKey([]string{"a", "b", "a"}),
+		canonicalCycleKey([]string{"a", "c", "a"}),
+	)
+}
+
+func TestCanonicalCycleKey_Empty(t *testing.T) {
+	assert.Empty(t, canonicalCycleKey(nil))
+	assert.Empty(t, canonicalCycleKey([]string{}))
+}
+
+// ---- collectReachableDependencies ----
+
+func TestCollectReachableDependencies_DependsOnTransitive(t *testing.T) {
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"a": {Name: "a", DependsOn: []string{"b"}},
+		"b": {Name: "b", DependsOn: []string{"c"}},
+		"c": {Name: "c"},
+	}
+	reachable := collectReachableDependencies("a", sol, nil)
+	assert.True(t, reachable["b"])
+	assert.True(t, reachable["c"])
+}
+
+func TestCollectReachableDependencies_InferredFromExpr(t *testing.T) {
+	// "main" references "dep" only via a CEL expression input. The dependency
+	// must be discovered (previously missed, causing false-positive warnings).
+	expr := celexp.Expression("_.dep")
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"main": {
+			Name: "main",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "cel",
+					Inputs: map[string]*spec.ValueRef{
+						"expression": {Expr: &expr},
+					},
+				}},
+			},
+		},
+		"dep": {Name: "dep"},
+	}
+	reachable := collectReachableDependencies("main", sol, nil)
+	assert.True(t, reachable["dep"], "dependency inferred from expr should be reachable")
+}
+
+func TestCollectReachableDependencies_InferredFromResolverRef(t *testing.T) {
+	depName := "dep"
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"main": {
+			Name: "main",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "static",
+					Inputs: map[string]*spec.ValueRef{
+						"value": {Resolver: &depName},
+					},
+				}},
+			},
+		},
+		"dep": {Name: "dep"},
+	}
+	reachable := collectReachableDependencies("main", sol, nil)
+	assert.True(t, reachable["dep"])
+}
+
+// ---- findEntriesSourceResolver ----
+
+func TestFindEntriesSourceResolver_ResolverRef(t *testing.T) {
+	name := "entriesSource"
+	step := resolver.ProviderSource{
+		Inputs: map[string]*spec.ValueRef{
+			"entries": {Resolver: &name},
+		},
+	}
+	assert.Equal(t, "entriesSource", findEntriesSourceResolver(step, nil))
+}
+
+func TestFindEntriesSourceResolver_DotNotation(t *testing.T) {
+	expr := celexp.Expression("_.myResolver.entries")
+	step := resolver.ProviderSource{
+		Inputs: map[string]*spec.ValueRef{
+			"entries": {Expr: &expr},
+		},
+	}
+	assert.Equal(t, "myResolver", findEntriesSourceResolver(step, nil))
+}
+
+func TestFindEntriesSourceResolver_BracketNotationDoubleQuote(t *testing.T) {
+	expr := celexp.Expression(`_["my-resolver"].entries`)
+	step := resolver.ProviderSource{
+		Inputs: map[string]*spec.ValueRef{
+			"entries": {Expr: &expr},
+		},
+	}
+	assert.Equal(t, "my-resolver", findEntriesSourceResolver(step, nil))
+}
+
+func TestFindEntriesSourceResolver_BracketNotationSingleQuote(t *testing.T) {
+	expr := celexp.Expression(`_['my-resolver'].entries`)
+	step := resolver.ProviderSource{
+		Inputs: map[string]*spec.ValueRef{
+			"entries": {Expr: &expr},
+		},
+	}
+	assert.Equal(t, "my-resolver", findEntriesSourceResolver(step, nil))
+}
+
+func TestFindEntriesSourceResolver_NoEntries(t *testing.T) {
+	step := resolver.ProviderSource{Inputs: map[string]*spec.ValueRef{}}
+	assert.Empty(t, findEntriesSourceResolver(step, nil))
+}
+
+// ---- discoverTemplateFilesFromResolver ----
+
+func TestDiscoverTemplateFilesFromResolver_HonorsRecursive(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "top.tpl"), []byte("x"), 0o600))
+	sub := filepath.Join(dir, "nested")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "deep.tpl"), []byte("y"), 0o600))
+
+	recursiveFalse := &spec.ValueRef{Literal: false}
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"tree": {
+			Name: "tree",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "directory",
+					Inputs: map[string]*spec.ValueRef{
+						"path":      {Literal: dir},
+						"recursive": recursiveFalse,
+					},
+				}},
+			},
+		},
+	}
+
+	files := discoverTemplateFilesFromResolver(sol, "tree", "")
+	assert.Len(t, files, 1, "non-recursive walk should only return top-level files")
+	assert.Equal(t, filepath.Join(dir, "top.tpl"), files[0])
+}
+
+func TestDiscoverTemplateFilesFromResolver_NonRecursiveByDefault(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "top.tpl"), []byte("x"), 0o600))
+	sub := filepath.Join(dir, "nested")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "deep.tpl"), []byte("y"), 0o600))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"tree": {
+			Name: "tree",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "directory",
+					Inputs: map[string]*spec.ValueRef{
+						"path": {Literal: dir},
+					},
+				}},
+			},
+		},
+	}
+
+	files := discoverTemplateFilesFromResolver(sol, "tree", "")
+	assert.Len(t, files, 1, "default walk should be non-recursive, matching the directory provider")
+	assert.Equal(t, filepath.Join(dir, "top.tpl"), files[0])
+}
+
+func TestDiscoverTemplateFilesFromResolver_HonorsRecursiveTrue(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "top.tpl"), []byte("x"), 0o600))
+	sub := filepath.Join(dir, "nested")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "deep.tpl"), []byte("y"), 0o600))
+
+	recursiveTrue := &spec.ValueRef{Literal: true}
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"tree": {
+			Name: "tree",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "directory",
+					Inputs: map[string]*spec.ValueRef{
+						"path":      {Literal: dir},
+						"recursive": recursiveTrue,
+					},
+				}},
+			},
+		},
+	}
+
+	files := discoverTemplateFilesFromResolver(sol, "tree", "")
+	assert.Len(t, files, 2, "recursive: true should descend into subdirectories")
+}
+
+func TestDiscoverTemplateFilesFromResolver_HonorsFilterGlob(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keep.tpl"), []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "skip.tpl"), []byte("y"), 0o600))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"tree": {
+			Name: "tree",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "directory",
+					Inputs: map[string]*spec.ValueRef{
+						"path":       {Literal: dir},
+						"filterGlob": {Literal: "keep.*"},
+					},
+				}},
+			},
+		},
+	}
+
+	files := discoverTemplateFilesFromResolver(sol, "tree", "")
+	assert.Len(t, files, 1)
+	assert.Equal(t, filepath.Join(dir, "keep.tpl"), files[0])
+}
+
+// contains is a helper for substring matching in test assertions.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// newFakeProviderWithCapabilities creates a test provider with specific capabilities.
+func newFakeProviderWithCapabilities(name string, caps []provider.Capability) *fakeProvider {
+	outputSchemas := make(map[provider.Capability]*jsonschema.Schema)
+	for _, cap := range caps {
+		switch cap {
+		case provider.CapabilityValidation:
+			outputSchemas[cap] = &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"valid":  {Type: "boolean"},
+					"errors": {Type: "array"},
+				},
+			}
+		default:
+			outputSchemas[cap] = &jsonschema.Schema{Type: "object"}
+		}
+	}
+	return &fakeProvider{
+		desc: &provider.Descriptor{
+			Name:          name,
+			APIVersion:    "v1",
+			Version:       semver.MustParse("1.0.0"),
+			Schema:        &jsonschema.Schema{Type: "object"},
+			OutputSchemas: outputSchemas,
+			Description:   "Test provider",
+			Capabilities:  caps,
+		},
 	}
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1333,6 +1333,33 @@ func TestLintState_InvalidBackendProvider(t *testing.T) {
 	assert.Len(t, findings, 1)
 }
 
+func TestLintState_BundlePluginSuppressesFinding(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		Bundle: solution.Bundle{
+			Plugins: []solution.PluginDependency{
+				{Name: "github", Kind: solution.PluginKindProvider, Version: ">=0.1.0"},
+			},
+		},
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "github",
+				Inputs:   map[string]*spec.ValueRef{"repo": {Literal: "my-org/my-repo"}},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "invalid-state-backend")
+	assert.Empty(t, findings, "bundle.plugins-declared provider should not trigger invalid-state-backend")
+}
+
 func TestLintState_ProviderWithoutCapabilityState(t *testing.T) {
 	sol := &solution.Solution{
 		APIVersion: "scafctl.io/v1",

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -57,13 +57,13 @@ var KnownRules = map[string]RuleMeta{
 	},
 	"hyphenated-name": {
 		Rule:        "hyphenated-name",
-		Severity:    string(SeverityInfo),
+		Severity:    string(SeverityWarning),
 		Category:    "naming",
 		Description: "A resolver name contains hyphens, which require bracket notation in CEL expressions.",
-		Why:         "Hyphens in resolver names require quoting in CEL: _[\"my-resolver\"] instead of _.my_resolver. This is more verbose and error-prone.",
-		Fix:         "Use underscores instead of hyphens for CEL-friendly access: my_resolver instead of my-resolver.",
+		Why:         "Hyphens in resolver names require quoting in CEL: _[\"my-resolver\"] instead of _.myResolver. This is more verbose and error-prone for both humans and AI agents.",
+		Fix:         "Use camelCase for CEL-friendly access: myResolver instead of my-resolver.",
 		Examples: []string{
-			"# Hyphenated (requires quoting in CEL):\nresolvers:\n  my-service:\n    ...\n# Access: _[\"my-service\"]\n\n# Underscored (direct CEL access):\nresolvers:\n  my_service:\n    ...\n# Access: _.my_service",
+			"# Hyphenated (requires quoting in CEL):\nresolvers:\n  my-service:\n    ...\n# Access: _[\"my-service\"]\n\n# camelCase (direct CEL access):\nresolvers:\n  myService:\n    ...\n# Access: _.myService",
 		},
 	},
 	"unused-resolver": {
@@ -450,6 +450,28 @@ var KnownRules = map[string]RuleMeta{
 		Fix:         "Either add sources patterns to the action or remove the fingerprint block.",
 		Examples: []string{
 			"# Correct:\nactions:\n  build:\n    sources:\n      - 'src/**/*.go'\n    fingerprint:\n      scope: files\n    provider: exec\n    inputs:\n      command: go build",
+		},
+	},
+	"missing-template-dependency": {
+		Rule:        "missing-template-dependency",
+		Severity:    string(SeverityWarning),
+		Category:    "dependency",
+		Description: "A go-template render-tree resolver reads external template files that reference resolvers not listed in its dependsOn and not otherwise reachable in its dependency graph.",
+		Why:         "When a go-template render-tree step renders external .tpl files, the DAG cannot auto-detect which resolver names are used inside those files. Missing dependencies cause 'map has no entry for key' runtime errors because the template executes before its data dependencies are resolved.",
+		Fix:         "Add the missing resolver names to the dependsOn list of the render-tree resolver, or of the resolver that consumes the rendered output.",
+		Examples: []string{
+			"# Template file (templates/main.tpl) uses {{ .appName }} and {{ .region }}\n# Ensure both are in dependsOn:\nresolvers:\n  rendered:\n    dependsOn: [appName, region, templateSource]\n    resolve:\n      with:\n        - provider: go-template\n          inputs:\n            operation: render-tree\n            entries:\n              rslvr: templateSource\n            data:\n              rslvr: _",
+		},
+	},
+	"resolver-cycle": {
+		Rule:        "resolver-cycle",
+		Severity:    string(SeverityError),
+		Category:    "dependency",
+		Description: "The resolver dependency graph contains a circular dependency.",
+		Why:         "Circular dependencies between resolvers create infinite loops that prevent the DAG from being scheduled. The dependency graph must be acyclic.",
+		Fix:         "Break the cycle by reordering dependencies, removing unnecessary references, or extracting cycle-causing logic into a separate resolver. When a validate block causes the cycle, extract the validation into a dedicated resolver that runs after all its dependencies.",
+		Examples: []string{
+			"# Problem: validate block creates a cycle\n# resolverA validate needs resolverB, but resolverB depends on resolverA\n\n# Fix: extract the validation into a separate resolver\nresolvers:\n  resolverA:\n    resolve:\n      with:\n        - provider: parameter\n          inputs:\n            key: inputA\n  validateA:\n    dependsOn: [resolverA, resolverB]\n    validate:\n      with:\n        - provider: validation\n          inputs:\n            expression:\n              expr: '_.resolverB.valid == true'\n            message: 'Validation failed'",
 		},
 	},
 	"invalid-fingerprint-scope": {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 47 rules — update this when new rules are added
-	assert.Equal(t, 47, len(KnownRules), "expected 47 known lint rules")
+	// We expect exactly 49 rules — update this when new rules are added
+	assert.Equal(t, 49, len(KnownRules), "expected 49 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -468,7 +468,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/solutions/lint-hyphenated-name/solution.yaml
+++ b/tests/integration/solutions/lint-hyphenated-name/solution.yaml
@@ -10,7 +10,7 @@ metadata:
 
 spec:
   resolvers:
-    # This resolver has a hyphenated name — should trigger lint info
+    # This resolver has a hyphenated name — should trigger lint warning
     my-service-name:
       description: Resolver with hyphenated name
       resolve:
@@ -19,7 +19,7 @@ spec:
             inputs:
               value: hello
 
-    # This resolver uses underscores — should NOT trigger lint info
+    # This resolver uses underscores — should NOT trigger lint warning
     my_safe_name:
       description: Resolver with underscored name
       resolve:
@@ -40,7 +40,7 @@ spec:
         tags: [lint, hyphenated-name]
         assertions:
           - expression: __exitCode == 0
-            message: "Hyphenated name is info-level, should not cause non-zero exit"
+            message: "Hyphenated name is warning-level, should not cause non-zero exit"
           - expression: >
               __output.findings.exists(f, f.ruleName == "hyphenated-name")
             message: "Should detect hyphenated resolver name"
@@ -48,5 +48,5 @@ spec:
               __output.findings.filter(f, f.ruleName == "hyphenated-name").size() == 1
             message: "Should only flag the hyphenated resolver, not the underscored one"
           - expression: >
-              __output.findings.exists(f, f.ruleName == "hyphenated-name" && f.severity == "info")
-            message: "Hyphenated-name finding should be info severity"
+              __output.findings.exists(f, f.ruleName == "hyphenated-name" && f.severity == "warning")
+            message: "Hyphenated-name finding should be warning severity"

--- a/tests/integration/solutions/lint-missing-template-dependency/solution.yaml
+++ b/tests/integration/solutions/lint-missing-template-dependency/solution.yaml
@@ -1,0 +1,102 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-missing-template-dependency
+  version: 1.0.0
+  description: |
+    Tests the missing-template-dependency lint rule that detects when a
+    render-tree resolver uses template files referencing resolvers not in
+    its dependency graph.
+
+bundle:
+  include:
+    - "templates/**"
+
+spec:
+  resolvers:
+    appName:
+      description: Application name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+
+    port:
+      description: Service port
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "8080"
+
+    templateFiles:
+      description: Read template files from disk
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    # This resolver uses render-tree but only depends on templateFiles.
+    # The template file templates/main.tpl references {{ .appName }} and
+    # {{ .port }}, which are NOT in this resolver's dependency graph.
+    rendered:
+      description: Render templates (missing dependencies on appName and port)
+      dependsOn: [templateFiles]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              entries:
+                expr: '_.templateFiles.entries'
+              data:
+                rslvr: templateFiles
+
+  testing:
+    config:
+      # lint: solution intentionally triggers missing-template-dependency
+      # resolve-defaults: render-tree cannot resolve without full deps
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
+
+    cases:
+      missing-deps-detected:
+        description: Lint detects template file references not in dependency graph
+        command: [lint]
+        args: ["-o", "json"]
+        files: ["templates/**"]
+        tags: [lint, missing-template-dependency]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Missing template dependency is warning-level, should not cause non-zero exit"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "missing-template-dependency")
+            message: "Should detect missing template dependency"
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "missing-template-dependency" && f.severity == "warning")
+            message: "Missing template dependency should be warning severity"
+
+      references-specific-resolvers:
+        description: Findings reference the specific missing resolver names
+        command: [lint]
+        args: ["-o", "json"]
+        files: ["templates/**"]
+        tags: [lint, missing-template-dependency]
+        assertions:
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "missing-template-dependency" &&
+                f.message.contains("appName"))
+            message: "Should mention appName as a missing dependency"
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "missing-template-dependency" &&
+                f.message.contains("port"))
+            message: "Should mention port as a missing dependency"

--- a/tests/integration/solutions/lint-missing-template-dependency/templates/main.tpl
+++ b/tests/integration/solutions/lint-missing-template-dependency/templates/main.tpl
@@ -1,0 +1,1 @@
+{{ .appName }} running on port {{ .port }}

--- a/tests/integration/solutions/lint-resolver-cycle/solution.yaml
+++ b/tests/integration/solutions/lint-resolver-cycle/solution.yaml
@@ -1,0 +1,72 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-resolver-cycle
+  version: 1.0.0
+  description: |
+    Tests the resolver-cycle lint rule. Resolver cycles are caught during
+    solution loading (spec validation), so the lint command fails with an
+    error message before producing JSON findings output.
+
+spec:
+  resolvers:
+    # Circular dependency: alpha -> beta -> alpha
+    alpha:
+      description: First resolver in a cycle
+      dependsOn: [beta]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: a
+
+    beta:
+      description: Second resolver in a cycle
+      dependsOn: [alpha]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: b
+
+    # Not part of any cycle — should not be flagged
+    standalone:
+      description: Independent resolver with no cycles
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: ok
+
+  testing:
+    config:
+      # lint: solution intentionally has a resolver cycle
+      # resolve-defaults: resolvers cannot be resolved due to the cycle
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
+
+    cases:
+      cycle-detected:
+        description: Lint fails with cycle error during solution load
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, resolver-cycle]
+        assertions:
+          - expression: __exitCode != 0
+            message: "Resolver cycle should cause non-zero exit"
+          - expression: >
+              __stderr.contains("cycle detected")
+            message: "Error message should mention cycle detected"
+          - expression: >
+              __stderr.contains("alpha") && __stderr.contains("beta")
+            message: "Error message should mention the resolvers involved in the cycle"
+
+      standalone-not-in-error:
+        description: Standalone resolver should not appear in the cycle error
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, resolver-cycle]
+        assertions:
+          - expression: >
+              !__stderr.contains("standalone")
+            message: "Standalone resolver should not appear in cycle error message"


### PR DESCRIPTION
- add `resolver-cycle` rule (error) detecting circular dependencies in the resolver dependency graph via DFS-based cycle detection
- add `missing-template-dependency` rule (warning) for render-tree resolvers whose template files reference resolvers not in dependsOn
- scan external .tpl/.tmpl/.gotmpl files on disk for resolver refs to suppress false-positive `unused-resolver` warnings
- change `hyphenated-name` severity from info to warning and recommend camelCase instead of underscores
- skip `invalid-state-backend` finding for providers declared in bundle.plugins (not resolvable at lint time)
- add integration test solutions for resolver-cycle and missing-template-dependency rules
- update lint stress-test solution with hyphenated-name trigger
- update linting tutorial with sections for new rules
- bump known rules count from 47 to 49

Closes #518