### PR TITLE
feat: wire plugin auto-fetch into MCP and improve provider behavior

### DIFF
--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -608,6 +608,11 @@ Converts a Go object into HCL (HashiCorp Configuration Language) format:
 //   host = "localhost"
 //   port = 443
 // }
+
+// Top-level scalar lists become bare HCL arrays:
+{{ list "repo:a:ref:main" "repo:b:ref:main" | toHcl }}
+// Output:
+// ["repo:a:ref:main", "repo:b:ref:main"]
 ```
 
 ##### toYaml

--- a/pkg/gotmpl/ext/hcl/hcl.go
+++ b/pkg/gotmpl/ext/hcl/hcl.go
@@ -172,24 +172,29 @@ func writeHclMap(buf *strings.Builder, m map[string]any, indent int) error {
 	return nil
 }
 
-// writeHclList writes a top-level list (array of blocks).
+// writeHclList writes a top-level list. Lists of maps/objects are rendered as
+// blocks; lists of scalars are rendered as a bare HCL array (["a", "b"]).
 func writeHclList(buf *strings.Builder, list []any, indent int) error {
 	if len(list) == 0 {
+		buf.WriteString("[]")
 		return nil
 	}
 
-	for _, item := range list {
-		switch v := item.(type) {
-		case map[string]any:
-			if err := writeHclMap(buf, v, indent); err != nil {
+	if isListOfMaps(list) {
+		for _, item := range list {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				return fmt.Errorf("expected map in list of maps, got %T", item)
+			}
+			if err := writeHclMap(buf, itemMap, indent); err != nil {
 				return err
 			}
-		default:
-			return fmt.Errorf("top-level list elements must be maps/objects, got %T", v)
 		}
+		return nil
 	}
 
-	return nil
+	// Top-level scalar list — emit as a bare HCL array.
+	return writeHclListValue(buf, list, indent)
 }
 
 // writeHclListValue writes a list value in HCL list syntax: [val1, val2, ...]

--- a/pkg/gotmpl/ext/hcl/hcl_test.go
+++ b/pkg/gotmpl/ext/hcl/hcl_test.go
@@ -208,6 +208,54 @@ func TestToHcl_TopLevelPrimitive(t *testing.T) {
 	}
 }
 
+func TestToHcl_TopLevelScalarList(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name:     "string list",
+			input:    []any{"repo:a:ref:main", "repo:b:ref:main"},
+			expected: `["repo:a:ref:main", "repo:b:ref:main"]`,
+		},
+		{
+			name:     "int list",
+			input:    []any{float64(1), float64(2), float64(3)},
+			expected: "[1, 2, 3]",
+		},
+		{
+			name:     "bool list",
+			input:    []any{true, false},
+			expected: "[true, false]",
+		},
+		{
+			name:     "empty list",
+			input:    []any{},
+			expected: "[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToHcl(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToHcl_TopLevelListOfMaps(t *testing.T) {
+	input := []any{
+		map[string]any{"name": "a"},
+		map[string]any{"name": "b"},
+	}
+
+	result, err := ToHcl(input)
+	require.NoError(t, err)
+	assert.Equal(t, "name = \"a\"\nname = \"b\"\n", result)
+}
+
 func TestToHcl_ComplexExample(t *testing.T) {
 	input := map[string]any{
 		"ami":           "abc-123",

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -116,7 +116,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintProviderInputs(sol, result, registry)
 
 	// Apply suppression directives parsed from inline YAML comments.
-	suppressions := ParseDirectives(sol.RawContent(), filePath)
+	suppressions := ParseDirectives(sol.RawContent(), filePath).WithSourceMap(result.sourceMap)
 	result.Findings = suppressions.Filter(result.Findings)
 	result.Findings = append(result.Findings, suppressions.UnusedFindings()...)
 
@@ -432,6 +432,11 @@ func lintTransformShapeMismatch(_ string, res *resolver.Resolver, location strin
 	if res.Resolve == nil || res.Transform == nil {
 		return
 	}
+	// A non-trivial phase-level when guard already protects every transform step,
+	// so the shape access is safe — don't flag.
+	if isNonTrivialGuard(res.Transform.When) {
+		return
+	}
 	if len(res.Resolve.With) < 2 || len(res.Transform.With) == 0 {
 		return
 	}
@@ -517,7 +522,7 @@ func lintTransformShapeMismatch(_ string, res *resolver.Resolver, location strin
 		stepLocation := fmt.Sprintf("%s.transform.with[%d]", location, i)
 
 		// Skip if the transform step has a when guard.
-		if step.When != nil && step.When.Expr != nil && strings.TrimSpace(string(*step.When.Expr)) != "" && strings.TrimSpace(string(*step.When.Expr)) != "true" {
+		if isNonTrivialGuard(step.When) {
 			continue
 		}
 
@@ -551,6 +556,17 @@ func lintTransformShapeMismatch(_ string, res *resolver.Resolver, location strin
 			}
 		}
 	}
+}
+
+// isNonTrivialGuard reports whether a when condition is a meaningful guard, i.e.
+// it has a non-empty CEL expression that is not the literal "true". Such a guard
+// is assumed to protect downstream shape-specific access.
+func isNonTrivialGuard(c *resolver.Condition) bool {
+	if c == nil || c.Expr == nil {
+		return false
+	}
+	expr := strings.TrimSpace(string(*c.Expr))
+	return expr != "" && expr != "true"
 }
 
 // lintResolverCycles checks for circular dependencies in the resolver dependency graph.

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -2165,6 +2165,24 @@ func TestLintTransformShapeMismatch(t *testing.T) {
 			expectRule: false,
 		},
 		{
+			name: "not flagged: phase-level when guard makes shape access valid",
+			resolver: &resolver.Resolver{
+				Resolve: &resolver.ResolvePhase{
+					With: []resolver.ProviderSource{
+						{Provider: "http", When: &resolver.Condition{Expr: &credExpr}},
+						{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: []any{}}}},
+					},
+				},
+				Transform: &resolver.TransformPhase{
+					When: &resolver.Condition{Expr: &guardExpr},
+					With: []resolver.ProviderTransform{
+						{Provider: "cel", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &bodyExpr}}},
+					},
+				},
+			},
+			expectRule: false,
+		},
+		{
 			name: "not flagged: transform does not access structured fields",
 			resolver: &resolver.Resolver{
 				Resolve: &resolver.ResolvePhase{

--- a/pkg/lint/suppress.go
+++ b/pkg/lint/suppress.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"bytes"
 	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 )
 
 // DirectiveType represents the kind of suppression directive.
@@ -49,6 +51,19 @@ type Directive struct {
 type SuppressionSet struct {
 	directives []Directive
 	used       []bool
+	sourceMap  *sourcepos.SourceMap
+}
+
+// WithSourceMap attaches a source map to the suppression set, enabling
+// block-scoped suppression. When set, a standalone or inline ignore directive
+// placed on a block key (e.g. `transform:`) suppresses findings whose logical
+// location falls anywhere within that block, even when the finding's resolved
+// line is deeper than the directive's line. Returns the set for chaining.
+func (ss *SuppressionSet) WithSourceMap(sm *sourcepos.SourceMap) *SuppressionSet {
+	if ss != nil {
+		ss.sourceMap = sm
+	}
+	return ss
 }
 
 // ParseDirectives scans raw YAML bytes for suppression comments and returns
@@ -268,6 +283,13 @@ func (ss *SuppressionSet) isSuppressed(f *Finding) bool {
 					return true
 				}
 			}
+			// Block-scoped fallback: when the directive targets a YAML block
+			// key (e.g. `transform:`), suppress findings located within that
+			// block even if the resolved line is deeper than the directive.
+			if ss.locationInBlockAt(f, ss.ignoreTargetLine(d)) {
+				ss.used[i] = true
+				return true
+			}
 
 		case DirectiveDisable:
 			// Find the matching enable directive (or EOF).
@@ -279,6 +301,44 @@ func (ss *SuppressionSet) isSuppressed(f *Finding) bool {
 
 		case DirectiveEnable:
 			// Enable directives don't suppress — they end a disable block.
+		}
+	}
+	return false
+}
+
+// ignoreTargetLine returns the source line of the YAML node that an ignore
+// directive targets. Inline directives target their own line; standalone
+// comments target the following line (the block key they annotate).
+func (ss *SuppressionSet) ignoreTargetLine(d *Directive) int {
+	if d.Inline {
+		return d.Line
+	}
+	return d.Line + 1
+}
+
+// locationInBlockAt reports whether the finding's logical location falls within
+// a YAML block whose key is recorded at the given source line. It requires a
+// source map; without one it always returns false (preserving line-based
+// behavior). The "spec." prefix on source-map paths is stripped to match lint
+// finding locations.
+func (ss *SuppressionSet) locationInBlockAt(f *Finding, line int) bool {
+	if ss.sourceMap == nil || line <= 0 || f.Location == "" {
+		return false
+	}
+	for _, p := range ss.sourceMap.Paths() {
+		pos, ok := ss.sourceMap.Get(p)
+		if !ok || pos.Line != line {
+			continue
+		}
+		// In compose scenarios, only consider blocks from the same source file.
+		if f.SourceFile != "" && pos.File != "" && f.SourceFile != pos.File {
+			continue
+		}
+		block := strings.TrimPrefix(p, "spec.")
+		if f.Location == block ||
+			strings.HasPrefix(f.Location, block+".") ||
+			strings.HasPrefix(f.Location, block+"[") {
+			return true
 		}
 	}
 	return false

--- a/pkg/lint/suppress_test.go
+++ b/pkg/lint/suppress_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -649,4 +650,126 @@ func BenchmarkFilter(b *testing.B) {
 		}
 		ss.Filter(findings)
 	}
+}
+
+// makeTransformSuppressYAML returns YAML where a standalone ignore directive on
+// line 8 annotates a `transform:` block whose key is on line 9.
+func makeTransformSuppressYAML() []byte {
+	return []byte("spec:\n" + // 1
+		"  resolvers:\n" + // 2
+		"    api_data:\n" + // 3
+		"      resolve:\n" + // 4
+		"        with:\n" + // 5
+		"          - provider: http\n" + // 6
+		"          - provider: static\n" + // 7
+		"      # scafctl-lint-ignore: transform-shape-mismatch\n" + // 8
+		"      transform:\n" + // 9
+		"        with:\n" + // 10
+		"          - provider: cel\n" + // 11
+		"            inputs:\n" + // 12
+		"              expression:\n" + // 13
+		"                expr: \"__self.body\"\n") // 14
+}
+
+func transformSourceMap() *sourcepos.SourceMap {
+	sm := sourcepos.NewSourceMap()
+	sm.Set("spec.resolvers.api_data.transform", sourcepos.Position{Line: 9, Column: 7, File: "test.yaml"})
+	return sm
+}
+
+func TestFilter_BlockScopedSuppression_StandaloneAboveTransform(t *testing.T) {
+	t.Parallel()
+
+	ss := ParseDirectives(makeTransformSuppressYAML(), "test.yaml").WithSourceMap(transformSourceMap())
+
+	// Finding resolves to a deeper line (14) inside the transform block.
+	finding := &Finding{
+		RuleName:   "transform-shape-mismatch",
+		Location:   "resolvers.api_data.transform.with[0]",
+		Line:       14,
+		SourceFile: "test.yaml",
+	}
+
+	kept := ss.Filter([]*Finding{finding})
+	assert.Empty(t, kept, "finding inside the annotated transform block should be suppressed")
+}
+
+func TestFilter_BlockScopedSuppression_RequiresSourceMap(t *testing.T) {
+	t.Parallel()
+
+	// Without a source map, the deeper-line finding is not suppressed.
+	ss := ParseDirectives(makeTransformSuppressYAML(), "test.yaml")
+
+	finding := &Finding{
+		RuleName:   "transform-shape-mismatch",
+		Location:   "resolvers.api_data.transform.with[0]",
+		Line:       14,
+		SourceFile: "test.yaml",
+	}
+
+	kept := ss.Filter([]*Finding{finding})
+	assert.Len(t, kept, 1, "without a source map only line-based matching applies")
+}
+
+func TestFilter_BlockScopedSuppression_RuleMustMatch(t *testing.T) {
+	t.Parallel()
+
+	ss := ParseDirectives(makeTransformSuppressYAML(), "test.yaml").WithSourceMap(transformSourceMap())
+
+	// A different rule inside the same block is not suppressed.
+	finding := &Finding{
+		RuleName:   "some-other-rule",
+		Location:   "resolvers.api_data.transform.with[0]",
+		Line:       14,
+		SourceFile: "test.yaml",
+	}
+
+	kept := ss.Filter([]*Finding{finding})
+	assert.Len(t, kept, 1, "block suppression must still respect the directive's rule list")
+}
+
+func TestFilter_BlockScopedSuppression_OutsideBlockNotSuppressed(t *testing.T) {
+	t.Parallel()
+
+	ss := ParseDirectives(makeTransformSuppressYAML(), "test.yaml").WithSourceMap(transformSourceMap())
+
+	// A finding in the resolve block (line 6) is outside the transform block.
+	finding := &Finding{
+		RuleName:   "transform-shape-mismatch",
+		Location:   "resolvers.api_data.resolve.with[0]",
+		Line:       6,
+		SourceFile: "test.yaml",
+	}
+
+	kept := ss.Filter([]*Finding{finding})
+	assert.Len(t, kept, 1, "findings outside the annotated block must not be suppressed")
+}
+
+func TestFilter_BlockScopedSuppression_InlineOnTransform(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte("spec:\n" + // 1
+		"  resolvers:\n" + // 2
+		"    api_data:\n" + // 3
+		"      transform: # scafctl-lint-ignore: transform-shape-mismatch\n" + // 4
+		"        with:\n" + // 5
+		"          - provider: cel\n" + // 6
+		"            inputs:\n" + // 7
+		"              expression:\n" + // 8
+		"                expr: \"__self.body\"\n") // 9
+
+	sm := sourcepos.NewSourceMap()
+	sm.Set("spec.resolvers.api_data.transform", sourcepos.Position{Line: 4, Column: 7, File: "test.yaml"})
+
+	ss := ParseDirectives(yaml, "test.yaml").WithSourceMap(sm)
+
+	finding := &Finding{
+		RuleName:   "transform-shape-mismatch",
+		Location:   "resolvers.api_data.transform.with[0]",
+		Line:       9,
+		SourceFile: "test.yaml",
+	}
+
+	kept := ss.Filter([]*Finding{finding})
+	assert.Empty(t, kept, "inline directive on transform key should suppress findings within the block")
 }

--- a/pkg/mcp/prepare_options.go
+++ b/pkg/mcp/prepare_options.go
@@ -1,0 +1,53 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+)
+
+// prepareOptions builds the base set of prepare.Option values used by every
+// MCP tool that loads a solution. It mirrors the CLI's `run` wiring so that
+// solutions referencing official plugin providers (e.g. directory, identity,
+// github) are auto-fetched and resolved the same way from the MCP server as
+// from the CLI. Any extra options are appended last so callers can add
+// tool-specific behavior (e.g. dry-run, discovery mode).
+//
+// All wiring is best-effort: when a dependency is unavailable the related
+// option is simply omitted, preserving the previous behavior for solutions
+// that do not use plugins.
+func (s *Server) prepareOptions(ctx context.Context, extra ...prepare.Option) []prepare.Option {
+	opts := []prepare.Option{
+		prepare.WithRegistry(s.registry),
+	}
+
+	// Wire plugin auto-fetch so that bundle.plugins declarations and official
+	// plugin providers trigger automatic download from configured catalogs.
+	if fetcher, err := prepare.BuildPluginFetcher(ctx); err == nil {
+		opts = append(opts, prepare.WithPluginFetcher(fetcher))
+	}
+
+	// Wire official provider auto-resolution from context.
+	if officialReg := official.RegistryFromContext(ctx); officialReg != nil {
+		opts = append(opts, prepare.WithOfficialProviders(officialReg))
+	}
+
+	// Pass the auth registry so auth handler plugins can be registered.
+	if authReg := auth.RegistryFromContext(ctx); authReg != nil {
+		opts = append(opts, prepare.WithAuthRegistry(authReg))
+	}
+
+	// Wire auth host deps so that plugin providers can request auth tokens
+	// from the host process via the gRPC HostService.
+	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
+		opts = append(opts, prepare.WithClientOptions(authOpts...))
+	}
+
+	return append(opts, extra...)
+}

--- a/pkg/mcp/prepare_options_test.go
+++ b/pkg/mcp/prepare_options_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_prepareOptions(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	t.Run("baseline always includes the registry option", func(t *testing.T) {
+		opts := srv.prepareOptions(context.Background())
+		assert.NotEmpty(t, opts, "expected at least the registry option")
+	})
+
+	t.Run("official registry adds an option", func(t *testing.T) {
+		base := srv.prepareOptions(context.Background())
+		ctx := official.WithRegistry(context.Background(), official.NewRegistry())
+		withOfficial := srv.prepareOptions(ctx)
+		assert.GreaterOrEqual(t, len(withOfficial), len(base)+1,
+			"official registry in context should add a prepare option")
+	})
+
+	t.Run("auth registry adds an option", func(t *testing.T) {
+		base := srv.prepareOptions(context.Background())
+		ctx := auth.WithRegistry(context.Background(), auth.NewRegistry())
+		withAuth := srv.prepareOptions(ctx)
+		assert.GreaterOrEqual(t, len(withAuth), len(base)+1,
+			"auth registry in context should add a prepare option")
+	})
+
+	t.Run("extra options are appended", func(t *testing.T) {
+		base := srv.prepareOptions(context.Background())
+		withExtra := srv.prepareOptions(context.Background(), prepare.WithStrict(true))
+		assert.Len(t, withExtra, len(base)+1,
+			"extra options should be appended to the base set")
+	})
+}

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -87,9 +87,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(ctx, path,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, path, s.prepareOptions(ctx)...)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
 			WithField("path"),

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -123,9 +123,7 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(ctx, path,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, path, s.prepareOptions(ctx)...)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
 			WithField("path"),

--- a/pkg/mcp/tools_run.go
+++ b/pkg/mcp/tools_run.go
@@ -120,9 +120,7 @@ func (s *Server) handleRunSolution(_ context.Context, request mcp.CallToolReques
 	}
 
 	// Load solution.
-	prepResult, err := prepare.Solution(ctx, path,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, path, s.prepareOptions(ctx)...)
 	if err != nil {
 		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
 			WithField("path"),

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -332,9 +332,7 @@ func (s *Server) handleLintSolution(_ context.Context, request mcp.CallToolReque
 	}
 
 	// Use prepare.Solution which handles catalog resolution and registry setup
-	prepResult, err := prepare.Solution(ctx, file,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, file, s.prepareOptions(ctx)...)
 	if err != nil {
 		errMsg := err.Error()
 
@@ -429,9 +427,7 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 	}
 
 	// Load solution via prepare.Solution
-	prepResult, err := prepare.Solution(ctx, path,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, path, s.prepareOptions(ctx)...)
 	if err != nil {
 		errMsg := err.Error()
 
@@ -695,9 +691,7 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 
 	// Load solution
-	prepResult, err := prepare.Solution(ctx, path,
-		prepare.WithRegistry(s.registry),
-	)
+	prepResult, err := prepare.Solution(ctx, path, s.prepareOptions(ctx)...)
 	if err != nil {
 		errMsg := err.Error()
 

--- a/pkg/plugin/grpc_host.go
+++ b/pkg/plugin/grpc_host.go
@@ -561,9 +561,65 @@ func HostDepsFromAuthRegistry(authReg *auth.Registry) *HostServiceDeps {
 			handlers := authReg.List()
 			var defaultHandler string
 			if len(handlers) > 0 {
+				// authReg.List() returns handler names in sorted order, so the
+				// default is the first handler alphabetically.
 				defaultHandler = handlers[0]
 			}
 			return handlers, defaultHandler, nil
+		},
+		AuthIdentityFunc: func(ctx context.Context, handler, scope string) (*proto.Claims, error) {
+			// Resolve empty handler name to the default handler (the first in
+			// authReg.List(), which is sorted, i.e. first alphabetically).
+			if handler == "" {
+				handlers := authReg.List()
+				if len(handlers) == 0 {
+					return nil, fmt.Errorf("no auth handlers registered")
+				}
+				handler = handlers[0]
+			}
+			h, err := authReg.Get(handler)
+			if err != nil {
+				return nil, fmt.Errorf("auth handler %q: %w", handler, err)
+			}
+
+			// When a scope is supplied, mint a token for that scope and derive
+			// claims from the JWT. This path works even when no ID token is
+			// cached (e.g. device-code sessions) because the access token
+			// itself carries identity claims.
+			if scope != "" {
+				token, terr := h.GetToken(ctx, auth.TokenOptions{Scope: scope})
+				if terr != nil {
+					return nil, fmt.Errorf("get token from %q for scope %q: %w", handler, scope, terr)
+				}
+				if token == nil {
+					return nil, fmt.Errorf("get token from %q for scope %q: handler returned no token", handler, scope)
+				}
+				if claims, perr := auth.ParseJWTClaims(token.AccessToken); perr == nil {
+					return claimsToProto(claims), nil
+				}
+				// Opaque/non-JWT access token: fall back to stored status claims.
+			}
+
+			// No scope (or the scoped token was opaque): use the claims cached
+			// at login time from the OIDC ID token.
+			st, serr := h.Status(ctx)
+			if serr != nil {
+				return nil, fmt.Errorf("get auth status from %q: %w", handler, serr)
+			}
+			if st == nil || !st.Authenticated {
+				return nil, fmt.Errorf("auth handler %q is not authenticated", handler)
+			}
+			if st.Claims == nil || st.Claims.IsEmpty() {
+				// Authenticated, but no identity claims are available without a
+				// scope. This is common for device-code sessions where no ID
+				// token is stored. Return an actionable error rather than a
+				// silent unauthenticated fallback.
+				return nil, fmt.Errorf(
+					"no identity claims available for auth handler %q without a scope; "+
+						"supply a scope (e.g. inputs.scope: api://<app-id>/.default) so a "+
+						"scoped token can be minted to derive identity claims", handler)
+			}
+			return claimsToProto(st.Claims), nil
 		},
 	}
 }

--- a/pkg/plugin/grpc_host_deps_test.go
+++ b/pkg/plugin/grpc_host_deps_test.go
@@ -5,6 +5,8 @@ package plugin
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -149,6 +151,153 @@ func TestHostDepsFromAuthRegistry_HandlersFunc_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, handlers)
 	assert.Empty(t, defaultH)
+}
+
+// makeTestJWT builds an unsigned three-part JWT whose payload encodes the given
+// claims. Only the payload (part index 1) is decoded by ParseJWTClaims.
+func makeTestJWT(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	enc := func(v any) string {
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	header := enc(map[string]string{"alg": "none", "typ": "JWT"})
+	return header + "." + enc(payload) + ".sig"
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_NoScope_StatusClaims(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.StatusResult = &auth.Status{
+		Authenticated: true,
+		Claims: &auth.Claims{
+			Subject: "user-123",
+			Email:   "user@example.com",
+			Name:    "Jane Doe",
+		},
+	}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	require.NotNil(t, deps.AuthIdentityFunc)
+
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "")
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	assert.Equal(t, "user-123", claims.Subject)
+	assert.Equal(t, "user@example.com", claims.Email)
+	assert.Equal(t, "Jane Doe", claims.Name)
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_NoScope_NoClaims(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	// Authenticated (e.g. device-code) but no cached identity claims.
+	mock.StatusResult = &auth.Status{Authenticated: true}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "")
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.Contains(t, err.Error(), "scope")
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_NotAuthenticated(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.StatusResult = &auth.Status{Authenticated: false}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "")
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_WithScope_JWTClaims(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	mock.GetTokenResult = &auth.Token{
+		AccessToken: makeTestJWT(t, map[string]any{
+			"sub":   "sub-from-jwt",
+			"email": "jwt@example.com",
+			"tid":   "tenant-1",
+			"oid":   "object-1",
+		}),
+		TokenType: "Bearer",
+	}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "api://app/.default")
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	assert.Equal(t, "sub-from-jwt", claims.Subject)
+	assert.Equal(t, "jwt@example.com", claims.Email)
+	assert.Equal(t, "tenant-1", claims.TenantId)
+	assert.Equal(t, "object-1", claims.ObjectId)
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_WithScope_OpaqueTokenFallsBack(t *testing.T) {
+	reg := auth.NewRegistry()
+	mock := auth.NewMockHandler("h")
+	// Opaque (non-JWT) access token -> claims derived from Status instead.
+	mock.GetTokenResult = &auth.Token{AccessToken: "opaque-token", TokenType: "Bearer"}
+	mock.StatusResult = &auth.Status{
+		Authenticated: true,
+		Claims:        &auth.Claims{Subject: "status-sub"},
+	}
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "api://app/.default")
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	assert.Equal(t, "status-sub", claims.Subject)
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_WithScope_NilToken(t *testing.T) {
+	reg := auth.NewRegistry()
+	// Handler returns (nil, nil) from GetToken: no token, no error.
+	mock := auth.NewMockHandler("h")
+	mock.GetTokenResult = nil
+	require.NoError(t, reg.Register(mock))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "h", "api://app/.default")
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.Contains(t, err.Error(), "handler returned no token")
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_UnknownHandler(t *testing.T) {
+	reg := auth.NewRegistry()
+	deps := HostDepsFromAuthRegistry(reg)
+
+	claims, err := deps.AuthIdentityFunc(context.Background(), "", "")
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.Contains(t, err.Error(), "no auth handlers registered")
+}
+
+func TestHostDepsFromAuthRegistry_IdentityFunc_EmptyHandlerResolvesToDefault(t *testing.T) {
+	reg := auth.NewRegistry()
+	mockA := auth.NewMockHandler("alpha")
+	mockA.StatusResult = &auth.Status{
+		Authenticated: true,
+		Claims:        &auth.Claims{Subject: "alpha-sub"},
+	}
+	require.NoError(t, reg.Register(mockA))
+	require.NoError(t, reg.Register(auth.NewMockHandler("beta")))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	claims, err := deps.AuthIdentityFunc(context.Background(), "", "")
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	assert.Equal(t, "alpha-sub", claims.Subject)
 }
 
 func BenchmarkHostDepsFromAuthRegistry(b *testing.B) {

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -132,29 +132,13 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"result": schemahelper.StringProp("The rendered template output (render operation)", schemahelper.WithExample("Hello, World!")),
-					"entries": schemahelper.ArrayProp("Array of rendered file entries (render-tree operation)",
-						schemahelper.WithItems(schemahelper.ObjectProp(
-							"A rendered file entry",
-							nil,
-							map[string]*jsonschema.Schema{
-								"path":    schemahelper.StringProp("Relative file path from the source directory"),
-								"content": schemahelper.StringProp("Rendered template content"),
-							},
-						))),
+					"result": schemahelper.AnyProp("The resolver value, auto-unwrapped. For the 'render' operation this is the rendered template string. For the 'render-tree' operation this is the array of rendered file entries (each an object with 'path' and 'content' strings). Reference the value directly as _.<resolver> -- the render-tree value is the bare array, there is no .entries wrapper.",
+						schemahelper.WithExample("Hello, World!")),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success": schemahelper.BoolProp("Whether the template rendered successfully"),
-					"result":  schemahelper.StringProp("The rendered template output (render operation)", schemahelper.WithExample("Hello, World!")),
-					"entries": schemahelper.ArrayProp("Array of rendered file entries (render-tree operation)",
-						schemahelper.WithItems(schemahelper.ObjectProp(
-							"A rendered file entry",
-							nil,
-							map[string]*jsonschema.Schema{
-								"path":    schemahelper.StringProp("Relative file path from the source directory"),
-								"content": schemahelper.StringProp("Rendered template content"),
-							},
-						))),
+					"result": schemahelper.AnyProp("The rendered output. For the 'render' operation this is the rendered template string. For the 'render-tree' operation this is the array of rendered file entries (each an object with 'path' and 'content' strings).",
+						schemahelper.WithExample("Hello, World!")),
 				}),
 			},
 			Tags: []string{"template", "go-template", "text/template", "transform", "render"},

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -469,6 +469,27 @@ func TestGoTemplateProvider_Descriptor_Schema(t *testing.T) {
 	assert.NotContains(t, desc.Schema.Required, "ignoredBlocks")
 }
 
+// TestGoTemplateProvider_OutputSchema_NoEntriesWrapper guards against the
+// render-tree schema-vs-runtime mismatch: the runtime resolver value for
+// render-tree auto-unwraps to a bare []{path, content} list, so the output
+// schema must NOT advertise a top-level "entries" property (which would lead
+// authors to write _.<resolver>.entries and hit a runtime indexing error).
+func TestGoTemplateProvider_OutputSchema_NoEntriesWrapper(t *testing.T) {
+	p := NewGoTemplateProvider()
+	desc := p.Descriptor()
+
+	for _, capability := range []provider.Capability{provider.CapabilityTransform, provider.CapabilityAction} {
+		schema, ok := desc.OutputSchemas[capability]
+		require.True(t, ok, "output schema should exist for capability %q", capability)
+		require.NotNil(t, schema)
+
+		assert.NotContains(t, schema.Properties, "entries",
+			"capability %q output schema must not advertise an 'entries' wrapper (render-tree value is a bare list)", capability)
+		assert.Contains(t, schema.Properties, "result",
+			"capability %q output schema should document the unwrapped value under 'result'", capability)
+	}
+}
+
 func TestGoTemplateProvider_Execute_IgnoredBlocks(t *testing.T) {
 	p := NewGoTemplateProvider()
 	ctx := context.Background()

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -28,6 +28,9 @@ const (
 	ProviderName = "parameter"
 	// Version is the version of the parameter provider
 	Version = "1.0.0"
+	// TypeString is the value for the "type" input that forces a parameter
+	// value to be returned verbatim as a string, suppressing type inference.
+	TypeString = "string"
 )
 
 // HTTPClient defines the interface for HTTP operations
@@ -104,6 +107,9 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 					schemahelper.WithExample("env")),
 				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
 					schemahelper.WithExample("fallback")),
+				"type": schemahelper.StringProp("Force the parameter value to be returned verbatim as a string, suppressing automatic type inference (boolean, number, JSON, CSV, file://, http://). The only supported value is \"string\".",
+					schemahelper.WithEnum(TypeString),
+					schemahelper.WithExample(TypeString)),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
@@ -141,6 +147,14 @@ inputs:
 					YAML: `provider: parameter
 inputs:
   key: dryRun`,
+				},
+				{
+					Name:        "Force a value to stay a string",
+					Description: "Return the value verbatim, suppressing type inference (e.g. keep a numeric ID as a string)",
+					YAML: `provider: parameter
+inputs:
+  key: billingId
+  type: string`,
 				},
 			},
 		},
@@ -184,6 +198,10 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 		return nil, fmt.Errorf("%s: key is required and must be a string", ProviderName)
 	}
 
+	// Determine whether the caller wants to suppress type coercion and keep
+	// the value verbatim as a string.
+	forceString := wantsStringType(inputs)
+
 	// Get parameters from context
 	params, ok := provider.ParametersFromContext(ctx)
 	if !ok {
@@ -192,14 +210,14 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 
 	// Check for dry-run mode
 	if dryRun := provider.DryRunFromContext(ctx); dryRun {
-		return p.executeDryRun(key, inputs)
+		return p.executeDryRun(key, forceString)
 	}
 
 	// Look up the parameter
 	rawValue, exists := params[key]
 	if !exists {
 		if def, hasDefault := inputs["default"]; hasDefault {
-			parsedDefault, err := p.parseValue(ctx, def)
+			parsedDefault, err := p.resolveValue(ctx, def, forceString)
 			if err != nil {
 				return nil, fmt.Errorf("%s: failed to parse default for parameter %q: %w", ProviderName, key, err)
 			}
@@ -216,7 +234,7 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 	}
 
 	// Parse the value according to precedence rules
-	parsedValue, err := p.parseValue(ctx, rawValue)
+	parsedValue, err := p.resolveValue(ctx, rawValue, forceString)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to parse parameter %q: %w", ProviderName, key, err)
 	}
@@ -229,6 +247,26 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 			"type":   detectType(parsedValue),
 		},
 	}, nil
+}
+
+// resolveValue returns the value for a parameter. When forceString is true the
+// value is returned verbatim as a string (with any surrounding double quotes
+// removed) and all type-inference rules are skipped; non-string inputs are
+// coerced to their string representation so the output type stays consistent
+// with the requested type: string. Otherwise the standard parsing precedence
+// rules are applied.
+func (p *ParameterProvider) resolveValue(ctx context.Context, value any, forceString bool) (any, error) {
+	if forceString {
+		str, ok := value.(string)
+		if !ok {
+			return fmt.Sprintf("%v", value), nil
+		}
+		if isQuoted(str) {
+			return strings.Trim(str, `"`), nil
+		}
+		return str, nil
+	}
+	return p.parseValue(ctx, value)
 }
 
 // parseValue applies the parsing precedence rules to a parameter value
@@ -355,14 +393,33 @@ func detectType(value any) string {
 	}
 }
 
-func (p *ParameterProvider) executeDryRun(key string, _ map[string]any) (*provider.Output, error) {
+func (p *ParameterProvider) executeDryRun(key string, forceString bool) (*provider.Output, error) {
+	typeName := "unknown"
+	if forceString {
+		typeName = "string"
+	}
 	return &provider.Output{
 		Data: "[DRY-RUN] Not retrieved",
 		Metadata: map[string]any{
 			"dryRun": true,
 			"key":    key,
 			"exists": false,
-			"type":   "unknown",
+			"type":   typeName,
 		},
 	}, nil
+}
+
+// wantsStringType reports whether the inputs request that the parameter value
+// be returned verbatim as a string (type: string), suppressing type inference.
+// The provider schema constrains the "type" input to the exact value
+// TypeString, so the comparison is an exact, case-sensitive match to mirror
+// what the executor validates before calling Execute. Surrounding whitespace is
+// not trimmed, so callers that bypass schema validation (e.g. direct resolver
+// execution) stay consistent with the descriptor's declared enum.
+func wantsStringType(inputs map[string]any) bool {
+	t, ok := inputs["type"].(string)
+	if !ok {
+		return false
+	}
+	return t == TypeString
 }

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -92,6 +92,78 @@ func TestParameterProvider_Execute_NoKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "key is required")
 }
 
+func TestParameterProvider_Execute_ForceString(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      any
+		typeIn   any
+		expected any
+	}{
+		{"integer kept as string", "52926", "string", "52926"},
+		{"boolean kept as string", "false", "string", "false"},
+		{"float kept as string", "3.14", "string", "3.14"},
+		{"csv kept as string", "a,b,c", "string", "a,b,c"},
+		{"json kept as string", `{"a":1}`, "string", `{"a":1}`},
+		{"quoted value is unquoted", `"52926"`, "string", "52926"},
+		{"non-string default coerced to string", int64(52926), "string", "52926"},
+		{"coercion still applies without type", "52926", nil, int64(52926)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParameterProvider()
+			ctx := provider.WithParameters(context.Background(), map[string]any{
+				"billingId": tt.raw,
+			})
+
+			inputs := map[string]any{"key": "billingId"}
+			if tt.typeIn != nil {
+				inputs["type"] = tt.typeIn
+			}
+
+			output, err := p.Execute(ctx, inputs)
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			assert.Equal(t, tt.expected, output.Data)
+			assert.Equal(t, true, output.Metadata["exists"])
+		})
+	}
+}
+
+func TestParameterProvider_Execute_ForceString_Default(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":     "billingId",
+		"type":    "string",
+		"default": "52926",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "52926", output.Data)
+	assert.Equal(t, false, output.Metadata["exists"])
+	assert.Equal(t, "string", output.Metadata["type"])
+}
+
+func TestParameterProvider_Execute_ForceString_DryRun(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithDryRun(provider.WithParameters(context.Background(), map[string]any{
+		"billingId": "52926",
+	}), true)
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":  "billingId",
+		"type": "string",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "string", output.Metadata["type"])
+	assert.Equal(t, true, output.Metadata["dryRun"])
+}
+
 func TestParameterProvider_ParseValue_Boolean(t *testing.T) {
 	p := NewParameterProvider()
 	ctx := context.Background()


### PR DESCRIPTION
- mcp: add Server.prepareOptions to mirror the CLI run wiring so MCP tools auto-fetch official plugin providers, resolve official and auth registries, and pass auth host deps; apply across run, dry-run, action, lint, render, and resolver preview tools
- plugin: add AuthIdentityFunc to the host service so plugin providers can derive identity claims from a scoped token or cached login claims, with an actionable error when neither is available
- provider(parameter): add type: string input to return a value verbatim and suppress type inference (boolean, number, JSON, CSV, file://, http://)
- provider(gotmpl): correct render-tree output schema to document the unwrapped bare list under result and drop the misleading entries wrapper
- gotmpl(hcl): render top-level scalar lists as bare HCL arrays and empty lists as []
- lint: add block-scoped suppression via source map so an ignore directive on a block key suppresses findings deeper in that block; skip transform-shape-mismatch when a non-trivial when guard protects the access