### PR TITLE
feat(mcp): add live resource subscriptions with file-watch notifications

### DIFF
--- a/docs/design/mcp-server-implementation-guide.md
+++ b/docs/design/mcp-server-implementation-guide.md
@@ -194,7 +194,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
         "scafctl",
         cfg.version,
         server.WithToolCapabilities(false),    // No listChanged for now
-        server.WithResourceCapabilities(true, false), // Subscribe=true, listChanged=false
+        server.WithResourceCapabilities(true, true), // Subscribe=true, listChanged=true
         server.WithRecovery(),                 // Recover from panics in handlers
         server.WithInstructions(serverInstructions),
     )

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -1917,10 +1917,38 @@ resource "aws_s3_bucket" "main" {
 }
 ```
 
+### Top-Level Scalar Lists
+
+When the value passed to `toHcl` is a top-level list of scalars (not a map), it
+renders as a bare HCL array. An empty list renders as `[]`.
+
+```yaml
+    refsHcl:
+      description: Render a list of refs as a bare HCL array
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: refs-hcl
+              template: |
+                {{ list "repo:a:ref:main" "repo:b:ref:main" | toHcl }}
+```
+
+Output:
+
+```hcl
+["repo:a:ref:main", "repo:b:ref:main"]
+```
+
+A top-level list of maps still renders as repeated HCL blocks, so `toHcl` picks
+the right shape automatically based on the list's element types.
+
 ### What You Learned
 
 - **`toHcl`** — Converts maps, lists, and primitives into HCL syntax.
 - **Nested structures** — Maps within maps render as nested HCL blocks.
+- **Top-level scalar lists** -- Render as a bare HCL array (`["a", "b"]`); empty lists render as `[]`.
 - **Combined with Sprig** — Use `indent` (from Sprig) to properly nest the generated HCL.
 - **Terraform workflows** — Generate provider blocks, resource definitions, and variable files from structured data.
 

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -760,7 +760,97 @@ scafctl lint explain missing-template-dependency
 {{% /tab %}}
 {{< /tabs >}}
 
-## 12. Using Lint with the MCP Server
+## 12. Suppressing Findings
+
+When a finding is a deliberate, reviewed exception, you can suppress it with an
+inline YAML comment directive instead of disabling the rule globally. Directives
+are read directly from the solution file, so they travel with the code they
+annotate.
+
+### Ignore a Single Location
+
+`# scafctl-lint-ignore` suppresses findings on the next line. Placed as an inline
+comment, it suppresses findings on its own line:
+
+```yaml
+spec:
+  resolvers:
+    # scafctl-lint-ignore: missing-description
+    api_data:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/data # scafctl-lint-ignore: insecure-url
+```
+
+Without a rule list (`# scafctl-lint-ignore`) the directive suppresses **all**
+rules at that location. With a comma-separated list
+(`# scafctl-lint-ignore: rule-a, rule-b`) it only suppresses the named rules.
+
+### Block-Scoped Suppression
+
+When the directive annotates a YAML block key (such as `transform:`), it
+suppresses matching findings anywhere inside that block -- even when the
+finding's reported line is deeper than the directive. This is handy for rules
+like `transform-shape-mismatch` whose finding points at a nested step:
+
+```yaml
+spec:
+  resolvers:
+    api_data:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      # scafctl-lint-ignore: transform-shape-mismatch
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body.items'
+```
+
+The same works inline on the block key:
+
+```yaml
+      transform: # scafctl-lint-ignore: transform-shape-mismatch
+```
+
+### Disable a Range or a Whole File
+
+Use a `disable`/`enable` pair to suppress findings across a range of lines, or
+`disable-file` to suppress them for the entire file:
+
+```yaml
+# scafctl-lint-disable: missing-description
+spec:
+  resolvers:
+    a: { resolve: { with: [{ provider: static, inputs: { value: 1 } }] } }
+    b: { resolve: { with: [{ provider: static, inputs: { value: 2 } }] } }
+# scafctl-lint-enable: missing-description
+```
+
+```yaml
+# scafctl-lint-disable-file: unused-resolver
+```
+
+| Directive | Scope |
+|-----------|-------|
+| `# scafctl-lint-ignore[: rules]` | Next line (or current line when inline); block-scoped when on a block key |
+| `# scafctl-lint-disable[: rules]` | From this line until a matching `enable` (or end of file) |
+| `# scafctl-lint-enable[: rules]` | Ends a preceding `disable` block |
+| `# scafctl-lint-disable-file[: rules]` | The entire file |
+
+> **Tip:** Prefer a narrow `scafctl-lint-ignore` on the exact line or block over
+> `disable-file`. Targeted suppressions keep the rest of the file linted and make
+> the intent obvious to reviewers.
+
+## 13. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -755,6 +755,18 @@ MCP resources are read-only data endpoints that AI agents can fetch on demand:
 | `provider://reference` | Compact reference of all providers with required/optional inputs, capabilities, and descriptions |
 | `solution://{name}/tests` | Functional test cases defined in a solution's `spec.testing.cases` — test names, descriptions, assertions, tags, and configuration |
 
+### Subscribing to Resource Updates
+
+The server advertises resource subscriptions, so clients that support them can call `resources/subscribe` on a `solution://` URI and receive a live `resources/updated` notification whenever the backing solution file changes on disk. This lets an AI agent keep its view of a solution -- its graph, schema, or tests -- fresh without re-fetching on a timer.
+
+Key behaviors:
+
+- **Sub-resources share the file.** Subscribing to any solution sub-resource (`solution://{name}/schema`, `solution://{name}/graph`, or `solution://{name}/tests`) watches the same underlying solution file, so an edit notifies every subscription for that solution.
+- **Debounced.** Rapid successive writes (such as an editor save-all) are collapsed into a single notification after a short quiet period (300ms).
+- **Atomic-save safe.** The server watches the parent directory of the solution file, so editors that save via rename are handled correctly.
+- **Local files only.** Solutions referenced by catalog name or URL have no watchable local file, so the subscription is acknowledged but no updates are emitted.
+- **Automatic cleanup.** Subscriptions are released on `resources/unsubscribe` and when the client session ends.
+
 ## 9. Available Prompts
 
 MCP prompts are predefined templates that guide AI agents through common workflows:

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -1236,6 +1236,69 @@ scafctl run resolver -f param-demo.yaml unknown=value
 {{% /tab %}}
 {{< /tabs >}}
 
+### Forcing a String Value
+
+By default the parameter provider infers a type from the raw value: `true`/`false`
+become booleans, numeric strings become numbers, JSON objects/arrays are parsed,
+comma-separated values become lists, and `file://`/`http://` values are loaded.
+When you need the value kept verbatim as a string -- for example a numeric ID
+with leading zeros, or a value that merely looks like JSON -- set `type: string`
+on the input. This suppresses all type inference and returns the value exactly as
+provided.
+
+Create a file called `param-string-demo.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: param-string-demo
+  version: 1.0.0
+spec:
+  resolvers:
+    # Inferred: "00042" would become the number 42
+    billingId:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: billingId
+    # Verbatim: stays the string "00042"
+    billingIdString:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: billingId
+              type: string
+```
+
+{{< tabs "run-resolver-tutorial-cmd-24b" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f param-string-demo.yaml billingId=00042 -o json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f param-string-demo.yaml billingId=00042 -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output -- type inference drops the leading zeros, `type: string` preserves them:
+
+```json
+{
+  "billingId": 42,
+  "billingIdString": "00042"
+}
+```
+
+> **Note:** `type: string` only accepts the literal value `string`. It applies to
+> both CLI-supplied values and the `default` input, so a `default` value is also
+> returned verbatim. Non-string defaults are coerced to their string form.
+
 ---
 
 ## Common Workflows

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -98,6 +98,10 @@ type Server struct {
 	// from "set to a named profile" (non-empty *string). The code never
 	// stores an empty string — clearing is done by storing nil.
 	profileOverride atomic.Value // *string
+
+	// subscriptions tracks MCP resource subscriptions and delivers live
+	// resources/updated notifications when a watched solution file changes.
+	subscriptions *subscriptionManager
 }
 
 // ServerOption configures the MCP server.
@@ -623,6 +627,13 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	}
 	s.cfgReloader = newConfigReloader(initialCfg, configReloaderTTL, s.logger)
 
+	// Build observability hooks and add subscription lifecycle hooks so the
+	// server can deliver live resources/updated notifications. The hooks
+	// close over s, so they observe s.subscriptions once it is initialized
+	// below (after the mcp-go server exists).
+	obsHooks := newObservabilityHooks(s.logger)
+	s.registerSubscriptionHooks(obsHooks)
+
 	// Build server options for mcp-go
 	serverOpts := []server.ServerOption{
 		server.WithToolCapabilities(true),
@@ -639,7 +650,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		// Task support for async long-running operations
 		server.WithTaskCapabilities(true, true, true),
 		// Observability hooks & middleware
-		server.WithHooks(newObservabilityHooks(s.logger)),
+		server.WithHooks(obsHooks),
 		server.WithToolHandlerMiddleware(toolTimingMiddleware(s.logger)),
 		server.WithResourceHandlerMiddleware(resourceTimingMiddleware(s.logger)),
 		// Completions providers
@@ -663,6 +674,11 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 
 	// Enable sampling capability
 	s.mcpServer.EnableSampling()
+
+	// Initialize the resource subscription manager now that the mcp-go server
+	// (the notifier) exists. The subscription hooks registered above reference
+	// s.subscriptions lazily, so they pick this up on the first subscribe.
+	s.subscriptions = newSubscriptionManager(s.mcpServer, s.resolveSubscriptionFile, subscriptionDebounceDuration, s.logger)
 
 	// Register all tools
 	s.registerTools()
@@ -723,6 +739,10 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 // Close releases resources owned by the server. Safe to call multiple times
 // and concurrently with Serve*/Handler/Info.
 func (s *Server) Close() {
+	if s.subscriptions != nil {
+		s.subscriptions.Close()
+	}
+
 	s.upstreamMu.Lock()
 	proxies := s.upstreamProxies
 	s.upstreamProxies = make(map[string]*upstream.Proxy)

--- a/pkg/mcp/subscriptions.go
+++ b/pkg/mcp/subscriptions.go
@@ -1,0 +1,431 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
+)
+
+// solutionResourceSuffixes are the routing suffixes appended to a solution URI
+// for its sub-resources. They are stripped when resolving the backing file so a
+// subscription to any sub-resource watches the same solution file.
+var solutionResourceSuffixes = []string{
+	"/graph/action",
+	"/graph/resolver",
+	"/graph",
+	"/schema",
+	"/tests",
+}
+
+// registerSubscriptionHooks wires resource subscription lifecycle hooks onto the
+// given hooks struct. The closures reference s.subscriptions lazily so they work
+// once the manager is initialized after the mcp-go server is built.
+func (s *Server) registerSubscriptionHooks(hooks *server.Hooks) {
+	hooks.AddAfterSubscribe(func(ctx context.Context, _ any, message *mcp.SubscribeRequest, _ *mcp.EmptyResult) {
+		if s.subscriptions == nil || message == nil {
+			return
+		}
+		sess := server.ClientSessionFromContext(ctx)
+		if sess == nil {
+			return
+		}
+		s.subscriptions.Subscribe(sess.SessionID(), message.Params.URI)
+	})
+
+	hooks.AddAfterUnsubscribe(func(ctx context.Context, _ any, message *mcp.UnsubscribeRequest, _ *mcp.EmptyResult) {
+		if s.subscriptions == nil || message == nil {
+			return
+		}
+		sess := server.ClientSessionFromContext(ctx)
+		if sess == nil {
+			return
+		}
+		s.subscriptions.Unsubscribe(sess.SessionID(), message.Params.URI)
+	})
+
+	hooks.AddOnUnregisterSession(func(_ context.Context, session server.ClientSession) {
+		if s.subscriptions == nil || session == nil {
+			return
+		}
+		s.subscriptions.RemoveSession(session.SessionID())
+	})
+}
+
+// resolveSubscriptionFile maps a solution:// resource URI to an absolute local
+// file path for watching. It returns an empty string when the URI is not a
+// solution resource or does not resolve to a watchable local file (e.g. a
+// catalog name or URL), in which case the subscription is acknowledged but not
+// watched.
+func (s *Server) resolveSubscriptionFile(uri string) string {
+	name := extractNameFromURI(uri, "solution://")
+	if name == "" {
+		return ""
+	}
+	for _, suffix := range solutionResourceSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			name = strings.TrimSuffix(name, suffix)
+			break
+		}
+	}
+	if name == "" {
+		return ""
+	}
+
+	// Subscriptions watch local files only. Avoid invoking the solution loader
+	// (which performs catalog resolution and may reach out to remote catalogs)
+	// for URIs that do not point at an existing local path, such as catalog
+	// names or URLs.
+	if _, err := os.Stat(name); err != nil {
+		return ""
+	}
+
+	sol, err := inspect.LoadSolution(s.ctx, name)
+	if err != nil {
+		s.logger.V(1).Info("mcp subscription: cannot load solution for watch", "uri", uri, "error", err)
+		return ""
+	}
+
+	path := sol.GetPath()
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	info, err := os.Stat(abs)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return filepath.Clean(abs)
+}
+
+// subscriptionDebounceDuration is how long the subscription manager waits after
+// the last file change before emitting a resources/updated notification. Rapid
+// successive writes (e.g. an editor save-all) are collapsed into a single
+// notification.
+const subscriptionDebounceDuration = 300 * time.Millisecond
+
+// resourceNotifier sends MCP notifications to a specific client session. It is
+// satisfied by *server.MCPServer and abstracted here so the subscription
+// manager can be unit tested without a live server.
+type resourceNotifier interface {
+	SendNotificationToSpecificClient(sessionID, method string, params map[string]any) error
+}
+
+// subscription is a single (session, uri) subscription and the local file that
+// backs it. file is empty when the URI does not resolve to a watchable local
+// file (e.g. a catalog or URL-backed solution).
+type subscription struct {
+	sessionID string
+	uri       string
+	file      string
+}
+
+// subscriptionManager tracks MCP resource subscriptions and delivers live
+// resources/updated notifications when the backing solution file changes on
+// disk. It watches the parent directory of each subscribed file so that
+// atomic-save (rename) editors are handled robustly, and debounces change
+// bursts before notifying.
+type subscriptionManager struct {
+	logger      logr.Logger
+	notifier    resourceNotifier
+	resolveFile func(uri string) string
+	debounce    time.Duration
+
+	mu      sync.Mutex
+	watcher *fsnotify.Watcher
+	closed  bool
+
+	// subs maps sessionID -> uri -> subscription.
+	subs map[string]map[string]subscription
+	// fileRefs counts how many subscriptions watch each file.
+	fileRefs map[string]int
+	// dirRefs counts how many watched files live under each directory.
+	dirRefs map[string]int
+	// timers holds the active debounce timer per file.
+	timers map[string]*time.Timer
+	// timerGen is the generation of the active debounce timer per file. A
+	// debounce callback captures its generation by value and only notifies when
+	// it still matches, so a stale callback that fired after a newer event
+	// replaced its timer is ignored.
+	timerGen map[string]uint64
+
+	wg sync.WaitGroup
+}
+
+// newSubscriptionManager creates a subscription manager. resolveFile maps a
+// subscribed URI to an absolute local file path, returning an empty string when
+// the URI is not backed by a watchable local file. A non-positive debounce
+// falls back to subscriptionDebounceDuration.
+func newSubscriptionManager(notifier resourceNotifier, resolveFile func(uri string) string, debounce time.Duration, lgr logr.Logger) *subscriptionManager {
+	if debounce <= 0 {
+		debounce = subscriptionDebounceDuration
+	}
+	return &subscriptionManager{
+		logger:      lgr,
+		notifier:    notifier,
+		resolveFile: resolveFile,
+		debounce:    debounce,
+		subs:        make(map[string]map[string]subscription),
+		fileRefs:    make(map[string]int),
+		dirRefs:     make(map[string]int),
+		timers:      make(map[string]*time.Timer),
+		timerGen:    make(map[string]uint64),
+	}
+}
+
+// Subscribe records a subscription for the given session and URI and begins
+// watching the backing file when the URI resolves to a local file. Subscribing
+// the same (session, uri) again refreshes the resolved file.
+func (m *subscriptionManager) Subscribe(sessionID, uri string) {
+	var file string
+	if m.resolveFile != nil {
+		file = m.resolveFile(uri)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+
+	if m.subs[sessionID] == nil {
+		m.subs[sessionID] = make(map[string]subscription)
+	}
+	if prev, ok := m.subs[sessionID][uri]; ok {
+		m.unwatchFileLocked(prev.file)
+	}
+	m.subs[sessionID][uri] = subscription{sessionID: sessionID, uri: uri, file: file}
+	m.watchFileLocked(file)
+}
+
+// Unsubscribe removes a single (session, uri) subscription and stops watching
+// the backing file when no other subscription references it.
+func (m *subscriptionManager) Unsubscribe(sessionID, uri string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	uris := m.subs[sessionID]
+	if uris == nil {
+		return
+	}
+	if sub, ok := uris[uri]; ok {
+		m.unwatchFileLocked(sub.file)
+		delete(uris, uri)
+		if len(uris) == 0 {
+			delete(m.subs, sessionID)
+		}
+	}
+}
+
+// RemoveSession drops all subscriptions for a session, typically when the
+// client session is unregistered.
+func (m *subscriptionManager) RemoveSession(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, sub := range m.subs[sessionID] {
+		m.unwatchFileLocked(sub.file)
+	}
+	delete(m.subs, sessionID)
+}
+
+// Close stops all watching and releases resources. It is safe to call multiple
+// times and concurrently with the watch loop.
+func (m *subscriptionManager) Close() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	for _, t := range m.timers {
+		t.Stop()
+	}
+	m.timers = make(map[string]*time.Timer)
+	m.timerGen = make(map[string]uint64)
+	w := m.watcher
+	m.watcher = nil
+	m.mu.Unlock()
+
+	if w != nil {
+		if err := w.Close(); err != nil {
+			m.logger.V(1).Info("mcp subscription: error closing file watcher", "error", err)
+		}
+	}
+	m.wg.Wait()
+}
+
+// watchFileLocked begins watching the parent directory of file. Callers must
+// hold m.mu.
+func (m *subscriptionManager) watchFileLocked(file string) {
+	if file == "" {
+		return
+	}
+	if m.fileRefs[file] == 0 {
+		dir := filepath.Dir(file)
+		if m.dirRefs[dir] == 0 {
+			if err := m.ensureWatcherLocked(); err != nil {
+				m.logger.Error(err, "mcp subscription: failed to create file watcher", "file", file)
+				return
+			}
+			if err := m.watcher.Add(dir); err != nil {
+				m.logger.Error(err, "mcp subscription: failed to watch directory", "dir", dir)
+				return
+			}
+		}
+		m.dirRefs[dir]++
+	}
+	m.fileRefs[file]++
+}
+
+// unwatchFileLocked decrements the reference counts for file and stops watching
+// its parent directory once no files under it remain. Callers must hold m.mu.
+func (m *subscriptionManager) unwatchFileLocked(file string) {
+	if file == "" {
+		return
+	}
+	if m.fileRefs[file] == 0 {
+		return
+	}
+	m.fileRefs[file]--
+	if m.fileRefs[file] > 0 {
+		return
+	}
+	delete(m.fileRefs, file)
+	if t := m.timers[file]; t != nil {
+		t.Stop()
+		delete(m.timers, file)
+	}
+	delete(m.timerGen, file)
+
+	dir := filepath.Dir(file)
+	if m.dirRefs[dir] == 0 {
+		return
+	}
+	m.dirRefs[dir]--
+	if m.dirRefs[dir] > 0 {
+		return
+	}
+	delete(m.dirRefs, dir)
+	if m.watcher != nil {
+		if err := m.watcher.Remove(dir); err != nil {
+			m.logger.V(1).Info("mcp subscription: failed to unwatch directory", "dir", dir, "error", err)
+		}
+	}
+}
+
+// ensureWatcherLocked lazily creates the fsnotify watcher and starts the watch
+// loop. Callers must hold m.mu.
+func (m *subscriptionManager) ensureWatcherLocked() error {
+	if m.watcher != nil {
+		return nil
+	}
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	m.watcher = w
+	m.wg.Add(1)
+	go m.watchLoop(w)
+	return nil
+}
+
+// watchLoop consumes filesystem events until the watcher is closed.
+func (m *subscriptionManager) watchLoop(w *fsnotify.Watcher) {
+	defer m.wg.Done()
+	for {
+		select {
+		case event, ok := <-w.Events:
+			if !ok {
+				return
+			}
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) {
+				continue
+			}
+			m.handleFileEvent(event.Name)
+
+		case err, ok := <-w.Errors:
+			if !ok {
+				return
+			}
+			m.logger.V(1).Info("mcp subscription: file watcher error", "error", err)
+		}
+	}
+}
+
+// handleFileEvent schedules a debounced notification for the changed file when
+// it is currently being watched.
+func (m *subscriptionManager) handleFileEvent(path string) {
+	clean := filepath.Clean(path)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	if m.fileRefs[clean] == 0 {
+		return
+	}
+	if t := m.timers[clean]; t != nil {
+		t.Stop()
+	}
+	m.timerGen[clean]++
+	gen := m.timerGen[clean]
+	m.timers[clean] = time.AfterFunc(m.debounce, func() { m.notifyFile(clean, gen) })
+}
+
+// notifyFile sends a resources/updated notification to every session subscribed
+// to a URI backed by the given file. gen is the debounce generation that
+// scheduled this call; the notification is skipped if a newer event has already
+// bumped the generation, so the debounced delivery is left to that newer timer.
+func (m *subscriptionManager) notifyFile(file string, gen uint64) {
+	m.mu.Lock()
+	// Only act when this callback is still the current debounce generation for
+	// the file. A newer event may have stored a fresh timer after this one fired
+	// but before it acquired the lock; in that case do nothing and let the newer
+	// timer deliver the debounced notification.
+	if m.timerGen[file] != gen {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.timers, file)
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	var targets []subscription
+	for _, uris := range m.subs {
+		for _, sub := range uris {
+			if sub.file == file {
+				targets = append(targets, sub)
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	for _, t := range targets {
+		err := m.notifier.SendNotificationToSpecificClient(
+			t.sessionID,
+			mcp.MethodNotificationResourceUpdated,
+			map[string]any{"uri": t.uri},
+		)
+		if err != nil {
+			m.logger.V(1).Info("mcp subscription: failed to send resource update",
+				"sessionID", t.sessionID, "uri", t.uri, "error", err)
+		}
+	}
+}

--- a/pkg/mcp/subscriptions_test.go
+++ b/pkg/mcp/subscriptions_test.go
@@ -1,0 +1,445 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDebounce = 60 * time.Millisecond
+	// testSettle is a generous wait used to confirm that NO notification is
+	// delivered. It must comfortably exceed testDebounce.
+	testSettle = 300 * time.Millisecond
+)
+
+// notifyCall records a single notification delivered to the fake notifier.
+type notifyCall struct {
+	sessionID string
+	method    string
+	uri       string
+}
+
+// fakeNotifier is a thread-safe resourceNotifier that records every call.
+type fakeNotifier struct {
+	mu    sync.Mutex
+	calls []notifyCall
+}
+
+func (f *fakeNotifier) SendNotificationToSpecificClient(sessionID, method string, params map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	uri, _ := params["uri"].(string)
+	f.calls = append(f.calls, notifyCall{sessionID: sessionID, method: method, uri: uri})
+	return nil
+}
+
+func (f *fakeNotifier) snapshot() []notifyCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]notifyCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func (f *fakeNotifier) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// newTestManager creates a manager whose resolver maps the given URIs to files.
+func newTestManager(notifier resourceNotifier, uriToFile map[string]string) *subscriptionManager {
+	resolve := func(uri string) string {
+		return uriToFile[uri]
+	}
+	return newSubscriptionManager(notifier, resolve, testDebounce, logr.Discard())
+}
+
+// writeFile writes content to path, failing the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestSubscriptionManager_NotifiesOnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file + "/graph"
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	time.Sleep(testDebounce) // let the directory watch register
+
+	writeFile(t, file, "v: 2")
+
+	require.Eventually(t, func() bool {
+		return notifier.count() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "expected a resources/updated notification")
+
+	calls := notifier.snapshot()
+	require.NotEmpty(t, calls)
+	assert.Equal(t, "session-1", calls[0].sessionID)
+	assert.Equal(t, mcp.MethodNotificationResourceUpdated, calls[0].method)
+	assert.Equal(t, uri, calls[0].uri)
+}
+
+func TestSubscriptionManager_UnsubscribeStopsNotifications(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	time.Sleep(testDebounce)
+	mgr.Unsubscribe("session-1", uri)
+
+	writeFile(t, file, "v: 2")
+	time.Sleep(testSettle)
+
+	assert.Equal(t, 0, notifier.count(), "no notification expected after unsubscribe")
+}
+
+func TestSubscriptionManager_RemoveSessionStopsNotifications(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uriGraph := "solution://" + file + "/graph"
+	uriSchema := "solution://" + file + "/schema"
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uriGraph: file, uriSchema: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uriGraph)
+	mgr.Subscribe("session-1", uriSchema)
+	time.Sleep(testDebounce)
+
+	mgr.RemoveSession("session-1")
+
+	writeFile(t, file, "v: 2")
+	time.Sleep(testSettle)
+
+	assert.Equal(t, 0, notifier.count(), "no notification expected after session removal")
+}
+
+func TestSubscriptionManager_MultipleSessionsNotified(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file + "/graph"
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	mgr.Subscribe("session-2", uri)
+	time.Sleep(testDebounce)
+
+	writeFile(t, file, "v: 2")
+
+	require.Eventually(t, func() bool {
+		return notifier.count() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "expected both sessions notified")
+
+	sessions := map[string]bool{}
+	for _, c := range notifier.snapshot() {
+		sessions[c.sessionID] = true
+	}
+	assert.True(t, sessions["session-1"])
+	assert.True(t, sessions["session-2"])
+}
+
+func TestSubscriptionManager_NonFileURINotWatched(t *testing.T) {
+	notifier := &fakeNotifier{}
+	// resolveFile returns "" for every URI (catalog/URL-backed solution).
+	mgr := newSubscriptionManager(notifier, func(string) string { return "" }, testDebounce, logr.Discard())
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", "solution://my-catalog-solution/graph")
+
+	mgr.mu.Lock()
+	watcher := mgr.watcher
+	mgr.mu.Unlock()
+
+	assert.Nil(t, watcher, "no file watcher should be created for non-file URIs")
+	assert.Equal(t, 0, notifier.count())
+}
+
+func TestSubscriptionManager_DebounceCollapsesBurst(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file + "/graph"
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	time.Sleep(testDebounce)
+
+	for i := 0; i < 5; i++ {
+		writeFile(t, file, "burst")
+	}
+
+	require.Eventually(t, func() bool {
+		return notifier.count() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Let any further (unexpected) debounced notifications settle.
+	time.Sleep(testSettle)
+	assert.Equal(t, 1, notifier.count(), "rapid writes should collapse into a single notification")
+}
+
+func TestSubscriptionManager_NotifiesOnAtomicSaveRename(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file + "/graph"
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	time.Sleep(testDebounce) // let the directory watch register
+
+	// Simulate an editor's atomic save: write to a temp file in the same
+	// directory, then rename it over the watched solution file.
+	tmp := filepath.Join(dir, "solution.yaml.tmp")
+	writeFile(t, tmp, "v: 2")
+	require.NoError(t, os.Rename(tmp, file))
+
+	require.Eventually(t, func() bool {
+		return notifier.count() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "expected a resources/updated notification for the atomic save")
+
+	// Let any further debounced notifications settle, then assert exactly one.
+	time.Sleep(testSettle)
+	require.Equal(t, 1, notifier.count(), "atomic save should yield exactly one notification")
+
+	calls := notifier.snapshot()
+	require.NotEmpty(t, calls)
+	assert.Equal(t, "session-1", calls[0].sessionID)
+	assert.Equal(t, mcp.MethodNotificationResourceUpdated, calls[0].method)
+	assert.Equal(t, uri, calls[0].uri)
+}
+
+func TestSubscriptionManager_NotifyFileIgnoresStaleTimer(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+	defer mgr.Close()
+
+	mgr.Subscribe("session-1", uri)
+	clean := filepath.Clean(file)
+
+	// Simulate the generation a newer event registered. A stale callback runs
+	// with an older generation; the current callback runs with the matching one.
+	mgr.mu.Lock()
+	mgr.timerGen[clean] = 5
+	mgr.mu.Unlock()
+
+	// A stale callback (older generation) must not notify or clear state.
+	mgr.notifyFile(clean, 4)
+	assert.Equal(t, 0, notifier.count(), "stale generation must not deliver a notification")
+	mgr.mu.Lock()
+	assert.Equal(t, uint64(5), mgr.timerGen[clean], "stale callback must not change the current generation")
+	mgr.mu.Unlock()
+
+	// The current generation delivers the notification and clears the timer.
+	mgr.notifyFile(clean, 5)
+	assert.Equal(t, 1, notifier.count(), "current generation should deliver a notification")
+	mgr.mu.Lock()
+	_, ok := mgr.timers[clean]
+	mgr.mu.Unlock()
+	assert.False(t, ok, "timer entry should be cleared after notifying")
+}
+
+func TestSubscriptionManager_CloseIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+
+	uri := "solution://" + file
+	notifier := &fakeNotifier{}
+	mgr := newTestManager(notifier, map[string]string{uri: file})
+
+	mgr.Subscribe("session-1", uri)
+
+	assert.NotPanics(t, func() {
+		mgr.Close()
+		mgr.Close()
+	})
+
+	// Subscriptions after close are no-ops and must not create a watcher.
+	mgr.Subscribe("session-2", uri)
+	mgr.mu.Lock()
+	watcher := mgr.watcher
+	mgr.mu.Unlock()
+	assert.Nil(t, watcher)
+}
+
+func TestNewSubscriptionManager_DefaultDebounce(t *testing.T) {
+	mgr := newSubscriptionManager(&fakeNotifier{}, func(string) string { return "" }, 0, logr.Discard())
+	defer mgr.Close()
+	assert.Equal(t, subscriptionDebounceDuration, mgr.debounce)
+}
+
+func TestServer_ResolveSubscriptionFile(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	solYAML := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sub-solution
+  version: 1.0.0
+  description: A solution for subscription resolution testing
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'hi'"
+`
+	require.NoError(t, os.WriteFile(solPath, []byte(solYAML), 0o600))
+	wantPath := filepath.Clean(solPath)
+
+	t.Run("resolves bare solution URI to file", func(t *testing.T) {
+		got := srv.resolveSubscriptionFile("solution://" + solPath)
+		assert.Equal(t, wantPath, got)
+	})
+
+	t.Run("strips sub-resource suffixes", func(t *testing.T) {
+		for _, suffix := range []string{"/graph", "/schema", "/tests", "/graph/action", "/graph/resolver"} {
+			got := srv.resolveSubscriptionFile("solution://" + solPath + suffix)
+			assert.Equalf(t, wantPath, got, "suffix %q should resolve to the solution file", suffix)
+		}
+	})
+
+	t.Run("returns empty for non-solution URI", func(t *testing.T) {
+		assert.Empty(t, srv.resolveSubscriptionFile("provider://exec"))
+	})
+
+	t.Run("returns empty for unloadable solution", func(t *testing.T) {
+		assert.Empty(t, srv.resolveSubscriptionFile("solution:///nonexistent/solution.yaml"))
+	})
+
+	t.Run("returns empty for empty name", func(t *testing.T) {
+		assert.Empty(t, srv.resolveSubscriptionFile("solution://"))
+	})
+}
+
+// fakeSession is a minimal server.ClientSession for exercising hooks.
+type fakeSession struct {
+	id string
+}
+
+func (f *fakeSession) Initialize()       {}
+func (f *fakeSession) Initialized() bool { return true }
+func (f *fakeSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return make(chan mcp.JSONRPCNotification, 1)
+}
+func (f *fakeSession) SessionID() string { return f.id }
+
+func TestServer_SubscriptionHooks(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	defer srv.Close()
+
+	hooks := &server.Hooks{}
+	srv.registerSubscriptionHooks(hooks)
+	require.Len(t, hooks.OnAfterSubscribe, 1)
+	require.Len(t, hooks.OnAfterUnsubscribe, 1)
+	require.Len(t, hooks.OnUnregisterSession, 1)
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "solution.yaml")
+	writeFile(t, file, "v: 1")
+	uri := "solution://" + file
+
+	// Force the manager to watch our temp file regardless of solution loading.
+	srv.subscriptions.resolveFile = func(string) string { return filepath.Clean(file) }
+
+	session := &fakeSession{id: "hook-session"}
+	ctx := srv.mcpServer.WithContext(context.Background(), session)
+
+	subReq := &mcp.SubscribeRequest{}
+	subReq.Params.URI = uri
+	hooks.OnAfterSubscribe[0](ctx, nil, subReq, &mcp.EmptyResult{})
+
+	srv.subscriptions.mu.Lock()
+	_, subscribed := srv.subscriptions.subs["hook-session"][uri]
+	srv.subscriptions.mu.Unlock()
+	assert.True(t, subscribed, "subscribe hook should record the subscription")
+
+	unsubReq := &mcp.UnsubscribeRequest{}
+	unsubReq.Params.URI = uri
+	hooks.OnAfterUnsubscribe[0](ctx, nil, unsubReq, &mcp.EmptyResult{})
+
+	srv.subscriptions.mu.Lock()
+	_, stillSubscribed := srv.subscriptions.subs["hook-session"][uri]
+	srv.subscriptions.mu.Unlock()
+	assert.False(t, stillSubscribed, "unsubscribe hook should remove the subscription")
+
+	// Subscribe again, then unregister the session to exercise cleanup.
+	hooks.OnAfterSubscribe[0](ctx, nil, subReq, &mcp.EmptyResult{})
+	hooks.OnUnregisterSession[0](ctx, session)
+
+	srv.subscriptions.mu.Lock()
+	_, sessionGone := srv.subscriptions.subs["hook-session"]
+	srv.subscriptions.mu.Unlock()
+	assert.False(t, sessionGone, "unregister hook should drop all session subscriptions")
+}
+
+func TestServer_SubscriptionHooks_Guards(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	defer srv.Close()
+
+	hooks := &server.Hooks{}
+	srv.registerSubscriptionHooks(hooks)
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		// nil message and missing session must be safe no-ops.
+		hooks.OnAfterSubscribe[0](ctx, nil, nil, &mcp.EmptyResult{})
+		hooks.OnAfterSubscribe[0](ctx, nil, &mcp.SubscribeRequest{}, &mcp.EmptyResult{})
+		hooks.OnAfterUnsubscribe[0](ctx, nil, nil, &mcp.EmptyResult{})
+		hooks.OnAfterUnsubscribe[0](ctx, nil, &mcp.UnsubscribeRequest{}, &mcp.EmptyResult{})
+		hooks.OnUnregisterSession[0](ctx, nil)
+	})
+}

--- a/tests/integration/solutions/lint-suppression/solution.yaml
+++ b/tests/integration/solutions/lint-suppression/solution.yaml
@@ -1,0 +1,95 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-suppression
+  version: 1.0.0
+  description: |
+    Tests inline lint suppression directives, including block-scoped
+    suppression. Two resolvers trigger the transform-shape-mismatch rule;
+    one is suppressed with a `# scafctl-lint-ignore` directive placed on its
+    `transform:` block key, the other is left flagged.
+
+spec:
+  resolvers:
+    # Triggers transform-shape-mismatch: the resolve chain mixes a structured
+    # http source with a non-structured static fallback ([]), and the transform
+    # accesses __self.body. No directive — the finding is reported.
+    shapeMismatchFlagged:
+      description: Resolver with an unguarded shape-mismatched transform
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body.items'
+
+    # Same shape mismatch, but a block-scoped ignore directive on the
+    # `transform:` key suppresses the finding for the whole transform block.
+    shapeMismatchSuppressed:
+      description: Resolver whose shape-mismatch finding is suppressed
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/data
+          - provider: static
+            inputs:
+              value: []
+      # scafctl-lint-ignore: transform-shape-mismatch
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: '__self.body.items'
+
+    # Root resolver so the two above are not reported as unused.
+    main:
+      description: Aggregates the two resolvers
+      type: string
+      dependsOn: [shapeMismatchFlagged, shapeMismatchSuppressed]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: done
+
+  testing:
+    config:
+      # lint: solution intentionally triggers transform-shape-mismatch
+      # resolve-defaults: http resolver requires network access
+      skipBuiltins: [lint, resolve-defaults, render-defaults]
+
+    cases:
+      flagged-finding-reported:
+        description: The unguarded resolver is reported by transform-shape-mismatch
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, suppression]
+        assertions:
+          - expression: __exitCode == 0
+            message: "transform-shape-mismatch is warning-level, should not fail"
+          - expression: >
+              __output.findings.exists(f,
+                f.ruleName == "transform-shape-mismatch" &&
+                f.location.contains("shapeMismatchFlagged"))
+            message: "Unsuppressed resolver should be flagged"
+
+      suppressed-finding-hidden:
+        description: The block-scoped ignore directive suppresses the finding
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, suppression]
+        assertions:
+          - expression: >
+              !__output.findings.exists(f,
+                f.ruleName == "transform-shape-mismatch" &&
+                f.location.contains("shapeMismatchSuppressed"))
+            message: "Block-scoped ignore should suppress the transform finding"

--- a/tests/integration/solutions/providers/go-template-extensions/solution.yaml
+++ b/tests/integration/solutions/providers/go-template-extensions/solution.yaml
@@ -315,6 +315,24 @@ spec:
                   {{ toHcl .toHclIndentData | indent 2 }}
                 }
 
+    toHclScalarList:
+      description: toHcl with a top-level scalar list renders a bare HCL array
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-scalar-list
+              template: '{{ list "repo:a:ref:main" "repo:b:ref:main" | toHcl }}'
+
+    toHclEmptyList:
+      description: toHcl with an empty list renders []
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-empty-list
+              template: '{{ list | toHcl }}'
+
     # ─────────────────────────────────────────────
     # Custom YAML Functions (toYaml, fromYaml, mustToYaml, mustFromYaml)
     # ─────────────────────────────────────────────
@@ -618,6 +636,22 @@ spec:
           - expression: '__output.toHclWithIndent.contains("resource")'
           - expression: '__output.toHclWithIndent.contains("ami")'
           - expression: '__output.toHclWithIndent.contains("instance_type")'
+
+      tohcl-scalar-list:
+        description: Verify toHcl renders a top-level scalar list as a bare HCL array
+        extends: [_base]
+        tags: [custom, toHcl, hcl]
+        assertions:
+          - expression: '__output.toHclScalarList.contains("[\"repo:a:ref:main\", \"repo:b:ref:main\"]")'
+            message: "Top-level scalar list should render as a bare HCL array"
+
+      tohcl-empty-list:
+        description: Verify toHcl renders an empty list as []
+        extends: [_base]
+        tags: [custom, toHcl, hcl]
+        assertions:
+          - expression: '__output.toHclEmptyList.contains("[]")'
+            message: "Empty list should render as []"
 
       # Custom YAML function tests
       toyaml-simple:

--- a/tests/integration/solutions/providers/parameter/solution.yaml
+++ b/tests/integration/solutions/providers/parameter/solution.yaml
@@ -77,6 +77,25 @@ spec:
             inputs:
               value: fallback-used
 
+    verbatimString:
+      description: Numeric-looking value forced to stay a string (type string)
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: billingId
+              default: "00042"
+              type: string
+
+    coercedNumber:
+      description: Same value with default type inference (becomes a number)
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: billingId
+              default: 42
+
   testing:
     config:
       # resolve-defaults: resolvers use parameter provider requiring external -r flag input
@@ -132,3 +151,21 @@ spec:
         assertions:
           - expression: __output.missingParam == "fallback-used"
             message: "Non-existent parameter should trigger fallback chain"
+
+      string-type-default:
+        description: Verify type string returns the default verbatim (no coercion)
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          - expression: __output.verbatimString == "00042"
+            message: "type string default should stay a verbatim string with leading zeros"
+
+      string-type-suppresses-coercion:
+        description: Verify type string keeps a numeric value as a string while default inference coerces it
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a", "-r", "billingId=12345"]
+        assertions:
+          - expression: __output.verbatimString == "12345"
+            message: "type string should keep the numeric value as a string"
+          - expression: __output.coercedNumber == 12345
+            message: "without type string the same value should be coerced to a number"


### PR DESCRIPTION
- mcp: add subscriptionManager that tracks (session, uri) resource subscriptions and delivers resources/updated notifications when a watched solution file changes on disk
- mcp: watch the parent directory of each subscribed file so atomic-save (rename) editors are handled, and debounce change bursts (300ms) into a single notification
- mcp: wire subscribe/unsubscribe/session-end lifecycle hooks into the server and resolve solution:// sub-resource URIs (graph, schema, tests) back to their backing file
- mcp: clean up the subscription manager on server Close
- docs: document MCP subscriptions, plus go-templates, linting, and run-resolver tutorial updates
- test: add integration solutions for lint suppression, go-template extensions, and parameter provider behavior